### PR TITLE
chore: Add Cursor issue analysis as a GitHub workflow

### DIFF
--- a/.github/cursorPrompts/issue-analysis.md
+++ b/.github/cursorPrompts/issue-analysis.md
@@ -1,0 +1,8 @@
+@cursor Analyze this MetaMask issue and provide:
+
+1. **Problem**: What's broken (2-3 sentences)
+2. **Root Cause**: 1-2 likely causes based on evidence
+3. **Target Repo(s)**: Which repo needs the fix (this repo/core/transaction-controller/other controllers in the core repo)
+4. **Solutions**: 2-3 approaches with pros/cons, recommend the best one
+
+If a solution is clear, suggest a code diff (highlight with + and - what have changed) that would resolve the issue, but do not open or create a pull request.

--- a/.github/workflows/cursor-issue-analysis.yml
+++ b/.github/workflows/cursor-issue-analysis.yml
@@ -21,13 +21,13 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const comments = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number
             });
 
-            const hasCursorComment = comments.data.some(comment => 
+            const hasCursorComment = comments.some(comment => 
               comment.body.trim().startsWith('@cursor')
             );
 

--- a/.github/workflows/cursor-issue-analysis.yml
+++ b/.github/workflows/cursor-issue-analysis.yml
@@ -1,0 +1,58 @@
+name: Cursor Issue Analysis
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  analyze-issue:
+    runs-on: ubuntu-latest
+    # Check if issue has team-confirmations AND (Sev1-high OR Sev2-normal)
+    if: |
+      contains(github.event.issue.labels.*.name, 'team-confirmations') &&
+      (contains(github.event.issue.labels.*.name, 'Sev1-high') || contains(github.event.issue.labels.*.name, 'Sev2-normal'))
+    steps:
+      - name: Check for existing @cursor comment
+        id: check-comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const hasCursorComment = comments.data.some(comment => 
+              comment.body.trim().startsWith('@cursor')
+            );
+
+            core.setOutput('exists', hasCursorComment);
+            return hasCursorComment;
+
+      - name: Add @cursor analysis comment
+        if: steps.check-comment.outputs.exists != 'true'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const body = [
+              '@cursor Analyze this MetaMask issue and provide:',
+              '',
+              '1. **Problem**: What\'s broken (2-3 sentences)',
+              '2. **Root Cause**: 1-2 likely causes based on evidence',
+              '3. **Target Repo(s)**: Which repo needs the fix (this repo/core/transaction-controller/other controllers in the core repo)',
+              '4. **Solutions**: 2-3 approaches with pros/cons, recommend the best one',
+              '',
+              'If a solution is clear, suggest a code diff (highlight with + and - what have changed) that would resolve the issue, but do not open or create a pull request.'
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });

--- a/.github/workflows/cursor-issue-analysis.yml
+++ b/.github/workflows/cursor-issue-analysis.yml
@@ -34,21 +34,20 @@ jobs:
             core.setOutput('exists', hasCursorComment);
             return hasCursorComment;
 
+      - name: Checkout repository
+        if: steps.check-comment.outputs.exists != 'true'
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/cursorPrompts
+          sparse-checkout-cone-mode: false
+
       - name: Add @cursor analysis comment
         if: steps.check-comment.outputs.exists != 'true'
         uses: actions/github-script@v6
         with:
           script: |
-            const body = [
-              '@cursor Analyze this MetaMask issue and provide:',
-              '',
-              '1. **Problem**: What\'s broken (2-3 sentences)',
-              '2. **Root Cause**: 1-2 likely causes based on evidence',
-              '3. **Target Repo(s)**: Which repo needs the fix (this repo/core/transaction-controller/other controllers in the core repo)',
-              '4. **Solutions**: 2-3 approaches with pros/cons, recommend the best one',
-              '',
-              'If a solution is clear, suggest a code diff (highlight with + and - what have changed) that would resolve the issue, but do not open or create a pull request.'
-            ].join('\n');
+            const fs = require('fs');
+            const body = fs.readFileSync('.github/cursorPrompts/issue-analysis.md', 'utf8');
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## **Description**
Adds Cursor issue analysis as a GitHub workflow.

When there is a new issue that's either (sev1 or sev2) and it's assigned to `team-confirmations`, it will trigger a Cursor issue analysis.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a GitHub Actions workflow that auto-posts a Cursor issue analysis template on qualifying Sev1/Sev2 `team-confirmations` issues without duplicating comments.
> 
> - **CI/CD**:
>   - **New Workflow**: Adds `/.github/workflows/cursor-issue-analysis.yml` to auto-comment an issue analysis when an issue is opened/labeled with `team-confirmations` and either `Sev1-high` or `Sev2-normal`.
>     - Skips if an existing `@cursor` comment is found.
>     - Sparse-checkouts `.github/cursorPrompts` and posts the contents of `issue-analysis.md` as the comment.
> - **Prompts**:
>   - Adds `.github/cursorPrompts/issue-analysis.md` containing the `@cursor` analysis template.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06933b32ae07a955ad423528783ab579ccc91dfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->