### PR TITLE
fix: cp-7.60.0 infinite loader in metamask pay

### DIFF
--- a/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
@@ -112,4 +112,21 @@ describe('useUpdateTokenAmount', () => {
         ) + toHex(15000).substring(2),
     });
   });
+
+  it('does not update amount if new amount is equal to current amount', () => {
+    const { result } = runHook({
+      transactionMeta: {
+        txParams: {
+          data: TOKEN_TRANSFER_DATA_MOCK,
+          from: '0x13',
+          to: tokenAddress1Mock,
+        },
+      },
+    });
+
+    result.current.updateTokenAmount('0.000000000000000001');
+
+    expect(updateEditableParamsMock).not.toHaveBeenCalled();
+    expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
+  });
 });

--- a/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.ts
@@ -59,6 +59,10 @@ export function useUpdateTokenAmount() {
         decimals ?? 18,
       ).decimalPlaces(0, BigNumber.ROUND_UP);
 
+      if (newAmountRaw.isEqualTo(amountRaw)) {
+        return;
+      }
+
       const transactionData = parseStandardTokenTransactionData(data);
       const recipient = transactionData?.args?._to;
 


### PR DESCRIPTION
## **Description**

Prevent infinite loader when updating amount with same value in metamask pay.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #23132 #22785 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids unnecessary updates by early-returning when the new token amount equals the current amount, with tests added.
> 
> - **Hooks**:
>   - Update `useUpdateTokenAmount` to early-return if `newAmountRaw` equals current `amountRaw`, preventing transaction data updates in `useUpdateTokenAmount.ts`.
> - **Tests**:
>   - Add test in `useUpdateTokenAmount.test.ts` asserting no calls to `updateEditableParams` or `updateAtomicBatchData` when amount is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be987719831923b3c33df823daf5c46fed096983. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->