### PR TITLE
Improve NVM initialization in .xcode.env

### DIFF
--- a/ios/.xcode.env
+++ b/ios/.xcode.env
@@ -1,5 +1,30 @@
-if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
-. "$HOME/.nvm/nvm.sh"
-elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
-. "$(brew --prefix nvm)/nvm.sh"
+# Script to initialize Node Version Manager (NVM) in the shell session.
+
+# Check if NVM is already sourced to prevent duplicate execution.
+if [ -z "${NVM_DIR}" ]; then
+  
+  # 1. Check for standard NVM installation path in the HOME directory.
+  if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+    
+    # Load NVM from the standard installation path.
+    . "$HOME/.nvm/nvm.sh"
+
+  # 2. Check for Homebrew installation path, if the 'brew' command is executable.
+  elif [[ -x "$(command -v brew)" ]]; then
+    
+    # Get the Homebrew prefix for NVM once.
+    NVM_BREW_PREFIX="$(brew --prefix nvm)"
+    
+    if [[ -s "${NVM_BREW_PREFIX}/nvm.sh" ]]; then
+      
+      # Load NVM from the Homebrew path.
+      . "${NVM_BREW_PREFIX}/nvm.sh"
+
+    fi
+  fi
 fi
+
+# Optional: Add the lines below to enable nvm auto-completion if desired.
+# if [[ -s "$NVM_DIR/bash_completion" ]]; then
+#   . "$NVM_DIR/bash_completion"
+# fi


### PR DESCRIPTION
Refactor NVM initialization script to prevent duplicate sourcing and improve clarity.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `ios/.xcode.env` to safely initialize NVM once, add Homebrew-based sourcing with single prefix lookup, and include optional autocomplete snippet.
> 
> - **iOS build env (`ios/.xcode.env`)**:
>   - Guard NVM sourcing with `NVM_DIR` check to avoid duplicate initialization.
>   - Prefer standard install (`$HOME/.nvm/nvm.sh`); fallback to Homebrew when `brew` exists.
>     - Compute `NVM_BREW_PREFIX` once and source `${NVM_BREW_PREFIX}/nvm.sh` if present.
>   - Add commented optional NVM auto-completion snippet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 394cb1030fbbb184c7cd8d4638c68fbe971c7715. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->