### PR TITLE
feat(Predict): cp-7.60.0 add side-specific errors for unfilled orders

### DIFF
--- a/app/components/UI/Predict/constants/errors.ts
+++ b/app/components/UI/Predict/constants/errors.ts
@@ -28,6 +28,8 @@ export const PREDICT_ERROR_CODES = {
   ACTIVITY_NOT_AVAILABLE: 'PREDICT_ACTIVITY_NOT_AVAILABLE',
   DEPOSIT_FAILED: 'PREDICT_DEPOSIT_FAILED',
   WITHDRAW_FAILED: 'PREDICT_WITHDRAW_FAILED',
+  BUY_ORDER_NOT_FULLY_FILLED: 'PREDICT_BUY_ORDER_NOT_FULLY_FILLED',
+  SELL_ORDER_NOT_FULLY_FILLED: 'PREDICT_SELL_ORDER_NOT_FULLY_FILLED',
 } as const;
 
 export const getPredictErrorMessages = () =>
@@ -58,5 +60,11 @@ export const getPredictErrorMessages = () =>
     ),
     [PREDICT_ERROR_CODES.ORDER_NOT_FULLY_FILLED]: strings(
       'predict.error_messages.order_not_fully_filled',
+    ),
+    [PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED]: strings(
+      'predict.error_messages.buy_order_not_fully_filled',
+    ),
+    [PREDICT_ERROR_CODES.SELL_ORDER_NOT_FULLY_FILLED]: strings(
+      'predict.error_messages.sell_order_not_fully_filled',
     ),
   }) as const;

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -37,6 +37,7 @@ import {
   Recurrence,
   Side,
 } from '../../types';
+import { PREDICT_ERROR_CODES } from '../../constants/errors';
 import { OrderPreview, PlaceOrderParams } from '../types';
 import { PolymarketProvider } from './PolymarketProvider';
 import {
@@ -1100,6 +1101,54 @@ describe('PolymarketProvider', () => {
       // Assert
       expect(result.success).toBe(false);
       expect(result.error).toBe('Maker address not found');
+    });
+
+    it('returns BUY_ORDER_NOT_FULLY_FILLED error when buy order cannot be fully filled', async () => {
+      // Arrange
+      const { provider, mockSigner } = setupPlaceOrderTest();
+      mockSubmitClobOrder.mockResolvedValue({
+        success: false,
+        response: undefined,
+        error: `order couldn't be fully filled`,
+      });
+      const preview = createMockOrderPreview({ side: Side.BUY });
+      const orderParams = {
+        signer: mockSigner,
+        providerId: 'polymarket',
+        preview,
+      };
+
+      // Act
+      const result = await provider.placeOrder(orderParams);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED);
+    });
+
+    it('returns SELL_ORDER_NOT_FULLY_FILLED error when sell order cannot be fully filled', async () => {
+      // Arrange
+      const { provider, mockSigner } = setupPlaceOrderTest();
+      mockSubmitClobOrder.mockResolvedValue({
+        success: false,
+        response: undefined,
+        error: `order couldn't be fully filled`,
+      });
+      const preview = createMockOrderPreview({ side: Side.SELL });
+      const orderParams = {
+        signer: mockSigner,
+        providerId: 'polymarket',
+        preview,
+      };
+
+      // Act
+      const result = await provider.placeOrder(orderParams);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        PREDICT_ERROR_CODES.SELL_ORDER_NOT_FULLY_FILLED,
+      );
     });
 
     it('fetches account state when not cached during placeOrder', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -1080,7 +1080,11 @@ export class PolymarketProvider implements PredictProvider {
           outcomeTokenId,
         });
         if (error.includes(`order couldn't be fully filled`)) {
-          throw new Error(PREDICT_ERROR_CODES.ORDER_NOT_FULLY_FILLED);
+          throw new Error(
+            side === Side.BUY
+              ? PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED
+              : PREDICT_ERROR_CODES.SELL_ORDER_NOT_FULLY_FILLED,
+          );
         }
         if (
           error.includes(`not available in your region`) ||

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1991,7 +1991,9 @@
       "preview_no_order_match_sell": "There isn't enough demand at market price to cash out right now.",
       "claim_failed": "Failed to claim",
       "unknown_error": "An unknown error occurred",
-      "order_not_fully_filled": "Failed to fill your order"
+      "order_not_fully_filled": "Failed to fill your order",
+      "buy_order_not_fully_filled": "Not enough shares available at market price to place your order right now.",
+      "sell_order_not_fully_filled": "There isn't enough demand at market price to cash out right now."
     }
   },
   "receive": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Replace generic ORDER_NOT_FULLY_FILLED error with BUY_ORDER_NOT_FULLY_FILLED 
and SELL_ORDER_NOT_FULLY_FILLED to provide clearer user feedback based on 
whether a buy or sell order could not be fully filled at market price.

- Added new error codes and localized messages
- Updated error handling in PolymarketProvider.placeOrder()
- Added test coverage for both buy and sell scenarios

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces generic unfilled order error with side-specific BUY/SELL errors, updates PolymarketProvider handling, adds tests, and localizes messages.
> 
> - **Predict (Errors)**:
>   - Add `PREDICT_BUY_ORDER_NOT_FULLY_FILLED` and `PREDICT_SELL_ORDER_NOT_FULLY_FILLED` to `PREDICT_ERROR_CODES`.
>   - Map new codes in `getPredictErrorMessages()`.
> - **PolymarketProvider**:
>   - On "order couldn't be fully filled", throw side-specific errors based on `Side.BUY` or `Side.SELL`.
> - **Tests**:
>   - Add test cases verifying BUY/SELL not-fully-filled errors returned by `placeOrder`.
> - **Locales**:
>   - Add `predict.error_messages.buy_order_not_fully_filled` and `sell_order_not_fully_filled` strings in `en.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cf15fda527696b2919c007c584b7669575f4d15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->