### PR TITLE
chore: Polish styles on v2 Perps AssetDetails screen

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.styles.ts
+++ b/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.styles.ts
@@ -10,20 +10,23 @@ const styleSheet = (params: { theme: Theme }) =>
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'space-between',
-      marginBottom: 8,
     },
     statsRowsContainer: {
-      backgroundColor: params.theme.colors.background.alternative,
-      borderRadius: 8,
-      padding: 16,
+      gap: 1,
     },
     statsRow: {
-      paddingVertical: 12,
-      borderBottomWidth: 1,
-      borderBottomColor: params.theme.colors.border.muted,
+      padding: 12,
+      backgroundColor: params.theme.colors.background.section,
+    },
+    statsRowFirst: {
+      borderTopLeftRadius: 8,
+      borderTopRightRadius: 8,
     },
     statsRowLast: {
-      paddingVertical: 12,
+      padding: 12,
+      backgroundColor: params.theme.colors.background.section,
+      borderBottomLeftRadius: 8,
+      borderBottomRightRadius: 8,
     },
     fundingRateContainer: {
       flexDirection: 'row',

--- a/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.tsx
@@ -131,7 +131,7 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
               color: TextColor.Default,
             },
           }}
-          style={styles.statsRow}
+          style={[styles.statsRow, styles.statsRowFirst]}
         />
 
         {/* 24h high */}

--- a/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useMemo,
 } from 'react';
+import { useNavigation, NavigationProp } from '@react-navigation/native';
 import Text, {
   TextVariant,
   TextColor,
@@ -25,9 +26,17 @@ import PerpsMarketStatisticsCard from '../PerpsMarketStatisticsCard';
 import PerpsPositionCard from '../PerpsPositionCard';
 import { PerpsMarketTabsProps, PerpsTabId } from './PerpsMarketTabs.types';
 import styleSheet from './PerpsMarketTabs.styles';
-import type { Position, Order } from '../../controllers/types';
+import type {
+  Position,
+  Order,
+  PerpsNavigationParamList,
+} from '../../controllers/types';
 import { usePerpsMarketStats } from '../../hooks/usePerpsMarketStats';
-import { usePerpsLivePositions, usePerpsLiveOrders } from '../../hooks/stream';
+import {
+  usePerpsLivePositions,
+  usePerpsLiveOrders,
+  usePerpsLivePrices,
+} from '../../hooks/stream';
 import type { PerpsTooltipContentKey } from '../PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.types';
 import PerpsBottomSheetTooltip from '../PerpsBottomSheetTooltip';
 import {
@@ -40,17 +49,24 @@ import Engine from '../../../../../core/Engine';
 import { getOrderDirection } from '../../utils/orderUtils';
 import usePerpsToasts from '../../hooks/usePerpsToasts';
 import { OrderDirection } from '../../types/perps-types';
+import Routes from '../../../../../constants/navigation/Routes';
 
 // Tab content component for Position tab
 interface PositionTabContentProps {
   tabLabel: string;
   position: Position | null;
   showIcon: boolean;
+  onAutoClosePress?: () => void;
+  onMarginPress?: () => void;
+  onSharePress?: () => void;
 }
 
 const PositionTabContent: React.FC<PositionTabContentProps> = ({
   position,
   showIcon,
+  onAutoClosePress,
+  onMarginPress,
+  onSharePress,
 }) => {
   const { styles } = useStyles(styleSheet, {});
 
@@ -65,6 +81,9 @@ const PositionTabContent: React.FC<PositionTabContentProps> = ({
         key={`${position.coin}`}
         position={position}
         showIcon={showIcon}
+        onAutoClosePress={onAutoClosePress}
+        onMarginPress={onMarginPress}
+        onSharePress={onSharePress}
       />
     </View>
   );
@@ -201,6 +220,7 @@ const PerpsMarketTabs: React.FC<PerpsMarketTabsProps> = ({
   activeSLOrderId,
 }) => {
   const { styles } = useStyles(styleSheet, {});
+  const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
   const hasUserInteracted = useRef(false);
   const hasSetInitialTab = useRef(false);
   const tabsListRef = useRef<TabsListRef>(null);
@@ -215,6 +235,12 @@ const PerpsMarketTabs: React.FC<PerpsMarketTabsProps> = ({
   });
   const { orders: allOrders } = usePerpsLiveOrders({ throttleMs: 0 });
 
+  // Subscribe to live prices for current position price
+  const livePrices = usePerpsLivePrices({
+    symbols: symbol ? [symbol] : [],
+    throttleMs: 1000,
+  });
+
   const position = useMemo(
     () => positions.find((p) => p.coin === symbol) || null,
     [positions, symbol],
@@ -223,6 +249,19 @@ const PerpsMarketTabs: React.FC<PerpsMarketTabsProps> = ({
     () => allOrders.filter((o) => o.symbol === symbol),
     [allOrders, symbol],
   );
+
+  // Get current price for the symbol
+  const currentPrice = useMemo(() => {
+    const priceData = livePrices[symbol];
+    if (priceData?.price) {
+      return parseFloat(priceData.price);
+    }
+    // Fallback to position entry price if available
+    if (position?.entryPrice) {
+      return parseFloat(position.entryPrice);
+    }
+    return 0;
+  }, [livePrices, symbol, position]);
 
   // State to track which orders are being cancelled for UI display
   const [cancellingOrderIds, setCancellingOrderIds] = useState<Set<string>>(
@@ -278,6 +317,40 @@ const PerpsMarketTabs: React.FC<PerpsMarketTabsProps> = ({
       }
     }
   }, [unfilledOrders, successfullyCancelledOrderIds]);
+
+  // Position management callbacks
+  const handleAutoClosePress = useCallback(() => {
+    if (!position) return;
+
+    navigation.navigate(Routes.PERPS.TPSL, {
+      asset: position.coin,
+      currentPrice,
+      position,
+      initialTakeProfitPrice: position.takeProfitPrice,
+      initialStopLossPrice: position.stopLossPrice,
+      onConfirm: async () => {
+        // TP/SL is set directly on the position, no need to handle here
+        // The position will update via WebSocket
+      },
+    });
+  }, [position, currentPrice, navigation]);
+
+  const handleMarginPress = useCallback(() => {
+    if (!position) return;
+
+    navigation.navigate(Routes.PERPS.SELECT_ADJUST_MARGIN_ACTION, {
+      position,
+    });
+  }, [position, navigation]);
+
+  const handleSharePress = useCallback(() => {
+    if (!position) return;
+
+    navigation.navigate(Routes.PERPS.PNL_HERO_CARD, {
+      position,
+      marketPrice: currentPrice.toString(),
+    });
+  }, [position, currentPrice, navigation]);
 
   const tabs = React.useMemo(() => {
     const dynamicTabs = [];
@@ -550,8 +623,11 @@ const PerpsMarketTabs: React.FC<PerpsMarketTabsProps> = ({
       tabLabel: strings('perps.market.position'),
       position,
       showIcon: true,
+      onAutoClosePress: handleAutoClosePress,
+      onMarginPress: handleMarginPress,
+      onSharePress: handleSharePress,
     }),
-    [position],
+    [position, handleAutoClosePress, handleMarginPress, handleSharePress],
   );
 
   const ordersTabProps = useMemo(

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.styles.ts
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.styles.ts
@@ -13,7 +13,7 @@ const styleSheet = (params: { theme: Theme }) => {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      marginBottom: 4,
+      marginBottom: 16,
     },
     listContainer: {
       gap: 1,

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.styles.ts
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.styles.ts
@@ -13,17 +13,24 @@ const styleSheet = (params: { theme: Theme }) => {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      marginBottom: 12,
+      marginBottom: 4,
+    },
+    listContainer: {
+      gap: 1,
     },
     tradeItem: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: 12,
-      borderBottomWidth: 1,
-      borderBottomColor: colors.border.muted,
+      padding: 12,
+      backgroundColor: colors.background.section,
     },
-    lastTradeItem: {
-      borderBottomWidth: 0,
+    tradeItemFirst: {
+      borderTopLeftRadius: 8,
+      borderTopRightRadius: 8,
+    },
+    tradeItemLast: {
+      borderBottomLeftRadius: 8,
+      borderBottomRightRadius: 8,
     },
     leftSection: {
       flex: 1,

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.tsx
@@ -88,11 +88,16 @@ const PerpsMarketTradesList: React.FC<PerpsMarketTradesListProps> = ({
   const renderItem = useCallback(
     (props: { item: PerpsTransaction; index: number }) => {
       const { item, index } = props;
+      const isFirstItem = index === 0;
       const isLastItem = index === trades.length - 1;
 
       return (
         <TouchableOpacity
-          style={[styles.tradeItem, isLastItem && styles.lastTradeItem]}
+          style={[
+            styles.tradeItem,
+            isFirstItem && styles.tradeItemFirst,
+            isLastItem && styles.tradeItemLast,
+          ]}
           onPress={() => handleTradePress(item)}
           activeOpacity={0.7}
         >
@@ -132,7 +137,7 @@ const PerpsMarketTradesList: React.FC<PerpsMarketTradesListProps> = ({
   // Render header section
   const renderHeader = () => (
     <View style={styles.header}>
-      <Text variant={TextVariant.HeadingSM} color={TextColor.Default}>
+      <Text variant={TextVariant.HeadingMD} color={TextColor.Default}>
         {strings('perps.market.recent_trades')}
       </Text>
       {!isLoading && trades.length > 0 && (
@@ -164,12 +169,14 @@ const PerpsMarketTradesList: React.FC<PerpsMarketTradesListProps> = ({
     }
 
     return (
-      <FlatList
-        data={trades}
-        renderItem={renderItem}
-        keyExtractor={(item, index) => `${item.id || index}`}
-        scrollEnabled={false}
-      />
+      <View style={styles.listContainer}>
+        <FlatList
+          data={trades}
+          renderItem={renderItem}
+          keyExtractor={(item, index) => `${item.id || index}`}
+          scrollEnabled={false}
+        />
+      </View>
     );
   };
 

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.styles.ts
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.styles.ts
@@ -19,8 +19,8 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     pnlSection: {
       flexDirection: 'row',
-      gap: 12,
-      marginBottom: 12,
+      gap: 8,
+      marginBottom: 8,
     },
     pnlCard: {
       flex: 1,
@@ -37,8 +37,8 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     sizeMarginRow: {
       flexDirection: 'row',
-      gap: 12,
-      marginBottom: 12,
+      gap: 8,
+      marginBottom: 8,
     },
     sizeContainer: {
       flex: 1,

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.styles.ts
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.styles.ts
@@ -9,9 +9,7 @@ const styleSheet = (params: { theme: Theme }) => {
     container: {
       backgroundColor: colors.background.default,
       borderRadius: 12,
-      borderWidth: 1,
-      borderColor: colors.border.default,
-      padding: 16,
+      // padding: 16,
     },
     header: {
       flexDirection: 'row',
@@ -26,7 +24,7 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     pnlCard: {
       flex: 1,
-      backgroundColor: colors.background.alternative,
+      backgroundColor: colors.background.section,
       borderRadius: 8,
       padding: 12,
       gap: 4,
@@ -47,7 +45,7 @@ const styleSheet = (params: { theme: Theme }) => {
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'space-between',
-      backgroundColor: colors.background.alternative,
+      backgroundColor: colors.background.section,
       borderRadius: 8,
       padding: 12,
     },
@@ -60,7 +58,7 @@ const styleSheet = (params: { theme: Theme }) => {
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'space-between',
-      backgroundColor: colors.background.alternative,
+      backgroundColor: colors.background.section,
       borderRadius: 8,
       padding: 12,
     },
@@ -72,7 +70,7 @@ const styleSheet = (params: { theme: Theme }) => {
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'space-between',
-      backgroundColor: colors.background.alternative,
+      backgroundColor: colors.background.section,
       borderRadius: 8,
       padding: 12,
       marginBottom: 12,
@@ -110,15 +108,25 @@ const styleSheet = (params: { theme: Theme }) => {
       alignSelf: 'flex-end',
     },
     detailsSection: {
-      gap: 12,
+      gap: 1,
     },
     detailsTitle: {
       marginBottom: 4,
     },
     detailRow: {
+      padding: 12,
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
+      backgroundColor: colors.background.section,
+    },
+    detailRowFirst: {
+      borderTopLeftRadius: 8,
+      borderTopRightRadius: 8,
+    },
+    detailRowLast: {
+      borderBottomLeftRadius: 8,
+      borderBottomRightRadius: 8,
     },
   });
 };

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.styles.ts
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.styles.ts
@@ -111,7 +111,7 @@ const styleSheet = (params: { theme: Theme }) => {
       gap: 1,
     },
     detailsTitle: {
-      marginBottom: 4,
+      marginBottom: 16,
     },
     detailRow: {
       padding: 12,

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.styles.ts
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.styles.ts
@@ -9,7 +9,6 @@ const styleSheet = (params: { theme: Theme }) => {
     container: {
       backgroundColor: colors.background.default,
       borderRadius: 12,
-      // padding: 16,
     },
     header: {
       flexDirection: 'row',

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.styles.ts
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.styles.ts
@@ -53,6 +53,11 @@ const styleSheet = (params: { theme: Theme }) => {
       flex: 1,
       gap: 4,
     },
+    sizeLabelRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+    },
     marginContainer: {
       flex: 1,
       flexDirection: 'row',
@@ -64,6 +69,11 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     marginLeftContent: {
       flex: 1,
+      gap: 4,
+    },
+    marginLabelRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
       gap: 4,
     },
     autoCloseSection: {
@@ -78,6 +88,17 @@ const styleSheet = (params: { theme: Theme }) => {
     autoCloseTextContainer: {
       flex: 1,
       gap: 4,
+    },
+    autoCloseButton: {
+      borderRadius: 8,
+    },
+    iconButton: {
+      backgroundColor: colors.background.muted,
+      borderRadius: 8,
+    },
+    iconButtonContainer: {
+      height: '100%',
+      alignItems: 'flex-end',
     },
     toggleContainer: {
       marginLeft: 16,

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -336,15 +336,18 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
         testID={PerpsPositionCardSelectorsIDs.DETAILS_SECTION}
       >
         <Text
-          variant={TextVariant.BodyMDMedium}
+          variant={TextVariant.HeadingMD}
           color={TextColor.Default}
           style={styles.detailsTitle}
         >
           {strings('perps.position.card.details_title')}
         </Text>
 
-        <View style={styles.detailRow}>
-          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+        <View style={[styles.detailRow, styles.detailRowFirst]}>
+          <Text
+            variant={TextVariant.BodyMDMedium}
+            color={TextColor.Alternative}
+          >
             {strings('perps.position.card.direction_label')}
           </Text>
           <Text
@@ -360,7 +363,10 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
         </View>
 
         <View style={styles.detailRow}>
-          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          <Text
+            variant={TextVariant.BodyMDMedium}
+            color={TextColor.Alternative}
+          >
             {strings('perps.position.card.entry_label')}
           </Text>
           <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
@@ -371,7 +377,10 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
         </View>
 
         <View style={styles.detailRow}>
-          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          <Text
+            variant={TextVariant.BodyMDMedium}
+            color={TextColor.Alternative}
+          >
             {strings('perps.position.card.liquidation_price_label')}
           </Text>
           <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
@@ -384,8 +393,11 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           </Text>
         </View>
 
-        <View style={styles.detailRow}>
-          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+        <View style={[styles.detailRow, styles.detailRowLast]}>
+          <Text
+            variant={TextVariant.BodyMDMedium}
+            color={TextColor.Alternative}
+          >
             {strings('perps.position.card.funding_payments_label')}
           </Text>
           <Text variant={TextVariant.BodyMD} color={fundingColor}>

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -5,10 +5,13 @@ import { strings } from '../../../../../../locales/i18n';
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../component-library/components/Buttons/ButtonIcon';
-import Icon, {
+import Button, {
+  ButtonVariants,
+  ButtonSize,
+} from '../../../../../component-library/components/Buttons/Button';
+import {
   IconColor,
   IconName,
-  IconSize,
 } from '../../../../../component-library/components/Icons/Icon';
 import Text, {
   TextColor,
@@ -156,7 +159,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             {strings('perps.position.card.pnl_label')}
           </Text>
           <Text
-            variant={TextVariant.HeadingSM}
+            variant={TextVariant.BodyMD}
             color={pnlNum >= 0 ? TextColor.Success : TextColor.Error}
             testID={PerpsPositionCardSelectorsIDs.PNL_VALUE}
           >
@@ -172,7 +175,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             {strings('perps.position.card.return_label')}
           </Text>
           <Text
-            variant={TextVariant.HeadingSM}
+            variant={TextVariant.BodyMD}
             color={roe >= 0 ? TextColor.Success : TextColor.Error}
             testID={PerpsPositionCardSelectorsIDs.RETURN_VALUE}
           >
@@ -205,12 +208,16 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
                 : `${formatPositionSize(absoluteSize.toString())} ${getPerpsDisplaySymbol(position.coin)}`}
             </Text>
           </View>
-          <Icon
-            name={IconName.SwapHorizontal}
-            size={IconSize.Md}
-            color={IconColor.Default}
-            testID={PerpsPositionCardSelectorsIDs.FLIP_ICON}
-          />
+          <View style={styles.iconButtonContainer}>
+            <ButtonIcon
+              iconName={IconName.SwapHorizontal}
+              size={ButtonIconSizes.Sm}
+              iconColor={IconColor.Default}
+              onPress={handleSizeToggle}
+              style={styles.iconButton}
+              testID={PerpsPositionCardSelectorsIDs.FLIP_ICON}
+            />
+          </View>
         </TouchableOpacity>
 
         <TouchableOpacity
@@ -234,12 +241,16 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             </Text>
           </View>
           {onMarginPress && (
-            <Icon
-              name={IconName.Arrow2Right}
-              size={IconSize.Md}
-              color={IconColor.Default}
-              testID={PerpsPositionCardSelectorsIDs.MARGIN_CHEVRON}
-            />
+            <View style={styles.iconButtonContainer}>
+              <ButtonIcon
+                iconName={IconName.Arrow2Right}
+                size={ButtonIconSizes.Sm}
+                iconColor={IconColor.Default}
+                onPress={onMarginPress}
+                style={styles.iconButton}
+                testID={PerpsPositionCardSelectorsIDs.MARGIN_CHEVRON}
+              />
+            </View>
           )}
         </TouchableOpacity>
       </View>
@@ -253,7 +264,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
         testID={PerpsPositionCardSelectorsIDs.AUTO_CLOSE_TOGGLE}
       >
         <View style={styles.autoCloseTextContainer}>
-          <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+          <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
             {strings('perps.auto_close.title')}
           </Text>
           {(() => {
@@ -315,19 +326,24 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             }
 
             return (
-              <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+              <Text variant={TextVariant.BodySM} color={TextColor.Default}>
                 {strings('perps.auto_close.description')}
               </Text>
             );
           })()}
         </View>
-        {onAutoClosePress && (
-          <Icon
-            name={IconName.Arrow2Right}
-            size={IconSize.Md}
-            color={IconColor.Default}
-          />
-        )}
+        <View>
+          {onAutoClosePress && (
+            <Button
+              variant={ButtonVariants.Secondary}
+              size={ButtonSize.Sm}
+              label={strings('perps.auto_close.set_button')}
+              labelTextVariant={TextVariant.BodyMD}
+              onPress={handleAutoCloseButtonPress}
+              style={styles.autoCloseButton}
+            />
+          )}
+        </View>
       </TouchableOpacity>
 
       {/* Details Section - Always expanded */}

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.styles.ts
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.styles.ts
@@ -14,7 +14,7 @@ const styleSheet = (params: { theme: Theme }) => {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      marginBottom: 4,
+      marginBottom: 16,
       paddingHorizontal: 16,
     },
     listContainer: {

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.styles.ts
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.styles.ts
@@ -14,14 +14,26 @@ const styleSheet = (params: { theme: Theme }) => {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      marginBottom: 12,
+      marginBottom: 4,
+      paddingHorizontal: 16,
+    },
+    listContainer: {
+      gap: 1,
       paddingHorizontal: 16,
     },
     activityItem: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: 12,
-      paddingHorizontal: 16,
+      padding: 12,
+      backgroundColor: colors.background.section,
+    },
+    activityItemFirst: {
+      borderTopLeftRadius: 8,
+      borderTopRightRadius: 8,
+    },
+    activityItemLast: {
+      borderBottomLeftRadius: 8,
+      borderBottomRightRadius: 8,
     },
     leftSection: {
       flexDirection: 'row',

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
@@ -67,11 +67,18 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
   }, []);
 
   const renderItem = useCallback(
-    (props: { item: PerpsTransaction }) => {
-      const { item } = props;
+    (props: { item: PerpsTransaction; index: number }) => {
+      const { item, index } = props;
+      const isFirstItem = index === 0;
+      const isLastItem = index === transactions.length - 1;
+
       return (
         <TouchableOpacity
-          style={styles.activityItem}
+          style={[
+            styles.activityItem,
+            isFirstItem && styles.activityItemFirst,
+            isLastItem && styles.activityItemLast,
+          ]}
           onPress={() => handleTransactionPress(item)}
           activeOpacity={0.7}
         >
@@ -105,14 +112,20 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
         </TouchableOpacity>
       );
     },
-    [styles, handleTransactionPress, iconSize, renderRightContent],
+    [
+      styles,
+      handleTransactionPress,
+      iconSize,
+      renderRightContent,
+      transactions.length,
+    ],
   );
 
   if (isLoading) {
     return (
       <View style={styles.container}>
         <View style={styles.header}>
-          <Text variant={TextVariant.HeadingSM} color={TextColor.Default}>
+          <Text variant={TextVariant.HeadingMD} color={TextColor.Default}>
             {strings('perps.home.recent_activity')}
           </Text>
         </View>
@@ -125,7 +138,7 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
     return (
       <View style={styles.container}>
         <View style={styles.header}>
-          <Text variant={TextVariant.HeadingSM} color={TextColor.Default}>
+          <Text variant={TextVariant.HeadingMD} color={TextColor.Default}>
             {strings('perps.home.recent_activity')}
           </Text>
         </View>
@@ -143,7 +156,7 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <Text variant={TextVariant.HeadingSM} color={TextColor.Default}>
+        <Text variant={TextVariant.HeadingMD} color={TextColor.Default}>
           {strings('perps.home.recent_activity')}
         </Text>
         <TouchableOpacity onPress={handleSeeAll}>

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
@@ -166,12 +166,14 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
         </TouchableOpacity>
       </View>
 
-      <FlatList
-        data={transactions}
-        renderItem={renderItem}
-        keyExtractor={(item, index) => `${item.id || index}`}
-        scrollEnabled={false}
-      />
+      <View style={styles.listContainer}>
+        <FlatList
+          data={transactions}
+          renderItem={renderItem}
+          keyExtractor={(item, index) => `${item.id || index}`}
+          scrollEnabled={false}
+        />
+      </View>
     </View>
   );
 };

--- a/app/components/UI/Perps/components/PerpsTabControlBar/PerpsTabControlBar.tsx
+++ b/app/components/UI/Perps/components/PerpsTabControlBar/PerpsTabControlBar.tsx
@@ -173,7 +173,7 @@ export const PerpsTabControlBar: React.FC<PerpsTabControlBarProps> = ({
               ]}
             >
               <Text
-                variant={TextVariant.BodyMDMedium}
+                variant={TextVariant.BodyMD}
                 color={TextColor.Default}
                 testID={PerpsTabViewSelectorsIDs.BALANCE_VALUE}
               >

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1428,6 +1428,7 @@
         "error_message": "Market data not found. Please go back and try again."
       },
       "statistics": "Overview",
+      "stats": "Stats",
       "24h_high": "24h high",
       "24h_low": "24h low",
       "24h_volume": "24h volume",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -950,6 +950,10 @@
     "loading_positions": "Loading positions...",
     "refreshing_positions": "Refreshing positions...",
     "no_open_orders": "No open orders",
+    "auto_close": {
+      "title": "Auto close",
+      "description": "Protect your margin, lock in gains"
+    },
     "deposit": {
       "title": "Amount to deposit",
       "get_usdc_hyperliquid": "Get USDC • Hyperliquid",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -952,7 +952,8 @@
     "no_open_orders": "No open orders",
     "auto_close": {
       "title": "Auto close",
-      "description": "Protect your margin, lock in gains"
+      "description": "Protect your margin, lock in gains",
+      "set_button": "Set"
     },
     "deposit": {
       "title": "Amount to deposit",


### PR DESCRIPTION
## **Description**

Some style polishing on details page origination from: https://github.com/MetaMask/metamask-mobile/pull/23230

1. Updates background colors of sections on asset detail page to match [designs](https://www.figma.com/design/Jp8owZibGXg26diIjDjVuq/Mobile-Perps?node-id=12313-7808&p=f&t=UojdgzBPz0sPnRQL-0)
2. Updates some missing i18n strings
3. Tweaks padding, title text, and font sizing to balance spacing.
4. Add handlers to `onAutoClosePress` `onSharePress` and `onMarginPress`
5. Other misc alignment, and font weight tweaks flagged from design

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/2c7080ad-0180-43e2-8a17-0476645b7b66

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Perps market/position UI and lists, adds position actions (auto-close, margin, share) with navigation and live price, and displays live funding rate; updates i18n.
> 
> - **UI/Styling (Perps Market & Lists)**
>   - Convert stats, position details, trades, and recent activity rows to card-style (`background.section`) with 1px gaps and rounded first/last items; adjust paddings/margins and elevate headings to `HeadingMD`.
>   - Replace inline icons with `ButtonIcon`/`Button` in `PerpsPositionCard`; tweak typography colors and containers.
> - **Position Actions & Navigation**
>   - `PerpsMarketTabs`: wire position actions using navigation to `Routes.PERPS.TPSL`, `SELECT_ADJUST_MARGIN_ACTION`, and `PNL_HERO_CARD`; pass callbacks to `PerpsPositionCard`.
>   - Subscribe to live prices to derive `currentPrice` for actions.
> - **Market Stats**
>   - `PerpsMarketStatisticsCard`: render funding rate with live updates via `usePerpsLivePrices` and countdown; add DEX badge; introduce first/last row styling.
> - **Lists**
>   - `PerpsMarketTradesList` and `PerpsRecentActivityList`: header spacing/typography updates; wrap `FlatList` in a `listContainer`; rounded first/last items.
> - **Misc**
>   - `PerpsTabControlBar`: minor text variant tweak.
>   - **i18n**: add `perps.auto_close` strings and `perps.market.stats`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b387b3267e52d5433b0b3f0dc7144be8f85954a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->