### PR TITLE
fix: cp-7.60.0 predict withdraw value in activity

### DIFF
--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -866,7 +866,7 @@ function decodeLegacySwapsTx(args) {
 
   if (isSwap) {
     if (!assetSymbol || sourceToken.symbol === assetSymbol) {
-      value = `${decimalSourceAmount} ${sourceToken.symbol}`;
+      value = `-${decimalSourceAmount} ${sourceToken.symbol}`;
       fiatValue = addCurrencySymbol(
         renderSourceTokenFiatNumber,
         currentCurrency,

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -36,6 +36,13 @@ import {
 } from '../Bridge/utils/transaction-history';
 import { calculateTotalGas, renderGwei } from './utils-gas';
 import { getTokenTransferData } from '../../Views/confirmations/utils/transaction-pay';
+import { hasTransactionType } from '../../Views/confirmations/utils/transaction';
+
+const POSITIVE_TRANSFER_TRANSACTION_TYPES = [
+  TransactionType.perpsDeposit,
+  TransactionType.predictDeposit,
+  TransactionType.predictWithdraw,
+];
 
 const { getSwapsContractAddress } = swapsUtils;
 
@@ -161,12 +168,21 @@ function getTokenTransfer(args) {
 
   const { SENT_TOKEN, RECEIVED_TOKEN } = TRANSACTION_TYPES;
   const transactionType = isSent ? SENT_TOKEN : RECEIVED_TOKEN;
+
+  const isPositive = hasTransactionType(
+    tx,
+    POSITIVE_TRANSFER_TRANSACTION_TYPES,
+  );
+
+  const signPrefix = isPositive ? '' : '- ';
+
   const transactionElement = {
     actionKey: renderActionKey,
     value: !renderTokenAmount
       ? strings('transaction.value_not_available')
       : renderTokenAmount,
-    fiatValue: !!renderTokenFiatAmount && `- ${renderTokenFiatAmount}`,
+    fiatValue:
+      !!renderTokenFiatAmount && `${signPrefix}${renderTokenFiatAmount}`,
     transactionType,
     nonce,
   };
@@ -850,7 +866,7 @@ function decodeLegacySwapsTx(args) {
 
   if (isSwap) {
     if (!assetSymbol || sourceToken.symbol === assetSymbol) {
-      value = `-${decimalSourceAmount} ${sourceToken.symbol}`;
+      value = `${decimalSourceAmount} ${sourceToken.symbol}`;
       fiatValue = addCurrencySymbol(
         renderSourceTokenFiatNumber,
         currentCurrency,
@@ -978,6 +994,7 @@ export default async function decodeTransaction(args) {
     switch (actionKey) {
       case strings('transactions.tx_review_perps_deposit'):
       case strings('transactions.tx_review_predict_deposit'):
+      case strings('transactions.tx_review_predict_withdraw'):
         [transactionElement, transactionDetails] = await decodeTransferTx({
           ...args,
           actionKey,

--- a/app/components/UI/TransactionElement/utils.test.js
+++ b/app/components/UI/TransactionElement/utils.test.js
@@ -1,8 +1,10 @@
+import { TransactionType } from '@metamask/transaction-controller';
 import {
   CONTRACT_CREATION_SIGNATURE,
   TRANSACTION_TYPES,
 } from '../../../util/transactions';
 import decodeTransaction from './utils';
+import { strings } from '../../../../locales/i18n';
 
 jest.mock('../../../core/Engine', () => ({
   context: {
@@ -76,6 +78,10 @@ const TX_PARAMS_MOCK = {
 };
 
 describe('Transaction Element Utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('decodeTransaction', () => {
     it('if set approval for all', async () => {
       const args = {
@@ -359,6 +365,85 @@ describe('Transaction Element Utils', () => {
         summaryFee: '0.0038 POL',
         summaryTotalAmount: '5.43 USDC / 0.0038 POL',
         summarySecondaryTotalAmount: undefined,
+        txChainId: '0x89',
+      });
+    });
+
+    it.each([
+      [
+        TransactionType.perpsDeposit,
+        strings('transactions.tx_review_perps_deposit'),
+      ],
+      [
+        TransactionType.predictDeposit,
+        strings('transactions.tx_review_predict_deposit'),
+      ],
+      [
+        TransactionType.predictWithdraw,
+        strings('transactions.tx_review_predict_withdraw'),
+      ],
+    ])('if %s', async (transactionType, title) => {
+      const args = {
+        tx: {
+          txParams: {
+            to: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+            from: '0x1440ec793ae50fa046b95bfeca5af475b6003f9e',
+            value: '52daf0',
+            data: '0xa9059cbb0000000000000000000000001234567890abcdef1234567890abcdef1234567800000000000000000000000000000000000000000000000000000000052daf0',
+            gas: '0x12345',
+            maxFeePerGas: '0x123456789',
+            maxPriorityFeePerGas: '0x123456789',
+            estimatedBaseFee: '0xABCDEF123',
+          },
+          hash: '0x942d7843454266b81bf631022aa5f3f944691731b62d67c4e80c4bb5740058bb',
+          type: transactionType,
+        },
+        currentCurrency: 'usd',
+        contractExchangeRates: {
+          '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359': {
+            price: 2.0,
+          },
+        },
+        conversionRate: 2.0,
+        totalGas: '0x64',
+        actionKey: 'key',
+        primaryCurrency: 'ETH',
+        selectedAddress: '0x1440ec793ae50fa046b95bfeca5af475b6003f9e',
+        ticker: 'POL',
+        txChainId: '0x89',
+        tokens: {
+          '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359': {
+            address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+            symbol: 'USDC',
+            decimals: 6,
+          },
+        },
+      };
+
+      const [transactionElement, transactionDetails] =
+        await decodeTransaction(args);
+
+      expect(transactionElement).toEqual({
+        actionKey: title,
+        renderTo: '0x1234567890abcdef1234567890abcdef12345678',
+        value: '5.43 USDC',
+        fiatValue: '$21.72',
+        nonce: undefined,
+        transactionType: 'transaction_sent_token',
+      });
+
+      expect(transactionDetails).toEqual({
+        renderTotalGas: '0.0038 POL',
+        renderValue: '5.43 USDC',
+        renderFrom: '0x1440ec793aE50fA046B95bFeCa5aF475b6003f9e',
+        renderTo: '0x1234567890AbcdEF1234567890aBcdef12345678',
+        renderGas: '74565',
+        renderGasPrice: 51,
+        hash: '0x942d7843454266b81bf631022aa5f3f944691731b62d67c4e80c4bb5740058bb',
+        summaryAmount: '5.43 USDC',
+        summaryFee: '0.0038 POL',
+        summaryTotalAmount: '5.43 USDC / 0.0038 POL',
+        summarySecondaryTotalAmount: '$21.73',
         txChainId: '0x89',
       });
     });


### PR DESCRIPTION
## **Description**

Ensure activity value matches withdraw amount for Predict withdraw transactions.

Also remove minus sign from Perps and Predict deposit transactions.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #23094 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

![Activity](https://github.com/user-attachments/assets/da126135-6a44-45a2-9829-2a3cee608330)

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the negative fiat prefix for Perps/Predict deposits and Predict withdraws, adds decode handling for Predict withdraw, and updates tests accordingly.
> 
> - **Transaction decoding (`app/components/UI/TransactionElement/utils.js`)**:
>   - Adjust fiat sign for token transfers using `hasTransactionType` and `POSITIVE_TRANSFER_TRANSACTION_TYPES` (`perpsDeposit`, `predictDeposit`, `predictWithdraw`), removing the minus for these types.
>   - Include `transactions.tx_review_predict_withdraw` in the transfer decoding switch to use `decodeTransferTx` with the original action key.
> - **Tests (`app/components/UI/TransactionElement/utils.test.js`)**:
>   - Add parameterized tests for `perpsDeposit`, `predictDeposit`, and `predictWithdraw` verifying positive fiat values and summaries.
>   - Minor setup: import additions and `beforeEach(jest.clearAllMocks)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e61b76974d82fbbd19d3af427f52cafd0f2d7563. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->