### PR TITLE
refactor: update swap button tracking for navbar integration

### DIFF
--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
@@ -127,14 +127,17 @@ export const useSwapBridgeNavigation = ({
       });
 
       // Track Swap button click with new consolidated event
+      const isFromNavbar = location === SwapBridgeNavigationLocation.TabBar;
       trackActionButtonClick(trackEvent, createEventBuilder, {
         action_name: ActionButtonType.SWAP,
-        action_position: ActionPosition.SECOND_POSITION,
+        // Omit action_position for navbar to avoid confusion with main action buttons
+        ...(isFromNavbar
+          ? {}
+          : { action_position: ActionPosition.SECOND_POSITION }),
         button_label: strings('asset_overview.swap'),
-        location:
-          location === 'TabBar'
-            ? ActionLocation.HOME
-            : ActionLocation.ASSET_DETAILS,
+        location: isFromNavbar
+          ? ActionLocation.NAVBAR
+          : ActionLocation.ASSET_DETAILS,
       });
       trackEvent(
         createEventBuilder(MetaMetricsEvents.SWAP_BUTTON_CLICKED)

--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/useSwapBridgeNavigation.test.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/useSwapBridgeNavigation.test.ts
@@ -509,11 +509,11 @@ describe('useSwapBridgeNavigation', () => {
         MetaMetricsEvents.ACTION_BUTTON_CLICKED,
       );
 
+      // When location is TabBar, action_position is omitted and location is navbar
       expect(mockAddProperties).toHaveBeenCalledWith({
         action_name: ActionButtonType.SWAP,
-        action_position: ActionPosition.SECOND_POSITION,
         button_label: 'Swap',
-        location: ActionLocation.HOME,
+        location: ActionLocation.NAVBAR,
       });
       expect(mockBuild).toHaveBeenCalled();
 

--- a/app/util/analytics/actionButtonTracking.test.ts
+++ b/app/util/analytics/actionButtonTracking.test.ts
@@ -80,11 +80,12 @@ describe('actionButtonTracking', () => {
       // Given/When/Then: enum values should match expected strings
       expect(ActionLocation.HOME).toBe('home');
       expect(ActionLocation.ASSET_DETAILS).toBe('asset details');
+      expect(ActionLocation.NAVBAR).toBe('navbar');
     });
 
     it('covers all location types', () => {
       // Given: all expected location types
-      const expectedLocations = ['home', 'asset details'];
+      const expectedLocations = ['home', 'asset details', 'navbar'];
 
       // When: checking enum values
       const actualLocations = Object.values(ActionLocation);
@@ -93,7 +94,7 @@ describe('actionButtonTracking', () => {
       expect(actualLocations).toEqual(
         expect.arrayContaining(expectedLocations),
       );
-      expect(actualLocations).toHaveLength(2);
+      expect(actualLocations).toHaveLength(3);
     });
   });
 
@@ -383,6 +384,7 @@ describe('actionButtonTracking', () => {
       const locationTestCases = [
         { location: ActionLocation.HOME, expected: 'home' },
         { location: ActionLocation.ASSET_DETAILS, expected: 'asset details' },
+        { location: ActionLocation.NAVBAR, expected: 'navbar' },
       ];
 
       locationTestCases.forEach((testCase) => {
@@ -542,10 +544,34 @@ describe('actionButtonTracking', () => {
       // Then: should include all properties
       expect(mockAddProperties).toHaveBeenCalledWith(properties);
     });
+
+    it('tracks swap button from navbar without action_position', () => {
+      // Given: navbar swap button properties without action_position
+      const properties: ActionButtonProperties = {
+        action_name: ActionButtonType.SWAP,
+        button_label: 'Swap',
+        location: ActionLocation.NAVBAR,
+      };
+
+      // When: tracking navbar swap button click
+      trackActionButtonClick(
+        mockTrackEvent,
+        mockCreateEventBuilder,
+        properties,
+      );
+
+      // Then: should track without action_position
+      expect(mockAddProperties).toHaveBeenCalledWith({
+        action_name: 'swap',
+        button_label: 'Swap',
+        location: 'navbar',
+      });
+      expect(mockBuild).toHaveBeenCalled();
+    });
   });
 
   describe('ActionButtonProperties interface', () => {
-    it('requires all mandatory properties', () => {
+    it('requires mandatory properties', () => {
       // Given: properties with all mandatory fields
       const validProperties: ActionButtonProperties = {
         action_name: ActionButtonType.BUY,
@@ -560,6 +586,22 @@ describe('actionButtonTracking', () => {
       expect(validProperties.action_position).toBeDefined();
       expect(validProperties.button_label).toBeDefined();
       expect(validProperties.location).toBeDefined();
+    });
+
+    it('allows action_position to be optional', () => {
+      // Given: properties without action_position (for navbar buttons)
+      const propertiesWithoutPosition: ActionButtonProperties = {
+        action_name: ActionButtonType.SWAP,
+        button_label: 'Swap',
+        location: ActionLocation.NAVBAR,
+      };
+
+      // When: creating properties without action_position
+      // Then: should be valid
+      expect(propertiesWithoutPosition.action_name).toBeDefined();
+      expect(propertiesWithoutPosition.button_label).toBeDefined();
+      expect(propertiesWithoutPosition.location).toBeDefined();
+      expect(propertiesWithoutPosition.action_position).toBeUndefined();
     });
 
     it('allows optional action_id property', () => {

--- a/app/util/analytics/actionButtonTracking.ts
+++ b/app/util/analytics/actionButtonTracking.ts
@@ -9,6 +9,7 @@ import { MetricsEventBuilder } from '../../core/Analytics/MetricsEventBuilder';
 export enum ActionLocation {
   HOME = 'home',
   ASSET_DETAILS = 'asset details',
+  NAVBAR = 'navbar',
 }
 
 export enum ActionButtonType {
@@ -33,13 +34,13 @@ export enum ActionPosition {
  * Properties for action button tracking
  *
  * @property action_name - The action that was clicked from the home page or asset details page
- * @property action_position - The position of the button in the action button for remote config use and a/b testing
+ * @property action_position - The position of the button in the action button for remote config use and a/b testing (optional, omitted for navbar)
  * @property button_label - The label of the button - i18n string
- * @property location - The location of the button (home, asset details)
+ * @property location - The location of the button (home, asset details, navbar)
  */
 export interface ActionButtonProperties extends JsonMap {
   action_name: ActionButtonType;
-  action_position: ActionPosition;
+  action_position?: ActionPosition;
   button_label: string;
   location?: ActionLocation;
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**


**What is the reason for the change?**

When users click the Swap button on the global navbar (TabBar), it was triggering the `Action Button` analytics event with the same metadata as the main action buttons at the top of the screen. Specifically, it included an `action_position` property and set `location` to `home`, making it impossible to distinguish between swaps initiated from the navbar versus swaps from the main action buttons.

**What is the improvement/solution?**

Updated the analytics tracking for the navbar Swap button to:
- Remove the `action_position` property (since it doesn't apply to navbar buttons and was misleading)
- Set the `location` property to `navbar` instead of `home` (allowing us to differentiate navbar swaps from main action button swaps)

This gives us accurate data on where users are initiating swaps from, which is critical for product analytics and decision-making.

segment-schema PR: https://github.com/Consensys/segment-schema/pull/389


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-209

## **Manual testing steps**

```gherkin
Feature: Navbar Swap Button Analytics Tracking

  Scenario: user clicks swap button from navbar

    Given user is on the home screen
    And analytics tracking is enabled
    When user taps the Swap button in the bottom navigation bar (TabBar)
    Then an "Action Button" analytics event should be sent
    And the event should have location set to "navbar"
    And the event should NOT include an action_position property

  Scenario: user clicks swap button from main action buttons (control test)

    Given user is on the home screen or asset details screen
    And analytics tracking is enabled
    When user taps the Swap button in the main action buttons
    Then an "Action Button" analytics event should be sent
    And the event should have location set to "home" or "asset details"
    And the event should include action_position set to 1 (second position)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets navbar Swap tracking to location `navbar` without `action_position`, adds `NAVBAR` enum, and makes `action_position` optional with corresponding tests.
> 
> - **Analytics**:
>   - Add `ActionLocation.NAVBAR` and update `ActionButtonProperties` to make `action_position` optional.
>   - Update JSDoc and tracking to accept navbar events without `action_position`.
> - **Hook (`useSwapBridgeNavigation`)**:
>   - Detect `TabBar` origin and track Swap with `location: NAVBAR`; omit `action_position` for navbar; otherwise use `ASSET_DETAILS` with `SECOND_POSITION`.
> - **Tests**:
>   - Expand enum coverage to include `NAVBAR` and adjust expected enum lengths.
>   - Add/adjust cases to verify navbar Swap tracking omits `action_position` and uses `location: navbar`.
>   - Keep existing cases for non-navbar paths using `ASSET_DETAILS` with `SECOND_POSITION`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa31219df52244197ae5783390a9f4c1af5fd5eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->