### PR TITLE
fix: cp-7.60.0 predict withdraw using gas station

### DIFF
--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -342,6 +342,7 @@ describe('useTransactionConfirm', () => {
         maxPriorityFeePerGas: '0x2',
       } as unknown as ReturnType<typeof useSelectedGasFeeToken>);
     });
+
     it('adds batchTransactions and gas properties when smart transaction is enabled', async () => {
       const { result } = renderHook();
 
@@ -367,6 +368,25 @@ describe('useTransactionConfirm', () => {
       useSelectedGasFeeTokenMock.mockReturnValue(
         undefined as unknown as ReturnType<typeof useSelectedGasFeeToken>,
       );
+
+      const { result } = renderHook();
+
+      await act(async () => {
+        await result.current.onConfirm();
+      });
+
+      expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
+        txMeta: expect.not.objectContaining({
+          batchTransactions: expect.any(Array),
+        }),
+      });
+    });
+
+    it('does nothing if isGasFeeTokenIgnoredIfBalance', async () => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: transactionIdMock,
+        isGasFeeTokenIgnoredIfBalance: true,
+      } as unknown as TransactionMeta);
 
       const { result } = renderHook();
 
@@ -427,6 +447,29 @@ describe('useTransactionConfirm', () => {
       useSelectedGasFeeTokenMock.mockReturnValue(
         undefined as unknown as ReturnType<typeof useSelectedGasFeeToken>,
       );
+
+      const { result } = renderHook();
+
+      await act(async () => {
+        await result.current.onConfirm();
+      });
+
+      expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
+        txMeta: expect.not.objectContaining({ isExternalSign: true }),
+      });
+    });
+
+    it('does nothing if isGasFeeTokenIgnoredIfBalance', async () => {
+      isSendBundleSupportedMock.mockReturnValue(Promise.resolve(false));
+
+      useSelectedGasFeeTokenMock.mockReturnValue({
+        transferTransaction: { data: '0xabc' },
+      } as unknown as ReturnType<typeof useSelectedGasFeeToken>);
+
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: transactionIdMock,
+        isGasFeeTokenIgnoredIfBalance: true,
+      } as unknown as TransactionMeta);
 
       const { result } = renderHook();
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -33,7 +33,8 @@ export function useTransactionConfirm() {
   const navigation = useNavigation();
   const transactionMetadata = useTransactionMetadataRequest();
   const selectedGasFeeToken = useSelectedGasFeeToken();
-  const { chainId, type } = transactionMetadata ?? {};
+  const { chainId, isGasFeeTokenIgnoredIfBalance, type } =
+    transactionMetadata ?? {};
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
   const quotes = useTransactionPayQuotes();
 
@@ -49,7 +50,7 @@ export function useTransactionConfirm() {
 
   const handleSmartTransaction = useCallback(
     (updatedMetadata: TransactionMeta) => {
-      if (!selectedGasFeeToken) {
+      if (!selectedGasFeeToken || isGasFeeTokenIgnoredIfBalance) {
         return;
       }
 
@@ -76,6 +77,7 @@ export function useTransactionConfirm() {
     },
     [
       selectedGasFeeToken,
+      isGasFeeTokenIgnoredIfBalance,
       isGaslessSupported,
       transactionMetadata?.isGasFeeSponsored,
     ],
@@ -83,7 +85,7 @@ export function useTransactionConfirm() {
 
   const handleGasless7702 = useCallback(
     (updatedMetadata: TransactionMeta) => {
-      if (!selectedGasFeeToken) {
+      if (!selectedGasFeeToken || isGasFeeTokenIgnoredIfBalance) {
         return;
       }
 
@@ -92,6 +94,7 @@ export function useTransactionConfirm() {
         isGaslessSupported && transactionMetadata?.isGasFeeSponsored;
     },
     [
+      isGasFeeTokenIgnoredIfBalance,
       isGaslessSupported,
       selectedGasFeeToken,
       transactionMetadata?.isGasFeeSponsored,

--- a/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
+++ b/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
@@ -148,6 +148,7 @@ export function getTransactionControllerInitMessenger(
       'NetworkController:getEIP1559Compatibility',
       'KeyringController:signEip7702Authorization',
       'KeyringController:signTypedMessage',
+      'RemoteFeatureFlagController:getState',
       'TransactionController:addTransaction',
       'TransactionController:addTransactionBatch',
       'TransactionController:getState',

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "@scure/bip32": "1.7.0",
     "@metamask/snaps-sdk": "^10.0.0",
     "react-native@0.76.9": "patch:react-native@npm%3A0.76.9#./.yarn/patches/react-native-npm-0.76.9-1c25352097.patch",
-    "@metamask/transaction-controller@npm:^62.2.0": "patch:@metamask/transaction-controller@npm%3A62.2.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch"
+    "@metamask/transaction-controller@npm:^62.3.0": "patch:@metamask/transaction-controller@npm%3A62.3.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch"
   },
   "dependencies": {
     "@config-plugins/detox": "^9.0.0",
@@ -286,8 +286,8 @@
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/swaps-controller": "^15.0.0",
     "@metamask/token-search-discovery-controller": "^4.0.0",
-    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.2.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch",
-    "@metamask/transaction-pay-controller": "^10.0.0",
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.3.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch",
+    "@metamask/transaction-pay-controller": "^10.1.0",
     "@metamask/tron-wallet-snap": "^1.10.0",
     "@metamask/utils": "^11.8.1",
     "@ngraveio/bc-ur": "^1.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7408,6 +7408,58 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/assets-controllers@npm:^91.0.0":
+  version: 91.0.0
+  resolution: "@metamask/assets-controllers@npm:91.0.0"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/abi-utils": "npm:^2.0.3"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/contract-metadata": "npm:^2.4.0"
+    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/keyring-api": "npm:^21.0.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/polling-controller": "npm:^16.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/snaps-sdk": "npm:^9.0.0"
+    "@metamask/snaps-utils": "npm:^11.0.0"
+    "@metamask/utils": "npm:^11.8.1"
+    "@types/bn.js": "npm:^5.1.5"
+    "@types/uuid": "npm:^8.3.0"
+    async-mutex: "npm:^0.5.0"
+    bitcoin-address-validation: "npm:^2.2.3"
+    bn.js: "npm:^5.2.1"
+    immer: "npm:^9.0.6"
+    lodash: "npm:^4.17.21"
+    multiformats: "npm:^9.9.0"
+    reselect: "npm:^5.1.1"
+    single-call-balance-checker-abi: "npm:^1.0.0"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/account-tree-controller": ^4.0.0
+    "@metamask/accounts-controller": ^35.0.0
+    "@metamask/approval-controller": ^8.0.0
+    "@metamask/core-backend": ^5.0.0
+    "@metamask/keyring-controller": ^25.0.0
+    "@metamask/network-controller": ^26.0.0
+    "@metamask/permission-controller": ^12.0.0
+    "@metamask/phishing-controller": ^16.0.0
+    "@metamask/preferences-controller": ^22.0.0
+    "@metamask/providers": ^22.0.0
+    "@metamask/snaps-controllers": ^14.0.0
+    "@metamask/transaction-controller": ^62.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/8e43d631a5ae86fc4801912e79d944ad087a605bb7a5e2813de64b6e068dc26482d25d37c3e2272e435a71ee8a7dafe875edb46cbfbcd150fb474588b45e6ff4
+  languageName: node
+  linkType: hard
+
 "@metamask/assets-controllers@patch:@metamask/assets-controllers@npm%3A89.0.1#~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch":
   version: 89.0.1
   resolution: "@metamask/assets-controllers@patch:@metamask/assets-controllers@npm%3A89.0.1#~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch::version=89.0.1&hash=6be0d3"
@@ -7561,6 +7613,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/bridge-controller@npm:^63.0.0":
+  version: 63.0.0
+  resolution: "@metamask/bridge-controller@npm:63.0.0"
+  dependencies:
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/constants": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/gas-fee-controller": "npm:^26.0.0"
+    "@metamask/keyring-api": "npm:^21.0.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-network-controller": "npm:^3.0.0"
+    "@metamask/polling-controller": "npm:^16.0.0"
+    "@metamask/utils": "npm:^11.8.1"
+    bignumber.js: "npm:^9.1.2"
+    reselect: "npm:^5.1.1"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/accounts-controller": ^35.0.0
+    "@metamask/assets-controllers": ^91.0.0
+    "@metamask/network-controller": ^26.0.0
+    "@metamask/remote-feature-flag-controller": ^2.0.0
+    "@metamask/snaps-controllers": ^14.0.0
+    "@metamask/transaction-controller": ^62.0.0
+  checksum: 10/53125ecf3938d8ec7c5b33b6ee7302b475616f73c24e2303a702fc31b446f9b7335adaf9451edc7070989542595dc6ac4199fd09d94f614e196e8066edc2855e
+  languageName: node
+  linkType: hard
+
 "@metamask/bridge-status-controller@npm:^61.0.0":
   version: 61.0.0
   resolution: "@metamask/bridge-status-controller@npm:61.0.0"
@@ -7580,6 +7664,28 @@ __metadata:
     "@metamask/snaps-controllers": ^14.0.0
     "@metamask/transaction-controller": ^61.0.0
   checksum: 10/5f84b9c46b57079a3d39dd570d5b9e1a0c475435e05c6ec183fd832e563ed362df927ce83c88f9026dbd3ccd279309686e900e15a2b5f17dcff2ebb39959b7b5
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-status-controller@npm:^63.0.0":
+  version: 63.0.0
+  resolution: "@metamask/bridge-status-controller@npm:63.0.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/polling-controller": "npm:^16.0.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.8.1"
+    bignumber.js: "npm:^9.1.2"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/accounts-controller": ^35.0.0
+    "@metamask/bridge-controller": ^63.0.0
+    "@metamask/gas-fee-controller": ^26.0.0
+    "@metamask/network-controller": ^26.0.0
+    "@metamask/snaps-controllers": ^14.0.0
+    "@metamask/transaction-controller": ^62.0.0
+  checksum: 10/04a814032f57d988f8b753c789ebd9293ee6205825d92b15d41c9fd9f11e39835d5920186e5a4bede8231d0af26b391e699def6a95be21e04c231d1761c821b6
   languageName: node
   linkType: hard
 
@@ -8553,6 +8659,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/multichain-network-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/multichain-network-controller@npm:3.0.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/keyring-api": "npm:^21.0.0"
+    "@metamask/keyring-internal-api": "npm:^9.0.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.8.1"
+    "@solana/addresses": "npm:^2.0.0"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@metamask/accounts-controller": ^35.0.0
+    "@metamask/network-controller": ^26.0.0
+  checksum: 10/b167cd4bed12285c1e37f74a681371c453936e1aaa7e1207fb98cd97cbfa8831ca9e96a569a8787caac3f5a831627435e001dc8febaad2e61a142e4298f57d2f
+  languageName: node
+  linkType: hard
+
 "@metamask/multichain-transactions-controller@npm:^6.0.0":
   version: 6.0.0
   resolution: "@metamask/multichain-transactions-controller@npm:6.0.0"
@@ -9437,9 +9563,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:62.2.0":
-  version: 62.2.0
-  resolution: "@metamask/transaction-controller@npm:62.2.0"
+"@metamask/transaction-controller@npm:62.3.0, @metamask/transaction-controller@npm:^62.2.0":
+  version: 62.3.0
+  resolution: "@metamask/transaction-controller@npm:62.3.0"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -9471,7 +9597,7 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/978884a159300253960443c331422da9355d26f118b6caa59a4924a99ccadae677a41330bf94497f1cb686cc68bea30431220621e4a9d1576652cb5a3489977a
+  checksum: 10/c6e4024359567692b8d2f29ccca678124692d28dca547a0bdec829d81aeda381f51840d981a047d69ae60fb24033b6a45d22bb1e8751f4de46a4f26733c30278
   languageName: node
   linkType: hard
 
@@ -9513,9 +9639,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.2.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch":
-  version: 62.2.0
-  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.2.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch::version=62.2.0&hash=1a3342"
+"@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.3.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch":
+  version: 62.3.0
+  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.3.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch::version=62.3.0&hash=1a3342"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -9547,34 +9673,33 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/aeac45f777786d040d4860cd49fc2665a632cd834eef3f5ef73e1a7fad95ead6bfb02a597a0b60f9bcc7036c0a88fa0affe27a5d9f11f595cb3cffdc13a446d4
+  checksum: 10/a8d7360285485c1d81b1eed2e7b744d82941450fe0825d195bc69d830576a5587624841a7e9f4e75169be2e77db4cde714ca4b35fc04ef6039625de1250849d6
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "@metamask/transaction-pay-controller@npm:10.0.0"
+"@metamask/transaction-pay-controller@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "@metamask/transaction-pay-controller@npm:10.1.0"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
+    "@metamask/assets-controllers": "npm:^91.0.0"
     "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/bridge-controller": "npm:^63.0.0"
+    "@metamask/bridge-status-controller": "npm:^63.0.0"
     "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/gas-fee-controller": "npm:^26.0.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^26.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^2.0.1"
+    "@metamask/transaction-controller": "npm:^62.2.0"
     "@metamask/utils": "npm:^11.8.1"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  peerDependencies:
-    "@metamask/assets-controllers": ^91.0.0
-    "@metamask/bridge-controller": ^63.0.0
-    "@metamask/bridge-status-controller": ^63.0.0
-    "@metamask/gas-fee-controller": ^26.0.0
-    "@metamask/network-controller": ^26.0.0
-    "@metamask/remote-feature-flag-controller": ^2.0.0
-    "@metamask/transaction-controller": ^62.0.0
-  checksum: 10/596b50c04ee658bd16aefc8000d8cdbe2ac04e82636e9029b828c352377ca1e1af6b3c33f129ea28ba966553f513f42988e6ad50bc4edb99c59a68467fe6a1f6
+  checksum: 10/59b7b07879b7ea36871906efd5b8c3328c16e72780a02b29a814544b2f970d9e625f286cd43f9e4b08cb8e9bffab66e12b296bfc36161c28b033b3b69093bd91
   languageName: node
   linkType: hard
 
@@ -35612,8 +35737,8 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/token-search-discovery-controller": "npm:^4.0.0"
-    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.2.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch"
-    "@metamask/transaction-pay-controller": "npm:^10.0.0"
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.3.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch"
+    "@metamask/transaction-pay-controller": "npm:^10.1.0"
     "@metamask/tron-wallet-snap": "npm:^1.10.0"
     "@metamask/utils": "npm:^11.8.1"
     "@ngraveio/bc-ur": "npm:^1.1.6"


### PR DESCRIPTION
## **Description**

Fix Predict withdraw when using gas station with insufficient existing token balance.

Bump `transaction-controller` and `transaction-pay-controller`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #23137 #23126

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents gas-fee token injection/external sign when `txMeta.isGasFeeTokenIgnoredIfBalance` is set; wires Remote Feature Flag messenger action; bumps transaction/transaction-pay controllers.
> 
> - **Confirmations**:
>   - Update `useTransactionConfirm` to skip adding `batchTransactions` and `isExternalSign` when `txMeta.isGasFeeTokenIgnoredIfBalance` is true.
>   - Include `isGasFeeTokenIgnoredIfBalance` in metadata handling for smart transactions and 7702 flows.
> - **Tests**:
>   - Add tests ensuring no gas-fee token batching or external signing when `isGasFeeTokenIgnoredIfBalance` is set.
> - **Messaging**:
>   - Allow `RemoteFeatureFlagController:getState` in `transaction-controller` init messenger.
> - **Dependencies**:
>   - Bump `@metamask/transaction-controller` to `62.3.0` and `@metamask/transaction-pay-controller` to `10.1.0` (with corresponding lockfile updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccbc4d8b69106e4f8ad9c85a83db6e26af4560ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->