### PR TITLE
fix: add staked energy and staked bandwidth to nontradabletokens list cp-7.60.0

### DIFF
--- a/app/components/UI/Bridge/hooks/useTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokens.test.ts
@@ -752,7 +752,7 @@ describe('useTokens', () => {
     it('filters out non-tradable Tron tokens from remainingTokens', async () => {
       const tronMaxBandwidthToken = {
         address: '0x789',
-        symbol: 'Max Bandwidth',
+        symbol: 'Max-Bandwidth',
         name: 'Max Bandwidth',
         decimals: 6,
         chainId: TrxScope.Mainnet,

--- a/app/components/UI/Bridge/utils/isTradableToken/index.test.ts
+++ b/app/components/UI/Bridge/utils/isTradableToken/index.test.ts
@@ -176,7 +176,7 @@ describe('isTradableToken', () => {
     it('returns false for Tron Energy token', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        name: 'Energy',
+        symbol: 'energy',
       });
 
       const result = isTradableToken(token);
@@ -187,7 +187,7 @@ describe('isTradableToken', () => {
     it('returns false for Tron Bandwidth token', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        name: 'Bandwidth',
+        symbol: 'bandwidth',
       });
 
       const result = isTradableToken(token);
@@ -198,7 +198,7 @@ describe('isTradableToken', () => {
     it('returns false for Tron Max Bandwidth token', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        name: 'Max Bandwidth',
+        symbol: 'max-bandwidth',
       });
 
       const result = isTradableToken(token);
@@ -209,7 +209,7 @@ describe('isTradableToken', () => {
     it('returns false for Tron energy token with lowercase', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        name: 'energy',
+        symbol: 'energy',
       });
 
       const result = isTradableToken(token);
@@ -220,7 +220,7 @@ describe('isTradableToken', () => {
     it('returns false for Tron bandwidth token with uppercase', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        name: 'BANDWIDTH',
+        symbol: 'BANDWIDTH',
       });
 
       const result = isTradableToken(token);
@@ -231,7 +231,7 @@ describe('isTradableToken', () => {
     it('returns false for Tron max bandwidth token with mixed case', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        name: 'mAx BaNdWiDtH',
+        symbol: 'MaX-BaNdWiDtH',
       });
 
       const result = isTradableToken(token);

--- a/app/components/UI/Bridge/utils/isTradableToken/index.ts
+++ b/app/components/UI/Bridge/utils/isTradableToken/index.ts
@@ -9,6 +9,7 @@ const nonTradableTokenNames: Record<Hex | CaipChainId, string[]> = {
     'max bandwidth',
     'staked for energy',
     'staked for bandwidth',
+    'max energy',
   ],
 };
 

--- a/app/components/UI/Bridge/utils/isTradableToken/index.ts
+++ b/app/components/UI/Bridge/utils/isTradableToken/index.ts
@@ -1,15 +1,20 @@
-import { TrxScope } from '@metamask/keyring-api';
+import { CaipChainId, TrxScope } from '@metamask/keyring-api';
 import { BridgeToken } from '../../types';
+import { Hex } from '@metamask/utils';
+
+const nonTradableTokenNames: Record<Hex | CaipChainId, string[]> = {
+  [TrxScope.Mainnet]: [
+    'energy',
+    'bandwidth',
+    'max bandwidth',
+    'staked for energy',
+    'staked for bandwidth',
+  ],
+};
 
 export const isTradableToken = (token: BridgeToken) => {
-  if (
-    token.chainId === TrxScope.Mainnet &&
-    (token.name?.toLowerCase() === 'energy' ||
-      token.name?.toLowerCase() === 'bandwidth' ||
-      token.name?.toLowerCase() === 'max bandwidth')
-  ) {
-    return false;
-  }
-
-  return true;
+  const isNonTradableToken = nonTradableTokenNames[token.chainId]?.includes(
+    token.name?.toLowerCase() ?? '',
+  );
+  return !isNonTradableToken;
 };

--- a/app/components/UI/Bridge/utils/isTradableToken/index.ts
+++ b/app/components/UI/Bridge/utils/isTradableToken/index.ts
@@ -1,21 +1,15 @@
-import { CaipChainId, TrxScope } from '@metamask/keyring-api';
+import { TrxScope } from '@metamask/keyring-api';
 import { BridgeToken } from '../../types';
-import { Hex } from '@metamask/utils';
-
-const nonTradableTokenNames: Record<Hex | CaipChainId, string[]> = {
-  [TrxScope.Mainnet]: [
-    'energy',
-    'bandwidth',
-    'max bandwidth',
-    'staked for energy',
-    'staked for bandwidth',
-    'max energy',
-  ],
-};
+import {
+  TRON_RESOURCE_SYMBOLS,
+  TronResourceSymbol,
+} from '../../../../../core/Multichain/constants';
 
 export const isTradableToken = (token: BridgeToken) => {
-  const isNonTradableToken = nonTradableTokenNames[token.chainId]?.includes(
-    token.name?.toLowerCase() ?? '',
-  );
-  return !isNonTradableToken;
+  if (token.chainId === TrxScope.Mainnet) {
+    return !TRON_RESOURCE_SYMBOLS.includes(
+      token.symbol?.toLowerCase() as TronResourceSymbol,
+    );
+  }
+  return true;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixed a bug where staked energy and staked bandwidth were displaying in the swap tokens lists

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where staked energy and staked bandwidth were displaying in the swap tokens lists

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/23141

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches non-tradable Tron token detection to symbol-based checks using shared constants and updates tests accordingly.
> 
> - **Bridge utils**:
>   - Update `isTradableToken` to determine non-tradable Tron tokens by `symbol` using `TRON_RESOURCE_SYMBOLS` (from `core/Multichain/constants`) instead of name matching.
> - **Tests**:
>   - Adjust `isTradableToken` tests to validate symbol-based filtering (e.g., `energy`, `bandwidth`, `max-bandwidth`, mixed/upper case).
>   - Update `useTokens` tests to use `symbol: 'Max-Bandwidth'` and verify filtering of non-tradable Tron tokens across `tokensWithBalance`, `topTokens`, and `remainingTokens`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b18269db809800f941163b31322cf6bb450d1e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->