### PR TITLE
feat(predict): navigate to transaction details from deposit toast

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictDepositToasts.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictDepositToasts.test.ts
@@ -7,6 +7,7 @@ import {
 import { usePredictDepositToasts } from './usePredictDepositToasts';
 import Engine from '../../../../core/Engine';
 import { ToastContext } from '../../../../component-library/components/Toast';
+import Routes from '../../../../constants/navigation/Routes';
 
 // Mock @react-navigation/native
 jest.mock('@react-navigation/native', () => ({
@@ -144,6 +145,7 @@ describe('usePredictDepositToasts', () => {
   let mockSubscribeCallback:
     | ((payload: {
         transactionMeta: {
+          id?: string;
           status: string;
           nestedTransactions?: { type: string }[];
           metamaskPay?: { totalFiat?: string };
@@ -350,6 +352,159 @@ describe('usePredictDepositToasts', () => {
 
       // Verify that deposit would be called (it will call navigateToConfirmation)
       expect(onPressRetry).toBeInstanceOf(Function);
+    });
+  });
+
+  describe('pending toast navigation', () => {
+    let mockNavigate: jest.Mock;
+
+    beforeEach(() => {
+      // Get the mock navigate function from the useNavigation mock
+      const { useNavigation } = jest.requireMock('@react-navigation/native');
+      mockNavigate = jest.fn();
+      useNavigation.mockReturnValue({
+        navigate: mockNavigate,
+      });
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    });
+
+    it('navigates to transactions view when pending toast link is pressed', async () => {
+      // Arrange
+      renderHook(() => usePredictDepositToasts(), { wrapper });
+
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          },
+        });
+      });
+
+      // Act
+      const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
+        .calls[0][0];
+      const onPressLink = toastCall.linkButtonOptions?.onPress;
+
+      act(() => {
+        onPressLink?.();
+      });
+
+      // Assert
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
+    });
+
+    it('navigates to transaction details when pending toast link is pressed with transaction id', async () => {
+      // Arrange
+      renderHook(() => usePredictDepositToasts(), { wrapper });
+      const transactionId = 'test-transaction-id-456';
+
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            id: transactionId,
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          },
+        });
+      });
+
+      // Act
+      const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
+        .calls[0][0];
+      const onPressLink = toastCall.linkButtonOptions?.onPress;
+
+      act(() => {
+        onPressLink?.();
+        jest.advanceTimersByTime(100);
+      });
+
+      // Assert
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTION_DETAILS, {
+        transactionId,
+      });
+      expect(mockNavigate).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not navigate to transaction details when transaction id is missing', async () => {
+      // Arrange
+      renderHook(() => usePredictDepositToasts(), { wrapper });
+
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          },
+        });
+      });
+
+      // Act
+      const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
+        .calls[0][0];
+      const onPressLink = toastCall.linkButtonOptions?.onPress;
+
+      act(() => {
+        onPressLink?.();
+        jest.advanceTimersByTime(100);
+      });
+
+      // Assert
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        Routes.TRANSACTION_DETAILS,
+        expect.anything(),
+      );
+    });
+
+    it('uses 100ms timeout before navigating to transaction details', async () => {
+      // Arrange
+      renderHook(() => usePredictDepositToasts(), { wrapper });
+      const transactionId = 'test-transaction-id-789';
+
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            id: transactionId,
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          },
+        });
+      });
+
+      // Act
+      const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
+        .calls[0][0];
+      const onPressLink = toastCall.linkButtonOptions?.onPress;
+
+      act(() => {
+        onPressLink?.();
+      });
+
+      // Assert - before timeout
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
+
+      // Act - advance timer
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      // Assert - after timeout
+      expect(mockNavigate).toHaveBeenCalledTimes(2);
+      expect(mockNavigate).toHaveBeenLastCalledWith(
+        Routes.TRANSACTION_DETAILS,
+        {
+          transactionId,
+        },
+      );
     });
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictDepositToasts.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictDepositToasts.test.ts
@@ -369,7 +369,7 @@ describe('usePredictDepositToasts', () => {
     });
 
     afterEach(() => {
-      jest.runOnlyPendingTimers();
+      jest.clearAllTimers();
       jest.useRealTimers();
     });
 

--- a/app/components/UI/Predict/hooks/usePredictDepositToasts.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictDepositToasts.test.ts
@@ -389,7 +389,7 @@ describe('usePredictDepositToasts', () => {
       // Act
       const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
         .calls[0][0];
-      const onPressLink = toastCall.linkButtonOptions?.onPress;
+      const onPressLink = toastCall.closeButtonOptions?.onPress;
 
       act(() => {
         onPressLink?.();
@@ -417,7 +417,7 @@ describe('usePredictDepositToasts', () => {
       // Act
       const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
         .calls[0][0];
-      const onPressLink = toastCall.linkButtonOptions?.onPress;
+      const onPressLink = toastCall.closeButtonOptions?.onPress;
 
       act(() => {
         onPressLink?.();
@@ -448,7 +448,7 @@ describe('usePredictDepositToasts', () => {
       // Act
       const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
         .calls[0][0];
-      const onPressLink = toastCall.linkButtonOptions?.onPress;
+      const onPressLink = toastCall.closeButtonOptions?.onPress;
 
       act(() => {
         onPressLink?.();
@@ -482,7 +482,7 @@ describe('usePredictDepositToasts', () => {
       // Act
       const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
         .calls[0][0];
-      const onPressLink = toastCall.linkButtonOptions?.onPress;
+      const onPressLink = toastCall.closeButtonOptions?.onPress;
 
       act(() => {
         onPressLink?.();

--- a/app/components/UI/Predict/hooks/usePredictDepositToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictDepositToasts.tsx
@@ -45,8 +45,17 @@ export const usePredictDepositToasts = ({
       description: strings('predict.deposit.available_in_minutes', {
         minutes: 1,
       }),
-      onPress: () => {
+      onPress: (transactionMeta) => {
         navigation.navigate(Routes.TRANSACTIONS_VIEW);
+
+        // Then use a timeout to navigate to the specific transaction details
+        if (transactionMeta?.id) {
+          setTimeout(() => {
+            navigation.navigate(Routes.TRANSACTION_DETAILS, {
+              transactionId: transactionMeta.id,
+            });
+          }, 100);
+        }
       },
     },
     confirmedToastConfig: {

--- a/app/components/UI/Predict/hooks/usePredictToasts.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictToasts.test.ts
@@ -250,6 +250,107 @@ describe('usePredictToasts', () => {
       });
     });
 
+    it('passes transactionMeta to onPress callback when link button is pressed', async () => {
+      // Arrange
+      const mockOnPress = jest.fn();
+      const configWithOnPress = {
+        ...defaultConfig,
+        pendingToastConfig: {
+          ...defaultConfig.pendingToastConfig,
+          onPress: mockOnPress,
+        },
+      };
+      renderHook(() => usePredictToasts(configWithOnPress), { wrapper });
+      const transactionMeta = {
+        id: 'test-transaction-id-123',
+        status: TransactionStatus.approved,
+        nestedTransactions: [{ type: TransactionType.predictDeposit }],
+      } as TransactionMeta;
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta,
+        });
+      });
+
+      // Assert
+      await waitFor(() => {
+        const toastCall = mockToastRef.current.showToast.mock.calls[0][0];
+        const linkButtonOnPress = toastCall.linkButtonOptions?.onPress;
+        expect(linkButtonOnPress).toBeDefined();
+
+        // Call the link button onPress
+        linkButtonOnPress?.();
+
+        expect(mockOnPress).toHaveBeenCalledWith(transactionMeta);
+      });
+    });
+
+    it('includes link button options when onPress is provided in pending toast config', async () => {
+      // Arrange
+      const mockOnPress = jest.fn();
+      const configWithOnPress = {
+        ...defaultConfig,
+        pendingToastConfig: {
+          ...defaultConfig.pendingToastConfig,
+          onPress: mockOnPress,
+        },
+      };
+      renderHook(() => usePredictToasts(configWithOnPress), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      await waitFor(() => {
+        expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            linkButtonOptions: expect.objectContaining({
+              label: expect.any(String),
+              onPress: expect.any(Function),
+            }),
+          }),
+        );
+      });
+    });
+
+    it('excludes link button options when onPress is not provided in pending toast config', async () => {
+      // Arrange
+      const configWithoutOnPress = {
+        ...defaultConfig,
+        pendingToastConfig: {
+          title: 'Processing',
+          description: 'Please wait',
+          getAmount: mockGetAmount,
+        },
+      };
+      renderHook(() => usePredictToasts(configWithoutOnPress), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      await waitFor(() => {
+        const toastCall = mockToastRef.current.showToast.mock.calls[0][0];
+        expect(toastCall.linkButtonOptions).toBeUndefined();
+      });
+    });
+
     it('calls getAmount with transaction metadata when showing pending toast', async () => {
       // Arrange
       renderHook(() => usePredictToasts(defaultConfig), { wrapper });

--- a/app/components/UI/Predict/hooks/usePredictToasts.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictToasts.test.ts
@@ -277,7 +277,7 @@ describe('usePredictToasts', () => {
       // Assert
       await waitFor(() => {
         const toastCall = mockToastRef.current.showToast.mock.calls[0][0];
-        const linkButtonOnPress = toastCall.linkButtonOptions?.onPress;
+        const linkButtonOnPress = toastCall.closeButtonOptions?.onPress;
         expect(linkButtonOnPress).toBeDefined();
 
         // Call the link button onPress
@@ -313,7 +313,7 @@ describe('usePredictToasts', () => {
       await waitFor(() => {
         expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
           expect.objectContaining({
-            linkButtonOptions: expect.objectContaining({
+            closeButtonOptions: expect.objectContaining({
               label: expect.any(String),
               onPress: expect.any(Function),
             }),

--- a/app/components/UI/Predict/hooks/usePredictToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToasts.tsx
@@ -42,7 +42,7 @@ interface ToastConfig {
 
 interface PendingToastConfig extends ToastConfig {
   getAmount?: (transactionMeta: TransactionMeta) => string;
-  onPress?: () => void;
+  onPress?: (transactionMeta?: TransactionMeta) => void;
 }
 
 interface ConfirmedToastConfig extends ToastConfig {
@@ -77,7 +77,15 @@ export const usePredictToasts = ({
   const { toastRef } = useContext(ToastContext);
 
   const showPendingToast = useCallback(
-    ({ amount, config }: { amount?: string; config: PendingToastConfig }) => {
+    ({
+      amount,
+      config,
+      transactionMeta,
+    }: {
+      amount?: string;
+      config: PendingToastConfig;
+      transactionMeta?: TransactionMeta;
+    }) => {
       const title = amount
         ? config.title.replace('{amount}', amount)
         : config.title;
@@ -108,7 +116,7 @@ export const usePredictToasts = ({
           ? {
               closeButtonOptions: {
                 label: strings('predict.deposit.track'),
-                onPress: config.onPress,
+                onPress: () => config.onPress?.(transactionMeta),
                 variant: ButtonVariants.Link,
               },
             }
@@ -218,7 +226,11 @@ export const usePredictToasts = ({
         pendingToastConfig
       ) {
         const amount = pendingToastConfig.getAmount?.(transactionMeta);
-        showPendingToast({ amount, config: pendingToastConfig });
+        showPendingToast({
+          amount,
+          config: pendingToastConfig,
+          transactionMeta,
+        });
       } else if (transactionMeta.status === TransactionStatus.confirmed) {
         clearTransaction?.();
         const amount = confirmedToastConfig.getAmount(transactionMeta);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Update pending toast onPress callback to accept transactionMeta parameter
- Add navigation to TRANSACTION_DETAILS route with transaction ID
- Apply 100ms timeout to ensure smooth navigation transition
- Enable users to view specific transaction details directly from deposit toast

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-332

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make pending deposit toast link navigate to Transactions, then (after 100ms) to the specific Transaction Details when an ID is available; update toast API to pass transaction metadata and add tests.
> 
> - **Hooks**
>   - `usePredictToasts`
>     - Change `pendingToastConfig.onPress` signature to accept `transactionMeta`.
>     - `showPendingToast` now passes `transactionMeta` to `onPress` and supports link button when provided.
>   - `usePredictDepositToasts`
>     - Pending toast `onPress` now navigates to `Routes.TRANSACTIONS_VIEW`, then (100ms delay) to `Routes.TRANSACTION_DETAILS` with `transactionId` if present.
> - **Tests**
>   - `usePredictDepositToasts.test.ts`
>     - Add navigation tests for pending toast link, including transaction ID handling and 100ms timeout.
>   - `usePredictToasts.test.ts`
>     - Verify `transactionMeta` is passed to `onPress`, presence/absence of link button options, and related behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f1f153058bbea7860f6b8d7eea77380621756d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->