### PR TITLE
chore: Polish visuals for Import NFT

### DIFF
--- a/app/components/UI/ActionView/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/ActionView/__snapshots__/index.test.tsx.snap
@@ -77,101 +77,101 @@ exports[`ActionView should render correctly 1`] = `
           Confirm
         </Text>
       </View>
-      <View
-        style={
-          [
-            {
-              "flexDirection": "row",
-              "gap": 16,
-              "paddingHorizontal": 16,
-              "paddingVertical": 16,
-              "width": "100%",
-            },
-            undefined,
-          ]
-        }
-      >
-        <TouchableOpacity
-          accessibilityRole="button"
-          accessible={true}
-          activeOpacity={1}
-          disabled={false}
-          onPressIn={[Function]}
-          onPressOut={[Function]}
-          style={
-            {
-              "alignItems": "center",
-              "alignSelf": "flex-start",
-              "backgroundColor": "#3c4d9d0f",
-              "borderColor": "transparent",
-              "borderRadius": 12,
-              "borderWidth": 1,
-              "flex": 1,
-              "flexDirection": "row",
-              "height": 48,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "paddingHorizontal": 16,
-            }
-          }
-          testID=""
-        >
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#121314",
-                "fontFamily": "Geist Medium",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Cancel
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          accessibilityRole="button"
-          accessible={true}
-          activeOpacity={1}
-          disabled={false}
-          loading={false}
-          onPressIn={[Function]}
-          onPressOut={[Function]}
-          style={
-            {
-              "alignItems": "center",
-              "alignSelf": "flex-start",
-              "backgroundColor": "#121314",
-              "borderRadius": 12,
-              "flex": 1,
-              "flexDirection": "row",
-              "height": 48,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "paddingHorizontal": 16,
-            }
-          }
-          testID=""
-        >
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#ffffff",
-                "fontFamily": "Geist Medium",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Confirm
-          </Text>
-        </TouchableOpacity>
-      </View>
     </View>
   </RCTScrollView>
+  <View
+    style={
+      [
+        {
+          "flexDirection": "row",
+          "gap": 16,
+          "paddingHorizontal": 16,
+          "paddingTop": 16,
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+  >
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      onPressIn={[Function]}
+      onPressOut={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "#3c4d9d0f",
+          "borderColor": "transparent",
+          "borderRadius": 12,
+          "borderWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "overflow": "hidden",
+          "paddingHorizontal": 16,
+        }
+      }
+      testID=""
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#121314",
+            "fontFamily": "Geist Medium",
+            "fontSize": 16,
+            "letterSpacing": 0,
+            "lineHeight": 24,
+          }
+        }
+      >
+        Cancel
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      loading={false}
+      onPressIn={[Function]}
+      onPressOut={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "#121314",
+          "borderRadius": 12,
+          "flex": 1,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "overflow": "hidden",
+          "paddingHorizontal": 16,
+        }
+      }
+      testID=""
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#ffffff",
+            "fontFamily": "Geist Medium",
+            "fontSize": 16,
+            "letterSpacing": 0,
+            "lineHeight": 24,
+          }
+        }
+      >
+        Confirm
+      </Text>
+    </TouchableOpacity>
+  </View>
 </View>
 `;

--- a/app/components/UI/ActionView/index.js
+++ b/app/components/UI/ActionView/index.js
@@ -25,7 +25,7 @@ const getStyles = (colors) =>
   StyleSheet.create({
     actionContainer: {
       flexDirection: 'row',
-      paddingVertical: 16,
+      paddingTop: 16,
       paddingHorizontal: 16,
       gap: 16,
       width: '100%',
@@ -98,38 +98,37 @@ export default function ActionView({
         >
           {children}
         </TouchableWithoutFeedback>
-
-        <View style={[styles.actionContainer, buttonContainerStyle]}>
-          {showCancelButton && (
-            <Button
-              onPress={onCancelPress}
-              variant={ButtonVariants.Secondary}
-              size={ButtonSize.Lg}
-              label={cancelText}
-              testID={cancelTestID}
-              style={styles.button}
-              isDisabled={confirmed}
-            />
-          )}
-          {showConfirmButton && (
-            <Button
-              onPress={onConfirmPress}
-              variant={ButtonVariants.Primary}
-              size={ButtonSize.Lg}
-              label={confirmText}
-              testID={confirmTestID}
-              style={[
-                styles.button,
-                confirmButtonState === ConfirmButtonState.Warning &&
-                  styles.confirmButtonWarning,
-              ]}
-              isDisabled={confirmed || confirmDisabled || loading}
-              loading={confirmed || loading}
-              isDanger={confirmButtonState === ConfirmButtonState.Error}
-            />
-          )}
-        </View>
       </KeyboardAwareScrollView>
+      <View style={[styles.actionContainer, buttonContainerStyle]}>
+        {showCancelButton && (
+          <Button
+            onPress={onCancelPress}
+            variant={ButtonVariants.Secondary}
+            size={ButtonSize.Lg}
+            label={cancelText}
+            testID={cancelTestID}
+            style={styles.button}
+            isDisabled={confirmed}
+          />
+        )}
+        {showConfirmButton && (
+          <Button
+            onPress={onConfirmPress}
+            variant={ButtonVariants.Primary}
+            size={ButtonSize.Lg}
+            label={confirmText}
+            testID={confirmTestID}
+            style={[
+              styles.button,
+              confirmButtonState === ConfirmButtonState.Warning &&
+                styles.confirmButtonWarning,
+            ]}
+            isDisabled={confirmed || confirmDisabled || loading}
+            loading={confirmed || loading}
+            isDanger={confirmButtonState === ConfirmButtonState.Error}
+          />
+        )}
+      </View>
     </View>
   );
 }

--- a/app/components/UI/AddCustomCollectible/index.tsx
+++ b/app/components/UI/AddCustomCollectible/index.tsx
@@ -51,10 +51,18 @@ const createStyles = (colors: any) =>
       flex: 1,
     },
     rowWrapper: {
-      padding: 20,
+      paddingTop: 24,
+      paddingHorizontal: 16,
+      gap: 16,
+    },
+    rowWrapperWithMargin: {
+      paddingTop: 24,
+      paddingBottom: 16,
+      paddingHorizontal: 16,
+      marginTop: 16,
     },
     rowTitleText: {
-      paddingBottom: 3,
+      paddingBottom: 4,
       // TODO: Replace "any" with type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...(fontStyles.normal as any),
@@ -62,7 +70,7 @@ const createStyles = (colors: any) =>
     },
     textInput: {
       borderWidth: 1,
-      borderRadius: 4,
+      borderRadius: 8,
       borderColor: colors.border.default,
       padding: 16,
       // TODO: Replace "any" with type
@@ -71,7 +79,8 @@ const createStyles = (colors: any) =>
       color: colors.text.default,
     },
     warningText: {
-      marginTop: 15,
+      paddingTop: 4,
+      minHeight: 0,
       color: colors.error.default,
       // TODO: Replace "any" with type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -81,11 +90,11 @@ const createStyles = (colors: any) =>
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'space-between',
-      padding: 16,
+      paddingVertical: 12,
+      paddingHorizontal: 16,
       borderWidth: 1,
       borderColor: colors.border.default,
       borderRadius: 8,
-      marginBottom: 16,
     },
     networkSelectorText: {
       ...fontStyles.normal,
@@ -303,91 +312,105 @@ const AddCustomCollectible = ({
       >
         <View>
           <View style={styles.rowWrapper}>
-            <TouchableOpacity
-              style={styles.networkSelectorContainer}
-              onPress={() => setOpenNetworkSelector(true)}
-              onLongPress={() => setOpenNetworkSelector(true)}
-            >
-              <Text style={styles.networkSelectorText}>
-                {selectedNetwork || strings('networks.select_network')}
+            <View>
+              <Text style={styles.rowTitleText}>
+                {strings('address_book.network')}
               </Text>
+              <TouchableOpacity
+                style={styles.networkSelectorContainer}
+                onPress={() => setOpenNetworkSelector(true)}
+                onLongPress={() => setOpenNetworkSelector(true)}
+              >
+                <Text style={styles.networkSelectorText}>
+                  {selectedNetwork || strings('networks.select_network')}
+                </Text>
 
-              <View style={styles.overlappingAvatarsContainer}>
-                {selectedNetwork ? (
-                  <Avatar
-                    variant={AvatarVariant.Network}
-                    size={AvatarSize.Sm}
-                    name={selectedNetwork}
-                    imageSource={getNetworkImageSource({
-                      networkType: 'evm',
-                      chainId: networkId,
-                    })}
+                <View style={styles.overlappingAvatarsContainer}>
+                  {selectedNetwork ? (
+                    <Avatar
+                      variant={AvatarVariant.Network}
+                      size={AvatarSize.Sm}
+                      name={selectedNetwork}
+                      imageSource={getNetworkImageSource({
+                        networkType: 'evm',
+                        chainId: networkId,
+                      })}
+                      testID={ImportTokenViewSelectorsIDs.SELECT_NETWORK_BUTTON}
+                    />
+                  ) : null}
+
+                  <ButtonIcon
+                    iconName={IconName.ArrowDown}
+                    iconColor={IconColor.Default}
                     testID={ImportTokenViewSelectorsIDs.SELECT_NETWORK_BUTTON}
+                    onPress={() => setOpenNetworkSelector(true)}
+                    accessibilityRole="button"
+                    style={styles.buttonIcon}
                   />
-                ) : null}
+                </View>
+              </TouchableOpacity>
+            </View>
 
-                <ButtonIcon
-                  iconName={IconName.ArrowDown}
-                  iconColor={IconColor.Default}
-                  testID={ImportTokenViewSelectorsIDs.SELECT_NETWORK_BUTTON}
-                  onPress={() => setOpenNetworkSelector(true)}
-                  accessibilityRole="button"
-                  style={styles.buttonIcon}
-                />
-              </View>
-            </TouchableOpacity>
+            <View>
+              <Text style={styles.rowTitleText}>
+                {strings('collectible.collectible_address')}
+              </Text>
+              <TextInput
+                style={[
+                  styles.textInput,
+                  inputWidth ? { width: inputWidth } : {},
+                ]}
+                placeholder={'0x...'}
+                placeholderTextColor={colors.text.alternative}
+                value={address}
+                onChangeText={onAddressChange}
+                onBlur={validateCustomCollectibleAddress}
+                testID={NFTImportScreenSelectorsIDs.ADDRESS_INPUT_BOX}
+                onSubmitEditing={jumpToAssetTokenId}
+                keyboardAppearance={themeAppearance}
+              />
+              {warningAddress ? (
+                <Text
+                  style={styles.warningText}
+                  testID={NFTImportScreenSelectorsIDs.ADDRESS_WARNING_MESSAGE}
+                >
+                  {warningAddress}
+                </Text>
+              ) : null}
+            </View>
 
-            <Text style={styles.rowTitleText}>
-              {strings('collectible.collectible_address')}
-            </Text>
-            <TextInput
-              style={[
-                styles.textInput,
-                inputWidth ? { width: inputWidth } : {},
-              ]}
-              placeholder={'0x...'}
-              placeholderTextColor={colors.text.muted}
-              value={address}
-              onChangeText={onAddressChange}
-              onBlur={validateCustomCollectibleAddress}
-              testID={NFTImportScreenSelectorsIDs.ADDRESS_INPUT_BOX}
-              onSubmitEditing={jumpToAssetTokenId}
-              keyboardAppearance={themeAppearance}
-            />
-            <Text
-              style={styles.warningText}
-              testID={NFTImportScreenSelectorsIDs.ADDRESS_WARNING_MESSAGE}
-            >
-              {warningAddress}
-            </Text>
-          </View>
-          <View style={styles.rowWrapper}>
-            <Text style={styles.rowTitleText}>
-              {strings('collectible.collectible_token_id')}
-            </Text>
-            <TextInput
-              style={[
-                styles.textInput,
-                inputWidth ? { width: inputWidth } : {},
-              ]}
-              value={tokenId}
-              keyboardType="numeric"
-              onChangeText={onTokenIdChange}
-              onBlur={validateCustomCollectibleTokenId}
-              testID={NFTImportScreenSelectorsIDs.IDENTIFIER_INPUT_BOX}
-              ref={assetTokenIdInput}
-              onSubmitEditing={addNft}
-              returnKeyType={'done'}
-              placeholder={strings('collectible.id_placeholder')}
-              placeholderTextColor={colors.text.muted}
-              keyboardAppearance={themeAppearance}
-            />
-            <Text
-              style={styles.warningText}
-              testID={NFTImportScreenSelectorsIDs.IDENTIFIER_WARNING_MESSAGE}
-            >
-              {warningTokenId}
-            </Text>
+            <View>
+              <Text style={styles.rowTitleText}>
+                {strings('collectible.collectible_token_id')}
+              </Text>
+              <TextInput
+                style={[
+                  styles.textInput,
+                  inputWidth ? { width: inputWidth } : {},
+                ]}
+                value={tokenId}
+                keyboardType="numeric"
+                onChangeText={onTokenIdChange}
+                onBlur={validateCustomCollectibleTokenId}
+                testID={NFTImportScreenSelectorsIDs.IDENTIFIER_INPUT_BOX}
+                ref={assetTokenIdInput}
+                onSubmitEditing={addNft}
+                returnKeyType={'done'}
+                placeholder={strings('collectible.id_placeholder')}
+                placeholderTextColor={colors.text.alternative}
+                keyboardAppearance={themeAppearance}
+              />
+              {warningTokenId ? (
+                <Text
+                  style={styles.warningText}
+                  testID={
+                    NFTImportScreenSelectorsIDs.IDENTIFIER_WARNING_MESSAGE
+                  }
+                >
+                  {warningTokenId}
+                </Text>
+              ) : null}
+            </View>
           </View>
         </View>
       </ActionView>

--- a/app/components/Views/AddAsset/AddAsset.styles.ts
+++ b/app/components/Views/AddAsset/AddAsset.styles.ts
@@ -27,6 +27,7 @@ const styleSheet = (params: { theme: Theme }) => {
     infoWrapper: {
       alignItems: 'center',
       marginTop: 10,
+      paddingHorizontal: 16,
     },
     tabContainer: {
       paddingHorizontal: 16,

--- a/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
+++ b/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`AddAsset component renders collectible view correctly 1`] = `
       {
         "alignItems": "center",
         "marginTop": 10,
+        "paddingHorizontal": 16,
       }
     }
     testID="add-asset-nft-banner"
@@ -164,309 +165,300 @@ exports[`AddAsset component renders collectible view correctly 1`] = `
             <View
               style={
                 {
-                  "padding": 20,
+                  "gap": 16,
+                  "paddingHorizontal": 16,
+                  "paddingTop": 24,
                 }
               }
             >
-              <TouchableOpacity
-                onLongPress={[Function]}
-                onPress={[Function]}
-                style={
-                  {
-                    "alignItems": "center",
-                    "borderColor": "#b7bbc8",
-                    "borderRadius": 8,
-                    "borderWidth": 1,
-                    "flexDirection": "row",
-                    "justifyContent": "space-between",
-                    "marginBottom": 16,
-                    "padding": 16,
-                  }
-                }
-              >
+              <View>
                 <Text
                   style={
                     {
                       "color": "#121314",
                       "fontFamily": "Geist Regular",
-                      "fontSize": 16,
+                      "paddingBottom": 4,
                     }
                   }
                 >
-                  Ethereum
+                  Network
                 </Text>
-                <View
+                <TouchableOpacity
+                  onLongPress={[Function]}
+                  onPress={[Function]}
                   style={
                     {
                       "alignItems": "center",
+                      "borderColor": "#b7bbc8",
+                      "borderRadius": 8,
+                      "borderWidth": 1,
                       "flexDirection": "row",
                       "justifyContent": "space-between",
+                      "paddingHorizontal": 16,
+                      "paddingVertical": 12,
                     }
                   }
                 >
+                  <Text
+                    style={
+                      {
+                        "color": "#121314",
+                        "fontFamily": "Geist Regular",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    Ethereum
+                  </Text>
                   <View
                     style={
                       {
                         "alignItems": "center",
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 8,
-                        "height": 24,
-                        "justifyContent": "center",
-                        "overflow": "hidden",
-                        "width": 24,
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
                       }
                     }
-                    testID="select-network-button"
                   >
-                    <Image
-                      onError={[Function]}
-                      resizeMode="contain"
-                      source="ethereum"
+                    <View
                       style={
                         {
+                          "alignItems": "center",
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 8,
                           "height": 24,
+                          "justifyContent": "center",
+                          "overflow": "hidden",
                           "width": 24,
                         }
                       }
-                      testID="network-avatar-image"
-                    />
-                  </View>
-                  <TouchableOpacity
-                    accessibilityRole="button"
-                    accessible={true}
-                    activeOpacity={1}
-                    disabled={false}
-                    onPress={[Function]}
-                    onPressIn={[Function]}
-                    onPressOut={[Function]}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "borderRadius": 8,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 16,
-                        "opacity": 1,
-                        "width": 28,
-                      }
-                    }
-                    testID="select-network-button"
-                  >
-                    <SvgMock
-                      color="#121314"
-                      fill="currentColor"
-                      height={20}
-                      name="ArrowDown"
+                      testID="select-network-button"
+                    >
+                      <Image
+                        onError={[Function]}
+                        resizeMode="contain"
+                        source="ethereum"
+                        style={
+                          {
+                            "height": 24,
+                            "width": 24,
+                          }
+                        }
+                        testID="network-avatar-image"
+                      />
+                    </View>
+                    <TouchableOpacity
+                      accessibilityRole="button"
+                      accessible={true}
+                      activeOpacity={1}
+                      disabled={false}
+                      onPress={[Function]}
+                      onPressIn={[Function]}
+                      onPressOut={[Function]}
                       style={
                         {
-                          "height": 20,
-                          "width": 20,
+                          "alignItems": "center",
+                          "borderRadius": 8,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 16,
+                          "opacity": 1,
+                          "width": 28,
                         }
                       }
-                      width={20}
-                    />
-                  </TouchableOpacity>
-                </View>
-              </TouchableOpacity>
-              <Text
-                style={
-                  {
-                    "color": "#121314",
-                    "fontFamily": "Geist Regular",
-                    "paddingBottom": 3,
-                  }
-                }
-              >
-                Address
-              </Text>
-              <TextInput
-                keyboardAppearance="light"
-                onBlur={[Function]}
-                onChangeText={[Function]}
-                onSubmitEditing={[Function]}
-                placeholder="0x..."
-                placeholderTextColor="#b7bbc8"
-                style={
-                  [
+                      testID="select-network-button"
+                    >
+                      <SvgMock
+                        color="#121314"
+                        fill="currentColor"
+                        height={20}
+                        name="ArrowDown"
+                        style={
+                          {
+                            "height": 20,
+                            "width": 20,
+                          }
+                        }
+                        width={20}
+                      />
+                    </TouchableOpacity>
+                  </View>
+                </TouchableOpacity>
+              </View>
+              <View>
+                <Text
+                  style={
                     {
-                      "borderColor": "#b7bbc8",
-                      "borderRadius": 4,
-                      "borderWidth": 1,
                       "color": "#121314",
                       "fontFamily": "Geist Regular",
-                      "padding": 16,
-                    },
-                    {},
-                  ]
-                }
-                testID="input-collectible-address"
-                value=""
-              />
-              <Text
-                style={
-                  {
-                    "color": "#ca3542",
-                    "fontFamily": "Geist Regular",
-                    "marginTop": 15,
+                      "paddingBottom": 4,
+                    }
                   }
-                }
-                testID="collectible-address-warning"
-              />
-            </View>
-            <View
-              style={
-                {
-                  "padding": 20,
-                }
-              }
-            >
-              <Text
-                style={
-                  {
-                    "color": "#121314",
-                    "fontFamily": "Geist Regular",
-                    "paddingBottom": 3,
+                >
+                  Address
+                </Text>
+                <TextInput
+                  keyboardAppearance="light"
+                  onBlur={[Function]}
+                  onChangeText={[Function]}
+                  onSubmitEditing={[Function]}
+                  placeholder="0x..."
+                  placeholderTextColor="#686e7d"
+                  style={
+                    [
+                      {
+                        "borderColor": "#b7bbc8",
+                        "borderRadius": 8,
+                        "borderWidth": 1,
+                        "color": "#121314",
+                        "fontFamily": "Geist Regular",
+                        "padding": 16,
+                      },
+                      {},
+                    ]
                   }
-                }
-              >
-                ID
-              </Text>
-              <TextInput
-                keyboardAppearance="light"
-                keyboardType="numeric"
-                onBlur={[Function]}
-                onChangeText={[Function]}
-                onSubmitEditing={[Function]}
-                placeholder="Enter the collectible ID"
-                placeholderTextColor="#b7bbc8"
-                returnKeyType="done"
-                style={
-                  [
+                  testID="input-collectible-address"
+                  value=""
+                />
+              </View>
+              <View>
+                <Text
+                  style={
                     {
-                      "borderColor": "#b7bbc8",
-                      "borderRadius": 4,
-                      "borderWidth": 1,
                       "color": "#121314",
                       "fontFamily": "Geist Regular",
-                      "padding": 16,
-                    },
-                    {},
-                  ]
-                }
-                testID="input-collectible-identifier"
-                value=""
-              />
-              <Text
-                style={
-                  {
-                    "color": "#ca3542",
-                    "fontFamily": "Geist Regular",
-                    "marginTop": 15,
+                      "paddingBottom": 4,
+                    }
                   }
-                }
-                testID="collectible-identifier-warning"
-              />
+                >
+                  ID
+                </Text>
+                <TextInput
+                  keyboardAppearance="light"
+                  keyboardType="numeric"
+                  onBlur={[Function]}
+                  onChangeText={[Function]}
+                  onSubmitEditing={[Function]}
+                  placeholder="Enter the collectible ID"
+                  placeholderTextColor="#686e7d"
+                  returnKeyType="done"
+                  style={
+                    [
+                      {
+                        "borderColor": "#b7bbc8",
+                        "borderRadius": 8,
+                        "borderWidth": 1,
+                        "color": "#121314",
+                        "fontFamily": "Geist Regular",
+                        "padding": 16,
+                      },
+                      {},
+                    ]
+                  }
+                  testID="input-collectible-identifier"
+                  value=""
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "flexDirection": "row",
-                  "gap": 16,
-                  "paddingHorizontal": 16,
-                  "paddingVertical": 16,
-                  "width": "100%",
-                },
-                undefined,
-              ]
-            }
-          >
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              disabled={false}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
-                {
-                  "alignItems": "center",
-                  "alignSelf": "flex-start",
-                  "backgroundColor": "#3c4d9d0f",
-                  "borderColor": "transparent",
-                  "borderRadius": 12,
-                  "borderWidth": 1,
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "height": 48,
-                  "justifyContent": "center",
-                  "overflow": "hidden",
-                  "paddingHorizontal": 16,
-                }
-              }
-              testID=""
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#121314",
-                    "fontFamily": "Geist Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                CANCEL
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              disabled={true}
-              loading={false}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
-                {
-                  "alignItems": "center",
-                  "alignSelf": "flex-start",
-                  "backgroundColor": "#121314",
-                  "borderRadius": 12,
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "height": 48,
-                  "justifyContent": "center",
-                  "opacity": 0.5,
-                  "overflow": "hidden",
-                  "paddingHorizontal": 16,
-                }
-              }
-              testID="add-collectible-button"
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#ffffff",
-                    "fontFamily": "Geist Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                IMPORT
-              </Text>
-            </TouchableOpacity>
           </View>
         </View>
       </RCTScrollView>
+      <View
+        style={
+          [
+            {
+              "flexDirection": "row",
+              "gap": 16,
+              "paddingHorizontal": 16,
+              "paddingTop": 16,
+              "width": "100%",
+            },
+            undefined,
+          ]
+        }
+      >
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessible={true}
+          activeOpacity={1}
+          disabled={false}
+          onPress={[Function]}
+          onPressIn={[Function]}
+          onPressOut={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "flex-start",
+              "backgroundColor": "#3c4d9d0f",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 1,
+              "flex": 1,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "overflow": "hidden",
+              "paddingHorizontal": 16,
+            }
+          }
+          testID=""
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Medium",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Cancel
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessible={true}
+          activeOpacity={1}
+          disabled={true}
+          loading={false}
+          onPress={[Function]}
+          onPressIn={[Function]}
+          onPressOut={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "flex-start",
+              "backgroundColor": "#121314",
+              "borderRadius": 12,
+              "flex": 1,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "opacity": 0.5,
+              "overflow": "hidden",
+              "paddingHorizontal": 16,
+            }
+          }
+          testID="add-collectible-button"
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#ffffff",
+                "fontFamily": "Geist Medium",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Import
+          </Text>
+        </TouchableOpacity>
+      </View>
     </View>
   </View>
 </RCTSafeAreaView>

--- a/app/components/Views/AddBookmark/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AddBookmark/__snapshots__/index.test.tsx.snap
@@ -172,104 +172,104 @@ exports[`AddBookmark should render correctly 1`] = `
             />
           </View>
         </View>
-        <View
-          style={
-            [
-              {
-                "flexDirection": "row",
-                "gap": 16,
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
-                "width": "100%",
-              },
-              undefined,
-            ]
-          }
-        >
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessible={true}
-            activeOpacity={1}
-            disabled={false}
-            onPress={[Function]}
-            onPressIn={[Function]}
-            onPressOut={[Function]}
-            style={
-              {
-                "alignItems": "center",
-                "alignSelf": "flex-start",
-                "backgroundColor": "#3c4d9d0f",
-                "borderColor": "transparent",
-                "borderRadius": 12,
-                "borderWidth": 1,
-                "flex": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "overflow": "hidden",
-                "paddingHorizontal": 16,
-              }
-            }
-            testID="add-bookmark-cancel-button"
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#121314",
-                  "fontFamily": "Geist Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Cancel
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessible={true}
-            activeOpacity={1}
-            disabled={false}
-            loading={false}
-            onPress={[Function]}
-            onPressIn={[Function]}
-            onPressOut={[Function]}
-            style={
-              {
-                "alignItems": "center",
-                "alignSelf": "flex-start",
-                "backgroundColor": "#121314",
-                "borderRadius": 12,
-                "flex": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "overflow": "hidden",
-                "paddingHorizontal": 16,
-              }
-            }
-            testID="add-bookmark-confirm-button"
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#ffffff",
-                  "fontFamily": "Geist Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Add
-            </Text>
-          </TouchableOpacity>
-        </View>
       </View>
     </RCTScrollView>
+    <View
+      style={
+        [
+          {
+            "flexDirection": "row",
+            "gap": 16,
+            "paddingHorizontal": 16,
+            "paddingTop": 16,
+            "width": "100%",
+          },
+          undefined,
+        ]
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#3c4d9d0f",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="add-bookmark-cancel-button"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#121314",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Cancel
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#121314",
+            "borderRadius": 12,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="add-bookmark-confirm-button"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Add
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
 </RCTSafeAreaView>
 `;

--- a/app/components/Views/RevealPrivateCredential/__snapshots__/RevealPrivateCredential.test.tsx.snap
+++ b/app/components/Views/RevealPrivateCredential/__snapshots__/RevealPrivateCredential.test.tsx.snap
@@ -321,64 +321,64 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
             />
           </View>
         </View>
-        <View
-          style={
-            [
-              {
-                "flexDirection": "row",
-                "gap": 16,
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
-                "width": "100%",
-              },
-              undefined,
-            ]
-          }
-        >
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessible={true}
-            activeOpacity={1}
-            disabled={true}
-            loading={false}
-            onPress={[Function]}
-            onPressIn={[Function]}
-            onPressOut={[Function]}
-            style={
-              {
-                "alignItems": "center",
-                "alignSelf": "flex-start",
-                "backgroundColor": "#121314",
-                "borderRadius": 12,
-                "flex": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "opacity": 0.5,
-                "overflow": "hidden",
-                "paddingHorizontal": 16,
-              }
-            }
-            testID="reveal-private-credential-next-button"
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#ffffff",
-                  "fontFamily": "Geist Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Next
-            </Text>
-          </TouchableOpacity>
-        </View>
       </View>
     </RCTScrollView>
+    <View
+      style={
+        [
+          {
+            "flexDirection": "row",
+            "gap": 16,
+            "paddingHorizontal": 16,
+            "paddingTop": 16,
+            "width": "100%",
+          },
+          undefined,
+        ]
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={true}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#121314",
+            "borderRadius": 12,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "opacity": 0.5,
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="reveal-private-credential-next-button"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Next
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
   <View />
 </View>
@@ -705,64 +705,64 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
             />
           </View>
         </View>
-        <View
-          style={
-            [
-              {
-                "flexDirection": "row",
-                "gap": 16,
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
-                "width": "100%",
-              },
-              undefined,
-            ]
-          }
-        >
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessible={true}
-            activeOpacity={1}
-            disabled={true}
-            loading={false}
-            onPress={[Function]}
-            onPressIn={[Function]}
-            onPressOut={[Function]}
-            style={
-              {
-                "alignItems": "center",
-                "alignSelf": "flex-start",
-                "backgroundColor": "#121314",
-                "borderRadius": 12,
-                "flex": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "opacity": 0.5,
-                "overflow": "hidden",
-                "paddingHorizontal": 16,
-              }
-            }
-            testID="reveal-private-credential-next-button"
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#ffffff",
-                  "fontFamily": "Geist Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Next
-            </Text>
-          </TouchableOpacity>
-        </View>
       </View>
     </RCTScrollView>
+    <View
+      style={
+        [
+          {
+            "flexDirection": "row",
+            "gap": 16,
+            "paddingHorizontal": 16,
+            "paddingTop": 16,
+            "width": "100%",
+          },
+          undefined,
+        ]
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={true}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#121314",
+            "borderRadius": 12,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "opacity": 0.5,
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="reveal-private-credential-next-button"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Next
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
   <View />
 </View>
@@ -1089,64 +1089,64 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
             />
           </View>
         </View>
-        <View
-          style={
-            [
-              {
-                "flexDirection": "row",
-                "gap": 16,
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
-                "width": "100%",
-              },
-              undefined,
-            ]
-          }
-        >
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessible={true}
-            activeOpacity={1}
-            disabled={true}
-            loading={false}
-            onPress={[Function]}
-            onPressIn={[Function]}
-            onPressOut={[Function]}
-            style={
-              {
-                "alignItems": "center",
-                "alignSelf": "flex-start",
-                "backgroundColor": "#121314",
-                "borderRadius": 12,
-                "flex": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "opacity": 0.5,
-                "overflow": "hidden",
-                "paddingHorizontal": 16,
-              }
-            }
-            testID="reveal-private-credential-next-button"
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#ffffff",
-                  "fontFamily": "Geist Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Next
-            </Text>
-          </TouchableOpacity>
-        </View>
       </View>
     </RCTScrollView>
+    <View
+      style={
+        [
+          {
+            "flexDirection": "row",
+            "gap": 16,
+            "paddingHorizontal": 16,
+            "paddingTop": 16,
+            "width": "100%",
+          },
+          undefined,
+        ]
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={true}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#121314",
+            "borderRadius": 12,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "opacity": 0.5,
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="reveal-private-credential-next-button"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Next
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
   <View />
 </View>
@@ -1561,64 +1561,64 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
             />
           </View>
         </View>
-        <View
-          style={
-            [
-              {
-                "flexDirection": "row",
-                "gap": 16,
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
-                "width": "100%",
-              },
-              undefined,
-            ]
-          }
-        >
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessible={true}
-            activeOpacity={1}
-            disabled={true}
-            loading={false}
-            onPress={[Function]}
-            onPressIn={[Function]}
-            onPressOut={[Function]}
-            style={
-              {
-                "alignItems": "center",
-                "alignSelf": "flex-start",
-                "backgroundColor": "#121314",
-                "borderRadius": 12,
-                "flex": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "opacity": 0.5,
-                "overflow": "hidden",
-                "paddingHorizontal": 16,
-              }
-            }
-            testID="reveal-private-credential-next-button"
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#ffffff",
-                  "fontFamily": "Geist Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Next
-            </Text>
-          </TouchableOpacity>
-        </View>
       </View>
     </RCTScrollView>
+    <View
+      style={
+        [
+          {
+            "flexDirection": "row",
+            "gap": 16,
+            "paddingHorizontal": 16,
+            "paddingTop": 16,
+            "width": "100%",
+          },
+          undefined,
+        ]
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={true}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#121314",
+            "borderRadius": 12,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "opacity": 0.5,
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="reveal-private-credential-next-button"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Next
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
   <View />
 </View>
@@ -2033,64 +2033,64 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
             />
           </View>
         </View>
-        <View
-          style={
-            [
-              {
-                "flexDirection": "row",
-                "gap": 16,
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
-                "width": "100%",
-              },
-              undefined,
-            ]
-          }
-        >
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessible={true}
-            activeOpacity={1}
-            disabled={true}
-            loading={false}
-            onPress={[Function]}
-            onPressIn={[Function]}
-            onPressOut={[Function]}
-            style={
-              {
-                "alignItems": "center",
-                "alignSelf": "flex-start",
-                "backgroundColor": "#121314",
-                "borderRadius": 12,
-                "flex": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "opacity": 0.5,
-                "overflow": "hidden",
-                "paddingHorizontal": 16,
-              }
-            }
-            testID="reveal-private-credential-next-button"
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#ffffff",
-                  "fontFamily": "Geist Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Next
-            </Text>
-          </TouchableOpacity>
-        </View>
       </View>
     </RCTScrollView>
+    <View
+      style={
+        [
+          {
+            "flexDirection": "row",
+            "gap": 16,
+            "paddingHorizontal": 16,
+            "paddingTop": 16,
+            "width": "100%",
+          },
+          undefined,
+        ]
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={true}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#121314",
+            "borderRadius": 12,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "opacity": 0.5,
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="reveal-private-credential-next-button"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Next
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
   <View />
 </View>

--- a/app/components/Views/confirmations/legacy/Approval/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/Approval/__snapshots__/index.test.tsx.snap
@@ -1009,105 +1009,105 @@ exports[`Approval render matches snapshot 1`] = `
                                                 </View>
                                               </RCTScrollView>
                                             </View>
-                                            <View
-                                              style={
-                                                [
-                                                  {
-                                                    "flexDirection": "row",
-                                                    "gap": 16,
-                                                    "paddingHorizontal": 16,
-                                                    "paddingVertical": 16,
-                                                    "width": "100%",
-                                                  },
-                                                  undefined,
-                                                ]
-                                              }
-                                            >
-                                              <TouchableOpacity
-                                                accessibilityRole="button"
-                                                accessible={true}
-                                                activeOpacity={1}
-                                                disabled={false}
-                                                onPress={[Function]}
-                                                onPressIn={[Function]}
-                                                onPressOut={[Function]}
-                                                style={
-                                                  {
-                                                    "alignItems": "center",
-                                                    "alignSelf": "flex-start",
-                                                    "backgroundColor": "#3c4d9d0f",
-                                                    "borderColor": "transparent",
-                                                    "borderRadius": 12,
-                                                    "borderWidth": 1,
-                                                    "flex": 1,
-                                                    "flexDirection": "row",
-                                                    "height": 48,
-                                                    "justifyContent": "center",
-                                                    "overflow": "hidden",
-                                                    "paddingHorizontal": 16,
-                                                  }
-                                                }
-                                                testID=""
-                                              >
-                                                <Text
-                                                  accessibilityRole="text"
-                                                  style={
-                                                    {
-                                                      "color": "#121314",
-                                                      "fontFamily": "Geist Medium",
-                                                      "fontSize": 16,
-                                                      "letterSpacing": 0,
-                                                      "lineHeight": 24,
-                                                    }
-                                                  }
-                                                >
-                                                  Reject
-                                                </Text>
-                                              </TouchableOpacity>
-                                              <TouchableOpacity
-                                                accessibilityRole="button"
-                                                accessible={true}
-                                                activeOpacity={1}
-                                                disabled={true}
-                                                loading={false}
-                                                onPress={[Function]}
-                                                onPressIn={[Function]}
-                                                onPressOut={[Function]}
-                                                style={
-                                                  {
-                                                    "alignItems": "center",
-                                                    "alignSelf": "flex-start",
-                                                    "backgroundColor": "#121314",
-                                                    "borderRadius": 12,
-                                                    "flex": 1,
-                                                    "flexDirection": "row",
-                                                    "height": 48,
-                                                    "justifyContent": "center",
-                                                    "opacity": 0.5,
-                                                    "overflow": "hidden",
-                                                    "paddingHorizontal": 16,
-                                                  }
-                                                }
-                                                testID=""
-                                              >
-                                                <Text
-                                                  accessibilityRole="text"
-                                                  style={
-                                                    {
-                                                      "color": "#ffffff",
-                                                      "fontFamily": "Geist Medium",
-                                                      "fontSize": 16,
-                                                      "letterSpacing": 0,
-                                                      "lineHeight": 24,
-                                                    }
-                                                  }
-                                                >
-                                                  Confirm
-                                                </Text>
-                                              </TouchableOpacity>
-                                            </View>
                                           </View>
                                         </RCTScrollView>
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "flexDirection": "row",
+                                                "gap": 16,
+                                                "paddingHorizontal": 16,
+                                                "paddingTop": 16,
+                                                "width": "100%",
+                                              },
+                                              undefined,
+                                            ]
+                                          }
+                                        >
+                                          <TouchableOpacity
+                                            accessibilityRole="button"
+                                            accessible={true}
+                                            activeOpacity={1}
+                                            disabled={false}
+                                            onPress={[Function]}
+                                            onPressIn={[Function]}
+                                            onPressOut={[Function]}
+                                            style={
+                                              {
+                                                "alignItems": "center",
+                                                "alignSelf": "flex-start",
+                                                "backgroundColor": "#3c4d9d0f",
+                                                "borderColor": "transparent",
+                                                "borderRadius": 12,
+                                                "borderWidth": 1,
+                                                "flex": 1,
+                                                "flexDirection": "row",
+                                                "height": 48,
+                                                "justifyContent": "center",
+                                                "overflow": "hidden",
+                                                "paddingHorizontal": 16,
+                                              }
+                                            }
+                                            testID=""
+                                          >
+                                            <Text
+                                              accessibilityRole="text"
+                                              style={
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "Geist Medium",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
+                                              }
+                                            >
+                                              Reject
+                                            </Text>
+                                          </TouchableOpacity>
+                                          <TouchableOpacity
+                                            accessibilityRole="button"
+                                            accessible={true}
+                                            activeOpacity={1}
+                                            disabled={true}
+                                            loading={false}
+                                            onPress={[Function]}
+                                            onPressIn={[Function]}
+                                            onPressOut={[Function]}
+                                            style={
+                                              {
+                                                "alignItems": "center",
+                                                "alignSelf": "flex-start",
+                                                "backgroundColor": "#121314",
+                                                "borderRadius": 12,
+                                                "flex": 1,
+                                                "flexDirection": "row",
+                                                "height": 48,
+                                                "justifyContent": "center",
+                                                "opacity": 0.5,
+                                                "overflow": "hidden",
+                                                "paddingHorizontal": 16,
+                                              }
+                                            }
+                                            testID=""
+                                          >
+                                            <Text
+                                              accessibilityRole="text"
+                                              style={
+                                                {
+                                                  "color": "#ffffff",
+                                                  "fontFamily": "Geist Medium",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
+                                              }
+                                            >
+                                              Confirm
+                                            </Text>
+                                          </TouchableOpacity>
+                                        </View>
                                       </View>
                                     </View>
                                   </View>

--- a/app/components/Views/confirmations/legacy/Approve/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/Approve/__snapshots__/index.test.tsx.snap
@@ -760,105 +760,105 @@ exports[`Approve renders transaction approval 1`] = `
                                                   </View>
                                                 </RCTScrollView>
                                               </View>
-                                              <View
-                                                style={
-                                                  [
-                                                    {
-                                                      "flexDirection": "row",
-                                                      "gap": 16,
-                                                      "paddingHorizontal": 16,
-                                                      "paddingVertical": 16,
-                                                      "width": "100%",
-                                                    },
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                <TouchableOpacity
-                                                  accessibilityRole="button"
-                                                  accessible={true}
-                                                  activeOpacity={1}
-                                                  disabled={false}
-                                                  onPress={[Function]}
-                                                  onPressIn={[Function]}
-                                                  onPressOut={[Function]}
-                                                  style={
-                                                    {
-                                                      "alignItems": "center",
-                                                      "alignSelf": "flex-start",
-                                                      "backgroundColor": "#3c4d9d0f",
-                                                      "borderColor": "transparent",
-                                                      "borderRadius": 12,
-                                                      "borderWidth": 1,
-                                                      "flex": 1,
-                                                      "flexDirection": "row",
-                                                      "height": 48,
-                                                      "justifyContent": "center",
-                                                      "overflow": "hidden",
-                                                      "paddingHorizontal": 16,
-                                                    }
-                                                  }
-                                                  testID=""
-                                                >
-                                                  <Text
-                                                    accessibilityRole="text"
-                                                    style={
-                                                      {
-                                                        "color": "#121314",
-                                                        "fontFamily": "Geist Medium",
-                                                        "fontSize": 16,
-                                                        "letterSpacing": 0,
-                                                        "lineHeight": 24,
-                                                      }
-                                                    }
-                                                  >
-                                                    Reject
-                                                  </Text>
-                                                </TouchableOpacity>
-                                                <TouchableOpacity
-                                                  accessibilityRole="button"
-                                                  accessible={true}
-                                                  activeOpacity={1}
-                                                  disabled={true}
-                                                  loading={false}
-                                                  onPress={[Function]}
-                                                  onPressIn={[Function]}
-                                                  onPressOut={[Function]}
-                                                  style={
-                                                    {
-                                                      "alignItems": "center",
-                                                      "alignSelf": "flex-start",
-                                                      "backgroundColor": "#121314",
-                                                      "borderRadius": 12,
-                                                      "flex": 1,
-                                                      "flexDirection": "row",
-                                                      "height": 48,
-                                                      "justifyContent": "center",
-                                                      "opacity": 0.5,
-                                                      "overflow": "hidden",
-                                                      "paddingHorizontal": 16,
-                                                    }
-                                                  }
-                                                  testID="Confirm"
-                                                >
-                                                  <Text
-                                                    accessibilityRole="text"
-                                                    style={
-                                                      {
-                                                        "color": "#ffffff",
-                                                        "fontFamily": "Geist Medium",
-                                                        "fontSize": 16,
-                                                        "letterSpacing": 0,
-                                                        "lineHeight": 24,
-                                                      }
-                                                    }
-                                                  >
-                                                    Approve
-                                                  </Text>
-                                                </TouchableOpacity>
-                                              </View>
                                             </View>
                                           </RCTScrollView>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "flexDirection": "row",
+                                                  "gap": 16,
+                                                  "paddingHorizontal": 16,
+                                                  "paddingTop": 16,
+                                                  "width": "100%",
+                                                },
+                                                undefined,
+                                              ]
+                                            }
+                                          >
+                                            <TouchableOpacity
+                                              accessibilityRole="button"
+                                              accessible={true}
+                                              activeOpacity={1}
+                                              disabled={false}
+                                              onPress={[Function]}
+                                              onPressIn={[Function]}
+                                              onPressOut={[Function]}
+                                              style={
+                                                {
+                                                  "alignItems": "center",
+                                                  "alignSelf": "flex-start",
+                                                  "backgroundColor": "#3c4d9d0f",
+                                                  "borderColor": "transparent",
+                                                  "borderRadius": 12,
+                                                  "borderWidth": 1,
+                                                  "flex": 1,
+                                                  "flexDirection": "row",
+                                                  "height": 48,
+                                                  "justifyContent": "center",
+                                                  "overflow": "hidden",
+                                                  "paddingHorizontal": 16,
+                                                }
+                                              }
+                                              testID=""
+                                            >
+                                              <Text
+                                                accessibilityRole="text"
+                                                style={
+                                                  {
+                                                    "color": "#121314",
+                                                    "fontFamily": "Geist Medium",
+                                                    "fontSize": 16,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                  }
+                                                }
+                                              >
+                                                Reject
+                                              </Text>
+                                            </TouchableOpacity>
+                                            <TouchableOpacity
+                                              accessibilityRole="button"
+                                              accessible={true}
+                                              activeOpacity={1}
+                                              disabled={true}
+                                              loading={false}
+                                              onPress={[Function]}
+                                              onPressIn={[Function]}
+                                              onPressOut={[Function]}
+                                              style={
+                                                {
+                                                  "alignItems": "center",
+                                                  "alignSelf": "flex-start",
+                                                  "backgroundColor": "#121314",
+                                                  "borderRadius": 12,
+                                                  "flex": 1,
+                                                  "flexDirection": "row",
+                                                  "height": 48,
+                                                  "justifyContent": "center",
+                                                  "opacity": 0.5,
+                                                  "overflow": "hidden",
+                                                  "paddingHorizontal": 16,
+                                                }
+                                              }
+                                              testID="Confirm"
+                                            >
+                                              <Text
+                                                accessibilityRole="text"
+                                                style={
+                                                  {
+                                                    "color": "#ffffff",
+                                                    "fontFamily": "Geist Medium",
+                                                    "fontSize": 16,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                  }
+                                                }
+                                              >
+                                                Approve
+                                              </Text>
+                                            </TouchableOpacity>
+                                          </View>
                                         </View>
                                       </View>
                                     </View>

--- a/app/components/Views/confirmations/legacy/ApproveView/Approve/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/ApproveView/Approve/__snapshots__/index.test.tsx.snap
@@ -760,105 +760,105 @@ exports[`Approve renders transaction approval 1`] = `
                                                   </View>
                                                 </RCTScrollView>
                                               </View>
-                                              <View
-                                                style={
-                                                  [
-                                                    {
-                                                      "flexDirection": "row",
-                                                      "gap": 16,
-                                                      "paddingHorizontal": 16,
-                                                      "paddingVertical": 16,
-                                                      "width": "100%",
-                                                    },
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                <TouchableOpacity
-                                                  accessibilityRole="button"
-                                                  accessible={true}
-                                                  activeOpacity={1}
-                                                  disabled={false}
-                                                  onPress={[Function]}
-                                                  onPressIn={[Function]}
-                                                  onPressOut={[Function]}
-                                                  style={
-                                                    {
-                                                      "alignItems": "center",
-                                                      "alignSelf": "flex-start",
-                                                      "backgroundColor": "#3c4d9d0f",
-                                                      "borderColor": "transparent",
-                                                      "borderRadius": 12,
-                                                      "borderWidth": 1,
-                                                      "flex": 1,
-                                                      "flexDirection": "row",
-                                                      "height": 48,
-                                                      "justifyContent": "center",
-                                                      "overflow": "hidden",
-                                                      "paddingHorizontal": 16,
-                                                    }
-                                                  }
-                                                  testID=""
-                                                >
-                                                  <Text
-                                                    accessibilityRole="text"
-                                                    style={
-                                                      {
-                                                        "color": "#121314",
-                                                        "fontFamily": "Geist Medium",
-                                                        "fontSize": 16,
-                                                        "letterSpacing": 0,
-                                                        "lineHeight": 24,
-                                                      }
-                                                    }
-                                                  >
-                                                    Reject
-                                                  </Text>
-                                                </TouchableOpacity>
-                                                <TouchableOpacity
-                                                  accessibilityRole="button"
-                                                  accessible={true}
-                                                  activeOpacity={1}
-                                                  disabled={true}
-                                                  loading={false}
-                                                  onPress={[Function]}
-                                                  onPressIn={[Function]}
-                                                  onPressOut={[Function]}
-                                                  style={
-                                                    {
-                                                      "alignItems": "center",
-                                                      "alignSelf": "flex-start",
-                                                      "backgroundColor": "#121314",
-                                                      "borderRadius": 12,
-                                                      "flex": 1,
-                                                      "flexDirection": "row",
-                                                      "height": 48,
-                                                      "justifyContent": "center",
-                                                      "opacity": 0.5,
-                                                      "overflow": "hidden",
-                                                      "paddingHorizontal": 16,
-                                                    }
-                                                  }
-                                                  testID="Confirm"
-                                                >
-                                                  <Text
-                                                    accessibilityRole="text"
-                                                    style={
-                                                      {
-                                                        "color": "#ffffff",
-                                                        "fontFamily": "Geist Medium",
-                                                        "fontSize": 16,
-                                                        "letterSpacing": 0,
-                                                        "lineHeight": 24,
-                                                      }
-                                                    }
-                                                  >
-                                                    Approve
-                                                  </Text>
-                                                </TouchableOpacity>
-                                              </View>
                                             </View>
                                           </RCTScrollView>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "flexDirection": "row",
+                                                  "gap": 16,
+                                                  "paddingHorizontal": 16,
+                                                  "paddingTop": 16,
+                                                  "width": "100%",
+                                                },
+                                                undefined,
+                                              ]
+                                            }
+                                          >
+                                            <TouchableOpacity
+                                              accessibilityRole="button"
+                                              accessible={true}
+                                              activeOpacity={1}
+                                              disabled={false}
+                                              onPress={[Function]}
+                                              onPressIn={[Function]}
+                                              onPressOut={[Function]}
+                                              style={
+                                                {
+                                                  "alignItems": "center",
+                                                  "alignSelf": "flex-start",
+                                                  "backgroundColor": "#3c4d9d0f",
+                                                  "borderColor": "transparent",
+                                                  "borderRadius": 12,
+                                                  "borderWidth": 1,
+                                                  "flex": 1,
+                                                  "flexDirection": "row",
+                                                  "height": 48,
+                                                  "justifyContent": "center",
+                                                  "overflow": "hidden",
+                                                  "paddingHorizontal": 16,
+                                                }
+                                              }
+                                              testID=""
+                                            >
+                                              <Text
+                                                accessibilityRole="text"
+                                                style={
+                                                  {
+                                                    "color": "#121314",
+                                                    "fontFamily": "Geist Medium",
+                                                    "fontSize": 16,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                  }
+                                                }
+                                              >
+                                                Reject
+                                              </Text>
+                                            </TouchableOpacity>
+                                            <TouchableOpacity
+                                              accessibilityRole="button"
+                                              accessible={true}
+                                              activeOpacity={1}
+                                              disabled={true}
+                                              loading={false}
+                                              onPress={[Function]}
+                                              onPressIn={[Function]}
+                                              onPressOut={[Function]}
+                                              style={
+                                                {
+                                                  "alignItems": "center",
+                                                  "alignSelf": "flex-start",
+                                                  "backgroundColor": "#121314",
+                                                  "borderRadius": 12,
+                                                  "flex": 1,
+                                                  "flexDirection": "row",
+                                                  "height": 48,
+                                                  "justifyContent": "center",
+                                                  "opacity": 0.5,
+                                                  "overflow": "hidden",
+                                                  "paddingHorizontal": 16,
+                                                }
+                                              }
+                                              testID="Confirm"
+                                            >
+                                              <Text
+                                                accessibilityRole="text"
+                                                style={
+                                                  {
+                                                    "color": "#ffffff",
+                                                    "fontFamily": "Geist Medium",
+                                                    "fontSize": 16,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                  }
+                                                }
+                                              >
+                                                Approve
+                                              </Text>
+                                            </TouchableOpacity>
+                                          </View>
                                         </View>
                                       </View>
                                     </View>

--- a/app/components/Views/confirmations/legacy/components/TransactionReview/__snapshots__/index.test.jsx.snap
+++ b/app/components/Views/confirmations/legacy/components/TransactionReview/__snapshots__/index.test.jsx.snap
@@ -937,102 +937,102 @@ exports[`TransactionReview should match snapshot 1`] = `
                 </View>
               </RCTScrollView>
             </View>
-            <View
-              style={
-                [
-                  {
-                    "flexDirection": "row",
-                    "gap": 16,
-                    "paddingHorizontal": 16,
-                    "paddingVertical": 16,
-                    "width": "100%",
-                  },
-                  undefined,
-                ]
-              }
-            >
-              <TouchableOpacity
-                accessibilityRole="button"
-                accessible={true}
-                activeOpacity={1}
-                disabled={false}
-                onPressIn={[Function]}
-                onPressOut={[Function]}
-                style={
-                  {
-                    "alignItems": "center",
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "#3c4d9d0f",
-                    "borderColor": "transparent",
-                    "borderRadius": 12,
-                    "borderWidth": 1,
-                    "flex": 1,
-                    "flexDirection": "row",
-                    "height": 48,
-                    "justifyContent": "center",
-                    "overflow": "hidden",
-                    "paddingHorizontal": 16,
-                  }
-                }
-                testID=""
-              >
-                <Text
-                  accessibilityRole="text"
-                  style={
-                    {
-                      "color": "#121314",
-                      "fontFamily": "Geist Medium",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Reject
-                </Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                accessibilityRole="button"
-                accessible={true}
-                activeOpacity={1}
-                disabled={false}
-                loading={false}
-                onPressIn={[Function]}
-                onPressOut={[Function]}
-                style={
-                  {
-                    "alignItems": "center",
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "#121314",
-                    "borderRadius": 12,
-                    "flex": 1,
-                    "flexDirection": "row",
-                    "height": 48,
-                    "justifyContent": "center",
-                    "overflow": "hidden",
-                    "paddingHorizontal": 16,
-                  }
-                }
-                testID=""
-              >
-                <Text
-                  accessibilityRole="text"
-                  style={
-                    {
-                      "color": "#ffffff",
-                      "fontFamily": "Geist Medium",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Confirm
-                </Text>
-              </TouchableOpacity>
-            </View>
           </View>
         </RCTScrollView>
+        <View
+          style={
+            [
+              {
+                "flexDirection": "row",
+                "gap": 16,
+                "paddingHorizontal": 16,
+                "paddingTop": 16,
+                "width": "100%",
+              },
+              undefined,
+            ]
+          }
+        >
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessible={true}
+            activeOpacity={1}
+            disabled={false}
+            onPressIn={[Function]}
+            onPressOut={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "alignSelf": "flex-start",
+                "backgroundColor": "#3c4d9d0f",
+                "borderColor": "transparent",
+                "borderRadius": 12,
+                "borderWidth": 1,
+                "flex": 1,
+                "flexDirection": "row",
+                "height": 48,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "paddingHorizontal": 16,
+              }
+            }
+            testID=""
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Reject
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessible={true}
+            activeOpacity={1}
+            disabled={false}
+            loading={false}
+            onPressIn={[Function]}
+            onPressOut={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "alignSelf": "flex-start",
+                "backgroundColor": "#121314",
+                "borderRadius": 12,
+                "flex": 1,
+                "flexDirection": "row",
+                "height": 48,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "paddingHorizontal": 16,
+              }
+            }
+            testID=""
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#ffffff",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Confirm
+            </Text>
+          </TouchableOpacity>
+        </View>
       </View>
     </View>
   </View>,

--- a/app/components/Views/confirmations/legacy/components/TypedSign/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/components/TypedSign/__snapshots__/index.test.tsx.snap
@@ -224,104 +224,104 @@ exports[`TypedSign onConfirm signs message 1`] = `
             </TouchableOpacity>
           </View>
         </View>
-        <View
-          style={
-            [
-              {
-                "flexDirection": "row",
-                "gap": 16,
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
-                "width": "100%",
-              },
-              undefined,
-            ]
-          }
-        >
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessible={true}
-            activeOpacity={1}
-            disabled={false}
-            onPress={[Function]}
-            onPressIn={[Function]}
-            onPressOut={[Function]}
-            style={
-              {
-                "alignItems": "center",
-                "alignSelf": "flex-start",
-                "backgroundColor": "#3c4d9d0f",
-                "borderColor": "transparent",
-                "borderRadius": 12,
-                "borderWidth": 1,
-                "flex": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "overflow": "hidden",
-                "paddingHorizontal": 16,
-              }
-            }
-            testID="request-signature-cancel-button"
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#121314",
-                  "fontFamily": "Geist Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Cancel
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessible={true}
-            activeOpacity={1}
-            disabled={false}
-            loading={false}
-            onPress={[Function]}
-            onPressIn={[Function]}
-            onPressOut={[Function]}
-            style={
-              {
-                "alignItems": "center",
-                "alignSelf": "flex-start",
-                "backgroundColor": "#121314",
-                "borderRadius": 12,
-                "flex": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "overflow": "hidden",
-                "paddingHorizontal": 16,
-              }
-            }
-            testID="request-signature-confirm-button"
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#ffffff",
-                  "fontFamily": "Geist Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Sign
-            </Text>
-          </TouchableOpacity>
-        </View>
       </View>
     </RCTScrollView>
+    <View
+      style={
+        [
+          {
+            "flexDirection": "row",
+            "gap": 16,
+            "paddingHorizontal": 16,
+            "paddingTop": 16,
+            "width": "100%",
+          },
+          undefined,
+        ]
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#3c4d9d0f",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="request-signature-cancel-button"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#121314",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Cancel
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#121314",
+            "borderRadius": 12,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="request-signature-confirm-button"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Sign
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
 </View>
 `;
@@ -550,104 +550,104 @@ exports[`TypedSign onReject rejects message 1`] = `
             </TouchableOpacity>
           </View>
         </View>
-        <View
-          style={
-            [
-              {
-                "flexDirection": "row",
-                "gap": 16,
-                "paddingHorizontal": 16,
-                "paddingVertical": 16,
-                "width": "100%",
-              },
-              undefined,
-            ]
-          }
-        >
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessible={true}
-            activeOpacity={1}
-            disabled={false}
-            onPress={[Function]}
-            onPressIn={[Function]}
-            onPressOut={[Function]}
-            style={
-              {
-                "alignItems": "center",
-                "alignSelf": "flex-start",
-                "backgroundColor": "#3c4d9d0f",
-                "borderColor": "transparent",
-                "borderRadius": 12,
-                "borderWidth": 1,
-                "flex": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "overflow": "hidden",
-                "paddingHorizontal": 16,
-              }
-            }
-            testID="request-signature-cancel-button"
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#121314",
-                  "fontFamily": "Geist Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Cancel
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessible={true}
-            activeOpacity={1}
-            disabled={false}
-            loading={false}
-            onPress={[Function]}
-            onPressIn={[Function]}
-            onPressOut={[Function]}
-            style={
-              {
-                "alignItems": "center",
-                "alignSelf": "flex-start",
-                "backgroundColor": "#121314",
-                "borderRadius": 12,
-                "flex": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "overflow": "hidden",
-                "paddingHorizontal": 16,
-              }
-            }
-            testID="request-signature-confirm-button"
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#ffffff",
-                  "fontFamily": "Geist Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Sign
-            </Text>
-          </TouchableOpacity>
-        </View>
       </View>
     </RCTScrollView>
+    <View
+      style={
+        [
+          {
+            "flexDirection": "row",
+            "gap": 16,
+            "paddingHorizontal": 16,
+            "paddingTop": 16,
+            "width": "100%",
+          },
+          undefined,
+        ]
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#3c4d9d0f",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="request-signature-cancel-button"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#121314",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Cancel
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#121314",
+            "borderRadius": 12,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="request-signature-confirm-button"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Sign
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
 </View>
 `;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2229,8 +2229,8 @@
       "add_token": "IMPORT"
     },
     "collectibles": {
-      "cancel_add_collectible": "CANCEL",
-      "add_collectible": "IMPORT"
+      "cancel_add_collectible": "Cancel",
+      "add_collectible": "Import"
     },
     "banners": {
       "search_desc": "Improved token detection is currently available on {{network}} network. ",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR updates the Import NFT screen to polish the UI.

### 1. **Enhanced Spacing and Padding Consistency**
- **ActionView Component**: Changed from `paddingVertical: 16` to `paddingTop: 16` to provide better spacing control and prevent unnecessary bottom padding
- **AddAsset Component**: Added `paddingHorizontal: 16` to `infoWrapper` for consistent horizontal spacing
- **AddCustomCollectible Component**: 
  - Replaced generic `padding: 20` with granular spacing: `paddingTop: 24`, `paddingHorizontal: 16`, and `gap: 16`
  - Updated `networkSelectorContainer` to use `paddingVertical: 12` and `paddingHorizontal: 16` instead of generic padding
  - Improved `rowTitleText` spacing with `paddingBottom: 4` (increased from 3)
  - Added `rowWrapperWithMargin` style for better section separation

### 2. **Improved Layout Structure**
- **ActionView Component**: Fixed `KeyboardAwareScrollView` positioning to properly wrap content, ensuring better keyboard handling and scroll behavior
- **AddCustomCollectible Component**: 
  - Restructured JSX to wrap form sections in proper `View` components for better layout hierarchy
  - Added network selector title for better visual organization
  - Improved component nesting for clearer structure

### 3. **Visual Polish and Consistency**
- **Border Radius**: Updated `textInput` border radius from `4` to `8` for a more modern, consistent look
- **Text Colors**: Changed placeholder text color from `colors.text.muted` to `colors.text.alternative` for better contrast and consistency
- **Warning Text Styling**: Enhanced warning text with `paddingTop: 4` and `minHeight: 0` to prevent layout shifts when warnings appear/disappear

### 4. **Better User Experience**
- **Conditional Warning Rendering**: Added conditional rendering for warning messages in AddCustomCollectible, preventing empty space when warnings are not present
- **Button Text Capitalization**: Updated collectible import buttons from "CANCEL"/"IMPORT" to "Cancel"/"Import" for better readability and consistency with design system

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

https://consensyssoftware.atlassian.net/jira/software/c/projects/MDP/boards/2972?assignee=712020%3Af728afed-dcd6-4eef-ab9b-f53abf5befc1&selectedIssue=MDP-270
https://consensyssoftware.atlassian.net/jira/software/c/projects/MDP/boards/2972?assignee=712020%3Af728afed-dcd6-4eef-ab9b-f53abf5befc1&selectedIssue=MDP-268

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/851a12d7-8460-431a-b7a6-e13e07e1677e



### **After**

https://github.com/user-attachments/assets/6eb5545d-cbfd-4add-96b3-900a986849fb




## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
