### PR TITLE
chore: add activity item for shield and holding m usd

### DIFF
--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/ActivityTab.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/ActivityTab.test.tsx
@@ -253,6 +253,7 @@ describe('ActivityTab', () => {
       startDate: Date.now(),
       endDate: Date.now() + 1000,
       tiers: [],
+      activityTypes: [],
     },
     balance: {
       total: 0,

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/ActivityDetailsSheet.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/ActivityDetailsSheet.tsx
@@ -1,18 +1,28 @@
 import React from 'react';
-import { ButtonVariant } from '@metamask/design-system-react-native';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import { ModalAction, ModalType } from '../../../RewardsBottomSheetModal';
 import { strings } from '../../../../../../../../locales/i18n';
 import { getEventDetails } from '../../../../utils/eventDetailsUtils';
-import { GenericEventDetails } from './GenericEventDetails';
+import { DetailsRow, GenericEventDetails } from './GenericEventDetails';
 import { SwapEventDetails } from './SwapEventDetails';
 import { CardEventDetails } from './CardEventDetails';
 import { MusdDepositEventDetails } from './MusdDepositEventDetails';
-import { PointsEventDto } from '../../../../../../../core/Engine/controllers/rewards-controller/types';
+import {
+  PointsEventDto,
+  SeasonActivityTypeDto,
+} from '../../../../../../../core/Engine/controllers/rewards-controller/types';
+import { resolveTemplate } from '../../../../utils/formatUtils';
 
 interface ActivityDetailsSheetProps {
   event: PointsEventDto;
+  activityTypes: SeasonActivityTypeDto[];
   accountName?: string;
   confirmAction?: ModalAction;
 }
@@ -21,18 +31,54 @@ interface ActivityDetailsSheetProps {
 export const ActivityDetailsSheet: React.FC<ActivityDetailsSheetProps> = ({
   event,
   accountName,
+  activityTypes,
 }) => {
+  const matchingActivityType = activityTypes.find(
+    (activity) => activity.type === event.type,
+  );
+
+  const extraDetails =
+    matchingActivityType && event.payload ? (
+      <DetailsRow label={strings('rewards.events.description')}>
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          {resolveTemplate(
+            matchingActivityType.description,
+            (event.payload ?? {}) as Record<string, string>,
+          )}
+        </Text>
+      </DetailsRow>
+    ) : null;
+
   switch (event.type) {
     case 'SWAP':
-      return <SwapEventDetails event={event} accountName={accountName} />;
+      return (
+        <SwapEventDetails
+          event={event as Extract<PointsEventDto, { type: 'SWAP' }>}
+          accountName={accountName}
+        />
+      );
     case 'CARD':
-      return <CardEventDetails event={event} accountName={accountName} />;
+      return (
+        <CardEventDetails
+          event={event as Extract<PointsEventDto, { type: 'CARD' }>}
+          accountName={accountName}
+        />
+      );
     case 'MUSD_DEPOSIT':
       return (
-        <MusdDepositEventDetails event={event} accountName={accountName} />
+        <MusdDepositEventDetails
+          event={event as Extract<PointsEventDto, { type: 'MUSD_DEPOSIT' }>}
+          accountName={accountName}
+        />
       );
     default:
-      return <GenericEventDetails event={event} accountName={accountName} />;
+      return (
+        <GenericEventDetails
+          event={event}
+          accountName={accountName}
+          extraDetails={extraDetails}
+        />
+      );
   }
 };
 
@@ -43,6 +89,7 @@ export const openActivityDetailsSheet = (
 ) => {
   const {
     event,
+    activityTypes,
     accountName,
     confirmAction = {
       label: strings('navigation.close'),
@@ -50,12 +97,16 @@ export const openActivityDetailsSheet = (
       variant: ButtonVariant.Secondary,
     },
   } = props;
-  const eventDetails = getEventDetails(event, accountName);
+  const eventDetails = getEventDetails(event, activityTypes, accountName);
 
   navigation.navigate(Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL, {
     title: eventDetails.title,
     description: (
-      <ActivityDetailsSheet event={event} accountName={accountName} />
+      <ActivityDetailsSheet
+        event={event}
+        accountName={accountName}
+        activityTypes={activityTypes}
+      />
     ),
     type: ModalType.Confirmation,
     showIcon: false,

--- a/app/components/UI/Rewards/hooks/useActivityDetailsConfirmAction.ts
+++ b/app/components/UI/Rewards/hooks/useActivityDetailsConfirmAction.ts
@@ -2,7 +2,10 @@ import { useMemo } from 'react';
 import { Linking } from 'react-native';
 import { ButtonVariant } from '@metamask/design-system-react-native';
 import { CaipAssetType } from '@metamask/utils';
-import { PointsEventDto } from '../../../../core/Engine/controllers/rewards-controller/types';
+import {
+  PointsEventDto,
+  SwapEventPayload,
+} from '../../../../core/Engine/controllers/rewards-controller/types';
 import { useTransactionExplorer } from './useTransactionExplorer';
 import { strings } from '../../../../../locales/i18n';
 import { ModalAction } from '../components/RewardsBottomSheetModal';
@@ -19,9 +22,11 @@ export const useActivityDetailsConfirmAction = (
 
   const explorerInfo = useTransactionExplorer(
     isSwap
-      ? (event.payload?.srcAsset?.type as CaipAssetType | undefined)
+      ? ((event.payload as SwapEventPayload)?.srcAsset?.type as
+          | CaipAssetType
+          | undefined)
       : undefined,
-    isSwap ? event.payload?.txHash : undefined,
+    isSwap ? (event.payload as SwapEventPayload)?.txHash : undefined,
   );
 
   return useMemo(() => {

--- a/app/components/UI/Rewards/hooks/useSeasonStatus.test.ts
+++ b/app/components/UI/Rewards/hooks/useSeasonStatus.test.ts
@@ -185,6 +185,7 @@ describe('useSeasonStatus', () => {
       startDate: 1640995200000,
       endDate: 1672531200000,
       tiers: [],
+      activityTypes: [],
     };
 
     const mockStatusData = {
@@ -516,6 +517,7 @@ describe('useSeasonStatus', () => {
         startDate: 1640995200000,
         endDate: 1672531200000,
         tiers: [],
+        activityTypes: [],
       };
 
       const mockStatusData = {
@@ -623,6 +625,7 @@ describe('useSeasonStatus', () => {
         startDate: 1640995200000,
         endDate: 1672531200000,
         tiers: [],
+        activityTypes: [],
       };
 
       const mockStatusData = {

--- a/app/components/UI/Rewards/utils/eventDetailsUtils.test.ts
+++ b/app/components/UI/Rewards/utils/eventDetailsUtils.test.ts
@@ -4,6 +4,7 @@ import {
   PointsEventDto,
   PointsEventEarnType,
   SwapEventPayload,
+  SeasonActivityTypeDto,
 } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { PerpsEventType } from './eventConstants';
 import {
@@ -48,29 +49,58 @@ jest.mock('../../../../../locales/i18n', () => ({
 }));
 
 // Mock formatUtils
-jest.mock('./formatUtils', () => ({
-  formatNumber: jest.fn((value: number) => value.toString()),
-  formatRewardsMusdDepositPayloadDate: jest.fn(
-    (isoDate: string | undefined) => {
-      // Mock implementation that matches the real implementation behavior
-      if (
-        !isoDate ||
-        typeof isoDate !== 'string' ||
-        !/^\d{4}-\d{2}-\d{2}$/.test(isoDate)
-      ) {
-        return null;
-      }
-      // Mock implementation that formats the date
-      const date = new Date(`${isoDate}T00:00:00Z`);
-      return new Intl.DateTimeFormat('en-US', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        timeZone: 'UTC',
-      }).format(date);
-    },
-  ),
-}));
+jest.mock('./formatUtils', () => {
+  const { IconName: IconEnum } = jest.requireActual(
+    '@metamask/design-system-react-native',
+  );
+  return {
+    formatNumber: jest.fn((value: number) => value.toString()),
+    formatRewardsMusdDepositPayloadDate: jest.fn(
+      (isoDate: string | undefined) => {
+        if (
+          !isoDate ||
+          typeof isoDate !== 'string' ||
+          !/^\d{4}-\d{2}-\d{2}$/.test(isoDate)
+        ) {
+          return null;
+        }
+        const date = new Date(`${isoDate}T00:00:00Z`);
+        return new Intl.DateTimeFormat('en-US', {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          timeZone: 'UTC',
+        }).format(date);
+      },
+    ),
+    resolveTemplate: jest.fn(
+      (template: string, values: Record<string, string>) =>
+        template.replace(/\$\{(\w+)\}/g, (match, placeholder) => {
+          const value = values[placeholder as keyof typeof values];
+          return value !== undefined ? String(value) : match;
+        }),
+    ),
+    getIconName: jest.fn((name: string) => {
+      const map: Record<string, (typeof IconEnum)[keyof typeof IconEnum]> = {
+        Star: IconEnum.Star,
+        ArrowDown: IconEnum.ArrowDown,
+        ArrowUp: IconEnum.ArrowUp,
+        ArrowRight: IconEnum.ArrowRight,
+        Lock: IconEnum.Lock,
+        Gift: IconEnum.Gift,
+        Edit: IconEnum.Edit,
+        ThumbUp: IconEnum.ThumbUp,
+        Speedometer: IconEnum.Speedometer,
+        Coin: IconEnum.Coin,
+        Card: IconEnum.Card,
+        Candlestick: IconEnum.Candlestick,
+        SwapVertical: IconEnum.SwapVertical,
+        UserCircleAdd: IconEnum.UserCircleAdd,
+      };
+      return map[name] ?? IconEnum.Star;
+    }),
+  };
+});
 
 describe('eventDetailsUtils', () => {
   beforeEach(() => {
@@ -548,7 +578,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return swap details
         expect(result).toEqual({
@@ -574,7 +604,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return perps details
         expect(result).toEqual({
@@ -598,7 +628,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return perps details
         expect(result).toEqual({
@@ -622,7 +652,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return perps details
         expect(result).toEqual({
@@ -646,7 +676,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return perps details
         expect(result).toEqual({
@@ -670,7 +700,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return perps details
         expect(result).toEqual({
@@ -694,7 +724,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return perps details
         expect(result).toEqual({
@@ -717,7 +747,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return undefined details
         expect(result).toEqual({
@@ -739,7 +769,7 @@ describe('eventDetailsUtils', () => {
           },
         });
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Opened position',
@@ -764,7 +794,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return card spend details
         expect(result).toEqual({
@@ -788,7 +818,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return card spend details with decimals
         expect(result).toEqual({
@@ -803,7 +833,7 @@ describe('eventDetailsUtils', () => {
         const event = createMockEvent('CARD', null);
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return card spend title with undefined details
         expect(result).toEqual({
@@ -818,7 +848,7 @@ describe('eventDetailsUtils', () => {
       it('returns correct details for REFERRAL event', () => {
         const event = createMockEvent('REFERRAL');
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Referral action',
@@ -832,7 +862,7 @@ describe('eventDetailsUtils', () => {
       it('returns correct details for SIGN_UP_BONUS event', () => {
         const event = createMockEvent('SIGN_UP_BONUS');
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Sign up bonus',
@@ -844,7 +874,7 @@ describe('eventDetailsUtils', () => {
       it('returns empty details when account name is not provided', () => {
         const event = createMockEvent('SIGN_UP_BONUS');
 
-        const result = getEventDetails(event, undefined);
+        const result = getEventDetails(event, [], undefined);
 
         expect(result).toEqual({
           title: 'Sign up bonus',
@@ -858,7 +888,7 @@ describe('eventDetailsUtils', () => {
       it('returns correct details for LOYALTY_BONUS event', () => {
         const event = createMockEvent('LOYALTY_BONUS');
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Loyalty bonus',
@@ -872,7 +902,7 @@ describe('eventDetailsUtils', () => {
       it('returns correct details for ONE_TIME_BONUS event', () => {
         const event = createMockEvent('ONE_TIME_BONUS');
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'One-time bonus',
@@ -886,7 +916,7 @@ describe('eventDetailsUtils', () => {
       it('returns correct details for PREDICT event', () => {
         const event = createMockEvent('PREDICT');
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Prediction',
@@ -904,7 +934,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return mUSD deposit details with formatted date
         expect(result).toEqual({
@@ -921,7 +951,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return mUSD deposit details with formatted date
         expect(result).toEqual({
@@ -936,7 +966,7 @@ describe('eventDetailsUtils', () => {
         const event = createMockEvent('MUSD_DEPOSIT', null);
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return mUSD deposit title with undefined details
         expect(result).toEqual({
@@ -954,7 +984,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return mUSD deposit title with undefined details
         expect(result).toEqual({
@@ -972,7 +1002,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return mUSD deposit title with undefined details
         expect(result).toEqual({
@@ -989,7 +1019,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return mUSD deposit title with undefined details
         expect(result).toEqual({
@@ -1006,7 +1036,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return mUSD deposit title with undefined details
         expect(result).toEqual({
@@ -1023,7 +1053,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return mUSD deposit title with undefined details
         expect(result).toEqual({
@@ -1040,7 +1070,7 @@ describe('eventDetailsUtils', () => {
         });
 
         // When getting event details
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         // Then it should return mUSD deposit title with undefined details
         expect(result).toEqual({
@@ -1055,7 +1085,7 @@ describe('eventDetailsUtils', () => {
       it('returns uncategorized event details for unknown type', () => {
         const event = createMockEvent('UNKNOWN_TYPE' as PointsEventDto['type']);
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Uncategorized event',
@@ -1078,7 +1108,7 @@ describe('eventDetailsUtils', () => {
           },
         });
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Opened position',
@@ -1099,7 +1129,7 @@ describe('eventDetailsUtils', () => {
           },
         });
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Opened position',
@@ -1120,7 +1150,7 @@ describe('eventDetailsUtils', () => {
           },
         });
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Opened position',
@@ -1141,7 +1171,7 @@ describe('eventDetailsUtils', () => {
           },
         });
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Opened position',
@@ -1162,7 +1192,7 @@ describe('eventDetailsUtils', () => {
           },
         });
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Opened position',
@@ -1187,7 +1217,7 @@ describe('eventDetailsUtils', () => {
           },
         });
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Swap',
@@ -1212,13 +1242,140 @@ describe('eventDetailsUtils', () => {
           },
         });
 
-        const result = getEventDetails(event, TEST_ADDRESS);
+        const result = getEventDetails(event, [], TEST_ADDRESS);
 
         expect(result).toEqual({
           title: 'Swap',
           details: '50 ETH to USDC',
           icon: IconName.SwapVertical,
         });
+      });
+    });
+  });
+
+  describe('Custom activity types', () => {
+    const CUSTOM_TYPE = 'CUSTOM_ACTION' as PointsEventDto['type'];
+
+    const makeCustomActivity = (
+      icon: string,
+      description: string = 'Custom description',
+    ): SeasonActivityTypeDto => ({
+      type: CUSTOM_TYPE as unknown as PointsEventEarnType,
+      title: 'Custom Title',
+      description,
+      icon,
+    });
+
+    const makeEvent = (): PointsEventDto => ({
+      id: 'custom-id',
+      timestamp: new Date('2024-02-01T00:00:00Z'),
+      value: 5,
+      bonus: null,
+      accountAddress: TEST_ADDRESS,
+      updatedAt: new Date('2024-02-01T00:00:00Z'),
+      type: CUSTOM_TYPE as PointsEventEarnType,
+      payload: null,
+    });
+
+    it('uses custom title, description, and icon when activityTypes provides a match', () => {
+      const activityTypes: SeasonActivityTypeDto[] = [
+        makeCustomActivity('Lock'),
+      ];
+      const event = makeEvent();
+
+      const result = getEventDetails(event, activityTypes, TEST_ADDRESS);
+
+      expect(result).toEqual({
+        title: 'Custom Title',
+        details: 'Custom description',
+        icon: IconName.Lock,
+      });
+    });
+
+    it('falls back to Star icon when provided invalid icon name', () => {
+      const activityTypes: SeasonActivityTypeDto[] = [
+        makeCustomActivity('NotARealIcon'),
+      ];
+      const event = makeEvent();
+
+      const result = getEventDetails(event, activityTypes, TEST_ADDRESS);
+
+      expect(result).toEqual({
+        title: 'Custom Title',
+        details: 'Custom description',
+        icon: IconName.Star,
+      });
+    });
+
+    it('returns uncategorized event when no matching activity type is found', () => {
+      const activityTypes: SeasonActivityTypeDto[] = [
+        // Different type that should not match
+        {
+          type: 'OTHER_ACTION' as unknown as PointsEventEarnType,
+          title: 'Other',
+          description: 'Other desc',
+          icon: 'Gift',
+        },
+      ];
+      const event = makeEvent();
+
+      const result = getEventDetails(event, activityTypes, TEST_ADDRESS);
+
+      expect(result).toEqual({
+        title: 'Uncategorized event',
+        details: undefined,
+        icon: IconName.Star,
+      });
+    });
+
+    it('preserves empty description value when provided by activityTypes', () => {
+      const activityTypes: SeasonActivityTypeDto[] = [
+        makeCustomActivity('ArrowDown', ''),
+      ];
+      const event = makeEvent();
+
+      const result = getEventDetails(event, activityTypes, TEST_ADDRESS);
+
+      expect(result).toEqual({
+        title: 'Custom Title',
+        details: '',
+        icon: IconName.ArrowDown,
+      });
+    });
+
+    it('resolves ${...} tokens in description using payload values', () => {
+      const activityTypes: SeasonActivityTypeDto[] = [
+        makeCustomActivity('Lock', 'Tx: ${txHash}'),
+      ];
+      const event: PointsEventDto = {
+        ...makeEvent(),
+        payload: { txHash: '0xabc123' } as unknown as Record<string, string>,
+      };
+
+      const result = getEventDetails(event, activityTypes, TEST_ADDRESS);
+
+      expect(result).toEqual({
+        title: 'Custom Title',
+        details: 'Tx: 0xabc123',
+        icon: IconName.Lock,
+      });
+    });
+
+    it('leaves ${...} tokens intact when payload is null', () => {
+      const activityTypes: SeasonActivityTypeDto[] = [
+        makeCustomActivity('ArrowRight', 'Tx: ${txHash}'),
+      ];
+      const event: PointsEventDto = {
+        ...makeEvent(),
+        payload: null,
+      };
+
+      const result = getEventDetails(event, activityTypes, TEST_ADDRESS);
+
+      expect(result).toEqual({
+        title: 'Custom Title',
+        details: 'Tx: ${txHash}',
+        icon: IconName.ArrowRight,
       });
     });
   });

--- a/app/components/UI/Rewards/utils/formatUtils.test.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.test.ts
@@ -10,6 +10,7 @@ import {
   formatUrl,
   formatUTCDate,
   formatRewardsMusdDepositPayloadDate,
+  resolveTemplate,
 } from './formatUtils';
 import { IconName } from '@metamask/design-system-react-native';
 import { getTimeDifferenceFromNow } from '../../../../util/date';
@@ -1126,6 +1127,57 @@ describe('formatUtils', () => {
       expect(enResult).toMatch(/11/);
       expect(deResult).toMatch(/11/);
       expect(jaResult).toMatch(/11/);
+    });
+  });
+
+  describe('resolveTemplate', () => {
+    it('replaces single placeholder with provided value', () => {
+      const template = 'Hello, ${name}!';
+      const values = { name: 'Alice' };
+      expect(resolveTemplate(template, values)).toBe('Hello, Alice!');
+    });
+
+    it('replaces multiple placeholders with provided values', () => {
+      const template = 'User: ${name}, Tier: ${tier}';
+      const values = { name: 'Bob', tier: 'Gold' };
+      expect(resolveTemplate(template, values)).toBe('User: Bob, Tier: Gold');
+    });
+
+    it('leaves placeholders intact when value is missing', () => {
+      const template = 'Hello, ${name}! Tier: ${tier}';
+      const values = { name: 'Charlie' };
+      expect(resolveTemplate(template, values)).toBe(
+        'Hello, Charlie! Tier: ${tier}',
+      );
+    });
+
+    it('replaces repeated occurrences of the same placeholder', () => {
+      const template = '${name} is ${name}';
+      const values = { name: 'Dana' };
+      expect(resolveTemplate(template, values)).toBe('Dana is Dana');
+    });
+
+    it('does not replace when value is an empty string (fallback to original token)', () => {
+      const template = 'Optional: ${field}';
+      const values = { field: '' };
+      expect(resolveTemplate(template, values)).toBe('Optional: ${field}');
+    });
+
+    it('does not match non-word placeholders (e.g., dot paths)', () => {
+      const template = 'Tx: ${payload.txHash}';
+      const values = { 'payload.txHash': '0xabc' } as unknown as Record<
+        string,
+        string
+      >;
+      expect(resolveTemplate(template, values)).toBe('Tx: ${payload.txHash}');
+    });
+
+    it('returns the original string when no placeholders exist', () => {
+      const template = 'Static string with no tokens';
+      const values = { anything: 'value' };
+      expect(resolveTemplate(template, values)).toBe(
+        'Static string with no tokens',
+      );
     });
   });
 });

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -163,3 +163,19 @@ export const formatUrl = (url: string): string => {
     return cleanedUrl;
   }
 };
+
+/**
+ * Resolves templated string in the format of ${placeholder}
+ * @param template - The templated string
+ * @param values - The values to replace the placeholders with
+ * @returns The resolved string
+ */
+
+export const resolveTemplate = (
+  template: string,
+  values: Record<string, string>,
+): string =>
+  template.replace(
+    /\${(\w+)}/g,
+    (match, placeholder) => values[placeholder] || match,
+  );

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -283,6 +283,7 @@ const createTestSeasonStatus = (
     startDate: new Date(Date.now() - 86400000), // 1 day ago
     endDate: new Date(Date.now() + 86400000), // 1 day from now
     tiers: createTestTiers(),
+    activityTypes: [],
   };
 
   return {
@@ -311,6 +312,7 @@ const createTestSeasonStatusState = (
     startDate: Date.now() - 86400000,
     endDate: Date.now() + 86400000,
     tiers: [],
+    activityTypes: [],
   },
   balance: {
     total: 100,
@@ -802,27 +804,25 @@ describe('RewardsController', () => {
         tiers: createTestTiers(),
       };
 
-      mockMessenger.call.mockImplementation(
-        (method: string, ..._: unknown[]) => {
-          if (method === 'RewardsDataService:getDiscoverSeasons') {
-            return Promise.resolve({
-              current: {
-                id: mockSeasonId,
-                startDate: new Date(now - 86400000),
-                endDate: new Date(now + 86400000),
-              },
-              next: null,
-            });
-          }
-          if (method === 'RewardsDataService:getSeasonMetadata') {
-            return Promise.resolve(mockSeasonMetadata);
-          }
-          if (method === 'RewardsDataService:estimatePoints') {
-            return Promise.resolve(mockResponse);
-          }
-          return Promise.resolve(null);
-        },
-      );
+      mockMessenger.call.mockImplementation((method, ..._args): any => {
+        if (method === 'RewardsDataService:getDiscoverSeasons') {
+          return Promise.resolve({
+            current: {
+              id: mockSeasonId,
+              startDate: new Date(now - 86400000),
+              endDate: new Date(now + 86400000),
+            },
+            next: null,
+          });
+        }
+        if (method === 'RewardsDataService:getSeasonMetadata') {
+          return Promise.resolve(mockSeasonMetadata);
+        }
+        if (method === 'RewardsDataService:estimatePoints') {
+          return Promise.resolve(mockResponse);
+        }
+        return Promise.resolve(null);
+      });
 
       const result = await controller.estimatePoints(mockRequest);
 
@@ -909,27 +909,25 @@ describe('RewardsController', () => {
         tiers: createTestTiers(),
       };
 
-      mockMessenger.call.mockImplementation(
-        (method: string, ..._: unknown[]) => {
-          if (method === 'RewardsDataService:getDiscoverSeasons') {
-            return Promise.resolve({
-              current: {
-                id: mockSeasonId,
-                startDate: new Date(now - 86400000),
-                endDate: new Date(now + 86400000),
-              },
-              next: null,
-            });
-          }
-          if (method === 'RewardsDataService:getSeasonMetadata') {
-            return Promise.resolve(mockSeasonMetadata);
-          }
-          if (method === 'RewardsDataService:estimatePoints') {
-            return Promise.resolve(mockResponse);
-          }
-          return Promise.resolve(null);
-        },
-      );
+      mockMessenger.call.mockImplementation((method, ..._args): any => {
+        if (method === 'RewardsDataService:getDiscoverSeasons') {
+          return Promise.resolve({
+            current: {
+              id: mockSeasonId,
+              startDate: new Date(now - 86400000),
+              endDate: new Date(now + 86400000),
+            },
+            next: null,
+          });
+        }
+        if (method === 'RewardsDataService:getSeasonMetadata') {
+          return Promise.resolve(mockSeasonMetadata);
+        }
+        if (method === 'RewardsDataService:estimatePoints') {
+          return Promise.resolve(mockResponse);
+        }
+        return Promise.resolve(null);
+      });
 
       const result = await controller.estimatePoints(mockRequest);
 
@@ -949,17 +947,15 @@ describe('RewardsController', () => {
 
       // Mock getSeasonMetadata to return null (no active season)
       // This simulates getSeasonMetadata('current') returning null
-      mockMessenger.call.mockImplementation(
-        (method: string, ..._: unknown[]) => {
-          if (method === 'RewardsDataService:getDiscoverSeasons') {
-            return Promise.resolve({
-              current: null,
-              next: null,
-            });
-          }
-          return Promise.resolve(null);
-        },
-      );
+      mockMessenger.call.mockImplementation((method, ..._args): any => {
+        if (method === 'RewardsDataService:getDiscoverSeasons') {
+          return Promise.resolve({
+            current: null,
+            next: null,
+          });
+        }
+        return Promise.resolve(null);
+      });
 
       const result = await controller.estimatePoints(mockRequest);
 
@@ -994,27 +990,25 @@ describe('RewardsController', () => {
 
       // Mock getSeasonMetadata to return valid season metadata
       // This simulates getSeasonMetadata('current') returning a valid season
-      mockMessenger.call.mockImplementation(
-        (method: string, ..._: unknown[]) => {
-          if (method === 'RewardsDataService:getDiscoverSeasons') {
-            return Promise.resolve({
-              current: {
-                id: mockSeasonId,
-                startDate: new Date(now - 86400000),
-                endDate: new Date(now + 86400000),
-              },
-              next: null,
-            });
-          }
-          if (method === 'RewardsDataService:getSeasonMetadata') {
-            return Promise.resolve(mockSeasonMetadata);
-          }
-          if (method === 'RewardsDataService:estimatePoints') {
-            return Promise.resolve(mockResponse);
-          }
-          return Promise.resolve(null);
-        },
-      );
+      mockMessenger.call.mockImplementation((method, ..._args): any => {
+        if (method === 'RewardsDataService:getDiscoverSeasons') {
+          return Promise.resolve({
+            current: {
+              id: mockSeasonId,
+              startDate: new Date(now - 86400000),
+              endDate: new Date(now + 86400000),
+            },
+            next: null,
+          });
+        }
+        if (method === 'RewardsDataService:getSeasonMetadata') {
+          return Promise.resolve(mockSeasonMetadata);
+        }
+        if (method === 'RewardsDataService:estimatePoints') {
+          return Promise.resolve(mockResponse);
+        }
+        return Promise.resolve(null);
+      });
 
       const result = await controller.estimatePoints(mockRequest);
 
@@ -1043,17 +1037,15 @@ describe('RewardsController', () => {
 
     it('should return false when getSeasonMetadata returns null', async () => {
       // Mock getSeasonMetadata to return null by having getDiscoverSeasons return null for current
-      mockMessenger.call.mockImplementation(
-        (method: string, ..._: unknown[]) => {
-          if (method === 'RewardsDataService:getDiscoverSeasons') {
-            return Promise.resolve({
-              current: null,
-              next: null,
-            });
-          }
-          return Promise.resolve(null);
-        },
-      );
+      mockMessenger.call.mockImplementation((method, ..._args): any => {
+        if (method === 'RewardsDataService:getDiscoverSeasons') {
+          return Promise.resolve({
+            current: null,
+            next: null,
+          });
+        }
+        return Promise.resolve(null);
+      });
 
       const result = await controller.hasActiveSeason();
 
@@ -1071,24 +1063,22 @@ describe('RewardsController', () => {
         tiers: createTestTiers(),
       };
 
-      mockMessenger.call.mockImplementation(
-        (method: string, ..._: unknown[]) => {
-          if (method === 'RewardsDataService:getDiscoverSeasons') {
-            return Promise.resolve({
-              current: {
-                id: mockSeasonId,
-                startDate: new Date(now + 86400000),
-                endDate: new Date(now + 172800000),
-              },
-              next: null,
-            });
-          }
-          if (method === 'RewardsDataService:getSeasonMetadata') {
-            return Promise.resolve(mockSeasonMetadata);
-          }
-          return Promise.resolve(null);
-        },
-      );
+      mockMessenger.call.mockImplementation((method, ..._args): any => {
+        if (method === 'RewardsDataService:getDiscoverSeasons') {
+          return Promise.resolve({
+            current: {
+              id: mockSeasonId,
+              startDate: new Date(now + 86400000),
+              endDate: new Date(now + 172800000),
+            },
+            next: null,
+          });
+        }
+        if (method === 'RewardsDataService:getSeasonMetadata') {
+          return Promise.resolve(mockSeasonMetadata);
+        }
+        return Promise.resolve(null);
+      });
 
       const result = await controller.hasActiveSeason();
 
@@ -1106,24 +1096,22 @@ describe('RewardsController', () => {
         tiers: createTestTiers(),
       };
 
-      mockMessenger.call.mockImplementation(
-        (method: string, ..._: unknown[]) => {
-          if (method === 'RewardsDataService:getDiscoverSeasons') {
-            return Promise.resolve({
-              current: {
-                id: mockSeasonId,
-                startDate: new Date(now - 172800000),
-                endDate: new Date(now - 86400000),
-              },
-              next: null,
-            });
-          }
-          if (method === 'RewardsDataService:getSeasonMetadata') {
-            return Promise.resolve(mockSeasonMetadata);
-          }
-          return Promise.resolve(null);
-        },
-      );
+      mockMessenger.call.mockImplementation((method, ..._args): any => {
+        if (method === 'RewardsDataService:getDiscoverSeasons') {
+          return Promise.resolve({
+            current: {
+              id: mockSeasonId,
+              startDate: new Date(now - 172800000),
+              endDate: new Date(now - 86400000),
+            },
+            next: null,
+          });
+        }
+        if (method === 'RewardsDataService:getSeasonMetadata') {
+          return Promise.resolve(mockSeasonMetadata);
+        }
+        return Promise.resolve(null);
+      });
 
       const result = await controller.hasActiveSeason();
 
@@ -1141,24 +1129,22 @@ describe('RewardsController', () => {
         tiers: createTestTiers(),
       };
 
-      mockMessenger.call.mockImplementation(
-        (method: string, ..._: unknown[]) => {
-          if (method === 'RewardsDataService:getDiscoverSeasons') {
-            return Promise.resolve({
-              current: {
-                id: mockSeasonId,
-                startDate: new Date(now - 86400000),
-                endDate: new Date(now + 86400000),
-              },
-              next: null,
-            });
-          }
-          if (method === 'RewardsDataService:getSeasonMetadata') {
-            return Promise.resolve(mockSeasonMetadata);
-          }
-          return Promise.resolve(null);
-        },
-      );
+      mockMessenger.call.mockImplementation((method, ..._args): any => {
+        if (method === 'RewardsDataService:getDiscoverSeasons') {
+          return Promise.resolve({
+            current: {
+              id: mockSeasonId,
+              startDate: new Date(now - 86400000),
+              endDate: new Date(now + 86400000),
+            },
+            next: null,
+          });
+        }
+        if (method === 'RewardsDataService:getSeasonMetadata') {
+          return Promise.resolve(mockSeasonMetadata);
+        }
+        return Promise.resolve(null);
+      });
 
       const result = await controller.hasActiveSeason();
 
@@ -1176,24 +1162,22 @@ describe('RewardsController', () => {
         tiers: createTestTiers(),
       };
 
-      mockMessenger.call.mockImplementation(
-        (method: string, ..._: unknown[]) => {
-          if (method === 'RewardsDataService:getDiscoverSeasons') {
-            return Promise.resolve({
-              current: {
-                id: mockSeasonId,
-                startDate: new Date(now),
-                endDate: new Date(now + 86400000),
-              },
-              next: null,
-            });
-          }
-          if (method === 'RewardsDataService:getSeasonMetadata') {
-            return Promise.resolve(mockSeasonMetadata);
-          }
-          return Promise.resolve(null);
-        },
-      );
+      mockMessenger.call.mockImplementation((method, ..._args): any => {
+        if (method === 'RewardsDataService:getDiscoverSeasons') {
+          return Promise.resolve({
+            current: {
+              id: mockSeasonId,
+              startDate: new Date(now),
+              endDate: new Date(now + 86400000),
+            },
+            next: null,
+          });
+        }
+        if (method === 'RewardsDataService:getSeasonMetadata') {
+          return Promise.resolve(mockSeasonMetadata);
+        }
+        return Promise.resolve(null);
+      });
 
       const result = await controller.hasActiveSeason();
 
@@ -1211,24 +1195,22 @@ describe('RewardsController', () => {
         tiers: createTestTiers(),
       };
 
-      mockMessenger.call.mockImplementation(
-        (method: string, ..._: unknown[]) => {
-          if (method === 'RewardsDataService:getDiscoverSeasons') {
-            return Promise.resolve({
-              current: {
-                id: mockSeasonId,
-                startDate: new Date(now - 86400000),
-                endDate: new Date(now),
-              },
-              next: null,
-            });
-          }
-          if (method === 'RewardsDataService:getSeasonMetadata') {
-            return Promise.resolve(mockSeasonMetadata);
-          }
-          return Promise.resolve(null);
-        },
-      );
+      mockMessenger.call.mockImplementation((method, ..._args): any => {
+        if (method === 'RewardsDataService:getDiscoverSeasons') {
+          return Promise.resolve({
+            current: {
+              id: mockSeasonId,
+              startDate: new Date(now - 86400000),
+              endDate: new Date(now),
+            },
+            next: null,
+          });
+        }
+        if (method === 'RewardsDataService:getSeasonMetadata') {
+          return Promise.resolve(mockSeasonMetadata);
+        }
+        return Promise.resolve(null);
+      });
 
       const result = await controller.hasActiveSeason();
 
@@ -3121,6 +3103,7 @@ describe('RewardsController', () => {
         startDate: Date.now() - 86400000, // 1 day ago
         endDate: Date.now() + 86400000, // 1 day from now
         tiers: createTestTiers(),
+        activityTypes: [],
       };
 
       const mockSeasonStatus: SeasonStatusState = {
@@ -3240,6 +3223,7 @@ describe('RewardsController', () => {
         startDate: new Date('2024-01-01T00:00:00Z'),
         endDate: new Date('2024-12-31T23:59:59Z'),
         tiers: createTestTiers(),
+        activityTypes: [],
       };
       const mockApiResponse = createTestSeasonStatus({
         season: mockSeasonMetadata,
@@ -3264,6 +3248,7 @@ describe('RewardsController', () => {
               startDate: new Date('2024-01-01T00:00:00Z').getTime(),
               endDate: new Date('2024-12-31T23:59:59Z').getTime(),
               tiers: createTestTiers(),
+              activityTypes: [],
               lastFetched: Date.now() - 7200000, // 2 hours ago (stale)
             },
           },
@@ -3313,6 +3298,7 @@ describe('RewardsController', () => {
         startDate: new Date('2024-01-01T00:00:00Z'),
         endDate: new Date('2024-12-31T23:59:59Z'),
         tiers: createTestTiers(),
+        activityTypes: [],
       };
       const mockApiResponse = createTestSeasonStatus({
         season: mockSeasonMetadata,
@@ -3339,6 +3325,7 @@ describe('RewardsController', () => {
               startDate: new Date('2024-01-01T00:00:00Z').getTime(),
               endDate: new Date('2024-12-31T23:59:59Z').getTime(),
               tiers: createTestTiers(),
+              activityTypes: [],
               lastFetched: Date.now(),
             },
           },
@@ -3430,6 +3417,7 @@ describe('RewardsController', () => {
               startDate: new Date('2024-01-01T00:00:00Z').getTime(),
               endDate: new Date('2024-12-31T23:59:59Z').getTime(),
               tiers: createTestTiers(),
+              activityTypes: [],
               lastFetched: Date.now(),
             },
           },
@@ -3481,6 +3469,7 @@ describe('RewardsController', () => {
             startDate: new Date('2024-01-01T00:00:00Z').getTime(),
             endDate: new Date('2024-12-31T23:59:59Z').getTime(),
             tiers: createTestTiers(),
+            activityTypes: [],
             lastFetched: Date.now(),
           },
         };
@@ -3527,6 +3516,7 @@ describe('RewardsController', () => {
         startDate: new Date('2024-01-01T00:00:00Z'),
         endDate: new Date('2024-12-31T23:59:59Z'),
         tiers: createTestTiers(),
+        activityTypes: [],
       };
       const mockSeasonStatus = createTestSeasonStatus({
         season: mockSeasonMetadata,
@@ -3571,6 +3561,7 @@ describe('RewardsController', () => {
             startDate: new Date('2024-01-01T00:00:00Z').getTime(),
             endDate: new Date('2024-12-31T23:59:59Z').getTime(),
             tiers: createTestTiers(),
+            activityTypes: [],
             lastFetched: Date.now(),
           },
         };
@@ -3691,6 +3682,7 @@ describe('RewardsController', () => {
             startDate: new Date('2024-01-01T00:00:00Z').getTime(),
             endDate: new Date('2024-12-31T23:59:59Z').getTime(),
             tiers: createTestTiers(),
+            activityTypes: [],
             lastFetched: Date.now(),
           },
         };
@@ -3783,6 +3775,7 @@ describe('RewardsController', () => {
         startDate: new Date('2024-01-01T00:00:00Z'),
         endDate: new Date('2024-12-31T23:59:59Z'),
         tiers: createTestTiers(),
+        activityTypes: [],
       };
       const mockSeasonStatus = createTestSeasonStatus({
         season: mockSeasonMetadata,
@@ -3836,6 +3829,7 @@ describe('RewardsController', () => {
             startDate: new Date('2024-01-01T00:00:00Z').getTime(),
             endDate: new Date('2024-12-31T23:59:59Z').getTime(),
             tiers: createTestTiers(),
+            activityTypes: [],
             lastFetched: Date.now(),
           },
         };
@@ -3930,6 +3924,7 @@ describe('RewardsController', () => {
         startDate: new Date('2024-01-01T00:00:00Z'),
         endDate: new Date('2024-12-31T23:59:59Z'),
         tiers: createTestTiers(),
+        activityTypes: [],
       };
       const mockSeasonStatus = createTestSeasonStatus({
         season: mockSeasonMetadata,
@@ -3991,6 +3986,7 @@ describe('RewardsController', () => {
             startDate: new Date('2024-01-01T00:00:00Z').getTime(),
             endDate: new Date('2024-12-31T23:59:59Z').getTime(),
             tiers: createTestTiers(),
+            activityTypes: [],
             lastFetched: Date.now(),
           },
         };
@@ -4111,6 +4107,7 @@ describe('RewardsController', () => {
             startDate: new Date('2024-01-01T00:00:00Z').getTime(),
             endDate: new Date('2024-12-31T23:59:59Z').getTime(),
             tiers: createTestTiers(),
+            activityTypes: [],
             lastFetched: Date.now(),
           },
         };
@@ -4207,6 +4204,7 @@ describe('RewardsController', () => {
             startDate: new Date('2024-01-01T00:00:00Z').getTime(),
             endDate: new Date('2024-12-31T23:59:59Z').getTime(),
             tiers: createTestTiers(),
+            activityTypes: [],
             lastFetched: Date.now(),
           },
         };
@@ -4292,6 +4290,7 @@ describe('RewardsController', () => {
             startDate: new Date('2024-01-01T00:00:00Z').getTime(),
             endDate: new Date('2024-12-31T23:59:59Z').getTime(),
             tiers: createTestTiers(),
+            activityTypes: [],
             lastFetched: Date.now(),
           },
         };
@@ -4368,6 +4367,7 @@ describe('RewardsController', () => {
             startDate: new Date('2024-01-01T00:00:00Z').getTime(),
             endDate: new Date('2024-12-31T23:59:59Z').getTime(),
             tiers: createTestTiers(),
+            activityTypes: [],
             lastFetched: Date.now(),
           },
         };
@@ -4440,6 +4440,7 @@ describe('RewardsController', () => {
             startDate: new Date('2024-01-01T00:00:00Z').getTime(),
             endDate: new Date('2024-12-31T23:59:59Z').getTime(),
             tiers: createTestTiers(),
+            activityTypes: [],
             lastFetched: Date.now(),
           },
         };
@@ -4498,6 +4499,7 @@ describe('RewardsController', () => {
             startDate: new Date('2024-01-01T00:00:00Z').getTime(),
             endDate: new Date('2024-12-31T23:59:59Z').getTime(),
             tiers: createTestTiers(),
+            activityTypes: [],
             lastFetched: Date.now(),
           },
         };
@@ -4555,6 +4557,7 @@ describe('RewardsController', () => {
             startDate: new Date('2024-01-01T00:00:00Z').getTime(),
             endDate: new Date('2024-12-31T23:59:59Z').getTime(),
             tiers: createTestTiers(),
+            activityTypes: [],
             lastFetched: Date.now(),
           },
         };
@@ -4610,6 +4613,7 @@ describe('RewardsController', () => {
         startDate: Date.now() - 86400000,
         endDate: Date.now() + 86400000,
         tiers: createTestTiers(),
+        activityTypes: [],
         lastFetched: recentTime,
       };
 
@@ -4645,6 +4649,7 @@ describe('RewardsController', () => {
         startDate: Date.now() + 86400000,
         endDate: Date.now() + 172800000,
         tiers: createTestTiers(),
+        activityTypes: [],
         lastFetched: recentTime,
       };
 
@@ -4680,6 +4685,7 @@ describe('RewardsController', () => {
         startDate: Date.now() - 86400000,
         endDate: Date.now() + 86400000,
         tiers: createTestTiers(),
+        activityTypes: [],
         lastFetched: staleTime,
       };
 
@@ -6790,6 +6796,7 @@ describe('RewardsController', () => {
         startDate: 1609459200000, // 2021-01-01
         endDate: 1640995200000, // 2022-01-01
         tiers,
+        activityTypes: [],
       };
 
       const seasonState: SeasonStateDto = {
@@ -6827,6 +6834,7 @@ describe('RewardsController', () => {
         startDate: startTimestamp,
         endDate: endTimestamp,
         tiers: createTestTiers(),
+        activityTypes: [],
       };
 
       const seasonState: SeasonStateDto = {
@@ -6856,6 +6864,7 @@ describe('RewardsController', () => {
         startDate: Date.now() - 86400000,
         endDate: Date.now() + 86400000,
         tiers: createTestTiers(),
+        activityTypes: [],
       };
 
       const updatedAtDate = new Date('2025-10-20T10:30:00.000Z');
@@ -6909,6 +6918,7 @@ describe('RewardsController', () => {
         startDate: Date.now(),
         endDate: Date.now() + 1000000,
         tiers: customTiers,
+        activityTypes: [],
       };
 
       const seasonState: SeasonStateDto = {
@@ -6940,6 +6950,7 @@ describe('RewardsController', () => {
         startDate: Date.now(),
         endDate: Date.now() + 86400000,
         tiers: createTestTiers(),
+        activityTypes: [],
       };
 
       const seasonState: SeasonStateDto = {
@@ -6967,6 +6978,7 @@ describe('RewardsController', () => {
         startDate: Date.now(),
         endDate: Date.now() + 86400000,
         tiers: createTestTiers(),
+        activityTypes: [],
       };
 
       const largeBalance = 999999999;
@@ -7582,6 +7594,7 @@ describe('RewardsController', () => {
               startDate: Date.now(),
               endDate: Date.now() + 1000,
               tiers: [],
+              activityTypes: [],
             },
           },
           subscriptionReferralDetails: {
@@ -7600,6 +7613,7 @@ describe('RewardsController', () => {
                 startDate: Date.now(),
                 endDate: Date.now(),
                 tiers: [],
+                activityTypes: [],
               },
               balance: { total: 100 },
               tier: {
@@ -10847,6 +10861,7 @@ describe('RewardsController', () => {
               startDate: Date.now(),
               endDate: Date.now() + 86400000,
               tiers: [],
+              activityTypes: [],
             },
             balance: { total: 1000 },
             tier: {
@@ -11000,6 +11015,7 @@ describe('RewardsController', () => {
               startDate: Date.now(),
               endDate: Date.now() + 86400000,
               tiers: [],
+              activityTypes: [],
             },
             balance: { total: 1000 },
             tier: {
@@ -11110,6 +11126,7 @@ describe('RewardsController', () => {
               startDate: Date.now(),
               endDate: Date.now() + 86400000,
               tiers: [],
+              activityTypes: [],
             },
             balance: { total: 500 },
             tier: {
@@ -11133,6 +11150,7 @@ describe('RewardsController', () => {
               startDate: Date.now(),
               endDate: Date.now() + 86400000,
               tiers: [],
+              activityTypes: [],
             },
             balance: { total: 1000 },
             tier: {
@@ -11156,6 +11174,7 @@ describe('RewardsController', () => {
               startDate: Date.now(),
               endDate: Date.now() + 86400000,
               tiers: [],
+              activityTypes: [],
             },
             balance: { total: 1500 },
             tier: {
@@ -11179,6 +11198,7 @@ describe('RewardsController', () => {
               startDate: Date.now(),
               endDate: Date.now() + 86400000,
               tiers: [],
+              activityTypes: [],
             },
             balance: { total: 2000 },
             tier: {
@@ -13239,6 +13259,7 @@ describe('RewardsController', () => {
               startDate: Date.now(),
               endDate: Date.now() + 86400000,
               tiers: [],
+              activityTypes: [],
             },
             balance: { total: 1000 },
             tier: {
@@ -13441,6 +13462,7 @@ describe('RewardsController', () => {
               startDate: Date.now(),
               endDate: Date.now() + 86400000,
               tiers: [],
+              activityTypes: [],
             },
             balance: { total: 500 },
             tier: {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -305,6 +305,7 @@ export class RewardsController extends BaseController<
       startDate: season.startDate.getTime(),
       endDate: season.endDate.getTime(),
       tiers: season.tiers,
+      activityTypes: season.activityTypes,
     };
   }
 
@@ -322,6 +323,7 @@ export class RewardsController extends BaseController<
         startDate: new Date(seasonMetadata.startDate),
         endDate: new Date(seasonMetadata.endDate),
         tiers: seasonMetadata.tiers,
+        activityTypes: seasonMetadata.activityTypes,
       },
       balance: {
         total: seasonState.balance,
@@ -1655,7 +1657,7 @@ export class RewardsController extends BaseController<
 
   /**
    * Get season metadata with caching. This fetches and caches the season metadata
-   * including id, name, dates, and tiers.
+   * including id, name, dates, tiers, and activity types.
    * @param type - The type of season to get
    * @returns Promise<SeasonDtoState> - The season metadata
    */
@@ -1714,6 +1716,7 @@ export class RewardsController extends BaseController<
             startDate: seasonMetadata.startDate,
             endDate: seasonMetadata.endDate,
             tiers: seasonMetadata.tiers,
+            activityTypes: seasonMetadata.activityTypes,
           });
 
           // Add lastFetched timestamp

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -1298,6 +1298,7 @@ describe('RewardsDataService', () => {
           rewards: [],
         },
       ],
+      activityTypes: [],
     };
 
     beforeEach(() => {

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
@@ -972,6 +972,11 @@ export class RewardsDataService {
       data.endDate = new Date(data.endDate);
     }
 
+    // Ensure activityTypes is always an array per SeasonMetadataDto
+    if (!Array.isArray(data.activityTypes)) {
+      data.activityTypes = [];
+    }
+
     return data as SeasonMetadataDto;
   }
 }

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -384,6 +384,7 @@ export type PointsEventDto = BasePointsEventDto &
         type: 'REFERRAL' | 'SIGN_UP_BONUS' | 'LOYALTY_BONUS' | 'ONE_TIME_BONUS';
         payload: null;
       }
+    | { type: string; payload: Record<string, string> | null }
   );
 
 export interface EstimatePointsDto {
@@ -454,6 +455,7 @@ export interface SeasonDto {
   startDate: Date;
   endDate: Date;
   tiers: SeasonTierDto[];
+  activityTypes: SeasonActivityTypeDto[];
 }
 
 export interface SeasonStatusBalanceDto {
@@ -576,6 +578,7 @@ export type SeasonDtoState = {
   startDate: number; // timestamp
   endDate: number; // timestamp
   tiers: SeasonTierDtoState[];
+  activityTypes: SeasonActivityTypeDto[];
   lastFetched?: number;
 };
 
@@ -1150,6 +1153,11 @@ export interface SeasonMetadataDto {
    * The tiers for the season
    */
   tiers: SeasonTierDto[];
+
+  /**
+   * Activity types for the season
+   */
+  activityTypes: SeasonActivityTypeDto[];
 }
 
 /**
@@ -1174,3 +1182,30 @@ export interface SeasonStateDto {
    */
   updatedAt: Date;
 }
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type SeasonActivityTypeDto = {
+  /**
+   * The activity type
+   * @example 'SWAP'
+   */
+  type: string;
+
+  /**
+   * The name of the activity type
+   * @example 'Swap'
+   */
+  title: string;
+
+  /**
+   * The description of the activity type
+   * @example 'Stake your M$D to earn points'
+   */
+  description: string;
+
+  /**
+   * The icon for the activity type
+   * @example 'Rocket'
+   */
+  icon: string;
+};

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -34,6 +34,10 @@ import {
 } from '../../core/Engine/controllers/rewards-controller/types';
 import { AccountGroupId } from '@metamask/account-api';
 
+const initialState: RewardsState = rewardsReducer(undefined, {
+  type: 'unknown',
+} as Action);
+
 describe('rewardsReducer', () => {
   const initialState: RewardsState = {
     activeTab: 'overview',
@@ -45,6 +49,7 @@ describe('rewardsReducer', () => {
     seasonStartDate: null,
     seasonEndDate: null,
     seasonTiers: [],
+    seasonActivityTypes: [],
 
     referralDetailsLoading: false,
     referralDetailsError: false,
@@ -309,6 +314,7 @@ describe('rewardsReducer', () => {
               rewards: [],
             },
           ],
+          activityTypes: [],
         },
         balance: {
           total: 500,
@@ -370,1545 +376,942 @@ describe('rewardsReducer', () => {
       expect(state.balanceUpdatedAt).toBe(null);
     });
 
-    describe('setReferralDetails', () => {
-      it('should update referral code when provided', () => {
-        // Arrange
-        const action = setReferralDetails({ referralCode: 'NEW123' });
+    it('should set seasonActivityTypes from season data', () => {
+      const mockSeasonStatus = {
+        season: {
+          id: 'season-activity',
+          name: 'Season Activity',
+          startDate: new Date('2024-02-01').getTime(),
+          endDate: new Date('2024-03-01').getTime(),
+          tiers: [],
+          activityTypes: [
+            {
+              type: 'SWAP',
+              title: 'Swap',
+              description: 'Swap desc',
+              icon: 'SwapVertical',
+            },
+            {
+              type: 'CARD',
+              title: 'Card spend',
+              description: 'Spend',
+              icon: 'Card',
+            },
+          ],
+        },
+      } as unknown as SeasonStatusState;
+      const action = setSeasonStatus(mockSeasonStatus);
 
-        // Act
-        const state = rewardsReducer(initialState, action);
+      const state = rewardsReducer(initialState, action);
 
-        // Assert
-        expect(state.referralCode).toBe('NEW123');
-        expect(state.refereeCount).toBe(0); // Should remain unchanged
+      expect(state.seasonActivityTypes).toEqual(
+        mockSeasonStatus.season.activityTypes,
+      );
+    });
+
+    it('should clear seasonActivityTypes when season status is null', () => {
+      const stateWithActivities = {
+        ...initialState,
+        seasonActivityTypes: [
+          {
+            type: 'REFERRAL',
+            title: 'Referral',
+            description: 'Refer a friend',
+            icon: 'UserCircleAdd',
+          },
+        ],
+      };
+      const action = setSeasonStatus(null);
+
+      const state = rewardsReducer(stateWithActivities, action);
+
+      expect(state.seasonActivityTypes).toEqual([]);
+    });
+  });
+
+  describe('setReferralDetails', () => {
+    it('should update referral code when provided', () => {
+      // Arrange
+      const action = setReferralDetails({ referralCode: 'NEW123' });
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.referralCode).toBe('NEW123');
+      expect(state.refereeCount).toBe(0); // Should remain unchanged
+    });
+
+    it('should update referee count when provided', () => {
+      // Arrange
+      const action = setReferralDetails({ refereeCount: 5 });
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.refereeCount).toBe(5);
+      expect(state.referralCode).toBe(null); // Should remain unchanged
+    });
+
+    it('should update multiple referral fields when provided', () => {
+      // Arrange
+      const action = setReferralDetails({
+        referralCode: 'MULTI123',
+        refereeCount: 10,
       });
 
-      it('should update referee count when provided', () => {
-        // Arrange
-        const action = setReferralDetails({ refereeCount: 5 });
+      // Act
+      const state = rewardsReducer(initialState, action);
 
-        // Act
-        const state = rewardsReducer(initialState, action);
+      // Assert
+      expect(state.referralCode).toBe('MULTI123');
+      expect(state.refereeCount).toBe(10);
+    });
 
-        // Assert
-        expect(state.refereeCount).toBe(5);
-        expect(state.referralCode).toBe(null); // Should remain unchanged
+    it('should handle empty payload without updating any fields', () => {
+      // Arrange
+      const stateWithData = {
+        ...initialState,
+        referralCode: 'EXISTING',
+        refereeCount: 3,
+      };
+      const action = setReferralDetails({});
+
+      // Act
+      const state = rewardsReducer(stateWithData, action);
+
+      // Assert
+      expect(state.referralCode).toBe('EXISTING');
+      expect(state.refereeCount).toBe(3);
+    });
+
+    it('should handle zero referee count', () => {
+      // Arrange
+      const stateWithReferees = { ...initialState, refereeCount: 5 };
+      const action = setReferralDetails({ refereeCount: 0 });
+
+      // Act
+      const state = rewardsReducer(stateWithReferees, action);
+
+      // Assert
+      expect(state.refereeCount).toBe(0);
+    });
+
+    it('should set referralDetailsLoading to false', () => {
+      // Arrange
+      const stateWithLoading = {
+        ...initialState,
+        referralDetailsLoading: true,
+      };
+      const action = setReferralDetails({ referralCode: 'TEST123' });
+
+      // Act
+      const state = rewardsReducer(stateWithLoading, action);
+
+      // Assert
+      expect(state.referralDetailsLoading).toBe(false);
+      expect(state.referralCode).toBe('TEST123');
+    });
+
+    it('should handle null referralCode explicitly', () => {
+      // Arrange
+      const stateWithCode = { ...initialState, referralCode: 'EXISTING' };
+      const action = setReferralDetails({
+        referralCode: null as unknown as string,
       });
 
-      it('should update multiple referral fields when provided', () => {
-        // Arrange
-        const action = setReferralDetails({
-          referralCode: 'MULTI123',
-          refereeCount: 10,
-        });
+      // Act
+      const state = rewardsReducer(stateWithCode, action);
 
-        // Act
-        const state = rewardsReducer(initialState, action);
+      // Assert
+      expect(state.referralCode).toBe(null);
+      expect(state.referralDetailsLoading).toBe(false);
+    });
 
-        // Assert
-        expect(state.referralCode).toBe('MULTI123');
-        expect(state.refereeCount).toBe(10);
+    it('should handle undefined referralCode in payload', () => {
+      // Arrange
+      const stateWithCode = { ...initialState, referralCode: 'EXISTING' };
+      const action = setReferralDetails({
+        referralCode: undefined,
+        refereeCount: 5,
       });
 
-      it('should handle empty payload without updating any fields', () => {
+      // Act
+      const state = rewardsReducer(stateWithCode, action);
+
+      // Assert
+      expect(state.referralCode).toBe('EXISTING'); // Should remain unchanged
+      expect(state.refereeCount).toBe(5);
+      expect(state.referralDetailsLoading).toBe(false);
+    });
+
+    it('should handle negative referee count', () => {
+      // Arrange
+      const action = setReferralDetails({ refereeCount: -1 });
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.refereeCount).toBe(-1); // Should accept negative values
+      expect(state.referralDetailsLoading).toBe(false);
+    });
+
+    it('updates balanceRefereePortion when referralPoints is provided', () => {
+      // Arrange
+      const action = setReferralDetails({ referralPoints: 500 });
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.balanceRefereePortion).toBe(500);
+      expect(state.referralDetailsLoading).toBe(false);
+    });
+
+    it('updates balanceRefereePortion with zero value', () => {
+      // Arrange
+      const stateWithPoints = {
+        ...initialState,
+        balanceRefereePortion: 300,
+      };
+      const action = setReferralDetails({ referralPoints: 0 });
+
+      // Act
+      const state = rewardsReducer(stateWithPoints, action);
+
+      // Assert
+      expect(state.balanceRefereePortion).toBe(0);
+    });
+
+    it('updates all fields including referralPoints when provided together', () => {
+      // Arrange
+      const action = setReferralDetails({
+        referralCode: 'COMBO123',
+        refereeCount: 15,
+        referralPoints: 750,
+      });
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.referralCode).toBe('COMBO123');
+      expect(state.refereeCount).toBe(15);
+      expect(state.balanceRefereePortion).toBe(750);
+      expect(state.referralDetailsLoading).toBe(false);
+    });
+
+    it('preserves balanceRefereePortion when referralPoints is not provided', () => {
+      // Arrange
+      const stateWithPoints = {
+        ...initialState,
+        balanceRefereePortion: 200,
+      };
+      const action = setReferralDetails({ referralCode: 'TEST456' });
+
+      // Act
+      const state = rewardsReducer(stateWithPoints, action);
+
+      // Assert
+      expect(state.balanceRefereePortion).toBe(200);
+      expect(state.referralCode).toBe('TEST456');
+    });
+
+    it('handles negative referralPoints value', () => {
+      // Arrange
+      const action = setReferralDetails({ referralPoints: -50 });
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.balanceRefereePortion).toBe(-50);
+    });
+
+    it('handles large referralPoints value', () => {
+      // Arrange
+      const action = setReferralDetails({ referralPoints: 999999 });
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.balanceRefereePortion).toBe(999999);
+    });
+
+    it('handles decimal referralPoints value', () => {
+      // Arrange
+      const action = setReferralDetails({ referralPoints: 125.75 });
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.balanceRefereePortion).toBe(125.75);
+    });
+  });
+
+  describe('setReferralDetailsError', () => {
+    it('should set referral details error to true', () => {
+      // Arrange
+      const action = setReferralDetailsError(true);
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.referralDetailsError).toBe(true);
+    });
+
+    it('should set referral details error to false', () => {
+      // Arrange
+      const stateWithError = {
+        ...initialState,
+        referralDetailsError: true,
+      };
+      const action = setReferralDetailsError(false);
+
+      // Act
+      const state = rewardsReducer(stateWithError, action);
+
+      // Assert
+      expect(state.referralDetailsError).toBe(false);
+    });
+
+    it('should not affect other state properties', () => {
+      // Arrange
+      const stateWithData = {
+        ...initialState,
+        referralCode: 'TEST123',
+        refereeCount: 5,
+        referralDetailsLoading: true,
+      };
+      const action = setReferralDetailsError(true);
+
+      // Act
+      const state = rewardsReducer(stateWithData, action);
+
+      // Assert
+      expect(state.referralDetailsError).toBe(true);
+      expect(state.referralCode).toBe('TEST123');
+      expect(state.refereeCount).toBe(5);
+      expect(state.referralDetailsLoading).toBe(true);
+    });
+  });
+
+  describe('setSeasonStatusLoading', () => {
+    it('should set season status loading to true when no season data exists', () => {
+      // Arrange
+      const action = setSeasonStatusLoading(true);
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.seasonStatusLoading).toBe(true);
+    });
+
+    it('should not set season status loading to true when season data already exists', () => {
+      // Arrange
+      const stateWithSeasonData = {
+        ...initialState,
+        seasonStartDate: new Date('2024-01-01'),
+        seasonStatusLoading: false,
+      };
+      const action = setSeasonStatusLoading(true);
+
+      // Act
+      const state = rewardsReducer(stateWithSeasonData, action);
+
+      // Assert
+      expect(state.seasonStatusLoading).toBe(false); // Should remain false due to guard clause
+    });
+
+    it('should set season status loading to false', () => {
+      // Arrange
+      const stateWithLoading = { ...initialState, seasonStatusLoading: true };
+      const action = setSeasonStatusLoading(false);
+
+      // Act
+      const state = rewardsReducer(stateWithLoading, action);
+
+      // Assert
+      expect(state.seasonStatusLoading).toBe(false);
+    });
+
+    it('should set season status loading to false even when season data exists', () => {
+      // Arrange
+      const stateWithSeasonDataAndLoading = {
+        ...initialState,
+        seasonStartDate: new Date('2024-01-01'),
+        seasonStatusLoading: true,
+      };
+      const action = setSeasonStatusLoading(false);
+
+      // Act
+      const state = rewardsReducer(stateWithSeasonDataAndLoading, action);
+
+      // Assert
+      expect(state.seasonStatusLoading).toBe(false);
+    });
+  });
+
+  describe('setSeasonStatusError', () => {
+    it('should set season status error to a string message', () => {
+      // Arrange
+      const errorMessage = 'Failed to fetch season status';
+      const action = setSeasonStatusError(errorMessage);
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.seasonStatusError).toBe(errorMessage);
+    });
+
+    it('should clear season status error when set to null', () => {
+      // Arrange
+      const stateWithError = {
+        ...initialState,
+        seasonStatusError: 'Previous error message',
+      };
+      const action = setSeasonStatusError(null);
+
+      // Act
+      const state = rewardsReducer(stateWithError, action);
+
+      // Assert
+      expect(state.seasonStatusError).toBe(null);
+    });
+
+    it('should replace existing error with new error message', () => {
+      // Arrange
+      const stateWithError = {
+        ...initialState,
+        seasonStatusError: 'Old error message',
+      };
+      const newErrorMessage = 'New error message';
+      const action = setSeasonStatusError(newErrorMessage);
+
+      // Act
+      const state = rewardsReducer(stateWithError, action);
+
+      // Assert
+      expect(state.seasonStatusError).toBe(newErrorMessage);
+    });
+
+    it('should handle network timeout error message', () => {
+      // Arrange
+      const timeoutError = 'Request timed out while fetching season status';
+      const action = setSeasonStatusError(timeoutError);
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.seasonStatusError).toBe(timeoutError);
+    });
+
+    it('should handle API error response message', () => {
+      // Arrange
+      const apiError = 'API returned 500: Internal server error';
+      const action = setSeasonStatusError(apiError);
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.seasonStatusError).toBe(apiError);
+    });
+
+    it('should not affect other state properties when setting error', () => {
+      // Arrange
+      const stateWithData = {
+        ...initialState,
+        seasonName: 'Test Season',
+        seasonId: 'season-123',
+        balanceTotal: 1000,
+        seasonStatusLoading: false,
+      };
+      const errorMessage = 'Something went wrong';
+      const action = setSeasonStatusError(errorMessage);
+
+      // Act
+      const state = rewardsReducer(stateWithData, action);
+
+      // Assert
+      expect(state.seasonStatusError).toBe(errorMessage);
+      expect(state.seasonName).toBe('Test Season');
+      expect(state.seasonId).toBe('season-123');
+      expect(state.balanceTotal).toBe(1000);
+      expect(state.seasonStatusLoading).toBe(false);
+    });
+  });
+
+  describe('setReferralDetailsLoading', () => {
+    it('should set referral details loading to true when no referral code exists', () => {
+      // Arrange
+      const action = setReferralDetailsLoading(true);
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.referralDetailsLoading).toBe(true);
+    });
+
+    it('should not set referral details loading to true when referral code already exists', () => {
+      // Arrange
+      const stateWithReferralCode = {
+        ...initialState,
+        referralCode: 'EXISTING123',
+        referralDetailsLoading: false,
+      };
+      const action = setReferralDetailsLoading(true);
+
+      // Act
+      const state = rewardsReducer(stateWithReferralCode, action);
+
+      // Assert
+      expect(state.referralDetailsLoading).toBe(false); // Should remain false due to guard clause
+    });
+
+    it('should set referral details loading to false', () => {
+      // Arrange
+      const stateWithLoading = {
+        ...initialState,
+        referralDetailsLoading: true,
+      };
+      const action = setReferralDetailsLoading(false);
+
+      // Act
+      const state = rewardsReducer(stateWithLoading, action);
+
+      // Assert
+      expect(state.referralDetailsLoading).toBe(false);
+    });
+
+    it('should set referral details loading to false even when referral code exists', () => {
+      // Arrange
+      const stateWithReferralCodeAndLoading = {
+        ...initialState,
+        referralCode: 'EXISTING123',
+        referralDetailsLoading: true,
+      };
+      const action = setReferralDetailsLoading(false);
+
+      // Act
+      const state = rewardsReducer(stateWithReferralCodeAndLoading, action);
+
+      // Assert
+      expect(state.referralDetailsLoading).toBe(false);
+    });
+  });
+
+  describe('setOnboardingActiveStep', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it.each([
+      OnboardingStep.INTRO,
+      OnboardingStep.STEP_1,
+      OnboardingStep.STEP_2,
+      OnboardingStep.STEP_3,
+      OnboardingStep.STEP_4,
+    ])('should set onboarding active step to %s', (step) => {
+      // Arrange
+      const action = setOnboardingActiveStep(step);
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.onboardingActiveStep).toBe(step);
+    });
+
+    it('should update from different onboarding step', () => {
+      // Arrange
+      const stateWithStep = {
+        ...initialState,
+        onboardingActiveStep: OnboardingStep.STEP_2,
+      };
+      const action = setOnboardingActiveStep(OnboardingStep.STEP_4);
+
+      // Act
+      const state = rewardsReducer(stateWithStep, action);
+
+      // Assert
+      expect(state.onboardingActiveStep).toBe(OnboardingStep.STEP_4);
+    });
+
+    it('should call logger even when step is the same', () => {
+      // Arrange
+      const stateWithStep = {
+        ...initialState,
+        onboardingActiveStep: OnboardingStep.STEP_1,
+      };
+      const action = setOnboardingActiveStep(OnboardingStep.STEP_1);
+
+      // Act
+      const state = rewardsReducer(stateWithStep, action);
+
+      // Assert
+      expect(state.onboardingActiveStep).toBe(OnboardingStep.STEP_1);
+    });
+  });
+
+  describe('resetOnboarding', () => {
+    it('should reset onboarding to INTRO step and clear referral code', () => {
+      // Arrange
+      const stateWithStep = {
+        ...initialState,
+        onboardingActiveStep: OnboardingStep.STEP_3,
+        onboardingReferralCode: 'REF123',
+      };
+      const action = resetOnboarding();
+
+      // Act
+      const state = rewardsReducer(stateWithStep, action);
+
+      // Assert
+      expect(state.onboardingActiveStep).toBe(OnboardingStep.INTRO);
+      expect(state.onboardingReferralCode).toBeNull();
+    });
+
+    it('should not affect other state properties', () => {
+      // Arrange
+      const stateWithData = {
+        ...initialState,
+        onboardingActiveStep: OnboardingStep.STEP_4,
+        onboardingReferralCode: 'REF456',
+        referralCode: 'KEEP123',
+        balanceTotal: 1500,
+      };
+      const action = resetOnboarding();
+
+      // Act
+      const state = rewardsReducer(stateWithData, action);
+
+      // Assert
+      expect(state.onboardingActiveStep).toBe(OnboardingStep.INTRO);
+      expect(state.onboardingReferralCode).toBeNull();
+      expect(state.referralCode).toBe('KEEP123');
+      expect(state.balanceTotal).toBe(1500);
+    });
+  });
+
+  describe('setOnboardingReferralCode', () => {
+    it('should set onboarding referral code', () => {
+      // Arrange
+      const action = setOnboardingReferralCode('REF123');
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.onboardingReferralCode).toBe('REF123');
+    });
+
+    it('should update existing onboarding referral code', () => {
+      // Arrange
+      const stateWithCode = {
+        ...initialState,
+        onboardingReferralCode: 'OLD_REF',
+      };
+      const action = setOnboardingReferralCode('NEW_REF');
+
+      // Act
+      const state = rewardsReducer(stateWithCode, action);
+
+      // Assert
+      expect(state.onboardingReferralCode).toBe('NEW_REF');
+    });
+
+    it('should set onboarding referral code to null', () => {
+      // Arrange
+      const stateWithCode = {
+        ...initialState,
+        onboardingReferralCode: 'REF123',
+      };
+      const action = setOnboardingReferralCode(null);
+
+      // Act
+      const state = rewardsReducer(stateWithCode, action);
+
+      // Assert
+      expect(state.onboardingReferralCode).toBeNull();
+    });
+
+    it('should not affect other state properties', () => {
+      // Arrange
+      const stateWithData = {
+        ...initialState,
+        onboardingActiveStep: OnboardingStep.STEP_2,
+        referralCode: 'KEEP123',
+        balanceTotal: 1500,
+      };
+      const action = setOnboardingReferralCode('REF789');
+
+      // Act
+      const state = rewardsReducer(stateWithData, action);
+
+      // Assert
+      expect(state.onboardingReferralCode).toBe('REF789');
+      expect(state.onboardingActiveStep).toBe(OnboardingStep.STEP_2);
+      expect(state.referralCode).toBe('KEEP123');
+      expect(state.balanceTotal).toBe(1500);
+    });
+  });
+
+  describe('setGeoRewardsMetadata', () => {
+    it('should update geo metadata when payload is provided', () => {
+      // Arrange
+      const geoMetadata = {
+        geoLocation: 'US',
+        optinAllowedForGeo: true,
+      };
+      const action = setGeoRewardsMetadata(geoMetadata);
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.geoLocation).toBe('US');
+      expect(state.optinAllowedForGeo).toBe(true);
+      expect(state.optinAllowedForGeoLoading).toBe(false);
+    });
+
+    it('should update geo metadata with different location', () => {
+      // Arrange
+      const geoMetadata = {
+        geoLocation: 'CA',
+        optinAllowedForGeo: false,
+      };
+      const action = setGeoRewardsMetadata(geoMetadata);
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.geoLocation).toBe('CA');
+      expect(state.optinAllowedForGeo).toBe(false);
+      expect(state.optinAllowedForGeoLoading).toBe(false);
+    });
+
+    it('should clear geo metadata when payload is null', () => {
+      // Arrange
+      const stateWithGeoData = {
+        ...initialState,
+        geoLocation: 'EU',
+        optinAllowedForGeo: true,
+        optinAllowedForGeoLoading: true,
+      };
+      const action = setGeoRewardsMetadata(null);
+
+      // Act
+      const state = rewardsReducer(stateWithGeoData, action);
+
+      // Assert
+      expect(state.geoLocation).toBe(null);
+      expect(state.optinAllowedForGeo).toBe(null);
+      expect(state.optinAllowedForGeoLoading).toBe(false);
+    });
+
+    it('should reset loading state when metadata is set', () => {
+      // Arrange
+      const stateWithLoading = {
+        ...initialState,
+        optinAllowedForGeoLoading: true,
+      };
+      const geoMetadata = {
+        geoLocation: 'UK',
+        optinAllowedForGeo: true,
+      };
+      const action = setGeoRewardsMetadata(geoMetadata);
+
+      // Act
+      const state = rewardsReducer(stateWithLoading, action);
+
+      // Assert
+      expect(state.geoLocation).toBe('UK');
+      expect(state.optinAllowedForGeo).toBe(true);
+      expect(state.optinAllowedForGeoLoading).toBe(false);
+    });
+  });
+
+  describe('setGeoRewardsMetadataLoading', () => {
+    it('should set geo rewards metadata loading to true', () => {
+      // Arrange
+      const action = setGeoRewardsMetadataLoading(true);
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.optinAllowedForGeoLoading).toBe(true);
+    });
+
+    it('should set geo rewards metadata loading to false', () => {
+      // Arrange
+      const stateWithLoading = {
+        ...initialState,
+        optinAllowedForGeoLoading: true,
+      };
+      const action = setGeoRewardsMetadataLoading(false);
+
+      // Act
+      const state = rewardsReducer(stateWithLoading, action);
+
+      // Assert
+      expect(state.optinAllowedForGeoLoading).toBe(false);
+    });
+  });
+
+  describe('setGeoRewardsMetadataError', () => {
+    it('should set geo rewards metadata error to true', () => {
+      // Arrange
+      const action = setGeoRewardsMetadataError(true);
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.optinAllowedForGeoError).toBe(true);
+    });
+
+    it('should set geo rewards metadata error to false', () => {
+      // Arrange
+      const stateWithError = {
+        ...initialState,
+        optinAllowedForGeoError: true,
+      };
+      const action = setGeoRewardsMetadataError(false);
+
+      // Act
+      const state = rewardsReducer(stateWithError, action);
+
+      // Assert
+      expect(state.optinAllowedForGeoError).toBe(false);
+    });
+
+    it('should not affect other geo metadata properties', () => {
+      // Arrange
+      const stateWithGeoData = {
+        ...initialState,
+        geoLocation: 'US',
+        optinAllowedForGeo: true,
+        optinAllowedForGeoLoading: true,
+      };
+      const action = setGeoRewardsMetadataError(true);
+
+      // Act
+      const state = rewardsReducer(stateWithGeoData, action);
+
+      // Assert
+      expect(state.optinAllowedForGeoError).toBe(true);
+      expect(state.geoLocation).toBe('US');
+      expect(state.optinAllowedForGeo).toBe(true);
+      expect(state.optinAllowedForGeoLoading).toBe(true);
+    });
+  });
+
+  describe('setCandidateSubscriptionId', () => {
+    it('should set candidate subscription ID to a string value', () => {
+      // Arrange
+      const action = setCandidateSubscriptionId('sub-12345');
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.candidateSubscriptionId).toBe('sub-12345');
+    });
+
+    it('should set candidate subscription ID to pending', () => {
+      // Arrange
+      const stateWithId = {
+        ...initialState,
+        candidateSubscriptionId: 'existing-id' as const,
+      };
+      const action = setCandidateSubscriptionId('pending');
+
+      // Act
+      const state = rewardsReducer(stateWithId, action);
+
+      // Assert
+      expect(state.candidateSubscriptionId).toBe('pending');
+    });
+
+    it('should set candidate subscription ID to error', () => {
+      // Arrange
+      const action = setCandidateSubscriptionId('error');
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.candidateSubscriptionId).toBe('error');
+    });
+
+    it('should set candidate subscription ID to retry', () => {
+      // Arrange
+      const action = setCandidateSubscriptionId('retry');
+
+      // Act
+      const state = rewardsReducer(initialState, action);
+
+      // Assert
+      expect(state.candidateSubscriptionId).toBe('retry');
+    });
+
+    it('should set candidate subscription ID to null', () => {
+      // Arrange
+      const stateWithId = {
+        ...initialState,
+        candidateSubscriptionId: 'existing-id' as const,
+      };
+      const action = setCandidateSubscriptionId(null);
+
+      // Act
+      const state = rewardsReducer(stateWithId, action);
+
+      // Assert
+      expect(state.candidateSubscriptionId).toBe(null);
+    });
+
+    it('should not affect other state properties when changing from non-valid state', () => {
+      // Arrange
+      const stateWithData = {
+        ...initialState,
+        candidateSubscriptionId: 'pending' as const,
+        referralCode: 'KEEP123',
+        balanceTotal: 1500,
+      };
+      const action = setCandidateSubscriptionId('new-id');
+
+      // Act
+      const state = rewardsReducer(stateWithData, action);
+
+      // Assert
+      expect(state.candidateSubscriptionId).toBe('new-id');
+      expect(state.referralCode).toBe('KEEP123');
+      expect(state.balanceTotal).toBe(1500);
+    });
+
+    describe('state reset logic when candidate ID changes', () => {
+      it('should reset UI state when changing from valid ID to different valid ID', () => {
         // Arrange
         const stateWithData = {
           ...initialState,
-          referralCode: 'EXISTING',
-          refereeCount: 3,
-        };
-        const action = setReferralDetails({});
-
-        // Act
-        const state = rewardsReducer(stateWithData, action);
-
-        // Assert
-        expect(state.referralCode).toBe('EXISTING');
-        expect(state.refereeCount).toBe(3);
-      });
-
-      it('should handle zero referee count', () => {
-        // Arrange
-        const stateWithReferees = { ...initialState, refereeCount: 5 };
-        const action = setReferralDetails({ refereeCount: 0 });
-
-        // Act
-        const state = rewardsReducer(stateWithReferees, action);
-
-        // Assert
-        expect(state.refereeCount).toBe(0);
-      });
-
-      it('should set referralDetailsLoading to false', () => {
-        // Arrange
-        const stateWithLoading = {
-          ...initialState,
-          referralDetailsLoading: true,
-        };
-        const action = setReferralDetails({ referralCode: 'TEST123' });
-
-        // Act
-        const state = rewardsReducer(stateWithLoading, action);
-
-        // Assert
-        expect(state.referralDetailsLoading).toBe(false);
-        expect(state.referralCode).toBe('TEST123');
-      });
-
-      it('should handle null referralCode explicitly', () => {
-        // Arrange
-        const stateWithCode = { ...initialState, referralCode: 'EXISTING' };
-        const action = setReferralDetails({
-          referralCode: null as unknown as string,
-        });
-
-        // Act
-        const state = rewardsReducer(stateWithCode, action);
-
-        // Assert
-        expect(state.referralCode).toBe(null);
-        expect(state.referralDetailsLoading).toBe(false);
-      });
-
-      it('should handle undefined referralCode in payload', () => {
-        // Arrange
-        const stateWithCode = { ...initialState, referralCode: 'EXISTING' };
-        const action = setReferralDetails({
-          referralCode: undefined,
-          refereeCount: 5,
-        });
-
-        // Act
-        const state = rewardsReducer(stateWithCode, action);
-
-        // Assert
-        expect(state.referralCode).toBe('EXISTING'); // Should remain unchanged
-        expect(state.refereeCount).toBe(5);
-        expect(state.referralDetailsLoading).toBe(false);
-      });
-
-      it('should handle negative referee count', () => {
-        // Arrange
-        const action = setReferralDetails({ refereeCount: -1 });
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.refereeCount).toBe(-1); // Should accept negative values
-        expect(state.referralDetailsLoading).toBe(false);
-      });
-
-      it('updates balanceRefereePortion when referralPoints is provided', () => {
-        // Arrange
-        const action = setReferralDetails({ referralPoints: 500 });
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.balanceRefereePortion).toBe(500);
-        expect(state.referralDetailsLoading).toBe(false);
-      });
-
-      it('updates balanceRefereePortion with zero value', () => {
-        // Arrange
-        const stateWithPoints = {
-          ...initialState,
-          balanceRefereePortion: 300,
-        };
-        const action = setReferralDetails({ referralPoints: 0 });
-
-        // Act
-        const state = rewardsReducer(stateWithPoints, action);
-
-        // Assert
-        expect(state.balanceRefereePortion).toBe(0);
-      });
-
-      it('updates all fields including referralPoints when provided together', () => {
-        // Arrange
-        const action = setReferralDetails({
-          referralCode: 'COMBO123',
-          refereeCount: 15,
-          referralPoints: 750,
-        });
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.referralCode).toBe('COMBO123');
-        expect(state.refereeCount).toBe(15);
-        expect(state.balanceRefereePortion).toBe(750);
-        expect(state.referralDetailsLoading).toBe(false);
-      });
-
-      it('preserves balanceRefereePortion when referralPoints is not provided', () => {
-        // Arrange
-        const stateWithPoints = {
-          ...initialState,
-          balanceRefereePortion: 200,
-        };
-        const action = setReferralDetails({ referralCode: 'TEST456' });
-
-        // Act
-        const state = rewardsReducer(stateWithPoints, action);
-
-        // Assert
-        expect(state.balanceRefereePortion).toBe(200);
-        expect(state.referralCode).toBe('TEST456');
-      });
-
-      it('handles negative referralPoints value', () => {
-        // Arrange
-        const action = setReferralDetails({ referralPoints: -50 });
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.balanceRefereePortion).toBe(-50);
-      });
-
-      it('handles large referralPoints value', () => {
-        // Arrange
-        const action = setReferralDetails({ referralPoints: 999999 });
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.balanceRefereePortion).toBe(999999);
-      });
-
-      it('handles decimal referralPoints value', () => {
-        // Arrange
-        const action = setReferralDetails({ referralPoints: 125.75 });
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.balanceRefereePortion).toBe(125.75);
-      });
-    });
-
-    describe('setReferralDetailsError', () => {
-      it('should set referral details error to true', () => {
-        // Arrange
-        const action = setReferralDetailsError(true);
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.referralDetailsError).toBe(true);
-      });
-
-      it('should set referral details error to false', () => {
-        // Arrange
-        const stateWithError = {
-          ...initialState,
-          referralDetailsError: true,
-        };
-        const action = setReferralDetailsError(false);
-
-        // Act
-        const state = rewardsReducer(stateWithError, action);
-
-        // Assert
-        expect(state.referralDetailsError).toBe(false);
-      });
-
-      it('should not affect other state properties', () => {
-        // Arrange
-        const stateWithData = {
-          ...initialState,
-          referralCode: 'TEST123',
-          refereeCount: 5,
-          referralDetailsLoading: true,
-        };
-        const action = setReferralDetailsError(true);
-
-        // Act
-        const state = rewardsReducer(stateWithData, action);
-
-        // Assert
-        expect(state.referralDetailsError).toBe(true);
-        expect(state.referralCode).toBe('TEST123');
-        expect(state.refereeCount).toBe(5);
-        expect(state.referralDetailsLoading).toBe(true);
-      });
-    });
-
-    describe('setSeasonStatusLoading', () => {
-      it('should set season status loading to true when no season data exists', () => {
-        // Arrange
-        const action = setSeasonStatusLoading(true);
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.seasonStatusLoading).toBe(true);
-      });
-
-      it('should not set season status loading to true when season data already exists', () => {
-        // Arrange
-        const stateWithSeasonData = {
-          ...initialState,
-          seasonStartDate: new Date('2024-01-01'),
-          seasonStatusLoading: false,
-        };
-        const action = setSeasonStatusLoading(true);
-
-        // Act
-        const state = rewardsReducer(stateWithSeasonData, action);
-
-        // Assert
-        expect(state.seasonStatusLoading).toBe(false); // Should remain false due to guard clause
-      });
-
-      it('should set season status loading to false', () => {
-        // Arrange
-        const stateWithLoading = { ...initialState, seasonStatusLoading: true };
-        const action = setSeasonStatusLoading(false);
-
-        // Act
-        const state = rewardsReducer(stateWithLoading, action);
-
-        // Assert
-        expect(state.seasonStatusLoading).toBe(false);
-      });
-
-      it('should set season status loading to false even when season data exists', () => {
-        // Arrange
-        const stateWithSeasonDataAndLoading = {
-          ...initialState,
-          seasonStartDate: new Date('2024-01-01'),
-          seasonStatusLoading: true,
-        };
-        const action = setSeasonStatusLoading(false);
-
-        // Act
-        const state = rewardsReducer(stateWithSeasonDataAndLoading, action);
-
-        // Assert
-        expect(state.seasonStatusLoading).toBe(false);
-      });
-    });
-
-    describe('setSeasonStatusError', () => {
-      it('should set season status error to a string message', () => {
-        // Arrange
-        const errorMessage = 'Failed to fetch season status';
-        const action = setSeasonStatusError(errorMessage);
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.seasonStatusError).toBe(errorMessage);
-      });
-
-      it('should clear season status error when set to null', () => {
-        // Arrange
-        const stateWithError = {
-          ...initialState,
-          seasonStatusError: 'Previous error message',
-        };
-        const action = setSeasonStatusError(null);
-
-        // Act
-        const state = rewardsReducer(stateWithError, action);
-
-        // Assert
-        expect(state.seasonStatusError).toBe(null);
-      });
-
-      it('should replace existing error with new error message', () => {
-        // Arrange
-        const stateWithError = {
-          ...initialState,
-          seasonStatusError: 'Old error message',
-        };
-        const newErrorMessage = 'New error message';
-        const action = setSeasonStatusError(newErrorMessage);
-
-        // Act
-        const state = rewardsReducer(stateWithError, action);
-
-        // Assert
-        expect(state.seasonStatusError).toBe(newErrorMessage);
-      });
-
-      it('should handle network timeout error message', () => {
-        // Arrange
-        const timeoutError = 'Request timed out while fetching season status';
-        const action = setSeasonStatusError(timeoutError);
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.seasonStatusError).toBe(timeoutError);
-      });
-
-      it('should handle API error response message', () => {
-        // Arrange
-        const apiError = 'API returned 500: Internal server error';
-        const action = setSeasonStatusError(apiError);
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.seasonStatusError).toBe(apiError);
-      });
-
-      it('should not affect other state properties when setting error', () => {
-        // Arrange
-        const stateWithData = {
-          ...initialState,
-          seasonName: 'Test Season',
+          candidateSubscriptionId: 'old-subscription-id',
           seasonId: 'season-123',
-          balanceTotal: 1000,
-          seasonStatusLoading: false,
-        };
-        const errorMessage = 'Something went wrong';
-        const action = setSeasonStatusError(errorMessage);
-
-        // Act
-        const state = rewardsReducer(stateWithData, action);
-
-        // Assert
-        expect(state.seasonStatusError).toBe(errorMessage);
-        expect(state.seasonName).toBe('Test Season');
-        expect(state.seasonId).toBe('season-123');
-        expect(state.balanceTotal).toBe(1000);
-        expect(state.seasonStatusLoading).toBe(false);
-      });
-    });
-
-    describe('setReferralDetailsLoading', () => {
-      it('should set referral details loading to true when no referral code exists', () => {
-        // Arrange
-        const action = setReferralDetailsLoading(true);
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.referralDetailsLoading).toBe(true);
-      });
-
-      it('should not set referral details loading to true when referral code already exists', () => {
-        // Arrange
-        const stateWithReferralCode = {
-          ...initialState,
-          referralCode: 'EXISTING123',
-          referralDetailsLoading: false,
-        };
-        const action = setReferralDetailsLoading(true);
-
-        // Act
-        const state = rewardsReducer(stateWithReferralCode, action);
-
-        // Assert
-        expect(state.referralDetailsLoading).toBe(false); // Should remain false due to guard clause
-      });
-
-      it('should set referral details loading to false', () => {
-        // Arrange
-        const stateWithLoading = {
-          ...initialState,
-          referralDetailsLoading: true,
-        };
-        const action = setReferralDetailsLoading(false);
-
-        // Act
-        const state = rewardsReducer(stateWithLoading, action);
-
-        // Assert
-        expect(state.referralDetailsLoading).toBe(false);
-      });
-
-      it('should set referral details loading to false even when referral code exists', () => {
-        // Arrange
-        const stateWithReferralCodeAndLoading = {
-          ...initialState,
-          referralCode: 'EXISTING123',
-          referralDetailsLoading: true,
-        };
-        const action = setReferralDetailsLoading(false);
-
-        // Act
-        const state = rewardsReducer(stateWithReferralCodeAndLoading, action);
-
-        // Assert
-        expect(state.referralDetailsLoading).toBe(false);
-      });
-    });
-
-    describe('setOnboardingActiveStep', () => {
-      beforeEach(() => {
-        jest.clearAllMocks();
-      });
-
-      afterEach(() => {
-        jest.restoreAllMocks();
-      });
-
-      it.each([
-        OnboardingStep.INTRO,
-        OnboardingStep.STEP_1,
-        OnboardingStep.STEP_2,
-        OnboardingStep.STEP_3,
-        OnboardingStep.STEP_4,
-      ])('should set onboarding active step to %s', (step) => {
-        // Arrange
-        const action = setOnboardingActiveStep(step);
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.onboardingActiveStep).toBe(step);
-      });
-
-      it('should update from different onboarding step', () => {
-        // Arrange
-        const stateWithStep = {
-          ...initialState,
-          onboardingActiveStep: OnboardingStep.STEP_2,
-        };
-        const action = setOnboardingActiveStep(OnboardingStep.STEP_4);
-
-        // Act
-        const state = rewardsReducer(stateWithStep, action);
-
-        // Assert
-        expect(state.onboardingActiveStep).toBe(OnboardingStep.STEP_4);
-      });
-
-      it('should call logger even when step is the same', () => {
-        // Arrange
-        const stateWithStep = {
-          ...initialState,
-          onboardingActiveStep: OnboardingStep.STEP_1,
-        };
-        const action = setOnboardingActiveStep(OnboardingStep.STEP_1);
-
-        // Act
-        const state = rewardsReducer(stateWithStep, action);
-
-        // Assert
-        expect(state.onboardingActiveStep).toBe(OnboardingStep.STEP_1);
-      });
-    });
-
-    describe('resetOnboarding', () => {
-      it('should reset onboarding to INTRO step and clear referral code', () => {
-        // Arrange
-        const stateWithStep = {
-          ...initialState,
-          onboardingActiveStep: OnboardingStep.STEP_3,
-          onboardingReferralCode: 'REF123',
-        };
-        const action = resetOnboarding();
-
-        // Act
-        const state = rewardsReducer(stateWithStep, action);
-
-        // Assert
-        expect(state.onboardingActiveStep).toBe(OnboardingStep.INTRO);
-        expect(state.onboardingReferralCode).toBeNull();
-      });
-
-      it('should not affect other state properties', () => {
-        // Arrange
-        const stateWithData = {
-          ...initialState,
-          onboardingActiveStep: OnboardingStep.STEP_4,
-          onboardingReferralCode: 'REF456',
-          referralCode: 'KEEP123',
-          balanceTotal: 1500,
-        };
-        const action = resetOnboarding();
-
-        // Act
-        const state = rewardsReducer(stateWithData, action);
-
-        // Assert
-        expect(state.onboardingActiveStep).toBe(OnboardingStep.INTRO);
-        expect(state.onboardingReferralCode).toBeNull();
-        expect(state.referralCode).toBe('KEEP123');
-        expect(state.balanceTotal).toBe(1500);
-      });
-    });
-
-    describe('setOnboardingReferralCode', () => {
-      it('should set onboarding referral code', () => {
-        // Arrange
-        const action = setOnboardingReferralCode('REF123');
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.onboardingReferralCode).toBe('REF123');
-      });
-
-      it('should update existing onboarding referral code', () => {
-        // Arrange
-        const stateWithCode = {
-          ...initialState,
-          onboardingReferralCode: 'OLD_REF',
-        };
-        const action = setOnboardingReferralCode('NEW_REF');
-
-        // Act
-        const state = rewardsReducer(stateWithCode, action);
-
-        // Assert
-        expect(state.onboardingReferralCode).toBe('NEW_REF');
-      });
-
-      it('should set onboarding referral code to null', () => {
-        // Arrange
-        const stateWithCode = {
-          ...initialState,
-          onboardingReferralCode: 'REF123',
-        };
-        const action = setOnboardingReferralCode(null);
-
-        // Act
-        const state = rewardsReducer(stateWithCode, action);
-
-        // Assert
-        expect(state.onboardingReferralCode).toBeNull();
-      });
-
-      it('should not affect other state properties', () => {
-        // Arrange
-        const stateWithData = {
-          ...initialState,
-          onboardingActiveStep: OnboardingStep.STEP_2,
-          referralCode: 'KEEP123',
-          balanceTotal: 1500,
-        };
-        const action = setOnboardingReferralCode('REF789');
-
-        // Act
-        const state = rewardsReducer(stateWithData, action);
-
-        // Assert
-        expect(state.onboardingReferralCode).toBe('REF789');
-        expect(state.onboardingActiveStep).toBe(OnboardingStep.STEP_2);
-        expect(state.referralCode).toBe('KEEP123');
-        expect(state.balanceTotal).toBe(1500);
-      });
-    });
-
-    describe('setGeoRewardsMetadata', () => {
-      it('should update geo metadata when payload is provided', () => {
-        // Arrange
-        const geoMetadata = {
-          geoLocation: 'US',
-          optinAllowedForGeo: true,
-        };
-        const action = setGeoRewardsMetadata(geoMetadata);
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.geoLocation).toBe('US');
-        expect(state.optinAllowedForGeo).toBe(true);
-        expect(state.optinAllowedForGeoLoading).toBe(false);
-      });
-
-      it('should update geo metadata with different location', () => {
-        // Arrange
-        const geoMetadata = {
-          geoLocation: 'CA',
-          optinAllowedForGeo: false,
-        };
-        const action = setGeoRewardsMetadata(geoMetadata);
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.geoLocation).toBe('CA');
-        expect(state.optinAllowedForGeo).toBe(false);
-        expect(state.optinAllowedForGeoLoading).toBe(false);
-      });
-
-      it('should clear geo metadata when payload is null', () => {
-        // Arrange
-        const stateWithGeoData = {
-          ...initialState,
-          geoLocation: 'EU',
-          optinAllowedForGeo: true,
-          optinAllowedForGeoLoading: true,
-        };
-        const action = setGeoRewardsMetadata(null);
-
-        // Act
-        const state = rewardsReducer(stateWithGeoData, action);
-
-        // Assert
-        expect(state.geoLocation).toBe(null);
-        expect(state.optinAllowedForGeo).toBe(null);
-        expect(state.optinAllowedForGeoLoading).toBe(false);
-      });
-
-      it('should reset loading state when metadata is set', () => {
-        // Arrange
-        const stateWithLoading = {
-          ...initialState,
-          optinAllowedForGeoLoading: true,
-        };
-        const geoMetadata = {
-          geoLocation: 'UK',
-          optinAllowedForGeo: true,
-        };
-        const action = setGeoRewardsMetadata(geoMetadata);
-
-        // Act
-        const state = rewardsReducer(stateWithLoading, action);
-
-        // Assert
-        expect(state.geoLocation).toBe('UK');
-        expect(state.optinAllowedForGeo).toBe(true);
-        expect(state.optinAllowedForGeoLoading).toBe(false);
-      });
-    });
-
-    describe('setGeoRewardsMetadataLoading', () => {
-      it('should set geo rewards metadata loading to true', () => {
-        // Arrange
-        const action = setGeoRewardsMetadataLoading(true);
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.optinAllowedForGeoLoading).toBe(true);
-      });
-
-      it('should set geo rewards metadata loading to false', () => {
-        // Arrange
-        const stateWithLoading = {
-          ...initialState,
-          optinAllowedForGeoLoading: true,
-        };
-        const action = setGeoRewardsMetadataLoading(false);
-
-        // Act
-        const state = rewardsReducer(stateWithLoading, action);
-
-        // Assert
-        expect(state.optinAllowedForGeoLoading).toBe(false);
-      });
-    });
-
-    describe('setGeoRewardsMetadataError', () => {
-      it('should set geo rewards metadata error to true', () => {
-        // Arrange
-        const action = setGeoRewardsMetadataError(true);
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.optinAllowedForGeoError).toBe(true);
-      });
-
-      it('should set geo rewards metadata error to false', () => {
-        // Arrange
-        const stateWithError = {
-          ...initialState,
-          optinAllowedForGeoError: true,
-        };
-        const action = setGeoRewardsMetadataError(false);
-
-        // Act
-        const state = rewardsReducer(stateWithError, action);
-
-        // Assert
-        expect(state.optinAllowedForGeoError).toBe(false);
-      });
-
-      it('should not affect other geo metadata properties', () => {
-        // Arrange
-        const stateWithGeoData = {
-          ...initialState,
-          geoLocation: 'US',
-          optinAllowedForGeo: true,
-          optinAllowedForGeoLoading: true,
-        };
-        const action = setGeoRewardsMetadataError(true);
-
-        // Act
-        const state = rewardsReducer(stateWithGeoData, action);
-
-        // Assert
-        expect(state.optinAllowedForGeoError).toBe(true);
-        expect(state.geoLocation).toBe('US');
-        expect(state.optinAllowedForGeo).toBe(true);
-        expect(state.optinAllowedForGeoLoading).toBe(true);
-      });
-    });
-
-    describe('setCandidateSubscriptionId', () => {
-      it('should set candidate subscription ID to a string value', () => {
-        // Arrange
-        const action = setCandidateSubscriptionId('sub-12345');
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.candidateSubscriptionId).toBe('sub-12345');
-      });
-
-      it('should set candidate subscription ID to pending', () => {
-        // Arrange
-        const stateWithId = {
-          ...initialState,
-          candidateSubscriptionId: 'existing-id' as const,
-        };
-        const action = setCandidateSubscriptionId('pending');
-
-        // Act
-        const state = rewardsReducer(stateWithId, action);
-
-        // Assert
-        expect(state.candidateSubscriptionId).toBe('pending');
-      });
-
-      it('should set candidate subscription ID to error', () => {
-        // Arrange
-        const action = setCandidateSubscriptionId('error');
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.candidateSubscriptionId).toBe('error');
-      });
-
-      it('should set candidate subscription ID to retry', () => {
-        // Arrange
-        const action = setCandidateSubscriptionId('retry');
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.candidateSubscriptionId).toBe('retry');
-      });
-
-      it('should set candidate subscription ID to null', () => {
-        // Arrange
-        const stateWithId = {
-          ...initialState,
-          candidateSubscriptionId: 'existing-id' as const,
-        };
-        const action = setCandidateSubscriptionId(null);
-
-        // Act
-        const state = rewardsReducer(stateWithId, action);
-
-        // Assert
-        expect(state.candidateSubscriptionId).toBe(null);
-      });
-
-      it('should not affect other state properties when changing from non-valid state', () => {
-        // Arrange
-        const stateWithData = {
-          ...initialState,
-          candidateSubscriptionId: 'pending' as const,
-          referralCode: 'KEEP123',
-          balanceTotal: 1500,
-        };
-        const action = setCandidateSubscriptionId('new-id');
-
-        // Act
-        const state = rewardsReducer(stateWithData, action);
-
-        // Assert
-        expect(state.candidateSubscriptionId).toBe('new-id');
-        expect(state.referralCode).toBe('KEEP123');
-        expect(state.balanceTotal).toBe(1500);
-      });
-
-      describe('state reset logic when candidate ID changes', () => {
-        it('should reset UI state when changing from valid ID to different valid ID', () => {
-          // Arrange
-          const stateWithData = {
-            ...initialState,
-            candidateSubscriptionId: 'old-subscription-id',
-            seasonId: 'season-123',
-            seasonName: 'Test Season',
-            seasonStartDate: new Date('2024-01-01'),
-            seasonEndDate: new Date('2024-12-31'),
-            seasonTiers: [
-              {
-                id: 'tier-1',
-                name: 'Tier 1',
-                pointsNeeded: 100,
-                image: {
-                  lightModeUrl: 'tier1.png',
-                  darkModeUrl: 'tier1-dark.png',
-                },
-                levelNumber: '1',
-                rewards: [],
-              },
-            ],
-            referralCode: 'REF123',
-            refereeCount: 5,
-            currentTier: {
-              id: 'current-tier',
-              name: 'Current Tier',
-              pointsNeeded: 1000,
-              image: {
-                lightModeUrl: 'current.png',
-                darkModeUrl: 'current-dark.png',
-              },
-              levelNumber: '2',
-              rewards: [],
-            },
-            nextTier: {
-              id: 'next-tier',
-              name: 'Next Tier',
-              pointsNeeded: 2000,
-              image: {
-                lightModeUrl: 'next.png',
-                darkModeUrl: 'next-dark.png',
-              },
-              levelNumber: '3',
-              rewards: [],
-            },
-            nextTierPointsNeeded: 1000,
-            balanceTotal: 1500,
-            balanceRefereePortion: 300,
-            balanceUpdatedAt: new Date('2024-06-01'),
-            onboardingActiveStep: OnboardingStep.STEP_2,
-            onboardingReferralCode: 'ONBOARDING_REF',
-            activeBoosts: [
-              {
-                id: 'boost-1',
-                name: 'Test Boost',
-                icon: {
-                  lightModeUrl: 'boost.png',
-                  darkModeUrl: 'boost-dark.png',
-                },
-                boostBips: 1000,
-                seasonLong: true,
-                backgroundColor: '#FF0000',
-              },
-            ],
-            pointsEvents: [
-              {
-                id: 'event-1',
-                type: 'SWAP' as const,
-                timestamp: new Date('2024-01-01'),
-                value: 100,
-                bonus: null,
-                accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-                updatedAt: new Date('2024-01-01'),
-                payload: null,
-              },
-            ],
-            unlockedRewards: [
-              {
-                id: 'reward-1',
-                seasonRewardId: 'season-reward-1',
-                claimStatus: RewardClaimStatus.CLAIMED,
-              },
-            ],
-          };
-          const action = setCandidateSubscriptionId('new-subscription-id');
-
-          // Act
-          const state = rewardsReducer(stateWithData, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('new-subscription-id');
-          // All UI state should be reset to initial values
-          expect(state.seasonId).toBe(initialState.seasonId);
-          expect(state.seasonName).toBe(initialState.seasonName);
-          expect(state.seasonStartDate).toBe(initialState.seasonStartDate);
-          expect(state.seasonEndDate).toBe(initialState.seasonEndDate);
-          expect(state.seasonTiers).toEqual(initialState.seasonTiers);
-          expect(state.referralCode).toBe(initialState.referralCode);
-          expect(state.refereeCount).toBe(initialState.refereeCount);
-          expect(state.currentTier).toBe(initialState.currentTier);
-          expect(state.nextTier).toBe(initialState.nextTier);
-          expect(state.nextTierPointsNeeded).toBe(
-            initialState.nextTierPointsNeeded,
-          );
-          expect(state.balanceTotal).toBe(initialState.balanceTotal);
-          expect(state.balanceRefereePortion).toBe(
-            initialState.balanceRefereePortion,
-          );
-          expect(state.balanceUpdatedAt).toBe(initialState.balanceUpdatedAt);
-          expect(state.activeBoosts).toBe(initialState.activeBoosts);
-          expect(state.pointsEvents).toBe(initialState.pointsEvents);
-          expect(state.unlockedRewards).toBe(initialState.unlockedRewards);
-          // Onboarding state should NOT be reset
-          expect(state.onboardingActiveStep).toBe(OnboardingStep.STEP_2);
-          expect(state.onboardingReferralCode).toBe('ONBOARDING_REF');
-        });
-
-        it('should NOT reset UI state when changing from pending to valid ID', () => {
-          // Arrange
-          const stateWithData = {
-            ...initialState,
-            candidateSubscriptionId: 'pending' as const,
-            seasonId: 'season-123',
-            seasonName: 'Test Season',
-            referralCode: 'REF123',
-            balanceTotal: 1500,
-          };
-          const action = setCandidateSubscriptionId('new-subscription-id');
-
-          // Act
-          const state = rewardsReducer(stateWithData, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('new-subscription-id');
-          // UI state should NOT be reset when coming from pending
-          expect(state.seasonId).toBe('season-123');
-          expect(state.seasonName).toBe('Test Season');
-          expect(state.referralCode).toBe('REF123');
-          expect(state.balanceTotal).toBe(1500);
-        });
-
-        it('should NOT reset UI state when changing from error to valid ID', () => {
-          // Arrange
-          const stateWithData = {
-            ...initialState,
-            candidateSubscriptionId: 'error' as const,
-            seasonId: 'season-456',
-            seasonName: 'Error Season',
-            referralCode: 'ERROR123',
-            balanceTotal: 2000,
-          };
-          const action = setCandidateSubscriptionId('new-subscription-id');
-
-          // Act
-          const state = rewardsReducer(stateWithData, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('new-subscription-id');
-          // UI state should NOT be reset when coming from error
-          expect(state.seasonId).toBe('season-456');
-          expect(state.seasonName).toBe('Error Season');
-          expect(state.referralCode).toBe('ERROR123');
-          expect(state.balanceTotal).toBe(2000);
-        });
-
-        it('should NOT reset UI state when changing from retry to valid ID', () => {
-          // Arrange
-          const stateWithData = {
-            ...initialState,
-            candidateSubscriptionId: 'retry' as const,
-            seasonId: 'season-789',
-            seasonName: 'Retry Season',
-            referralCode: 'RETRY123',
-            balanceTotal: 3000,
-          };
-          const action = setCandidateSubscriptionId('new-subscription-id');
-
-          // Act
-          const state = rewardsReducer(stateWithData, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('new-subscription-id');
-          // UI state should NOT be reset when coming from retry
-          expect(state.seasonId).toBe('season-789');
-          expect(state.seasonName).toBe('Retry Season');
-          expect(state.referralCode).toBe('RETRY123');
-          expect(state.balanceTotal).toBe(3000);
-        });
-
-        it('should NOT reset UI state when changing from null to valid ID', () => {
-          // Arrange
-          const stateWithData = {
-            ...initialState,
-            candidateSubscriptionId: null,
-            seasonId: 'season-null',
-            seasonName: 'Null Season',
-            referralCode: 'NULL123',
-            balanceTotal: 4000,
-          };
-          const action = setCandidateSubscriptionId('new-subscription-id');
-
-          // Act
-          const state = rewardsReducer(stateWithData, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('new-subscription-id');
-          // UI state should NOT be reset when coming from null
-          expect(state.seasonId).toBe('season-null');
-          expect(state.seasonName).toBe('Null Season');
-          expect(state.referralCode).toBe('NULL123');
-          expect(state.balanceTotal).toBe(4000);
-        });
-
-        it('should NOT reset UI state when changing to same valid ID', () => {
-          // Arrange
-          const stateWithData = {
-            ...initialState,
-            candidateSubscriptionId: 'same-subscription-id',
-            seasonId: 'season-same',
-            seasonName: 'Same Season',
-            referralCode: 'SAME123',
-            balanceTotal: 5000,
-          };
-          const action = setCandidateSubscriptionId('same-subscription-id');
-
-          // Act
-          const state = rewardsReducer(stateWithData, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('same-subscription-id');
-          // UI state should NOT be reset when ID doesn't change
-          expect(state.seasonId).toBe('season-same');
-          expect(state.seasonName).toBe('Same Season');
-          expect(state.referralCode).toBe('SAME123');
-          expect(state.balanceTotal).toBe(5000);
-        });
-
-        it('should reset UI state when changing from valid ID to pending', () => {
-          // Arrange
-          const stateWithData = {
-            ...initialState,
-            candidateSubscriptionId: 'valid-subscription-id',
-            seasonId: 'season-valid',
-            seasonName: 'Valid Season',
-            referralCode: 'VALID123',
-            balanceTotal: 6000,
-          };
-          const action = setCandidateSubscriptionId('pending');
-
-          // Act
-          const state = rewardsReducer(stateWithData, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('pending');
-          // UI state should be reset when changing from valid ID to pending
-          expect(state.seasonId).toBe(initialState.seasonId);
-          expect(state.seasonName).toBe(initialState.seasonName);
-          expect(state.referralCode).toBe(initialState.referralCode);
-          expect(state.balanceTotal).toBe(initialState.balanceTotal);
-        });
-
-        it('should reset UI state when changing from valid ID to error', () => {
-          // Arrange
-          const stateWithData = {
-            ...initialState,
-            candidateSubscriptionId: 'valid-subscription-id',
-            seasonId: 'season-valid',
-            seasonName: 'Valid Season',
-            referralCode: 'VALID123',
-            balanceTotal: 6000,
-          };
-          const action = setCandidateSubscriptionId('error');
-
-          // Act
-          const state = rewardsReducer(stateWithData, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('error');
-          // UI state should be reset when changing from valid ID to error
-          expect(state.seasonId).toBe(initialState.seasonId);
-          expect(state.seasonName).toBe(initialState.seasonName);
-          expect(state.referralCode).toBe(initialState.referralCode);
-          expect(state.balanceTotal).toBe(initialState.balanceTotal);
-        });
-
-        it('should reset UI state when changing from valid ID to retry', () => {
-          // Arrange
-          const stateWithData = {
-            ...initialState,
-            candidateSubscriptionId: 'valid-subscription-id',
-            seasonId: 'season-valid',
-            seasonName: 'Valid Season',
-            referralCode: 'VALID123',
-            balanceTotal: 6000,
-          };
-          const action = setCandidateSubscriptionId('retry');
-
-          // Act
-          const state = rewardsReducer(stateWithData, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('retry');
-          // UI state should be reset when changing from valid ID to retry
-          expect(state.seasonId).toBe(initialState.seasonId);
-          expect(state.seasonName).toBe(initialState.seasonName);
-          expect(state.referralCode).toBe(initialState.referralCode);
-          expect(state.balanceTotal).toBe(initialState.balanceTotal);
-        });
-
-        it('should reset UI state when changing from valid ID to null', () => {
-          // Arrange
-          const stateWithData = {
-            ...initialState,
-            candidateSubscriptionId: 'valid-subscription-id',
-            seasonId: 'season-valid',
-            seasonName: 'Valid Season',
-            referralCode: 'VALID123',
-            balanceTotal: 6000,
-          };
-          const action = setCandidateSubscriptionId(null);
-
-          // Act
-          const state = rewardsReducer(stateWithData, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe(null);
-          // UI state should be reset when changing from valid ID to null
-          expect(state.seasonId).toBe(initialState.seasonId);
-          expect(state.seasonName).toBe(initialState.seasonName);
-          expect(state.referralCode).toBe(initialState.referralCode);
-          expect(state.balanceTotal).toBe(initialState.balanceTotal);
-        });
-      });
-
-      describe('state transitions between special states', () => {
-        it('should handle transition from pending to error', () => {
-          // Arrange
-          const stateWithPending = {
-            ...initialState,
-            candidateSubscriptionId: 'pending' as const,
-            seasonId: 'season-pending',
-            referralCode: 'PENDING123',
-          };
-          const action = setCandidateSubscriptionId('error');
-
-          // Act
-          const state = rewardsReducer(stateWithPending, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('error');
-          expect(state.seasonId).toBe('season-pending'); // Should not reset
-          expect(state.referralCode).toBe('PENDING123'); // Should not reset
-        });
-
-        it('should handle transition from error to retry', () => {
-          // Arrange
-          const stateWithError = {
-            ...initialState,
-            candidateSubscriptionId: 'error' as const,
-            seasonId: 'season-error',
-            referralCode: 'ERROR123',
-          };
-          const action = setCandidateSubscriptionId('retry');
-
-          // Act
-          const state = rewardsReducer(stateWithError, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('retry');
-          expect(state.seasonId).toBe('season-error'); // Should not reset
-          expect(state.referralCode).toBe('ERROR123'); // Should not reset
-        });
-
-        it('should handle transition from retry to pending', () => {
-          // Arrange
-          const stateWithRetry = {
-            ...initialState,
-            candidateSubscriptionId: 'retry' as const,
-            seasonId: 'season-retry',
-            referralCode: 'RETRY123',
-          };
-          const action = setCandidateSubscriptionId('pending');
-
-          // Act
-          const state = rewardsReducer(stateWithRetry, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('pending');
-          expect(state.seasonId).toBe('season-retry'); // Should not reset
-          expect(state.referralCode).toBe('RETRY123'); // Should not reset
-        });
-
-        it('should handle transition from null to pending', () => {
-          // Arrange
-          const stateWithNull = {
-            ...initialState,
-            candidateSubscriptionId: null,
-            seasonId: 'season-null',
-            referralCode: 'NULL123',
-          };
-          const action = setCandidateSubscriptionId('pending');
-
-          // Act
-          const state = rewardsReducer(stateWithNull, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe('pending');
-          expect(state.seasonId).toBe('season-null'); // Should not reset
-          expect(state.referralCode).toBe('NULL123'); // Should not reset
-        });
-
-        it('should handle transition from pending to null', () => {
-          // Arrange
-          const stateWithPending = {
-            ...initialState,
-            candidateSubscriptionId: 'pending' as const,
-            seasonId: 'season-pending',
-            referralCode: 'PENDING123',
-          };
-          const action = setCandidateSubscriptionId(null);
-
-          // Act
-          const state = rewardsReducer(stateWithPending, action);
-
-          // Assert
-          expect(state.candidateSubscriptionId).toBe(null);
-          expect(state.seasonId).toBe('season-pending'); // Should not reset
-          expect(state.referralCode).toBe('PENDING123'); // Should not reset
-        });
-      });
-    });
-
-    describe('setHideUnlinkedAccountsBanner', () => {
-      it('should set hide unlinked accounts banner to true', () => {
-        // Arrange
-        const action = setHideUnlinkedAccountsBanner(true);
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.hideUnlinkedAccountsBanner).toBe(true);
-      });
-
-      it('should set hide unlinked accounts banner to false', () => {
-        // Arrange
-        const stateWithBannerHidden = {
-          ...initialState,
-          hideUnlinkedAccountsBanner: true,
-        };
-        const action = setHideUnlinkedAccountsBanner(false);
-
-        // Act
-        const state = rewardsReducer(stateWithBannerHidden, action);
-
-        // Assert
-        expect(state.hideUnlinkedAccountsBanner).toBe(false);
-      });
-
-      it('should not affect other state properties', () => {
-        // Arrange
-        const stateWithData = {
-          ...initialState,
-          hideUnlinkedAccountsBanner: false,
-          referralCode: 'KEEP123',
-          balanceTotal: 1500,
-        };
-        const action = setHideUnlinkedAccountsBanner(true);
-
-        // Act
-        const state = rewardsReducer(stateWithData, action);
-
-        // Assert
-        expect(state.hideUnlinkedAccountsBanner).toBe(true);
-        expect(state.referralCode).toBe('KEEP123');
-        expect(state.balanceTotal).toBe(1500);
-      });
-    });
-
-    describe('setHideCurrentAccountNotOptedInBanner', () => {
-      it('should add new account banner entry when it does not exist', () => {
-        // Arrange
-        const accountGroupId: AccountGroupId = 'keyring:wallet1/1';
-        const action = setHideCurrentAccountNotOptedInBanner({
-          accountGroupId,
-          hide: true,
-        });
-
-        // Act
-        const state = rewardsReducer(initialState, action);
-
-        // Assert
-        expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(1);
-        expect(state.hideCurrentAccountNotOptedInBanner[0]).toEqual({
-          accountGroupId,
-          hide: true,
-        });
-      });
-
-      it('should update existing account banner entry', () => {
-        // Arrange
-        const accountGroupId: AccountGroupId = 'keyring:wallet1/1';
-        const stateWithExistingEntry = {
-          ...initialState,
-          hideCurrentAccountNotOptedInBanner: [
-            {
-              accountGroupId,
-              hide: false,
-            },
-          ],
-        };
-        const action = setHideCurrentAccountNotOptedInBanner({
-          accountGroupId,
-          hide: true,
-        });
-
-        // Act
-        const state = rewardsReducer(stateWithExistingEntry, action);
-
-        // Assert
-        expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(1);
-        expect(state.hideCurrentAccountNotOptedInBanner[0]).toEqual({
-          accountGroupId,
-          hide: true,
-        });
-      });
-
-      it('should add multiple different account entries', () => {
-        // Arrange
-        const accountGroupId1: AccountGroupId = 'keyring:wallet1/1';
-        const accountGroupId2: AccountGroupId = 'keyring:wallet2/2';
-
-        let currentState = initialState;
-
-        // Add first account
-        const action1 = setHideCurrentAccountNotOptedInBanner({
-          accountGroupId: accountGroupId1,
-          hide: true,
-        });
-        currentState = rewardsReducer(currentState, action1);
-
-        // Add second account
-        const action2 = setHideCurrentAccountNotOptedInBanner({
-          accountGroupId: accountGroupId2,
-          hide: false,
-        });
-
-        // Act
-        const state = rewardsReducer(currentState, action2);
-
-        // Assert
-        expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(2);
-        expect(state.hideCurrentAccountNotOptedInBanner[0]).toEqual({
-          accountGroupId: accountGroupId1,
-          hide: true,
-        });
-        expect(state.hideCurrentAccountNotOptedInBanner[1]).toEqual({
-          accountGroupId: accountGroupId2,
-          hide: false,
-        });
-      });
-
-      it('should update specific account without affecting others', () => {
-        // Arrange
-        const accountGroupId1: AccountGroupId = 'keyring:wallet1/1';
-        const accountGroupId2: AccountGroupId = 'keyring:wallet2/2';
-        const stateWithMultipleEntries = {
-          ...initialState,
-          hideCurrentAccountNotOptedInBanner: [
-            {
-              accountGroupId: accountGroupId1,
-              hide: true,
-            },
-            {
-              accountGroupId: accountGroupId2,
-              hide: false,
-            },
-          ],
-        };
-        const action = setHideCurrentAccountNotOptedInBanner({
-          accountGroupId: accountGroupId1,
-          hide: false,
-        });
-
-        // Act
-        const state = rewardsReducer(stateWithMultipleEntries, action);
-
-        // Assert
-        expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(2);
-        expect(state.hideCurrentAccountNotOptedInBanner[0]).toEqual({
-          accountGroupId: accountGroupId1,
-          hide: false, // Updated
-        });
-        expect(state.hideCurrentAccountNotOptedInBanner[1]).toEqual({
-          accountGroupId: accountGroupId2,
-          hide: false, // Unchanged
-        });
-      });
-
-      it('should not affect other state properties', () => {
-        // Arrange
-        const stateWithData = {
-          ...initialState,
-          activeTab: 'activity' as const,
-          referralCode: 'TEST123',
-          hideUnlinkedAccountsBanner: true,
-        };
-        const accountGroupId: AccountGroupId = 'keyring:wallet1/1';
-        const action = setHideCurrentAccountNotOptedInBanner({
-          accountGroupId,
-          hide: true,
-        });
-
-        // Act
-        const state = rewardsReducer(stateWithData, action);
-
-        // Assert
-        expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(1);
-        expect(state.activeTab).toBe('activity');
-        expect(state.referralCode).toBe('TEST123');
-        expect(state.hideUnlinkedAccountsBanner).toBe(true);
-      });
-    });
-
-    describe('resetRewardsState', () => {
-      it('should reset all state to initial values', () => {
-        // Arrange
-        const stateWithData: RewardsState = {
-          activeTab: 'activity' as const,
-          seasonStatusLoading: true,
-          seasonId: 'test-season-id',
-          referralDetailsLoading: false,
-          referralCode: 'TEST123',
-          refereeCount: 10,
-          currentTier: {
-            id: 'tier-platinum',
-            name: 'Platinum',
-            pointsNeeded: 1000,
-            image: {
-              lightModeUrl: 'platinum.png',
-              darkModeUrl: 'platinum-dark.png',
-            },
-            levelNumber: 'Level 10',
-            rewards: [],
-          },
-          seasonStatusError: null,
-          nextTier: {
-            id: 'tier-diamond',
-            name: 'Diamond',
-            pointsNeeded: 2000,
-            image: {
-              lightModeUrl: 'diamond.png',
-              darkModeUrl: 'diamond-dark.png',
-            },
-            levelNumber: 'Level 20',
-            rewards: [],
-          },
-          nextTierPointsNeeded: 1000,
-          balanceTotal: 5000,
-          balanceRefereePortion: 1000,
-          balanceUpdatedAt: new Date('2024-01-01'),
           seasonName: 'Test Season',
           seasonStartDate: new Date('2024-01-01'),
           seasonEndDate: new Date('2024-12-31'),
@@ -1918,198 +1321,15 @@ describe('rewardsReducer', () => {
               name: 'Tier 1',
               pointsNeeded: 100,
               image: {
-                lightModeUrl: 'tier-1.png',
-                darkModeUrl: 'tier-1-dark.png',
-              },
-              levelNumber: 'Level 1',
-              rewards: [],
-            },
-          ],
-          onboardingActiveStep: OnboardingStep.STEP_1,
-          onboardingReferralCode: 'REF123',
-          candidateSubscriptionId: 'some-id',
-          geoLocation: 'US',
-          optinAllowedForGeo: true,
-          optinAllowedForGeoLoading: false,
-          hideUnlinkedAccountsBanner: true,
-          hideCurrentAccountNotOptedInBanner: [
-            {
-              accountGroupId: 'keyring:wallet1/1' as AccountGroupId,
-              hide: true,
-            },
-          ],
-          activeBoosts: [
-            {
-              id: 'boost-1',
-              name: 'Test Boost 1',
-              icon: {
-                lightModeUrl: 'light1.png',
-                darkModeUrl: 'dark1.png',
-              },
-              boostBips: 1000,
-              seasonLong: true,
-              backgroundColor: '#FF0000',
-            },
-          ],
-          pointsEvents: null,
-          activeBoostsLoading: false,
-          activeBoostsError: false,
-          unlockedRewards: [],
-          unlockedRewardLoading: false,
-          unlockedRewardError: false,
-          referralDetailsError: false,
-          optinAllowedForGeoError: false,
-        };
-        const action = resetRewardsState();
-
-        // Act
-        const state = rewardsReducer(stateWithData, action);
-
-        // Assert
-        expect(state).toEqual(initialState);
-      });
-    });
-
-    describe('persist/REHYDRATE', () => {
-      it('should restore persisted UI state while resetting non-persistent state', () => {
-        // Arrange
-        const persistedRewardsState: RewardsState = {
-          activeTab: 'activity',
-          seasonStatusLoading: true,
-          seasonId: 'test-season-id',
-          referralDetailsLoading: false,
-          referralCode: 'PERSISTED123',
-          refereeCount: 15,
-          currentTier: {
-            id: 'tier-diamond',
-            name: 'Diamond',
-            pointsNeeded: 1000,
-            image: {
-              lightModeUrl: 'https://example.com/diamond-light.png',
-              darkModeUrl: 'https://example.com/diamond-dark.png',
-            },
-            levelNumber: '4',
-            rewards: [],
-          },
-          nextTier: null,
-          nextTierPointsNeeded: null,
-          balanceTotal: 2000,
-          balanceRefereePortion: 400,
-          balanceUpdatedAt: new Date('2024-05-01'),
-          seasonName: 'Persisted Season',
-          seasonStartDate: new Date('2024-01-01'),
-          seasonEndDate: new Date('2024-12-31'),
-          seasonTiers: [
-            {
-              id: 'tier-1',
-              name: 'Tier 1',
-              pointsNeeded: 100,
-              image: {
-                lightModeUrl: 'https://example.com/tier1-light.png',
-                darkModeUrl: 'https://example.com/tier1-dark.png',
+                lightModeUrl: 'tier1.png',
+                darkModeUrl: 'tier1-dark.png',
               },
               levelNumber: '1',
               rewards: [],
             },
           ],
-          onboardingActiveStep: OnboardingStep.STEP_2,
-          onboardingReferralCode: 'PERSISTED_REF',
-          candidateSubscriptionId: 'some-id',
-          geoLocation: 'CA',
-          optinAllowedForGeo: true,
-          optinAllowedForGeoLoading: false,
-          hideUnlinkedAccountsBanner: true,
-          hideCurrentAccountNotOptedInBanner: [
-            {
-              accountGroupId: 'keyring:wallet1/1' as AccountGroupId,
-              hide: true,
-            },
-          ],
-          activeBoosts: [
-            {
-              id: 'boost-1',
-              name: 'Test Boost 1',
-              icon: {
-                lightModeUrl: 'light1.png',
-                darkModeUrl: 'dark1.png',
-              },
-              boostBips: 1000,
-              seasonLong: true,
-              backgroundColor: '#FF0000',
-            },
-          ],
-          pointsEvents: null,
-          seasonStatusError: null,
-          activeBoostsLoading: false,
-          activeBoostsError: false,
-          unlockedRewards: [],
-          unlockedRewardLoading: false,
-          unlockedRewardError: false,
-          referralDetailsError: false,
-          optinAllowedForGeoError: false,
-        };
-        const rehydrateAction = {
-          type: 'persist/REHYDRATE',
-          payload: {
-            rewards: persistedRewardsState,
-          },
-        };
-
-        // Act
-        const state = rewardsReducer(initialState, rehydrateAction);
-
-        // Assert - Should restore persisted UI state while keeping current non-persistent state
-        const expectedState = {
-          ...initialState,
-          // Restored from persisted state
-          seasonId: persistedRewardsState.seasonId,
-          seasonName: persistedRewardsState.seasonName,
-          seasonStartDate: persistedRewardsState.seasonStartDate,
-          seasonEndDate: persistedRewardsState.seasonEndDate,
-          seasonTiers: persistedRewardsState.seasonTiers,
-          referralCode: persistedRewardsState.referralCode,
-          refereeCount: persistedRewardsState.refereeCount,
-          currentTier: persistedRewardsState.currentTier,
-          nextTier: persistedRewardsState.nextTier,
-          balanceTotal: persistedRewardsState.balanceTotal,
-          balanceUpdatedAt: persistedRewardsState.balanceUpdatedAt,
-          activeBoosts: persistedRewardsState.activeBoosts,
-          pointsEvents: persistedRewardsState.pointsEvents,
-          unlockedRewards: persistedRewardsState.unlockedRewards,
-          hideUnlinkedAccountsBanner:
-            persistedRewardsState.hideUnlinkedAccountsBanner,
-          hideCurrentAccountNotOptedInBanner:
-            persistedRewardsState.hideCurrentAccountNotOptedInBanner,
-          // These fields are restored from persisted state
-          nextTierPointsNeeded: persistedRewardsState.nextTierPointsNeeded,
-          balanceRefereePortion: persistedRewardsState.balanceRefereePortion,
-        };
-        expect(state).toEqual(expectedState);
-      });
-
-      it('should preserve all persisted UI state fields', () => {
-        // Arrange
-        const persistedRewardsState: RewardsState = {
-          ...initialState,
-          seasonId: 'persisted-season-id',
-          seasonName: 'Persisted Season Name',
-          seasonStartDate: new Date('2024-01-01'),
-          seasonEndDate: new Date('2024-12-31'),
-          seasonTiers: [
-            {
-              id: 'tier-persisted',
-              name: 'Persisted Tier',
-              pointsNeeded: 500,
-              image: {
-                lightModeUrl: 'persisted.png',
-                darkModeUrl: 'persisted-dark.png',
-              },
-              levelNumber: '2',
-              rewards: [],
-            },
-          ],
-          referralCode: 'PERSISTED_CODE',
-          refereeCount: 25,
+          referralCode: 'REF123',
+          refereeCount: 5,
           currentTier: {
             id: 'current-tier',
             name: 'Current Tier',
@@ -2118,7 +1338,7 @@ describe('rewardsReducer', () => {
               lightModeUrl: 'current.png',
               darkModeUrl: 'current-dark.png',
             },
-            levelNumber: '3',
+            levelNumber: '2',
             rewards: [],
           },
           nextTier: {
@@ -2129,1184 +1349,2056 @@ describe('rewardsReducer', () => {
               lightModeUrl: 'next.png',
               darkModeUrl: 'next-dark.png',
             },
-            levelNumber: '4',
+            levelNumber: '3',
             rewards: [],
           },
-          balanceTotal: 3000,
+          nextTierPointsNeeded: 1000,
+          balanceTotal: 1500,
+          balanceRefereePortion: 300,
           balanceUpdatedAt: new Date('2024-06-01'),
+          onboardingActiveStep: OnboardingStep.STEP_2,
+          onboardingReferralCode: 'ONBOARDING_REF',
           activeBoosts: [
             {
-              id: 'persisted-boost',
-              name: 'Persisted Boost',
+              id: 'boost-1',
+              name: 'Test Boost',
               icon: {
                 lightModeUrl: 'boost.png',
                 darkModeUrl: 'boost-dark.png',
               },
-              boostBips: 1500,
+              boostBips: 1000,
               seasonLong: true,
-              backgroundColor: '#00FF00',
+              backgroundColor: '#FF0000',
             },
           ],
-          pointsEvents: [],
+          pointsEvents: [
+            {
+              id: 'event-1',
+              type: 'SWAP' as const,
+              timestamp: new Date('2024-01-01'),
+              value: 100,
+              bonus: null,
+              accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+              updatedAt: new Date('2024-01-01'),
+              payload: null,
+            },
+          ],
           unlockedRewards: [
             {
-              id: 'unlocked-reward',
-              seasonRewardId: 'season-reward-id',
-              claimStatus: RewardClaimStatus.UNCLAIMED,
+              id: 'reward-1',
+              seasonRewardId: 'season-reward-1',
+              claimStatus: RewardClaimStatus.CLAIMED,
             },
           ],
-          hideUnlinkedAccountsBanner: true,
-          hideCurrentAccountNotOptedInBanner: [
+          seasonActivityTypes: [
             {
-              accountGroupId: 'keyring:wallet1/1' as AccountGroupId,
-              hide: true,
+              type: 'PREDICT',
+              title: 'Predict',
+              description: 'Prediction',
+              icon: 'Speedometer',
             },
           ],
         };
-        const rehydrateAction = {
-          type: 'persist/REHYDRATE',
-          payload: {
-            rewards: persistedRewardsState,
-          },
-        };
+        const action = setCandidateSubscriptionId('new-subscription-id');
 
         // Act
-        const state = rewardsReducer(initialState, rehydrateAction);
+        const state = rewardsReducer(stateWithData, action);
 
-        // Assert - All persisted UI state should be preserved
-        expect(state.seasonId).toBe(persistedRewardsState.seasonId);
-        expect(state.seasonName).toBe(persistedRewardsState.seasonName);
-        expect(state.seasonStartDate).toEqual(
-          persistedRewardsState.seasonStartDate,
-        );
-        expect(state.seasonEndDate).toEqual(
-          persistedRewardsState.seasonEndDate,
-        );
-        expect(state.seasonTiers).toEqual(persistedRewardsState.seasonTiers);
-        expect(state.referralCode).toBe(persistedRewardsState.referralCode);
-        expect(state.refereeCount).toBe(persistedRewardsState.refereeCount);
-        expect(state.currentTier).toEqual(persistedRewardsState.currentTier);
-        expect(state.nextTier).toEqual(persistedRewardsState.nextTier);
-        expect(state.balanceTotal).toBe(persistedRewardsState.balanceTotal);
-        expect(state.balanceUpdatedAt).toEqual(
-          persistedRewardsState.balanceUpdatedAt,
-        );
-        expect(state.activeBoosts).toEqual(persistedRewardsState.activeBoosts);
-        expect(state.pointsEvents).toEqual(persistedRewardsState.pointsEvents);
-        expect(state.unlockedRewards).toEqual(
-          persistedRewardsState.unlockedRewards,
-        );
-        expect(state.hideUnlinkedAccountsBanner).toBe(
-          persistedRewardsState.hideUnlinkedAccountsBanner,
-        );
-        expect(state.hideCurrentAccountNotOptedInBanner).toEqual(
-          persistedRewardsState.hideCurrentAccountNotOptedInBanner,
-        );
-
-        // Non-persistent state should remain from current state
+        // Assert
+        expect(state.candidateSubscriptionId).toBe('new-subscription-id');
+        // All UI state should be reset to initial values
+        expect(state.seasonId).toBe(initialState.seasonId);
+        expect(state.seasonName).toBe(initialState.seasonName);
+        expect(state.seasonStartDate).toBe(initialState.seasonStartDate);
+        expect(state.seasonEndDate).toBe(initialState.seasonEndDate);
+        expect(state.seasonTiers).toEqual(initialState.seasonTiers);
+        expect(state.referralCode).toBe(initialState.referralCode);
+        expect(state.refereeCount).toBe(initialState.refereeCount);
+        expect(state.currentTier).toBe(initialState.currentTier);
+        expect(state.nextTier).toBe(initialState.nextTier);
         expect(state.nextTierPointsNeeded).toBe(
           initialState.nextTierPointsNeeded,
         );
+        expect(state.balanceTotal).toBe(initialState.balanceTotal);
         expect(state.balanceRefereePortion).toBe(
           initialState.balanceRefereePortion,
         );
-      });
-
-      it('should preserve current non-persistent state while restoring persisted UI state', () => {
-        // Arrange
-        const currentState = {
-          ...initialState,
-          nextTierPointsNeeded: 500, // This should be preserved
-          balanceRefereePortion: 100, // This should be preserved
-          activeTab: 'levels' as const, // This should be reset to initial
-          seasonStatusLoading: true, // This should be reset to initial
-          onboardingActiveStep: OnboardingStep.STEP_3, // This should be reset to initial
-          onboardingReferralCode: 'CURRENT_REF', // This should be reset to initial
-        };
-        const persistedRewardsState: RewardsState = {
-          ...initialState,
-          seasonId: 'persisted-season',
-          seasonName: 'Persisted Season',
-          referralCode: 'PERSISTED123',
-          balanceTotal: 2000,
-          hideUnlinkedAccountsBanner: true,
-          onboardingActiveStep: OnboardingStep.STEP_4, // This should NOT be persisted
-          onboardingReferralCode: 'PERSISTED_REF', // This should NOT be persisted
-        };
-        const rehydrateAction = {
-          type: 'persist/REHYDRATE',
-          payload: {
-            rewards: persistedRewardsState,
-          },
-        };
-
-        // Act
-        const state = rewardsReducer(currentState, rehydrateAction);
-
-        // Assert - Non-persistent state should be preserved from current state
-        expect(state.nextTierPointsNeeded).toBe(null); // Restored from persisted state (initialState)
-        expect(state.balanceRefereePortion).toBe(0); // Restored from persisted state (initialState)
-
-        // Persisted UI state should be restored
-        expect(state.seasonId).toBe('persisted-season');
-        expect(state.seasonName).toBe('Persisted Season');
-        expect(state.referralCode).toBe('PERSISTED123');
-        expect(state.balanceTotal).toBe(2000);
-        expect(state.hideUnlinkedAccountsBanner).toBe(true);
-
-        // Non-persistent state should be reset to initial
-        expect(state.activeTab).toBe(initialState.activeTab);
-        expect(state.seasonStatusLoading).toBe(
-          initialState.seasonStatusLoading,
+        expect(state.balanceUpdatedAt).toBe(initialState.balanceUpdatedAt);
+        expect(state.activeBoosts).toBe(initialState.activeBoosts);
+        expect(state.pointsEvents).toBe(initialState.pointsEvents);
+        expect(state.unlockedRewards).toBe(initialState.unlockedRewards);
+        expect(state.seasonActivityTypes).toEqual(
+          initialState.seasonActivityTypes,
         );
-        expect(state.onboardingActiveStep).toBe(
-          initialState.onboardingActiveStep,
-        );
-        expect(state.onboardingReferralCode).toBe(
-          initialState.onboardingReferralCode,
-        );
+        // Onboarding state should NOT be reset
+        expect(state.onboardingActiveStep).toBe(OnboardingStep.STEP_2);
+        expect(state.onboardingReferralCode).toBe('ONBOARDING_REF');
       });
 
-      it('should return current state when no rewards data in rehydrate payload', () => {
-        // Arrange
-        const currentState = { ...initialState, referralCode: 'CURRENT123' };
-        const rehydrateAction = {
-          type: 'persist/REHYDRATE',
-          payload: {
-            someOtherReducer: {},
-          },
-        };
-
-        // Act
-        const state = rewardsReducer(currentState, rehydrateAction);
-
-        // Assert
-        expect(state).toEqual(currentState);
-      });
-
-      it('should return current state when rehydrate payload is empty', () => {
-        // Arrange
-        const currentState = { ...initialState, referralCode: 'CURRENT123' };
-        const rehydrateAction = {
-          type: 'persist/REHYDRATE',
-          payload: undefined,
-        };
-
-        // Act
-        const state = rewardsReducer(currentState, rehydrateAction);
-
-        // Assert
-        expect(state).toEqual(currentState);
-      });
-    });
-
-    describe('unknown actions', () => {
-      it('should return unchanged state for unknown actions', () => {
+      it('should NOT reset UI state when changing from pending to valid ID', () => {
         // Arrange
         const stateWithData = {
           ...initialState,
-          referralCode: 'SOME_CODE',
-          balanceTotal: 1000,
-          activeTab: 'activity' as const,
+          candidateSubscriptionId: 'pending' as const,
+          seasonId: 'season-123',
+          seasonName: 'Test Season',
+          referralCode: 'REF123',
+          balanceTotal: 1500,
         };
-        const unknownAction = { type: 'UNKNOWN_ACTION', payload: 'some data' };
+        const action = setCandidateSubscriptionId('new-subscription-id');
 
         // Act
-        const state = rewardsReducer(
-          stateWithData,
-          unknownAction as unknown as Action,
-        );
+        const state = rewardsReducer(stateWithData, action);
 
         // Assert
-        expect(state).toEqual(stateWithData);
-        expect(state).toBe(stateWithData); // Should be the same reference
+        expect(state.candidateSubscriptionId).toBe('new-subscription-id');
+        // UI state should NOT be reset when coming from pending
+        expect(state.seasonId).toBe('season-123');
+        expect(state.seasonName).toBe('Test Season');
+        expect(state.referralCode).toBe('REF123');
+        expect(state.balanceTotal).toBe(1500);
       });
 
-      it('should return initial state for unknown action when state is undefined', () => {
+      it('should NOT reset UI state when changing from error to valid ID', () => {
         // Arrange
-        const unknownAction = { type: 'UNKNOWN_ACTION', payload: 'some data' };
+        const stateWithData = {
+          ...initialState,
+          candidateSubscriptionId: 'error' as const,
+          seasonId: 'season-456',
+          seasonName: 'Error Season',
+          referralCode: 'ERROR123',
+          balanceTotal: 2000,
+        };
+        const action = setCandidateSubscriptionId('new-subscription-id');
 
         // Act
-        const state = rewardsReducer(
-          undefined,
-          unknownAction as unknown as Action,
-        );
+        const state = rewardsReducer(stateWithData, action);
 
         // Assert
-        expect(state).toEqual(initialState);
+        expect(state.candidateSubscriptionId).toBe('new-subscription-id');
+        // UI state should NOT be reset when coming from error
+        expect(state.seasonId).toBe('season-456');
+        expect(state.seasonName).toBe('Error Season');
+        expect(state.referralCode).toBe('ERROR123');
+        expect(state.balanceTotal).toBe(2000);
+      });
+
+      it('should NOT reset UI state when changing from retry to valid ID', () => {
+        // Arrange
+        const stateWithData = {
+          ...initialState,
+          candidateSubscriptionId: 'retry' as const,
+          seasonId: 'season-789',
+          seasonName: 'Retry Season',
+          referralCode: 'RETRY123',
+          balanceTotal: 3000,
+        };
+        const action = setCandidateSubscriptionId('new-subscription-id');
+
+        // Act
+        const state = rewardsReducer(stateWithData, action);
+
+        // Assert
+        expect(state.candidateSubscriptionId).toBe('new-subscription-id');
+        // UI state should NOT be reset when coming from retry
+        expect(state.seasonId).toBe('season-789');
+        expect(state.seasonName).toBe('Retry Season');
+        expect(state.referralCode).toBe('RETRY123');
+        expect(state.balanceTotal).toBe(3000);
+      });
+
+      it('should NOT reset UI state when changing from null to valid ID', () => {
+        // Arrange
+        const stateWithData = {
+          ...initialState,
+          candidateSubscriptionId: null,
+          seasonId: 'season-null',
+          seasonName: 'Null Season',
+          referralCode: 'NULL123',
+          balanceTotal: 4000,
+        };
+        const action = setCandidateSubscriptionId('new-subscription-id');
+
+        // Act
+        const state = rewardsReducer(stateWithData, action);
+
+        // Assert
+        expect(state.candidateSubscriptionId).toBe('new-subscription-id');
+        // UI state should NOT be reset when coming from null
+        expect(state.seasonId).toBe('season-null');
+        expect(state.seasonName).toBe('Null Season');
+        expect(state.referralCode).toBe('NULL123');
+        expect(state.balanceTotal).toBe(4000);
+      });
+
+      it('should NOT reset UI state when changing to same valid ID', () => {
+        // Arrange
+        const stateWithData = {
+          ...initialState,
+          candidateSubscriptionId: 'same-subscription-id',
+          seasonId: 'season-same',
+          seasonName: 'Same Season',
+          referralCode: 'SAME123',
+          balanceTotal: 5000,
+        };
+        const action = setCandidateSubscriptionId('same-subscription-id');
+
+        // Act
+        const state = rewardsReducer(stateWithData, action);
+
+        // Assert
+        expect(state.candidateSubscriptionId).toBe('same-subscription-id');
+        // UI state should NOT be reset when ID doesn't change
+        expect(state.seasonId).toBe('season-same');
+        expect(state.seasonName).toBe('Same Season');
+        expect(state.referralCode).toBe('SAME123');
+        expect(state.balanceTotal).toBe(5000);
+      });
+
+      it('should reset UI state when changing from valid ID to pending', () => {
+        // Arrange
+        const stateWithData = {
+          ...initialState,
+          candidateSubscriptionId: 'valid-subscription-id',
+          seasonId: 'season-valid',
+          seasonName: 'Valid Season',
+          referralCode: 'VALID123',
+          balanceTotal: 6000,
+        };
+        const action = setCandidateSubscriptionId('pending');
+
+        // Act
+        const state = rewardsReducer(stateWithData, action);
+
+        // Assert
+        expect(state.candidateSubscriptionId).toBe('pending');
+        // UI state should be reset when changing from valid ID to pending
+        expect(state.seasonId).toBe(initialState.seasonId);
+        expect(state.seasonName).toBe(initialState.seasonName);
+        expect(state.referralCode).toBe(initialState.referralCode);
+        expect(state.balanceTotal).toBe(initialState.balanceTotal);
+      });
+
+      it('should reset UI state when changing from valid ID to error', () => {
+        // Arrange
+        const stateWithData = {
+          ...initialState,
+          candidateSubscriptionId: 'valid-subscription-id',
+          seasonId: 'season-valid',
+          seasonName: 'Valid Season',
+          referralCode: 'VALID123',
+          balanceTotal: 6000,
+        };
+        const action = setCandidateSubscriptionId('error');
+
+        // Act
+        const state = rewardsReducer(stateWithData, action);
+
+        // Assert
+        expect(state.candidateSubscriptionId).toBe('error');
+        // UI state should be reset when changing from valid ID to error
+        expect(state.seasonId).toBe(initialState.seasonId);
+        expect(state.seasonName).toBe(initialState.seasonName);
+        expect(state.referralCode).toBe(initialState.referralCode);
+        expect(state.balanceTotal).toBe(initialState.balanceTotal);
+      });
+
+      it('should reset UI state when changing from valid ID to retry', () => {
+        // Arrange
+        const stateWithData = {
+          ...initialState,
+          candidateSubscriptionId: 'valid-subscription-id',
+          seasonId: 'season-valid',
+          seasonName: 'Valid Season',
+          referralCode: 'VALID123',
+          balanceTotal: 6000,
+        };
+        const action = setCandidateSubscriptionId('retry');
+
+        // Act
+        const state = rewardsReducer(stateWithData, action);
+
+        // Assert
+        expect(state.candidateSubscriptionId).toBe('retry');
+        // UI state should be reset when changing from valid ID to retry
+        expect(state.seasonId).toBe(initialState.seasonId);
+        expect(state.seasonName).toBe(initialState.seasonName);
+        expect(state.referralCode).toBe(initialState.referralCode);
+        expect(state.balanceTotal).toBe(initialState.balanceTotal);
+      });
+
+      it('should reset UI state when changing from valid ID to null', () => {
+        // Arrange
+        const stateWithData = {
+          ...initialState,
+          candidateSubscriptionId: 'valid-subscription-id',
+          seasonId: 'season-valid',
+          seasonName: 'Valid Season',
+          referralCode: 'VALID123',
+          balanceTotal: 6000,
+        };
+        const action = setCandidateSubscriptionId(null);
+
+        // Act
+        const state = rewardsReducer(stateWithData, action);
+
+        // Assert
+        expect(state.candidateSubscriptionId).toBe(null);
+        // UI state should be reset when changing from valid ID to null
+        expect(state.seasonId).toBe(initialState.seasonId);
+        expect(state.seasonName).toBe(initialState.seasonName);
+        expect(state.referralCode).toBe(initialState.referralCode);
+        expect(state.balanceTotal).toBe(initialState.balanceTotal);
+      });
+    });
+
+    describe('state transitions between special states', () => {
+      it('should handle transition from pending to error', () => {
+        // Arrange
+        const stateWithPending = {
+          ...initialState,
+          candidateSubscriptionId: 'pending' as const,
+          seasonId: 'season-pending',
+          referralCode: 'PENDING123',
+        };
+        const action = setCandidateSubscriptionId('error');
+
+        // Act
+        const state = rewardsReducer(stateWithPending, action);
+
+        // Assert
+        expect(state.candidateSubscriptionId).toBe('error');
+        expect(state.seasonId).toBe('season-pending'); // Should not reset
+        expect(state.referralCode).toBe('PENDING123'); // Should not reset
+      });
+
+      it('should handle transition from error to retry', () => {
+        // Arrange
+        const stateWithError = {
+          ...initialState,
+          candidateSubscriptionId: 'error' as const,
+          seasonId: 'season-error',
+          referralCode: 'ERROR123',
+        };
+        const action = setCandidateSubscriptionId('retry');
+
+        // Act
+        const state = rewardsReducer(stateWithError, action);
+
+        // Assert
+        expect(state.candidateSubscriptionId).toBe('retry');
+        expect(state.seasonId).toBe('season-error'); // Should not reset
+        expect(state.referralCode).toBe('ERROR123'); // Should not reset
+      });
+
+      it('should handle transition from retry to pending', () => {
+        // Arrange
+        const stateWithRetry = {
+          ...initialState,
+          candidateSubscriptionId: 'retry' as const,
+          seasonId: 'season-retry',
+          referralCode: 'RETRY123',
+        };
+        const action = setCandidateSubscriptionId('pending');
+
+        // Act
+        const state = rewardsReducer(stateWithRetry, action);
+
+        // Assert
+        expect(state.candidateSubscriptionId).toBe('pending');
+        expect(state.seasonId).toBe('season-retry'); // Should not reset
+        expect(state.referralCode).toBe('RETRY123'); // Should not reset
+      });
+
+      it('should handle transition from null to pending', () => {
+        // Arrange
+        const stateWithNull = {
+          ...initialState,
+          candidateSubscriptionId: null,
+          seasonId: 'season-null',
+          referralCode: 'NULL123',
+        };
+        const action = setCandidateSubscriptionId('pending');
+
+        // Act
+        const state = rewardsReducer(stateWithNull, action);
+
+        // Assert
+        expect(state.candidateSubscriptionId).toBe('pending');
+        expect(state.seasonId).toBe('season-null'); // Should not reset
+        expect(state.referralCode).toBe('NULL123'); // Should not reset
+      });
+
+      it('should handle transition from pending to null', () => {
+        // Arrange
+        const stateWithPending = {
+          ...initialState,
+          candidateSubscriptionId: 'pending' as const,
+          seasonId: 'season-pending',
+          referralCode: 'PENDING123',
+        };
+        const action = setCandidateSubscriptionId(null);
+
+        // Act
+        const state = rewardsReducer(stateWithPending, action);
+
+        // Assert
+        expect(state.candidateSubscriptionId).toBe(null);
+        expect(state.seasonId).toBe('season-pending'); // Should not reset
+        expect(state.referralCode).toBe('PENDING123'); // Should not reset
       });
     });
   });
 
-  describe('setActiveBoosts', () => {
-    it('should set active boosts array', () => {
+  describe('setHideUnlinkedAccountsBanner', () => {
+    it('should set hide unlinked accounts banner to true', () => {
       // Arrange
-      const mockBoosts = [
-        {
-          id: 'boost-1',
-          name: 'Test Boost 1',
-          icon: {
-            lightModeUrl: 'light1.png',
-            darkModeUrl: 'dark1.png',
-          },
-          boostBips: 1000,
-          seasonLong: true,
-          backgroundColor: '#FF0000',
-        },
-        {
-          id: 'boost-2',
-          name: 'Test Boost 2',
-          icon: {
-            lightModeUrl: 'light2.png',
-            darkModeUrl: 'dark2.png',
-          },
-          boostBips: 500,
-          seasonLong: false,
-          startDate: '2024-01-01',
-          endDate: '2024-01-31',
-          backgroundColor: '#00FF00',
-        },
-      ];
-      const action = setActiveBoosts(mockBoosts);
+      const action = setHideUnlinkedAccountsBanner(true);
 
       // Act
       const state = rewardsReducer(initialState, action);
 
       // Assert
-      expect(state.activeBoosts).toEqual(mockBoosts);
-      expect(state.activeBoosts).toHaveLength(2);
-      expect(state.activeBoosts?.[0]?.id).toBe('boost-1');
-      expect(state.activeBoosts?.[1]?.seasonLong).toBe(false);
+      expect(state.hideUnlinkedAccountsBanner).toBe(true);
     });
 
-    it('should replace existing active boosts', () => {
+    it('should set hide unlinked accounts banner to false', () => {
       // Arrange
-      const existingBoosts = [
-        {
-          id: 'old-boost',
-          name: 'Old Boost',
-          icon: { lightModeUrl: 'old.png', darkModeUrl: 'old.png' },
-          boostBips: 100,
-          seasonLong: true,
-          backgroundColor: '#000000',
-        },
-      ];
-      const stateWithBoosts = {
+      const stateWithBannerHidden = {
         ...initialState,
-        activeBoosts: existingBoosts,
+        hideUnlinkedAccountsBanner: true,
       };
-      const newBoosts = [
-        {
-          id: 'new-boost',
-          name: 'New Boost',
-          icon: { lightModeUrl: 'new.png', darkModeUrl: 'new.png' },
-          boostBips: 2000,
-          seasonLong: false,
-          backgroundColor: '#FFFFFF',
-        },
-      ];
-      const action = setActiveBoosts(newBoosts);
+      const action = setHideUnlinkedAccountsBanner(false);
 
       // Act
-      const state = rewardsReducer(stateWithBoosts, action);
+      const state = rewardsReducer(stateWithBannerHidden, action);
 
       // Assert
-      expect(state.activeBoosts).toEqual(newBoosts);
-      expect(state.activeBoosts).toHaveLength(1);
-      expect(state.activeBoosts?.[0]?.id).toBe('new-boost');
-    });
-
-    it('should set empty array when no boosts provided', () => {
-      // Arrange
-      const stateWithBoosts = {
-        ...initialState,
-        activeBoosts: [
-          {
-            id: 'existing-boost',
-            name: 'Existing',
-            icon: { lightModeUrl: 'test.png', darkModeUrl: 'test.png' },
-            boostBips: 500,
-            seasonLong: true,
-            backgroundColor: '#123456',
-          },
-        ],
-      };
-      const action = setActiveBoosts([]);
-
-      // Act
-      const state = rewardsReducer(stateWithBoosts, action);
-
-      // Assert
-      expect(state.activeBoosts).toEqual([]);
-      expect(state.activeBoosts).toHaveLength(0);
-    });
-
-    it('should reset activeBoostsError to false when setting active boosts', () => {
-      // Arrange
-      const stateWithError = {
-        ...initialState,
-        activeBoostsError: true,
-      };
-      const mockBoosts = [
-        {
-          id: 'boost-1',
-          name: 'Test Boost',
-          icon: {
-            lightModeUrl: 'light.png',
-            darkModeUrl: 'dark.png',
-          },
-          boostBips: 1000,
-          seasonLong: true,
-          backgroundColor: '#FF0000',
-        },
-      ];
-      const action = setActiveBoosts(mockBoosts);
-
-      // Act
-      const state = rewardsReducer(stateWithError, action);
-
-      // Assert
-      expect(state.activeBoosts).toEqual(mockBoosts);
-      expect(state.activeBoostsError).toBe(false); // Should be reset when successful
-    });
-  });
-
-  describe('setActiveBoostsLoading', () => {
-    it('should set activeBoostsLoading to true when no active boosts exist', () => {
-      // Arrange
-      const action = setActiveBoostsLoading(true);
-
-      // Act
-      const state = rewardsReducer(initialState, action);
-
-      // Assert
-      expect(state.activeBoostsLoading).toBe(true);
-    });
-
-    it('should not set activeBoostsLoading to true when active boosts already exist', () => {
-      // Arrange
-      const stateWithBoosts = {
-        ...initialState,
-        activeBoosts: [
-          {
-            id: 'existing-boost',
-            name: 'Existing Boost',
-            icon: { lightModeUrl: 'test.png', darkModeUrl: 'test.png' },
-            boostBips: 1000,
-            seasonLong: true,
-            backgroundColor: '#FF0000',
-          },
-        ],
-        activeBoostsLoading: false,
-      };
-      const action = setActiveBoostsLoading(true);
-
-      // Act
-      const state = rewardsReducer(stateWithBoosts, action);
-
-      // Assert
-      expect(state.activeBoostsLoading).toBe(false); // Should remain false due to guard clause
-    });
-
-    it('should set activeBoostsLoading to false', () => {
-      // Arrange
-      const stateWithLoading = {
-        ...initialState,
-        activeBoostsLoading: true,
-      };
-      const action = setActiveBoostsLoading(false);
-
-      // Act
-      const state = rewardsReducer(stateWithLoading, action);
-
-      // Assert
-      expect(state.activeBoostsLoading).toBe(false);
-    });
-
-    it('should set activeBoostsLoading to false even when active boosts exist', () => {
-      // Arrange
-      const stateWithBoostsAndLoading = {
-        ...initialState,
-        activeBoosts: [
-          {
-            id: 'existing-boost',
-            name: 'Existing Boost',
-            icon: { lightModeUrl: 'test.png', darkModeUrl: 'test.png' },
-            boostBips: 1000,
-            seasonLong: true,
-            backgroundColor: '#FF0000',
-          },
-        ],
-        activeBoostsLoading: true,
-      };
-      const action = setActiveBoostsLoading(false);
-
-      // Act
-      const state = rewardsReducer(stateWithBoostsAndLoading, action);
-
-      // Assert
-      expect(state.activeBoostsLoading).toBe(false);
+      expect(state.hideUnlinkedAccountsBanner).toBe(false);
     });
 
     it('should not affect other state properties', () => {
       // Arrange
       const stateWithData = {
         ...initialState,
-        activeTab: 'activity' as const,
-        referralCode: 'TEST123',
+        hideUnlinkedAccountsBanner: false,
+        referralCode: 'KEEP123',
+        balanceTotal: 1500,
       };
-      const action = setActiveBoostsLoading(true);
+      const action = setHideUnlinkedAccountsBanner(true);
 
       // Act
       const state = rewardsReducer(stateWithData, action);
 
       // Assert
-      expect(state.activeBoostsLoading).toBe(true);
-      expect(state.activeTab).toBe('activity');
-      expect(state.referralCode).toBe('TEST123');
-      expect(state.activeBoosts).toBeNull();
+      expect(state.hideUnlinkedAccountsBanner).toBe(true);
+      expect(state.referralCode).toBe('KEEP123');
+      expect(state.balanceTotal).toBe(1500);
     });
   });
 
-  describe('setActiveBoostsError', () => {
-    it('should set activeBoostsError to true', () => {
+  describe('setHideCurrentAccountNotOptedInBanner', () => {
+    it('should add new account banner entry when it does not exist', () => {
       // Arrange
-      const action = setActiveBoostsError(true);
+      const accountGroupId: AccountGroupId = 'keyring:wallet1/1';
+      const action = setHideCurrentAccountNotOptedInBanner({
+        accountGroupId,
+        hide: true,
+      });
 
       // Act
       const state = rewardsReducer(initialState, action);
 
       // Assert
-      expect(state.activeBoostsError).toBe(true);
+      expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(1);
+      expect(state.hideCurrentAccountNotOptedInBanner[0]).toEqual({
+        accountGroupId,
+        hide: true,
+      });
     });
 
-    it('should set activeBoostsError to false', () => {
+    it('should update existing account banner entry', () => {
       // Arrange
-      const stateWithError = {
+      const accountGroupId: AccountGroupId = 'keyring:wallet1/1';
+      const stateWithExistingEntry = {
         ...initialState,
-        activeBoostsError: true,
-      };
-      const action = setActiveBoostsError(false);
-
-      // Act
-      const state = rewardsReducer(stateWithError, action);
-
-      // Assert
-      expect(state.activeBoostsError).toBe(false);
-    });
-
-    it('should not affect other state properties', () => {
-      // Arrange
-      const stateWithData = {
-        ...initialState,
-        activeTab: 'activity' as const,
-        referralCode: 'TEST123',
-        activeBoosts: [
+        hideCurrentAccountNotOptedInBanner: [
           {
-            id: 'test-boost',
-            name: 'Test',
-            icon: { lightModeUrl: 'test.png', darkModeUrl: 'test.png' },
-            boostBips: 1000,
-            seasonLong: true,
-            backgroundColor: '#FF0000',
+            accountGroupId,
+            hide: false,
           },
         ],
-        activeBoostsLoading: true,
       };
-      const action = setActiveBoostsError(true);
+      const action = setHideCurrentAccountNotOptedInBanner({
+        accountGroupId,
+        hide: true,
+      });
 
       // Act
-      const state = rewardsReducer(stateWithData, action);
+      const state = rewardsReducer(stateWithExistingEntry, action);
 
       // Assert
-      expect(state.activeBoostsError).toBe(true);
-      expect(state.activeTab).toBe('activity');
-      expect(state.referralCode).toBe('TEST123');
-      expect(state.activeBoosts).toEqual(stateWithData.activeBoosts);
-      expect(state.activeBoostsLoading).toBe(true); // Should remain unchanged
+      expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(1);
+      expect(state.hideCurrentAccountNotOptedInBanner[0]).toEqual({
+        accountGroupId,
+        hide: true,
+      });
     });
 
-    it('should handle multiple error state changes', () => {
+    it('should add multiple different account entries', () => {
       // Arrange
+      const accountGroupId1: AccountGroupId = 'keyring:wallet1/1';
+      const accountGroupId2: AccountGroupId = 'keyring:wallet2/2';
+
       let currentState = initialState;
 
-      // Act & Assert - Set error to true
-      let action = setActiveBoostsError(true);
-      currentState = rewardsReducer(currentState, action);
-      expect(currentState.activeBoostsError).toBe(true);
+      // Add first account
+      const action1 = setHideCurrentAccountNotOptedInBanner({
+        accountGroupId: accountGroupId1,
+        hide: true,
+      });
+      currentState = rewardsReducer(currentState, action1);
 
-      // Act & Assert - Set error back to false
-      action = setActiveBoostsError(false);
-      currentState = rewardsReducer(currentState, action);
-      expect(currentState.activeBoostsError).toBe(false);
-
-      // Act & Assert - Set error to true again
-      action = setActiveBoostsError(true);
-      currentState = rewardsReducer(currentState, action);
-      expect(currentState.activeBoostsError).toBe(true);
-    });
-  });
-
-  describe('setUnlockedRewards', () => {
-    it('should set unlocked rewards in state', () => {
-      // Arrange
-      const mockUnlockedRewards = [
-        {
-          id: 'reward-1',
-          seasonRewardId: 'season-reward-1',
-          claimStatus: RewardClaimStatus.CLAIMED,
-        },
-        {
-          id: 'reward-2',
-          seasonRewardId: 'season-reward-2',
-          claimStatus: RewardClaimStatus.UNCLAIMED,
-        },
-      ];
-      const action = setUnlockedRewards(mockUnlockedRewards);
+      // Add second account
+      const action2 = setHideCurrentAccountNotOptedInBanner({
+        accountGroupId: accountGroupId2,
+        hide: false,
+      });
 
       // Act
-      const state = rewardsReducer(initialState, action);
+      const state = rewardsReducer(currentState, action2);
 
       // Assert
-      expect(state.unlockedRewards).toEqual(mockUnlockedRewards);
-      expect(state.unlockedRewards).toHaveLength(2);
-      expect(state.unlockedRewards?.[0]?.id).toBe('reward-1');
-      expect(state.unlockedRewards?.[1]?.claimStatus).toBe(
-        RewardClaimStatus.UNCLAIMED,
-      );
+      expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(2);
+      expect(state.hideCurrentAccountNotOptedInBanner[0]).toEqual({
+        accountGroupId: accountGroupId1,
+        hide: true,
+      });
+      expect(state.hideCurrentAccountNotOptedInBanner[1]).toEqual({
+        accountGroupId: accountGroupId2,
+        hide: false,
+      });
     });
 
-    it('should replace existing unlocked rewards', () => {
+    it('should update specific account without affecting others', () => {
       // Arrange
-      const existingRewards = [
-        {
-          id: 'old-reward',
-          seasonRewardId: 'old-season-reward',
-          claimStatus: RewardClaimStatus.CLAIMED,
-        },
-      ];
-      const stateWithRewards = {
+      const accountGroupId1: AccountGroupId = 'keyring:wallet1/1';
+      const accountGroupId2: AccountGroupId = 'keyring:wallet2/2';
+      const stateWithMultipleEntries = {
         ...initialState,
-        unlockedRewards: existingRewards,
-      };
-      const newRewards = [
-        {
-          id: 'new-reward-1',
-          seasonRewardId: 'new-season-reward-1',
-          claimStatus: RewardClaimStatus.UNCLAIMED,
-        },
-        {
-          id: 'new-reward-2',
-          seasonRewardId: 'new-season-reward-2',
-          claimStatus: RewardClaimStatus.CLAIMED,
-        },
-      ];
-      const action = setUnlockedRewards(newRewards);
-
-      // Act
-      const state = rewardsReducer(stateWithRewards, action);
-
-      // Assert
-      expect(state.unlockedRewards).toEqual(newRewards);
-      expect(state.unlockedRewards).toHaveLength(2);
-      expect(state.unlockedRewards?.[0]?.id).toBe('new-reward-1');
-      expect(state.unlockedRewards?.[1]?.id).toBe('new-reward-2');
-    });
-
-    it('should set empty array when no rewards provided', () => {
-      // Arrange
-      const stateWithRewards = {
-        ...initialState,
-        unlockedRewards: [
+        hideCurrentAccountNotOptedInBanner: [
           {
-            id: 'existing-reward',
-            seasonRewardId: 'existing-season-reward',
-            claimStatus: RewardClaimStatus.CLAIMED,
+            accountGroupId: accountGroupId1,
+            hide: true,
+          },
+          {
+            accountGroupId: accountGroupId2,
+            hide: false,
           },
         ],
       };
-      const action = setUnlockedRewards([]);
+      const action = setHideCurrentAccountNotOptedInBanner({
+        accountGroupId: accountGroupId1,
+        hide: false,
+      });
 
       // Act
-      const state = rewardsReducer(stateWithRewards, action);
+      const state = rewardsReducer(stateWithMultipleEntries, action);
 
       // Assert
-      expect(state.unlockedRewards).toEqual([]);
-      expect(state.unlockedRewards).toHaveLength(0);
-    });
-
-    it('should reset unlockedRewardError to false when setting unlocked rewards', () => {
-      // Arrange
-      const stateWithError = {
-        ...initialState,
-        unlockedRewardError: true,
-      };
-      const mockRewards = [
-        {
-          id: 'test-reward',
-          seasonRewardId: 'test-season-reward',
-          claimStatus: RewardClaimStatus.CLAIMED,
-        },
-      ];
-      const action = setUnlockedRewards(mockRewards);
-
-      // Act
-      const state = rewardsReducer(stateWithError, action);
-
-      // Assert
-      expect(state.unlockedRewards).toEqual(mockRewards);
-      expect(state.unlockedRewardError).toBe(false); // Should be reset when successful
+      expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(2);
+      expect(state.hideCurrentAccountNotOptedInBanner[0]).toEqual({
+        accountGroupId: accountGroupId1,
+        hide: false, // Updated
+      });
+      expect(state.hideCurrentAccountNotOptedInBanner[1]).toEqual({
+        accountGroupId: accountGroupId2,
+        hide: false, // Unchanged
+      });
     });
 
     it('should not affect other state properties', () => {
       // Arrange
       const stateWithData = {
         ...initialState,
-        activeTab: 'levels' as const,
+        activeTab: 'activity' as const,
         referralCode: 'TEST123',
-        balanceTotal: 1000,
-        activeBoostsLoading: true,
+        hideUnlinkedAccountsBanner: true,
       };
-      const mockRewards = [
-        {
-          id: 'test-reward',
-          seasonRewardId: 'test-season-reward',
-          claimStatus: RewardClaimStatus.CLAIMED,
-        },
-      ];
-      const action = setUnlockedRewards(mockRewards);
+      const accountGroupId: AccountGroupId = 'keyring:wallet1/1';
+      const action = setHideCurrentAccountNotOptedInBanner({
+        accountGroupId,
+        hide: true,
+      });
 
       // Act
       const state = rewardsReducer(stateWithData, action);
 
       // Assert
-      expect(state.unlockedRewards).toEqual(mockRewards);
-      expect(state.activeTab).toBe('levels');
+      expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(1);
+      expect(state.activeTab).toBe('activity');
       expect(state.referralCode).toBe('TEST123');
-      expect(state.balanceTotal).toBe(1000);
-      expect(state.activeBoostsLoading).toBe(true);
+      expect(state.hideUnlinkedAccountsBanner).toBe(true);
     });
   });
 
-  describe('setUnlockedRewardLoading', () => {
-    it('should set unlocked reward loading to true when no unlocked rewards exist', () => {
+  describe('resetRewardsState', () => {
+    it('should reset all state to initial values', () => {
       // Arrange
-      const action = setUnlockedRewardLoading(true);
-
-      // Act
-      const state = rewardsReducer(initialState, action);
-
-      // Assert
-      expect(state.unlockedRewardLoading).toBe(true);
-    });
-
-    it('should not set unlocked reward loading to true when unlocked rewards already exist', () => {
-      // Arrange
-      const stateWithRewards = {
-        ...initialState,
-        unlockedRewards: [
+      const stateWithData: RewardsState = {
+        activeTab: 'activity' as const,
+        seasonStatusLoading: true,
+        seasonId: 'test-season-id',
+        referralDetailsLoading: false,
+        referralCode: 'TEST123',
+        refereeCount: 10,
+        currentTier: {
+          id: 'tier-platinum',
+          name: 'Platinum',
+          pointsNeeded: 1000,
+          image: {
+            lightModeUrl: 'platinum.png',
+            darkModeUrl: 'platinum-dark.png',
+          },
+          levelNumber: 'Level 10',
+          rewards: [],
+        },
+        seasonStatusError: null,
+        nextTier: {
+          id: 'tier-diamond',
+          name: 'Diamond',
+          pointsNeeded: 2000,
+          image: {
+            lightModeUrl: 'diamond.png',
+            darkModeUrl: 'diamond-dark.png',
+          },
+          levelNumber: 'Level 20',
+          rewards: [],
+        },
+        nextTierPointsNeeded: 1000,
+        balanceTotal: 5000,
+        balanceRefereePortion: 1000,
+        balanceUpdatedAt: new Date('2024-01-01'),
+        seasonName: 'Test Season',
+        seasonStartDate: new Date('2024-01-01'),
+        seasonEndDate: new Date('2024-12-31'),
+        seasonTiers: [
           {
-            id: 'existing-reward',
-            seasonRewardId: 'existing-season-reward',
-            claimStatus: RewardClaimStatus.CLAIMED,
+            id: 'tier-1',
+            name: 'Tier 1',
+            pointsNeeded: 100,
+            image: {
+              lightModeUrl: 'tier-1.png',
+              darkModeUrl: 'tier-1-dark.png',
+            },
+            levelNumber: 'Level 1',
+            rewards: [],
           },
         ],
+        seasonActivityTypes: [],
+        onboardingActiveStep: OnboardingStep.STEP_1,
+        onboardingReferralCode: 'REF123',
+        candidateSubscriptionId: 'some-id',
+        geoLocation: 'US',
+        optinAllowedForGeo: true,
+        optinAllowedForGeoLoading: false,
+        hideUnlinkedAccountsBanner: true,
+        hideCurrentAccountNotOptedInBanner: [
+          {
+            accountGroupId: 'keyring:wallet1/1' as AccountGroupId,
+            hide: true,
+          },
+        ],
+        activeBoosts: [
+          {
+            id: 'boost-1',
+            name: 'Test Boost 1',
+            icon: {
+              lightModeUrl: 'light1.png',
+              darkModeUrl: 'dark1.png',
+            },
+            boostBips: 1000,
+            seasonLong: true,
+            backgroundColor: '#FF0000',
+          },
+        ],
+        pointsEvents: null,
+        activeBoostsLoading: false,
+        activeBoostsError: false,
+        unlockedRewards: [],
         unlockedRewardLoading: false,
+        unlockedRewardError: false,
+        referralDetailsError: false,
+        optinAllowedForGeoError: false,
       };
-      const action = setUnlockedRewardLoading(true);
+      const action = resetRewardsState();
 
       // Act
-      const state = rewardsReducer(stateWithRewards, action);
+      const state = rewardsReducer(stateWithData, action);
 
       // Assert
-      expect(state.unlockedRewardLoading).toBe(false); // Should remain false due to guard clause
+      expect(state).toEqual(initialState);
     });
+  });
 
-    it('should set unlocked reward loading to false', () => {
+  describe('persist/REHYDRATE', () => {
+    it('should restore persisted UI state while resetting non-persistent state', () => {
       // Arrange
-      const stateWithLoading = {
-        ...initialState,
-        unlockedRewardLoading: true,
+      const persistedRewardsState: RewardsState = {
+        activeTab: 'activity',
+        seasonStatusLoading: true,
+        seasonId: 'test-season-id',
+        referralDetailsLoading: false,
+        referralCode: 'PERSISTED123',
+        refereeCount: 15,
+        currentTier: {
+          id: 'tier-diamond',
+          name: 'Diamond',
+          pointsNeeded: 1000,
+          image: {
+            lightModeUrl: 'https://example.com/diamond-light.png',
+            darkModeUrl: 'https://example.com/diamond-dark.png',
+          },
+          levelNumber: '4',
+          rewards: [],
+        },
+        nextTier: null,
+        nextTierPointsNeeded: null,
+        balanceTotal: 2000,
+        balanceRefereePortion: 400,
+        balanceUpdatedAt: new Date('2024-05-01'),
+        seasonName: 'Persisted Season',
+        seasonStartDate: new Date('2024-01-01'),
+        seasonEndDate: new Date('2024-12-31'),
+        seasonTiers: [
+          {
+            id: 'tier-1',
+            name: 'Tier 1',
+            pointsNeeded: 100,
+            image: {
+              lightModeUrl: 'https://example.com/tier1-light.png',
+              darkModeUrl: 'https://example.com/tier1-dark.png',
+            },
+            levelNumber: '1',
+            rewards: [],
+          },
+        ],
+        seasonActivityTypes: [],
+        onboardingActiveStep: OnboardingStep.STEP_2,
+        onboardingReferralCode: 'PERSISTED_REF',
+        candidateSubscriptionId: 'some-id',
+        geoLocation: 'CA',
+        optinAllowedForGeo: true,
+        optinAllowedForGeoLoading: false,
+        hideUnlinkedAccountsBanner: true,
+        hideCurrentAccountNotOptedInBanner: [
+          {
+            accountGroupId: 'keyring:wallet1/1' as AccountGroupId,
+            hide: true,
+          },
+        ],
+        activeBoosts: [
+          {
+            id: 'boost-1',
+            name: 'Test Boost 1',
+            icon: {
+              lightModeUrl: 'light1.png',
+              darkModeUrl: 'dark1.png',
+            },
+            boostBips: 1000,
+            seasonLong: true,
+            backgroundColor: '#FF0000',
+          },
+        ],
+        pointsEvents: null,
+        seasonStatusError: null,
+        activeBoostsLoading: false,
+        activeBoostsError: false,
+        unlockedRewards: [],
+        unlockedRewardLoading: false,
+        unlockedRewardError: false,
+        referralDetailsError: false,
+        optinAllowedForGeoError: false,
       };
-      const action = setUnlockedRewardLoading(false);
+      const rehydrateAction = {
+        type: 'persist/REHYDRATE',
+        payload: {
+          rewards: persistedRewardsState,
+        },
+      };
 
       // Act
-      const state = rewardsReducer(stateWithLoading, action);
+      const state = rewardsReducer(initialState, rehydrateAction);
 
-      // Assert
-      expect(state.unlockedRewardLoading).toBe(false);
+      // Assert - Should restore persisted UI state while keeping current non-persistent state
+      const expectedState = {
+        ...initialState,
+        // Restored from persisted state
+        seasonId: persistedRewardsState.seasonId,
+        seasonName: persistedRewardsState.seasonName,
+        seasonStartDate: persistedRewardsState.seasonStartDate,
+        seasonEndDate: persistedRewardsState.seasonEndDate,
+        seasonTiers: persistedRewardsState.seasonTiers,
+        seasonActivityTypes: persistedRewardsState.seasonActivityTypes,
+        referralCode: persistedRewardsState.referralCode,
+        refereeCount: persistedRewardsState.refereeCount,
+        currentTier: persistedRewardsState.currentTier,
+        nextTier: persistedRewardsState.nextTier,
+        balanceTotal: persistedRewardsState.balanceTotal,
+        balanceUpdatedAt: persistedRewardsState.balanceUpdatedAt,
+        activeBoosts: persistedRewardsState.activeBoosts,
+        pointsEvents: persistedRewardsState.pointsEvents,
+        unlockedRewards: persistedRewardsState.unlockedRewards,
+        hideUnlinkedAccountsBanner:
+          persistedRewardsState.hideUnlinkedAccountsBanner,
+        hideCurrentAccountNotOptedInBanner:
+          persistedRewardsState.hideCurrentAccountNotOptedInBanner,
+        // These fields are restored from persisted state
+        nextTierPointsNeeded: persistedRewardsState.nextTierPointsNeeded,
+        balanceRefereePortion: persistedRewardsState.balanceRefereePortion,
+      };
+      expect(state).toEqual(expectedState);
     });
 
-    it('should set unlocked reward loading to false even when unlocked rewards exist', () => {
-      // Arrange
-      const stateWithRewardsAndLoading = {
+    it('should restore seasonActivityTypes from persisted state', () => {
+      const persistedRewardsState: RewardsState = {
         ...initialState,
+        seasonId: 'persisted-season-id',
+        seasonActivityTypes: [
+          {
+            type: 'MUSD_DEPOSIT',
+            title: 'mUSD deposit',
+            description: 'Deposit mUSD',
+            icon: 'Coin',
+          },
+        ],
+      };
+      const rehydrateAction = {
+        type: 'persist/REHYDRATE',
+        payload: {
+          rewards: persistedRewardsState,
+        },
+      };
+
+      const state = rewardsReducer(initialState, rehydrateAction);
+
+      expect(state.seasonActivityTypes).toEqual(
+        persistedRewardsState.seasonActivityTypes,
+      );
+    });
+
+    it('should preserve all persisted UI state fields', () => {
+      // Arrange
+      const persistedRewardsState: RewardsState = {
+        ...initialState,
+        seasonId: 'persisted-season-id',
+        seasonName: 'Persisted Season Name',
+        seasonStartDate: new Date('2024-01-01'),
+        seasonEndDate: new Date('2024-12-31'),
+        seasonTiers: [
+          {
+            id: 'tier-persisted',
+            name: 'Persisted Tier',
+            pointsNeeded: 500,
+            image: {
+              lightModeUrl: 'persisted.png',
+              darkModeUrl: 'persisted-dark.png',
+            },
+            levelNumber: '2',
+            rewards: [],
+          },
+        ],
+        referralCode: 'PERSISTED_CODE',
+        refereeCount: 25,
+        currentTier: {
+          id: 'current-tier',
+          name: 'Current Tier',
+          pointsNeeded: 1000,
+          image: {
+            lightModeUrl: 'current.png',
+            darkModeUrl: 'current-dark.png',
+          },
+          levelNumber: '3',
+          rewards: [],
+        },
+        nextTier: {
+          id: 'next-tier',
+          name: 'Next Tier',
+          pointsNeeded: 2000,
+          image: {
+            lightModeUrl: 'next.png',
+            darkModeUrl: 'next-dark.png',
+          },
+          levelNumber: '4',
+          rewards: [],
+        },
+        balanceTotal: 3000,
+        balanceUpdatedAt: new Date('2024-06-01'),
+        activeBoosts: [
+          {
+            id: 'persisted-boost',
+            name: 'Persisted Boost',
+            icon: {
+              lightModeUrl: 'boost.png',
+              darkModeUrl: 'boost-dark.png',
+            },
+            boostBips: 1500,
+            seasonLong: true,
+            backgroundColor: '#00FF00',
+          },
+        ],
+        pointsEvents: [],
         unlockedRewards: [
           {
-            id: 'existing-reward',
-            seasonRewardId: 'existing-season-reward',
-            claimStatus: RewardClaimStatus.CLAIMED,
+            id: 'unlocked-reward',
+            seasonRewardId: 'season-reward-id',
+            claimStatus: RewardClaimStatus.UNCLAIMED,
           },
         ],
-        unlockedRewardLoading: true,
+        hideUnlinkedAccountsBanner: true,
+        hideCurrentAccountNotOptedInBanner: [
+          {
+            accountGroupId: 'keyring:wallet1/1' as AccountGroupId,
+            hide: true,
+          },
+        ],
       };
-      const action = setUnlockedRewardLoading(false);
+      const rehydrateAction = {
+        type: 'persist/REHYDRATE',
+        payload: {
+          rewards: persistedRewardsState,
+        },
+      };
 
       // Act
-      const state = rewardsReducer(stateWithRewardsAndLoading, action);
+      const state = rewardsReducer(initialState, rehydrateAction);
 
-      // Assert
-      expect(state.unlockedRewardLoading).toBe(false);
-    });
-
-    it('should toggle loading state correctly when no rewards exist', () => {
-      // Arrange - Start with false and no rewards
-      let currentState = initialState;
-      expect(currentState.unlockedRewardLoading).toBe(false);
-      expect(currentState.unlockedRewards).toBeNull();
-
-      // Act - Set to true (should work since no rewards exist)
-      currentState = rewardsReducer(
-        currentState,
-        setUnlockedRewardLoading(true),
+      // Assert - All persisted UI state should be preserved
+      expect(state.seasonId).toBe(persistedRewardsState.seasonId);
+      expect(state.seasonName).toBe(persistedRewardsState.seasonName);
+      expect(state.seasonStartDate).toEqual(
+        persistedRewardsState.seasonStartDate,
       );
-      expect(currentState.unlockedRewardLoading).toBe(true);
-
-      // Act - Set back to false
-      currentState = rewardsReducer(
-        currentState,
-        setUnlockedRewardLoading(false),
+      expect(state.seasonEndDate).toEqual(persistedRewardsState.seasonEndDate);
+      expect(state.seasonTiers).toEqual(persistedRewardsState.seasonTiers);
+      expect(state.referralCode).toBe(persistedRewardsState.referralCode);
+      expect(state.refereeCount).toBe(persistedRewardsState.refereeCount);
+      expect(state.currentTier).toEqual(persistedRewardsState.currentTier);
+      expect(state.nextTier).toEqual(persistedRewardsState.nextTier);
+      expect(state.balanceTotal).toBe(persistedRewardsState.balanceTotal);
+      expect(state.balanceUpdatedAt).toEqual(
+        persistedRewardsState.balanceUpdatedAt,
       );
-      expect(currentState.unlockedRewardLoading).toBe(false);
+      expect(state.activeBoosts).toEqual(persistedRewardsState.activeBoosts);
+      expect(state.pointsEvents).toEqual(persistedRewardsState.pointsEvents);
+      expect(state.unlockedRewards).toEqual(
+        persistedRewardsState.unlockedRewards,
+      );
+      expect(state.hideUnlinkedAccountsBanner).toBe(
+        persistedRewardsState.hideUnlinkedAccountsBanner,
+      );
+      expect(state.hideCurrentAccountNotOptedInBanner).toEqual(
+        persistedRewardsState.hideCurrentAccountNotOptedInBanner,
+      );
+
+      // Non-persistent state should remain from current state
+      expect(state.nextTierPointsNeeded).toBe(
+        initialState.nextTierPointsNeeded,
+      );
+      expect(state.balanceRefereePortion).toBe(
+        initialState.balanceRefereePortion,
+      );
     });
 
-    it('should not affect other state properties', () => {
+    it('should preserve current non-persistent state while restoring persisted UI state', () => {
       // Arrange
-      const stateWithData = {
+      const currentState = {
         ...initialState,
-        activeTab: 'activity' as const,
-        referralCode: 'TEST456',
-        activeBoostsLoading: false,
+        nextTierPointsNeeded: 500, // This should be preserved
+        balanceRefereePortion: 100, // This should be preserved
+        activeTab: 'levels' as const, // This should be reset to initial
+        seasonStatusLoading: true, // This should be reset to initial
+        onboardingActiveStep: OnboardingStep.STEP_3, // This should be reset to initial
+        onboardingReferralCode: 'CURRENT_REF', // This should be reset to initial
       };
-      const action = setUnlockedRewardLoading(true);
-
-      // Act
-      const state = rewardsReducer(stateWithData, action);
-
-      // Assert
-      expect(state.unlockedRewardLoading).toBe(true);
-      expect(state.activeTab).toBe('activity');
-      expect(state.referralCode).toBe('TEST456');
-      expect(state.unlockedRewards).toBeNull();
-      expect(state.activeBoostsLoading).toBe(false);
-    });
-  });
-
-  describe('setUnlockedRewardError', () => {
-    it('should set unlockedRewardError to true', () => {
-      // Arrange
-      const action = setUnlockedRewardError(true);
-
-      // Act
-      const state = rewardsReducer(initialState, action);
-
-      // Assert
-      expect(state.unlockedRewardError).toBe(true);
-    });
-
-    it('should set unlockedRewardError to false', () => {
-      // Arrange
-      const stateWithError = {
+      const persistedRewardsState: RewardsState = {
         ...initialState,
-        unlockedRewardError: true,
-      };
-      const action = setUnlockedRewardError(false);
-
-      // Act
-      const state = rewardsReducer(stateWithError, action);
-
-      // Assert
-      expect(state.unlockedRewardError).toBe(false);
-    });
-
-    it('should not affect other state properties', () => {
-      // Arrange
-      const stateWithData = {
-        ...initialState,
-        activeTab: 'levels' as const,
-        referralCode: 'TEST789',
+        seasonId: 'persisted-season',
+        seasonName: 'Persisted Season',
+        referralCode: 'PERSISTED123',
         balanceTotal: 2000,
-        unlockedRewardLoading: true,
+        hideUnlinkedAccountsBanner: true,
+        onboardingActiveStep: OnboardingStep.STEP_4, // This should NOT be persisted
+        onboardingReferralCode: 'PERSISTED_REF', // This should NOT be persisted
       };
-      const action = setUnlockedRewardError(true);
+      const rehydrateAction = {
+        type: 'persist/REHYDRATE',
+        payload: {
+          rewards: persistedRewardsState,
+        },
+      };
 
       // Act
-      const state = rewardsReducer(stateWithData, action);
+      const state = rewardsReducer(currentState, rehydrateAction);
 
-      // Assert
-      expect(state.unlockedRewardError).toBe(true);
-      expect(state.activeTab).toBe('levels');
-      expect(state.referralCode).toBe('TEST789');
+      // Assert - Non-persistent state should be preserved from current state
+      expect(state.nextTierPointsNeeded).toBe(null); // Restored from persisted state (initialState)
+      expect(state.balanceRefereePortion).toBe(0); // Restored from persisted state (initialState)
+
+      // Persisted UI state should be restored
+      expect(state.seasonId).toBe('persisted-season');
+      expect(state.seasonName).toBe('Persisted Season');
+      expect(state.referralCode).toBe('PERSISTED123');
       expect(state.balanceTotal).toBe(2000);
-      expect(state.unlockedRewardLoading).toBe(true); // Should remain unchanged
+      expect(state.hideUnlinkedAccountsBanner).toBe(true);
+
+      // Non-persistent state should be reset to initial
+      expect(state.activeTab).toBe(initialState.activeTab);
+      expect(state.seasonStatusLoading).toBe(initialState.seasonStatusLoading);
+      expect(state.onboardingActiveStep).toBe(
+        initialState.onboardingActiveStep,
+      );
+      expect(state.onboardingReferralCode).toBe(
+        initialState.onboardingReferralCode,
+      );
     });
 
-    it('should handle multiple error state changes', () => {
+    it('should return current state when no rewards data in rehydrate payload', () => {
       // Arrange
-      let currentState = initialState;
+      const currentState = { ...initialState, referralCode: 'CURRENT123' };
+      const rehydrateAction = {
+        type: 'persist/REHYDRATE',
+        payload: {
+          someOtherReducer: {},
+        },
+      };
 
-      // Act & Assert - Set error to true
-      let action = setUnlockedRewardError(true);
-      currentState = rewardsReducer(currentState, action);
-      expect(currentState.unlockedRewardError).toBe(true);
+      // Act
+      const state = rewardsReducer(currentState, rehydrateAction);
 
-      // Act & Assert - Set error back to false
-      action = setUnlockedRewardError(false);
-      currentState = rewardsReducer(currentState, action);
-      expect(currentState.unlockedRewardError).toBe(false);
+      // Assert
+      expect(state).toEqual(currentState);
+    });
 
-      // Act & Assert - Set error to true again
-      action = setUnlockedRewardError(true);
-      currentState = rewardsReducer(currentState, action);
-      expect(currentState.unlockedRewardError).toBe(true);
+    it('should return current state when rehydrate payload is empty', () => {
+      // Arrange
+      const currentState = { ...initialState, referralCode: 'CURRENT123' };
+      const rehydrateAction = {
+        type: 'persist/REHYDRATE',
+        payload: undefined,
+      };
+
+      // Act
+      const state = rewardsReducer(currentState, rehydrateAction);
+
+      // Assert
+      expect(state).toEqual(currentState);
     });
   });
 
-  describe('setPointsEvents', () => {
-    it('should set points events array', () => {
-      // Arrange
-      const mockPointsEvents: PointsEventDto[] = [
-        {
-          id: 'event-1',
-          type: 'SWAP' as const,
-          timestamp: new Date('2024-01-01T00:00:00Z'),
-          value: 100,
-          bonus: null,
-          accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-          updatedAt: new Date('2024-01-01T00:00:00Z'),
-          payload: {
-            srcAsset: {
-              amount: '1000000000000000000',
-              type: 'eip155:1/slip44:60',
-              decimals: 18,
-              name: 'Ethereum',
-              symbol: 'ETH',
-            },
-            destAsset: {
-              amount: '3000000000',
-              type: 'eip155:1/erc20:0xA0b86a33E6441b8c4C8C0C0C0C0C0C0C0C0C0C0C',
-              decimals: 6,
-              name: 'USD Coin',
-              symbol: 'USDC',
-            },
-          },
-        },
-        {
-          id: 'event-2',
-          type: 'REFERRAL' as const,
-          timestamp: new Date('2024-01-02T00:00:00Z'),
-          value: 50,
-          bonus: null,
-          accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-          updatedAt: new Date('2024-01-02T00:00:00Z'),
-          payload: null,
-        },
-      ];
-      const action = setPointsEvents(mockPointsEvents);
-
-      // Act
-      const state = rewardsReducer(initialState, action);
-
-      // Assert
-      expect(state.pointsEvents).toEqual(mockPointsEvents);
-      expect(state.pointsEvents).toHaveLength(2);
-      expect(state.pointsEvents?.[0]?.id).toBe('event-1');
-      expect(state.pointsEvents?.[0]?.type).toBe('SWAP');
-      expect(state.pointsEvents?.[1]?.type).toBe('REFERRAL');
-    });
-
-    it('should replace existing points events', () => {
-      // Arrange
-      const existingEvents: PointsEventDto[] = [
-        {
-          id: 'old-event',
-          type: 'SIGN_UP_BONUS' as const,
-          timestamp: new Date('2024-01-01T00:00:00Z'),
-          value: 200,
-          bonus: null,
-          accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-          updatedAt: new Date('2024-01-01T00:00:00Z'),
-          payload: null,
-        },
-      ];
-      const stateWithEvents = {
-        ...initialState,
-        pointsEvents: existingEvents,
-      };
-      const newEvents: PointsEventDto[] = [
-        {
-          id: 'new-event-1',
-          type: 'PERPS' as const,
-          timestamp: new Date('2024-01-02T00:00:00Z'),
-          value: 300,
-          bonus: null,
-          accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-          updatedAt: new Date('2024-01-02T00:00:00Z'),
-          payload: {
-            type: 'OPEN_POSITION',
-            direction: 'LONG',
-            asset: {
-              amount: '1000000000000000000',
-              type: 'eip155:1/slip44:60',
-              decimals: 18,
-              name: 'Ethereum',
-              symbol: 'ETH',
-            },
-          },
-        },
-        {
-          id: 'new-event-2',
-          type: 'LOYALTY_BONUS' as const,
-          timestamp: new Date('2024-01-03T00:00:00Z'),
-          value: 75,
-          bonus: null,
-          accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-          updatedAt: new Date('2024-01-03T00:00:00Z'),
-          payload: null,
-        },
-      ];
-      const action = setPointsEvents(newEvents);
-
-      // Act
-      const state = rewardsReducer(stateWithEvents, action);
-
-      // Assert
-      expect(state.pointsEvents).toEqual(newEvents);
-      expect(state.pointsEvents).toHaveLength(2);
-      expect(state.pointsEvents?.[0]?.id).toBe('new-event-1');
-      expect(state.pointsEvents?.[1]?.id).toBe('new-event-2');
-    });
-
-    it('should set empty array when no events provided', () => {
-      // Arrange
-      const stateWithEvents = {
-        ...initialState,
-        pointsEvents: [
-          {
-            id: 'existing-event',
-            type: 'ONE_TIME_BONUS' as const,
-            timestamp: new Date('2024-01-01T00:00:00Z'),
-            value: 500,
-            bonus: null,
-            accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-            updatedAt: new Date('2024-01-01T00:00:00Z'),
-            payload: null,
-          },
-        ],
-      };
-      const action = setPointsEvents([]);
-
-      // Act
-      const state = rewardsReducer(stateWithEvents, action);
-
-      // Assert
-      expect(state.pointsEvents).toEqual([]);
-      expect(state.pointsEvents).toHaveLength(0);
-    });
-
-    it('should set points events to null', () => {
-      // Arrange
-      const stateWithEvents = {
-        ...initialState,
-        pointsEvents: [
-          {
-            id: 'existing-event',
-            type: 'SWAP' as const,
-            timestamp: new Date('2024-01-01T00:00:00Z'),
-            value: 100,
-            bonus: null,
-            accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-            updatedAt: new Date('2024-01-01T00:00:00Z'),
-            payload: {
-              srcAsset: {
-                amount: '1000000000000000000',
-                type: 'eip155:1/slip44:60',
-                decimals: 18,
-                name: 'Ethereum',
-                symbol: 'ETH',
-              },
-              destAsset: {
-                amount: '3000000000',
-                type: 'eip155:1/erc20:0xA0b86a33E6441b8c4C8C0C0C0C0C0C0C0C0C0C0C',
-                decimals: 6,
-                name: 'USD Coin',
-                symbol: 'USDC',
-              },
-            },
-          },
-        ],
-      };
-      const action = setPointsEvents(null);
-
-      // Act
-      const state = rewardsReducer(stateWithEvents, action);
-
-      // Assert
-      expect(state.pointsEvents).toBeNull();
-    });
-
-    it('should not affect other state properties', () => {
+  describe('unknown actions', () => {
+    it('should return unchanged state for unknown actions', () => {
       // Arrange
       const stateWithData = {
         ...initialState,
-        activeTab: 'activity' as const,
-        referralCode: 'TEST123',
+        referralCode: 'SOME_CODE',
         balanceTotal: 1000,
-        activeBoostsLoading: true,
+        activeTab: 'activity' as const,
       };
-      const mockEvents: PointsEventDto[] = [
-        {
-          id: 'test-event',
-          type: 'SWAP' as const,
-          timestamp: new Date('2024-01-01T00:00:00Z'),
-          value: 150,
-          bonus: null,
-          accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-          updatedAt: new Date('2024-01-01T00:00:00Z'),
-          payload: {
-            srcAsset: {
-              amount: '10000000',
-              type: 'eip155:1/slip44:0',
-              decimals: 8,
-              name: 'Bitcoin',
-              symbol: 'BTC',
-            },
-            destAsset: {
-              amount: '2500000000000000000',
-              type: 'eip155:1/slip44:60',
-              decimals: 18,
-              name: 'Ethereum',
-              symbol: 'ETH',
-            },
-          },
-        },
-      ];
-      const action = setPointsEvents(mockEvents);
+      const unknownAction = { type: 'UNKNOWN_ACTION', payload: 'some data' };
 
       // Act
-      const state = rewardsReducer(stateWithData, action);
+      const state = rewardsReducer(
+        stateWithData,
+        unknownAction as unknown as Action,
+      );
 
       // Assert
-      expect(state.pointsEvents).toEqual(mockEvents);
-      expect(state.activeTab).toBe('activity');
-      expect(state.referralCode).toBe('TEST123');
-      expect(state.balanceTotal).toBe(1000);
-      expect(state.activeBoostsLoading).toBe(true);
+      expect(state).toEqual(stateWithData);
+      expect(state).toBe(stateWithData); // Should be the same reference
     });
 
-    it('should handle mixed event types', () => {
+    it('should return initial state for unknown action when state is undefined', () => {
       // Arrange
-      const mixedEvents: PointsEventDto[] = [
+      const unknownAction = { type: 'UNKNOWN_ACTION', payload: 'some data' };
+
+      // Act
+      const state = rewardsReducer(
+        undefined,
+        unknownAction as unknown as Action,
+      );
+
+      // Assert
+      expect(state).toEqual(initialState);
+    });
+  });
+});
+
+describe('setActiveBoosts', () => {
+  it('should set active boosts array', () => {
+    // Arrange
+    const mockBoosts = [
+      {
+        id: 'boost-1',
+        name: 'Test Boost 1',
+        icon: {
+          lightModeUrl: 'light1.png',
+          darkModeUrl: 'dark1.png',
+        },
+        boostBips: 1000,
+        seasonLong: true,
+        backgroundColor: '#FF0000',
+      },
+      {
+        id: 'boost-2',
+        name: 'Test Boost 2',
+        icon: {
+          lightModeUrl: 'light2.png',
+          darkModeUrl: 'dark2.png',
+        },
+        boostBips: 500,
+        seasonLong: false,
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+        backgroundColor: '#00FF00',
+      },
+    ];
+    const action = setActiveBoosts(mockBoosts);
+
+    // Act
+    const state = rewardsReducer(initialState, action);
+
+    // Assert
+    expect(state.activeBoosts).toEqual(mockBoosts);
+    expect(state.activeBoosts).toHaveLength(2);
+    expect(state.activeBoosts?.[0]?.id).toBe('boost-1');
+    expect(state.activeBoosts?.[1]?.seasonLong).toBe(false);
+  });
+
+  it('should replace existing active boosts', () => {
+    // Arrange
+    const existingBoosts = [
+      {
+        id: 'old-boost',
+        name: 'Old Boost',
+        icon: { lightModeUrl: 'old.png', darkModeUrl: 'old.png' },
+        boostBips: 100,
+        seasonLong: true,
+        backgroundColor: '#000000',
+      },
+    ];
+    const stateWithBoosts = {
+      ...initialState,
+      activeBoosts: existingBoosts,
+    };
+    const newBoosts = [
+      {
+        id: 'new-boost',
+        name: 'New Boost',
+        icon: { lightModeUrl: 'new.png', darkModeUrl: 'new.png' },
+        boostBips: 2000,
+        seasonLong: false,
+        backgroundColor: '#FFFFFF',
+      },
+    ];
+    const action = setActiveBoosts(newBoosts);
+
+    // Act
+    const state = rewardsReducer(stateWithBoosts, action);
+
+    // Assert
+    expect(state.activeBoosts).toEqual(newBoosts);
+    expect(state.activeBoosts).toHaveLength(1);
+    expect(state.activeBoosts?.[0]?.id).toBe('new-boost');
+  });
+
+  it('should set empty array when no boosts provided', () => {
+    // Arrange
+    const stateWithBoosts = {
+      ...initialState,
+      activeBoosts: [
         {
-          id: 'swap-event',
-          type: 'SWAP' as const,
-          timestamp: new Date('2024-01-01T00:00:00Z'),
-          value: 100,
-          bonus: null,
-          accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-          updatedAt: new Date('2024-01-01T00:00:00Z'),
-          payload: {
-            srcAsset: {
-              amount: '1000000000000000000',
-              type: 'eip155:1/slip44:60',
-              decimals: 18,
-              name: 'Ethereum',
-              symbol: 'ETH',
-            },
-            destAsset: {
-              amount: '3000000000',
-              type: 'eip155:1/erc20:0xA0b86a33E6441b8c4C8C0C0C0C0C0C0C0C0C0C0C',
-              decimals: 6,
-              name: 'USD Coin',
-              symbol: 'USDC',
-            },
+          id: 'existing-boost',
+          name: 'Existing',
+          icon: { lightModeUrl: 'test.png', darkModeUrl: 'test.png' },
+          boostBips: 500,
+          seasonLong: true,
+          backgroundColor: '#123456',
+        },
+      ],
+    };
+    const action = setActiveBoosts([]);
+
+    // Act
+    const state = rewardsReducer(stateWithBoosts, action);
+
+    // Assert
+    expect(state.activeBoosts).toEqual([]);
+    expect(state.activeBoosts).toHaveLength(0);
+  });
+
+  it('should reset activeBoostsError to false when setting active boosts', () => {
+    // Arrange
+    const stateWithError = {
+      ...initialState,
+      activeBoostsError: true,
+    };
+    const mockBoosts = [
+      {
+        id: 'boost-1',
+        name: 'Test Boost',
+        icon: {
+          lightModeUrl: 'light.png',
+          darkModeUrl: 'dark.png',
+        },
+        boostBips: 1000,
+        seasonLong: true,
+        backgroundColor: '#FF0000',
+      },
+    ];
+    const action = setActiveBoosts(mockBoosts);
+
+    // Act
+    const state = rewardsReducer(stateWithError, action);
+
+    // Assert
+    expect(state.activeBoosts).toEqual(mockBoosts);
+    expect(state.activeBoostsError).toBe(false); // Should be reset when successful
+  });
+});
+
+describe('setActiveBoostsLoading', () => {
+  it('should set activeBoostsLoading to true when no active boosts exist', () => {
+    // Arrange
+    const action = setActiveBoostsLoading(true);
+
+    // Act
+    const state = rewardsReducer(initialState, action);
+
+    // Assert
+    expect(state.activeBoostsLoading).toBe(true);
+  });
+
+  it('should not set activeBoostsLoading to true when active boosts already exist', () => {
+    // Arrange
+    const stateWithBoosts = {
+      ...initialState,
+      activeBoosts: [
+        {
+          id: 'existing-boost',
+          name: 'Existing Boost',
+          icon: { lightModeUrl: 'test.png', darkModeUrl: 'test.png' },
+          boostBips: 1000,
+          seasonLong: true,
+          backgroundColor: '#FF0000',
+        },
+      ],
+      activeBoostsLoading: false,
+    };
+    const action = setActiveBoostsLoading(true);
+
+    // Act
+    const state = rewardsReducer(stateWithBoosts, action);
+
+    // Assert
+    expect(state.activeBoostsLoading).toBe(false); // Should remain false due to guard clause
+  });
+
+  it('should set activeBoostsLoading to false', () => {
+    // Arrange
+    const stateWithLoading = {
+      ...initialState,
+      activeBoostsLoading: true,
+    };
+    const action = setActiveBoostsLoading(false);
+
+    // Act
+    const state = rewardsReducer(stateWithLoading, action);
+
+    // Assert
+    expect(state.activeBoostsLoading).toBe(false);
+  });
+
+  it('should set activeBoostsLoading to false even when active boosts exist', () => {
+    // Arrange
+    const stateWithBoostsAndLoading = {
+      ...initialState,
+      activeBoosts: [
+        {
+          id: 'existing-boost',
+          name: 'Existing Boost',
+          icon: { lightModeUrl: 'test.png', darkModeUrl: 'test.png' },
+          boostBips: 1000,
+          seasonLong: true,
+          backgroundColor: '#FF0000',
+        },
+      ],
+      activeBoostsLoading: true,
+    };
+    const action = setActiveBoostsLoading(false);
+
+    // Act
+    const state = rewardsReducer(stateWithBoostsAndLoading, action);
+
+    // Assert
+    expect(state.activeBoostsLoading).toBe(false);
+  });
+
+  it('should not affect other state properties', () => {
+    // Arrange
+    const stateWithData = {
+      ...initialState,
+      activeTab: 'activity' as const,
+      referralCode: 'TEST123',
+    };
+    const action = setActiveBoostsLoading(true);
+
+    // Act
+    const state = rewardsReducer(stateWithData, action);
+
+    // Assert
+    expect(state.activeBoostsLoading).toBe(true);
+    expect(state.activeTab).toBe('activity');
+    expect(state.referralCode).toBe('TEST123');
+    expect(state.activeBoosts).toBeNull();
+  });
+});
+
+describe('setActiveBoostsError', () => {
+  it('should set activeBoostsError to true', () => {
+    // Arrange
+    const action = setActiveBoostsError(true);
+
+    // Act
+    const state = rewardsReducer(initialState, action);
+
+    // Assert
+    expect(state.activeBoostsError).toBe(true);
+  });
+
+  it('should set activeBoostsError to false', () => {
+    // Arrange
+    const stateWithError = {
+      ...initialState,
+      activeBoostsError: true,
+    };
+    const action = setActiveBoostsError(false);
+
+    // Act
+    const state = rewardsReducer(stateWithError, action);
+
+    // Assert
+    expect(state.activeBoostsError).toBe(false);
+  });
+
+  it('should not affect other state properties', () => {
+    // Arrange
+    const stateWithData = {
+      ...initialState,
+      activeTab: 'activity' as const,
+      referralCode: 'TEST123',
+      activeBoosts: [
+        {
+          id: 'test-boost',
+          name: 'Test',
+          icon: { lightModeUrl: 'test.png', darkModeUrl: 'test.png' },
+          boostBips: 1000,
+          seasonLong: true,
+          backgroundColor: '#FF0000',
+        },
+      ],
+      activeBoostsLoading: true,
+    };
+    const action = setActiveBoostsError(true);
+
+    // Act
+    const state = rewardsReducer(stateWithData, action);
+
+    // Assert
+    expect(state.activeBoostsError).toBe(true);
+    expect(state.activeTab).toBe('activity');
+    expect(state.referralCode).toBe('TEST123');
+    expect(state.activeBoosts).toEqual(stateWithData.activeBoosts);
+    expect(state.activeBoostsLoading).toBe(true); // Should remain unchanged
+  });
+
+  it('should handle multiple error state changes', () => {
+    // Arrange
+    let currentState = initialState;
+
+    // Act & Assert - Set error to true
+    let action = setActiveBoostsError(true);
+    currentState = rewardsReducer(currentState, action);
+    expect(currentState.activeBoostsError).toBe(true);
+
+    // Act & Assert - Set error back to false
+    action = setActiveBoostsError(false);
+    currentState = rewardsReducer(currentState, action);
+    expect(currentState.activeBoostsError).toBe(false);
+
+    // Act & Assert - Set error to true again
+    action = setActiveBoostsError(true);
+    currentState = rewardsReducer(currentState, action);
+    expect(currentState.activeBoostsError).toBe(true);
+  });
+});
+
+describe('setUnlockedRewards', () => {
+  it('should set unlocked rewards in state', () => {
+    // Arrange
+    const mockUnlockedRewards = [
+      {
+        id: 'reward-1',
+        seasonRewardId: 'season-reward-1',
+        claimStatus: RewardClaimStatus.CLAIMED,
+      },
+      {
+        id: 'reward-2',
+        seasonRewardId: 'season-reward-2',
+        claimStatus: RewardClaimStatus.UNCLAIMED,
+      },
+    ];
+    const action = setUnlockedRewards(mockUnlockedRewards);
+
+    // Act
+    const state = rewardsReducer(initialState, action);
+
+    // Assert
+    expect(state.unlockedRewards).toEqual(mockUnlockedRewards);
+    expect(state.unlockedRewards).toHaveLength(2);
+    expect(state.unlockedRewards?.[0]?.id).toBe('reward-1');
+    expect(state.unlockedRewards?.[1]?.claimStatus).toBe(
+      RewardClaimStatus.UNCLAIMED,
+    );
+  });
+
+  it('should replace existing unlocked rewards', () => {
+    // Arrange
+    const existingRewards = [
+      {
+        id: 'old-reward',
+        seasonRewardId: 'old-season-reward',
+        claimStatus: RewardClaimStatus.CLAIMED,
+      },
+    ];
+    const stateWithRewards = {
+      ...initialState,
+      unlockedRewards: existingRewards,
+    };
+    const newRewards = [
+      {
+        id: 'new-reward-1',
+        seasonRewardId: 'new-season-reward-1',
+        claimStatus: RewardClaimStatus.UNCLAIMED,
+      },
+      {
+        id: 'new-reward-2',
+        seasonRewardId: 'new-season-reward-2',
+        claimStatus: RewardClaimStatus.CLAIMED,
+      },
+    ];
+    const action = setUnlockedRewards(newRewards);
+
+    // Act
+    const state = rewardsReducer(stateWithRewards, action);
+
+    // Assert
+    expect(state.unlockedRewards).toEqual(newRewards);
+    expect(state.unlockedRewards).toHaveLength(2);
+    expect(state.unlockedRewards?.[0]?.id).toBe('new-reward-1');
+    expect(state.unlockedRewards?.[1]?.id).toBe('new-reward-2');
+  });
+
+  it('should set empty array when no rewards provided', () => {
+    // Arrange
+    const stateWithRewards = {
+      ...initialState,
+      unlockedRewards: [
+        {
+          id: 'existing-reward',
+          seasonRewardId: 'existing-season-reward',
+          claimStatus: RewardClaimStatus.CLAIMED,
+        },
+      ],
+    };
+    const action = setUnlockedRewards([]);
+
+    // Act
+    const state = rewardsReducer(stateWithRewards, action);
+
+    // Assert
+    expect(state.unlockedRewards).toEqual([]);
+    expect(state.unlockedRewards).toHaveLength(0);
+  });
+
+  it('should reset unlockedRewardError to false when setting unlocked rewards', () => {
+    // Arrange
+    const stateWithError = {
+      ...initialState,
+      unlockedRewardError: true,
+    };
+    const mockRewards = [
+      {
+        id: 'test-reward',
+        seasonRewardId: 'test-season-reward',
+        claimStatus: RewardClaimStatus.CLAIMED,
+      },
+    ];
+    const action = setUnlockedRewards(mockRewards);
+
+    // Act
+    const state = rewardsReducer(stateWithError, action);
+
+    // Assert
+    expect(state.unlockedRewards).toEqual(mockRewards);
+    expect(state.unlockedRewardError).toBe(false); // Should be reset when successful
+  });
+
+  it('should not affect other state properties', () => {
+    // Arrange
+    const stateWithData = {
+      ...initialState,
+      activeTab: 'levels' as const,
+      referralCode: 'TEST123',
+      balanceTotal: 1000,
+      activeBoostsLoading: true,
+    };
+    const mockRewards = [
+      {
+        id: 'test-reward',
+        seasonRewardId: 'test-season-reward',
+        claimStatus: RewardClaimStatus.CLAIMED,
+      },
+    ];
+    const action = setUnlockedRewards(mockRewards);
+
+    // Act
+    const state = rewardsReducer(stateWithData, action);
+
+    // Assert
+    expect(state.unlockedRewards).toEqual(mockRewards);
+    expect(state.activeTab).toBe('levels');
+    expect(state.referralCode).toBe('TEST123');
+    expect(state.balanceTotal).toBe(1000);
+    expect(state.activeBoostsLoading).toBe(true);
+  });
+});
+
+describe('setUnlockedRewardLoading', () => {
+  it('should set unlocked reward loading to true when no unlocked rewards exist', () => {
+    // Arrange
+    const action = setUnlockedRewardLoading(true);
+
+    // Act
+    const state = rewardsReducer(initialState, action);
+
+    // Assert
+    expect(state.unlockedRewardLoading).toBe(true);
+  });
+
+  it('should not set unlocked reward loading to true when unlocked rewards already exist', () => {
+    // Arrange
+    const stateWithRewards = {
+      ...initialState,
+      unlockedRewards: [
+        {
+          id: 'existing-reward',
+          seasonRewardId: 'existing-season-reward',
+          claimStatus: RewardClaimStatus.CLAIMED,
+        },
+      ],
+      unlockedRewardLoading: false,
+    };
+    const action = setUnlockedRewardLoading(true);
+
+    // Act
+    const state = rewardsReducer(stateWithRewards, action);
+
+    // Assert
+    expect(state.unlockedRewardLoading).toBe(false); // Should remain false due to guard clause
+  });
+
+  it('should set unlocked reward loading to false', () => {
+    // Arrange
+    const stateWithLoading = {
+      ...initialState,
+      unlockedRewardLoading: true,
+    };
+    const action = setUnlockedRewardLoading(false);
+
+    // Act
+    const state = rewardsReducer(stateWithLoading, action);
+
+    // Assert
+    expect(state.unlockedRewardLoading).toBe(false);
+  });
+
+  it('should set unlocked reward loading to false even when unlocked rewards exist', () => {
+    // Arrange
+    const stateWithRewardsAndLoading = {
+      ...initialState,
+      unlockedRewards: [
+        {
+          id: 'existing-reward',
+          seasonRewardId: 'existing-season-reward',
+          claimStatus: RewardClaimStatus.CLAIMED,
+        },
+      ],
+      unlockedRewardLoading: true,
+    };
+    const action = setUnlockedRewardLoading(false);
+
+    // Act
+    const state = rewardsReducer(stateWithRewardsAndLoading, action);
+
+    // Assert
+    expect(state.unlockedRewardLoading).toBe(false);
+  });
+
+  it('should toggle loading state correctly when no rewards exist', () => {
+    // Arrange - Start with false and no rewards
+    let currentState = initialState;
+    expect(currentState.unlockedRewardLoading).toBe(false);
+    expect(currentState.unlockedRewards).toBeNull();
+
+    // Act - Set to true (should work since no rewards exist)
+    currentState = rewardsReducer(currentState, setUnlockedRewardLoading(true));
+    expect(currentState.unlockedRewardLoading).toBe(true);
+
+    // Act - Set back to false
+    currentState = rewardsReducer(
+      currentState,
+      setUnlockedRewardLoading(false),
+    );
+    expect(currentState.unlockedRewardLoading).toBe(false);
+  });
+
+  it('should not affect other state properties', () => {
+    // Arrange
+    const stateWithData = {
+      ...initialState,
+      activeTab: 'activity' as const,
+      referralCode: 'TEST456',
+      activeBoostsLoading: false,
+    };
+    const action = setUnlockedRewardLoading(true);
+
+    // Act
+    const state = rewardsReducer(stateWithData, action);
+
+    // Assert
+    expect(state.unlockedRewardLoading).toBe(true);
+    expect(state.activeTab).toBe('activity');
+    expect(state.referralCode).toBe('TEST456');
+    expect(state.unlockedRewards).toBeNull();
+    expect(state.activeBoostsLoading).toBe(false);
+  });
+});
+
+describe('setUnlockedRewardError', () => {
+  it('should set unlockedRewardError to true', () => {
+    // Arrange
+    const action = setUnlockedRewardError(true);
+
+    // Act
+    const state = rewardsReducer(initialState, action);
+
+    // Assert
+    expect(state.unlockedRewardError).toBe(true);
+  });
+
+  it('should set unlockedRewardError to false', () => {
+    // Arrange
+    const stateWithError = {
+      ...initialState,
+      unlockedRewardError: true,
+    };
+    const action = setUnlockedRewardError(false);
+
+    // Act
+    const state = rewardsReducer(stateWithError, action);
+
+    // Assert
+    expect(state.unlockedRewardError).toBe(false);
+  });
+
+  it('should not affect other state properties', () => {
+    // Arrange
+    const stateWithData = {
+      ...initialState,
+      activeTab: 'levels' as const,
+      referralCode: 'TEST789',
+      balanceTotal: 2000,
+      unlockedRewardLoading: true,
+    };
+    const action = setUnlockedRewardError(true);
+
+    // Act
+    const state = rewardsReducer(stateWithData, action);
+
+    // Assert
+    expect(state.unlockedRewardError).toBe(true);
+    expect(state.activeTab).toBe('levels');
+    expect(state.referralCode).toBe('TEST789');
+    expect(state.balanceTotal).toBe(2000);
+    expect(state.unlockedRewardLoading).toBe(true); // Should remain unchanged
+  });
+
+  it('should handle multiple error state changes', () => {
+    // Arrange
+    let currentState = initialState;
+
+    // Act & Assert - Set error to true
+    let action = setUnlockedRewardError(true);
+    currentState = rewardsReducer(currentState, action);
+    expect(currentState.unlockedRewardError).toBe(true);
+
+    // Act & Assert - Set error back to false
+    action = setUnlockedRewardError(false);
+    currentState = rewardsReducer(currentState, action);
+    expect(currentState.unlockedRewardError).toBe(false);
+
+    // Act & Assert - Set error to true again
+    action = setUnlockedRewardError(true);
+    currentState = rewardsReducer(currentState, action);
+    expect(currentState.unlockedRewardError).toBe(true);
+  });
+});
+
+describe('setPointsEvents', () => {
+  it('should set points events array', () => {
+    // Arrange
+    const mockPointsEvents: PointsEventDto[] = [
+      {
+        id: 'event-1',
+        type: 'SWAP' as const,
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+        value: 100,
+        bonus: null,
+        accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        updatedAt: new Date('2024-01-01T00:00:00Z'),
+        payload: {
+          srcAsset: {
+            amount: '1000000000000000000',
+            type: 'eip155:1/slip44:60',
+            decimals: 18,
+            name: 'Ethereum',
+            symbol: 'ETH',
+          },
+          destAsset: {
+            amount: '3000000000',
+            type: 'eip155:1/erc20:0xA0b86a33E6441b8c4C8C0C0C0C0C0C0C0C0C0C0C',
+            decimals: 6,
+            name: 'USD Coin',
+            symbol: 'USDC',
           },
         },
-        {
-          id: 'perps-event',
-          type: 'PERPS' as const,
-          timestamp: new Date('2024-01-02T00:00:00Z'),
-          value: 200,
-          bonus: null,
-          accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-          updatedAt: new Date('2024-01-02T00:00:00Z'),
-          payload: {
-            type: 'CLOSE_POSITION',
-            direction: 'SHORT',
-            asset: {
-              amount: '5000000000000000000',
-              type: 'eip155:1/slip44:60',
-              decimals: 18,
-              name: 'Ethereum',
-              symbol: 'ETH',
-            },
+      },
+      {
+        id: 'event-2',
+        type: 'REFERRAL' as const,
+        timestamp: new Date('2024-01-02T00:00:00Z'),
+        value: 50,
+        bonus: null,
+        accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        updatedAt: new Date('2024-01-02T00:00:00Z'),
+        payload: null,
+      },
+    ];
+    const action = setPointsEvents(mockPointsEvents);
+
+    // Act
+    const state = rewardsReducer(initialState, action);
+
+    // Assert
+    expect(state.pointsEvents).toEqual(mockPointsEvents);
+    expect(state.pointsEvents).toHaveLength(2);
+    expect(state.pointsEvents?.[0]?.id).toBe('event-1');
+    expect(state.pointsEvents?.[0]?.type).toBe('SWAP');
+    expect(state.pointsEvents?.[1]?.type).toBe('REFERRAL');
+  });
+
+  it('should replace existing points events', () => {
+    // Arrange
+    const existingEvents: PointsEventDto[] = [
+      {
+        id: 'old-event',
+        type: 'SIGN_UP_BONUS' as const,
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+        value: 200,
+        bonus: null,
+        accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        updatedAt: new Date('2024-01-01T00:00:00Z'),
+        payload: null,
+      },
+    ];
+    const stateWithEvents = {
+      ...initialState,
+      pointsEvents: existingEvents,
+    };
+    const newEvents: PointsEventDto[] = [
+      {
+        id: 'new-event-1',
+        type: 'PERPS' as const,
+        timestamp: new Date('2024-01-02T00:00:00Z'),
+        value: 300,
+        bonus: null,
+        accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        updatedAt: new Date('2024-01-02T00:00:00Z'),
+        payload: {
+          type: 'OPEN_POSITION',
+          direction: 'LONG',
+          asset: {
+            amount: '1000000000000000000',
+            type: 'eip155:1/slip44:60',
+            decimals: 18,
+            name: 'Ethereum',
+            symbol: 'ETH',
           },
         },
+      },
+      {
+        id: 'new-event-2',
+        type: 'LOYALTY_BONUS' as const,
+        timestamp: new Date('2024-01-03T00:00:00Z'),
+        value: 75,
+        bonus: null,
+        accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        updatedAt: new Date('2024-01-03T00:00:00Z'),
+        payload: null,
+      },
+    ];
+    const action = setPointsEvents(newEvents);
+
+    // Act
+    const state = rewardsReducer(stateWithEvents, action);
+
+    // Assert
+    expect(state.pointsEvents).toEqual(newEvents);
+    expect(state.pointsEvents).toHaveLength(2);
+    expect(state.pointsEvents?.[0]?.id).toBe('new-event-1');
+    expect(state.pointsEvents?.[1]?.id).toBe('new-event-2');
+  });
+
+  it('should set empty array when no events provided', () => {
+    // Arrange
+    const stateWithEvents = {
+      ...initialState,
+      pointsEvents: [
         {
-          id: 'referral-event',
-          type: 'REFERRAL' as const,
-          timestamp: new Date('2024-01-03T00:00:00Z'),
-          value: 50,
-          bonus: null,
-          accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-          updatedAt: new Date('2024-01-03T00:00:00Z'),
-          payload: null,
-        },
-        {
-          id: 'signup-event',
-          type: 'SIGN_UP_BONUS' as const,
-          timestamp: new Date('2024-01-04T00:00:00Z'),
-          value: 1000,
-          bonus: null,
-          accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-          updatedAt: new Date('2024-01-04T00:00:00Z'),
-          payload: null,
-        },
-        {
-          id: 'loyalty-event',
-          type: 'LOYALTY_BONUS' as const,
-          timestamp: new Date('2024-01-05T00:00:00Z'),
-          value: 75,
-          bonus: null,
-          accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-          updatedAt: new Date('2024-01-05T00:00:00Z'),
-          payload: null,
-        },
-        {
-          id: 'onetime-event',
+          id: 'existing-event',
           type: 'ONE_TIME_BONUS' as const,
-          timestamp: new Date('2024-01-06T00:00:00Z'),
+          timestamp: new Date('2024-01-01T00:00:00Z'),
           value: 500,
           bonus: null,
           accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
-          updatedAt: new Date('2024-01-06T00:00:00Z'),
+          updatedAt: new Date('2024-01-01T00:00:00Z'),
           payload: null,
         },
-      ];
-      const action = setPointsEvents(mixedEvents);
+      ],
+    };
+    const action = setPointsEvents([]);
 
-      // Act
-      const state = rewardsReducer(initialState, action);
+    // Act
+    const state = rewardsReducer(stateWithEvents, action);
 
-      // Assert
-      expect(state.pointsEvents).toEqual(mixedEvents);
-      expect(state.pointsEvents).toHaveLength(6);
-      expect(state.pointsEvents?.[0]?.type).toBe('SWAP');
-      expect(state.pointsEvents?.[1]?.type).toBe('PERPS');
-      expect(state.pointsEvents?.[2]?.type).toBe('REFERRAL');
-      expect(state.pointsEvents?.[3]?.type).toBe('SIGN_UP_BONUS');
-      expect(state.pointsEvents?.[4]?.type).toBe('LOYALTY_BONUS');
-      expect(state.pointsEvents?.[5]?.type).toBe('ONE_TIME_BONUS');
-    });
+    // Assert
+    expect(state.pointsEvents).toEqual([]);
+    expect(state.pointsEvents).toHaveLength(0);
+  });
+
+  it('should set points events to null', () => {
+    // Arrange
+    const stateWithEvents = {
+      ...initialState,
+      pointsEvents: [
+        {
+          id: 'existing-event',
+          type: 'SWAP' as const,
+          timestamp: new Date('2024-01-01T00:00:00Z'),
+          value: 100,
+          bonus: null,
+          accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+          updatedAt: new Date('2024-01-01T00:00:00Z'),
+          payload: {
+            srcAsset: {
+              amount: '1000000000000000000',
+              type: 'eip155:1/slip44:60',
+              decimals: 18,
+              name: 'Ethereum',
+              symbol: 'ETH',
+            },
+            destAsset: {
+              amount: '3000000000',
+              type: 'eip155:1/erc20:0xA0b86a33E6441b8c4C8C0C0C0C0C0C0C0C0C0C0C',
+              decimals: 6,
+              name: 'USD Coin',
+              symbol: 'USDC',
+            },
+          },
+        },
+      ],
+    };
+    const action = setPointsEvents(null);
+
+    // Act
+    const state = rewardsReducer(stateWithEvents, action);
+
+    // Assert
+    expect(state.pointsEvents).toBeNull();
+  });
+
+  it('should not affect other state properties', () => {
+    // Arrange
+    const stateWithData = {
+      ...initialState,
+      activeTab: 'activity' as const,
+      referralCode: 'TEST123',
+      balanceTotal: 1000,
+      activeBoostsLoading: true,
+    };
+    const mockEvents: PointsEventDto[] = [
+      {
+        id: 'test-event',
+        type: 'SWAP' as const,
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+        value: 150,
+        bonus: null,
+        accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        updatedAt: new Date('2024-01-01T00:00:00Z'),
+        payload: {
+          srcAsset: {
+            amount: '10000000',
+            type: 'eip155:1/slip44:0',
+            decimals: 8,
+            name: 'Bitcoin',
+            symbol: 'BTC',
+          },
+          destAsset: {
+            amount: '2500000000000000000',
+            type: 'eip155:1/slip44:60',
+            decimals: 18,
+            name: 'Ethereum',
+            symbol: 'ETH',
+          },
+        },
+      },
+    ];
+    const action = setPointsEvents(mockEvents);
+
+    // Act
+    const state = rewardsReducer(stateWithData, action);
+
+    // Assert
+    expect(state.pointsEvents).toEqual(mockEvents);
+    expect(state.activeTab).toBe('activity');
+    expect(state.referralCode).toBe('TEST123');
+    expect(state.balanceTotal).toBe(1000);
+    expect(state.activeBoostsLoading).toBe(true);
+  });
+
+  it('should handle mixed event types', () => {
+    // Arrange
+    const mixedEvents: PointsEventDto[] = [
+      {
+        id: 'swap-event',
+        type: 'SWAP' as const,
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+        value: 100,
+        bonus: null,
+        accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        updatedAt: new Date('2024-01-01T00:00:00Z'),
+        payload: {
+          srcAsset: {
+            amount: '1000000000000000000',
+            type: 'eip155:1/slip44:60',
+            decimals: 18,
+            name: 'Ethereum',
+            symbol: 'ETH',
+          },
+          destAsset: {
+            amount: '3000000000',
+            type: 'eip155:1/erc20:0xA0b86a33E6441b8c4C8C0C0C0C0C0C0C0C0C0C0C',
+            decimals: 6,
+            name: 'USD Coin',
+            symbol: 'USDC',
+          },
+        },
+      },
+      {
+        id: 'perps-event',
+        type: 'PERPS' as const,
+        timestamp: new Date('2024-01-02T00:00:00Z'),
+        value: 200,
+        bonus: null,
+        accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        updatedAt: new Date('2024-01-02T00:00:00Z'),
+        payload: {
+          type: 'CLOSE_POSITION',
+          direction: 'SHORT',
+          asset: {
+            amount: '5000000000000000000',
+            type: 'eip155:1/slip44:60',
+            decimals: 18,
+            name: 'Ethereum',
+            symbol: 'ETH',
+          },
+        },
+      },
+      {
+        id: 'referral-event',
+        type: 'REFERRAL' as const,
+        timestamp: new Date('2024-01-03T00:00:00Z'),
+        value: 50,
+        bonus: null,
+        accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        updatedAt: new Date('2024-01-03T00:00:00Z'),
+        payload: null,
+      },
+      {
+        id: 'signup-event',
+        type: 'SIGN_UP_BONUS' as const,
+        timestamp: new Date('2024-01-04T00:00:00Z'),
+        value: 1000,
+        bonus: null,
+        accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        updatedAt: new Date('2024-01-04T00:00:00Z'),
+        payload: null,
+      },
+      {
+        id: 'loyalty-event',
+        type: 'LOYALTY_BONUS' as const,
+        timestamp: new Date('2024-01-05T00:00:00Z'),
+        value: 75,
+        bonus: null,
+        accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        updatedAt: new Date('2024-01-05T00:00:00Z'),
+        payload: null,
+      },
+      {
+        id: 'onetime-event',
+        type: 'ONE_TIME_BONUS' as const,
+        timestamp: new Date('2024-01-06T00:00:00Z'),
+        value: 500,
+        bonus: null,
+        accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        updatedAt: new Date('2024-01-06T00:00:00Z'),
+        payload: null,
+      },
+    ];
+    const action = setPointsEvents(mixedEvents);
+
+    // Act
+    const state = rewardsReducer(initialState, action);
+
+    // Assert
+    expect(state.pointsEvents).toEqual(mixedEvents);
+    expect(state.pointsEvents).toHaveLength(6);
+    expect(state.pointsEvents?.[0]?.type).toBe('SWAP');
+    expect(state.pointsEvents?.[1]?.type).toBe('PERPS');
+    expect(state.pointsEvents?.[2]?.type).toBe('REFERRAL');
+    expect(state.pointsEvents?.[3]?.type).toBe('SIGN_UP_BONUS');
+    expect(state.pointsEvents?.[4]?.type).toBe('LOYALTY_BONUS');
+    expect(state.pointsEvents?.[5]?.type).toBe('ONE_TIME_BONUS');
   });
 });

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -6,6 +6,7 @@ import {
   PointsBoostDto,
   RewardDto,
   PointsEventDto,
+  SeasonActivityTypeDto,
 } from '../../core/Engine/controllers/rewards-controller/types';
 import { OnboardingStep } from './types';
 import { AccountGroupId } from '@metamask/account-api';
@@ -26,6 +27,7 @@ export interface RewardsState {
   seasonStartDate: Date | null;
   seasonEndDate: Date | null;
   seasonTiers: SeasonTierDto[];
+  seasonActivityTypes: SeasonActivityTypeDto[];
 
   // Subscription Referral state
   referralDetailsLoading: boolean;
@@ -84,6 +86,7 @@ export const initialState: RewardsState = {
   seasonStartDate: null,
   seasonEndDate: null,
   seasonTiers: [],
+  seasonActivityTypes: [],
 
   referralDetailsLoading: false,
   referralDetailsError: false,
@@ -153,6 +156,7 @@ const rewardsSlice = createSlice({
         ? new Date(action.payload.season.endDate)
         : null;
       state.seasonTiers = action.payload?.season.tiers || [];
+      state.seasonActivityTypes = action.payload?.season.activityTypes || [];
 
       // Season Balance state
       state.balanceTotal =
@@ -257,6 +261,7 @@ const rewardsSlice = createSlice({
         state.seasonStartDate = initialState.seasonStartDate;
         state.seasonEndDate = initialState.seasonEndDate;
         state.seasonTiers = initialState.seasonTiers;
+        state.seasonActivityTypes = initialState.seasonActivityTypes;
         state.referralCode = initialState.referralCode;
         state.refereeCount = initialState.refereeCount;
         state.currentTier = initialState.currentTier;
@@ -370,6 +375,7 @@ const rewardsSlice = createSlice({
           seasonStartDate: action.payload.rewards.seasonStartDate,
           seasonEndDate: action.payload.rewards.seasonEndDate,
           seasonTiers: action.payload.rewards.seasonTiers,
+          seasonActivityTypes: action.payload.rewards.seasonActivityTypes,
           referralCode: action.payload.rewards.referralCode,
           refereeCount: action.payload.rewards.refereeCount,
           currentTier: action.payload.rewards.currentTier,

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -17,6 +17,7 @@ import {
   selectSeasonStartDate,
   selectSeasonEndDate,
   selectSeasonTiers,
+  selectSeasonActivityTypes,
   selectOnboardingActiveStep,
   selectOnboardingReferralCode,
   selectGeoLocation,
@@ -41,6 +42,7 @@ import { OnboardingStep } from './types';
 import {
   RewardDto,
   SeasonTierDto,
+  SeasonActivityTypeDto,
   PointsEventDto,
 } from '../../core/Engine/controllers/rewards-controller/types';
 import { RootState } from '..';
@@ -518,6 +520,42 @@ describe('Rewards selectors', () => {
 
       const { result } = renderHook(() => useSelector(selectSeasonTiers));
       expect(result.current).toEqual(mockTiers);
+    });
+  });
+
+  describe('selectSeasonActivityTypes', () => {
+    it('returns empty array when season activity types are not set', () => {
+      const mockState = { rewards: { seasonActivityTypes: [] } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectSeasonActivityTypes),
+      );
+      expect(result.current).toEqual([]);
+    });
+
+    it('returns season activity types when set', () => {
+      const mockActivityTypes: SeasonActivityTypeDto[] = [
+        {
+          type: 'SWAP',
+          title: 'Swap',
+          description: 'Swap tokens',
+          icon: 'SwapVertical',
+        },
+        {
+          type: 'CARD',
+          title: 'Card spend',
+          description: 'Spend with card',
+          icon: 'Card',
+        },
+      ];
+      const mockState = { rewards: { seasonActivityTypes: mockActivityTypes } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectSeasonActivityTypes),
+      );
+      expect(result.current).toEqual(mockActivityTypes);
     });
   });
 

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -46,6 +46,9 @@ export const selectSeasonEndDate = (state: RootState) =>
 export const selectSeasonTiers = (state: RootState) =>
   state.rewards.seasonTiers;
 
+export const selectSeasonActivityTypes = (state: RootState) =>
+  state.rewards.seasonActivityTypes;
+
 export const selectOnboardingActiveStep = (state: RootState): OnboardingStep =>
   state.rewards.onboardingActiveStep;
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6715,7 +6715,8 @@
       "points": "Points",
       "points_base": "Base",
       "points_boost": "Boost",
-      "points_total": "Total"
+      "points_total": "Total",
+      "description": "Description"
     },
     "onboarding": {
       "not_supported_region_title": "Region not supported",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
https://consensyssoftware.atlassian.net/browse/RWDS-844
Create a new way render unknown activity types based on data from the backend.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support to render unknown activity events using backend-provided season activity types and templated descriptions, wiring activityTypes through controller, state, selectors, and UI.
> 
> - **Rewards UI/UX**:
>   - Activity rows and details now consume `activityTypes` from Redux (`selectSeasonActivityTypes`) and pass them to `getEventDetails`/`openActivityDetailsSheet` to render titles/icons and a templated "Description" row.
>   - `ActivityEventRow` improves network icon extraction (typed payloads, safer parsing) and passes `confirmAction`.
> - **Utils**:
>   - `getEventDetails(event, activityTypes, accountName)` supports custom types using `getIconName` and `resolveTemplate` for descriptions; adds per-event extra description in details sheet.
>   - New `resolveTemplate` helper; locale adds `rewards.events.description`.
> - **State/Selectors**:
>   - Introduces `SeasonActivityTypeDto`; adds `seasonActivityTypes` to `SeasonDto/SeasonDtoState/SeasonStatusDto`, Redux state, rehydration, and selectors.
> - **Engine/Data**:
>   - Rewards controller and data service fetch/persist `activityTypes`; state conversion and caching updated; ensure array defaulting.
> - **Tests**:
>   - Extensive updates/coverage across components, utils, reducers, selectors, and controller to reflect new `activityTypes`, templating, and network parsing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f6fadbd4cfb61d9dab4e9bc17a04b1a2218831a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->