### PR TITLE
fix: cp-7.60.0 perps deposit activity filtering

### DIFF
--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -14,7 +14,7 @@ import { strings } from '../../../../locales/i18n';
 import { toDateFormat } from '../../../util/date';
 import TransactionDetails from './TransactionDetails';
 import { safeToChecksumAddress } from '../../../util/address';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import StyledButton from '../StyledButton';
 import Modal from 'react-native-modal';
 import decodeTransaction from './utils';
@@ -34,7 +34,10 @@ import { selectTickerByChainId } from '../../../selectors/networkController';
 import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../selectors/multichainAccounts/accountTreeController';
 import { selectPrimaryCurrency } from '../../../selectors/settings';
-import { selectSwapsTransactions } from '../../../selectors/transactionController';
+import {
+  selectSwapsTransactions,
+  selectTransactions,
+} from '../../../selectors/transactionController';
 import { swapsControllerTokens } from '../../../reducers/swaps';
 import {
   FINAL_NON_CONFIRMED_STATUSES,
@@ -224,6 +227,10 @@ class TransactionElement extends PureComponent {
      * Whether to render a bottom border for row separation (used in unified list)
      */
     showBottomBorder: PropTypes.bool,
+    /**
+     * All EVM transactions in controller state
+     */
+    transactions: PropTypes.arrayOf(PropTypes.object).isRequired,
   };
 
   state = {
@@ -377,10 +384,12 @@ class TransactionElement extends PureComponent {
     return null;
   };
 
-  renderTxElementIcon = (transactionElement, status, chainId) => {
+  renderTxElementIcon = (transactionElement, tx) => {
+    const { chainId: txChainId, requiredTransactionIds, status, type } = tx;
     const { transactionType } = transactionElement;
     const { colors, typography } = this.context || mockTheme;
     const styles = createStyles(colors, typography);
+    const { transactions } = this.props;
 
     const isFailedTransaction = status === 'cancelled' || status === 'failed';
     let icon;
@@ -422,6 +431,14 @@ class TransactionElement extends PureComponent {
           : transactionIconApprove;
         break;
     }
+
+    const perpsDepositChainId =
+      type === TransactionType.perpsDeposit && requiredTransactionIds?.length
+        ? transactions?.find((t) => t.id === requiredTransactionIds[0])?.chainId
+        : undefined;
+
+    const chainId = perpsDepositChainId ?? txChainId;
+
     return (
       <BadgeWrapper
         badgeElement={
@@ -448,6 +465,7 @@ class TransactionElement extends PureComponent {
       isLedgerAccount,
       i,
       tx: { time, status, isSmartTransaction, chainId, type },
+      tx,
       bridgeTxHistoryData: { bridgeTxHistoryItem, isBridgeComplete },
     } = this.props;
     const isBridgeTransaction = type === TransactionType.bridge;
@@ -478,7 +496,7 @@ class TransactionElement extends PureComponent {
           </ListItem.Date>
           <ListItem.Content style={styles.listItemContent}>
             <ListItem.Icon>
-              {this.renderTxElementIcon(transactionElement, status, chainId)}
+              {this.renderTxElementIcon(transactionElement, tx)}
             </ListItem.Icon>
             <ListItem.Body>
               <ListItem.Title numberOfLines={1} style={styles.listItemTitle}>
@@ -780,9 +798,14 @@ TransactionElement.contextType = ThemeContext;
 // Create a wrapper functional component
 const TransactionElementWithBridge = (props) => {
   const bridgeTxHistoryData = useBridgeTxHistoryData({ evmTxMeta: props.tx });
+  const transactions = useSelector(selectTransactions);
 
   return (
-    <TransactionElement {...props} bridgeTxHistoryData={bridgeTxHistoryData} />
+    <TransactionElement
+      {...props}
+      bridgeTxHistoryData={bridgeTxHistoryData}
+      transactions={transactions}
+    />
   );
 };
 

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -235,7 +235,7 @@ const UnifiedTransactionsView = ({
     let allConfirmedFiltered: TransactionMetaWithImport[] = [];
     if (isRemoveGlobalNetworkSelectorEnabled()) {
       allConfirmedFiltered = allConfirmed.filter((tx) =>
-        isTransactionOnChains(tx, enabledEVMChainIds, allConfirmed),
+        isTransactionOnChains(tx, enabledEVMChainIds, transactionMetaPool),
       );
     } else if (isPopularNetwork) {
       const popularChainIds: Hex[] = [
@@ -244,14 +244,14 @@ const UnifiedTransactionsView = ({
         ...PopularList.map((n) => n.chainId as Hex),
       ];
       allConfirmedFiltered = allConfirmed.filter((tx) =>
-        isTransactionOnChains(tx, popularChainIds, allConfirmed),
+        isTransactionOnChains(tx, popularChainIds, transactionMetaPool),
       );
     } else {
       allConfirmedFiltered = allConfirmed.filter((tx) =>
         isTransactionOnChains(
           tx,
           currentEvmChainId ? [currentEvmChainId as Hex] : [],
-          allConfirmed,
+          transactionMetaPool,
         ),
       );
     }

--- a/app/util/activity/index.ts
+++ b/app/util/activity/index.ts
@@ -168,7 +168,21 @@ export function isTransactionOnChains(
   chainIds: Hex[],
   allTransactions: TransactionMeta[],
 ): boolean {
-  const { chainId, requiredTransactionIds } = transaction;
+  const { chainId, requiredTransactionIds, type } = transaction;
+
+  // Hide Perps deposit transaction if it was funded by a non-selected chain.
+  if (type === TransactionType.perpsDeposit && requiredTransactionIds?.length) {
+    const requiredTransaction = allTransactions.find(
+      (t) => t.id === requiredTransactionIds[0],
+    );
+
+    if (
+      requiredTransaction &&
+      !chainIds.includes(requiredTransaction.chainId)
+    ) {
+      return false;
+    }
+  }
 
   if (chainIds.includes(chainId)) {
     return true;


### PR DESCRIPTION
## **Description**

Hide Perps deposit transactions in activity when filtering to Arbitrum and source chain is not Arbitrum.

Change network icon for Perps deposit transactions to match source chain.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #23099 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

![Icon](https://github.com/user-attachments/assets/9a4026c7-0d4e-4a14-bc9a-9dfe09d9e119)

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hides Perps deposit transactions when their source chain isn’t selected and updates the transaction icon badge to reflect the source network, while refining chain filtering inputs and adding tests.
> 
> - **Activity filtering**:
>   - Update `isTransactionOnChains` to hide `perpsDeposit` when the required (funding) transaction’s chain isn’t in selected `chainIds`.
>   - Add comprehensive tests for `isTransactionOnChains`, including `perpsDeposit` scenarios.
> - **Unified Transactions View**:
>   - Use `transactionMetaPool` instead of `allConfirmed` when calling `isTransactionOnChains` to ensure correct chain context.
> - **UI** (`app/components/UI/TransactionElement`):
>   - Compute network badge chain for `perpsDeposit` from first `requiredTransactionId` (falls back to tx `chainId`).
>   - Inject all controller `transactions` via `useSelector(selectTransactions)` and new required prop.
>   - Adjust `renderTxElementIcon` signature to accept `tx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a10afc51726ca8139de3b05dfdc56fd971bad6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->