### PR TITLE
feat(predict): cp-7.60.0 append utm_source to entryPoint in predict deeplinks

### DIFF
--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handlePredictUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handlePredictUrl.test.ts
@@ -74,7 +74,7 @@ describe('handlePredictUrl', () => {
       });
     });
 
-    it('handles multiple URL parameters', async () => {
+    it('handles multiple URL parameters with utm_source in entryPoint', async () => {
       await handlePredictUrl({
         predictPath: '?market=xyz123&utm_source=campaign&debug=true',
       });
@@ -83,7 +83,7 @@ describe('handlePredictUrl', () => {
         screen: Routes.PREDICT.MARKET_DETAILS,
         params: {
           marketId: 'xyz123',
-          entryPoint: 'deeplink',
+          entryPoint: 'deeplink_campaign',
         },
       });
     });
@@ -158,13 +158,13 @@ describe('handlePredictUrl', () => {
       });
     });
 
-    it('navigates to market list when only other parameters provided', async () => {
+    it('navigates to market list with utm_source in entryPoint when only utm_source provided', async () => {
       await handlePredictUrl({ predictPath: '?utm_source=campaign' });
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
         screen: Routes.PREDICT.MARKET_LIST,
         params: {
-          entryPoint: 'deeplink',
+          entryPoint: 'deeplink_campaign',
         },
       });
     });
@@ -247,7 +247,7 @@ describe('handlePredictUrl', () => {
 
       expect(DevLogger.log).toHaveBeenCalledWith(
         '[handlePredictUrl] Parsed navigation parameters:',
-        { market: '23246' },
+        { market: '23246', utmSource: undefined },
       );
     });
 
@@ -346,7 +346,7 @@ describe('handlePredictUrl', () => {
       });
     });
 
-    it('sets entryPoint to deeplink when origin is undefined', async () => {
+    it('sets entryPoint to deeplink when origin is undefined and no utm_source', async () => {
       await handlePredictUrl({
         predictPath: '?market=23246',
         origin: undefined,
@@ -361,7 +361,7 @@ describe('handlePredictUrl', () => {
       });
     });
 
-    it('sets entryPoint to deeplink when origin is deeplink', async () => {
+    it('sets entryPoint to deeplink when origin is deeplink and no utm_source', async () => {
       await handlePredictUrl({
         predictPath: '?market=23246',
         origin: 'deeplink',
@@ -406,6 +406,145 @@ describe('handlePredictUrl', () => {
       expect(DevLogger.log).toHaveBeenCalledWith(
         '[handlePredictUrl] Entry point:',
         'carousel',
+      );
+    });
+  });
+
+  describe('utm_source parameter handling', () => {
+    it('sets entryPoint to deeplink_test when utm_source is test', async () => {
+      await handlePredictUrl({
+        predictPath: '?market=23246&utm_source=test',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '23246',
+          entryPoint: 'deeplink_test',
+        },
+      });
+    });
+
+    it('sets entryPoint to deeplink_twitter when utm_source is twitter', async () => {
+      await handlePredictUrl({
+        predictPath: '?marketId=12345&utm_source=twitter',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '12345',
+          entryPoint: 'deeplink_twitter',
+        },
+      });
+    });
+
+    it('appends utm_source to carousel origin', async () => {
+      await handlePredictUrl({
+        predictPath: '?market=23246&utm_source=test',
+        origin: 'carousel',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '23246',
+          entryPoint: 'carousel_test',
+        },
+      });
+    });
+
+    it('appends utm_source to deeplink origin', async () => {
+      await handlePredictUrl({
+        predictPath: '?market=23246&utm_source=test',
+        origin: 'deeplink',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '23246',
+          entryPoint: 'deeplink_test',
+        },
+      });
+    });
+
+    it('appends utm_source to notification origin', async () => {
+      await handlePredictUrl({
+        predictPath: '?market=23246&utm_source=campaign',
+        origin: 'notification',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '23246',
+          entryPoint: 'notification_campaign',
+        },
+      });
+    });
+
+    it('does not append utm_source when it equals origin', async () => {
+      await handlePredictUrl({
+        predictPath: '?market=23246&utm_source=carousel',
+        origin: 'carousel',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '23246',
+          entryPoint: 'carousel',
+        },
+      });
+    });
+
+    it('does not append utm_source when it equals default deeplink', async () => {
+      await handlePredictUrl({
+        predictPath: '?market=23246&utm_source=deeplink',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '23246',
+          entryPoint: 'deeplink',
+        },
+      });
+    });
+
+    it('navigates to market list with deeplink_test entryPoint when no market but utm_source present', async () => {
+      await handlePredictUrl({
+        predictPath: '?utm_source=test',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+        params: {
+          entryPoint: 'deeplink_test',
+        },
+      });
+    });
+
+    it('logs parsed utm_source in navigation parameters', async () => {
+      await handlePredictUrl({
+        predictPath: '?market=23246&utm_source=test',
+      });
+
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        '[handlePredictUrl] Parsed navigation parameters:',
+        { market: '23246', utmSource: 'test' },
+      );
+    });
+
+    it('logs entry point with utm_source suffix', async () => {
+      await handlePredictUrl({
+        predictPath: '?market=23246&utm_source=test',
+      });
+
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        '[handlePredictUrl] Entry point:',
+        'deeplink_test',
       );
     });
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR enhances the predict deeplink handler to include UTM source tracking in the `entryPoint` parameter passed to screens.

**What changed:**
- Parse `utm_source` from predict deeplink URL parameters
- Append `utm_source` to the `entryPoint` (e.g., `deeplink_test`, `carousel_twitter`)
- Skip appending if `utm_source` equals the base `entryPoint` to avoid duplicates like `deeplink_deeplink`

**Why:**
This allows analytics to track the specific UTM source that brought users to the predict feature via deeplinks, enabling better attribution and campaign performance measurement.

**Examples:**
| URL | Origin | entryPoint |
|-----|--------|------------|
| `predict?utm_source=test` | - | `deeplink_test` |
| `predict?utm_source=twitter` | `carousel` | `carousel_twitter` |
| `predict?utm_source=deeplink` | - | `deeplink` (no duplicate) |

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict deeplink utm_source tracking

  Scenario: user opens predict deeplink with utm_source parameter
    Given the app is installed and user is logged in

    When user opens deeplink "https://metamask.app.link/predict?utm_source=test"
    Then user navigates to predict market list
    And entryPoint is set to "deeplink_test"

  Scenario: user opens predict deeplink with market and utm_source
    Given the app is installed and user is logged in

    When user opens deeplink "https://metamask.app.link/predict?marketId=1231&utm_source=twitter"
    Then user navigates to predict market details for market 1231
    And entryPoint is set to "deeplink_twitter"

  Scenario: user opens predict deeplink with utm_source matching origin
    Given the app is installed and user is logged in

    When user opens deeplink "https://metamask.app.link/predict?utm_source=deeplink"
    Then user navigates to predict market list
    And entryPoint is set to "deeplink" (not "deeplink_deeplink")
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - No UI changes

### **After**

N/A - No UI changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Parse utm_source from predict deeplinks and append it to the entryPoint (unless equal to base), updating navigation behavior and logs with comprehensive tests.
> 
> - **Core: `app/core/DeeplinkManager/handlers/legacy/handlePredictUrl.ts`**
>   - Parse `utm_source` from query into `PredictNavigationParams`.
>   - Derive `entryPoint` from `origin` (or `deeplink`) and append `_<utm_source>` when present and different.
>   - Apply computed `entryPoint` to both market details and market list navigations.
>   - Enhance logging to include parsed `utmSource` and final `entryPoint`.
> - **Tests: `__tests__/handlePredictUrl.test.ts`**
>   - Update expectations to reflect `entryPoint` suffixing when `utm_source` exists.
>   - Add cases for multiple params, various origins (carousel/deeplink/notification), equality guard (no duplicate), and no-market with `utm_source`.
>   - Verify logs include `utmSource` in parsed params and `entryPoint` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c6638143428c2cafce018a5857f172f6f5a646b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->