### PR TITLE
feat(analytics): Add rpc_domain property to custom RPC analytics events

### DIFF
--- a/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.test.tsx
+++ b/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.test.tsx
@@ -600,6 +600,7 @@ describe('useNetworkConnectionBanner', () => {
         banner_type: 'degraded',
         chain_id_caip: 'eip155:137',
         rpc_endpoint_url: 'polygon-rpc.com',
+        rpc_domain: 'polygon-rpc.com',
       });
     });
 
@@ -783,6 +784,7 @@ describe('useNetworkConnectionBanner', () => {
         banner_type: 'degraded',
         chain_id_caip: 'eip155:137',
         rpc_endpoint_url: 'polygon-rpc.com',
+        rpc_domain: 'polygon-rpc.com',
       });
     });
 

--- a/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.test.tsx
+++ b/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.test.tsx
@@ -258,6 +258,7 @@ describe('useNetworkConnectionBanner', () => {
         banner_type: 'degraded',
         chain_id_caip: 'eip155:1',
         rpc_endpoint_url: 'mainnet.infura.io',
+        rpc_domain: 'mainnet.infura.io',
       });
     });
 
@@ -289,6 +290,7 @@ describe('useNetworkConnectionBanner', () => {
         banner_type: 'unavailable',
         chain_id_caip: 'eip155:1',
         rpc_endpoint_url: 'mainnet.infura.io',
+        rpc_domain: 'mainnet.infura.io',
       });
     });
 
@@ -323,6 +325,7 @@ describe('useNetworkConnectionBanner', () => {
         banner_type: 'degraded',
         chain_id_caip: 'eip155:1',
         rpc_endpoint_url: 'custom',
+        rpc_domain: 'custom',
       });
     });
 
@@ -625,6 +628,7 @@ describe('useNetworkConnectionBanner', () => {
         banner_type: 'unavailable',
         chain_id_caip: 'eip155:137',
         rpc_endpoint_url: 'polygon-rpc.com',
+        rpc_domain: 'polygon-rpc.com',
       });
     });
 

--- a/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.ts
+++ b/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.ts
@@ -67,6 +67,7 @@ const useNetworkConnectionBanner = (): {
       shouldShowPopularNetworks: false,
     });
 
+    const sanitizedUrl = sanitizeRpcUrl(rpcUrl);
     trackEvent(
       createEventBuilder(
         MetaMetricsEvents.NETWORK_CONNECTION_BANNER_UPDATE_RPC_CLICKED,
@@ -74,7 +75,9 @@ const useNetworkConnectionBanner = (): {
         .addProperties({
           banner_type: status,
           chain_id_caip: `eip155:${hexToNumber(chainId)}`,
-          rpc_endpoint_url: sanitizeRpcUrl(rpcUrl),
+          // @deprecated: will be removed in a future release
+          rpc_endpoint_url: sanitizedUrl,
+          rpc_domain: sanitizedUrl,
         })
         .build(),
     );
@@ -196,6 +199,7 @@ const useNetworkConnectionBanner = (): {
 
   useEffect(() => {
     if (networkConnectionBannerState.visible) {
+      const sanitizedUrl = sanitizeRpcUrl(networkConnectionBannerState.rpcUrl);
       trackEvent(
         createEventBuilder(MetaMetricsEvents.NETWORK_CONNECTION_BANNER_SHOWN)
           .addProperties({
@@ -203,9 +207,8 @@ const useNetworkConnectionBanner = (): {
             chain_id_caip: `eip155:${hexToNumber(
               networkConnectionBannerState.chainId,
             )}`,
-            rpc_endpoint_url: sanitizeRpcUrl(
-              networkConnectionBannerState.rpcUrl,
-            ),
+            rpc_endpoint_url: sanitizedUrl,
+            rpc_domain: sanitizedUrl,
           })
           .build(),
       );

--- a/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
+++ b/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
@@ -79,6 +79,7 @@ describe('onRpcEndpointUnavailable', () => {
         properties: {
           chain_id_caip: 'eip155:11155111',
           rpc_endpoint_url: 'example.com',
+          rpc_domain: 'example.com',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -109,6 +110,7 @@ describe('onRpcEndpointUnavailable', () => {
           chain_id_caip: 'eip155:11155111',
           http_status: 420,
           rpc_endpoint_url: 'example.com',
+          rpc_domain: 'example.com',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -138,6 +140,7 @@ describe('onRpcEndpointUnavailable', () => {
         properties: {
           chain_id_caip: 'eip155:11155111',
           rpc_endpoint_url: 'custom',
+          rpc_domain: 'custom',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -236,6 +239,7 @@ describe('onRpcEndpointDegraded', () => {
         properties: {
           chain_id_caip: 'eip155:11155111',
           rpc_endpoint_url: 'example.com',
+          rpc_domain: 'example.com',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -266,6 +270,7 @@ describe('onRpcEndpointDegraded', () => {
           chain_id_caip: 'eip155:11155111',
           http_status: 420,
           rpc_endpoint_url: 'example.com',
+          rpc_domain: 'example.com',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -295,6 +300,7 @@ describe('onRpcEndpointDegraded', () => {
         properties: {
           chain_id_caip: 'eip155:11155111',
           rpc_endpoint_url: 'custom',
+          rpc_domain: 'custom',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */

--- a/app/core/Engine/controllers/network-controller/messenger-action-handlers.ts
+++ b/app/core/Engine/controllers/network-controller/messenger-action-handlers.ts
@@ -146,13 +146,15 @@ export function trackRpcEndpointEvent(
     return;
   }
 
+  const isPublicEndpoint = isPublicEndpointUrl(endpointUrl, infuraProjectId);
+  const rpcDomain = isPublicEndpoint ? onlyKeepHost(endpointUrl) : 'custom';
   // The names of Segment properties have a particular case.
   /* eslint-disable @typescript-eslint/naming-convention */
   const properties = {
     chain_id_caip: `eip155:${hexToNumber(chainId)}`,
-    rpc_endpoint_url: isPublicEndpointUrl(endpointUrl, infuraProjectId)
-      ? onlyKeepHost(endpointUrl)
-      : 'custom',
+    // @deprecated: will be removed in a future release
+    rpc_endpoint_url: rpcDomain,
+    rpc_domain: rpcDomain,
     ...(isObject(error) &&
     'httpStatus' in error &&
     isValidJson(error.httpStatus)


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds `rpc_domain` property to custom RPC UX analytics events while retaining the existing `rpc_endpoint_url` property.

## Changes

- Added `rpc_domain` property to RPC analytics events:
  - `RPC_SERVICE_UNAVAILABLE`
  - `RPC_SERVICE_DEGRADED`
  - `NETWORK_CONNECTION_BANNER_SHOWN`
  - `NETWORK_CONNECTION_BANNER_UPDATE_RPC_CLICKED`
- Both `rpc_domain` and `rpc_endpoint_url` now track the same value:
  - `'custom'` for custom RPC endpoints
  - Domain host for public endpoints (e.g., `'mainnet.infura.io'`)
- Marked `rpc_endpoint_url` as deprecated for future removal
- Updated unit tests to assert both properties

## Files Changed

- `app/core/Engine/controllers/network-controller/messenger-action-handlers.ts`
- `app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.ts`
- Corresponding test files

---


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPC-133

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add rpc_domain to RPC analytics events (mirroring deprecated rpc_endpoint_url) and update hook/controller logic and tests to use sanitized domain values.
> 
> - **Analytics**:
>   - Add `rpc_domain` to RPC telemetry and align with deprecated `rpc_endpoint_url` (same value: host for public endpoints, `custom` for non-public).
>   - Apply to `RPC_SERVICE_UNAVAILABLE`, `RPC_SERVICE_DEGRADED`, `NETWORK_CONNECTION_BANNER_SHOWN`, and `NETWORK_CONNECTION_BANNER_UPDATE_RPC_CLICKED`.
>   - Centralize domain sanitization (via `sanitizeRpcUrl`/`onlyKeepHost`); continue capturing `http_status` when present.
> - **Hook (`useNetworkConnectionBanner`)**:
>   - Compute `sanitizedUrl` once; include `rpc_domain` and deprecated `rpc_endpoint_url` in tracked properties.
> - **Controller (`messenger-action-handlers`)**:
>   - Derive `rpcDomain` once; add `rpc_domain` and keep deprecated `rpc_endpoint_url`.
> - **Tests**:
>   - Update assertions to include `rpc_domain` across scenarios (public/custom, degraded/unavailable, with/without `http_status`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3414c3a8d05e55948db95393839e47f529fb8bbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->