### PR TITLE
fix: cp-7.60.0 remove max button from metamask pay deposits

### DIFF
--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.test.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.test.tsx
@@ -88,4 +88,20 @@ describe('DepositKeyboard', () => {
 
     expect(getByText('Test Button')).toBeDefined();
   });
+
+  it('renders max button if hasMax', () => {
+    const { getByText } = render({
+      hasMax: true,
+    });
+
+    expect(getByText('Max')).toBeDefined();
+  });
+
+  it('renders 90% button if hasMax is false', () => {
+    const { getByText } = render({
+      hasMax: false,
+    });
+
+    expect(getByText('90%')).toBeDefined();
+  });
 });

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import KeypadComponent, { KeypadChangeData } from '../../../../Base/Keypad';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './deposit-keyboard.styles';
@@ -28,15 +28,21 @@ const PERCENTAGE_BUTTONS = [
     value: 50,
   },
   {
-    label: 'Max',
-    value: 100,
+    label: '90%',
+    value: 90,
   },
 ];
+
+const MAX_BUTTON = {
+  label: 'Max',
+  value: 100,
+};
 
 export interface DepositKeyboardProps {
   alertMessage?: string;
   doneLabel?: string;
   hasInput?: boolean;
+  hasMax?: boolean;
   onChange: (value: string) => void;
   onPercentagePress: (percentage: number) => void;
   onDonePress: () => void;
@@ -48,6 +54,7 @@ export const DepositKeyboard = memo(
     alertMessage,
     doneLabel,
     hasInput,
+    hasMax,
     onChange,
     onDonePress,
     onPercentagePress,
@@ -71,6 +78,17 @@ export const DepositKeyboard = memo(
       [onPercentagePress],
     );
 
+    const buttons = useMemo(() => {
+      const newButtons = [...PERCENTAGE_BUTTONS];
+
+      if (hasMax) {
+        newButtons.pop();
+        newButtons.push(MAX_BUTTON);
+      }
+
+      return newButtons;
+    }, [hasMax]);
+
     return (
       <View>
         <Box
@@ -91,7 +109,7 @@ export const DepositKeyboard = memo(
           )}
           {!alertMessage &&
             !hasInput &&
-            PERCENTAGE_BUTTONS.map(({ label, value: buttonValue }) => (
+            buttons.map(({ label, value: buttonValue }) => (
               <Button
                 key={buttonValue}
                 label={label}

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -54,10 +54,11 @@ export interface CustomAmountInfoProps {
   children?: ReactNode;
   currency?: string;
   disablePay?: boolean;
+  hasMax?: boolean;
 }
 
 export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
-  ({ children, currency, disablePay }) => {
+  ({ children, currency, disablePay, hasMax }) => {
     useClearConfirmationOnBackSwipe();
     useAutomaticTransactionPayToken({ disable: disablePay });
     useTransactionPayMetrics();
@@ -131,6 +132,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               onDonePress={handleDone}
               onPercentagePress={updatePendingAmountPercentage}
               hasInput={hasInput}
+              hasMax={hasMax}
             />
           )}
           {!hasTokens && <BuySection />}

--- a/app/components/Views/confirmations/components/info/predict-withdraw-info/predict-withdraw-info.tsx
+++ b/app/components/Views/confirmations/components/info/predict-withdraw-info/predict-withdraw-info.tsx
@@ -19,7 +19,7 @@ export function PredictWithdrawInfo() {
   });
 
   return (
-    <CustomAmountInfo disablePay currency={PREDICT_CURRENCY}>
+    <CustomAmountInfo disablePay hasMax currency={PREDICT_CURRENCY}>
       <PredictWithdrawBalance />
     </CustomAmountInfo>
   );

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -156,71 +156,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
           isBlocking: true,
           title: strings('alert_system.insufficient_pay_token_balance.message'),
           message: strings(
-            'alert_system.insufficient_pay_token_balance_fees.message',
-            { amount: '$1.21' },
-          ),
-          severity: Severity.Danger,
-        },
-      ]);
-    });
-
-    it('returns alert if pay token balance shortfall is equal to total amount', () => {
-      useTransactionPayTokenMock.mockReturnValue({
-        payToken: {
-          ...PAY_TOKEN_MOCK,
-          balanceRaw: '999',
-        },
-        setPayToken: jest.fn(),
-      });
-
-      useTransactionPayRequiredTokensMock.mockReturnValue([
-        {
-          ...REQUIRED_TOKEN_MOCK,
-          amountUsd: '0.02',
-        },
-      ]);
-
-      const { result } = runHook();
-
-      expect(result.current).toStrictEqual([
-        {
-          key: AlertKeys.InsufficientPayTokenFees,
-          field: RowAlertKey.Amount,
-          isBlocking: true,
-          title: strings('alert_system.insufficient_pay_token_balance.message'),
-          message: strings(
             'alert_system.insufficient_pay_token_balance_fees_no_target.message',
-          ),
-          severity: Severity.Danger,
-        },
-      ]);
-    });
-
-    it('returns alert if pay token balance shortfall is negative due to bad exchange rates', () => {
-      useTransactionPayTokenMock.mockReturnValue({
-        payToken: {
-          ...PAY_TOKEN_MOCK,
-          balanceRaw: '999',
-        },
-        setPayToken: jest.fn(),
-      });
-
-      useTransactionPayTotalsMock.mockReturnValue({
-        ...TOTALS_MOCK,
-        sourceAmount: { ...TOTALS_MOCK.sourceAmount, usd: '1.19' },
-      });
-
-      const { result } = runHook();
-
-      expect(result.current).toStrictEqual([
-        {
-          key: AlertKeys.InsufficientPayTokenFees,
-          field: RowAlertKey.Amount,
-          isBlocking: true,
-          title: strings('alert_system.insufficient_pay_token_balance.message'),
-          message: strings(
-            'alert_system.insufficient_pay_token_balance_fees.message',
-            { amount: '$1.23' },
           ),
           severity: Severity.Danger,
         },
@@ -246,8 +182,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
           isBlocking: true,
           title: strings('alert_system.insufficient_pay_token_balance.message'),
           message: strings(
-            'alert_system.insufficient_pay_token_balance_fees.message',
-            { amount: '$1.11' },
+            'alert_system.insufficient_pay_token_balance_fees_no_target.message',
           ),
           severity: Severity.Danger,
         },
@@ -280,7 +215,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
           isBlocking: true,
           title: strings('alert_system.insufficient_pay_token_balance.message'),
           message: strings(
-            'alert_system.insufficient_pay_token_balance_fees.message',
+            'alert_system.insufficient_pay_token_balance_fees_no_target.message',
             { amount: '$1.11' },
           ),
           severity: Severity.Danger,

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -13,7 +13,6 @@ import {
 import { useSelector } from 'react-redux';
 import { selectTickerByChainId } from '../../../../../selectors/networkController';
 import { RootState } from '../../../../../reducers';
-import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
 import { getNativeTokenAddress } from '../../utils/asset';
 
@@ -25,7 +24,6 @@ export function useInsufficientPayTokenBalanceAlert({
   const { payToken } = useTransactionPayToken();
   const requiredTokens = useTransactionPayRequiredTokens();
   const totals = useTransactionPayTotals();
-  const formatFiat = useFiatFormatter({ currency: 'usd' });
   const isLoading = useIsTransactionPayLoading();
   const isSourceGasFeeToken = totals?.fees.isSourceGasFeeToken ?? false;
   const isPendingAlert = Boolean(pendingAmountUsd !== undefined);
@@ -71,32 +69,6 @@ export function useInsufficientPayTokenBalanceAlert({
         : '0',
     );
   }, [isLoading, isPayTokenNative, isSourceGasFeeToken, totals]);
-
-  const totalSourceAmountUsd = useMemo(
-    () =>
-      new BigNumber(totals?.sourceAmount.usd ?? '0').plus(
-        isPayTokenNative || isSourceGasFeeToken
-          ? new BigNumber(totals?.fees.sourceNetwork.max.usd ?? '0')
-          : '0',
-      ),
-    [isPayTokenNative, isSourceGasFeeToken, totals],
-  );
-
-  const targetAmountUsd = useMemo(() => {
-    const shortfall = totalSourceAmountUsd.minus(balanceUsd ?? '0');
-    const targetUsdValue = totalAmountUsd.minus(shortfall);
-    const targetUsd = formatFiat(targetUsdValue);
-
-    if (targetUsdValue.isLessThanOrEqualTo(0)) {
-      return undefined;
-    }
-
-    if (targetUsdValue.isGreaterThan(totalAmountUsd)) {
-      return formatFiat(totalAmountUsd);
-    }
-
-    return targetUsd;
-  }, [balanceUsd, formatFiat, totalAmountUsd, totalSourceAmountUsd]);
 
   const totalSourceNetworkFeeRaw = useMemo(
     () => new BigNumber(totals?.fees.sourceNetwork.max.raw ?? '0'),
@@ -158,14 +130,9 @@ export function useInsufficientPayTokenBalanceAlert({
           ...baseAlert,
           key: AlertKeys.InsufficientPayTokenFees,
           title: strings('alert_system.insufficient_pay_token_balance.message'),
-          message: targetAmountUsd
-            ? strings(
-                'alert_system.insufficient_pay_token_balance_fees.message',
-                { amount: targetAmountUsd },
-              )
-            : strings(
-                'alert_system.insufficient_pay_token_balance_fees_no_target.message',
-              ),
+          message: strings(
+            'alert_system.insufficient_pay_token_balance_fees_no_target.message',
+          ),
         },
       ];
     }
@@ -189,7 +156,6 @@ export function useInsufficientPayTokenBalanceAlert({
     isInsufficientForInput,
     isInsufficientForFees,
     isInsufficientForSourceNetwork,
-    targetAmountUsd,
     ticker,
   ]);
 }


### PR DESCRIPTION
## **Description**

Replace the `Max` button in the Predict and Perps deposit confirmations with a `90%` button.

Remove the target amount from the insufficient fees alert.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #23265 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="300" alt="90" src="https://github.com/user-attachments/assets/23ce05c6-cd03-4052-b5e5-eae1d9115106" />

<img width="300" alt="Alert" src="https://github.com/user-attachments/assets/87c0f5da-2550-4b4d-98e9-bccda557c195" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Default deposit quick-select to 90% with an opt-in Max via hasMax, and simplify insufficient fees alert to a no-target message.
> 
> - **UI**:
>   - **`DepositKeyboard`**: Default to a `90%` quick-select button instead of `Max`; add `hasMax` prop to switch to `Max` when needed; memoize percentage buttons; update tests to cover `hasMax` behavior.
>   - **`CustomAmountInfo` / `PredictWithdrawInfo`**: Thread `hasMax` through to `DepositKeyboard`; enable `Max` for Predict withdraw flow.
> - **Alerts**:
>   - **`useInsufficientPayTokenBalanceAlert`**: Remove target-amount calculation/formatting; always use `_fees_no_target` message for insufficient fees; clean up related logic and tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b24248b541bd6266931ecb3b6546f3660f014602. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->