### PR TITLE
refactor: update AccountSelector animations to use screen width instead of height

### DIFF
--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -90,7 +90,7 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
-  const { height: screenHeight } = useWindowDimensions();
+  const { width: screenWidth } = useWindowDimensions();
   const { trackEvent, createEventBuilder } = useMetrics();
   const routeParams = useMemo(() => route?.params, [route?.params]);
 
@@ -162,11 +162,11 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
     useState(false);
 
   // Animation using react-native-reanimated - only for full-page version
-  const translateY = useSharedValue(screenHeight);
+  const translateX = useSharedValue(screenWidth);
 
-  // Backdrop opacity animation - fades in as screen slides up
+  // Backdrop opacity animation - fades in as screen slides in from right
   const backdropOpacity = useDerivedValue(() =>
-    interpolate(translateY.value, [screenHeight, 0], [0, 0.5]),
+    interpolate(translateX.value, [screenWidth, 0], [0, 0.5]),
   );
 
   useEffect(() => {
@@ -185,7 +185,7 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
       });
     };
 
-    translateY.value = withSpring(
+    translateX.value = withSpring(
       0,
       {
         damping: 20,
@@ -204,8 +204,8 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
         navigation.goBack();
       };
 
-      translateY.value = withTiming(
-        screenHeight,
+      translateX.value = withTiming(
+        screenWidth,
         { duration: AnimationDuration.Fast },
         () => runOnJS(onCloseComplete)(),
       );
@@ -213,7 +213,7 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
       // BottomSheet version: close the sheet
       sheetRef.current?.onCloseBottomSheet();
     }
-  }, [isFullPageAccountList, translateY, navigation, screenHeight]);
+  }, [isFullPageAccountList, translateX, navigation, screenWidth]);
 
   const _onSelectAccount = useCallback(
     (address: string) => {
@@ -412,7 +412,7 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
   ]);
 
   const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: translateY.value }],
+    transform: [{ translateX: translateX.value }],
   }));
 
   const backdropStyle = useAnimatedStyle(() => ({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updated the Account List transition animation from bottom-top (vertical slide) to right-left (horizontal slide) to align with the new design system patterns. The change affects the full-page account list view when the `fullPageAccountList` feature flag is enabled.

**What is the reason for the change?**
- The design system has been updated to use right-left transitions for full-page modals instead of the previous bottom-top pattern
- This change ensures consistency with the new design system guidelines

**What is the improvement/solution?**
- Changed animation from `translateY` (vertical) to `translateX` (horizontal)
- Updated initial animation value from `screenHeight` to `screenWidth`
- Updated backdrop opacity interpolation to work with horizontal translation
- Maintained the same spring animation configuration for smooth transitions

## **Changelog**

CHANGELOG entry: Updated Account List transition animation to slide in from the right instead of from the bottom (behind feature flag)

## **Related issues**

Fixes: [TMCU-223](https://consensyssoftware.atlassian.net/browse/TMCU-223)

## **Manual testing steps**

```gherkin
Feature: Account List Transition Animation

  Scenario: user opens account list with full-page feature flag enabled

    Given the app is running with the `fullPageAccountList` feature flag enabled
    And the user is on the wallet/home screen

    When user taps on the account selector/account name

    Then the account list should slide in from the right (left-to-right animation)
    And the backdrop should fade in smoothly
    And when user selects an account or taps back, the list should slide out to the right
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/fcc87382-b920-4a12-94a1-2caf3e6e7f7d


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/494ccf12-2648-4a40-b8cd-4ecc151aff12


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TMCU-223]: https://consensyssoftware.atlassian.net/browse/TMCU-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches full-page AccountSelector transition from vertical (height/translateY) to horizontal (width/translateX), updating animations and backdrop interpolation accordingly.
> 
> - **AccountSelector (`app/components/Views/AccountSelector/AccountSelector.tsx`)**:
>   - Replace vertical animation with horizontal:
>     - Use `screenWidth` instead of `screenHeight` and `translateX` instead of `translateY`.
>     - Update enter/exit animations to spring/timing on `translateX`.
>     - Adjust backdrop opacity interpolation to `[screenWidth, 0]` on `translateX`.
>     - Update animated styles to transform with `translateX`.
>   - Applies only when `fullPageAccountList` feature flag is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7028f659afb40ea2a3efb3b3cfb9a185dce328ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->