### PR TITLE
fix: opt in for rewards when no active season cp-7.61.0 

### DIFF
--- a/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
@@ -171,6 +171,7 @@ const OnboardingIntroStep: React.FC<{
     // Show geo error modal if geo check failed
     if (
       optinAllowedForGeoError &&
+      optinAllowedForGeo !== null &&
       !optinAllowedForGeo &&
       !optinAllowedForGeoLoading &&
       !subscriptionId
@@ -183,8 +184,8 @@ const OnboardingIntroStep: React.FC<{
       return false;
     }
 
-    // Check for geo restrictions
-    if (!optinAllowedForGeo) {
+    // Check for geo restrictions - only if geo metadata has been fetched
+    if (optinAllowedForGeo !== null && !optinAllowedForGeo) {
       showErrorModal(
         'rewards.onboarding.not_supported_region_title',
         'rewards.onboarding.not_supported_region_description',
@@ -414,7 +415,10 @@ const OnboardingIntroStep: React.FC<{
           {renderActions()}
         </ImageBackground>
       ) : (
-        <OnboardingNoActiveSeasonStep canContinue={canContinue} />
+        <OnboardingNoActiveSeasonStep
+          canContinue={canContinue}
+          geoLoading={optinAllowedForGeoLoading}
+        />
       )}
     </Box>
   );

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
@@ -88,21 +88,20 @@ const OnboardingIntroStep: React.FC<{
   const candidateSubscriptionId = useSelector(selectCandidateSubscriptionId);
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
 
-  useEffect(() => {
-    const fetchHasActiveSeason = async () => {
-      try {
-        const result = await Engine.controllerMessenger.call(
-          'RewardsController:hasActiveSeason',
-        );
-        setHasActiveSeason(result);
-      } catch {
-        setHasActiveSeason(false);
-      }
-    };
-    if (!subscriptionId) {
-      fetchHasActiveSeason();
+  const fetchHasActiveSeason = useCallback(async () => {
+    try {
+      const result = await Engine.controllerMessenger.call(
+        'RewardsController:hasActiveSeason',
+      );
+      setHasActiveSeason(result);
+    } catch {
+      setHasActiveSeason(false);
     }
-  }, [subscriptionId]);
+  }, []);
+
+  useEffect(() => {
+    fetchHasActiveSeason();
+  }, [fetchHasActiveSeason]);
 
   // Computed state
   const candidateSubscriptionIdLoading =

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Image, ImageBackground, Platform, Text as RNText } from 'react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
@@ -42,6 +48,7 @@ import Device from '../../../../../util/device';
 import { REWARDS_GTM_MODAL_SHOWN } from '../../../../../constants/storage';
 import storageWrapper from '../../../../../store/storage-wrapper';
 import { REWARDS_VIEW_SELECTORS } from '../../Views/RewardsView.constants';
+import OnboardingNoActiveSeasonStep from './OnboardingNoActiveSeasonStep';
 
 /**
  * OnboardingIntroStep Component
@@ -59,6 +66,7 @@ const OnboardingIntroStep: React.FC<{
   const dispatch = useDispatch();
   const tw = useTailwind();
   const isLargeDevice = useMemo(() => Device.isLargeDevice(), []);
+  const [hasActiveSeason, setHasActiveSeason] = useState<boolean | null>(null);
 
   const setHasSeenRewardsIntroModal = useCallback(async () => {
     await storageWrapper.setItem(REWARDS_GTM_MODAL_SHOWN, 'true');
@@ -79,6 +87,22 @@ const OnboardingIntroStep: React.FC<{
   const optinAllowedForGeoError = useSelector(selectOptinAllowedForGeoError);
   const candidateSubscriptionId = useSelector(selectCandidateSubscriptionId);
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
+
+  useEffect(() => {
+    const fetchHasActiveSeason = async () => {
+      try {
+        const result = await Engine.controllerMessenger.call(
+          'RewardsController:hasActiveSeason',
+        );
+        setHasActiveSeason(result);
+      } catch {
+        setHasActiveSeason(false);
+      }
+    };
+    if (!subscriptionId) {
+      fetchHasActiveSeason();
+    }
+  }, [subscriptionId]);
 
   // Computed state
   const candidateSubscriptionIdLoading =
@@ -144,10 +168,7 @@ const OnboardingIntroStep: React.FC<{
     [navigation],
   );
 
-  /**
-   * Handles the confirm/continue button press
-   */
-  const handleNext = useCallback(async () => {
+  const canContinue = useCallback(() => {
     // Show geo error modal if geo check failed
     if (
       optinAllowedForGeoError &&
@@ -160,7 +181,7 @@ const OnboardingIntroStep: React.FC<{
         'rewards.onboarding.geo_check_fail_description',
         fetchGeoRewardsMetadata,
       );
-      return;
+      return false;
     }
 
     // Check for geo restrictions
@@ -169,7 +190,7 @@ const OnboardingIntroStep: React.FC<{
         'rewards.onboarding.not_supported_region_title',
         'rewards.onboarding.not_supported_region_description',
       );
-      return;
+      return false;
     }
 
     // Check for hardware account restrictions for default account associated with group.
@@ -182,7 +203,7 @@ const OnboardingIntroStep: React.FC<{
         'rewards.onboarding.not_supported_hardware_account_title',
         'rewards.onboarding.not_supported_hardware_account_description',
       );
-      return;
+      return false;
     }
 
     // Check if any account in the active account group is supported for opt-in
@@ -202,24 +223,34 @@ const OnboardingIntroStep: React.FC<{
         'rewards.onboarding.not_supported_account_type_title',
         'rewards.onboarding.not_supported_account_type_description',
       );
+      return false;
+    }
+
+    return true;
+  }, [
+    optinAllowedForGeoError,
+    optinAllowedForGeo,
+    optinAllowedForGeoLoading,
+    subscriptionId,
+    accountGroupAccounts,
+    showRetryErrorModal,
+    fetchGeoRewardsMetadata,
+    showErrorModal,
+  ]);
+
+  /**
+   * Handles the confirm/continue button press
+   */
+  const handleNext = useCallback(async () => {
+    // Show geo error modal if geo check failed
+    if (!canContinue()) {
       return;
     }
 
     // Proceed to next onboarding step
     dispatch(setOnboardingActiveStep(OnboardingStep.STEP_2));
     navigation.navigate(Routes.REWARDS_ONBOARDING_1);
-  }, [
-    dispatch,
-    navigation,
-    optinAllowedForGeo,
-    optinAllowedForGeoError,
-    optinAllowedForGeoLoading,
-    subscriptionId,
-    showErrorModal,
-    showRetryErrorModal,
-    fetchGeoRewardsMetadata,
-    accountGroupAccounts,
-  ]);
+  }, [dispatch, navigation, canContinue]);
 
   /**
    * Handles the skip button press
@@ -355,29 +386,37 @@ const OnboardingIntroStep: React.FC<{
     </Box>
   );
 
-  if (candidateSubscriptionIdLoading || !!subscriptionId) {
+  if (
+    candidateSubscriptionIdLoading ||
+    !!subscriptionId ||
+    hasActiveSeason === null
+  ) {
     return <Skeleton width="100%" height="100%" />;
   }
 
   return (
     <Box twClassName="min-h-full" testID="onboarding-intro-container">
-      <ImageBackground
-        source={introBg}
-        style={tw.style(`flex-1 px-4 pt-8 ${isLargeDevice ? 'pb-8' : ''}`)}
-        resizeMode="cover"
-      >
-        {/* Spacer */}
-        {isLargeDevice && <Box twClassName="flex-basis-[10%]" />}
+      {hasActiveSeason ? (
+        <ImageBackground
+          source={introBg}
+          style={tw.style(`flex-1 px-4 pt-8 ${isLargeDevice ? 'pb-8' : ''}`)}
+          resizeMode="cover"
+        >
+          {/* Spacer */}
+          {isLargeDevice && <Box twClassName="flex-basis-[10%]" />}
 
-        {/* Title Section */}
-        {renderTitle()}
+          {/* Title Section */}
+          {renderTitle()}
 
-        {/* Image Section */}
-        {renderImage()}
+          {/* Image Section */}
+          {renderImage()}
 
-        {/* Actions Section */}
-        {renderActions()}
-      </ImageBackground>
+          {/* Actions Section */}
+          {renderActions()}
+        </ImageBackground>
+      ) : (
+        <OnboardingNoActiveSeasonStep canContinue={canContinue} />
+      )}
     </Box>
   );
 };

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
@@ -171,7 +171,6 @@ const OnboardingIntroStep: React.FC<{
     // Show geo error modal if geo check failed
     if (
       optinAllowedForGeoError &&
-      optinAllowedForGeo !== null &&
       !optinAllowedForGeo &&
       !optinAllowedForGeoLoading &&
       !subscriptionId

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingNoActiveSeasonStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingNoActiveSeasonStep.tsx
@@ -1,28 +1,19 @@
 import React, { useCallback } from 'react';
-import { Image, Linking, useWindowDimensions } from 'react-native';
+import { Image, useWindowDimensions } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useOptin } from '../../hooks/useOptIn';
-import {
-  Box,
-  Text,
-  TextVariant,
-  BoxAlignItems,
-  BoxFlexDirection,
-} from '@metamask/design-system-react-native';
+import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
 import step1Img from '../../../../../images/rewards/rewards-onboarding-step1.png';
 import Step1BgImg from '../../../../../images/rewards/rewards-onboarding-step1-bg.svg';
 import { strings } from '../../../../../../locales/i18n';
 import OnboardingStepComponent from './OnboardingStep';
 import { selectRewardsSubscriptionId } from '../../../../../selectors/rewards';
 import RewardsErrorBanner from '../RewardsErrorBanner';
-import {
-  REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
-  REWARDS_ONBOARD_TERMS_URL,
-} from './constants';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useTheme } from '../../../../../util/theme';
+import RewardsLegalDisclaimer from './RewardsLegalDisclaimer';
 
 export interface OnboardingNoActiveSeasonStepProps {
   canContinue: () => boolean;
@@ -79,52 +70,22 @@ const OnboardingNoActiveSeasonStep: React.FC<
     </Box>
   );
 
-  const renderLegalDisclaimer = () => {
-    const openTermsOfUse = () => {
-      Linking.openURL(REWARDS_ONBOARD_TERMS_URL);
-    };
-
-    const openLearnMore = () => {
-      Linking.openURL(REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL);
-    };
-
-    return (
-      <Box twClassName="w-full flex-row mt-4">
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="justify-center flex-wrap gap-2"
-        >
-          <Text
-            variant={TextVariant.BodySm}
-            twClassName="text-alternative text-center"
-          >
-            {strings('rewards.onboarding.no_active_season.legal_disclaimer_1')}{' '}
-            <Text
-              variant={TextVariant.BodySm}
-              twClassName="text-primary-default"
-              onPress={openTermsOfUse}
-            >
-              {strings(
-                'rewards.onboarding.no_active_season.legal_disclaimer_2',
-              )}
-            </Text>
-            {strings('rewards.onboarding.no_active_season.legal_disclaimer_3')}{' '}
-            <Text
-              variant={TextVariant.BodySm}
-              twClassName="text-primary-default"
-              onPress={openLearnMore}
-            >
-              {strings(
-                'rewards.onboarding.no_active_season.legal_disclaimer_4',
-              )}
-            </Text>
-            .{' '}
-          </Text>
-        </Box>
-      </Box>
-    );
-  };
+  const renderLegalDisclaimer = () => (
+    <RewardsLegalDisclaimer
+      disclaimerPart1={strings(
+        'rewards.onboarding.no_active_season.legal_disclaimer_1',
+      )}
+      disclaimerPart2={strings(
+        'rewards.onboarding.no_active_season.legal_disclaimer_2',
+      )}
+      disclaimerPart3={strings(
+        'rewards.onboarding.no_active_season.legal_disclaimer_3',
+      )}
+      disclaimerPart4={strings(
+        'rewards.onboarding.no_active_season.legal_disclaimer_4',
+      )}
+    />
+  );
 
   const renderStepImage = () => (
     <>

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingNoActiveSeasonStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingNoActiveSeasonStep.tsx
@@ -1,0 +1,181 @@
+import React, { useCallback } from 'react';
+import { Image, Linking, useWindowDimensions } from 'react-native';
+import { useSelector } from 'react-redux';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { useOptin } from '../../hooks/useOptIn';
+import {
+  Box,
+  Text,
+  TextVariant,
+  BoxAlignItems,
+  BoxFlexDirection,
+} from '@metamask/design-system-react-native';
+import step1Img from '../../../../../images/rewards/rewards-onboarding-step1.png';
+import Step1BgImg from '../../../../../images/rewards/rewards-onboarding-step1-bg.svg';
+import { strings } from '../../../../../../locales/i18n';
+import OnboardingStepComponent from './OnboardingStep';
+import { selectRewardsSubscriptionId } from '../../../../../selectors/rewards';
+import RewardsErrorBanner from '../RewardsErrorBanner';
+import {
+  REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
+  REWARDS_ONBOARD_TERMS_URL,
+} from './constants';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import Routes from '../../../../../constants/navigation/Routes';
+import { useTheme } from '../../../../../util/theme';
+
+export interface OnboardingNoActiveSeasonStepProps {
+  canContinue: () => boolean;
+}
+
+/**
+ * OnboardingNoActiveSeasonStep Component
+ *
+ * Displays a sign-up form when there is no active rewards season.
+ * Allows users to sign up for rewards without referral code validation.
+ */
+const OnboardingNoActiveSeasonStep: React.FC<
+  OnboardingNoActiveSeasonStepProps
+> = ({ canContinue }) => {
+  const tw = useTailwind();
+  const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const { colors } = useTheme();
+  const navigation = useNavigation();
+  const { width: screenWidth, height: screenHeight } = useWindowDimensions();
+  const { optin, optinError, optinLoading } = useOptin();
+
+  const handleNext = useCallback(() => {
+    if (!canContinue()) {
+      return;
+    }
+
+    optin({});
+  }, [optin, canContinue]);
+
+  const renderStepInfo = () => (
+    <Box twClassName="flex-col gap-2 min-h-40">
+      {/* Opt in error message */}
+      {optinError && (
+        <RewardsErrorBanner
+          title={strings('rewards.optin_error.title')}
+          description={strings('rewards.optin_error.description')}
+        />
+      )}
+
+      {/* Title and Description */}
+      <Box twClassName="w-full gap-4">
+        <Text variant={TextVariant.HeadingLg} twClassName="text-center">
+          {strings('rewards.onboarding.no_active_season.title')}
+        </Text>
+
+        <Text
+          variant={TextVariant.BodyMd}
+          twClassName="text-center text-alternative"
+        >
+          {strings('rewards.onboarding.no_active_season.description')}
+        </Text>
+      </Box>
+    </Box>
+  );
+
+  const renderLegalDisclaimer = () => {
+    const openTermsOfUse = () => {
+      Linking.openURL(REWARDS_ONBOARD_TERMS_URL);
+    };
+
+    const openLearnMore = () => {
+      Linking.openURL(REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL);
+    };
+
+    return (
+      <Box twClassName="w-full flex-row mt-4">
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="justify-center flex-wrap gap-2"
+        >
+          <Text
+            variant={TextVariant.BodySm}
+            twClassName="text-alternative text-center"
+          >
+            {strings('rewards.onboarding.no_active_season.legal_disclaimer_1')}{' '}
+            <Text
+              variant={TextVariant.BodySm}
+              twClassName="text-primary-default"
+              onPress={openTermsOfUse}
+            >
+              {strings(
+                'rewards.onboarding.no_active_season.legal_disclaimer_2',
+              )}
+            </Text>
+            {strings('rewards.onboarding.no_active_season.legal_disclaimer_3')}{' '}
+            <Text
+              variant={TextVariant.BodySm}
+              twClassName="text-primary-default"
+              onPress={openLearnMore}
+            >
+              {strings(
+                'rewards.onboarding.no_active_season.legal_disclaimer_4',
+              )}
+            </Text>
+            .{' '}
+          </Text>
+        </Box>
+      </Box>
+    );
+  };
+
+  const renderStepImage = () => (
+    <>
+      <Step1BgImg
+        name="rewards-onboarding-step1-bg"
+        fill={colors.background.muted}
+        style={tw.style('absolute')}
+        width={screenWidth}
+        height={screenHeight}
+      />
+
+      <Image
+        source={step1Img}
+        style={tw.style('h-[75%] z-10')}
+        testID="step-1-image"
+        resizeMode="contain"
+      />
+    </>
+  );
+
+  const onNextLoadingText = optinLoading
+    ? strings('rewards.onboarding.no_active_season.sign_up_loading')
+    : '';
+
+  const onNextDisabled = !!subscriptionId;
+
+  /**
+   * Auto-redirect to dashboard if user is already opted in
+   */
+  useFocusEffect(
+    useCallback(() => {
+      if (subscriptionId) {
+        navigation.navigate(Routes.REWARDS_DASHBOARD);
+      }
+    }, [subscriptionId, navigation]),
+  );
+
+  return (
+    <OnboardingStepComponent
+      currentStep={4}
+      onNext={handleNext}
+      onNextLoading={optinLoading}
+      onNextLoadingText={onNextLoadingText}
+      onNextDisabled={onNextDisabled}
+      nextButtonText={strings('rewards.onboarding.no_active_season.sign_up')}
+      renderStepImage={renderStepImage}
+      renderStepInfo={renderStepInfo}
+      nextButtonAlternative={renderLegalDisclaimer}
+      disableSwipe
+      showProgressIndicator={false}
+    />
+  );
+};
+
+export default OnboardingNoActiveSeasonStep;

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingNoActiveSeasonStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingNoActiveSeasonStep.tsx
@@ -26,6 +26,7 @@ import { useTheme } from '../../../../../util/theme';
 
 export interface OnboardingNoActiveSeasonStepProps {
   canContinue: () => boolean;
+  geoLoading?: boolean;
 }
 
 /**
@@ -36,7 +37,7 @@ export interface OnboardingNoActiveSeasonStepProps {
  */
 const OnboardingNoActiveSeasonStep: React.FC<
   OnboardingNoActiveSeasonStepProps
-> = ({ canContinue }) => {
+> = ({ canContinue, geoLoading = false }) => {
   const tw = useTailwind();
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
   const { colors } = useTheme();
@@ -144,9 +145,19 @@ const OnboardingNoActiveSeasonStep: React.FC<
     </>
   );
 
-  const onNextLoadingText = optinLoading
-    ? strings('rewards.onboarding.no_active_season.sign_up_loading')
-    : '';
+  const isLoading = optinLoading || geoLoading;
+  let onNextLoadingText = '';
+  if (isLoading) {
+    if (optinLoading) {
+      onNextLoadingText = strings(
+        'rewards.onboarding.no_active_season.sign_up_loading',
+      );
+    } else {
+      onNextLoadingText = strings(
+        'rewards.onboarding.intro_confirm_geo_loading',
+      );
+    }
+  }
 
   const onNextDisabled = !!subscriptionId;
 
@@ -165,7 +176,7 @@ const OnboardingNoActiveSeasonStep: React.FC<
     <OnboardingStepComponent
       currentStep={4}
       onNext={handleNext}
-      onNextLoading={optinLoading}
+      onNextLoading={isLoading}
       onNextLoadingText={onNextLoadingText}
       onNextDisabled={onNextDisabled}
       nextButtonText={strings('rewards.onboarding.no_active_season.sign_up')}

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingStep.tsx
@@ -28,6 +28,7 @@ import { REWARDS_VIEW_SELECTORS } from '../../Views/RewardsView.constants';
 interface OnboardingStepProps {
   // Progress indicator props
   currentStep: number;
+  showProgressIndicator?: boolean;
 
   // Navigation handlers
   onNext: () => void;
@@ -52,6 +53,7 @@ interface OnboardingStepProps {
 
 const OnboardingStepComponent: React.FC<OnboardingStepProps> = ({
   currentStep,
+  showProgressIndicator = true,
   onNext,
   onPrevious,
   onSkip,
@@ -118,11 +120,13 @@ const OnboardingStepComponent: React.FC<OnboardingStepProps> = ({
           />
         </Box>
 
-        <ProgressIndicator
-          totalSteps={4}
-          currentStep={currentStep}
-          variant="bars"
-        />
+        {showProgressIndicator && (
+          <ProgressIndicator
+            totalSteps={4}
+            currentStep={currentStep}
+            variant="bars"
+          />
+        )}
       </Box>
       <Box twClassName="flex-col flex-1 justify-between items-center">
         {/* Only render image container if renderStepImage is provided */}

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingStep4.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingStep4.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Image, ActivityIndicator, Linking } from 'react-native';
+import { Image, ActivityIndicator } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useOptin } from '../../hooks/useOptIn';
@@ -9,7 +9,6 @@ import {
   Text,
   TextVariant,
   BoxAlignItems,
-  BoxFlexDirection,
   IconSize,
   Icon,
   IconName,
@@ -25,12 +24,9 @@ import OnboardingStepComponent from './OnboardingStep';
 import { selectRewardsSubscriptionId } from '../../../../../selectors/rewards';
 import { selectOnboardingReferralCode } from '../../../../../reducers/rewards/selectors';
 import RewardsErrorBanner from '../RewardsErrorBanner';
-import {
-  REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
-  REWARDS_ONBOARD_TERMS_URL,
-} from './constants';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
+import RewardsLegalDisclaimer from './RewardsLegalDisclaimer';
 
 const OnboardingStep4: React.FC = () => {
   const tw = useTailwind();
@@ -170,48 +166,14 @@ const OnboardingStep4: React.FC = () => {
     </Box>
   );
 
-  const renderLegalDisclaimer = () => {
-    const openTermsOfUse = () => {
-      Linking.openURL(REWARDS_ONBOARD_TERMS_URL);
-    };
-
-    const openLearnMore = () => {
-      Linking.openURL(REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL);
-    };
-
-    return (
-      <Box twClassName="w-full flex-row mt-4">
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="justify-center flex-wrap gap-2"
-        >
-          <Text
-            variant={TextVariant.BodySm}
-            twClassName="text-alternative text-center"
-          >
-            {strings('rewards.onboarding.step4_legal_disclaimer_1')}{' '}
-            <Text
-              variant={TextVariant.BodySm}
-              twClassName="text-primary-default"
-              onPress={openTermsOfUse}
-            >
-              {strings('rewards.onboarding.step4_legal_disclaimer_2')}
-            </Text>
-            {strings('rewards.onboarding.step4_legal_disclaimer_3')}{' '}
-            <Text
-              variant={TextVariant.BodySm}
-              twClassName="text-primary-default"
-              onPress={openLearnMore}
-            >
-              {strings('rewards.onboarding.step4_legal_disclaimer_4')}
-            </Text>
-            .{' '}
-          </Text>
-        </Box>
-      </Box>
-    );
-  };
+  const renderLegalDisclaimer = () => (
+    <RewardsLegalDisclaimer
+      disclaimerPart1={strings('rewards.onboarding.step4_legal_disclaimer_1')}
+      disclaimerPart2={strings('rewards.onboarding.step4_legal_disclaimer_2')}
+      disclaimerPart3={strings('rewards.onboarding.step4_legal_disclaimer_3')}
+      disclaimerPart4={strings('rewards.onboarding.step4_legal_disclaimer_4')}
+    />
+  );
 
   let onNextLoadingText = '';
   if (optinLoading) {

--- a/app/components/UI/Rewards/components/Onboarding/RewardsLegalDisclaimer.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/RewardsLegalDisclaimer.test.tsx
@@ -1,0 +1,281 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { Linking } from 'react-native';
+import RewardsLegalDisclaimer from './RewardsLegalDisclaimer';
+import {
+  REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
+  REWARDS_ONBOARD_TERMS_URL,
+} from './constants';
+
+// Mock Linking
+jest.mock('react-native', () => {
+  const actual = jest.requireActual('react-native');
+  return {
+    ...actual,
+    Linking: {
+      openURL: jest.fn(),
+    },
+  };
+});
+
+const mockLinkingOpenURL = Linking.openURL as jest.MockedFunction<
+  typeof Linking.openURL
+>;
+
+// Mock design system components
+jest.mock('@metamask/design-system-react-native', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    Box: function MockBox({
+      children,
+      testID,
+      twClassName,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+      twClassName?: string;
+      [key: string]: unknown;
+    }) {
+      const ReactActual = jest.requireActual('react');
+      return ReactActual.createElement(View, { testID, ...props }, children);
+    },
+    Text: function MockText({
+      children,
+      variant,
+      twClassName,
+      onPress,
+      testID,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      variant?: string;
+      twClassName?: string;
+      onPress?: () => void;
+      testID?: string;
+      [key: string]: unknown;
+    }) {
+      const ReactActual = jest.requireActual('react');
+      return ReactActual.createElement(
+        Text,
+        { testID, onPress, ...props },
+        children,
+      );
+    },
+    TextVariant: {
+      BodySm: 'BodySm',
+    },
+    BoxFlexDirection: {
+      Row: 'row',
+    },
+    BoxAlignItems: {
+      Center: 'center',
+    },
+  };
+});
+
+// Mock useTailwind hook
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({
+    style: jest.fn((styles) => (typeof styles === 'string' ? {} : styles)),
+  }),
+}));
+
+describe('RewardsLegalDisclaimer', () => {
+  const defaultProps = {
+    disclaimerPart1: 'By continuing, you agree to the',
+    disclaimerPart2: 'Terms of Use',
+    disclaimerPart3: 'and',
+    disclaimerPart4: 'Learn More',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders container with testID', () => {
+      const { getByTestId } = render(
+        <RewardsLegalDisclaimer {...defaultProps} />,
+      );
+
+      expect(
+        getByTestId('rewards-legal-disclaimer-container'),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders content box with testID', () => {
+      const { getByTestId } = render(
+        <RewardsLegalDisclaimer {...defaultProps} />,
+      );
+
+      expect(getByTestId('rewards-legal-disclaimer-content')).toBeOnTheScreen();
+    });
+
+    it('renders main text element with testID', () => {
+      const { getByTestId } = render(
+        <RewardsLegalDisclaimer {...defaultProps} />,
+      );
+
+      expect(getByTestId('rewards-legal-disclaimer-text')).toBeOnTheScreen();
+    });
+
+    it('renders disclaimer part1 with testID and text', () => {
+      const { getByTestId } = render(
+        <RewardsLegalDisclaimer {...defaultProps} />,
+      );
+
+      const part1 = getByTestId('rewards-legal-disclaimer-part1');
+
+      expect(part1).toBeOnTheScreen();
+      expect(part1).toHaveTextContent(defaultProps.disclaimerPart1);
+    });
+
+    it('renders terms link with testID and text', () => {
+      const { getByTestId } = render(
+        <RewardsLegalDisclaimer {...defaultProps} />,
+      );
+
+      const termsLink = getByTestId('rewards-legal-disclaimer-terms-link');
+
+      expect(termsLink).toBeOnTheScreen();
+      expect(termsLink).toHaveTextContent(defaultProps.disclaimerPart2);
+    });
+
+    it('renders disclaimer part3 with testID and text', () => {
+      const { getByTestId } = render(
+        <RewardsLegalDisclaimer {...defaultProps} />,
+      );
+
+      const part3 = getByTestId('rewards-legal-disclaimer-part3');
+
+      expect(part3).toBeOnTheScreen();
+      expect(part3).toHaveTextContent(defaultProps.disclaimerPart3);
+    });
+
+    it('renders learn more link with testID and text', () => {
+      const { getByTestId } = render(
+        <RewardsLegalDisclaimer {...defaultProps} />,
+      );
+
+      const learnMoreLink = getByTestId(
+        'rewards-legal-disclaimer-learn-more-link',
+      );
+
+      expect(learnMoreLink).toBeOnTheScreen();
+      expect(learnMoreLink).toHaveTextContent(defaultProps.disclaimerPart4);
+    });
+  });
+
+  describe('Link interactions', () => {
+    it('opens terms URL when terms link is pressed', () => {
+      const { getByTestId } = render(
+        <RewardsLegalDisclaimer {...defaultProps} />,
+      );
+
+      const termsLink = getByTestId('rewards-legal-disclaimer-terms-link');
+
+      fireEvent.press(termsLink);
+
+      expect(mockLinkingOpenURL).toHaveBeenCalledTimes(1);
+      expect(mockLinkingOpenURL).toHaveBeenCalledWith(
+        REWARDS_ONBOARD_TERMS_URL,
+      );
+    });
+
+    it('opens learn more URL when learn more link is pressed', () => {
+      const { getByTestId } = render(
+        <RewardsLegalDisclaimer {...defaultProps} />,
+      );
+
+      const learnMoreLink = getByTestId(
+        'rewards-legal-disclaimer-learn-more-link',
+      );
+
+      fireEvent.press(learnMoreLink);
+
+      expect(mockLinkingOpenURL).toHaveBeenCalledTimes(1);
+      expect(mockLinkingOpenURL).toHaveBeenCalledWith(
+        REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
+      );
+    });
+
+    it('opens both links when both are pressed', () => {
+      const { getByTestId } = render(
+        <RewardsLegalDisclaimer {...defaultProps} />,
+      );
+
+      const termsLink = getByTestId('rewards-legal-disclaimer-terms-link');
+      const learnMoreLink = getByTestId(
+        'rewards-legal-disclaimer-learn-more-link',
+      );
+
+      fireEvent.press(termsLink);
+      fireEvent.press(learnMoreLink);
+
+      expect(mockLinkingOpenURL).toHaveBeenCalledTimes(2);
+      expect(mockLinkingOpenURL).toHaveBeenNthCalledWith(
+        1,
+        REWARDS_ONBOARD_TERMS_URL,
+      );
+      expect(mockLinkingOpenURL).toHaveBeenNthCalledWith(
+        2,
+        REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
+      );
+    });
+  });
+
+  describe('Text content', () => {
+    it('displays all text parts in correct order', () => {
+      const customProps = {
+        disclaimerPart1: 'Custom part 1',
+        disclaimerPart2: 'Custom Terms',
+        disclaimerPart3: 'Custom part 3',
+        disclaimerPart4: 'Custom Learn More',
+      };
+
+      const { getByTestId } = render(
+        <RewardsLegalDisclaimer {...customProps} />,
+      );
+
+      expect(getByTestId('rewards-legal-disclaimer-part1')).toHaveTextContent(
+        customProps.disclaimerPart1,
+      );
+      expect(
+        getByTestId('rewards-legal-disclaimer-terms-link'),
+      ).toHaveTextContent(customProps.disclaimerPart2);
+      expect(getByTestId('rewards-legal-disclaimer-part3')).toHaveTextContent(
+        customProps.disclaimerPart3,
+      );
+      expect(
+        getByTestId('rewards-legal-disclaimer-learn-more-link'),
+      ).toHaveTextContent(customProps.disclaimerPart4);
+    });
+
+    it('handles empty string text parts', () => {
+      const emptyProps = {
+        disclaimerPart1: '',
+        disclaimerPart2: '',
+        disclaimerPart3: '',
+        disclaimerPart4: '',
+      };
+
+      const { getByTestId } = render(
+        <RewardsLegalDisclaimer {...emptyProps} />,
+      );
+
+      expect(getByTestId('rewards-legal-disclaimer-part1')).toHaveTextContent(
+        '',
+      );
+      expect(
+        getByTestId('rewards-legal-disclaimer-terms-link'),
+      ).toHaveTextContent('');
+      expect(getByTestId('rewards-legal-disclaimer-part3')).toHaveTextContent(
+        '',
+      );
+      expect(
+        getByTestId('rewards-legal-disclaimer-learn-more-link'),
+      ).toHaveTextContent('');
+    });
+  });
+});

--- a/app/components/UI/Rewards/components/Onboarding/RewardsLegalDisclaimer.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/RewardsLegalDisclaimer.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { Linking } from 'react-native';
+import {
+  Box,
+  Text,
+  TextVariant,
+  BoxAlignItems,
+  BoxFlexDirection,
+} from '@metamask/design-system-react-native';
+import {
+  REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
+  REWARDS_ONBOARD_TERMS_URL,
+} from './constants';
+
+interface RewardsLegalDisclaimerProps {
+  /**
+   * The first part of the legal disclaimer text (before the Terms of Use link)
+   */
+  disclaimerPart1: string;
+  /**
+   * The Terms of Use link text
+   */
+  disclaimerPart2: string;
+  /**
+   * The middle part of the legal disclaimer text (between the two links)
+   */
+  disclaimerPart3: string;
+  /**
+   * The Learn More link text
+   */
+  disclaimerPart4: string;
+}
+
+/**
+ * RewardsLegalDisclaimer Component
+ *
+ * A reusable component that renders the legal disclaimer text with clickable links
+ * for Terms of Use and Learn More. Used across multiple onboarding steps.
+ */
+const RewardsLegalDisclaimer: React.FC<RewardsLegalDisclaimerProps> = ({
+  disclaimerPart1,
+  disclaimerPart2,
+  disclaimerPart3,
+  disclaimerPart4,
+}) => {
+  const openTermsOfUse = () => {
+    Linking.openURL(REWARDS_ONBOARD_TERMS_URL);
+  };
+
+  const openLearnMore = () => {
+    Linking.openURL(REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL);
+  };
+
+  return (
+    <Box
+      testID="rewards-legal-disclaimer-container"
+      twClassName="w-full flex-row mt-4"
+    >
+      <Box
+        testID="rewards-legal-disclaimer-content"
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        twClassName="justify-center flex-wrap gap-2 flex-1"
+      >
+        <Text
+          testID="rewards-legal-disclaimer-text"
+          variant={TextVariant.BodySm}
+          twClassName="text-alternative text-center"
+        >
+          <Text
+            testID="rewards-legal-disclaimer-part1"
+            variant={TextVariant.BodySm}
+            twClassName="text-alternative text-center"
+          >
+            {disclaimerPart1}
+          </Text>{' '}
+          <Text
+            testID="rewards-legal-disclaimer-terms-link"
+            variant={TextVariant.BodySm}
+            twClassName="text-primary-default"
+            onPress={openTermsOfUse}
+          >
+            {disclaimerPart2}
+          </Text>
+          <Text
+            testID="rewards-legal-disclaimer-part3"
+            variant={TextVariant.BodySm}
+            twClassName="text-alternative text-center"
+          >
+            {disclaimerPart3}
+          </Text>{' '}
+          <Text
+            testID="rewards-legal-disclaimer-learn-more-link"
+            variant={TextVariant.BodySm}
+            twClassName="text-primary-default"
+            onPress={openLearnMore}
+          >
+            {disclaimerPart4}
+          </Text>
+          .{' '}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+export default RewardsLegalDisclaimer;

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingIntroStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingIntroStep.test.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react-native';
+import { screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { renderWithProviders, createMockDispatch } from '../testUtils';
+import Routes from '../../../../../../constants/navigation/Routes';
+import { REWARDS_GTM_MODAL_SHOWN } from '../../../../../../constants/storage';
+import Engine from '../../../../../../core/Engine';
 // Mock tailwind preset to provide ThemeProvider and Theme.Light used by ButtonHero
 jest.mock('@metamask/design-system-twrnc-preset', () => {
   const ReactActual = jest.requireActual('react');
@@ -69,9 +73,6 @@ jest.mock('../OnboardingIntroStep', () => {
     });
   return { __esModule: true, default: Wrapper };
 });
-import { renderWithProviders, createMockDispatch } from '../testUtils';
-import Routes from '../../../../../../constants/navigation/Routes';
-import { REWARDS_GTM_MODAL_SHOWN } from '../../../../../../constants/storage';
 // Use the mocked component with no required props to avoid TS errors
 const OnboardingIntroStep = jest.requireMock('../OnboardingIntroStep')
   .default as unknown as React.ComponentType<Record<string, never>>;
@@ -166,10 +167,12 @@ jest.mock('../../../hooks/useGeoRewardsMetadata', () => ({
 // Tailwind mock is handled in test-utils.ts
 
 // Mock Engine controllerMessenger
-const mockControllerMessengerCall = jest.fn();
-jest.mock('../../../../../../core/Engine/Engine', () => ({
-  controllerMessenger: {
-    call: mockControllerMessengerCall,
+jest.mock('../../../../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    controllerMessenger: {
+      call: jest.fn(),
+    },
   },
 }));
 
@@ -207,6 +210,10 @@ jest.mock('../../../../../../store/storage-wrapper', () => ({
 }));
 
 describe('OnboardingIntroStep', () => {
+  const mockEngineCall = Engine.controllerMessenger.call as jest.MockedFunction<
+    typeof Engine.controllerMessenger.call
+  >;
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -219,10 +226,14 @@ describe('OnboardingIntroStep', () => {
     ).isHardwareAccount as jest.Mock;
     mockIsHardwareAccount.mockReturnValue(false);
 
-    // Reset controller messenger mock to default (returns true for isOptInSupported)
-    mockControllerMessengerCall.mockImplementation((method) => {
+    // Reset controller messenger mock to default (returns true for isOptInSupported and hasActiveSeason)
+    mockEngineCall.mockImplementation((...args: unknown[]) => {
+      const method = args[0] as string;
       if (method === 'RewardsController:isOptInSupported') {
         return true; // Default to true for supported account types
+      }
+      if (method === 'RewardsController:hasActiveSeason') {
+        return Promise.resolve(true); // Return Promise for async call
       }
       return undefined;
     });
@@ -278,37 +289,62 @@ describe('OnboardingIntroStep', () => {
   });
 
   describe('rendering', () => {
-    it('should render without crashing', () => {
+    it('should render without crashing', async () => {
       renderWithProviders(<OnboardingIntroStep />);
-      expect(screen.getByTestId('onboarding-intro-container')).toBeDefined();
+
+      // Wait for the async state update from fetchHasActiveSeason to complete
+      await waitFor(() => {
+        expect(screen.getByTestId('onboarding-intro-container')).toBeDefined();
+      });
     });
 
-    it('should render intro title and description', () => {
+    it('should render intro title and description', async () => {
+      // Ensure the mock returns Promise for hasActiveSeason
+      mockEngineCall.mockImplementation((...args: unknown[]) => {
+        const method = args[0] as string;
+        if (method === 'RewardsController:isOptInSupported') {
+          return true;
+        }
+        if (method === 'RewardsController:hasActiveSeason') {
+          return Promise.resolve(true);
+        }
+        return undefined;
+      });
+
       renderWithProviders(<OnboardingIntroStep />);
 
-      expect(
-        screen.getByText('mocked_rewards.onboarding.intro_title'),
-      ).toBeDefined();
+      // Wait for the async state update from fetchHasActiveSeason to complete
+      await waitFor(() => {
+        expect(
+          screen.getByText('mocked_rewards.onboarding.intro_title'),
+        ).toBeDefined();
+      });
+
       expect(
         screen.getByText('mocked_rewards.onboarding.intro_description'),
       ).toBeDefined();
     });
 
-    it('should render confirm and skip buttons', () => {
+    it('should render confirm and skip buttons', async () => {
       renderWithProviders(<OnboardingIntroStep />);
 
-      expect(
-        screen.getByText('mocked_rewards.onboarding.intro_confirm'),
-      ).toBeDefined();
+      // Wait for the async state update from fetchHasActiveSeason to complete
+      await waitFor(() => {
+        expect(
+          screen.getByText('mocked_rewards.onboarding.intro_confirm'),
+        ).toBeDefined();
+      });
+
       expect(
         screen.getByText('mocked_rewards.onboarding.intro_skip'),
       ).toBeDefined();
     });
 
-    it('should render intro image', () => {
+    it('should render intro image', async () => {
       renderWithProviders(<OnboardingIntroStep />);
 
-      const introImage = screen.getByTestId('intro-image');
+      // Wait for the async state update from fetchHasActiveSeason to complete
+      const introImage = await waitFor(() => screen.getByTestId('intro-image'));
       expect(introImage).toBeDefined();
     });
   });
@@ -333,22 +369,24 @@ describe('OnboardingIntroStep', () => {
   });
 
   describe('user interactions', () => {
-    it('should handle skip button press', () => {
+    it('should handle skip button press', async () => {
       renderWithProviders(<OnboardingIntroStep />);
 
-      const skipButton = screen.getByText(
-        'mocked_rewards.onboarding.intro_skip',
+      // Wait for the async state update from fetchHasActiveSeason to complete
+      const skipButton = await waitFor(() =>
+        screen.getByText('mocked_rewards.onboarding.intro_skip'),
       );
       fireEvent.press(skipButton);
 
       expect(mockGoBack).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle next button press when geo is allowed and account is valid', () => {
+    it('should handle next button press when geo is allowed and account is valid', async () => {
       renderWithProviders(<OnboardingIntroStep />);
 
-      const confirmButton = screen.getByText(
-        'mocked_rewards.onboarding.intro_confirm',
+      // Wait for the async state update from fetchHasActiveSeason to complete
+      const confirmButton = await waitFor(() =>
+        screen.getByText('mocked_rewards.onboarding.intro_confirm'),
       );
       fireEvent.press(confirmButton);
 
@@ -358,7 +396,7 @@ describe('OnboardingIntroStep', () => {
   });
 
   describe('loading states', () => {
-    it('should show loading state when checking geo permissions', () => {
+    it('should show loading state when checking geo permissions', async () => {
       const mockUseSelector = jest.requireMock('react-redux')
         .useSelector as jest.Mock;
       mockUseSelector.mockImplementation((selector) => {
@@ -407,15 +445,16 @@ describe('OnboardingIntroStep', () => {
 
       renderWithProviders(<OnboardingIntroStep />);
 
-      const confirmButton = screen.getByText(
-        'mocked_rewards.onboarding.intro_confirm_geo_loading',
+      // Wait for the async state update from fetchHasActiveSeason to complete
+      const confirmButton = await waitFor(() =>
+        screen.getByText('mocked_rewards.onboarding.intro_confirm_geo_loading'),
       );
       expect(confirmButton).toBeDefined();
     });
   });
 
   describe('account validation', () => {
-    it('should show error modal for Solana accounts', () => {
+    it('should show error modal for Solana accounts', async () => {
       // Note: Solana accounts are now filtered out before reaching OnboardingIntroStep
       // by the account group selector. This test verifies behavior if a Solana account
       // somehow exists in the group (which shouldn't happen in practice).
@@ -478,8 +517,9 @@ describe('OnboardingIntroStep', () => {
 
       renderWithProviders(<OnboardingIntroStep />);
 
-      const confirmButton = screen.getByText(
-        'mocked_rewards.onboarding.intro_confirm',
+      // Wait for the async state update from fetchHasActiveSeason to complete
+      const confirmButton = await waitFor(() =>
+        screen.getByText('mocked_rewards.onboarding.intro_confirm'),
       );
       fireEvent.press(confirmButton);
 
@@ -487,7 +527,7 @@ describe('OnboardingIntroStep', () => {
       expect(mockNavigate).toHaveBeenCalled();
     });
 
-    it('should show error modal for geo-restricted regions', () => {
+    it('should show error modal for geo-restricted regions', async () => {
       // Ensure hardware account check returns false so geo check is reached
       const mockIsHardwareAccount = jest.requireMock(
         '../../../../../../util/address',
@@ -543,8 +583,9 @@ describe('OnboardingIntroStep', () => {
 
       renderWithProviders(<OnboardingIntroStep />);
 
-      const confirmButton = screen.getByText(
-        'mocked_rewards.onboarding.intro_confirm',
+      // Wait for the async state update from fetchHasActiveSeason to complete
+      const confirmButton = await waitFor(() =>
+        screen.getByText('mocked_rewards.onboarding.intro_confirm'),
       );
       fireEvent.press(confirmButton);
 
@@ -564,7 +605,7 @@ describe('OnboardingIntroStep', () => {
       );
     });
 
-    it('should show error modal when account group contains hardware wallet', () => {
+    it('should show error modal when account group contains hardware wallet', async () => {
       // Create account group with hardware wallet account
       const hardwareAccountGroup = createMockAccountGroupAccounts([
         { id: 'test-hardware-account', address: '0x123', type: 'eip155:eoa' },
@@ -625,8 +666,9 @@ describe('OnboardingIntroStep', () => {
 
       renderWithProviders(<OnboardingIntroStep />);
 
-      const confirmButton = screen.getByText(
-        'mocked_rewards.onboarding.intro_confirm',
+      // Wait for the async state update from fetchHasActiveSeason to complete
+      const confirmButton = await waitFor(() =>
+        screen.getByText('mocked_rewards.onboarding.intro_confirm'),
       );
       fireEvent.press(confirmButton);
 
@@ -647,7 +689,7 @@ describe('OnboardingIntroStep', () => {
       );
     });
 
-    it('should proceed to onboarding when account group has no hardware wallet', () => {
+    it('should proceed to onboarding when account group has no hardware wallet', async () => {
       // Reset all mocks
       jest.clearAllMocks();
 
@@ -662,10 +704,14 @@ describe('OnboardingIntroStep', () => {
       ).isHardwareAccount as jest.Mock;
       mockIsHardwareAccount.mockReturnValue(false);
 
-      // Mock controller messenger to return true for isOptInSupported
-      mockControllerMessengerCall.mockImplementation((method) => {
+      // Mock controller messenger to return true for isOptInSupported and hasActiveSeason
+      mockEngineCall.mockImplementation((...args: unknown[]) => {
+        const method = args[0] as string;
         if (method === 'RewardsController:isOptInSupported') {
           return true;
+        }
+        if (method === 'RewardsController:hasActiveSeason') {
+          return Promise.resolve(true);
         }
         return undefined;
       });
@@ -719,8 +765,9 @@ describe('OnboardingIntroStep', () => {
 
       renderWithProviders(<OnboardingIntroStep />);
 
-      const confirmButton = screen.getByText(
-        'mocked_rewards.onboarding.intro_confirm',
+      // Wait for the async state update from fetchHasActiveSeason to complete
+      const confirmButton = await waitFor(() =>
+        screen.getByText('mocked_rewards.onboarding.intro_confirm'),
       );
       fireEvent.press(confirmButton);
 
@@ -728,7 +775,7 @@ describe('OnboardingIntroStep', () => {
       expect(mockNavigate).toHaveBeenCalled();
     });
 
-    it('should show error modal when no account in group is supported for opt-in', () => {
+    it('should show error modal when no account in group is supported for opt-in', async () => {
       // Create account group with unsupported account type
       const unsupportedAccountGroup = createMockAccountGroupAccounts([
         {
@@ -739,12 +786,17 @@ describe('OnboardingIntroStep', () => {
       ]);
 
       // Mock isOptInSupported to return false for all accounts in this group
-      mockControllerMessengerCall.mockImplementation((method, account) => {
+      mockEngineCall.mockImplementation((...args: unknown[]) => {
+        const method = args[0] as string;
+        const account = args[1] as { type?: string } | undefined;
         if (
           method === 'RewardsController:isOptInSupported' &&
           account?.type === 'unsupported:type'
         ) {
           return false;
+        }
+        if (method === 'RewardsController:hasActiveSeason') {
+          return Promise.resolve(true);
         }
         return true;
       });
@@ -804,8 +856,9 @@ describe('OnboardingIntroStep', () => {
 
       renderWithProviders(<OnboardingIntroStep />);
 
-      const confirmButton = screen.getByText(
-        'mocked_rewards.onboarding.intro_confirm',
+      // Wait for the async state update from fetchHasActiveSeason to complete
+      const confirmButton = await waitFor(() =>
+        screen.getByText('mocked_rewards.onboarding.intro_confirm'),
       );
       fireEvent.press(confirmButton);
 
@@ -825,7 +878,7 @@ describe('OnboardingIntroStep', () => {
       );
     });
 
-    it('should proceed to onboarding when account group has at least one supported account', () => {
+    it('should proceed to onboarding when account group has at least one supported account', async () => {
       // Reset all mocks
       jest.clearAllMocks();
 
@@ -840,10 +893,14 @@ describe('OnboardingIntroStep', () => {
       ).isHardwareAccount as jest.Mock;
       mockIsHardwareAccount.mockReturnValue(false);
 
-      // Mock isOptInSupported to return true
-      mockControllerMessengerCall.mockImplementation((method) => {
+      // Mock isOptInSupported and hasActiveSeason to return true
+      mockEngineCall.mockImplementation((...args: unknown[]) => {
+        const method = args[0] as string;
         if (method === 'RewardsController:isOptInSupported') {
           return true;
+        }
+        if (method === 'RewardsController:hasActiveSeason') {
+          return Promise.resolve(true);
         }
         return undefined;
       });
@@ -900,9 +957,10 @@ describe('OnboardingIntroStep', () => {
 
       renderWithProviders(<OnboardingIntroStep />);
 
+      // Wait for the async state update from fetchHasActiveSeason to complete
       // Verify the button is rendered
-      const confirmButton = screen.getByText(
-        'mocked_rewards.onboarding.intro_confirm',
+      const confirmButton = await waitFor(() =>
+        screen.getByText('mocked_rewards.onboarding.intro_confirm'),
       );
 
       // Press the button

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingNoActiveSeasonStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingNoActiveSeasonStep.test.tsx
@@ -1,0 +1,610 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react-native';
+import { Linking } from 'react-native';
+import { renderWithProviders, createMockDispatch } from '../testUtils';
+import OnboardingNoActiveSeasonStep from '../OnboardingNoActiveSeasonStep';
+import Routes from '../../../../../../constants/navigation/Routes';
+import {
+  REWARDS_ONBOARD_TERMS_URL,
+  REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
+} from '../constants';
+import { selectRewardsSubscriptionId } from '../../../../../../selectors/rewards';
+
+// Mock navigation
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  const ReactActual = jest.requireActual('react');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+    useFocusEffect: (effect: () => void | (() => void)) => {
+      ReactActual.useEffect(() => {
+        const cleanup = effect();
+        return cleanup;
+      });
+    },
+  };
+});
+
+// Mock redux
+const mockDispatch = createMockDispatch();
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+  useSelector: jest.fn(),
+}));
+
+// Mock design system
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({
+    style: jest.fn((styles) => ({
+      testID: `tw-${Array.isArray(styles) ? styles.join('-') : styles}`,
+    })),
+  }),
+}));
+
+// Mock theme
+jest.mock('../../../../../../util/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      background: {
+        muted: '#f5f5f5',
+      },
+    },
+  }),
+}));
+
+// Mock strings
+jest.mock('../../../../../../../locales/i18n', () => ({
+  strings: (key: string) => `mocked_${key}`,
+}));
+
+// Mock RewardsErrorBanner
+jest.mock('../../RewardsErrorBanner', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ title, description }: { title: string; description: string }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'rewards-error-banner' },
+        ReactActual.createElement(Text, { testID: 'error-title' }, title),
+        ReactActual.createElement(
+          Text,
+          { testID: 'error-description' },
+          description,
+        ),
+      ),
+  };
+});
+
+// Mock all image and SVG imports
+jest.mock(
+  '../../../../../images/rewards/rewards-onboarding-step1.png',
+  () => 'step1Img',
+);
+jest.mock(
+  '../../../../../images/rewards/rewards-onboarding-step1-bg.svg',
+  () => 'Step1BgImg',
+);
+
+// Mock design system components
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text: RNText, Pressable } = jest.requireActual('react-native');
+
+  return {
+    Text: ({
+      children,
+      onPress,
+      ...props
+    }: {
+      children: React.ReactNode;
+      onPress?: () => void;
+      [key: string]: unknown;
+    }) => {
+      if (onPress) {
+        return ReactActual.createElement(
+          Pressable,
+          { onPress, testID: props.testID || 'text' },
+          ReactActual.createElement(RNText, props, children),
+        );
+      }
+      return ReactActual.createElement(
+        RNText,
+        { ...props, testID: props.testID || 'text' },
+        children,
+      );
+    },
+    TextVariant: {
+      HeadingLg: 'HeadingLg',
+      BodyMd: 'BodyMd',
+      BodySm: 'BodySm',
+    },
+    Box: ({
+      children,
+      ...props
+    }: {
+      children: React.ReactNode;
+      [key: string]: unknown;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { ...props, testID: props.testID || 'box' },
+        children,
+      ),
+    BoxAlignItems: {
+      Center: 'Center',
+    },
+    BoxFlexDirection: {
+      Row: 'Row',
+    },
+  };
+});
+
+// Mock React Native components
+jest.mock('react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const RN = jest.requireActual('react-native');
+
+  return {
+    ...RN,
+    Image: (props: { testID?: string; [key: string]: unknown }) =>
+      ReactActual.createElement(RN.View, {
+        testID: props.testID || 'image',
+        ...props,
+      }),
+    Linking: {
+      openURL: jest.fn(),
+    },
+    useWindowDimensions: () => ({
+      width: 375,
+      height: 812,
+    }),
+  };
+});
+
+// Mock hooks
+const mockOptin = jest.fn();
+const mockUseOptin = {
+  optin: mockOptin,
+  optinError: null as string | null,
+  optinLoading: false,
+};
+
+jest.mock('../../../hooks/useOptIn', () => ({
+  useOptin: () => mockUseOptin,
+}));
+
+// Mock OnboardingStepComponent
+jest.mock('../OnboardingStep', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+
+  return {
+    __esModule: true,
+    default: ({
+      renderStepInfo,
+      renderStepImage,
+      nextButtonAlternative,
+      onNext,
+      onNextDisabled,
+      onNextLoading,
+      onNextLoadingText,
+      nextButtonText,
+      ...props
+    }: {
+      renderStepInfo: () => React.ReactElement;
+      renderStepImage?: () => React.ReactElement;
+      nextButtonAlternative?: () => React.ReactElement;
+      onNext: () => void;
+      onNextDisabled?: boolean;
+      onNextLoading?: boolean;
+      onNextLoadingText?: string;
+      nextButtonText?: string;
+      [key: string]: unknown;
+    }) =>
+      ReactActual.createElement(
+        View,
+        {
+          testID: 'onboarding-step-container',
+          ...props,
+        },
+        renderStepInfo?.(),
+        renderStepImage?.(),
+        nextButtonAlternative?.(),
+        ReactActual.createElement(
+          View,
+          {
+            testID: 'next-button',
+            onPress: onNext,
+            disabled: onNextDisabled || onNextLoading,
+          },
+          nextButtonText || 'Next',
+        ),
+        onNextLoadingText &&
+          ReactActual.createElement(
+            View,
+            {
+              testID: 'loading-text',
+            },
+            onNextLoadingText,
+          ),
+      ),
+  };
+});
+
+describe('OnboardingNoActiveSeasonStep', () => {
+  const mockCanContinue = jest.fn(() => true);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseOptin.optinError = null;
+    mockUseOptin.optinLoading = false;
+    mockCanContinue.mockReturnValue(true);
+
+    // Set up default useSelector mock
+    const mockUseSelector = jest.requireMock('react-redux')
+      .useSelector as jest.Mock;
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectRewardsSubscriptionId) {
+        return null;
+      }
+      return undefined;
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders step content with title and description', () => {
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      expect(
+        screen.getByText('mocked_rewards.onboarding.no_active_season.title'),
+      ).toBeDefined();
+      expect(
+        screen.getByText(
+          'mocked_rewards.onboarding.no_active_season.description',
+        ),
+      ).toBeDefined();
+    });
+
+    it('renders step image', () => {
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      expect(screen.getByTestId('step-1-image')).toBeDefined();
+    });
+
+    it('renders navigation container', () => {
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      expect(screen.getByTestId('onboarding-step-container')).toBeDefined();
+    });
+  });
+
+  describe('error states', () => {
+    it('displays error banner when optin fails', () => {
+      mockUseOptin.optinError = 'Network error';
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      expect(screen.getByTestId('rewards-error-banner')).toBeDefined();
+    });
+
+    it('hides error banner when no optin error exists', () => {
+      mockUseOptin.optinError = null;
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      expect(screen.queryByTestId('rewards-error-banner')).toBeNull();
+    });
+  });
+
+  describe('loading states', () => {
+    it('displays loading text when optin is in progress', () => {
+      mockUseOptin.optinLoading = true;
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      const loadingElement = screen.getByTestId('loading-text');
+      expect(loadingElement).toBeDefined();
+      expect(loadingElement.props.children).toBe(
+        'mocked_rewards.onboarding.no_active_season.sign_up_loading',
+      );
+    });
+
+    it('hides loading text when optin is not in progress', () => {
+      mockUseOptin.optinLoading = false;
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      expect(
+        screen.queryByText(
+          'mocked_rewards.onboarding.no_active_season.sign_up_loading',
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe('button states', () => {
+    it('disables next button when subscriptionId exists', () => {
+      const mockUseSelector = jest.requireMock('react-redux')
+        .useSelector as jest.Mock;
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectRewardsSubscriptionId) {
+          return 'sub-123';
+        }
+        return undefined;
+      });
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton.props.disabled).toBe(true);
+    });
+
+    it('enables next button when subscriptionId does not exist', () => {
+      const mockUseSelector = jest.requireMock('react-redux')
+        .useSelector as jest.Mock;
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectRewardsSubscriptionId) {
+          return null;
+        }
+        return undefined;
+      });
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton.props.disabled).toBe(false);
+    });
+
+    it('disables next button when optin is loading', () => {
+      mockUseOptin.optinLoading = true;
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton.props.disabled).toBe(true);
+    });
+  });
+
+  describe('legal disclaimer', () => {
+    it('renders legal disclaimer text', () => {
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      // Legal disclaimer text is split across nested Text components
+      // Use regex to match text that may be part of a larger string
+      expect(
+        screen.getByText(
+          /mocked_rewards\.onboarding\.no_active_season\.legal_disclaimer_1/,
+        ),
+      ).toBeDefined();
+      expect(
+        screen.getByText(
+          'mocked_rewards.onboarding.no_active_season.legal_disclaimer_2',
+        ),
+      ).toBeDefined();
+      expect(
+        screen.getByText(
+          /mocked_rewards\.onboarding\.no_active_season\.legal_disclaimer_3/,
+        ),
+      ).toBeDefined();
+      expect(
+        screen.getByText(
+          'mocked_rewards.onboarding.no_active_season.legal_disclaimer_4',
+        ),
+      ).toBeDefined();
+    });
+
+    it('opens terms of use URL when link is pressed', () => {
+      const mockOpenURL = jest.spyOn(Linking, 'openURL');
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      const termsLink = screen.getByText(
+        'mocked_rewards.onboarding.no_active_season.legal_disclaimer_2',
+      );
+      fireEvent.press(termsLink);
+
+      expect(mockOpenURL).toHaveBeenCalledWith(REWARDS_ONBOARD_TERMS_URL);
+    });
+
+    it('opens learn more URL when link is pressed', () => {
+      const mockOpenURL = jest.spyOn(Linking, 'openURL');
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      const learnMoreLink = screen.getByText(
+        'mocked_rewards.onboarding.no_active_season.legal_disclaimer_4',
+      );
+      fireEvent.press(learnMoreLink);
+
+      expect(mockOpenURL).toHaveBeenCalledWith(
+        REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
+      );
+    });
+  });
+
+  describe('next button interaction', () => {
+    it('calls optin with empty object when next button is pressed and canContinue returns true', () => {
+      mockCanContinue.mockReturnValue(true);
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      const nextButton = screen.getByTestId('next-button');
+      fireEvent.press(nextButton);
+
+      expect(mockCanContinue).toHaveBeenCalled();
+      expect(mockOptin).toHaveBeenCalledWith({});
+    });
+
+    it('does not call optin when canContinue returns false', () => {
+      mockCanContinue.mockReturnValue(false);
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      const nextButton = screen.getByTestId('next-button');
+      fireEvent.press(nextButton);
+
+      expect(mockCanContinue).toHaveBeenCalled();
+      expect(mockOptin).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('auto-redirect to dashboard', () => {
+    it('navigates to dashboard when subscriptionId exists on focus', () => {
+      const mockUseSelector = jest.requireMock('react-redux')
+        .useSelector as jest.Mock;
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectRewardsSubscriptionId) {
+          return 'sub-123';
+        }
+        return undefined;
+      });
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_DASHBOARD);
+    });
+
+    it('does not navigate when subscriptionId does not exist', () => {
+      const mockUseSelector = jest.requireMock('react-redux')
+        .useSelector as jest.Mock;
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectRewardsSubscriptionId) {
+          return null;
+        }
+        return undefined;
+      });
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      expect(mockNavigate).not.toHaveBeenCalledWith(Routes.REWARDS_DASHBOARD);
+    });
+  });
+
+  describe('component props', () => {
+    it('passes correct props to OnboardingStepComponent', () => {
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      const container = screen.getByTestId('onboarding-step-container');
+      expect(container).toBeDefined();
+      expect(container.props.disableSwipe).toBe(true);
+      expect(container.props.showProgressIndicator).toBe(false);
+    });
+
+    it('renders step image through renderStepImage prop', () => {
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      expect(screen.getByTestId('step-1-image')).toBeDefined();
+    });
+
+    it('renders legal disclaimer through nextButtonAlternative prop', () => {
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      // Legal disclaimer text is split across nested Text components
+      // Use regex to match text that may be part of a larger string
+      expect(
+        screen.getByText(
+          /mocked_rewards\.onboarding\.no_active_season\.legal_disclaimer_1/,
+        ),
+      ).toBeDefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles canContinue callback being called multiple times', () => {
+      mockCanContinue.mockReturnValue(true);
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      const nextButton = screen.getByTestId('next-button');
+      fireEvent.press(nextButton);
+      fireEvent.press(nextButton);
+
+      expect(mockCanContinue).toHaveBeenCalledTimes(2);
+    });
+
+    it('handles optin error state with loading state', () => {
+      mockUseOptin.optinError = 'Error occurred';
+      mockUseOptin.optinLoading = true;
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      expect(screen.getByTestId('rewards-error-banner')).toBeDefined();
+      const loadingElement = screen.getByTestId('loading-text');
+      expect(loadingElement).toBeDefined();
+      expect(loadingElement.props.children).toBe(
+        'mocked_rewards.onboarding.no_active_season.sign_up_loading',
+      );
+    });
+
+    it('handles subscriptionId state correctly', () => {
+      const mockUseSelector = jest.requireMock('react-redux')
+        .useSelector as jest.Mock;
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectRewardsSubscriptionId) {
+          return 'existing-subscription';
+        }
+        return undefined;
+      });
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      const nextButton = screen.getByTestId('next-button');
+      // Button should be disabled when subscriptionId exists
+      expect(nextButton.props.disabled).toBe(true);
+    });
+  });
+});

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingNoActiveSeasonStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingNoActiveSeasonStep.test.tsx
@@ -342,6 +342,50 @@ describe('OnboardingNoActiveSeasonStep', () => {
         ),
       ).toBeNull();
     });
+
+    it('displays geo loading text when geoLoading is true and optin is not loading', () => {
+      mockUseOptin.optinLoading = false;
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep
+          canContinue={mockCanContinue}
+          geoLoading
+        />,
+      );
+
+      const loadingElement = screen.getByTestId('loading-text');
+      expect(loadingElement).toBeDefined();
+      expect(loadingElement.props.children).toBe(
+        'mocked_rewards.onboarding.intro_confirm_geo_loading',
+      );
+    });
+
+    it('prioritizes optin loading text when both optinLoading and geoLoading are true', () => {
+      mockUseOptin.optinLoading = true;
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep
+          canContinue={mockCanContinue}
+          geoLoading
+        />,
+      );
+
+      const loadingElement = screen.getByTestId('loading-text');
+      expect(loadingElement).toBeDefined();
+      expect(loadingElement.props.children).toBe(
+        'mocked_rewards.onboarding.no_active_season.sign_up_loading',
+      );
+    });
+
+    it('hides loading text when neither optinLoading nor geoLoading are true', () => {
+      mockUseOptin.optinLoading = false;
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      expect(screen.queryByTestId('loading-text')).toBeNull();
+    });
   });
 
   describe('button states', () => {
@@ -386,6 +430,34 @@ describe('OnboardingNoActiveSeasonStep', () => {
 
       renderWithProviders(
         <OnboardingNoActiveSeasonStep canContinue={mockCanContinue} />,
+      );
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton.props.disabled).toBe(true);
+    });
+
+    it('disables next button when geoLoading is true', () => {
+      mockUseOptin.optinLoading = false;
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep
+          canContinue={mockCanContinue}
+          geoLoading
+        />,
+      );
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton.props.disabled).toBe(true);
+    });
+
+    it('disables next button when both optinLoading and geoLoading are true', () => {
+      mockUseOptin.optinLoading = true;
+
+      renderWithProviders(
+        <OnboardingNoActiveSeasonStep
+          canContinue={mockCanContinue}
+          geoLoading
+        />,
       );
 
       const nextButton = screen.getByTestId('next-button');

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep4.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep4.test.tsx
@@ -637,7 +637,13 @@ describe('OnboardingStep4', () => {
       renderWithProviders(<OnboardingStep4 />);
 
       expect(
+        screen.getByText('mocked_rewards.onboarding.step4_legal_disclaimer_1'),
+      ).toBeDefined();
+      expect(
         screen.getByText('mocked_rewards.onboarding.step4_legal_disclaimer_2'),
+      ).toBeDefined();
+      expect(
+        screen.getByText('mocked_rewards.onboarding.step4_legal_disclaimer_3'),
       ).toBeDefined();
       expect(
         screen.getByText('mocked_rewards.onboarding.step4_legal_disclaimer_4'),

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6914,7 +6914,17 @@
       "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
       "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
       "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step4_legal_disclaimer_4": "learn more",
+      "no_active_season": {
+        "title": "Sign up for Rewards",
+        "description": "Get more out of MetaMask with the best loyalty program in crypto.",
+        "sign_up": "Sign up",
+        "sign_up_loading": "Signing up...",
+        "legal_disclaimer_1": "By clicking 'Sign up,' you agree to the MetaMask Rewards",
+        "legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
+        "legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
+        "legal_disclaimer_4": "learn more"
+      }
     },
     "settings": {
       "title": "Rewards Settings",


### PR DESCRIPTION
## **Description**

Due to the upcoming end of season 1, the onboarding flow doesn't make sense any more when there's no active season. This PR changes that so that users end up on a simplified onboarding.

## **Changelog**

CHANGELOG entry: fix opt in for no rewards active season

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-855, https://github.com/MetaMask/metamask-mobile/issues/23396

## **Screenshots/Recordings**

### **After**

<img width="676" height="1482" alt="image" src="https://github.com/user-attachments/assets/827f2cec-1fa3-4e80-bd88-ffc6db27a493" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an alternate onboarding path that enables opt-in when no season is active by checking `hasActiveSeason`, adds `OnboardingNoActiveSeasonStep`, and extracts a reusable `RewardsLegalDisclaimer`, with tests and strings updated.
> 
> - **Rewards Onboarding flow**:
>   - Check active season via `RewardsController:hasActiveSeason` in `OnboardingIntroStep`; show skeleton until resolved and branch UI.
>   - Factor validation into `canContinue()`; `handleNext` uses it.
>   - If no active season, render new simplified sign-up `OnboardingNoActiveSeasonStep` (uses `useOptin`, handles geo/loading, auto-redirects if already opted in).
> - **Components**:
>   - New `OnboardingNoActiveSeasonStep` with custom image/background and disabled progress indicator.
>   - New reusable `RewardsLegalDisclaimer`; replace inline legal text in `OnboardingStep4` and reuse in no-season step.
>   - `OnboardingStep`: add `showProgressIndicator` prop to toggle progress bars.
> - **Tests**:
>   - Add tests for `OnboardingNoActiveSeasonStep` and `RewardsLegalDisclaimer`.
>   - Update `OnboardingIntroStep` and `OnboardingStep4` tests for new season check and disclaimer usage.
> - **i18n**:
>   - Add `rewards.onboarding.no_active_season.*` strings and related copy updates in `en.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ba9211ceae923c691fa8d128702a3cd7f3368fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->