### PR TITLE
feat(predict): implement share market button

### DIFF
--- a/app/components/UI/Predict/components/PredictShareButton/PredictShareButton.test.tsx
+++ b/app/components/UI/Predict/components/PredictShareButton/PredictShareButton.test.tsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import { Share } from 'react-native';
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import PredictShareButton from './PredictShareButton';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { ToastContext } from '../../../../../component-library/components/Toast';
+import { PredictMarketDetailsSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
+
+// Mock i18n strings
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => key),
+}));
+
+// Create mock toast ref
+const mockShowToast = jest.fn();
+const mockToastRef = {
+  current: {
+    showToast: mockShowToast,
+    closeToast: jest.fn(),
+  },
+};
+
+// Wrapper to provide ToastContext
+const ToastWrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(
+    ToastContext.Provider,
+    { value: { toastRef: mockToastRef } },
+    children,
+  );
+
+const renderShareButton = (marketId?: string) =>
+  renderWithProvider(
+    <ToastWrapper>
+      <PredictShareButton marketId={marketId} />
+    </ToastWrapper>,
+  );
+
+describe('PredictShareButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('Component Rendering', () => {
+    it('renders share icon button with correct testID', () => {
+      renderShareButton('market-123');
+
+      expect(
+        screen.getByTestId(PredictMarketDetailsSelectorsIDs.SHARE_BUTTON),
+      ).toBeOnTheScreen();
+    });
+
+    it('sets accessibility role and label for screen readers', () => {
+      renderShareButton('market-123');
+
+      const button = screen.getByTestId(
+        PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
+      );
+
+      expect(button.props.accessibilityRole).toBe('button');
+      expect(button.props.accessible).toBe(true);
+    });
+  });
+
+  describe('Share Functionality', () => {
+    it('calls Share.share with URL containing marketId and utm_source', async () => {
+      jest.spyOn(Share, 'share').mockResolvedValue({
+        action: Share.dismissedAction,
+      });
+      renderShareButton('market-123');
+
+      const button = screen.getByTestId(
+        PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
+      );
+      fireEvent.press(button);
+
+      await waitFor(() => {
+        expect(Share.share).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: 'https://link.metamask.io/predict?market=market-123&utm_source=user_shared',
+          }),
+          {},
+        );
+      });
+    });
+
+    it('generates URL with empty marketId when prop is undefined', async () => {
+      jest.spyOn(Share, 'share').mockResolvedValue({
+        action: Share.dismissedAction,
+      });
+      renderShareButton(undefined);
+
+      const button = screen.getByTestId(
+        PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
+      );
+      fireEvent.press(button);
+
+      await waitFor(() => {
+        expect(Share.share).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: 'https://link.metamask.io/predict?market=&utm_source=user_shared',
+          }),
+          {},
+        );
+      });
+    });
+
+    it('passes message containing the share URL', async () => {
+      jest.spyOn(Share, 'share').mockResolvedValue({
+        action: Share.dismissedAction,
+      });
+      renderShareButton('market-456');
+
+      const button = screen.getByTestId(
+        PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
+      );
+      fireEvent.press(button);
+
+      await waitFor(() => {
+        expect(Share.share).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              'https://link.metamask.io/predict?market=market-456&utm_source=user_shared',
+            ),
+          }),
+          {},
+        );
+      });
+    });
+  });
+
+  describe('Copy to Clipboard', () => {
+    it('displays toast notification when user copies to clipboard', async () => {
+      jest.spyOn(Share, 'share').mockResolvedValue({
+        action: Share.sharedAction,
+        activityType: 'com.apple.UIKit.activity.CopyToPasteboard',
+      });
+      renderShareButton('market-123');
+
+      const button = screen.getByTestId(
+        PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
+      );
+      fireEvent.press(button);
+
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variant: 'Icon',
+            hasNoTimeout: false,
+            labelOptions: expect.arrayContaining([
+              expect.objectContaining({
+                isBold: true,
+              }),
+            ]),
+          }),
+        );
+      });
+    });
+
+    it('does not display toast for other share actions', async () => {
+      jest.spyOn(Share, 'share').mockResolvedValue({
+        action: Share.sharedAction,
+        activityType: 'com.apple.UIKit.activity.Message',
+      });
+      renderShareButton('market-123');
+
+      const button = screen.getByTestId(
+        PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
+      );
+      fireEvent.press(button);
+
+      await waitFor(() => {
+        expect(Share.share).toHaveBeenCalled();
+      });
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Share Dialog Outcomes', () => {
+    it('completes without error when share is dismissed', async () => {
+      jest.spyOn(Share, 'share').mockResolvedValue({
+        action: Share.dismissedAction,
+      });
+      renderShareButton('market-123');
+
+      const button = screen.getByTestId(
+        PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
+      );
+      fireEvent.press(button);
+
+      await waitFor(() => {
+        expect(Share.share).toHaveBeenCalled();
+      });
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('completes without error when share succeeds', async () => {
+      jest.spyOn(Share, 'share').mockResolvedValue({
+        action: Share.sharedAction,
+        activityType: 'com.apple.UIKit.activity.AirDrop',
+      });
+      renderShareButton('market-123');
+
+      const button = screen.getByTestId(
+        PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
+      );
+      fireEvent.press(button);
+
+      await waitFor(() => {
+        expect(Share.share).toHaveBeenCalled();
+      });
+      // No toast for non-clipboard share actions
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('catches Share.share rejection without crashing', async () => {
+      jest.spyOn(Share, 'share').mockRejectedValue(new Error('Share failed'));
+      renderShareButton('market-123');
+
+      const button = screen.getByTestId(
+        PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
+      );
+
+      // Pressing button should not throw
+      expect(() => fireEvent.press(button)).not.toThrow();
+
+      await waitFor(() => {
+        expect(Share.share).toHaveBeenCalled();
+      });
+    });
+
+    it('does not display error toast when sharing fails', async () => {
+      jest.spyOn(Share, 'share').mockRejectedValue(new Error('Share failed'));
+      renderShareButton('market-123');
+
+      const button = screen.getByTestId(
+        PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
+      );
+      fireEvent.press(button);
+
+      await waitFor(() => {
+        expect(Share.share).toHaveBeenCalled();
+      });
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles missing toastRef without crashing', async () => {
+      jest.spyOn(Share, 'share').mockResolvedValue({
+        action: Share.sharedAction,
+        activityType: 'com.apple.UIKit.activity.CopyToPasteboard',
+      });
+
+      // Render with null toastRef
+      const NullToastWrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(
+          ToastContext.Provider,
+          { value: { toastRef: { current: null } } },
+          children,
+        );
+
+      renderWithProvider(
+        <NullToastWrapper>
+          <PredictShareButton marketId="market-123" />
+        </NullToastWrapper>,
+      );
+
+      const button = screen.getByTestId(
+        PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
+      );
+
+      // Should not throw even when toastRef.current is null
+      expect(() => fireEvent.press(button)).not.toThrow();
+
+      await waitFor(() => {
+        expect(Share.share).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/app/components/UI/Predict/components/PredictShareButton/PredictShareButton.test.tsx
+++ b/app/components/UI/Predict/components/PredictShareButton/PredictShareButton.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Share } from 'react-native';
-import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, screen } from '@testing-library/react-native';
 import PredictShareButton from './PredictShareButton';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { ToastContext } from '../../../../../component-library/components/Toast';
@@ -54,6 +54,7 @@ describe('PredictShareButton', () => {
     });
 
     it('sets accessibility role and label for screen readers', () => {
+      const { strings } = jest.requireMock('../../../../../../locales/i18n');
       renderShareButton('market-123');
 
       const button = screen.getByTestId(
@@ -62,6 +63,7 @@ describe('PredictShareButton', () => {
 
       expect(button.props.accessibilityRole).toBe('button');
       expect(button.props.accessible).toBe(true);
+      expect(strings).toHaveBeenCalledWith('predict.buttons.share');
     });
   });
 
@@ -75,16 +77,17 @@ describe('PredictShareButton', () => {
       const button = screen.getByTestId(
         PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
       );
-      fireEvent.press(button);
 
-      await waitFor(() => {
-        expect(Share.share).toHaveBeenCalledWith(
-          expect.objectContaining({
-            url: 'https://link.metamask.io/predict?market=market-123&utm_source=user_shared',
-          }),
-          {},
-        );
+      await act(async () => {
+        await fireEvent.press(button);
       });
+
+      expect(Share.share).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://link.metamask.io/predict?market=market-123&utm_source=user_shared',
+        }),
+        {},
+      );
     });
 
     it('generates URL with empty marketId when prop is undefined', async () => {
@@ -96,16 +99,17 @@ describe('PredictShareButton', () => {
       const button = screen.getByTestId(
         PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
       );
-      fireEvent.press(button);
 
-      await waitFor(() => {
-        expect(Share.share).toHaveBeenCalledWith(
-          expect.objectContaining({
-            url: 'https://link.metamask.io/predict?market=&utm_source=user_shared',
-          }),
-          {},
-        );
+      await act(async () => {
+        await fireEvent.press(button);
       });
+
+      expect(Share.share).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://link.metamask.io/predict?market=&utm_source=user_shared',
+        }),
+        {},
+      );
     });
 
     it('passes message containing the share URL', async () => {
@@ -117,18 +121,19 @@ describe('PredictShareButton', () => {
       const button = screen.getByTestId(
         PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
       );
-      fireEvent.press(button);
 
-      await waitFor(() => {
-        expect(Share.share).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: expect.stringContaining(
-              'https://link.metamask.io/predict?market=market-456&utm_source=user_shared',
-            ),
-          }),
-          {},
-        );
+      await act(async () => {
+        await fireEvent.press(button);
       });
+
+      expect(Share.share).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'https://link.metamask.io/predict?market=market-456&utm_source=user_shared',
+          ),
+        }),
+        {},
+      );
     });
   });
 
@@ -143,21 +148,22 @@ describe('PredictShareButton', () => {
       const button = screen.getByTestId(
         PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
       );
-      fireEvent.press(button);
 
-      await waitFor(() => {
-        expect(mockShowToast).toHaveBeenCalledWith(
-          expect.objectContaining({
-            variant: 'Icon',
-            hasNoTimeout: false,
-            labelOptions: expect.arrayContaining([
-              expect.objectContaining({
-                isBold: true,
-              }),
-            ]),
-          }),
-        );
+      await act(async () => {
+        await fireEvent.press(button);
       });
+
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'Icon',
+          hasNoTimeout: false,
+          labelOptions: expect.arrayContaining([
+            expect.objectContaining({
+              isBold: true,
+            }),
+          ]),
+        }),
+      );
     });
 
     it('does not display toast for other share actions', async () => {
@@ -170,11 +176,12 @@ describe('PredictShareButton', () => {
       const button = screen.getByTestId(
         PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
       );
-      fireEvent.press(button);
 
-      await waitFor(() => {
-        expect(Share.share).toHaveBeenCalled();
+      await act(async () => {
+        await fireEvent.press(button);
       });
+
+      expect(Share.share).toHaveBeenCalled();
       expect(mockShowToast).not.toHaveBeenCalled();
     });
   });
@@ -189,11 +196,12 @@ describe('PredictShareButton', () => {
       const button = screen.getByTestId(
         PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
       );
-      fireEvent.press(button);
 
-      await waitFor(() => {
-        expect(Share.share).toHaveBeenCalled();
+      await act(async () => {
+        await fireEvent.press(button);
       });
+
+      expect(Share.share).toHaveBeenCalled();
       expect(mockShowToast).not.toHaveBeenCalled();
     });
 
@@ -207,12 +215,13 @@ describe('PredictShareButton', () => {
       const button = screen.getByTestId(
         PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
       );
-      fireEvent.press(button);
 
-      await waitFor(() => {
-        expect(Share.share).toHaveBeenCalled();
+      await act(async () => {
+        await fireEvent.press(button);
       });
+
       // No toast for non-clipboard share actions
+      expect(Share.share).toHaveBeenCalled();
       expect(mockShowToast).not.toHaveBeenCalled();
     });
   });
@@ -227,11 +236,11 @@ describe('PredictShareButton', () => {
       );
 
       // Pressing button should not throw
-      expect(() => fireEvent.press(button)).not.toThrow();
-
-      await waitFor(() => {
-        expect(Share.share).toHaveBeenCalled();
+      await act(async () => {
+        await fireEvent.press(button);
       });
+
+      expect(Share.share).toHaveBeenCalled();
     });
 
     it('does not display error toast when sharing fails', async () => {
@@ -241,11 +250,12 @@ describe('PredictShareButton', () => {
       const button = screen.getByTestId(
         PredictMarketDetailsSelectorsIDs.SHARE_BUTTON,
       );
-      fireEvent.press(button);
 
-      await waitFor(() => {
-        expect(Share.share).toHaveBeenCalled();
+      await act(async () => {
+        await fireEvent.press(button);
       });
+
+      expect(Share.share).toHaveBeenCalled();
       expect(mockShowToast).not.toHaveBeenCalled();
     });
   });
@@ -276,11 +286,11 @@ describe('PredictShareButton', () => {
       );
 
       // Should not throw even when toastRef.current is null
-      expect(() => fireEvent.press(button)).not.toThrow();
-
-      await waitFor(() => {
-        expect(Share.share).toHaveBeenCalled();
+      await act(async () => {
+        await fireEvent.press(button);
       });
+
+      expect(Share.share).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictShareButton/PredictShareButton.tsx
+++ b/app/components/UI/Predict/components/PredictShareButton/PredictShareButton.tsx
@@ -1,0 +1,93 @@
+import React, { useCallback, useContext } from 'react';
+import { Pressable, Share } from 'react-native';
+import Icon, {
+  IconName,
+  IconSize,
+} from '../../../../../component-library/components/Icons/Icon';
+import { useTheme } from '../../../../../util/theme';
+import { PredictMarketDetailsSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  ToastContext,
+  ToastVariants,
+} from '../../../../../component-library/components/Toast';
+import { Box } from '@metamask/design-system-react-native';
+
+interface PredictShareButtonProps {
+  marketId?: string;
+}
+
+const PredictShareButton: React.FC<PredictShareButtonProps> = ({
+  marketId,
+}) => {
+  const { toastRef } = useContext(ToastContext);
+  const { colors } = useTheme();
+
+  const handleSharePress = useCallback(async () => {
+    try {
+      const url = `https://link.metamask.io/predict?market=${marketId ?? ''}&utm_source=user_shared`;
+
+      const result = await Share.share(
+        {
+          url,
+          message: `Check out this prediction market on MetaMask:\n\n${url}`,
+        },
+        {},
+      );
+      if (result.action === Share.sharedAction) {
+        if (
+          result.activityType === 'com.apple.UIKit.activity.CopyToPasteboard'
+        ) {
+          // Copied to clipboard
+          return toastRef?.current?.showToast({
+            variant: ToastVariants.Icon,
+            labelOptions: [
+              {
+                label: strings('predict.toasts.copied_to_clipboard'),
+                isBold: true,
+              },
+            ],
+            iconName: IconName.Confirmation,
+            backgroundColor: 'transparent',
+            iconColor: colors.success.default,
+            hasNoTimeout: false,
+            customBottomOffset: -50,
+            // Need to style manually otherwise the icon is not centered and the text is too far away
+            startAccessory: (
+              <Box twClassName="items-center justify-center align-center pr-[12px]">
+                <Icon
+                  name={IconName.Confirmation}
+                  color={colors.success.default}
+                  size={IconSize.Lg}
+                />
+              </Box>
+            ),
+          });
+        }
+        // Shared
+      } else if (result.action === Share.dismissedAction) {
+        // Dismissed
+      }
+    } catch (_error) {
+      // Ignore errors
+    }
+  }, [colors.success.default, marketId, toastRef]);
+
+  return (
+    <Pressable
+      onPress={handleSharePress}
+      hitSlop={12}
+      accessibilityRole="button"
+      accessibilityLabel={strings('predict.buttons.share')}
+      testID={PredictMarketDetailsSelectorsIDs.SHARE_BUTTON}
+    >
+      <Icon
+        name={IconName.Share}
+        size={IconSize.Lg}
+        color={colors.icon.default}
+      />
+    </Pressable>
+  );
+};
+
+export default PredictShareButton;

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -252,6 +252,18 @@ jest.mock('../../components/PredictMarketOutcome', () => {
   };
 });
 
+jest.mock('../../components/PredictShareButton/PredictShareButton', () => {
+  const { View } = jest.requireActual('react-native');
+  return function MockPredictShareButton({ marketId }: { marketId?: string }) {
+    return (
+      <View
+        testID="predict-share-button"
+        accessibilityHint={`marketId:${marketId ?? 'undefined'}`}
+      />
+    );
+  };
+});
+
 jest.mock('../../../../Base/TabBar', () => {
   const { View, Text } = jest.requireActual('react-native');
   return function MockTabBar({ textStyle }: { textStyle: object }) {
@@ -621,6 +633,33 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest();
 
       expect(screen.getByTestId('icon-ArrowLeft')).toBeOnTheScreen();
+    });
+
+    it('renders share button in header when market data is loaded', () => {
+      setupPredictMarketDetailsTest();
+
+      expect(screen.getByTestId('predict-share-button')).toBeOnTheScreen();
+    });
+
+    it('passes market.id to share button', () => {
+      setupPredictMarketDetailsTest({ id: 'test-market-id' });
+
+      const shareButton = screen.getByTestId('predict-share-button');
+
+      expect(shareButton.props.accessibilityHint).toBe(
+        'marketId:test-market-id',
+      );
+    });
+
+    it('hides share button when market is not loaded (shows skeleton)', () => {
+      setupPredictMarketDetailsTest({}, {}, { market: { market: null } });
+
+      expect(
+        screen.queryByTestId('predict-share-button'),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.getByTestId('predict-details-header-skeleton-back-button'),
+      ).toBeOnTheScreen();
     });
   });
 
@@ -1181,7 +1220,7 @@ describe('PredictMarketDetails', () => {
     it('uses correct string keys for back button', () => {
       setupPredictMarketDetailsTest();
 
-      expect(strings).toHaveBeenCalledWith('back');
+      expect(strings).toHaveBeenCalledWith('predict.buttons.back');
     });
   });
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -70,6 +70,7 @@ import ButtonHero from '../../../../../component-library/components-temp/Buttons
 import PredictDetailsHeaderSkeleton from '../../components/PredictDetailsHeaderSkeleton';
 import PredictDetailsContentSkeleton from '../../components/PredictDetailsContentSkeleton';
 import PredictDetailsButtonsSkeleton from '../../components/PredictDetailsButtonsSkeleton';
+import PredictShareButton from '../../components/PredictShareButton/PredictShareButton';
 
 const PRICE_HISTORY_TIMEFRAMES: PredictPriceHistoryInterval[] = [
   PredictPriceHistoryInterval.ONE_HOUR,
@@ -648,7 +649,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
             onPress={handleBackPress}
             hitSlop={12}
             accessibilityRole="button"
-            accessibilityLabel={strings('back')}
+            accessibilityLabel={strings('predict.buttons.back')}
             style={tw.style('items-center justify-center rounded-full')}
             testID={PredictMarketDetailsSelectorsIDs.BACK_BUTTON}
           >
@@ -680,6 +681,9 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
           <Text variant={TextVariant.HeadingMD} color={TextColor.Default}>
             {title || market?.title || ''}
           </Text>
+        </Box>
+        <Box twClassName="pr-2">
+          <PredictShareButton marketId={market?.id} />
         </Box>
       </Box>
     );

--- a/e2e/selectors/Predict/Predict.selectors.ts
+++ b/e2e/selectors/Predict/Predict.selectors.ts
@@ -53,6 +53,7 @@ export const PredictMarketDetailsSelectorsIDs = {
 
   // Header
   BACK_BUTTON: 'predict-market-details-back-button',
+  SHARE_BUTTON: 'predict-market-details-share-button',
 
   // Tabs
   TAB_BAR: 'predict-market-details-tab-bar',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1780,6 +1780,13 @@
     "prediction_markets": "Prediction Markets",
     "market_list": "Market List",
     "loading": "Loading...",
+    "buttons": {
+      "back": "Back",
+      "share": "Share"
+    },
+    "toasts": {
+      "copied_to_clipboard": "Copied to clipboard"
+    },
     "gtm_content": {
       "title": "PREDICT AND WIN",
       "title_description": "Trade on the outcome of real-world events, like sports or elections.",


### PR DESCRIPTION
## **Description**

This PR adds a share button to the Prediction Market details screen, allowing users to share markets with others via the native share sheet.

**What is the reason for the change?**
Users want to share interesting prediction markets with friends and on social media. Currently there's no way to share a market link directly from the app.

**What is the improvement/solution?**
- Added a new `PredictShareButton` component in the market details header (next to the title)
- Tapping the button opens the native share sheet with a deep link to the market (`https://link.metamask.io/predict?market={marketId}&utm_source=user_shared`)
- When the user copies the link to clipboard (iOS), a toast notification confirms the action
- Includes proper accessibility support (role, label) for screen readers

## **Changelog**

CHANGELOG entry: Added share button to prediction market details screen

## **Related issues**

Fixes: [PRED-251](https://consensyssoftware.atlassian.net/browse/PRED-251)

## **Manual testing steps**

```gherkin
Feature: Share Prediction Market

  Scenario: User shares a prediction market
    Given user is on a prediction market details screen

    When user taps the share icon in the header
    Then the native share sheet opens with the market link

  Scenario: User copies market link to clipboard (iOS)
    Given user is on a prediction market details screen
    And user has tapped the share icon

    When user selects "Copy" from the share sheet
    Then a toast notification displays "Copied to clipboard"

  Scenario: User dismisses share sheet
    Given user is on a prediction market details screen
    And user has tapped the share icon

    When user dismisses the share sheet
    Then no toast is shown and user remains on market details
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/5a6354d5-cb1d-4de1-876d-c36119d04a02


https://github.com/user-attachments/assets/6f1ca9d1-9bbe-4530-8033-4b9d5b781383



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-251]: https://consensyssoftware.atlassian.net/browse/PRED-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `PredictShareButton` in market details header to share deep links via native sheet (with clipboard toast), updates selectors/i18n, and adds comprehensive tests.
> 
> - **Predict UI**:
>   - **New `PredictShareButton`** (`app/components/UI/Predict/components/PredictShareButton/PredictShareButton.tsx`): opens native share sheet with deep link, shows toast on clipboard copy, accessible, testID `predict-market-details-share-button`.
>   - Integrated into `PredictMarketDetails` header, passing `market.id`; updated back button accessibility label to `strings('predict.buttons.back')`.
> - **Tests**:
>   - Added unit tests for `PredictShareButton` covering rendering, share flows, clipboard toast, errors, and edge cases.
>   - Updated `PredictMarketDetails` tests to verify share button presence/props and skeleton behavior.
> - **E2E Selectors**:
>   - Added `PredictMarketDetailsSelectorsIDs.SHARE_BUTTON` in `e2e/selectors/Predict/Predict.selectors.ts`.
> - **Localization**:
>   - Added `predict.buttons.back`, `predict.buttons.share`, and `predict.toasts.copied_to_clipboard` to `locales/languages/en.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 689f061cba72e7d517b1777af175a670fe2b8721. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->