### PR TITLE
feat(segment): add isFullView prop to TokenList and TokenListItem components

### DIFF
--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItemBip44.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItemBip44.tsx
@@ -46,6 +46,7 @@ interface TokenListItemProps {
   setShowScamWarningModal: (arg: boolean) => void;
   privacyMode: boolean;
   showPercentageChange?: boolean;
+  isFullView?: boolean;
 }
 
 export const TokenListItemBip44 = React.memo(
@@ -55,6 +56,7 @@ export const TokenListItemBip44 = React.memo(
     setShowScamWarningModal,
     privacyMode,
     showPercentageChange = true,
+    isFullView = false,
   }: TokenListItemProps) => {
     const { trackEvent, createEventBuilder } = useMetrics();
     const navigation = useNavigation();
@@ -118,7 +120,7 @@ export const TokenListItemBip44 = React.memo(
       trackEvent(
         createEventBuilder(MetaMetricsEvents.TOKEN_DETAILS_OPENED)
           .addProperties({
-            source: 'mobile-token-list',
+            source: isFullView ? 'mobile-token-list-page' : 'mobile-token-list',
             chain_id: token.chainId,
             token_symbol: token.symbol,
           })

--- a/app/components/UI/Tokens/TokenList/TokenListItem/index.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/index.tsx
@@ -84,6 +84,7 @@ interface TokenListItemProps {
   setShowScamWarningModal: (arg: boolean) => void;
   privacyMode: boolean;
   showPercentageChange?: boolean;
+  isFullView?: boolean;
 }
 
 export const TokenListItem = React.memo(
@@ -93,6 +94,7 @@ export const TokenListItem = React.memo(
     setShowScamWarningModal,
     privacyMode,
     showPercentageChange = true,
+    isFullView = false,
   }: TokenListItemProps) => {
     const { trackEvent, createEventBuilder } = useMetrics();
     const navigation = useNavigation();
@@ -316,7 +318,7 @@ export const TokenListItem = React.memo(
       trackEvent(
         createEventBuilder(MetaMetricsEvents.TOKEN_DETAILS_OPENED)
           .addProperties({
-            source: 'mobile-token-list',
+            source: isFullView ? 'mobile-token-list-page' : 'mobile-token-list',
             chain_id: token.chainId,
             token_symbol: token.symbol,
           })

--- a/app/components/UI/Tokens/TokenList/index.tsx
+++ b/app/components/UI/Tokens/TokenList/index.tsx
@@ -100,6 +100,7 @@ const TokenListComponent = ({
         setShowScamWarningModal={setShowScamWarningModal}
         privacyMode={privacyMode}
         showPercentageChange={showPercentageChange}
+        isFullView={isFullView}
       />
     ),
     [
@@ -108,6 +109,7 @@ const TokenListComponent = ({
       privacyMode,
       showPercentageChange,
       TokenListItemComponent,
+      isFullView,
     ],
   );
 
@@ -125,6 +127,7 @@ const TokenListComponent = ({
             setShowScamWarningModal={setShowScamWarningModal}
             privacyMode={privacyMode}
             showPercentageChange={showPercentageChange}
+            isFullView={isFullView}
           />
         ))}
         {shouldShowViewAllButton && (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Description**

**What is the reason for the change?**

The "Token List Item Clicked" Segment event currently sends the same `source` property value (`mobile-token-list`) regardless of whether users click a token from the wallet home page or from the dedicated full token list page. This makes it impossible to differentiate user behavior between these two contexts in analytics.

**What is the improvement/solution?**

This PR adds differentiation to the token click tracking by introducing a new `source` value:
- `mobile-token-list` - sent when tokens are clicked from the wallet home page (existing behavior, maintains backward compatibility)
- `mobile-token-list-page` - sent when tokens are clicked from the full token list page (accessed via "View all tokens")

The implementation adds an `isFullView` prop that flows through the component hierarchy (`TokensFullView` → `Tokens` → `TokenList` → `TokenListItem/TokenListItemBip44`) and conditionally sets the source property in the Segment tracking event.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-207](https://consensyssoftware.atlassian.net/browse/TMCU-207)

## **Manual testing steps**

```gherkin
Feature: Token List Item Click Tracking Differentiation

  Scenario: user clicks token from wallet home page
    Given the user is on the wallet home page
    And tokens are visible in the token list
    When user taps on any token in the list
    Then a "Token List Item Clicked" event is sent to Segment
    And the event contains property source="mobile-token-list"
    And the user navigates to the token details page

  Scenario: user clicks token from full token list page
    Given the user is on the wallet home page
    And tokens are visible in the token list
    When user taps "View all tokens" button
    And user is navigated to the full token list page
    And user taps on any token in the list
    Then a "Token List Item Clicked" event is sent to Segment
    And the event contains property source="mobile-token-list-page"
    And the user navigates to the token details page
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TMCU-207]: https://consensyssoftware.atlassian.net/browse/TMCU-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an isFullView prop plumbed through TokenList -> TokenListItem/TokenListItemBip44 to set analytics source to 'mobile-token-list-page' vs 'mobile-token-list', with minor full-view layout padding.
> 
> - **Analytics/Tracking**:
>   - `TOKEN_DETAILS_OPENED` event now sets `source` based on `isFullView` in `TokenListItem` and `TokenListItemBip44` (`mobile-token-list-page` vs `mobile-token-list`).
> - **UI/Props flow**:
>   - Introduces optional `isFullView` prop on `TokenList`, `TokenListItem`, and `TokenListItemBip44` and passes it through both FlashList rendering and homepage list mapping.
>   - Applies horizontal padding (`contentContainerStyle`) to `FlashList` when `isFullView` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a75e04b63fd4229219b6a1a13fef9dfa8577fbc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->