### PR TITLE
refactor(Predict): migrate Text component to design system

### DIFF
--- a/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.tsx
+++ b/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.tsx
@@ -2,6 +2,9 @@ import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
@@ -13,10 +16,6 @@ import Button, {
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import Icon, {
   IconName,
   IconSize,
@@ -131,13 +130,16 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
           </Box>
           <Box twClassName="flex-1 -mt-1">
             <Text
-              variant={TextVariant.HeadingMD}
-              color={TextColor.Default}
+              variant={TextVariant.HeadingMd}
+              color={TextColor.TextDefault}
               style={tw.style('font-medium')}
             >
               {getTitle()}
             </Text>
-            <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
               ${getVolumeDisplay()} {strings('predict.volume_abbreviated')}
             </Text>
           </Box>
@@ -149,11 +151,12 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
                 twClassName="gap-1"
               >
                 <Text
-                  variant={TextVariant.BodyMDMedium}
+                  variant={TextVariant.BodyMd}
+                  twClassName="font-medium"
                   color={
                     outcomeToken.price === 1
-                      ? TextColor.Default
-                      : TextColor.Alternative
+                      ? TextColor.TextDefault
+                      : TextColor.TextAlternative
                   }
                 >
                   {outcomeToken.price === 1
@@ -166,8 +169,8 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
                     size={IconSize.Md}
                     color={
                       outcomeToken.price === 1
-                        ? TextColor.Success
-                        : TextColor.Muted
+                        ? TextColor.SuccessDefault
+                        : TextColor.TextMuted
                     }
                   />
                 )}
@@ -175,7 +178,7 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
             ) : (
               <Text
                 style={tw.style('text-[20px] font-medium')}
-                color={TextColor.Default}
+                color={TextColor.TextDefault}
               >
                 {getYesPercentage()}
               </Text>
@@ -192,7 +195,7 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
             label={
               <Text
                 style={tw.style('font-medium text-center')}
-                color={TextColor.Success}
+                color={TextColor.SuccessDefault}
               >
                 {outcome.tokens[0].title}
                 {isBiggerLabel ? '\n' : ' • '}
@@ -209,7 +212,7 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
             label={
               <Text
                 style={tw.style('font-medium text-center')}
-                color={TextColor.Error}
+                color={TextColor.ErrorDefault}
               >
                 {outcome.tokens[1].title}
                 {isBiggerLabel ? '\n' : ' • '}

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -7,6 +7,9 @@ import {
   Icon,
   IconName,
   IconSize,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
@@ -35,10 +38,6 @@ import Button, {
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { BottomSheetRef } from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import Engine from '../../../../../core/Engine';
 import { usePredictPlaceOrder } from '../../hooks/usePredictPlaceOrder';
@@ -288,7 +287,7 @@ const PredictBuyPreview = () => {
         <Box flexDirection={BoxFlexDirection.Row} twClassName="min-w-0 gap-4">
           <Box twClassName="flex-1 min-w-0">
             <Text
-              variant={TextVariant.HeadingSM}
+              variant={TextVariant.HeadingSm}
               numberOfLines={1}
               ellipsizeMode="tail"
             >
@@ -302,27 +301,30 @@ const PredictBuyPreview = () => {
               {!!outcomeGroupTitle && (
                 <>
                   <Text
-                    variant={TextVariant.BodySMMedium}
-                    color={TextColor.Alternative}
+                    variant={TextVariant.BodySm}
+                    twClassName="font-medium"
+                    color={TextColor.TextAlternative}
                     numberOfLines={1}
                     ellipsizeMode="tail"
                   >
                     {outcomeGroupTitle}
                   </Text>
                   <Text
-                    variant={TextVariant.BodySMMedium}
-                    color={TextColor.Alternative}
+                    variant={TextVariant.BodySm}
+                    twClassName="font-medium"
+                    color={TextColor.TextAlternative}
                   >
                     {separator}
                   </Text>
                 </>
               )}
               <Text
-                variant={TextVariant.BodySMMedium}
+                variant={TextVariant.BodySm}
+                twClassName="font-medium"
                 color={
                   outcomeToken?.title === 'Yes'
-                    ? TextColor.Success
-                    : TextColor.Error
+                    ? TextColor.SuccessDefault
+                    : TextColor.ErrorDefault
                 }
                 numberOfLines={1}
                 ellipsizeMode="tail"
@@ -361,7 +363,10 @@ const PredictBuyPreview = () => {
           {isBalanceLoading ? (
             <Skeleton width={120} height={20} />
           ) : (
-            <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+            >
               {`${strings('predict.order.available')}: `}
               {formatPrice(balance, { minimumDecimals: 2, maximumDecimals: 2 })}
             </Text>
@@ -373,13 +378,21 @@ const PredictBuyPreview = () => {
           justifyContent={BoxJustifyContent.Center}
           twClassName="mt-2"
         >
-          <Text variant={TextVariant.BodyLGMedium} color={TextColor.Success}>
+          <Text
+            variant={TextVariant.BodyLg}
+            twClassName="font-medium"
+            color={TextColor.SuccessDefault}
+          >
             {`${strings('predict.order.to_win')} `}
           </Text>
           {isCalculating && isUserInputChange ? (
             <Skeleton width={80} height={24} style={tw.style('rounded-md')} />
           ) : (
-            <Text variant={TextVariant.BodyLGMedium} color={TextColor.Success}>
+            <Text
+              variant={TextVariant.BodyLg}
+              twClassName="font-medium"
+              color={TextColor.SuccessDefault}
+            >
               {formatPrice(toWin, {
                 minimumDecimals: 2,
                 maximumDecimals: 2,
@@ -398,8 +411,8 @@ const PredictBuyPreview = () => {
       return (
         <Box twClassName="px-12 pb-4">
           <Text
-            variant={TextVariant.BodySM}
-            color={TextColor.Error}
+            variant={TextVariant.BodySm}
+            color={TextColor.ErrorDefault}
             style={tw.style('text-center')}
           >
             {strings('predict.order.prediction_insufficient_funds', {
@@ -417,8 +430,8 @@ const PredictBuyPreview = () => {
       return (
         <Box twClassName="px-12 pb-4">
           <Text
-            variant={TextVariant.BodySM}
-            color={TextColor.Error}
+            variant={TextVariant.BodySm}
+            color={TextColor.ErrorDefault}
             style={tw.style('text-center')}
           >
             {strings('predict.order.prediction_minimum_bet', {
@@ -455,8 +468,9 @@ const PredictBuyPreview = () => {
             <Box twClassName="flex-row items-center gap-1">
               <ActivityIndicator size="small" />
               <Text
-                variant={TextVariant.BodyLGMedium}
-                color={TextColor.Inverse}
+                variant={TextVariant.BodyLg}
+                twClassName="font-medium"
+                color={TextColor.PrimaryInverse}
               >
                 {`${strings('predict.order.placing_prediction')}...`}
               </Text>
@@ -481,7 +495,10 @@ const PredictBuyPreview = () => {
         size={ButtonSizeHero.Lg}
         style={tw.style('w-full')}
       >
-        <Text variant={TextVariant.BodyMDMedium} style={tw.style('text-white')}>
+        <Text
+          variant={TextVariant.BodyMd}
+          style={tw.style('text-white font-medium')}
+        >
           {outcomeToken?.title} ·{' '}
           {formatCents(preview?.sharePrice ?? outcomeToken?.price ?? 0)}
         </Text>
@@ -502,8 +519,8 @@ const PredictBuyPreview = () => {
         <Box justifyContent={BoxJustifyContent.Center} twClassName="gap-2">
           {errorMessage && (
             <Text
-              variant={TextVariant.BodySM}
-              color={TextColor.Error}
+              variant={TextVariant.BodySm}
+              color={TextColor.ErrorDefault}
               style={tw.style('text-center pb-2')}
             >
               {errorMessage}
@@ -511,11 +528,14 @@ const PredictBuyPreview = () => {
           )}
           <Box twClassName="w-full h-12">{renderActionButton()}</Box>
           <Box twClassName="text-center items-center flex-row gap-1 justify-center">
-            <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+            >
               {strings('predict.consent_sheet.disclaimer')}
             </Text>
             <Text
-              variant={TextVariant.BodyXS}
+              variant={TextVariant.BodyXs}
               style={tw.style('text-info-default')}
               onPress={() => {
                 Linking.openURL('https://polymarket.com/tos');

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -22,10 +22,6 @@ import Button, {
   ButtonSize,
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useTheme } from '../../../../../util/theme';
 import { TraceName } from '../../../../../util/trace';
@@ -41,6 +37,9 @@ import {
   BoxAlignItems,
   BoxJustifyContent,
   ButtonSize as ButtonSizeHero,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import Icon, {
   IconName,
@@ -680,9 +679,12 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
             testID={`${PredictMarketDetailsSelectorsIDs.TAB_BAR}-tab-${index}`}
           >
             <Text
-              variant={TextVariant.BodyMDMedium}
+              variant={TextVariant.BodyMd}
+              twClassName="font-medium"
               color={
-                activeTab === index ? TextColor.Default : TextColor.Alternative
+                activeTab === index
+                  ? TextColor.TextDefault
+                  : TextColor.TextAlternative
               }
               style={tw.style('text-center')}
             >
@@ -742,7 +744,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
           }
           style={titleLineCount >= 2 ? tw.style('mt-[-5px]') : undefined}
         >
-          <Text variant={TextVariant.HeadingMD} color={TextColor.Default}>
+          <Text variant={TextVariant.HeadingMd} color={TextColor.TextDefault}>
             {title || market?.title || ''}
           </Text>
         </Box>
@@ -767,8 +769,9 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
                   color={colors.text.alternative}
                 />
                 <Text
-                  variant={TextVariant.BodyMDMedium}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  twClassName="font-medium"
+                  color={TextColor.TextAlternative}
                 >
                   {strings('predict.market_details.market_resulted_to', {
                     outcome: winningOutcomeToken.title,
@@ -783,8 +786,9 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
                   color={colors.text.alternative}
                 />
                 <Text
-                  variant={TextVariant.BodyMDMedium}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  twClassName="font-medium"
+                  color={TextColor.TextAlternative}
                 >
                   {strings('predict.market_details.market_ended_on', {
                     outcome: winningOutcomeToken.title,
@@ -807,8 +811,9 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
                 color={colors.text.default}
               />
               <Text
-                variant={TextVariant.BodyMDMedium}
-                color={TextColor.Default}
+                variant={TextVariant.BodyMd}
+                twClassName="font-medium"
+                color={TextColor.TextDefault}
               >
                 {strings('predict.market_details.waiting_for_final_resolution')}
               </Text>
@@ -847,7 +852,11 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
 
     return (
       <Box twClassName="space-y-4">
-        <Text variant={TextVariant.BodyMDMedium} color={TextColor.Alternative}>
+        <Text
+          variant={TextVariant.BodyMd}
+          twClassName="font-medium"
+          color={TextColor.TextAlternative}
+        >
           {strings('predict.market_details.no_positions_found')}
         </Text>
       </Box>
@@ -873,11 +882,19 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
               size={IconSize.Md}
               color={colors.text.muted}
             />
-            <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+            <Text
+              variant={TextVariant.BodyMd}
+              twClassName="font-medium"
+              color={TextColor.TextDefault}
+            >
               {strings('predict.market_details.volume')}
             </Text>
           </Box>
-          <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+          <Text
+            variant={TextVariant.BodyMd}
+            twClassName="font-medium"
+            color={TextColor.TextDefault}
+          >
             ${formatVolume(market?.outcomes[0].volume || 0)}
           </Text>
         </Box>
@@ -897,11 +914,19 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
               size={IconSize.Md}
               color={colors.text.muted}
             />
-            <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+            <Text
+              variant={TextVariant.BodyMd}
+              twClassName="font-medium"
+              color={TextColor.TextDefault}
+            >
               {strings('predict.market_details.end_date')}
             </Text>
           </Box>
-          <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+          <Text
+            variant={TextVariant.BodyMd}
+            twClassName="font-medium"
+            color={TextColor.TextDefault}
+          >
             {market?.endDate
               ? new Date(market?.endDate).toLocaleDateString()
               : 'N/A'}
@@ -923,7 +948,11 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
               size={IconSize.Md}
               color={colors.text.muted}
             />
-            <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+            <Text
+              variant={TextVariant.BodyMd}
+              twClassName="font-medium"
+              color={TextColor.TextDefault}
+            >
               {strings('predict.market_details.resolution_details')}
             </Text>
           </Box>
@@ -934,8 +963,9 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
           >
             <Pressable onPress={handlePolymarketResolution}>
               <Text
-                variant={TextVariant.BodyMDMedium}
-                color={colors.primary.default}
+                variant={TextVariant.BodyMd}
+                twClassName="font-medium"
+                color={TextColor.PrimaryDefault}
               >
                 Polymarket
               </Text>
@@ -949,7 +979,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
         </Box>
       </Box>
       <Box twClassName="w-full border-t border-muted" />
-      <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+      <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
         {market?.description}
       </Text>
     </Box>
@@ -971,8 +1001,8 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
               onPress={handleClaimPress}
             >
               <Text
-                variant={TextVariant.BodyMDMedium}
-                style={tw.style('text-white')}
+                variant={TextVariant.BodyMd}
+                style={tw.style('text-white font-medium')}
               >
                 {strings('confirm.predict_claim.button_label')}
               </Text>
@@ -999,7 +1029,10 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
                 width={ButtonWidthTypes.Full}
                 style={tw.style('flex-1 bg-success-muted')}
                 label={
-                  <Text style={tw.style('font-bold')} color={TextColor.Success}>
+                  <Text
+                    style={tw.style('font-bold')}
+                    color={TextColor.SuccessDefault}
+                  >
                     {firstOpenOutcome?.tokens[0].title} • {getYesPercentage()}¢
                   </Text>
                 }
@@ -1016,7 +1049,10 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
                 width={ButtonWidthTypes.Full}
                 style={tw.style('flex-1 bg-error-muted')}
                 label={
-                  <Text style={tw.style('font-bold')} color={TextColor.Error}>
+                  <Text
+                    style={tw.style('font-bold')}
+                    color={TextColor.ErrorDefault}
+                  >
                     {firstOpenOutcome?.tokens[1].title} •{' '}
                     {100 - getYesPercentage()}¢
                   </Text>
@@ -1111,15 +1147,16 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
                 twClassName="gap-2"
               >
                 <Text
-                  variant={TextVariant.BodyMDMedium}
-                  color={TextColor.Default}
+                  variant={TextVariant.BodyMd}
+                  twClassName="font-medium"
+                  color={TextColor.TextDefault}
                 >
                   {strings('predict.resolved_outcomes')}
                 </Text>
                 <Box twClassName="px-2 py-0.5 rounded bg-muted">
                   <Text
-                    variant={TextVariant.BodySM}
-                    color={TextColor.Alternative}
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextAlternative}
                   >
                     {closedOutcomes.length}
                   </Text>
@@ -1269,7 +1306,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
           justifyContent={BoxJustifyContent.Center}
           twClassName="gap-1"
         >
-          <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
             {strings('predict.market_details.fee_exemption')}
           </Text>
         </Box>

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.styles.ts
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.styles.ts
@@ -1,6 +1,5 @@
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
-import { fontStyles } from '../../../../../styles/common';
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
@@ -31,7 +30,7 @@ const styleSheet = (params: { theme: Theme }) => {
       lineHeight: 24,
       letterSpacing: 0,
       textAlign: 'center',
-      ...fontStyles.bold,
+      fontWeight: 'bold',
     },
     bottomContainer: {
       flexDirection: 'column',

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
@@ -1,6 +1,9 @@
 import {
   Box,
   ButtonSize as ButtonSizeHero,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
@@ -23,10 +26,6 @@ import Button, {
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
 import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks/useStyles';
 import Engine from '../../../../../core/Engine';
 import { TraceName } from '../../../../../util/trace';
@@ -182,8 +181,9 @@ const PredictSellPreview = () => {
             <Box twClassName="flex-row items-center gap-1">
               <ActivityIndicator size="small" />
               <Text
-                variant={TextVariant.BodyLGMedium}
-                color={TextColor.Inverse}
+                variant={TextVariant.BodyLg}
+                twClassName="font-medium"
+                color={TextColor.PrimaryInverse}
               >
                 {`${strings('predict.order.cashing_out_loading')}`}
               </Text>
@@ -210,7 +210,10 @@ const PredictSellPreview = () => {
         isLoading={isLoading}
         size={ButtonSizeHero.Lg}
       >
-        <Text variant={TextVariant.BodyMDMedium} style={tw.style('text-white')}>
+        <Text
+          variant={TextVariant.BodyMd}
+          style={tw.style('text-white font-medium')}
+        >
           {strings('predict.cash_out')}
         </Text>
       </ButtonHero>
@@ -220,7 +223,7 @@ const PredictSellPreview = () => {
   return (
     <SafeAreaView style={tw.style('flex-1 bg-background-default')}>
       <BottomSheetHeader onClose={() => goBack()}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingMd}>
           {strings('predict.cash_out')}
         </Text>
       </BottomSheetHeader>
@@ -254,13 +257,15 @@ const PredictSellPreview = () => {
             <>
               <Text
                 style={styles.currentValue}
-                variant={TextVariant.BodyMDMedium}
+                variant={TextVariant.BodyMd}
+                twClassName="font-medium"
               >
                 {formatPrice(currentValue, { maximumDecimals: 2 })}
               </Text>
               <Text
-                variant={TextVariant.BodyMDMedium}
-                color={TextColor.Alternative}
+                variant={TextVariant.BodyMd}
+                twClassName="font-medium"
+                color={TextColor.TextAlternative}
               >
                 {strings('predict.at_price_per_share', {
                   size: formatPositionSize(size, {
@@ -272,8 +277,13 @@ const PredictSellPreview = () => {
               </Text>
               <Text
                 style={styles.percentPnl}
-                color={percentPnl > 0 ? TextColor.Success : TextColor.Error}
-                variant={TextVariant.BodyMDMedium}
+                twClassName="font-medium"
+                color={
+                  percentPnl > 0
+                    ? TextColor.SuccessDefault
+                    : TextColor.ErrorDefault
+                }
+                variant={TextVariant.BodyMd}
               >
                 {`${signal}${formatPrice(Math.abs(cashPnl), {
                   maximumDecimals: 4,
@@ -285,8 +295,8 @@ const PredictSellPreview = () => {
         <View style={styles.bottomContainer}>
           {placeOrderError && (
             <Text
-              variant={TextVariant.BodySM}
-              color={TextColor.Error}
+              variant={TextVariant.BodySm}
+              color={TextColor.ErrorDefault}
               style={tw.style('text-center')}
             >
               {placeOrderError}
@@ -297,12 +307,13 @@ const PredictSellPreview = () => {
               <Image source={{ uri: icon }} style={styles.positionIcon} />
             </Box>
             <Box twClassName="flex-col gap-1 flex-1">
-              <Text variant={TextVariant.HeadingSM}>{outcomeTitle}</Text>
+              <Text variant={TextVariant.HeadingSm}>{outcomeTitle}</Text>
               <Text
                 numberOfLines={1}
                 ellipsizeMode="tail"
-                variant={TextVariant.BodySMMedium}
-                color={TextColor.Alternative}
+                variant={TextVariant.BodySm}
+                twClassName="font-medium"
+                color={TextColor.TextAlternative}
               >
                 {outcomeGroupTitle
                   ? strings('predict.cashout_info_multiple', {
@@ -321,7 +332,7 @@ const PredictSellPreview = () => {
           </Box>
           <View style={styles.cashOutButtonContainer}>
             {renderCashOutButton()}
-            <Text variant={TextVariant.BodyXS} style={styles.cashOutButtonText}>
+            <Text variant={TextVariant.BodyXs} style={styles.cashOutButtonText}>
               {strings('predict.cash_out_info')}
             </Text>
           </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Replace Text imports from component-library with @metamask/design-system-react-native
- Update Text variant names to match design system conventions:
  - HeadingMD → HeadingMd, HeadingSM → HeadingSm
  - BodyMDMedium → BodyMd, BodyLGMedium → BodyLg
  - BodySM → BodySm, BodySMMedium → BodySm
  - BodyXS → BodyXs
- Update TextColor enum values to design system tokens:
  - Default → TextDefault
  - Alternative → TextAlternative
  - Success → SuccessDefault
  - Error → ErrorDefault
  - Muted → TextMuted
  - Inverse → PrimaryInverse
- Add twClassName='font-medium' to Text components that previously used Medium variants (BodyMDMedium, BodyLGMedium, BodySMMedium) to preserve font weight
- Remove unused fontStyles import in PredictSellPreview.styles.ts
- Replace fontStyles.bold with fontWeight: 'bold'

Affected components:
- PredictMarketOutcome
- PredictSellPreview
- PredictBuyPreview
- PredictMarketDetails

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-310?atlOrigin=eyJpIjoiOTE5YjJjNmRjOTAzNDU3N2EwZTQwNDcwMjJhMmViZGIiLCJwIjoiaiJ9

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces legacy Text usage with @metamask/design-system-react-native across Predict screens, updating variants/colors and preserving weights, plus minor style cleanup.
> 
> - **UI/Design System Migration**
>   - Replace `component-library` `Text` with `@metamask/design-system-react-native` `Text` across Predict screens.
>   - Update typography variants (e.g., `HeadingMD/SM` → `HeadingMd/Sm`, `Body*Medium` → `Body*` + `font-medium`, `BodyXS/SM/MD/LG` → `BodyXs/Sm/Md/Lg`).
>   - Map color tokens to design system equivalents (`Default` → `TextDefault`, `Alternative` → `TextAlternative`, `Success` → `SuccessDefault`, `Error` → `ErrorDefault`, `Muted` → `TextMuted`, `Inverse` → `PrimaryInverse`).
> - **Components Updated**
>   - `PredictMarketOutcome`: Heading/body/text colors and winner/loser/price labels updated to new tokens and variants.
>   - `PredictBuyPreview`: Header, balance, errors, "to win", CTA labels, and disclaimers migrated to new variants/colors.
>   - `PredictMarketDetails`: Header title, tabs, status/messages, about section, resolved/outcomes chips, footnote text migrated to new variants/colors.
>   - `PredictSellPreview`: Header, cash-out values/PnL, info text, CTA, footnote migrated to new variants/colors.
> - **Styles Cleanup**
>   - `PredictSellPreview.styles.ts`: remove `fontStyles` import and use `fontWeight: 'bold'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b752a3b02f15fd104a99058ff95abfb3d30c225. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->