### PR TITLE
fix: cp-7.60.0 gas station with metamask pay if send bundle supported

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
@@ -611,12 +611,12 @@ describe('Transaction Controller Init', () => {
       expect(await optionFn?.(mockTransactionMeta)).toBe(false);
     });
 
-    it('returns true if isGasFeeTokenIgnoredIfBalance', async () => {
+    it('returns true if isExternalSign', async () => {
       const mockTransactionMeta = {
         id: '123',
         status: 'approved',
         chainId: '0x13',
-        isGasFeeTokenIgnoredIfBalance: true,
+        isExternalSign: true,
       } as unknown as TransactionMeta;
 
       const optionFn = testConstructorOption('isEIP7702GasFeeTokensEnabled');
@@ -666,7 +666,7 @@ describe('Transaction Controller Init', () => {
     expect(resultNonce).toBe(toHex(99));
   });
 
-  it('calls 7702 publish hook if isGasFeeTokenIgnoredIfBalance', async () => {
+  it('calls 7702 publish hook if isExternalSign', async () => {
     const delegation7702Mock: jest.MockedFn<PublishHook> = jest.fn();
 
     jest.mocked(Delegation7702PublishHook).mockImplementation(
@@ -680,14 +680,12 @@ describe('Transaction Controller Init', () => {
 
     const hooks = testConstructorOption('hooks');
 
-    const transactionMetaWithGasFeeTokenIgnored = {
+    const transactionMeta = {
       ...MOCK_TRANSACTION_META,
-      isGasFeeTokenIgnoredIfBalance: true,
+      isExternalSign: true,
     } as TransactionMeta;
 
-    const result = await hooks?.publish?.(
-      transactionMetaWithGasFeeTokenIgnored,
-    );
+    const result = await hooks?.publish?.(transactionMeta);
 
     expect(delegation7702Mock).toHaveBeenCalled();
     expect(result).toEqual({ transactionHash: '0xde702' });

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
@@ -131,7 +131,7 @@ export const TransactionControllerInit: ControllerInitFunction<
           updateTransactions: true,
         },
         isEIP7702GasFeeTokensEnabled: async (transactionMeta) => {
-          const { chainId, isGasFeeTokenIgnoredIfBalance } = transactionMeta;
+          const { chainId, isExternalSign } = transactionMeta;
           const state = getState();
 
           const isSmartTransactionEnabled = selectShouldUseSmartTransaction(
@@ -148,7 +148,7 @@ export const TransactionControllerInit: ControllerInitFunction<
           return (
             !isSmartTransactionEnabled ||
             !isSendBundleSupportedChain ||
-            Boolean(isGasFeeTokenIgnoredIfBalance)
+            Boolean(isExternalSign)
           );
         },
         isSimulationEnabled: () =>
@@ -219,13 +219,9 @@ async function publishHook({
     return payResult;
   }
 
-  const { isGasFeeTokenIgnoredIfBalance } = transactionMeta;
+  const { isExternalSign } = transactionMeta;
 
-  if (
-    !shouldUseSmartTransaction ||
-    !sendBundleSupport ||
-    isGasFeeTokenIgnoredIfBalance
-  ) {
+  if (!shouldUseSmartTransaction || !sendBundleSupport || isExternalSign) {
     const hook = new Delegation7702PublishHook({
       isAtomicBatchSupported: transactionController.isAtomicBatchSupported.bind(
         transactionController,


### PR DESCRIPTION
## **Description**

Ensure MetaMask pay source transactions using gas station are supported on chains where send bundle is supported via smart transactions.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to: [#23135](https://github.com/MetaMask/metamask-mobile/issues/23135)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables EIP-7702 gas fee tokens and routes publishing via Delegation7702 when `isExternalSign` is set, with corresponding tests.
> 
> - **Engine: Transaction Controller**
>   - `isEIP7702GasFeeTokensEnabled`: include `isExternalSign`; enable when smart tx disabled, send bundle unsupported, or `isExternalSign` is true.
>   - `hooks.publish`: fallback to `Delegation7702PublishHook` when smart tx disabled, send bundle unsupported, or `isExternalSign`.
> - **Tests** (`transaction-controller-init.test.ts`):
>   - Add case enabling EIP-7702 gas fee tokens when `isExternalSign`.
>   - Add case routing publish via 7702 hook when `isExternalSign`.
>   - Verify nonce lock usage via 7702 hook `getNextNonce`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60f89c45c94fac2bd821815af6979c6d99d2402a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->