### PR TITLE
feat: implement burn address validation in address book and contact forms

### DIFF
--- a/app/components/UI/AddToAddressBookWrapper/AddToAddressBookWrapper.tsx
+++ b/app/components/UI/AddToAddressBookWrapper/AddToAddressBookWrapper.tsx
@@ -12,6 +12,7 @@ import { useTheme } from '../../../util/theme';
 import Text from '../../Base/Text';
 import useExistingAddress from '../../hooks/useExistingAddress';
 import ActionModal from '../ActionModal';
+import { LOWER_CASED_BURN_ADDRESSES } from '../../../constants/address';
 
 import createStyles from './styles';
 
@@ -35,7 +36,11 @@ export const AddToAddressBookWrapper = ({
   const [showAddToAddressBook, setShowAddToAddressBook] = useState(false);
   const [alias, setAlias] = useState<string>();
 
-  if (!address || existingContact) {
+  if (
+    !address ||
+    existingContact ||
+    LOWER_CASED_BURN_ADDRESSES.includes(address?.toLowerCase())
+  ) {
     if (defaultNull) {
       return null;
     }
@@ -45,6 +50,10 @@ export const AddToAddressBookWrapper = ({
 
   const onSaveToAddressBook = () => {
     if (!alias) return;
+    // Prevent saving burn addresses to address book
+    if (LOWER_CASED_BURN_ADDRESSES.includes(address?.toLowerCase())) {
+      return;
+    }
     const { AddressBookController } = Engine.context;
     AddressBookController.set(address, alias, chainId);
     setToAddressName?.(alias);

--- a/app/components/Views/Settings/Contacts/ContactForm/index.test.tsx
+++ b/app/components/Views/Settings/Contacts/ContactForm/index.test.tsx
@@ -355,4 +355,66 @@ describe('ContactForm', () => {
     );
     expect(deleteButton).toBeTruthy();
   });
+
+  it('rejects burn address 0x0000000000000000000000000000000000000000', async () => {
+    const validateAddressOrENSMock = jest.requireMock(
+      '../../../../../util/address',
+    ).validateAddressOrENS;
+
+    const burnAddress = '0x0000000000000000000000000000000000000000';
+    validateAddressOrENSMock.mockResolvedValueOnce({
+      addressError: 'Invalid address',
+      toEnsName: null,
+      addressReady: false,
+      toEnsAddress: null,
+      errorContinue: false,
+    });
+
+    const { findByTestId } = renderContactForm();
+
+    const addressInput = await findByTestId(
+      AddContactViewSelectorsIDs.ADDRESS_INPUT,
+    );
+    fireEvent.changeText(addressInput, burnAddress);
+
+    await waitFor(() => {
+      expect(validateAddressOrENSMock).toHaveBeenCalledWith(
+        burnAddress,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+
+  it('rejects burn address 0x000000000000000000000000000000000000dEaD', async () => {
+    const validateAddressOrENSMock = jest.requireMock(
+      '../../../../../util/address',
+    ).validateAddressOrENS;
+
+    const burnAddress = '0x000000000000000000000000000000000000dEaD';
+    validateAddressOrENSMock.mockResolvedValueOnce({
+      addressError: 'Invalid address',
+      toEnsName: null,
+      addressReady: false,
+      toEnsAddress: null,
+      errorContinue: false,
+    });
+
+    const { findByTestId } = renderContactForm();
+
+    const addressInput = await findByTestId(
+      AddContactViewSelectorsIDs.ADDRESS_INPUT,
+    );
+    fireEvent.changeText(addressInput, burnAddress);
+
+    await waitFor(() => {
+      expect(validateAddressOrENSMock).toHaveBeenCalledWith(
+        burnAddress,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
 });

--- a/app/components/Views/confirmations/hooks/alerts/useBurnAddressAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useBurnAddressAlert.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { Alert, Severity } from '../../types/alerts';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { AlertKeys } from '../../constants/alerts';
-import { LOWER_CASED_BURN_ADDRESSES } from '../../utils/send-address-validations';
+import { LOWER_CASED_BURN_ADDRESSES } from '../../../../../constants/address';
 import { strings } from '../../../../../../locales/i18n';
 import {
   useNestedTransactionTransferRecipients,

--- a/app/components/Views/confirmations/hooks/send/useContacts.ts
+++ b/app/components/Views/confirmations/hooks/send/useContacts.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { selectAddressBook } from '../../../../../selectors/addressBookController';
 import { type RecipientType } from '../../components/UI/recipient';
-import { LOWER_CASED_BURN_ADDRESSES } from '../../utils/send-address-validations';
+import { LOWER_CASED_BURN_ADDRESSES } from '../../../../../constants/address';
 import { useSendType } from './useSendType';
 
 export const useContacts = () => {

--- a/app/components/Views/confirmations/utils/send-address-validations.ts
+++ b/app/components/Views/confirmations/utils/send-address-validations.ts
@@ -14,11 +14,7 @@ import {
   isBtcMainnetAddress,
   isTronAddress,
 } from '../../../../core/Multichain/utils';
-
-export const LOWER_CASED_BURN_ADDRESSES = [
-  '0x0000000000000000000000000000000000000000',
-  '0x000000000000000000000000000000000000dead',
-];
+import { LOWER_CASED_BURN_ADDRESSES } from '../../../../constants/address';
 
 export const validateBitcoinAddress = (
   toAddress: string,

--- a/app/constants/address.ts
+++ b/app/constants/address.ts
@@ -1,3 +1,19 @@
 const TEST_ADDRESS = '0x2990079bcdEe240329a520d2444386FC119da21a';
 
 export default TEST_ADDRESS;
+
+/**
+ * List of known burn addresses that should be rejected when adding contacts.
+ * These addresses are commonly used for token burning and should not be saved as contacts.
+ */
+export const BURN_ADDRESSES = [
+  '0x0000000000000000000000000000000000000000',
+  '0x000000000000000000000000000000000000dEaD',
+] as const;
+
+/**
+ * Lower-cased version of burn addresses for case-insensitive comparisons.
+ */
+export const LOWER_CASED_BURN_ADDRESSES = BURN_ADDRESSES.map((addr) =>
+  addr.toLowerCase(),
+) as readonly string[];

--- a/app/util/address/index.test.ts
+++ b/app/util/address/index.test.ts
@@ -24,7 +24,9 @@ import {
   areAddressesEqual,
   toChecksumAddress,
   renderShortAccountName,
+  validateAddressOrENS,
 } from '.';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   mockHDKeyringAddress,
   mockQrKeyringAddress,
@@ -93,6 +95,8 @@ jest.mock('../../selectors/networkController', () => ({
 jest.mock('../../util/ENSUtils', () => ({
   getCachedENSName: jest.fn().mockReturnValue(''),
   isDefaultAccountName: jest.fn().mockReturnValue(false),
+  doENSLookup: jest.fn().mockResolvedValue(null),
+  doENSReverseLookup: jest.fn().mockResolvedValue(null),
 }));
 
 describe('isENS', () => {
@@ -736,5 +740,88 @@ describe('areAddressesEqual', () => {
     it('returns false when comparing Solana address with EVM address', () => {
       expect(areAddressesEqual(solanaAddress, ethAddress1)).toBe(false);
     });
+  });
+});
+
+describe('validateAddressOrENS', () => {
+  const mockAddressBook = {};
+  const mockInternalAccounts: InternalAccount[] = [];
+  const chainId = '0x1' as const;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects burn address 0x0000000000000000000000000000000000000000', async () => {
+    const burnAddress = '0x0000000000000000000000000000000000000000';
+    const result = await validateAddressOrENS(
+      burnAddress,
+      mockAddressBook,
+      mockInternalAccounts,
+      chainId,
+    );
+
+    expect(result.addressError).toBeDefined();
+    expect(result.addressReady).toBe(false);
+    expect(result.addToAddressToAddressBook).toBe(false);
+  });
+
+  it('rejects burn address 0x000000000000000000000000000000000000dEaD', async () => {
+    const burnAddress = '0x000000000000000000000000000000000000dEaD';
+    const result = await validateAddressOrENS(
+      burnAddress,
+      mockAddressBook,
+      mockInternalAccounts,
+      chainId,
+    );
+
+    expect(result.addressError).toBeDefined();
+    expect(result.addressReady).toBe(false);
+    expect(result.addToAddressToAddressBook).toBe(false);
+  });
+
+  it('rejects burn address with different case', async () => {
+    const burnAddress = '0x000000000000000000000000000000000000DEAD';
+    const result = await validateAddressOrENS(
+      burnAddress,
+      mockAddressBook,
+      mockInternalAccounts,
+      chainId,
+    );
+
+    expect(result.addressError).toBeDefined();
+    expect(result.addressReady).toBe(false);
+    expect(result.addToAddressToAddressBook).toBe(false);
+  });
+
+  it('rejects ENS that resolves to burn address', async () => {
+    const { doENSLookup } = jest.requireMock('../../util/ENSUtils');
+    const burnAddress = '0x0000000000000000000000000000000000000000';
+    doENSLookup.mockResolvedValueOnce(burnAddress);
+
+    const result = await validateAddressOrENS(
+      'test.eth',
+      mockAddressBook,
+      mockInternalAccounts,
+      chainId,
+    );
+
+    expect(result.addressError).toBeDefined();
+    expect(result.addressReady).toBe(false);
+    expect(result.addToAddressToAddressBook).toBe(false);
+    expect(doENSLookup).toHaveBeenCalledWith('test.eth', chainId);
+  });
+
+  it('accepts valid non-burn address', async () => {
+    const validAddress = '0x87187657B35F461D0CEEC338D9B8E944A193AFE2';
+    const result = await validateAddressOrENS(
+      validAddress,
+      mockAddressBook,
+      mockInternalAccounts,
+      chainId,
+    );
+
+    expect(result.addressError).toBeFalsy();
+    expect(result.addressReady).toBe(true);
   });
 });

--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -33,6 +33,7 @@ import {
   CONTACT_ALREADY_SAVED,
   SYMBOL_ERROR,
 } from '../../../app/constants/error';
+import { LOWER_CASED_BURN_ADDRESSES } from '../../constants/address';
 import { PROTOCOLS } from '../../constants/deeplinks';
 import TransactionTypes from '../../core/TransactionTypes';
 import { selectChainId } from '../../selectors/networkController';
@@ -646,6 +647,22 @@ export async function validateAddressOrENS(
   let [addressReady, addToAddressToAddressBook] = [false, false];
 
   if (isValidHexAddress(toAccount, { mixedCaseUseChecksum: true })) {
+    // Check if address is a burn address
+    if (LOWER_CASED_BURN_ADDRESSES.includes(toAccount.toLowerCase())) {
+      addressError = strings('transaction.invalid_address');
+      addressReady = false;
+      return {
+        addressError,
+        toEnsName,
+        addressReady,
+        toEnsAddress,
+        addToAddressToAddressBook,
+        toAddressName,
+        errorContinue,
+        confusableCollection,
+      };
+    }
+
     const contactAlreadySaved = checkIfAddressAlreadySaved(
       toAccount,
       addressBook,
@@ -717,6 +734,22 @@ export async function validateAddressOrENS(
     );
 
     if (resolvedAddress) {
+      // Check if resolved ENS address is a burn address
+      if (LOWER_CASED_BURN_ADDRESSES.includes(resolvedAddress.toLowerCase())) {
+        addressError = strings('transaction.invalid_address');
+        addressReady = false;
+        return {
+          addressError,
+          toEnsName,
+          addressReady,
+          toEnsAddress,
+          addToAddressToAddressBook,
+          toAddressName,
+          errorContinue,
+          confusableCollection,
+        };
+      }
+
       if (!contactAlreadySaved) {
         addToAddressToAddressBook = true;
       } else {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Prevents users from adding burn addresses to their contacts. Previously, adding a burn address to contacts bypassed address validation in the send flow, which could lead to accidental sends to burn addresses.

**What is the reason for the change?**

Users were adding burn addresses (0x0000000000000000000000000000000000000000 and 0x000000000000000000000000000000000000dEaD) to contacts
Contacts skip some address validation in the send flow
This allowed accidental sends to burn addresses

**What is the improvement/solution?**

Added validation to reject both burn addresses when adding contacts
Validation applies to:

- Direct address input in the ContactForm
- ENS names that resolve to burn addresses
- Quick add via AddToAddressBookWrapper
- Centralized burn address constants in app/constants/address.ts for consistency
- Aligned mobile behavior with the extension (both addresses are now blocked)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where users could accidentally add burn addresses to their contacts, which could lead to sending funds to unrecoverable addresses

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-191

## **Manual testing steps**

```gherkin
Feature: Prevent adding burn addresses to contacts

  Scenario: User tries to add zero address as contact

    Given the user is on the Contacts screen
    When user taps "Add Contact" and enters "0x0000000000000000000000000000000000000000" as the address
    Then user sees an "Invalid address" error message
    And the contact is not saved

  Scenario: User tries to add dead address as contact

    Given the user is on the Contacts screen
    When user taps "Add Contact" and enters "0x000000000000000000000000000000000000dEaD" as the address
    Then user sees an "Invalid address" error message
    And the contact is not saved
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="391" height="832" alt="Screenshot 2025-11-27 at 11 51 34" src="https://github.com/user-attachments/assets/964ac1fd-864f-4f30-88dc-5899d0e4a9c6" />

<!-- [screenshots/recordings] -->

### **After**
<img width="398" height="824" alt="Screenshot 2025-11-27 at 11 45 17" src="https://github.com/user-attachments/assets/695a9d6e-585e-4632-a3ef-e0f9c648baf1" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Blocks known burn addresses across contact add flows and send validations, and centralizes burn address constants with comprehensive tests.
> 
> - **Validation/Logic**:
>   - `util/address/validateAddressOrENS`: Rejects burn addresses and ENS resolving to burn; prevents suggesting to add them to address book.
>   - `confirmations/utils/send-address-validations`: Uses centralized `LOWER_CASED_BURN_ADDRESSES`; `validateHexAddress` rejects burn addresses.
> - **UI/Flows**:
>   - `UI/AddToAddressBookWrapper`: Skips/blocks quick-add for burn addresses and prevents saving them.
>   - `confirmations/hooks/send/useContacts`: Filters burn addresses from EVM contacts list.
>   - `confirmations/hooks/alerts/useBurnAddressAlert`: Updated to use centralized constants.
> - **Constants**:
>   - Added `app/constants/address.ts` with `BURN_ADDRESSES` and `LOWER_CASED_BURN_ADDRESSES` for shared use.
> - **Tests**:
>   - `Settings/Contacts/ContactForm/index.test.tsx`: Ensures burn addresses trigger validation and are not saved.
>   - `util/address/index.test.ts`: Tests rejection of burn addresses (direct and via ENS) and acceptance of valid addresses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5a168bdbd326d4aedd602c7e18c9aee87a92d2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->