### PR TITLE
fix: cp-7.60.0 automatic highest balance token in metamask pay

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -84,11 +84,11 @@ describe('useAutomaticTransactionPayToken', () => {
     isHardwareAccountMock.mockReturnValue(false);
   });
 
-  it('selects target token if has balance', () => {
+  it('selects first token', () => {
     useTransactionPayAvailableTokensMock.mockReturnValue([
       {
         address: TOKEN_ADDRESS_2_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
+        chainId: CHAIN_ID_2_MOCK,
       },
       {
         address: TOKEN_ADDRESS_3_MOCK,
@@ -103,57 +103,13 @@ describe('useAutomaticTransactionPayToken', () => {
     runHook();
 
     expect(setPayTokenMock).toHaveBeenCalledWith({
-      address: TOKEN_ADDRESS_1_MOCK,
-      chainId: CHAIN_ID_1_MOCK,
-    });
-  });
-
-  it('selects token with highest balance on same chain if insufficient balance on target token', () => {
-    useTransactionPayAvailableTokensMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_3_MOCK,
-        chainId: CHAIN_ID_2_MOCK,
-      },
-      {
-        address: TOKEN_ADDRESS_2_MOCK,
-        chainId: CHAIN_ID_2_MOCK,
-      },
-      {
-        address: TOKEN_ADDRESS_3_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-      },
-    ] as AssetType[]);
-
-    runHook();
-
-    expect(setPayTokenMock).toHaveBeenCalledWith({
-      address: TOKEN_ADDRESS_3_MOCK,
-      chainId: CHAIN_ID_1_MOCK,
-    });
-  });
-
-  it('selects token with highest balance on alternate chain if insufficient balance on same chain', () => {
-    useTransactionPayAvailableTokensMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_3_MOCK,
-        chainId: CHAIN_ID_2_MOCK,
-      },
-      {
-        address: TOKEN_ADDRESS_2_MOCK,
-        chainId: CHAIN_ID_2_MOCK,
-      },
-    ] as AssetType[]);
-
-    runHook();
-
-    expect(setPayTokenMock).toHaveBeenCalledWith({
-      address: TOKEN_ADDRESS_3_MOCK,
+      address: TOKEN_ADDRESS_2_MOCK,
       chainId: CHAIN_ID_2_MOCK,
     });
   });
 
-  it('selects target token if insufficient balance on all chains', () => {
-    useTransactionPayAvailableTokensMock.mockReturnValue([]);
+  it('selects target token if no tokens with balance', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue([] as AssetType[]);
 
     runHook();
 

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -97,38 +97,10 @@ function getBestToken({
     return targetTokenFallback;
   }
 
-  const requiredToken = tokens.find(
-    (t) =>
-      t.address.toLowerCase() === targetToken?.address.toLowerCase() &&
-      t.chainId === targetToken?.chainId,
-  );
-
-  if (requiredToken) {
+  if (tokens?.length) {
     return {
-      address: requiredToken.address as Hex,
-      chainId: requiredToken.chainId as Hex,
-    };
-  }
-
-  const sameChainHighestBalanceToken = tokens.find(
-    (t) => t.chainId === targetToken?.chainId,
-  );
-
-  if (sameChainHighestBalanceToken) {
-    return {
-      address: sameChainHighestBalanceToken.address as Hex,
-      chainId: sameChainHighestBalanceToken.chainId as Hex,
-    };
-  }
-
-  const alternateChainHighestBalanceToken = tokens.find(
-    (t) => t.chainId !== targetToken?.chainId,
-  );
-
-  if (alternateChainHighestBalanceToken) {
-    return {
-      address: alternateChainHighestBalanceToken.address as Hex,
-      chainId: alternateChainHighestBalanceToken.chainId as Hex,
+      address: tokens[0].address as Hex,
+      chainId: tokens[0].chainId as Hex,
     };
   }
 


### PR DESCRIPTION
## **Description**

Automatically select the highest balance token on any chain in Perps and Predict deposits.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #23131 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies automatic pay token selection to the first available token with balance, falling back to target token when none or on hardware wallets, and updates tests accordingly.
> 
> - **Logic (useAutomaticTransactionPayToken.ts)**
>   - Replace multi-step selection (target match → highest balance same chain → highest balance alt chain) with simple rule: pick `tokens[0]` if any; otherwise fall back to required target token; always fall back for hardware wallets.
> - **Tests (useAutomaticTransactionPayToken.test.ts)**
>   - Update expectations to select the first available token.
>   - Remove scenarios around highest-balance and cross-chain selection.
>   - Keep fallbacks: target token when no tokens, hardware wallets, and disabled state does nothing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6907490c07813dcaf8185fc8c8c37168f0b556e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->