### PR TITLE
chore: cp-7.61.0 add Icon as ButtonVariant type to support button icons for Toast component

### DIFF
--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.tsx
@@ -69,7 +69,7 @@ const ListItemMultiSelectButton: React.FC<ListItemMultiSelectButtonProps> = ({
             iconName={buttonIcon}
             iconColor={IconColor.Default}
             testID={buttonProps?.buttonTestId || BUTTON_TEST_ID}
-            onPress={buttonProps?.onButtonClick}
+            onPress={buttonProps?.onButtonClick as () => void}
             accessibilityRole="button"
           />
         </View>

--- a/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.tsx
@@ -62,7 +62,7 @@ const ListItemMultiSelectWithMenuButton: React.FC<
             iconName={buttonIcon}
             iconColor={IconColor.Default}
             testID={buttonProps?.buttonTestId || BUTTON_TEST_ID}
-            onPress={buttonProps?.onButtonClick}
+            onPress={buttonProps?.onButtonClick as () => void}
             accessibilityRole="button"
           />
         </View>

--- a/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.types.ts
+++ b/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.types.ts
@@ -40,6 +40,10 @@ export interface ButtonIconProps extends TouchableOpacityProps {
    * Optional param to disable the button.
    */
   isDisabled?: boolean;
+  /**
+   * Function to trigger when pressing the button.
+   */
+  onPress?: () => void;
 }
 
 /**

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -31,6 +31,8 @@ import Button, { ButtonVariants } from '../Buttons/Button';
 
 // Internal dependencies.
 import {
+  ButtonIconVariant,
+  ToastCloseButtonOptions,
   ToastDescriptionOptions,
   ToastLabelOptions,
   ToastLinkButtonOptions,
@@ -40,9 +42,9 @@ import {
 } from './Toast.types';
 import styleSheet from './Toast.styles';
 import { ToastSelectorsIDs } from '../../../../e2e/selectors/wallet/ToastModal.selectors';
-import { ButtonProps } from '../Buttons/Button/Button.types';
 import { TAB_BAR_HEIGHT } from '../Navigation/TabBar/TabBar.constants';
 import { useStyles } from '../../hooks';
+import ButtonIcon from '../Buttons/ButtonIcon';
 
 const visibilityDuration = 2750;
 const animationDuration = 250;
@@ -165,15 +167,25 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
       />
     );
 
-  const renderCloseButton = (closeButtonOptions?: ButtonProps) => (
-    <Button
-      variant={ButtonVariants.Primary}
-      onPress={() => closeButtonOptions?.onPress()}
-      label={closeButtonOptions?.label}
-      endIconName={closeButtonOptions?.endIconName}
-      style={closeButtonOptions?.style}
-    />
-  );
+  const renderCloseButton = (closeButtonOptions?: ToastCloseButtonOptions) => {
+    if (closeButtonOptions?.variant === ButtonIconVariant.Icon) {
+      return (
+        <ButtonIcon
+          onPress={() => closeButtonOptions?.onPress?.()}
+          iconName={closeButtonOptions?.iconName}
+        />
+      );
+    }
+    return (
+      <Button
+        variant={ButtonVariants.Primary}
+        onPress={() => closeButtonOptions?.onPress()}
+        label={closeButtonOptions?.label}
+        endIconName={closeButtonOptions?.endIconName}
+        style={closeButtonOptions?.style}
+      />
+    );
+  };
 
   const renderAvatar = () => {
     switch (toastOptions?.variant) {

--- a/app/component-library/components/Toast/Toast.types.ts
+++ b/app/component-library/components/Toast/Toast.types.ts
@@ -4,6 +4,7 @@ import { ImageSourcePropType } from 'react-native';
 // External Dependencies.
 import { AvatarAccountType } from '../Avatars/Avatar/variants/AvatarAccount';
 import { ButtonProps } from '../Buttons/Button/Button.types';
+import { ButtonIconProps } from '../Buttons/ButtonIcon/ButtonIcon.types';
 import { IconName } from '../Icons/Icon';
 import { ReactElement } from 'react';
 
@@ -49,9 +50,17 @@ interface BaseToastVariants {
   labelOptions: ToastLabelOptions;
   descriptionOptions?: ToastDescriptionOptions;
   linkButtonOptions?: ToastLinkButtonOptions;
-  closeButtonOptions?: ButtonProps;
+  closeButtonOptions?: ToastCloseButtonOptions;
   startAccessory?: ReactElement;
   customBottomOffset?: number;
+}
+
+export type ToastCloseButtonOptions =
+  | ButtonProps
+  | (ButtonIconProps & { variant: ButtonIconVariant });
+
+export enum ButtonIconVariant {
+  Icon = 'Icon',
 }
 
 /**

--- a/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.test.tsx
@@ -143,6 +143,9 @@ jest.mock('../../../../../component-library/components/Icons/Icon', () => {
     IconSize: {
       Md: 'Md',
     },
+    IconColor: {
+      Default: 'Default',
+    },
   };
 });
 

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -193,6 +193,7 @@ import { useRewardsIntroModal } from '../../UI/Rewards/hooks/useRewardsIntroModa
 import NftGrid from '../../UI/NftGrid/NftGrid';
 import { AssetPollingProvider } from '../../hooks/AssetPolling/AssetPollingProvider';
 import { selectDisplayCardButton } from '../../../core/redux/slices/card';
+import { ButtonIconVariant } from '../../../component-library/components/Toast/Toast.types';
 
 const createStyles = ({ colors }: Theme) =>
   RNStyleSheet.create({
@@ -951,8 +952,8 @@ const Wallet = ({
         },
       ],
       closeButtonOptions: {
-        label: 'x', // Hacky solution as there isn't a close icon button variant
-        variant: ButtonVariants.Primary,
+        variant: ButtonIconVariant.Icon,
+        iconName: IconName.Close,
         onPress: () => {
           storePna25Acknowledged();
           trackEvent(


### PR DESCRIPTION
## **Description**

Adds ButtonIcon as an option for Toast close button, preserving all other existing Toast close button behaviour (which currently defaults to Button.Primary components). Uses the ButtonIcon for the PNA25 toast.

## **Changelog**

CHANGELOG entry: update Toast close button to support ButtonIcon component

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-713

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Toast close button was hardcoded to Primary:
<img width="397" height="817" alt="image" src="https://github.com/user-attachments/assets/6dc84874-57a5-49d2-9182-0a7ba6a5cc96" />


### **After**

Toast close button supports Icon:
<img width="387" height="766" alt="image" src="https://github.com/user-attachments/assets/e3d31d84-409f-4cc6-b585-7298bad98c6a" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ButtonIcon-based close button support to Toast and switches PNA25 toast to use an icon close button, plus minor typing updates.
> 
> - **Toast**:
>   - Add `ToastCloseButtonOptions` union allowing `ButtonIcon` via `ButtonIconVariant.Icon` in `Toast.types`.
>   - Update `Toast.tsx` to render `ButtonIcon` when `closeButtonOptions.variant` is `Icon`; otherwise render standard `Button`.
> - **Wallet**:
>   - Switch PNA25 toast `closeButtonOptions` to icon close button (`IconName.Close`) and import `ButtonIconVariant`.
> - **ButtonIcon**:
>   - Add `onPress?: () => void` to `ButtonIconProps`.
> - **List Items**:
>   - Type fixes: cast `onPress` handlers to `() => void` in `ListItemMultiSelectButton` and `ListItemMultiSelectWithMenuButton`.
> - **Tests**:
>   - Extend Icon mock to include `IconColor.Default` in `TrendingTokenNetworkBottomSheet.test.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df89f425544270f2e548823323954c10e80cb670. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->