### PR TITLE
fix: cp-7.60.0 Generate correct blockchain explorer urls on bridge txs

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.test.tsx
@@ -71,8 +71,11 @@ describe('BlockExplorersModal', () => {
       },
       { state: mockState },
     );
-    const etherscanButtons = getAllByText('Etherscan');
-    expect(etherscanButtons).toHaveLength(2);
+    const etherscanButton = getAllByText('Etherscan');
+    expect(etherscanButton).toHaveLength(1);
+
+    const optimisticButton = getAllByText('Optimistic');
+    expect(optimisticButton).toHaveLength(1);
   });
 
   it('should handle missing destination chain transaction hash', () => {

--- a/app/components/UI/Bridge/hooks/useMultichainBlockExplorerTxUrl/index.ts
+++ b/app/components/UI/Bridge/hooks/useMultichainBlockExplorerTxUrl/index.ts
@@ -8,7 +8,6 @@ import { useSelector } from 'react-redux';
 import {
   createProviderConfig,
   selectEvmNetworkConfigurationsByChainId,
-  selectProviderConfig,
 } from '../../../../../selectors/networkController';
 import { useMemo } from 'react';
 import { NetworkConfiguration } from '@metamask/network-controller';
@@ -43,7 +42,6 @@ export const useMultichainBlockExplorerTxUrl = ({
   const nonEvmNetworkConfigurations = useSelector(
     selectNonEvmNetworkConfigurationsByChainId,
   );
-  const providerConfig = useSelector(selectProviderConfig);
 
   // Format chainId based on whether it's EVM or not
   const isNonEvm = chainId ? isNonEvmChainId(chainId) : false;
@@ -64,8 +62,8 @@ export const useMultichainBlockExplorerTxUrl = ({
     () =>
       evmNetworkConfig
         ? getProviderConfigForNetwork(evmNetworkConfig)
-        : providerConfig,
-    [evmNetworkConfig, providerConfig],
+        : undefined,
+    [evmNetworkConfig],
   );
 
   const blockExplorer = useBlockExplorer();
@@ -86,7 +84,7 @@ export const useMultichainBlockExplorerTxUrl = ({
     // EVM
     const baseUrl =
       blockExplorer.getEvmBlockExplorerUrl(formatChainIdToHex(chainId)) ??
-      getEtherscanBaseUrl(evmProviderConfig.type);
+      getEtherscanBaseUrl(evmProviderConfig?.type ?? '');
 
     explorerTxUrl = etherscanLink.createCustomExplorerLink(txHash, baseUrl);
   }

--- a/app/components/UI/Bridge/hooks/useMultichainBlockExplorerTxUrl/useMultichainBlockExplorerTxUrl.test.tsx
+++ b/app/components/UI/Bridge/hooks/useMultichainBlockExplorerTxUrl/useMultichainBlockExplorerTxUrl.test.tsx
@@ -3,66 +3,537 @@ import { renderHookWithProvider } from '../../../../../util/test/renderWithProvi
 import { useMultichainBlockExplorerTxUrl } from '.';
 import { waitFor } from '@testing-library/react-native';
 import { ChainId } from '@metamask/bridge-controller';
+import { getTransactionUrl } from '../../../../../core/Multichain/utils';
+import {
+  getBlockExplorerName,
+  getNetworkImageSource,
+} from '../../../../../util/networks';
+import { getEtherscanBaseUrl } from '../../../../../util/etherscan';
+import useBlockExplorer from '../../../../hooks/useBlockExplorer';
+import etherscanLink from '@metamask/etherscan-link';
+
+// Mock all external dependencies
+jest.mock('../../../../../core/Multichain/utils');
+jest.mock('../../../../../util/networks');
+jest.mock('../../../../../util/etherscan');
+jest.mock('../../../../hooks/useBlockExplorer');
+jest.mock('@metamask/etherscan-link');
+
+const mockGetTransactionUrl = getTransactionUrl as jest.MockedFunction<
+  typeof getTransactionUrl
+>;
+const mockGetBlockExplorerName = getBlockExplorerName as jest.MockedFunction<
+  typeof getBlockExplorerName
+>;
+const mockGetNetworkImageSource = getNetworkImageSource as jest.MockedFunction<
+  typeof getNetworkImageSource
+>;
+const mockGetEtherscanBaseUrl = getEtherscanBaseUrl as jest.MockedFunction<
+  typeof getEtherscanBaseUrl
+>;
+const mockUseBlockExplorer = useBlockExplorer as jest.MockedFunction<
+  typeof useBlockExplorer
+>;
+const mockCreateCustomExplorerLink =
+  etherscanLink.createCustomExplorerLink as jest.MockedFunction<
+    typeof etherscanLink.createCustomExplorerLink
+  >;
 
 describe('useMultichainBlockExplorerTxUrl', () => {
+  const mockBlockExplorerHook = {
+    getEvmBlockExplorerUrl: jest.fn(),
+    getBlockExplorerName: jest.fn(),
+    getBlockExplorerUrl: jest.fn(),
+    toBlockExplorer: jest.fn(),
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // Setup default mock implementations
+    mockUseBlockExplorer.mockReturnValue(mockBlockExplorerHook);
+    mockGetNetworkImageSource.mockReturnValue(1);
+    mockGetEtherscanBaseUrl.mockReturnValue('https://etherscan.io');
+    mockCreateCustomExplorerLink.mockImplementation(
+      (hash, baseUrl) => `${baseUrl}/tx/${hash}`,
+    );
   });
 
-  it('should return undefined when chainId is missing', () => {
-    const { result } = renderHookWithProvider(
-      () => useMultichainBlockExplorerTxUrl({ txHash: '0x123' }),
-      { state: initialState },
-    );
-
-    expect(result.current).toBeUndefined();
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
-  it('should return undefined when txHash is missing', () => {
-    const { result } = renderHookWithProvider(
-      () => useMultichainBlockExplorerTxUrl({ chainId: 1 }),
-      { state: initialState },
-    );
+  describe('parameter validation', () => {
+    it('returns undefined when chainId is missing', () => {
+      const { result } = renderHookWithProvider(
+        () => useMultichainBlockExplorerTxUrl({ txHash: '0x123' }),
+        { state: initialState },
+      );
 
-    expect(result.current).toBeUndefined();
+      expect(result.current).toBeUndefined();
+    });
+
+    it('returns undefined when txHash is missing', () => {
+      const { result } = renderHookWithProvider(
+        () => useMultichainBlockExplorerTxUrl({ chainId: 1 }),
+        { state: initialState },
+      );
+
+      expect(result.current).toBeUndefined();
+    });
+
+    it('returns undefined when both chainId and txHash are missing', () => {
+      const { result } = renderHookWithProvider(
+        () => useMultichainBlockExplorerTxUrl({}),
+        { state: initialState },
+      );
+
+      expect(result.current).toBeUndefined();
+    });
   });
 
-  it('should return EVM block explorer URL for EVM chain', async () => {
-    const { result } = renderHookWithProvider(
-      () =>
-        useMultichainBlockExplorerTxUrl({
-          chainId: 1,
-          txHash: '0x123456789abcdef',
-        }),
-      { state: initialState },
-    );
+  describe('EVM chains', () => {
+    it('returns EVM block explorer URL for Ethereum mainnet', async () => {
+      mockBlockExplorerHook.getEvmBlockExplorerUrl.mockReturnValue(
+        'https://etherscan.io',
+      );
+      mockBlockExplorerHook.getBlockExplorerName.mockReturnValue('Etherscan');
 
-    await waitFor(() => {
-      expect(result.current).toEqual({
-        explorerTxUrl: 'https://etherscan.io/tx/0x123456789abcdef',
-        explorerName: 'Etherscan',
-        networkImageSource: 1,
-        chainName: 'Ethereum Mainnet',
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: 1,
+            txHash: '0x123456789abcdef',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current).toEqual({
+          explorerTxUrl: 'https://etherscan.io/tx/0x123456789abcdef',
+          explorerName: 'Etherscan',
+          networkImageSource: 1,
+          chainName: 'Ethereum Mainnet',
+        });
+      });
+
+      expect(mockBlockExplorerHook.getEvmBlockExplorerUrl).toHaveBeenCalledWith(
+        '0x1',
+      );
+      expect(mockCreateCustomExplorerLink).toHaveBeenCalledWith(
+        '0x123456789abcdef',
+        'https://etherscan.io',
+      );
+    });
+
+    it('returns EVM block explorer URL for Optimism', async () => {
+      mockBlockExplorerHook.getEvmBlockExplorerUrl.mockReturnValue(
+        'https://optimistic.etherscan.io',
+      );
+      mockBlockExplorerHook.getBlockExplorerName.mockReturnValue(
+        'Optimism Explorer',
+      );
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: 10,
+            txHash: '0xabc123',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current).toEqual({
+          explorerTxUrl: 'https://optimistic.etherscan.io/tx/0xabc123',
+          explorerName: 'Optimism Explorer',
+          networkImageSource: 1,
+          chainName: 'Optimism',
+        });
+      });
+
+      expect(mockBlockExplorerHook.getEvmBlockExplorerUrl).toHaveBeenCalledWith(
+        '0xa',
+      );
+    });
+
+    it('falls back to etherscan base URL when getEvmBlockExplorerUrl returns null', async () => {
+      mockBlockExplorerHook.getEvmBlockExplorerUrl.mockReturnValue(null);
+      mockBlockExplorerHook.getBlockExplorerName.mockReturnValue('Etherscan');
+      mockGetEtherscanBaseUrl.mockReturnValue('https://etherscan.io');
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: 1,
+            txHash: '0xfallback123',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.explorerTxUrl).toBe(
+          'https://etherscan.io/tx/0xfallback123',
+        );
+      });
+
+      expect(mockGetEtherscanBaseUrl).toHaveBeenCalledWith('mainnet');
+      expect(mockCreateCustomExplorerLink).toHaveBeenCalledWith(
+        '0xfallback123',
+        'https://etherscan.io',
+      );
+    });
+
+    it('uses provider config from evmNetworkConfig when available', async () => {
+      mockBlockExplorerHook.getEvmBlockExplorerUrl.mockReturnValue(
+        'https://etherscan.io',
+      );
+      mockBlockExplorerHook.getBlockExplorerName.mockReturnValue('Etherscan');
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: 1,
+            txHash: '0x999',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.chainName).toBe('Ethereum Mainnet');
+      });
+    });
+
+    it('returns chainName from evmNetworkConfig when available', async () => {
+      mockBlockExplorerHook.getEvmBlockExplorerUrl.mockReturnValue(
+        'https://etherscan.io',
+      );
+      mockBlockExplorerHook.getBlockExplorerName.mockReturnValue('Etherscan');
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: 10,
+            txHash: '0xtest',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.chainName).toBe('Optimism');
+      });
+    });
+
+    it('returns undefined chainName when evmNetworkConfig is not available', async () => {
+      mockBlockExplorerHook.getEvmBlockExplorerUrl.mockReturnValue(
+        'https://example.io',
+      );
+      mockBlockExplorerHook.getBlockExplorerName.mockReturnValue('Explorer');
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: 999, // Unknown chain
+            txHash: '0xunknown',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.chainName).toBeUndefined();
       });
     });
   });
 
-  it('should return Solana block explorer URL for Solana chain', async () => {
-    const { result } = renderHookWithProvider(
-      () =>
-        useMultichainBlockExplorerTxUrl({
-          chainId: ChainId.SOLANA,
-          txHash: 'solana-tx-hash',
-        }),
-      { state: initialState },
-    );
+  describe('non-EVM chains', () => {
+    it('returns Solana block explorer URL for Solana chain', async () => {
+      mockGetTransactionUrl.mockReturnValue(
+        'https://solscan.io/tx/solana-tx-hash',
+      );
+      mockGetBlockExplorerName.mockReturnValue('Solscan');
 
-    await waitFor(() => {
-      expect(result.current).toEqual({
-        explorerTxUrl: 'https://solscan.io/tx/solana-tx-hash',
-        explorerName: 'Solscan',
-        networkImageSource: 1,
-        chainName: 'Solana',
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: ChainId.SOLANA,
+            txHash: 'solana-tx-hash',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current).toEqual({
+          explorerTxUrl: 'https://solscan.io/tx/solana-tx-hash',
+          explorerName: 'Solscan',
+          networkImageSource: 1,
+          chainName: 'Solana',
+        });
+      });
+
+      expect(mockGetTransactionUrl).toHaveBeenCalledWith(
+        'solana-tx-hash',
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      );
+      expect(mockGetBlockExplorerName).toHaveBeenCalledWith(
+        'https://solscan.io/tx/solana-tx-hash',
+      );
+    });
+
+    it('uses blockExplorer.getBlockExplorerName for non-EVM chain when explorerTxUrl is empty', async () => {
+      mockGetTransactionUrl.mockReturnValue('');
+      mockBlockExplorerHook.getBlockExplorerName.mockReturnValue(
+        'Default Explorer',
+      );
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: ChainId.SOLANA,
+            txHash: 'solana-tx-no-url',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.explorerName).toBe('Default Explorer');
+      });
+
+      expect(mockBlockExplorerHook.getBlockExplorerName).toHaveBeenCalled();
+    });
+
+    it('returns chainName from nonEvmNetworkConfigurations for Solana', async () => {
+      mockGetTransactionUrl.mockReturnValue('https://solscan.io/tx/solana-tx');
+      mockGetBlockExplorerName.mockReturnValue('Solscan');
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: ChainId.SOLANA,
+            txHash: 'solana-tx',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.chainName).toBe('Solana');
+      });
+    });
+
+    it('returns undefined chainName when nonEvmNetworkConfiguration is not available', async () => {
+      mockGetTransactionUrl.mockReturnValue('https://explorer.io/tx/unknown');
+      mockGetBlockExplorerName.mockReturnValue('Explorer');
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: 999999999, // Unknown non-EVM chain
+            txHash: 'unknown-tx',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.chainName).toBeUndefined();
+      });
+    });
+  });
+
+  describe('network image source', () => {
+    it('calls getNetworkImageSource with formatted chainId for EVM chains', async () => {
+      mockBlockExplorerHook.getEvmBlockExplorerUrl.mockReturnValue(
+        'https://etherscan.io',
+      );
+      mockBlockExplorerHook.getBlockExplorerName.mockReturnValue('Etherscan');
+      mockGetNetworkImageSource.mockReturnValue(42);
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: 1,
+            txHash: '0xtest',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.networkImageSource).toBe(42);
+      });
+
+      expect(mockGetNetworkImageSource).toHaveBeenCalledWith({
+        chainId: '0x1',
+      });
+    });
+
+    it('calls getNetworkImageSource with formatted chainId for non-EVM chains', async () => {
+      mockGetTransactionUrl.mockReturnValue('https://solscan.io/tx/solana-tx');
+      mockGetBlockExplorerName.mockReturnValue('Solscan');
+      mockGetNetworkImageSource.mockReturnValue(99);
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: ChainId.SOLANA,
+            txHash: 'solana-tx',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.networkImageSource).toBe(99);
+      });
+
+      expect(mockGetNetworkImageSource).toHaveBeenCalledWith({
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      });
+    });
+  });
+
+  describe('explorer name determination', () => {
+    it('uses getBlockExplorerName from URL for non-EVM chains with explorerTxUrl', async () => {
+      mockGetTransactionUrl.mockReturnValue(
+        'https://custom-solana-explorer.io/tx/hash123',
+      );
+      mockGetBlockExplorerName.mockReturnValue('Custom Solana Explorer');
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: ChainId.SOLANA,
+            txHash: 'hash123',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.explorerName).toBe('Custom Solana Explorer');
+      });
+
+      expect(mockGetBlockExplorerName).toHaveBeenCalledWith(
+        'https://custom-solana-explorer.io/tx/hash123',
+      );
+    });
+
+    it('uses blockExplorer.getBlockExplorerName for EVM chains', async () => {
+      mockBlockExplorerHook.getEvmBlockExplorerUrl.mockReturnValue(
+        'https://polygonscan.com',
+      );
+      mockBlockExplorerHook.getBlockExplorerName.mockReturnValue('PolygonScan');
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: 137,
+            txHash: '0xpolygon',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.explorerName).toBe('PolygonScan');
+      });
+
+      expect(mockBlockExplorerHook.getBlockExplorerName).toHaveBeenCalledWith(
+        'eip155:137',
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles etherscanLink returning custom explorer link correctly', async () => {
+      mockBlockExplorerHook.getEvmBlockExplorerUrl.mockReturnValue(
+        'https://custom.explorer',
+      );
+      mockBlockExplorerHook.getBlockExplorerName.mockReturnValue(
+        'Custom Explorer',
+      );
+      mockCreateCustomExplorerLink.mockReturnValue(
+        'https://custom.explorer/transaction/0xcustom',
+      );
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: 1,
+            txHash: '0xcustom',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.explorerTxUrl).toBe(
+          'https://custom.explorer/transaction/0xcustom',
+        );
+      });
+
+      expect(mockCreateCustomExplorerLink).toHaveBeenCalledWith(
+        '0xcustom',
+        'https://custom.explorer',
+      );
+    });
+
+    it('handles getTransactionUrl returning empty string for non-EVM chains', async () => {
+      mockGetTransactionUrl.mockReturnValue('');
+      mockBlockExplorerHook.getBlockExplorerName.mockReturnValue('Explorer');
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: ChainId.SOLANA,
+            txHash: 'missing-tx',
+          }),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.explorerTxUrl).toBe('');
+      });
+    });
+
+    it('handles state with custom network configuration', async () => {
+      const customState = {
+        ...initialState,
+        engine: {
+          ...initialState.engine,
+          backgroundState: {
+            ...initialState.engine.backgroundState,
+            NetworkController: {
+              ...initialState.engine.backgroundState.NetworkController,
+              networkConfigurationsByChainId: {
+                ...initialState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId,
+                '0x89': {
+                  chainId: '0x89' as `0x${string}`,
+                  rpcEndpoints: [
+                    {
+                      networkClientId: 'polygonNetworkClientId',
+                    },
+                  ],
+                  defaultRpcEndpointIndex: 0,
+                  nativeCurrency: 'MATIC',
+                  name: 'Polygon Mainnet',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      mockBlockExplorerHook.getEvmBlockExplorerUrl.mockReturnValue(
+        'https://polygonscan.com',
+      );
+      mockBlockExplorerHook.getBlockExplorerName.mockReturnValue('PolygonScan');
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useMultichainBlockExplorerTxUrl({
+            chainId: 137,
+            txHash: '0xpolygon123',
+          }),
+        { state: customState },
+      );
+
+      await waitFor(() => {
+        expect(result.current?.chainName).toBe('Polygon Mainnet');
       });
     });
   });

--- a/app/components/hooks/useBlockExplorer.ts
+++ b/app/components/hooks/useBlockExplorer.ts
@@ -193,6 +193,7 @@ const useBlockExplorer = (chainId?: string) => {
     toBlockExplorer,
     getBlockExplorerUrl,
     getBlockExplorerName,
+    getEvmBlockExplorerUrl,
   };
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix an issue where the blockchain explorer urls were not generated successfully when bridging assets.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Generate correct blockchain explorer URLs when bridging assets

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/23171

## **Manual testing steps**

```gherkin
Ensure that the correct blockchain URLs are generated when visiting the transaction
details screen after bridging/swapping assets. 

Also ensure that the correct URLs are also generated for old bridge/swaps transactions (no regressions).
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects multichain block explorer URL generation for bridge transactions with proper EVM/non-EVM handling and comprehensive tests.
> 
> - **Bridge Hook (`useMultichainBlockExplorerTxUrl`)**:
>   - Uses `useBlockExplorer` to resolve EVM explorer base URLs via `getEvmBlockExplorerUrl` with fallback to `getEtherscanBaseUrl`.
>   - Builds EVM tx links with `etherscan-link.createCustomExplorerLink`.
>   - Keeps non-EVM (e.g., Solana) URLs via `getTransactionUrl`; derives explorer name from URL or `useBlockExplorer`.
>   - Derives `explorerName`, `chainName`, and `networkImageSource` consistently (EVM via CAIP/hex; non-EVM via config).
> - **Hook Tests** (`useMultichainBlockExplorerTxUrl.test.tsx`):
>   - Add extensive coverage for parameter validation, EVM/non-EVM paths, fallback logic, explorer name resolution, network image sourcing, and custom network configs.
>   - Mocks external utilities (`etherscan-link`, `useBlockExplorer`, `getEtherscanBaseUrl`, network utils).
> - **Block Explorer Modal Test** (`BlockExplorersModal.test.tsx`):
>   - Adjust expectations to show one `Etherscan` and one `Optimistic` button instead of two `Etherscan`.
> - **`useBlockExplorer`**:
>   - Exposes `getEvmBlockExplorerUrl` in the returned API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe97a35058148f33f640650df0d80c9e10b64877. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->