### PR TITLE
chore: switch to uat rewards for local/dev

### DIFF
--- a/app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.test.ts
@@ -9,32 +9,32 @@ jest.mock('../../../../AppConstants', () => ({
 }));
 
 describe('getDefaultRewardsApiBaseUrlForMetaMaskEnv', () => {
-  it('returns DEV api url for local or dev env', async () => {
+  it('returns UAT api url for local or dev env', async () => {
     // Act
     let apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('dev');
 
     // Assert
-    expect(apiUrl).toEqual('https://api.dev');
+    expect(apiUrl).toEqual('https://api.uat');
 
     // Act
     apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('local');
 
     // Assert
-    expect(apiUrl).toEqual('https://api.dev');
+    expect(apiUrl).toEqual('https://api.uat');
   });
 
-  it('returns DEV api url for undefined or unknown env', async () => {
+  it('returns UAT api url for undefined or unknown env', async () => {
     // Act
     let apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv(undefined);
 
     // Assert
-    expect(apiUrl).toEqual('https://api.dev');
+    expect(apiUrl).toEqual('https://api.uat');
 
     // Act
     apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('unknown');
 
     // Assert
-    expect(apiUrl).toEqual('https://api.dev');
+    expect(apiUrl).toEqual('https://api.uat');
   });
 
   it('returns UAT api url for e2e or exp env', async () => {

--- a/app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.ts
+++ b/app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.ts
@@ -15,6 +15,6 @@ export const getDefaultRewardsApiBaseUrlForMetaMaskEnv = (
     case 'dev':
     case 'local':
     default:
-      return AppConstants.REWARDS_API_URL.DEV;
+      return AppConstants.REWARDS_API_URL.UAT;
   }
 };


### PR DESCRIPTION
## **Description**

Switch to UAT for any non prod or RC.

## **Changelog**

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch default rewards API base URL to UAT for dev/local/undefined/unknown environments; tests updated accordingly.
> 
> - **Rewards API URL selection**:
>   - `getDefaultRewardsApiBaseUrlForMetaMaskEnv` now returns `UAT` for `dev`, `local`, and fallback (`default`) cases.
>   - `production`, `beta`, `pre-release`, `rc` remain `PRD`; `e2e`/`exp` remain `UAT`.
> - **Tests**:
>   - Updated assertions in `rewards-api-url.test.ts` to expect `UAT` for `dev`, `local`, `undefined`, and `unknown`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cfcdfe0cb64bde1fe453343a8db0fbcd21d5cc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->