### PR TITLE
fix(predict): cp-7.60.0 improve spacing and styling in Predict components

### DIFF
--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
@@ -156,12 +156,13 @@ const PredictBalance: React.FC<PredictBalanceProps> = ({ onLayout }) => {
             </Text>
           </Box>
           <BadgeWrapper
-            style={tw.style('self-center border-bg-muted')}
+            style={tw.style('self-center')}
             badgePosition={BadgePosition.BottomRight}
             badgeElement={
               <Badge
                 variant={BadgeVariant.Network}
                 imageSource={images.POL}
+                style={tw.style('border-background-muted')}
                 name="Polygon"
               />
             }

--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
@@ -98,16 +98,16 @@ const PredictBalance: React.FC<PredictBalanceProps> = ({ onLayout }) => {
           </Box>
           <Skeleton width={48} height={48} style={tw.style('rounded-full')} />
         </Box>
-        <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-2">
+        <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-3">
           <Skeleton
             width="50%"
             height={40}
-            style={tw.style('rounded-full flex-1')}
+            style={tw.style('rounded-xl flex-1')}
           />
           <Skeleton
             width="50%"
             height={40}
-            style={tw.style('rounded-full flex-1')}
+            style={tw.style('rounded-xl flex-1')}
           />
         </Box>
       </Box>
@@ -145,18 +145,18 @@ const PredictBalance: React.FC<PredictBalanceProps> = ({ onLayout }) => {
           alignItems={BoxAlignItems.Center}
         >
           <Box>
-            <Text style={tw.style('text-heading-md font-bold')}>
+            <Text style={tw.style('text-body-md font-bold')}>
               {formatPrice(balance, { maximumDecimals: 2 })}
             </Text>
             <Text
-              style={tw.style('color-alternative')}
+              style={tw.style('color-alternative text-body-sm')}
               color={TextColor.Alternative}
             >
               {strings('predict.available_balance')}
             </Text>
           </Box>
           <BadgeWrapper
-            style={tw.style('self-center')}
+            style={tw.style('self-center border-bg-muted')}
             badgePosition={BadgePosition.BottomRight}
             badgeElement={
               <Badge
@@ -173,7 +173,7 @@ const PredictBalance: React.FC<PredictBalanceProps> = ({ onLayout }) => {
             />
           </BadgeWrapper>
         </Box>
-        <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-2">
+        <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-3">
           <Button
             variant={
               hasBalance ? ButtonVariants.Secondary : ButtonVariants.Primary

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -224,7 +224,7 @@ const PredictPositionsHeader = forwardRef<
                 <Box
                   flexDirection={BoxFlexDirection.Row}
                   alignItems={BoxAlignItems.Center}
-                  twClassName="flex-row items-center"
+                  twClassName="flex-row items-center gap-1"
                 >
                   {isBalanceLoading ? (
                     <Skeleton


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adjust gaps, text sizes, and badge styling in PredictBalance and PredictPositionsHeader for better visual consistency and hierarchy.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts gaps, text sizes, skeleton rounding, and adds a muted badge border in PredictBalance; adds small spacing between balance value and arrow in PredictPositionsHeader.
> 
> - **PredictBalance (`PredictBalance.tsx`)**:
>   - Increase button/skeleton gap from `gap-2` to `gap-3`; change skeleton rounding from `rounded-full` to `rounded-xl`.
>   - Update balance typography from `text-heading-md` to `text-body-md`; add `text-body-sm` to subtitle.
>   - Add `border-background-muted` to network `Badge`.
> - **PredictPositionsHeader (`PredictPositionsHeader.tsx`)**:
>   - Add `gap-1` between balance text and arrow icon in the header row.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61687f5ecb290488a1744d4f955bb715e8bf04c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->