### PR TITLE
fix: cp-7.60.0 predict claim button style

### DIFF
--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.styles.ts
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.styles.ts
@@ -1,6 +1,5 @@
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../../util/theme/models';
-import { lightTheme } from '@metamask/design-tokens';
 
 const styleSheet = (params: { theme: Theme }) =>
   StyleSheet.create({
@@ -22,12 +21,6 @@ const styleSheet = (params: { theme: Theme }) =>
 
     bottom: {
       textAlign: 'center',
-    },
-
-    button: {
-      width: '100%',
-      height: 48,
-      backgroundColor: lightTheme.colors.primary.default,
     },
   });
 

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
@@ -6,9 +6,6 @@ import Avatar, {
   AvatarVariant,
 } from '../../../../../../component-library/components/Avatars/Avatar';
 import AvatarGroup from '../../../../../../component-library/components/Avatars/AvatarGroup';
-import Button, {
-  ButtonVariants,
-} from '../../../../../../component-library/components/Buttons/Button';
 import Text, {
   TextColor,
   TextVariant,
@@ -23,6 +20,8 @@ import { PredictPosition } from '../../../../../UI/Predict';
 import { AlignItems, FlexDirection } from '../../../../../UI/Box/box.types';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { BigNumber } from 'bignumber.js';
+import ButtonHero from '../../../../../../component-library/components-temp/Buttons/ButtonHero';
+import { ButtonBaseSize } from '@metamask/design-system-react-native';
 
 export interface PredictClaimFooterProps {
   onPress: () => void;
@@ -51,15 +50,14 @@ export function PredictClaimFooter({ onPress }: PredictClaimFooterProps) {
       ) : (
         <SingleWin wonPositions={wonPositions} />
       )}
-      <Button
-        variant={ButtonVariants.Primary}
-        labelTextVariant={TextVariant.BodyLGMedium}
-        style={styles.button}
-        label={strings('confirm.predict_claim.button_label')}
-        onPress={onPress}
-        isInverse
+      <ButtonHero
         testID={PredictClaimConfirmationSelectorsIDs.CLAIM_CONFIRM_BUTTON}
-      />
+        onPress={onPress}
+        size={ButtonBaseSize.Lg}
+        isFullWidth
+      >
+        {strings('confirm.predict_claim.button_label')}
+      </ButtonHero>
       <Text
         variant={TextVariant.BodyXS}
         color={TextColor.Alternative}


### PR DESCRIPTION
## **Description**

Update text colour of Predict claim button in light theme.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #23096 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="300" alt="Claim" src="https://github.com/user-attachments/assets/cf4f7ecc-ba59-48c7-a6a9-88cff992c7c4" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace Predict claim CTA with ButtonHero and drop light-theme-specific button styling.
> 
> - **Predict Claim Footer (`predict-claim-footer.tsx`)**:
>   - Replace `Button` with `ButtonHero`; move label to children, remove variant/label props.
>   - Set `size` to `ButtonBaseSize.Lg` and `isFullWidth`.
>   - Add imports for `ButtonHero` and `ButtonBaseSize`.
> - **Styles (`predict-claim-footer.styles.ts`)**:
>   - Remove hardcoded `button` style and `lightTheme` dependency; keep container/top/bottom styles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44a2213ea866f9082dfcfcda5df7c71e0fefec5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->