### PR TITLE
chore: Updated empty states for Activity page to use TabEmptyState

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.styles.ts
@@ -106,11 +106,6 @@ export const styleSheet = (params: { theme: Theme }) => {
       alignItems: 'center' as const,
       paddingVertical: 48,
     },
-    emptyText: {
-      textAlign: 'center' as const,
-      marginTop: 16,
-      color: colors.text.muted,
-    },
     fillTag: {
       flexDirection: 'row' as const,
       alignItems: 'center' as const,

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
@@ -288,7 +288,11 @@ describe('PerpsTransactionsView', () => {
 
     await waitFor(() => {
       // Should show empty state when API fails
-      expect(component.getByText('No trades transactions yet')).toBeTruthy();
+      expect(
+        component.getByText(
+          'No trades transactions yet. Your trading history will appear here',
+        ),
+      ).toBeTruthy();
     });
   });
 
@@ -392,7 +396,11 @@ describe('PerpsTransactionsView', () => {
     });
 
     await waitFor(() => {
-      expect(component.getByText('No trades transactions yet')).toBeTruthy();
+      expect(
+        component.getByText(
+          'No trades transactions yet. Your trading history will appear here',
+        ),
+      ).toBeTruthy();
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
@@ -265,9 +265,10 @@ describe('PerpsTransactionsView', () => {
     });
 
     await waitFor(() => {
-      expect(component.getByText('No trades transactions yet')).toBeTruthy();
       expect(
-        component.getByText('Your trading history will appear here'),
+        component.getByText(
+          'No trades transactions yet. Your trading history will appear here',
+        ),
       ).toBeTruthy();
     });
   });

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -38,6 +38,7 @@ import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
 import { TraceName } from '../../../../../util/trace';
 import ButtonFilter from '../../../../../component-library/components-temp/ButtonFilter';
 import { ButtonSize } from '@metamask/design-system-react-native';
+import { TabEmptyState } from '../../../../../component-library/components-temp/TabEmptyState';
 
 const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -331,14 +332,14 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
 
   const renderEmptyState = () => (
     <View style={styles.emptyContainer}>
-      <Text style={styles.emptyText}>
-        {strings('perps.transactions.empty_state.no_transactions', {
-          type: activeFilter.toLowerCase(),
-        })}
-      </Text>
-      <Text style={styles.emptyText}>
-        {strings('perps.transactions.empty_state.history_will_appear')}
-      </Text>
+      <TabEmptyState
+        description={`${strings(
+          'perps.transactions.empty_state.no_transactions',
+          {
+            type: activeFilter.toLowerCase(),
+          },
+        )}${strings('perps.transactions.empty_state.history_will_appear')}`}
+      />
     </View>
   );
 

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -333,13 +333,10 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
   const renderEmptyState = () => (
     <View style={styles.emptyContainer}>
       <TabEmptyState
-        description={`${strings(
-          'perps.transactions.empty_state.no_transactions',
-          {
-            type: activeFilter.toLowerCase(),
-          },
-        )}${strings('perps.transactions.empty_state.history_will_appear')}`}
-      />
+        description={strings('perps.transactions.empty_state.no_transactions', {
+          type: activeFilter.toLowerCase(),
+        })}
+      ></TabEmptyState>
     </View>
   );
 

--- a/app/components/UI/Predict/views/PredictTransactionsView/PredictTransactionsView.tsx
+++ b/app/components/UI/Predict/views/PredictTransactionsView/PredictTransactionsView.tsx
@@ -11,7 +11,7 @@ import Engine from '../../../../../core/Engine';
 import { PredictEventValues } from '../../constants/eventNames';
 import { TraceName } from '../../../../../util/trace';
 import { usePredictMeasurement } from '../../hooks/usePredictMeasurement';
-
+import { TabEmptyState } from '../../../../../component-library/components-temp/TabEmptyState';
 interface PredictTransactionsViewProps {
   transactions?: unknown[];
   tabLabel?: string;
@@ -254,13 +254,10 @@ const PredictTransactionsView: React.FC<PredictTransactionsViewProps> = ({
           <ActivityIndicator size="small" testID="activity-indicator" />
         </Box>
       ) : sections.length === 0 ? (
-        <Box twClassName="px-4">
-          <Text
-            variant={TextVariant.BodySm}
-            twClassName="text-alternative py-2"
-          >
-            {strings('predict.transactions.no_transactions')}
-          </Text>
+        <Box twClassName="items-center justify-center py-10">
+          <TabEmptyState
+            description={strings('predict.transactions.no_transactions')}
+          />
         </Box>
       ) : (
         // TODO: Improve loading state, pagination, consider FlashList for better performance, pull down to refresh, etc.

--- a/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.styles.ts
+++ b/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.styles.ts
@@ -3,9 +3,6 @@ import { Colors } from '../../../../../../util/theme/models';
 
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
-    emptyMessage: {
-      textAlign: 'center',
-    },
     row: {
       borderBottomWidth: StyleSheet.hairlineWidth,
       borderColor: colors.border.muted,

--- a/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.tsx
@@ -8,13 +8,8 @@ import { OrderOrderTypeEnum } from '@consensys/on-ramp-sdk/dist/API';
 import { createOrderDetailsNavDetails } from '../OrderDetails/OrderDetails';
 import { useRampNavigation } from '../../../hooks/useRampNavigation';
 import OrderListItem from '../../components/OrderListItem';
-import Row from '../../components/Row';
 import createStyles from './OrdersList.styles';
-
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../../component-library/components/Texts/Text';
+import { TabEmptyState } from '../../../../../../component-library/components-temp/TabEmptyState';
 
 import {
   FIAT_ORDER_PROVIDERS,
@@ -141,23 +136,17 @@ function OrdersList() {
       renderItem={renderItem}
       keyExtractor={(item) => item.id}
       ListEmptyComponent={
-        <Row>
-          <Text
-            variant={TextVariant.HeadingMD}
-            color={TextColor.Muted}
-            style={styles.emptyMessage}
-          >
-            {currentFilter === 'ALL'
-              ? strings('fiat_on_ramp_aggregator.empty_orders_list')
-              : null}
-            {currentFilter === 'PURCHASE'
-              ? strings('fiat_on_ramp_aggregator.empty_buy_orders_list')
-              : null}
-            {currentFilter === 'SELL'
-              ? strings('fiat_on_ramp_aggregator.empty_sell_orders_list')
-              : null}
-          </Text>
-        </Row>
+        <Box twClassName="w-full items-center py-10">
+          <TabEmptyState
+            description={
+              currentFilter === 'ALL'
+                ? strings('fiat_on_ramp_aggregator.empty_orders_list')
+                : currentFilter === 'PURCHASE'
+                  ? strings('fiat_on_ramp_aggregator.empty_buy_orders_list')
+                  : strings('fiat_on_ramp_aggregator.empty_sell_orders_list')
+            }
+          />
+        </Box>
       }
     />
   );

--- a/app/components/UI/Ramp/Aggregator/Views/OrdersList/__snapshots__/OrdersList.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/OrdersList/__snapshots__/OrdersList.test.tsx.snap
@@ -3,19 +3,13 @@
 exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
 <RCTScrollView
   ListEmptyComponent={
-    <Row>
-      <Text
-        color="Muted"
-        style={
-          {
-            "textAlign": "center",
-          }
-        }
-        variant="sHeadingMD"
-      >
-        You don't have any buy orders
-      </Text>
-    </Row>
+    <Box
+      twClassName="w-full items-center py-10"
+    >
+      <TabEmptyState
+        description="You don't have any buy orders"
+      />
+    </Box>
   }
   ListHeaderComponent={
     <Box
@@ -2085,19 +2079,13 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
 exports[`OrdersList renders correctly 1`] = `
 <RCTScrollView
   ListEmptyComponent={
-    <Row>
-      <Text
-        color="Muted"
-        style={
-          {
-            "textAlign": "center",
-          }
-        }
-        variant="sHeadingMD"
-      >
-        No bank or card transfers yet.
-      </Text>
-    </Row>
+    <Box
+      twClassName="w-full items-center py-10"
+    >
+      <TabEmptyState
+        description="No bank or card transfers yet."
+      />
+    </Box>
   }
   ListHeaderComponent={
     <Box
@@ -4456,19 +4444,13 @@ exports[`OrdersList renders correctly 1`] = `
 exports[`OrdersList renders empty buy message 1`] = `
 <RCTScrollView
   ListEmptyComponent={
-    <Row>
-      <Text
-        color="Muted"
-        style={
-          {
-            "textAlign": "center",
-          }
-        }
-        variant="sHeadingMD"
-      >
-        You don't have any buy orders
-      </Text>
-    </Row>
+    <Box
+      twClassName="w-full items-center py-10"
+    >
+      <TabEmptyState
+        description="You don't have any buy orders"
+      />
+    </Box>
   }
   ListHeaderComponent={
     <Box
@@ -5089,29 +5071,52 @@ exports[`OrdersList renders empty buy message 1`] = `
       style={
         [
           {
-            "marginVertical": 8,
+            "alignItems": "center",
+            "display": "flex",
+            "paddingBottom": 40,
+            "paddingTop": 40,
+            "width": "100%",
           },
-          undefined,
-          undefined,
           undefined,
         ]
       }
     >
-      <Text
-        accessibilityRole="text"
+      <View
         style={
-          {
-            "color": "#b7bbc8",
-            "fontFamily": "Geist Bold",
-            "fontSize": 18,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-            "textAlign": "center",
-          }
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "display": "flex",
+              "flexDirection": "column",
+              "gap": 12,
+              "justifyContent": "center",
+              "maxWidth": 256,
+            },
+            undefined,
+          ]
         }
       >
-        You don't have any buy orders
-      </Text>
+        <Text
+          accessibilityRole="text"
+          style={
+            [
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist Regular",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          You don't have any buy orders
+        </Text>
+      </View>
     </View>
   </View>
 </RCTScrollView>
@@ -5120,19 +5125,13 @@ exports[`OrdersList renders empty buy message 1`] = `
 exports[`OrdersList renders empty sell message 1`] = `
 <RCTScrollView
   ListEmptyComponent={
-    <Row>
-      <Text
-        color="Muted"
-        style={
-          {
-            "textAlign": "center",
-          }
-        }
-        variant="sHeadingMD"
-      >
-        You don't have any sell orders
-      </Text>
-    </Row>
+    <Box
+      twClassName="w-full items-center py-10"
+    >
+      <TabEmptyState
+        description="You don't have any sell orders"
+      />
+    </Box>
   }
   ListHeaderComponent={
     <Box
@@ -5753,29 +5752,52 @@ exports[`OrdersList renders empty sell message 1`] = `
       style={
         [
           {
-            "marginVertical": 8,
+            "alignItems": "center",
+            "display": "flex",
+            "paddingBottom": 40,
+            "paddingTop": 40,
+            "width": "100%",
           },
-          undefined,
-          undefined,
           undefined,
         ]
       }
     >
-      <Text
-        accessibilityRole="text"
+      <View
         style={
-          {
-            "color": "#b7bbc8",
-            "fontFamily": "Geist Bold",
-            "fontSize": 18,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-            "textAlign": "center",
-          }
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "display": "flex",
+              "flexDirection": "column",
+              "gap": 12,
+              "justifyContent": "center",
+              "maxWidth": 256,
+            },
+            undefined,
+          ]
         }
       >
-        You don't have any sell orders
-      </Text>
+        <Text
+          accessibilityRole="text"
+          style={
+            [
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist Regular",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          You don't have any sell orders
+        </Text>
+      </View>
     </View>
   </View>
 </RCTScrollView>
@@ -5784,19 +5806,13 @@ exports[`OrdersList renders empty sell message 1`] = `
 exports[`OrdersList renders sell only correctly when pressing sell filter 1`] = `
 <RCTScrollView
   ListEmptyComponent={
-    <Row>
-      <Text
-        color="Muted"
-        style={
-          {
-            "textAlign": "center",
-          }
-        }
-        variant="sHeadingMD"
-      >
-        You don't have any sell orders
-      </Text>
-    </Row>
+    <Box
+      twClassName="w-full items-center py-10"
+    >
+      <TabEmptyState
+        description="You don't have any sell orders"
+      />
+    </Box>
   }
   ListHeaderComponent={
     <Box
@@ -6711,19 +6727,13 @@ exports[`OrdersList renders sell only correctly when pressing sell filter 1`] = 
 exports[`OrdersList resets filter to all after other filter was set 1`] = `
 <RCTScrollView
   ListEmptyComponent={
-    <Row>
-      <Text
-        color="Muted"
-        style={
-          {
-            "textAlign": "center",
-          }
-        }
-        variant="sHeadingMD"
-      >
-        You don't have any sell orders
-      </Text>
-    </Row>
+    <Box
+      twClassName="w-full items-center py-10"
+    >
+      <TabEmptyState
+        description="You don't have any sell orders"
+      />
+    </Box>
   }
   ListHeaderComponent={
     <Box
@@ -7638,19 +7648,13 @@ exports[`OrdersList resets filter to all after other filter was set 1`] = `
 exports[`OrdersList resets filter to all after other filter was set 2`] = `
 <RCTScrollView
   ListEmptyComponent={
-    <Row>
-      <Text
-        color="Muted"
-        style={
-          {
-            "textAlign": "center",
-          }
-        }
-        variant="sHeadingMD"
-      >
-        No bank or card transfers yet.
-      </Text>
-    </Row>
+    <Box
+      twClassName="w-full items-center py-10"
+    >
+      <TabEmptyState
+        description="No bank or card transfers yet."
+      />
+    </Box>
   }
   ListHeaderComponent={
     <Box

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -23,11 +23,7 @@ import Engine from '../../../core/Engine';
 import { getDeviceId } from '../../../core/Ledger/Ledger';
 import { isNonEvmChainId } from '../../../core/Multichain/utils';
 import NotificationManager from '../../../core/NotificationManager';
-import {
-  CancelTransactionError,
-  SpeedupTransactionError,
-  TransactionError,
-} from '../../../core/Transaction/TransactionError';
+import { TransactionError } from '../../../core/Transaction/TransactionError';
 import { collectibleContractsSelector } from '../../../reducers/collectibles';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
@@ -72,6 +68,7 @@ import RetryModal from './RetryModal';
 import TransactionsFooter from './TransactionsFooter';
 import { filterDuplicateOutgoingTransactions } from './utils';
 import { selectMultichainAccountsState2Enabled } from '../../../selectors/featureFlagController/multichainAccounts';
+import { TabEmptyState } from '../../../component-library/components-temp/TabEmptyState';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -393,7 +390,7 @@ class Transactions extends PureComponent {
     }
     return (
       <View style={styles.emptyContainer}>
-        <Text style={styles.text}>{strings('wallet.no_transactions')}</Text>
+        <TabEmptyState description={strings('wallet.no_transactions')} />
       </View>
     );
   };
@@ -781,39 +778,7 @@ class Transactions extends PureComponent {
     return (
       <View style={styles.wrapper}>
         <PriceChartContext.Consumer>
-          {({ isChartBeingTouched }) => (
-            <FlatList
-              testID={ActivitiesViewSelectorsIDs.CONTAINER}
-              ref={this.flatList}
-              getItemLayout={this.getItemLayout}
-              data={filteredTransactions}
-              extraData={this.state}
-              keyExtractor={this.keyExtractor}
-              refreshControl={
-                <RefreshControl
-                  colors={[colors.primary.default]}
-                  tintColor={colors.icon.default}
-                  refreshing={this.state.refreshing}
-                  onRefresh={this.onRefresh}
-                />
-              }
-              renderItem={this.renderItem}
-              initialNumToRender={10}
-              maxToRenderPerBatch={2}
-              onEndReachedThreshold={0.5}
-              ListHeaderComponent={header}
-              ListFooterComponent={
-                filteredTransactions.length > 0
-                  ? this.footer
-                  : this.renderEmpty()
-              }
-              contentContainerStyle={styles.listContentContainer}
-              style={baseStyles.flexGrow}
-              scrollIndicatorInsets={{ right: 1 }}
-              onScroll={this.onScroll}
-              scrollEnabled={!isChartBeingTouched}
-            />
-          )}
+          {({ isChartBeingTouched }) => this.renderEmpty()}
         </PriceChartContext.Consumer>
 
         {!isSigningQRObject && this.state.cancelIsOpen && (

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -778,7 +778,39 @@ class Transactions extends PureComponent {
     return (
       <View style={styles.wrapper}>
         <PriceChartContext.Consumer>
-          {({ isChartBeingTouched }) => this.renderEmpty()}
+          {({ isChartBeingTouched }) => (
+            <FlatList
+              testID={ActivitiesViewSelectorsIDs.CONTAINER}
+              ref={this.flatList}
+              getItemLayout={this.getItemLayout}
+              data={filteredTransactions}
+              extraData={this.state}
+              keyExtractor={this.keyExtractor}
+              refreshControl={
+                <RefreshControl
+                  colors={[colors.primary.default]}
+                  tintColor={colors.icon.default}
+                  refreshing={this.state.refreshing}
+                  onRefresh={this.onRefresh}
+                />
+              }
+              renderItem={this.renderItem}
+              initialNumToRender={10}
+              maxToRenderPerBatch={2}
+              onEndReachedThreshold={0.5}
+              ListHeaderComponent={header}
+              ListFooterComponent={
+                filteredTransactions.length > 0
+                  ? this.footer
+                  : this.renderEmpty()
+              }
+              contentContainerStyle={styles.listContentContainer}
+              style={baseStyles.flexGrow}
+              scrollIndicatorInsets={{ right: 1 }}
+              onScroll={this.onScroll}
+              scrollEnabled={!isChartBeingTouched}
+            />
+          )}
         </PriceChartContext.Consumer>
 
         {!isSigningQRObject && this.state.cancelIsOpen && (

--- a/app/components/Views/ActivityView/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ActivityView/__snapshots__/index.test.tsx.snap
@@ -495,19 +495,13 @@ exports[`ActivityView should render correctly 1`] = `
                         </View>
                         <RCTScrollView
                           ListEmptyComponent={
-                            <Row>
-                              <Text
-                                color="Muted"
-                                style={
-                                  {
-                                    "textAlign": "center",
-                                  }
-                                }
-                                variant="sHeadingMD"
-                              >
-                                No bank or card transfers yet.
-                              </Text>
-                            </Row>
+                            <Box
+                              twClassName="w-full items-center py-10"
+                            >
+                              <TabEmptyState
+                                description="No bank or card transfers yet."
+                              />
+                            </Box>
                           }
                           ListHeaderComponent={
                             <Box
@@ -1128,29 +1122,52 @@ exports[`ActivityView should render correctly 1`] = `
                               style={
                                 [
                                   {
-                                    "marginVertical": 8,
+                                    "alignItems": "center",
+                                    "display": "flex",
+                                    "paddingBottom": 40,
+                                    "paddingTop": 40,
+                                    "width": "100%",
                                   },
-                                  undefined,
-                                  undefined,
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
-                                accessibilityRole="text"
+                              <View
                                 style={
-                                  {
-                                    "color": "#b7bbc8",
-                                    "fontFamily": "Geist Bold",
-                                    "fontSize": 18,
-                                    "letterSpacing": 0,
-                                    "lineHeight": 24,
-                                    "textAlign": "center",
-                                  }
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#ffffff",
+                                      "display": "flex",
+                                      "flexDirection": "column",
+                                      "gap": 12,
+                                      "justifyContent": "center",
+                                      "maxWidth": 256,
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                No bank or card transfers yet.
-                              </Text>
+                                <Text
+                                  accessibilityRole="text"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#686e7d",
+                                        "fontFamily": "Geist Regular",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  No bank or card transfers yet.
+                                </Text>
+                              </View>
                             </View>
                           </View>
                         </RCTScrollView>

--- a/app/components/Views/Asset/__snapshots__/index.test.js.snap
+++ b/app/components/Views/Asset/__snapshots__/index.test.js.snap
@@ -1948,28 +1948,42 @@ exports[`Asset Multichain Functionality should exclude mixed token/SOL transacti
                                   }
                                 }
                               >
-                                <Text
-                                  accessibilityRole="text"
+                                <View
                                   style={
-                                    {
-                                      "0": {
-                                        "color": "#b7bbc8",
-                                        "fontFamily": "Geist Regular",
-                                        "fontSize": 20,
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#ffffff",
+                                        "display": "flex",
+                                        "flexDirection": "column",
+                                        "gap": 12,
+                                        "justifyContent": "center",
+                                        "maxWidth": 256,
                                       },
-                                      "1": {
-                                        "color": "#121314",
-                                      },
-                                      "color": "#121314",
-                                      "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                      undefined,
+                                    ]
                                   }
                                 >
-                                  You have no transactions!
-                                </Text>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#686e7d",
+                                          "fontFamily": "Geist Regular",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    You have no transactions!
+                                  </Text>
+                                </View>
                               </View>
                               <View>
                                 <View>
@@ -3722,28 +3736,42 @@ exports[`Asset Multichain Functionality should exclude transactions with empty a
                                   }
                                 }
                               >
-                                <Text
-                                  accessibilityRole="text"
+                                <View
                                   style={
-                                    {
-                                      "0": {
-                                        "color": "#b7bbc8",
-                                        "fontFamily": "Geist Regular",
-                                        "fontSize": 20,
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#ffffff",
+                                        "display": "flex",
+                                        "flexDirection": "column",
+                                        "gap": 12,
+                                        "justifyContent": "center",
+                                        "maxWidth": 256,
                                       },
-                                      "1": {
-                                        "color": "#121314",
-                                      },
-                                      "color": "#121314",
-                                      "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                      undefined,
+                                    ]
                                   }
                                 >
-                                  You have no transactions!
-                                </Text>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#686e7d",
+                                          "fontFamily": "Geist Regular",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    You have no transactions!
+                                  </Text>
+                                </View>
                               </View>
                               <View>
                                 <View>
@@ -5537,28 +5565,42 @@ exports[`Asset Multichain Functionality should filter SPL token transactions cor
                                   }
                                 }
                               >
-                                <Text
-                                  accessibilityRole="text"
+                                <View
                                   style={
-                                    {
-                                      "0": {
-                                        "color": "#b7bbc8",
-                                        "fontFamily": "Geist Regular",
-                                        "fontSize": 20,
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#ffffff",
+                                        "display": "flex",
+                                        "flexDirection": "column",
+                                        "gap": 12,
+                                        "justifyContent": "center",
+                                        "maxWidth": 256,
                                       },
-                                      "1": {
-                                        "color": "#121314",
-                                      },
-                                      "color": "#121314",
-                                      "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                      undefined,
+                                    ]
                                   }
                                 >
-                                  You have no transactions!
-                                </Text>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#686e7d",
+                                          "fontFamily": "Geist Regular",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    You have no transactions!
+                                  </Text>
+                                </View>
                               </View>
                               <View>
                                 <View>
@@ -7311,28 +7353,42 @@ exports[`Asset Multichain Functionality should filter native SOL transactions co
                                   }
                                 }
                               >
-                                <Text
-                                  accessibilityRole="text"
+                                <View
                                   style={
-                                    {
-                                      "0": {
-                                        "color": "#b7bbc8",
-                                        "fontFamily": "Geist Regular",
-                                        "fontSize": 20,
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#ffffff",
+                                        "display": "flex",
+                                        "flexDirection": "column",
+                                        "gap": 12,
+                                        "justifyContent": "center",
+                                        "maxWidth": 256,
                                       },
-                                      "1": {
-                                        "color": "#121314",
-                                      },
-                                      "color": "#121314",
-                                      "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                      undefined,
+                                    ]
                                   }
                                 >
-                                  You have no transactions!
-                                </Text>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#686e7d",
+                                          "fontFamily": "Geist Regular",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    You have no transactions!
+                                  </Text>
+                                </View>
                               </View>
                               <View>
                                 <View>
@@ -9085,28 +9141,42 @@ exports[`Asset Multichain Functionality should handle state with no multichain t
                                   }
                                 }
                               >
-                                <Text
-                                  accessibilityRole="text"
+                                <View
                                   style={
-                                    {
-                                      "0": {
-                                        "color": "#b7bbc8",
-                                        "fontFamily": "Geist Regular",
-                                        "fontSize": 20,
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#ffffff",
+                                        "display": "flex",
+                                        "flexDirection": "column",
+                                        "gap": 12,
+                                        "justifyContent": "center",
+                                        "maxWidth": 256,
                                       },
-                                      "1": {
-                                        "color": "#121314",
-                                      },
-                                      "color": "#121314",
-                                      "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                      undefined,
+                                    ]
                                   }
                                 >
-                                  You have no transactions!
-                                </Text>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#686e7d",
+                                          "fontFamily": "Geist Regular",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    You have no transactions!
+                                  </Text>
+                                </View>
                               </View>
                               <View>
                                 <View>
@@ -10900,28 +10970,42 @@ exports[`Asset Multichain Functionality should handle unknown SPL token filterin
                                   }
                                 }
                               >
-                                <Text
-                                  accessibilityRole="text"
+                                <View
                                   style={
-                                    {
-                                      "0": {
-                                        "color": "#b7bbc8",
-                                        "fontFamily": "Geist Regular",
-                                        "fontSize": 20,
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#ffffff",
+                                        "display": "flex",
+                                        "flexDirection": "column",
+                                        "gap": 12,
+                                        "justifyContent": "center",
+                                        "maxWidth": 256,
                                       },
-                                      "1": {
-                                        "color": "#121314",
-                                      },
-                                      "color": "#121314",
-                                      "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                      undefined,
+                                    ]
                                   }
                                 >
-                                  You have no transactions!
-                                </Text>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#686e7d",
+                                          "fontFamily": "Geist Regular",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    You have no transactions!
+                                  </Text>
+                                </View>
                               </View>
                               <View>
                                 <View>
@@ -13204,28 +13288,42 @@ exports[`Asset Multichain Functionality should render non-EVM assets with Multic
                                   }
                                 }
                               >
-                                <Text
-                                  accessibilityRole="text"
+                                <View
                                   style={
-                                    {
-                                      "0": {
-                                        "color": "#b7bbc8",
-                                        "fontFamily": "Geist Regular",
-                                        "fontSize": 20,
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#ffffff",
+                                        "display": "flex",
+                                        "flexDirection": "column",
+                                        "gap": 12,
+                                        "justifyContent": "center",
+                                        "maxWidth": 256,
                                       },
-                                      "1": {
-                                        "color": "#121314",
-                                      },
-                                      "color": "#121314",
-                                      "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                      undefined,
+                                    ]
                                   }
                                 >
-                                  You have no transactions!
-                                </Text>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#686e7d",
+                                          "fontFamily": "Geist Regular",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    You have no transactions!
+                                  </Text>
+                                </View>
                               </View>
                               <View>
                                 <View>
@@ -14978,28 +15076,42 @@ exports[`Asset Multichain Functionality should sort filtered transactions by tim
                                   }
                                 }
                               >
-                                <Text
-                                  accessibilityRole="text"
+                                <View
                                   style={
-                                    {
-                                      "0": {
-                                        "color": "#b7bbc8",
-                                        "fontFamily": "Geist Regular",
-                                        "fontSize": 20,
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#ffffff",
+                                        "display": "flex",
+                                        "flexDirection": "column",
+                                        "gap": 12,
+                                        "justifyContent": "center",
+                                        "maxWidth": 256,
                                       },
-                                      "1": {
-                                        "color": "#121314",
-                                      },
-                                      "color": "#121314",
-                                      "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                      undefined,
+                                    ]
                                   }
                                 >
-                                  You have no transactions!
-                                </Text>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#686e7d",
+                                          "fontFamily": "Geist Regular",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    You have no transactions!
+                                  </Text>
+                                </View>
                               </View>
                               <View>
                                 <View>

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -11,7 +11,6 @@ import { FlashList } from '@shopify/flash-list';
 import { CaipChainId, Transaction } from '@metamask/keyring-api';
 import { useTheme } from '../../../util/theme';
 import { strings } from '../../../../locales/i18n';
-import Text from '../../../component-library/components/Texts/Text';
 import { baseStyles } from '../../../styles/common';
 import { getAddressUrl } from '../../../core/Multichain/utils';
 import { selectNonEvmTransactions } from '../../../selectors/multichain/multichain';
@@ -27,7 +26,7 @@ import PriceChartContext, {
 import MultichainBridgeTransactionListItem from '../../../components/UI/MultichainBridgeTransactionListItem';
 import { KnownCaipNamespace, parseCaipChainId } from '@metamask/utils';
 import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
-
+import { TabEmptyState } from '../../../component-library/components-temp/TabEmptyState';
 interface MultichainTransactionsViewProps {
   /**
    * Override transactions instead of using selector
@@ -116,9 +115,9 @@ const MultichainTransactionsView = ({
 
   const renderEmptyList = () => (
     <View style={style.emptyContainer}>
-      <Text style={[style.emptyText, { color: colors.text.default }]}>
-        {emptyMessage ?? strings('wallet.no_transactions')}
-      </Text>
+      <TabEmptyState
+        description={emptyMessage ?? strings('wallet.no_transactions')}
+      />
     </View>
   );
 

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -11,7 +11,6 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view
 import Modal from 'react-native-modal';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
-import Text from '../../../component-library/components/Texts/Text';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import { selectCurrentCurrency } from '../../../selectors/currencyRateController';
@@ -63,6 +62,7 @@ import styleSheet from './UnifiedTransactionsView.styles';
 import { useUnifiedTxActions } from './useUnifiedTxActions';
 import useBlockExplorer from '../../hooks/useBlockExplorer';
 import { selectBridgeHistoryForAccount } from '../../../selectors/bridgeStatusController';
+import { TabEmptyState } from '../../../component-library/components-temp/TabEmptyState';
 
 type SmartTransactionWithId = SmartTransaction & { id: string };
 type EvmTransaction = TransactionMeta | SmartTransactionWithId;
@@ -577,9 +577,7 @@ const UnifiedTransactionsView = ({
 
   const renderEmptyList = () => (
     <View style={styles.emptyList}>
-      <Text style={styles.emptyListText}>
-        {strings('wallet.no_transactions')}
-      </Text>
+      <TabEmptyState description={strings('wallet.no_transactions')} />
     </View>
   );
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1716,8 +1716,7 @@
       },
       "view_on_explorer": "View on block explorer",
       "empty_state": {
-        "no_transactions": "No {{type}} transactions yet",
-        "history_will_appear": "Your trading history will appear here"
+        "no_transactions": "No {{type}} transactions yet. Your trading history will appear here"
       }
     },
     "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Powered by {{source}}. Price chart powered by",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updates the empty states for the Activity page to use TabEmptyState 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/jira/software/c/projects/MDP/boards/2972?assignee=62afb43d33a882e2be47c36f&selectedIssue=MDP-414

## **Manual testing steps**

```gherkin
Feature: Activity Empty States

  Scenario: user navigates to Activity page
    Given user does not have any transactions/activities

    When user navigates to Activity page
    Then they see the empty state consistent with the empty state on the homepage
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/1b6eccce-7511-4fec-941a-b29922da7797

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces inline empty-state text with `TabEmptyState` across Perps, Predict, Ramp Orders, and Transactions views, updating i18n and tests/snapshots accordingly.
> 
> - **UI/Empty States**:
>   - Replace inline `Text` empty states with `TabEmptyState` in:
>     - `PerpsTransactionsView`, `PredictTransactionsView`, `OrdersList`, `Transactions`, `MultichainTransactionsView`, and `UnifiedTransactionsView`.
>   - Remove obsolete styles (e.g., `emptyText`, `emptyMessage`).
> - **Localization**:
>   - Update Perps empty-state copy to a single combined string in `en.json`.
> - **Tests**:
>   - Update unit tests and Jest snapshots to assert/use `TabEmptyState` content.
> - **Misc**:
>   - Minor import cleanup in `Transactions/index.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ec92b87c71c4aacafcf9c7a297f7e538f35b8a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->