### PR TITLE
chore: add PNA25 toast metrics

### DIFF
--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -955,6 +955,14 @@ const Wallet = ({
         variant: ButtonVariants.Primary,
         onPress: () => {
           storePna25Acknowledged();
+          trackEvent(
+            createEventBuilder(MetaMetricsEvents.TOAST_DISPLAYED)
+              .addProperties({
+                toast_name: 'pna25',
+                closed: true,
+              })
+              .build(),
+          );
           currentToast?.closeToast();
         },
       },
@@ -968,7 +976,22 @@ const Wallet = ({
     });
 
     pna25ToastShownRef.current = true;
-  }, [shouldShowPna25Toast, storePna25Acknowledged, currentToast]);
+
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.TOAST_DISPLAYED)
+        .addProperties({
+          toast_name: 'pna25',
+          closed: false,
+        })
+        .build(),
+    );
+  }, [
+    shouldShowPna25Toast,
+    storePna25Acknowledged,
+    currentToast,
+    trackEvent,
+    createEventBuilder,
+  ]);
 
   /**
    * Network onboarding state

--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -299,6 +299,7 @@ enum EVENT_NAME {
   SEND_FLOW = 'Send Flow',
   SEND = 'Send',
   DAPP_INTERACTIONS = 'Dapp Interactions',
+  TOAST_DISPLAYED = 'Toast Displayed',
 
   // Send Flow
   SEND_ASSET_SELECTED = 'Send Asset Selected',
@@ -1491,6 +1492,9 @@ const events = {
   // QR Scanner
   QR_SCANNER_OPENED: generateOpt(EVENT_NAME.QR_SCANNER_OPENED),
   QR_SCANNED: generateOpt(EVENT_NAME.QR_SCANNED),
+
+  // Toast
+  TOAST_DISPLAYED: generateOpt(EVENT_NAME.TOAST_DISPLAYED),
 };
 
 /**


### PR DESCRIPTION
## **Description**

Adds the ToastDisplayed metric when a) the user sees the toast and b) when the user closes the toast.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-725

## **Manual testing steps**

Run locally and see the following events on view and close:

```
TRACK event saved {"event": "Toast Displayed", "properties": {"closed": false, "toast_name": "pna25"}, "type": "track"}
```

```
TRACK event saved {"event": "Toast Displayed", "properties": {"closed": true, "toast_name": "pna25"}, "type": "track"}
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tracks PNA25 toast impressions and closes via new Toast Displayed analytics event.
> 
> - **Analytics**:
>   - Add `TOAST_DISPLAYED` to `EVENT_NAME` and export `MetaMetricsEvents.TOAST_DISPLAYED`.
> - **Wallet (PNA25 toast)**:
>   - Track toast shown with `MetaMetricsEvents.TOAST_DISPLAYED` and properties `{ toast_name: 'pna25', closed: false }`.
>   - Track toast closed in close handler with `{ toast_name: 'pna25', closed: true }`.
>   - Update effect dependencies to include `trackEvent` and `createEventBuilder`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e2d6c105860e6f4cf98483524936b5f5df91b1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->