### PR TITLE
fix: Reset recipient when existing asset selected but new one picked

### DIFF
--- a/app/components/Views/confirmations/components/nft-list/nft-list.tsx
+++ b/app/components/Views/confirmations/components/nft-list/nft-list.tsx
@@ -20,7 +20,11 @@ interface NftListProps {
 
 export function NftList({ nfts }: NftListProps) {
   const { gotToSendScreen } = useSendScreenNavigation();
-  const { updateAsset } = useSendContext();
+  const {
+    updateAsset,
+    asset: existingSelectedAsset,
+    updateTo,
+  } = useSendContext();
   const { captureAssetSelected } = useAssetSelectionMetrics();
   const [visibleNftCount, setVisibleNftCount] = useState(NFT_COUNT_PER_PAGE);
 
@@ -32,13 +36,26 @@ export function NftList({ nfts }: NftListProps) {
       );
       captureAssetSelected(nft, position.toString());
       updateAsset(nft);
+
+      // Reset the to address when a new asset is selected
+      if (existingSelectedAsset) {
+        updateTo('');
+      }
+
       if (nft.standard === 'ERC1155') {
         gotToSendScreen(Routes.SEND.AMOUNT);
       } else {
         gotToSendScreen(Routes.SEND.RECIPIENT);
       }
     },
-    [captureAssetSelected, gotToSendScreen, nfts, updateAsset],
+    [
+      captureAssetSelected,
+      existingSelectedAsset,
+      gotToSendScreen,
+      nfts,
+      updateAsset,
+      updateTo,
+    ],
   );
 
   const handleShowMore = useCallback(() => {

--- a/app/components/Views/confirmations/components/token-list/token-list.test.tsx
+++ b/app/components/Views/confirmations/components/token-list/token-list.test.tsx
@@ -6,9 +6,9 @@ import * as AssetSelectionMetrics from '../../hooks/send/metrics/useAssetSelecti
 import { TokenList } from './token-list';
 import { AssetType } from '../../types/token';
 import Routes from '../../../../../constants/navigation/Routes';
+import { useSendContext } from '../../context/send-context';
 
 const mockGotToSendScreen = jest.fn();
-const mockUpdateAsset = jest.fn();
 
 jest.mock('../../hooks/send/useSendScreenNavigation', () => ({
   useSendScreenNavigation: () => ({
@@ -17,9 +17,7 @@ jest.mock('../../hooks/send/useSendScreenNavigation', () => ({
 }));
 
 jest.mock('../../context/send-context', () => ({
-  useSendContext: () => ({
-    updateAsset: mockUpdateAsset,
-  }),
+  useSendContext: jest.fn(),
 }));
 
 jest.mock('../UI/token', () => {
@@ -93,6 +91,17 @@ const manyTokens: AssetType[] = Array.from({ length: 25 }, (_, i) => ({
 }));
 
 describe('TokenList', () => {
+  const mockUpdateAsset = jest.fn();
+  const mockUseSendContext = jest.mocked(useSendContext);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSendContext.mockReturnValue({
+      updateAsset: mockUpdateAsset,
+      asset: undefined,
+    } as unknown as ReturnType<typeof useSendContext>);
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -128,6 +137,20 @@ describe('TokenList', () => {
 
       expect(mockUpdateAsset).toHaveBeenCalledWith(mockTokens[0]);
       expect(mockGotToSendScreen).toHaveBeenCalledWith(Routes.SEND.AMOUNT);
+    });
+
+    it('calls updateTo when there is an existing asset selected', () => {
+      const mockUpdateTo = jest.fn();
+      mockUseSendContext.mockReturnValue({
+        updateAsset: mockUpdateAsset,
+        updateTo: mockUpdateTo,
+        asset: mockTokens[0],
+      } as unknown as ReturnType<typeof useSendContext>);
+
+      const { getByTestId } = render(<TokenList tokens={mockTokens} />);
+
+      fireEvent.press(getByTestId('token-ETH'));
+      expect(mockUpdateTo).toHaveBeenCalledWith('');
     });
 
     it('handles second token press correctly', () => {

--- a/app/components/Views/confirmations/components/token-list/token-list.test.tsx
+++ b/app/components/Views/confirmations/components/token-list/token-list.test.tsx
@@ -102,10 +102,6 @@ describe('TokenList', () => {
     } as unknown as ReturnType<typeof useSendContext>);
   });
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe('token rendering', () => {
     it('renders tokens when provided', () => {
       const { getByTestId } = render(<TokenList tokens={mockTokens} />);

--- a/app/components/Views/confirmations/components/token-list/token-list.tsx
+++ b/app/components/Views/confirmations/components/token-list/token-list.tsx
@@ -20,7 +20,11 @@ interface TokenListProps {
 
 export function TokenList({ onSelect, tokens }: TokenListProps) {
   const { gotToSendScreen } = useSendScreenNavigation();
-  const { updateAsset } = useSendContext();
+  const {
+    updateAsset,
+    asset: existingSelectedAsset,
+    updateTo,
+  } = useSendContext();
   const { captureAssetSelected } = useAssetSelectionMetrics();
   const [visibleTokenCount, setVisibleTokenCount] =
     useState(TOKEN_COUNT_PER_PAGE);
@@ -38,9 +42,23 @@ export function TokenList({ onSelect, tokens }: TokenListProps) {
 
       captureAssetSelected(asset, position.toString());
       updateAsset(asset);
+
+      // Reset the to address when a new asset is selected
+      if (existingSelectedAsset) {
+        updateTo('');
+      }
+
       gotToSendScreen(Routes.SEND.AMOUNT);
     },
-    [captureAssetSelected, gotToSendScreen, onSelect, tokens, updateAsset],
+    [
+      captureAssetSelected,
+      existingSelectedAsset,
+      gotToSendScreen,
+      onSelect,
+      tokens,
+      updateAsset,
+      updateTo,
+    ],
   );
 
   const handleShowMore = useCallback(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

If nonEVM asset and recipient is selected and then if user picks EVM token, then nonEVM recipient is persisting, or vice versa. 

This PR aims to reset `recipient` when there is an existing asset selected. 


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Reset recipient when new asset is selected while sending assets

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22707

## **Manual testing steps**

1. Go send flow - pick an EVM token
2. Set amount - go next step
3. Set a recipient - go next step
4. Now go all way back to asset selection
5. Pick a nonEVM token - set amount - go next page
6. See recipient is empty

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/5b4dbee0-2096-4aeb-873a-4f491995fba7



### **After**

https://github.com/user-attachments/assets/70044ea3-c516-4862-b117-a40a1a8449e0

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resets the recipient (`updateTo('')`) when switching assets during the send flow, updating token/NFT list logic and tests.
> 
> - **Send flow**:
>   - `TokenList` (`app/components/Views/confirmations/components/token-list/token-list.tsx`): on token press, after `updateAsset`, if an existing asset is selected, call `updateTo('')`; updated hook deps.
>   - `NftList` (`app/components/Views/confirmations/components/nft-list/nft-list.tsx`): same recipient reset on NFT press; preserves navigation differences for `ERC1155` vs others; updated hook deps.
> - **Tests**:
>   - `token-list.test.tsx` and `nft-list.test.tsx`: mock `useSendContext` to include `asset`/`updateTo`; add tests asserting `updateTo('')` is called when an asset was already selected; keep existing navigation/metrics assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a76084b1190ffc5621f81a5ed17c4a5c22c76f89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->