### PR TITLE
fix: cp-7.60.0 alerts persisting in metamask pay

### DIFF
--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -59,13 +59,12 @@ const ConfirmWrapped = ({
   styles: ReturnType<typeof styleSheet>;
   route?: UnstakeConfirmationViewProps['route'];
 }) => {
-  const alerts = useConfirmationAlerts();
   const isScrollDisabled = useDisableScroll();
 
   return (
     <ConfirmationContextProvider>
       <ConfirmationAssetPollingProvider>
-        <AlertsContextProvider alerts={alerts}>
+        <ConfirmationAlerts>
           <QRHardwareContextProvider>
             <LedgerContextProvider>
               <Title />
@@ -88,7 +87,7 @@ const ConfirmWrapped = ({
               <Splash />
             </LedgerContextProvider>
           </QRHardwareContextProvider>
-        </AlertsContextProvider>
+        </ConfirmationAlerts>
       </ConfirmationAssetPollingProvider>
     </ConfirmationContextProvider>
   );
@@ -166,6 +165,14 @@ export const Confirm = ({ route }: ConfirmProps) => {
     </BottomSheet>
   );
 };
+
+function ConfirmationAlerts({ children }: { children: ReactNode }) {
+  const alerts = useConfirmationAlerts();
+
+  return (
+    <AlertsContextProvider alerts={alerts}>{children}</AlertsContextProvider>
+  );
+}
 
 function Loader() {
   const { styles } = useStyles(styleSheet, { isFullScreenConfirmation: true });

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -48,7 +48,7 @@ import Button, {
 } from '../../../../../../component-library/components/Buttons/Button';
 import { useAlerts } from '../../../context/alert-system-context';
 import { useTransactionConfirm } from '../../../hooks/transactions/useTransactionConfirm';
-import Engine from '../../../../../../core/Engine';
+import EngineService from '../../../../../../core/EngineService';
 
 export interface CustomAmountInfoProps {
   children?: ReactNode;
@@ -77,7 +77,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       amountHumanDebounced,
       hasInput,
       isInputChanged,
-      transactionId,
       updatePendingAmount,
       updatePendingAmountPercentage,
       updateTokenAmount,
@@ -89,18 +88,15 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       pendingTokenAmount: amountHumanDebounced,
     });
 
-    const handleDone = useCallback(async () => {
-      await updateTokenAmount();
+    const handleDone = useCallback(() => {
+      updateTokenAmount();
+      EngineService.flushState();
       setIsKeyboardVisible(false);
     }, [updateTokenAmount]);
 
     const handleAmountPress = useCallback(() => {
       setIsKeyboardVisible(true);
-
-      Engine.controllerMessenger.call('TransactionPayController:clearQuotes', {
-        transactionId,
-      });
-    }, [transactionId]);
+    }, []);
 
     return (
       <Box style={styles.container}>

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -48,6 +48,7 @@ import Button, {
 } from '../../../../../../component-library/components/Buttons/Button';
 import { useAlerts } from '../../../context/alert-system-context';
 import { useTransactionConfirm } from '../../../hooks/transactions/useTransactionConfirm';
+import Engine from '../../../../../../core/Engine';
 
 export interface CustomAmountInfoProps {
   children?: ReactNode;
@@ -76,6 +77,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       amountHumanDebounced,
       hasInput,
       isInputChanged,
+      transactionId,
       updatePendingAmount,
       updatePendingAmountPercentage,
       updateTokenAmount,
@@ -94,7 +96,11 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
     const handleAmountPress = useCallback(() => {
       setIsKeyboardVisible(true);
-    }, []);
+
+      Engine.controllerMessenger.call('TransactionPayController:clearQuotes', {
+        transactionId,
+      });
+    }, [transactionId]);
 
     return (
       <Box style={styles.container}>

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -52,10 +52,15 @@ const NATIVE_TOKEN_MOCK = {
   balanceRaw: '100',
 } as NonNullable<ReturnType<typeof useTokenWithBalance>>;
 
-function runHook() {
-  return renderHookWithProvider(() => useInsufficientPayTokenBalanceAlert(), {
-    state: merge({}, otherControllersMock),
-  });
+function runHook(
+  props: Parameters<typeof useInsufficientPayTokenBalanceAlert>[0] = {},
+) {
+  return renderHookWithProvider(
+    () => useInsufficientPayTokenBalanceAlert(props),
+    {
+      state: merge({}, otherControllersMock),
+    },
+  );
 }
 
 describe('useInsufficientPayTokenBalanceAlert', () => {
@@ -282,6 +287,20 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
         },
       ]);
     });
+
+    it('returns no alert if pending amount provided', () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: {
+          ...PAY_TOKEN_MOCK,
+          balanceRaw: '999',
+        },
+        setPayToken: jest.fn(),
+      });
+
+      const { result } = runHook({ pendingAmountUsd: '1.23' });
+
+      expect(result.current).toStrictEqual([]);
+    });
   });
 
   describe('for source network fee', () => {
@@ -352,6 +371,17 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
       });
 
       const { result } = runHook();
+
+      expect(result.current).toStrictEqual([]);
+    });
+
+    it('returns no alert if pending amount provided', () => {
+      useTokenWithBalanceMock.mockReturnValue({
+        ...NATIVE_TOKEN_MOCK,
+        balanceRaw: '99',
+      } as ReturnType<typeof useTokenWithBalance>);
+
+      const { result } = runHook({ pendingAmountUsd: '1.23' });
 
       expect(result.current).toStrictEqual([]);
     });

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -185,7 +185,37 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
           title: strings('alert_system.insufficient_pay_token_balance.message'),
           message: strings(
             'alert_system.insufficient_pay_token_balance_fees_no_target.message',
-            { amount: '$1.21' },
+          ),
+          severity: Severity.Danger,
+        },
+      ]);
+    });
+
+    it('returns alert if pay token balance shortfall is negative due to bad exchange rates', () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: {
+          ...PAY_TOKEN_MOCK,
+          balanceRaw: '999',
+        },
+        setPayToken: jest.fn(),
+      });
+
+      useTransactionPayTotalsMock.mockReturnValue({
+        ...TOTALS_MOCK,
+        sourceAmount: { ...TOTALS_MOCK.sourceAmount, usd: '1.19' },
+      });
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([
+        {
+          key: AlertKeys.InsufficientPayTokenFees,
+          field: RowAlertKey.Amount,
+          isBlocking: true,
+          title: strings('alert_system.insufficient_pay_token_balance.message'),
+          message: strings(
+            'alert_system.insufficient_pay_token_balance_fees.message',
+            { amount: '$1.23' },
           ),
           severity: Severity.Danger,
         },

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -28,6 +28,7 @@ export function useInsufficientPayTokenBalanceAlert({
   const formatFiat = useFiatFormatter({ currency: 'usd' });
   const isLoading = useIsTransactionPayLoading();
   const isSourceGasFeeToken = totals?.fees.isSourceGasFeeToken ?? false;
+  const isPendingAlert = Boolean(pendingAmountUsd !== undefined);
 
   const sourceChainId = payToken?.chainId ?? '0x0';
 
@@ -100,18 +101,23 @@ export function useInsufficientPayTokenBalanceAlert({
   );
 
   const isInsufficientForFees = useMemo(
-    () => payToken && totalSourceAmountRaw.isGreaterThan(balanceRaw ?? '0'),
-    [balanceRaw, payToken, totalSourceAmountRaw],
+    () =>
+      !isPendingAlert &&
+      payToken &&
+      totalSourceAmountRaw.isGreaterThan(balanceRaw ?? '0'),
+    [balanceRaw, isPendingAlert, payToken, totalSourceAmountRaw],
   );
 
   const isInsufficientForSourceNetwork = useMemo(
     () =>
       payToken &&
       !isPayTokenNative &&
+      !isPendingAlert &&
       !isSourceGasFeeToken &&
       totalSourceNetworkFeeRaw.isGreaterThan(nativeToken?.balanceRaw ?? '0'),
     [
       isPayTokenNative,
+      isPendingAlert,
       isSourceGasFeeToken,
       nativeToken?.balanceRaw,
       payToken,

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -87,7 +87,15 @@ export function useInsufficientPayTokenBalanceAlert({
     const targetUsdValue = totalAmountUsd.minus(shortfall);
     const targetUsd = formatFiat(targetUsdValue);
 
-    return targetUsdValue.isLessThanOrEqualTo(0) ? undefined : targetUsd;
+    if (targetUsdValue.isLessThanOrEqualTo(0)) {
+      return undefined;
+    }
+
+    if (targetUsdValue.isGreaterThan(totalAmountUsd)) {
+      return formatFiat(totalAmountUsd);
+    }
+
+    return targetUsd;
   }, [balanceUsd, formatFiat, totalAmountUsd, totalSourceAmountUsd]);
 
   const totalSourceNetworkFeeRaw = useMemo(

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -40,7 +40,7 @@ export function useTransactionCustomAmount({
   );
 
   const transactionMeta = useTransactionMetadataRequest() as TransactionMeta;
-  const { chainId, id: transactionId } = transactionMeta;
+  const { chainId } = transactionMeta;
 
   const tokenAddress = getTokenAddress(transactionMeta);
   const tokenFiatRate = useTokenFiatRate(tokenAddress, chainId, currency) ?? 1;
@@ -112,7 +112,6 @@ export function useTransactionCustomAmount({
     amountHumanDebounced,
     hasInput,
     isInputChanged,
-    transactionId,
     updatePendingAmount,
     updatePendingAmountPercentage,
     updateTokenAmount,

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -40,7 +40,7 @@ export function useTransactionCustomAmount({
   );
 
   const transactionMeta = useTransactionMetadataRequest() as TransactionMeta;
-  const { chainId } = transactionMeta;
+  const { chainId, id: transactionId } = transactionMeta;
 
   const tokenAddress = getTokenAddress(transactionMeta);
   const tokenFiatRate = useTokenFiatRate(tokenAddress, chainId, currency) ?? 1;
@@ -112,6 +112,7 @@ export function useTransactionCustomAmount({
     amountHumanDebounced,
     hasInput,
     isInputChanged,
+    transactionId,
     updatePendingAmount,
     updatePendingAmountPercentage,
     updateTokenAmount,


### PR DESCRIPTION
## **Description**

Prevent quote specific alerts persisting when keyboard is visible in MetaMask Pay.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #23134 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents MetaMask Pay alerts from persisting while editing amounts by gating fee/network alerts during input, adds a `ConfirmationAlerts` wrapper, and updates tests.
> 
> - **Alerts handling**
>   - Suppress fee/native-balance alerts while a pending amount is being edited via new `pendingAmountUsd` option in `useInsufficientPayTokenBalanceAlert` and `isPendingAlert` guards.
>   - Improve target amount calculation to clamp within valid bounds and handle negative shortfalls.
>   - Update tests to cover pending-amount behavior and edge cases (negative shortfall, no-target messages).
> - **UI/Provider refactor**
>   - Replace inline `AlertsContextProvider` usage with new `ConfirmationAlerts` wrapper in `confirm-component.tsx` that sources alerts via `useConfirmationAlerts`.
> - **Custom amount flow**
>   - On Done, call `updateTokenAmount()` and `EngineService.flushState()` to finalize state before hiding keyboard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66d25494ad99e203d77e6a16f3efc9ad49aba8b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->