### PR TITLE
feat: rewards hold musd way to earn cp-7.61.0 

### DIFF
--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
@@ -25,6 +25,8 @@ import {
   SwapBridgeNavigationLocation,
   useSwapBridgeNavigation,
 } from '../../../../../Bridge/hooks/useSwapBridgeNavigation';
+import { useRampNavigation } from '../../../../../Ramp/hooks/useRampNavigation';
+import { toCaipAssetType } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import { selectIsFirstTimePerpsUser } from '../../../../../Perps/selectors/perpsController';
 import {
@@ -272,26 +274,16 @@ export const WaysToEarn = () => {
     location: SwapBridgeNavigationLocation.Rewards,
     sourcePage: 'rewards_overview',
   });
-  const musdSourceToken = useMemo(() => {
+
+  // Create CAIP-19 assetId for mUSD to use with buy page
+  const musdAssetId = useMemo(() => {
     const chainId = NETWORKS_CHAIN_ID.LINEA_MAINNET;
     const address = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
     const decimalChainId = getDecimalChainId(chainId);
-    const image = `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/${decimalChainId}/erc20/${address}.png`;
-
-    return {
-      address,
-      chainId,
-      symbol: 'MUSD',
-      name: 'MUSD',
-      decimals: 6,
-      image,
-    };
+    return toCaipAssetType('eip155', decimalChainId, 'erc20', address);
   }, []);
-  const { goToSwaps: goToSwapsForHoldMusd } = useSwapBridgeNavigation({
-    location: SwapBridgeNavigationLocation.Rewards,
-    sourcePage: 'rewards_overview',
-    sourceToken: musdSourceToken,
-  });
+
+  const { goToBuy } = useRampNavigation();
 
   const goToPerps = useCallback(() => {
     if (isFirstTimePerpsUser) {
@@ -337,7 +329,7 @@ export const WaysToEarn = () => {
         Linking.openURL('https://go.metamask.io/turtle-musd');
         break;
       case WayToEarnType.HOLD_MUSD:
-        goToSwapsForHoldMusd();
+        goToBuy({ assetId: musdAssetId });
         break;
     }
   };

--- a/app/components/hooks/useFeatureFlag.ts
+++ b/app/components/hooks/useFeatureFlag.ts
@@ -6,6 +6,7 @@ export enum FeatureFlagNames {
   otaUpdatesEnabled = 'otaUpdatesEnabled',
   rewardsEnableCardSpend = 'rewardsEnableCardSpend',
   rewardsEnableMusdDeposit = 'rewardsEnableMusdDeposit',
+  rewardsEnableMusdHolding = 'rewardsEnableMusdHolding',
   cardFeature = 'cardFeature', //remote config
   sampleFeatureCounterEnabled = 'sampleFeatureCounterEnabled',
   bridgeConfigV2 = 'bridgeConfigV2', //remote config

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6998,6 +6998,16 @@
           "description": "Earn points on every $100 mUSD you deposit.",
           "cta_label": "Deposit mUSD"
         }
+      },
+      "hold_musd": {
+        "title": "Hold mUSD",
+        "description": "2 points per $100 held",
+        "sheet": {
+          "title": "Hold mUSD",
+          "points": "2 points per $100",
+          "description": "Earn points on every $100 mUSD you hold.",
+          "cta_label": "Buy mUSD"
+        }
       }
     },
     "referral": {


### PR DESCRIPTION
## **Description**

This PR makes it so that, depending on the relevant featureflag, the hold musd ways to earn tile/card will render on the rewards dashboard. When clicking/pressing it a bottom sheet will open with information. In that bottom sheet, if the cta is clicked/pressed, the user navigates to the buy flow and the token to buy is preset to MUSD on Linea.

## **Changelog**

CHANGELOG entry: feat: rewards hold musd ways to earn

## **Screenshots/Recordings**

### **After**

<img width="628" height="736" alt="Screenshot-2025-11-27-13:59:41" src="https://github.com/user-attachments/assets/81947968-5ad2-4b56-b7ba-1335eaebce3e" />

<img width="663" height="377" alt="Screenshot-2025-11-27-14:00:06" src="https://github.com/user-attachments/assets/8d611243-ac4f-4539-9d8a-793c4c3eb318" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a feature‑flagged “Hold mUSD” earn option that opens a bottom sheet and routes to buy mUSD on Linea via Ramp using a CAIP-19 assetId, with supporting strings and tests.
> 
> - **Rewards UI (`WaysToEarn`)**
>   - Add `WayToEarnType.HOLD_MUSD` tile, bottom-sheet content, and CTA handling.
>   - CTA uses `useRampNavigation().goToBuy` with CAIP-19 `assetId` for mUSD on Linea (built via `NETWORKS_CHAIN_ID`, `getDecimalChainId`, `toCaipAssetType`).
>   - Gate rendering with `FeatureFlagNames.rewardsEnableMusdHolding`; include filtering and modal wiring.
>   - Minor: use `useMemo` for computed `musdAssetId`.
> - **Feature Flags**
>   - Introduce `rewardsEnableMusdHolding` in `FeatureFlagNames`.
> - **Localization**
>   - Add `rewards.ways_to_earn.hold_musd.*` strings (title, descriptions, sheet, CTA).
> - **Tests**
>   - Expand `WaysToEarn.test.tsx` with mocks for Ramp/navigation/utils and assertions for Hold mUSD visibility, modal, and correct `assetId`; verify integration with Swap/Bridge hook and metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b07c2000fc30da789c9ad6ef1e6dea0643641fae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->