### PR TITLE
feat: add mUsdTag component to the convert confirmation view

### DIFF
--- a/app/components/UI/Earn/components/MusdTag/MusdTag.test.tsx
+++ b/app/components/UI/Earn/components/MusdTag/MusdTag.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import MusdTag, { MUSD_TAG_SELECTOR } from './MusdTag';
+
+describe('MusdTag', () => {
+  it('renders correctly with amount and default symbol', () => {
+    const { getByTestId, getByText } = renderWithProvider(
+      <MusdTag amount="10" />,
+    );
+    expect(getByTestId(MUSD_TAG_SELECTOR)).toBeDefined();
+    expect(getByText('10 mUSD')).toBeDefined();
+  });
+
+  it('renders correctly with custom symbol', () => {
+    const { getByText } = renderWithProvider(
+      <MusdTag amount="25" symbol="USDC" />,
+    );
+    expect(getByText('25 USDC')).toBeDefined();
+  });
+
+  it('renders without background when showBackground is false', () => {
+    const { getByText } = renderWithProvider(
+      <MusdTag amount="10" showBackground={false} />,
+    );
+    expect(getByText('10 mUSD')).toBeDefined();
+  });
+
+  it('uses custom testID when provided', () => {
+    const customTestID = 'custom-musd-tag';
+    const { getByTestId } = renderWithProvider(
+      <MusdTag amount="50" testID={customTestID} />,
+    );
+    expect(getByTestId(customTestID)).toBeDefined();
+  });
+
+  it('renders correctly with 0 amount', () => {
+    const { getByText } = renderWithProvider(<MusdTag amount="0" />);
+    expect(getByText('0 mUSD')).toBeDefined();
+  });
+
+  it('renders correctly with large amount', () => {
+    const { getByText } = renderWithProvider(<MusdTag amount="1,500" />);
+    expect(getByText('1,500 mUSD')).toBeDefined();
+  });
+});

--- a/app/components/UI/Earn/components/MusdTag/MusdTag.tsx
+++ b/app/components/UI/Earn/components/MusdTag/MusdTag.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import TagBase, {
+  TagSeverity,
+  TagShape,
+} from '../../../../../component-library/base-components/TagBase';
+import { TextVariant } from '../../../../../component-library/components/Texts/Text';
+import { useStyles } from '../../../../../component-library/hooks';
+import { useTheme } from '../../../../../util/theme';
+
+export const MUSD_TAG_SELECTOR = 'musd-tag';
+
+interface MusdTagProps {
+  /**
+   * Amount of mUSD to display
+   */
+  amount: string;
+  /**
+   * Token symbol (defaults to 'mUSD')
+   */
+  symbol?: string;
+  /**
+   * Whether to show the background color
+   * @default true
+   */
+  showBackground?: boolean;
+  /**
+   * Optional test ID for the component
+   */
+  testID?: string;
+}
+
+const createStyles = () =>
+  StyleSheet.create({
+    wrapper: {
+      marginTop: 8,
+      marginBottom: 8,
+    },
+  });
+
+/**
+ * Tag component that displays mUSD amount.
+ * Used in mUSD conversion flow to show the output amount.
+ */
+const MusdTag: React.FC<MusdTagProps> = ({
+  amount,
+  symbol = 'mUSD',
+  showBackground = true,
+  testID,
+}) => {
+  const { colors } = useTheme();
+  const { styles } = useStyles(createStyles, {});
+
+  const tagStyle = {
+    backgroundColor: showBackground ? colors.background.section : 'transparent',
+    paddingHorizontal: 16,
+    paddingTop: 6,
+    paddingBottom: 6,
+  };
+
+  return (
+    <View style={styles.wrapper}>
+      <TagBase
+        shape={TagShape.Pill}
+        includesBorder={false}
+        textProps={{
+          variant: TextVariant.BodySMMedium,
+        }}
+        severity={TagSeverity.Neutral}
+        testID={testID || MUSD_TAG_SELECTOR}
+        gap={6}
+        style={tagStyle}
+      >
+        {`${amount} ${symbol}`}
+      </TagBase>
+    </View>
+  );
+};
+
+export default MusdTag;

--- a/app/components/UI/Earn/components/MusdTag/index.ts
+++ b/app/components/UI/Earn/components/MusdTag/index.ts
@@ -1,0 +1,2 @@
+export { default } from './MusdTag';
+export { MUSD_TAG_SELECTOR } from './MusdTag';

--- a/app/components/UI/Rewards/components/RewardsTag/RewardsTag.test.tsx
+++ b/app/components/UI/Rewards/components/RewardsTag/RewardsTag.test.tsx
@@ -90,4 +90,16 @@ describe('RewardsTag', () => {
 
     expect(getByTestId(customTestID)).toBeDefined();
   });
+
+  it('renders without background when showBackground is false', () => {
+    const { getByText } = render(
+      <RewardsTag points={100} showBackground={false} />,
+    );
+    expect(getByText('100 points')).toBeDefined();
+  });
+
+  it('renders with background by default', () => {
+    const { getByText } = render(<RewardsTag points={100} />);
+    expect(getByText('100 points')).toBeDefined();
+  });
 });

--- a/app/components/UI/Rewards/components/RewardsTag/RewardsTag.tsx
+++ b/app/components/UI/Rewards/components/RewardsTag/RewardsTag.tsx
@@ -34,6 +34,11 @@ interface RewardsTagProps {
    */
   showInfoIcon?: boolean;
   /**
+   * Whether to show the background color
+   * @default true
+   */
+  showBackground?: boolean;
+  /**
    * Background color variant
    * @default RewardsTagBackgroundVariant.Subsection
    */
@@ -64,6 +69,7 @@ const RewardsTag: React.FC<RewardsTagProps> = ({
   points,
   onPress,
   showInfoIcon = false,
+  showBackground = true,
   backgroundVariant = RewardsTagBackgroundVariant.Subsection,
   suffix,
   testID,
@@ -72,10 +78,11 @@ const RewardsTag: React.FC<RewardsTagProps> = ({
   const { colors } = useTheme();
   const { styles } = useStyles(createStyles, {});
 
-  const backgroundColor =
-    backgroundVariant === RewardsTagBackgroundVariant.Muted
+  const backgroundColor = showBackground
+    ? backgroundVariant === RewardsTagBackgroundVariant.Muted
       ? colors.background.muted
-      : colors.background.subsection;
+      : colors.background.subsection
+    : 'transparent';
 
   const tagStyle = {
     backgroundColor,

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -29,8 +29,8 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { useTransactionConfirm } from '../../../hooks/transactions/useTransactionConfirm';
 import { useRewardsAccountOptedIn } from '../../../../../UI/Rewards/hooks/useRewardsAccountOptedIn';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { MUSD_CONVERSION_TRANSACTION_TYPE } from '../../../../../UI/Earn/constants/musd';
 import { REWARDS_TAG_SELECTOR } from '../../../../../UI/Rewards/components/RewardsTag';
+import { MUSD_TAG_SELECTOR } from '../../../../../UI/Earn/components/MusdTag';
 import { useTokenFiatRates } from '../../../hooks/tokens/useTokenFiatRates';
 
 jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe');
@@ -289,7 +289,7 @@ describe('CustomAmountInfo', () => {
   describe('Rewards', () => {
     it('renders RewardsTag for mUSD conversion', () => {
       useTransactionMetadataRequestMock.mockReturnValue({
-        type: MUSD_CONVERSION_TRANSACTION_TYPE,
+        type: TransactionType.musdConversion,
         txParams: { from: '0x123' },
       } as never);
 
@@ -311,13 +311,13 @@ describe('CustomAmountInfo', () => {
 
     it('calculates points correctly for $100', () => {
       useTransactionMetadataRequestMock.mockReturnValue({
-        type: MUSD_CONVERSION_TRANSACTION_TYPE,
+        type: TransactionType.musdConversion,
         txParams: { from: '0x123' },
       } as never);
       useTransactionCustomAmountMock.mockReturnValue({
         amountFiat: '100',
-        amountHuman: '0',
-        amountHumanDebounced: '0',
+        amountHuman: '100',
+        amountHumanDebounced: '100',
         hasInput: true,
         isInputChanged: false,
         updatePendingAmount: noop,
@@ -332,13 +332,13 @@ describe('CustomAmountInfo', () => {
 
     it('calculates points correctly for $199', () => {
       useTransactionMetadataRequestMock.mockReturnValue({
-        type: MUSD_CONVERSION_TRANSACTION_TYPE,
+        type: TransactionType.musdConversion,
         txParams: { from: '0x123' },
       } as never);
       useTransactionCustomAmountMock.mockReturnValue({
         amountFiat: '199',
-        amountHuman: '0',
-        amountHumanDebounced: '0',
+        amountHuman: '199',
+        amountHumanDebounced: '199',
         hasInput: true,
         isInputChanged: false,
         updatePendingAmount: noop,
@@ -353,13 +353,13 @@ describe('CustomAmountInfo', () => {
 
     it('calculates points correctly for $300', () => {
       useTransactionMetadataRequestMock.mockReturnValue({
-        type: MUSD_CONVERSION_TRANSACTION_TYPE,
+        type: TransactionType.musdConversion,
         txParams: { from: '0x123' },
       } as never);
       useTransactionCustomAmountMock.mockReturnValue({
         amountFiat: '300',
-        amountHuman: '0',
-        amountHumanDebounced: '0',
+        amountHuman: '300',
+        amountHumanDebounced: '300',
         hasInput: true,
         isInputChanged: false,
         updatePendingAmount: noop,
@@ -374,7 +374,7 @@ describe('CustomAmountInfo', () => {
 
     it('renders 0 points when amount is empty', () => {
       useTransactionMetadataRequestMock.mockReturnValue({
-        type: MUSD_CONVERSION_TRANSACTION_TYPE,
+        type: TransactionType.musdConversion,
         txParams: { from: '0x123' },
       } as never);
       useTransactionCustomAmountMock.mockReturnValue({
@@ -395,7 +395,7 @@ describe('CustomAmountInfo', () => {
 
     it('opens rewards tooltip when RewardsTag is pressed', () => {
       useTransactionMetadataRequestMock.mockReturnValue({
-        type: MUSD_CONVERSION_TRANSACTION_TYPE,
+        type: TransactionType.musdConversion,
         txParams: { from: '0x123' },
       } as never);
 
@@ -410,6 +410,75 @@ describe('CustomAmountInfo', () => {
       // Note: Modal content isn't testable in React Native tests,
       // but RewardsTooltipBottomSheet has its own comprehensive test coverage
       expect(getByTestId('rewards-tooltip-bottom-sheet')).toBeDefined();
+    });
+  });
+
+  describe('mUSD Tag', () => {
+    it('renders MusdTag for mUSD conversion', () => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        type: TransactionType.musdConversion,
+        txParams: { from: '0x123' },
+        chainId: '0x1',
+      } as never);
+
+      const { getByTestId } = render();
+
+      expect(getByTestId(MUSD_TAG_SELECTOR)).toBeDefined();
+    });
+
+    it('displays correct mUSD amount', () => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        type: TransactionType.musdConversion,
+        txParams: { from: '0x123' },
+        chainId: '0x1',
+      } as never);
+      useTransactionCustomAmountMock.mockReturnValue({
+        amountFiat: '100',
+        amountHuman: '100',
+        amountHumanDebounced: '100',
+        hasInput: true,
+        isInputChanged: false,
+        updatePendingAmount: noop,
+        updatePendingAmountPercentage: noop,
+        updateTokenAmount: noop,
+      });
+
+      const { getByText } = render();
+
+      expect(getByText('100 mUSD')).toBeDefined();
+    });
+
+    it('formats amount with 2 decimal places', () => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        type: TransactionType.musdConversion,
+        txParams: { from: '0x123' },
+        chainId: '0x1',
+      } as never);
+      useTransactionCustomAmountMock.mockReturnValue({
+        amountFiat: '100.5',
+        amountHuman: '100.5',
+        amountHumanDebounced: '100.5',
+        hasInput: true,
+        isInputChanged: false,
+        updatePendingAmount: noop,
+        updatePendingAmountPercentage: noop,
+        updateTokenAmount: noop,
+      });
+
+      const { getByText } = render();
+
+      expect(getByText('100.5 mUSD')).toBeDefined();
+    });
+
+    it('does not render MusdTag for non-mUSD transactions', () => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        type: TransactionType.perpsDeposit,
+        txParams: { from: '0x123' },
+      } as never);
+
+      const { queryByTestId } = render();
+
+      expect(queryByTestId(MUSD_TAG_SELECTOR)).toBeNull();
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change?

We want to add mUsd Tag to the convert confirmation view that will update when input is updated and convert to Musd no matter the curency settings.

2. What is the improvement/solution?

Add an MusdTag component and use it in the confirmation screen when the tx type is an musd conversion
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds an Musd tag component when the conf tx has mUsd conversion type

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-101

## **Manual testing steps**

```gherkin
Feature: add musd tag to convert confirmation view
  Scenario: user clicks convert on a supported token
    Given user routes to the confirmation screen 

    When user enters input
    Then the musd tag should update with that value in mUSd
    Then the rewards tag should update as well according to the amount of mUsd
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/e911f47c-a3ac-48d0-bcca-53f22711d186

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an `mUSD` tag component and integrates it into the mUSD conversion confirmation flow, updates rewards tag background handling and points calculation, and adds comprehensive tests.
> 
> - **UI Components**:
>   - **`Earn/MusdTag`**: New `MusdTag` component with props (`amount`, `symbol`, `showBackground`, `testID`), pill styling, and export via `index.ts`.
>   - **`RewardsTag`**: Adds `showBackground` prop and updates background logic; retains variants; non-pressable/pressable behavior unchanged.
> - **Confirmation View (`custom-amount-info`)**:
>   - Shows `MusdTag` (no background) for `TransactionType.musdConversion`; hides `PayTokenAmount` in this case.
>   - Computes rewards as 5 points per $100 using `amountHuman` (mUSD), renders `RewardsTag` without background.
>   - Uses `limitToMaximumDecimalPlaces(..., 2)` for displayed mUSD amount.
> - **Tests**:
>   - New tests for `MusdTag` rendering, custom symbol, background toggle, and formatting.
>   - Update confirmation tests to use `TransactionType.musdConversion`, validate `MusdTag` presence/amount and rewards points, and add `RewardsTag` background cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ef6df4cbc7233cc753b57bf2671d77e2e2e2b6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->