### PR TITLE
fix(perps): cp-7.61.0 invalid transactions refresh

### DIFF
--- a/app/components/UI/Perps/components/PerpsTransactionsSkeleton/PerpsTransactionsSkeleton.tsx
+++ b/app/components/UI/Perps/components/PerpsTransactionsSkeleton/PerpsTransactionsSkeleton.tsx
@@ -20,8 +20,14 @@ const PerpsTransactionsSkeleton: React.FC<PerpsTransactionsSkeletonProps> = ({
 }) => {
   const { styles } = useStyles(styleSheet, {});
 
-  const renderSkeletonTransactionItem = () => (
-    <View style={styles.transactionItem} key="skeleton-transaction">
+  const renderSkeletonTransactionItem = (
+    sectionIndex: number,
+    itemIndex: number,
+  ) => (
+    <View
+      style={styles.transactionItem}
+      key={`skeleton-transaction-${sectionIndex}-${itemIndex}`}
+    >
       {/* Token logo skeleton */}
       <View style={styles.tokenIconContainer}>
         <Skeleton width={36} height={36} style={styles.tokenIcon} />
@@ -52,7 +58,9 @@ const PerpsTransactionsSkeleton: React.FC<PerpsTransactionsSkeletonProps> = ({
       </View>
 
       {/* Transaction items skeleton */}
-      {Array.from({ length: 3 }, () => renderSkeletonTransactionItem())}
+      {Array.from({ length: 3 }, (_, itemIndex) =>
+        renderSkeletonTransactionItem(sectionIndex, itemIndex),
+      )}
     </View>
   );
 

--- a/app/components/UI/Perps/constants/transactionsHistoryConfig.ts
+++ b/app/components/UI/Perps/constants/transactionsHistoryConfig.ts
@@ -5,4 +5,11 @@ export const PERPS_TRANSACTIONS_HISTORY_CONSTANTS = {
   FLASH_LIST_DRAW_DISTANCE: 200,
   FLASH_LIST_SCROLL_EVENT_THROTTLE: 16,
   LIST_ITEM_SELECTOR_OPACITY: 0.7,
+  /**
+   * Default number of days to look back for funding history.
+   * HyperLiquid API requires a startTime and returns max 500 records.
+   * Using 365 days ensures most users see their complete recent history.
+   * Can be increased if users need older funding data.
+   */
+  DEFAULT_FUNDING_HISTORY_DAYS: 365,
 } as const;

--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
@@ -26,6 +26,7 @@ import {
   TP_SL_CONFIG,
   WITHDRAWAL_CONSTANTS,
 } from '../../constants/perpsConfig';
+import { PERPS_TRANSACTIONS_HISTORY_CONSTANTS } from '../../constants/transactionsHistoryConfig';
 import { HyperLiquidClientService } from '../../services/HyperLiquidClientService';
 import { HyperLiquidSubscriptionService } from '../../services/HyperLiquidSubscriptionService';
 import { HyperLiquidWalletService } from '../../services/HyperLiquidWalletService';
@@ -3982,9 +3983,19 @@ export class HyperLiquidProvider implements IPerpsProvider {
         params?.accountId,
       );
 
+      // HyperLiquid API requires startTime to be a number (not undefined)
+      // Default to configured days ago to get recent funding payments
+      // Using 0 (epoch) would return oldest 500 records, missing latest payments
+      const defaultStartTime =
+        Date.now() -
+        PERPS_TRANSACTIONS_HISTORY_CONSTANTS.DEFAULT_FUNDING_HISTORY_DAYS *
+          24 *
+          60 *
+          60 *
+          1000;
       const rawFunding = await infoClient.userFunding({
         user: userAddress,
-        startTime: params?.startTime || 0,
+        startTime: params?.startTime ?? defaultStartTime,
         endTime: params?.endTime,
       });
 

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
@@ -169,7 +169,7 @@ describe('usePerpsTransactionHistory', () => {
       userHistory: mockUserHistory,
       isLoading: false,
       error: null,
-      refetch: jest.fn().mockResolvedValue(undefined),
+      refetch: jest.fn().mockResolvedValue(mockUserHistory),
     });
 
     // Mock transform functions
@@ -182,13 +182,19 @@ describe('usePerpsTransactionHistory', () => {
   });
 
   describe('initial state', () => {
-    it('returns initial state correctly', () => {
+    it('returns initial state correctly', async () => {
       const { result } = renderHook(() => usePerpsTransactionHistory());
 
       expect(result.current.transactions).toEqual([]);
-      expect(result.current.isLoading).toBe(true); // Hook immediately starts fetching
+      // Initial loading state is false, becomes true when fetch starts
+      expect(result.current.isLoading).toBe(false);
       expect(result.current.error).toBeNull();
       expect(typeof result.current.refetch).toBe('function');
+
+      // Wait for initial fetch to complete
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
     });
 
     it('skips initial fetch when skipInitialFetch is true', () => {
@@ -217,9 +223,10 @@ describe('usePerpsTransactionHistory', () => {
       expect(mockProvider.getOrders).toHaveBeenCalledWith({
         accountId: undefined,
       });
+      // startTime default is handled in HyperLiquidProvider, not here
       expect(mockProvider.getFunding).toHaveBeenCalledWith({
         accountId: undefined,
-        startTime: 0,
+        startTime: undefined,
         endTime: undefined,
       });
 
@@ -301,9 +308,10 @@ describe('usePerpsTransactionHistory', () => {
       expect(mockProvider.getOrders).toHaveBeenCalledWith({
         accountId: undefined,
       });
+      // startTime default is handled in HyperLiquidProvider, not here
       expect(mockProvider.getFunding).toHaveBeenCalledWith({
         accountId: undefined,
-        startTime: 0,
+        startTime: undefined,
         endTime: undefined,
       });
       expect(mockUseUserHistory).toHaveBeenCalledWith({

--- a/app/components/UI/Perps/hooks/useUserHistory.ts
+++ b/app/components/UI/Perps/hooks/useUserHistory.ts
@@ -66,11 +66,6 @@ export const useUserHistory = ({
     }
   }, [startTime, endTime, accountId]);
 
-  // NOTE: Auto-fetch removed intentionally (TAT-2057)
-  // usePerpsTransactionHistory now controls the fetch flow to ensure
-  // user history is fetched BEFORE fetchAllTransactions reads from it.
-  // This prevents race conditions that caused alternating data on refresh.
-
   return {
     userHistory,
     isLoading,

--- a/app/components/UI/Perps/hooks/useUserHistory.ts
+++ b/app/components/UI/Perps/hooks/useUserHistory.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import Engine from '../../../../core/Engine';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { UserHistoryItem, GetUserHistoryParams } from '../controllers/types';
@@ -14,7 +14,7 @@ interface UseUserHistoryResult {
   userHistory: UserHistoryItem[];
   isLoading: boolean;
   error: string | null;
-  refetch: () => Promise<void>;
+  refetch: () => Promise<UserHistoryItem[]>;
 }
 
 /**
@@ -29,7 +29,7 @@ export const useUserHistory = ({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchUserHistory = useCallback(async () => {
+  const fetchUserHistory = useCallback(async (): Promise<UserHistoryItem[]> => {
     try {
       setIsLoading(true);
       setError(null);
@@ -53,20 +53,23 @@ export const useUserHistory = ({
 
       DevLogger.log('User history fetched successfully:', history);
       setUserHistory(history);
+      return history;
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : 'Failed to fetch user history';
       DevLogger.log('Error fetching user history:', errorMessage);
       setError(errorMessage);
       setUserHistory([]);
+      return [];
     } finally {
       setIsLoading(false);
     }
   }, [startTime, endTime, accountId]);
 
-  useEffect(() => {
-    fetchUserHistory();
-  }, [fetchUserHistory]);
+  // NOTE: Auto-fetch removed intentionally (TAT-2057)
+  // usePerpsTransactionHistory now controls the fetch flow to ensure
+  // user history is fetched BEFORE fetchAllTransactions reads from it.
+  // This prevents race conditions that caused alternating data on refresh.
 
   return {
     userHistory,


### PR DESCRIPTION
## **Description**

Fixes a bug where funding payments in the Activity/Transactions view would alternate between showing different date ranges on each refresh (e.g., Nov 5th � Oct 31st � Nov 5th).

**Root cause:** Multiple race conditions in the transaction history fetching logic:

1. **Dependency array issue:** The `fetchAllTransactions` callback had `userHistory` (an array) in its dependency array, causing callback recreation on every fetch.

2. **Initial fetch race condition:** Both `useUserHistory` and `usePerpsTransactionHistory` had their own `useEffect` hooks that triggered fetches on mount. These ran in parallel, so `fetchAllTransactions` would read an empty `userHistoryRef.current` before user history completed.

3. **Epoch time fallback:** When `startTime` was undefined, it defaulted to `0` (epoch time 1970), causing the HyperLiquid API to return the oldest 500 records instead of the newest.

**Solution:**
1. Use a `useRef` to hold the latest `userHistory` value, removing it from the callback's dependency array.
2. Remove the auto-fetch `useEffect` from `useUserHistory` - let the parent hook control the fetch flow.
3. Use an `initialFetchDone` ref to ensure initial fetch runs once, and use `refetch()` for the initial load. The `refetch()` function fetches user history first, updates the ref, then fetches all transactions - ensuring sequential data flow.
4. Replace the `startTime || 0` fallback with a configurable constant (`DEFAULT_FUNDING_HISTORY_DAYS = 365`).
5. Fixed duplicate React key warning in `PerpsTransactionsSkeleton` by adding section/item indices to keys.

## **Changelog**

CHANGELOG entry: Fixed funding payments alternating between different date ranges on refresh in Activity view

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2057

## **Manual testing steps**

```gherkin
Feature: Funding payments display consistency

  Scenario: user refreshes Activity view multiple times
    Given user has funding payment history in their account
    And user navigates to the Activity/Transactions view
    And user selects the "Funding" tab

    When user refreshes the page multiple times (pull-to-refresh)
    Then the same funding payments should be displayed consistently
    And the latest funding payments should always be visible
    And the data should not alternate between different date ranges
```

## **Screenshots/Recordings**

### **Before**

Data alternates between Nov 5th and Oct 31st on each refresh due to race conditions in the useCallback dependency array.

### **After**

Data remains consistent across refreshes, always showing the latest funding payments.

https://github.com/user-attachments/assets/cc252246-7518-497c-934f-2315648b27ee


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
