### PR TITLE
refactor(ramp): add horizontal padding to ScreenLayout content

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -594,6 +594,7 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                 [
                                   {
                                     "padding": 15,
+                                    "paddingHorizontal": 16,
                                   },
                                   undefined,
                                   undefined,
@@ -1772,6 +1773,7 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -2786,6 +2788,7 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -5636,6 +5639,7 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                 [
                                   {
                                     "padding": 15,
+                                    "paddingHorizontal": 16,
                                   },
                                   undefined,
                                   undefined,
@@ -6518,6 +6522,7 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -7532,6 +7537,7 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -8959,6 +8965,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                 [
                                   {
                                     "padding": 15,
+                                    "paddingHorizontal": 16,
                                   },
                                   undefined,
                                   undefined,
@@ -9750,6 +9757,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -10764,6 +10772,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -12191,6 +12200,7 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                 [
                                   {
                                     "padding": 15,
+                                    "paddingHorizontal": 16,
                                   },
                                   undefined,
                                   undefined,
@@ -13326,6 +13336,7 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -14340,6 +14351,7 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -15007,6 +15019,7 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                 [
                                   {
                                     "padding": 15,
+                                    "paddingHorizontal": 16,
                                   },
                                   undefined,
                                   undefined,
@@ -16064,6 +16077,7 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -17078,6 +17092,7 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -18505,6 +18520,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                 [
                                   {
                                     "padding": 15,
+                                    "paddingHorizontal": 16,
                                   },
                                   undefined,
                                   undefined,
@@ -19260,6 +19276,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -20274,6 +20291,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -20941,6 +20959,7 @@ exports[`BuildQuote View renders correctly 1`] = `
                                 [
                                   {
                                     "padding": 15,
+                                    "paddingHorizontal": 16,
                                   },
                                   undefined,
                                   undefined,
@@ -22119,6 +22138,7 @@ exports[`BuildQuote View renders correctly 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -23133,6 +23153,7 @@ exports[`BuildQuote View renders correctly 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -23703,6 +23724,7 @@ exports[`BuildQuote View renders correctly 2`] = `
                                 [
                                   {
                                     "padding": 15,
+                                    "paddingHorizontal": 16,
                                   },
                                   undefined,
                                   undefined,
@@ -24797,6 +24819,7 @@ exports[`BuildQuote View renders correctly 2`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -25875,6 +25898,7 @@ exports[`BuildQuote View renders correctly 2`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,

--- a/app/components/UI/Ramp/Aggregator/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
@@ -482,6 +482,7 @@ exports[`OrderDetails renders a cancelled order 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -1418,6 +1419,7 @@ exports[`OrderDetails renders a cancelled order 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -1975,6 +1977,7 @@ exports[`OrderDetails renders a completed order 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -2929,6 +2932,7 @@ exports[`OrderDetails renders a completed order 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -3486,6 +3490,7 @@ exports[`OrderDetails renders a created order 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -4455,6 +4460,7 @@ exports[`OrderDetails renders a created order 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -4960,6 +4966,7 @@ exports[`OrderDetails renders a failed order 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -5896,6 +5903,7 @@ exports[`OrderDetails renders a failed order 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -6453,6 +6461,7 @@ exports[`OrderDetails renders a pending order 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -7422,6 +7431,7 @@ exports[`OrderDetails renders a pending order 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -9049,6 +9059,7 @@ exports[`OrderDetails renders non-transacted orders 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -10033,6 +10044,7 @@ exports[`OrderDetails renders non-transacted orders 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -10603,6 +10615,7 @@ exports[`OrderDetails renders the support links if the provider has them 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -11603,6 +11616,7 @@ exports[`OrderDetails renders the support links if the provider has them 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -12160,6 +12174,7 @@ exports[`OrderDetails renders transacted orders that do not have timeDescription
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -13129,6 +13144,7 @@ exports[`OrderDetails renders transacted orders that do not have timeDescription
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -13634,6 +13650,7 @@ exports[`OrderDetails renders transacted orders that have timeDescriptionPending
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -14618,6 +14635,7 @@ exports[`OrderDetails renders transacted orders that have timeDescriptionPending
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -1365,6 +1365,7 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -3697,6 +3698,7 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                     [
                                       {
                                         "padding": 15,
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
                                       {
@@ -3785,6 +3787,7 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                         [
                                           {
                                             "padding": 15,
+                                            "paddingHorizontal": 16,
                                           },
                                           undefined,
                                           {
@@ -5585,6 +5588,7 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {

--- a/app/components/UI/Ramp/Aggregator/Views/SendTransaction/__snapshots__/SendTransaction.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/SendTransaction/__snapshots__/SendTransaction.test.tsx.snap
@@ -461,6 +461,7 @@ exports[`SendTransaction View renders correctly 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -715,6 +716,7 @@ exports[`SendTransaction View renders correctly 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -1278,6 +1280,7 @@ exports[`SendTransaction View renders correctly for custom action payment method
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -1450,6 +1453,7 @@ exports[`SendTransaction View renders correctly for custom action payment method
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -2013,6 +2017,7 @@ exports[`SendTransaction View renders correctly for token 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -2271,6 +2276,7 @@ exports[`SendTransaction View renders correctly for token 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/ActivationKeyForm.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/ActivationKeyForm.test.tsx.snap
@@ -464,6 +464,7 @@ exports[`AddActivationKey renders correctly 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/Settings.test.tsx.snap
@@ -478,6 +478,7 @@ exports[`Settings Activation Keys renders correctly when is loading 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -1696,6 +1697,7 @@ exports[`Settings Activation Keys renders correctly when there are no keys 1`] =
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -2472,6 +2474,7 @@ exports[`Settings Region renders correctly when region is not set 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -3077,6 +3080,7 @@ exports[`Settings Region renders correctly when region is set 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -3720,6 +3724,7 @@ exports[`Settings renders correctly 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -4363,6 +4368,7 @@ exports[`Settings renders correctly for internal builds 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,

--- a/app/components/UI/Ramp/Aggregator/components/ScreenLayout.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/ScreenLayout.tsx
@@ -23,6 +23,7 @@ const createStyles = (colors: Colors) =>
     },
     content: {
       padding: 15,
+      paddingHorizontal: 16,
     },
     grow: {
       flex: 1,

--- a/app/components/UI/Ramp/Deposit/Views/AdditionalVerification/__snapshots__/AdditionalVerification.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/AdditionalVerification/__snapshots__/AdditionalVerification.test.tsx.snap
@@ -558,6 +558,7 @@ exports[`AdditionalVerification Component render matches snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -631,6 +632,7 @@ exports[`AdditionalVerification Component render matches snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {

--- a/app/components/UI/Ramp/Deposit/Views/BankDetails/__snapshots__/BankDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BankDetails/__snapshots__/BankDetails.test.tsx.snap
@@ -580,6 +580,7 @@ exports[`BankDetails Component render matches snapshot 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     {
@@ -913,6 +914,7 @@ exports[`BankDetails Component render matches snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -1690,6 +1692,7 @@ exports[`BankDetails Component render matches snapshot with bank info shown 1`] 
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     {
@@ -2236,6 +2239,7 @@ exports[`BankDetails Component render matches snapshot with bank info shown 1`] 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,

--- a/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
@@ -589,6 +589,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -1422,6 +1423,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -2175,6 +2177,7 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -3008,6 +3011,7 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -3761,6 +3765,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -4594,6 +4599,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -5347,6 +5353,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -6180,6 +6187,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -6933,6 +6941,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -7826,6 +7835,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -8579,6 +8589,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -9457,6 +9468,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -10210,6 +10222,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
                                     undefined,
@@ -10921,6 +10934,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -558,6 +558,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -1813,6 +1814,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -2432,6 +2434,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -3687,6 +3690,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -4306,6 +4310,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -5561,6 +5566,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -6180,6 +6186,7 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -7374,6 +7381,7 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -7993,6 +8001,7 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -9187,6 +9196,7 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -9805,6 +9815,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -10999,6 +11010,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -11618,6 +11630,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -12905,6 +12918,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -13524,6 +13538,7 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -14673,6 +14688,7 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -15292,6 +15308,7 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -16486,6 +16503,7 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -17105,6 +17123,7 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -18299,6 +18318,7 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -18918,6 +18938,7 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -20112,6 +20133,7 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -20731,6 +20753,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -21925,6 +21948,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -22544,6 +22568,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -23831,6 +23856,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -24450,6 +24476,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -25642,6 +25669,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -26261,6 +26289,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -27546,6 +27575,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -28165,6 +28195,7 @@ exports[`BuildQuote Component User Details Error displays user details error ale
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -29452,6 +29483,7 @@ exports[`BuildQuote Component User Details Error displays user details error ale
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,
@@ -30071,6 +30103,7 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -31265,6 +31298,7 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 undefined,

--- a/app/components/UI/Ramp/Deposit/Views/DepositOrderDetails/__snapshots__/DepositOrderDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/DepositOrderDetails/__snapshots__/DepositOrderDetails.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`DepositOrderDetails Component renders an error screen if a CREATED orde
               [
                 {
                   "padding": 15,
+                  "paddingHorizontal": 16,
                 },
                 undefined,
                 {
@@ -242,6 +243,7 @@ exports[`DepositOrderDetails Component renders error state correctly 1`] = `
               [
                 {
                   "padding": 15,
+                  "paddingHorizontal": 16,
                 },
                 undefined,
                 undefined,
@@ -761,6 +763,7 @@ exports[`DepositOrderDetails Component renders loading state correctly 1`] = `
           [
             {
               "padding": 15,
+              "paddingHorizontal": 16,
             },
             undefined,
             undefined,
@@ -867,6 +870,7 @@ exports[`DepositOrderDetails Component renders processing state correctly 1`] = 
               [
                 {
                   "padding": 15,
+                  "paddingHorizontal": 16,
                 },
                 undefined,
                 undefined,
@@ -1411,6 +1415,7 @@ exports[`DepositOrderDetails Component renders success state correctly 1`] = `
               [
                 {
                   "padding": 15,
+                  "paddingHorizontal": 16,
                 },
                 undefined,
                 undefined,

--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
@@ -589,6 +589,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     {
                                       "flex": 1,
@@ -1514,6 +1515,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                 [
                                   {
                                     "padding": 15,
+                                    "paddingHorizontal": 16,
                                   },
                                   undefined,
                                   {
@@ -2268,6 +2270,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     {
                                       "flex": 1,
@@ -3125,6 +3128,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                 [
                                   {
                                     "padding": 15,
+                                    "paddingHorizontal": 16,
                                   },
                                   undefined,
                                   {
@@ -3879,6 +3883,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     {
                                       "flex": 1,
@@ -4744,6 +4749,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                 [
                                   {
                                     "padding": 15,
+                                    "paddingHorizontal": 16,
                                   },
                                   undefined,
                                   {
@@ -5498,6 +5504,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     {
                                       "flex": 1,
@@ -6384,6 +6391,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                 [
                                   {
                                     "padding": 15,
+                                    "paddingHorizontal": 16,
                                   },
                                   undefined,
                                   {

--- a/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
@@ -558,6 +558,7 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -790,6 +791,7 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -1420,6 +1422,7 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -1666,6 +1669,7 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -2296,6 +2300,7 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -2528,6 +2533,7 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -3158,6 +3164,7 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -3404,6 +3411,7 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {

--- a/app/components/UI/Ramp/Deposit/Views/KycProcessing/__snapshots__/KycProcessing.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/KycProcessing/__snapshots__/KycProcessing.test.tsx.snap
@@ -558,6 +558,7 @@ exports[`KycProcessing Component render matches snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -714,6 +715,7 @@ exports[`KycProcessing Component render matches snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -1306,6 +1308,7 @@ exports[`KycProcessing Component renders approved state snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -1484,6 +1487,7 @@ exports[`KycProcessing Component renders approved state snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -2112,6 +2116,7 @@ exports[`KycProcessing Component renders error state snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -2276,6 +2281,7 @@ exports[`KycProcessing Component renders error state snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -2904,6 +2910,7 @@ exports[`KycProcessing Component renders loading state snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -3060,6 +3067,7 @@ exports[`KycProcessing Component renders loading state snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -3652,6 +3660,7 @@ exports[`KycProcessing Component renders pending forms state snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -3816,6 +3825,7 @@ exports[`KycProcessing Component renders pending forms state snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -4444,6 +4454,7 @@ exports[`KycProcessing Component renders rejected state snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -4608,6 +4619,7 @@ exports[`KycProcessing Component renders rejected state snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {

--- a/app/components/UI/Ramp/Deposit/Views/Modals/WebviewModal/__snapshots__/WebviewModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/WebviewModal/__snapshots__/WebviewModal.test.tsx.snap
@@ -1142,6 +1142,7 @@ exports[`WebviewModal Component should display error view when webview HTTP erro
                                         [
                                           {
                                             "padding": 15,
+                                            "paddingHorizontal": 16,
                                           },
                                           undefined,
                                           {

--- a/app/components/UI/Ramp/Deposit/Views/OrderProcessing/__snapshots__/OrderProcessing.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/OrderProcessing/__snapshots__/OrderProcessing.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`OrderProcessing Component renders created state correctly 1`] = `
           [
             {
               "padding": 15,
+              "paddingHorizontal": 16,
             },
             undefined,
             {
@@ -526,6 +527,7 @@ exports[`OrderProcessing Component renders created state correctly 1`] = `
           [
             {
               "padding": 15,
+              "paddingHorizontal": 16,
             },
             undefined,
             undefined,
@@ -635,6 +637,7 @@ exports[`OrderProcessing Component renders error state correctly 1`] = `
           [
             {
               "padding": 15,
+              "paddingHorizontal": 16,
             },
             undefined,
             {
@@ -1115,6 +1118,7 @@ exports[`OrderProcessing Component renders error state correctly 1`] = `
           [
             {
               "padding": 15,
+              "paddingHorizontal": 16,
             },
             undefined,
             undefined,
@@ -1313,6 +1317,7 @@ exports[`OrderProcessing Component renders processing state correctly 1`] = `
           [
             {
               "padding": 15,
+              "paddingHorizontal": 16,
             },
             undefined,
             {
@@ -1797,6 +1802,7 @@ exports[`OrderProcessing Component renders processing state correctly 1`] = `
           [
             {
               "padding": 15,
+              "paddingHorizontal": 16,
             },
             undefined,
             undefined,
@@ -1906,6 +1912,7 @@ exports[`OrderProcessing Component renders success state correctly 1`] = `
           [
             {
               "padding": 15,
+              "paddingHorizontal": 16,
             },
             undefined,
             {
@@ -2386,6 +2393,7 @@ exports[`OrderProcessing Component renders success state correctly 1`] = `
           [
             {
               "padding": 15,
+              "paddingHorizontal": 16,
             },
             undefined,
             undefined,

--- a/app/components/UI/Ramp/Deposit/Views/OtpCode/__snapshots__/OtpCode.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/OtpCode/__snapshots__/OtpCode.test.tsx.snap
@@ -353,6 +353,7 @@ exports[`OtpCode Screen calls resendOtp when resend link is clicked and properly
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -766,6 +767,7 @@ exports[`OtpCode Screen calls resendOtp when resend link is clicked and properly
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -1193,6 +1195,7 @@ exports[`OtpCode Screen render matches snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -1626,6 +1629,7 @@ exports[`OtpCode Screen render matches snapshot 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -2053,6 +2057,7 @@ exports[`OtpCode Screen renders cooldown timer snapshot after resending OTP 1`] 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -2466,6 +2471,7 @@ exports[`OtpCode Screen renders cooldown timer snapshot after resending OTP 1`] 
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -2893,6 +2899,7 @@ exports[`OtpCode Screen renders error snapshot when API call fails 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -3352,6 +3359,7 @@ exports[`OtpCode Screen renders error snapshot when API call fails 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {
@@ -3778,6 +3786,7 @@ exports[`OtpCode Screen renders resend error snapshot when resend fails 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 {
                                   "flex": 1,
@@ -4191,6 +4200,7 @@ exports[`OtpCode Screen renders resend error snapshot when resend fails 1`] = `
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {

--- a/app/components/UI/Ramp/Deposit/Views/VerifyIdentity/__snapshots__/VerifyIdentity.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/VerifyIdentity/__snapshots__/VerifyIdentity.test.tsx.snap
@@ -361,6 +361,7 @@ exports[`VerifyIdentity Component renders verify identity screen with all conten
                                   [
                                     {
                                       "padding": 15,
+                                      "paddingHorizontal": 16,
                                     },
                                     {
                                       "flex": 1,
@@ -486,6 +487,7 @@ exports[`VerifyIdentity Component renders verify identity screen with all conten
                               [
                                 {
                                   "padding": 15,
+                                  "paddingHorizontal": 16,
                                 },
                                 undefined,
                                 {

--- a/app/components/UI/Ramp/Deposit/components/ErrorView/__snapshots__/ErrorView.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/ErrorView/__snapshots__/ErrorView.test.tsx.snap
@@ -343,6 +343,7 @@ exports[`ErrorView Component renders with all props and matches snapshot 1`] = `
                             [
                               {
                                 "padding": 15,
+                                "paddingHorizontal": 16,
                               },
                               undefined,
                               {
@@ -804,6 +805,7 @@ exports[`ErrorView Component renders with default props and matches snapshot 1`]
                             [
                               {
                                 "padding": 15,
+                                "paddingHorizontal": 16,
                               },
                               undefined,
                               {


### PR DESCRIPTION


## **Description**

Added horizontal padding (16px) to the `ScreenLayout` component's content section to improve UI consistency across Ramp/Deposit screens.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-2866

## **Manual testing steps**

```gherkin
Feature: ScreenLayout padding

  Scenario: user views any Ramp screen
    Given user opens any Ramp/Deposit flow screen
    When user views the content area
    Then content should have consistent 16px horizontal padding
```

## **Screenshots/Recordings**

### **Before**

<img width="299" alt="image" src="https://github.com/user-attachments/assets/d01c740b-07c0-4b98-b021-e21a69d96ac8" />


### **After**

<img width="299" alt="image" src="https://github.com/user-attachments/assets/a3e30aaf-a908-47a1-ac69-5619eee29b88" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

