### PR TITLE
fix(perps): Prevent duplicate day markers on TradingView chart

### DIFF
--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
@@ -56,6 +56,22 @@ export const createTradingViewChartTemplate = (
         window.allCandleData = []; // Store all loaded data for zoom functionality
         window.visiblePriceRange = null; // Track visible price range for dynamic decimal precision
 
+        // Helper function to get date string in user's timezone (YYYY-MM-DD)
+        window.getDateString = function(date, userTimezone) {
+            const year = date.toLocaleString('en-US', { year: 'numeric', timeZone: userTimezone });
+            const month = date.toLocaleString('en-US', { month: '2-digit', timeZone: userTimezone });
+            const day = date.toLocaleString('en-US', { day: '2-digit', timeZone: userTimezone });
+            return year + '-' + month + '-' + day;
+        };
+        
+        // Helper function to check if a date is today in user's timezone
+        window.isToday = function(date, userTimezone) {
+            const now = new Date();
+            const todayString = window.getDateString(now, userTimezone);
+            const dateString = window.getDateString(date, userTimezone);
+            return todayString === dateString;
+        };
+
         // Cache for Intl.NumberFormat instances to avoid expensive recreation
         // Key: decimal count (e.g., "0", "2", "4"), Value: NumberFormat instance
         window.formatterCache = new Map();
@@ -200,25 +216,46 @@ export const createTradingViewChartTemplate = (
                                 timeZone: userTimezone
                             });
                         case 'DayOfMonth':
-                            return date.toLocaleString('en-US', { 
-                                month: 'short',
+                            // Always show day + month for DayOfMonth tick type (e.g., 1D candles)
+                            // Format: "17 Nov" (day before month)
+                            const day = date.toLocaleString('en-US', { 
                                 day: 'numeric',
                                 timeZone: userTimezone
                             });
+                            const month = date.toLocaleString('en-US', { 
+                                month: 'short',
+                                timeZone: userTimezone
+                            });
+                            return day + ' ' + month;
                         case 'Hour':
-                            return date.toLocaleString('en-US', { 
-                                hour: '2-digit', 
-                                minute: '2-digit',
-                                hour12: false,
-                                timeZone: userTimezone
-                            });
                         case 'Minute':
-                            return date.toLocaleString('en-US', { 
-                                hour: '2-digit', 
-                                minute: '2-digit',
-                                hour12: false,
-                                timeZone: userTimezone
-                            });
+                            // Show date + time if not today, otherwise just time
+                            if (!window.isToday(date, userTimezone)) {
+                                // Format: "17 Nov 00:15"
+                                const day = date.toLocaleString('en-US', { 
+                                    day: 'numeric',
+                                    timeZone: userTimezone
+                                });
+                                const month = date.toLocaleString('en-US', { 
+                                    month: 'short',
+                                    timeZone: userTimezone
+                                });
+                                const timeStr = date.toLocaleString('en-US', { 
+                                    hour: '2-digit', 
+                                    minute: '2-digit',
+                                    hour12: false,
+                                    timeZone: userTimezone
+                                });
+                                return day + ' ' + month + ' ' + timeStr;
+                            } else {
+                                // Show time only for today
+                                return date.toLocaleString('en-US', { 
+                                    hour: '2-digit', 
+                                    minute: '2-digit',
+                                    hour12: false,
+                                    timeZone: userTimezone
+                                });
+                            }
                         case 'Second':
                             return date.toLocaleString('en-US', { 
                                 hour: '2-digit', 
@@ -241,46 +278,95 @@ export const createTradingViewChartTemplate = (
                         const timeSpanHours = (visibleRange.to - visibleRange.from) / 3600;
 
                         if (timeSpanHours <= 24) {
-                            // Less than 24 hours: show time only
-                            return date.toLocaleString('en-US', { 
-                                hour: '2-digit', 
-                                minute: '2-digit',
-                                hour12: false,
-                                timeZone: userTimezone
-                            });
+                            // Less than 24 hours: show date + time if not today, otherwise just time
+                            if (!window.isToday(date, userTimezone)) {
+                                // Format: "17 Nov 00:15"
+                                const day = date.toLocaleString('en-US', { 
+                                    day: 'numeric',
+                                    timeZone: userTimezone
+                                });
+                                const month = date.toLocaleString('en-US', { 
+                                    month: 'short',
+                                    timeZone: userTimezone
+                                });
+                                const timeStr = date.toLocaleString('en-US', { 
+                                    hour: '2-digit', 
+                                    minute: '2-digit',
+                                    hour12: false,
+                                    timeZone: userTimezone
+                                });
+                                return day + ' ' + month + ' ' + timeStr;
+                            } else {
+                                // Show time only for today
+                                return date.toLocaleString('en-US', { 
+                                    hour: '2-digit', 
+                                    minute: '2-digit',
+                                    hour12: false,
+                                    timeZone: userTimezone
+                                });
+                            }
                         } else if (timeSpanHours <= 24 * 7) {
-                            // Less than a week: show date only
-                            return date.toLocaleString('en-US', { 
-                                month: 'short',
-                                day: 'numeric',
-                                timeZone: userTimezone
-                            });
-                        } else if (timeSpanHours <= 24 * 30) {
-                            // Less than a month: show date only
-                            return date.toLocaleString('en-US', { 
-                                month: 'short',
-                                day: 'numeric',
-                                timeZone: userTimezone
-                            });
+                           // Less than a week: show date + time if not today, otherwise just time
+                            if (!window.isToday(date, userTimezone)) {
+                                // Format: "17 Nov 00:15"
+                                const day = date.toLocaleString('en-US', { 
+                                    day: 'numeric',
+                                    timeZone: userTimezone
+                                });
+                                const month = date.toLocaleString('en-US', { 
+                                    month: 'short',
+                                    timeZone: userTimezone
+                                });
+                                const timeStr = date.toLocaleString('en-US', { 
+                                    hour: '2-digit', 
+                                    minute: '2-digit',
+                                    hour12: false,
+                                    timeZone: userTimezone
+                                });
+                                return day + ' ' + month + ' ' + timeStr;
+                            } else {
+                                // Show time only for today
+                                return date.toLocaleString('en-US', { 
+                                    hour: '2-digit', 
+                                    minute: '2-digit',
+                                    hour12: false,
+                                    timeZone: userTimezone
+                                });
+                            }
                         } else {
-                            // More than a month: show month only
-                            return date.toLocaleString('en-US', { 
+                             // Longer ranges: always show day + month (e.g., "17 Nov")
+                            // This is especially important for 1D candles
+                            const day = date.toLocaleString('en-US', { 
+                                day: 'numeric',
+                                timeZone: userTimezone
+                            });
+                            const month = date.toLocaleString('en-US', { 
                                 month: 'short',
                                 timeZone: userTimezone
                             });
+                            return day + ' ' + month;
                         }
                     }
                 }
                 
                 // Final fallback: show date and time
-                return date.toLocaleString('en-US', { 
-                    month: 'short',
+                // Format: "17 Nov 00:15"
+                const day = date.toLocaleString('en-US', { 
                     day: 'numeric',
+                    timeZone: userTimezone
+                });
+                const month = date.toLocaleString('en-US', { 
+                    month: 'short',
+                    timeZone: userTimezone
+                });
+                const timeStr = date.toLocaleString('en-US', { 
                     hour: '2-digit', 
                     minute: '2-digit',
                     hour12: false,
                     timeZone: userTimezone
                 });
+
+                return day + ' ' + month + ' ' + timeStr;
             }
         };
         


### PR DESCRIPTION
## **Description**

This PR enhances the TradingView chart's timestamp display system to prevent duplicate day markers and improve date label clarity across different chart time ranges.

**What is the reason for the change?**
The TradingView chart was displaying duplicate or redundant date labels on the X-axis, particularly when viewing charts at different time scales (hourly, daily, weekly). This made the chart harder to read.

## **Changelog**

CHANGELOG entry: Fixed duplicate day markers on TradingView chart X-axis and improved timestamp display clarity

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1807

## **Manual testing steps**

```gherkin
Feature: TradingView Chart Day Markers

  Scenario: user views chart with different timeframes
    Given the user is on the Perps trading screen
    And the TradingView chart is loaded with data

    When user selects different timeframes (1H, 1D, 1W)
    Then the chart should show clear day markers without duplicates
    And day boundaries should display date + time (e.g., "17 Nov 00:15")
    And subsequent hours on the same day should show time only (e.g., "01:15")
    And today's date should show time only without the date label

  Scenario: user scrolls through chart history
    Given the user has a chart with day markers displayed
    
    When user scrolls or zooms the chart to view different time periods
    Then the displayed date tracking should reset
    And new day markers should appear correctly for the newly visible range
    And no duplicate day markers should appear
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/8b2607df-38a3-4eb0-b05e-8a00a8e9fbee

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/a9f5776c-0276-442c-946d-6e392c4bbd93


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors chart time label formatting to show day+month on daily ticks and conditional date+time on intraday ticks, preventing duplicate day markers and improving clarity across zoom ranges.
> 
> - **TradingView chart timestamp formatting** (`app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx`):
>   - Add helpers `getDateString` and `isToday` for timezone-aware date checks.
>   - Update `formatTimestamp`:
>     - `DayOfMonth`: always `"DD Mon"` (e.g., `17 Nov`).
>     - `Hour`/`Minute`: show `"DD Mon HH:MM"` if not today, else `"HH:MM"`.
>     - `Second`: unchanged (HH:MM:SS).
>     - Fallback based on visible range mirrors above rules; longer ranges always `"DD Mon"`.
>     - Crosshair labels remain full date+time.
>   - Adjust final fallback to return `"DD Mon HH:MM"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 418c660e4ec89a189b741953157b5bcf35cd6531. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->