### PR TITLE
ci: ensure E2E tests results are success for final check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: ci
+
 on:
   push:
     branches: [main]
@@ -46,6 +47,7 @@ jobs:
           else
             echo "No changes detected"
           fi
+
   dedupe:
     runs-on: ubuntu-latest
     steps:
@@ -77,6 +79,7 @@ jobs:
             echo "Duplicate dependencies detected; run 'yarn deduplicate' to remove them"
             exit 1
           fi
+
   git-safe-dependencies:
     runs-on: ubuntu-latest
     steps:
@@ -101,6 +104,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           command: yarn git-safe-dependencies
+
   scripts:
     runs-on: ubuntu-latest
     strategy:
@@ -139,6 +143,7 @@ jobs:
           else
             echo "No changes detected"
           fi
+
   unit-tests:
     runs-on: ubuntu-latest
     strategy:
@@ -182,6 +187,7 @@ jobs:
           else
             echo "No changes detected"
           fi
+
   merge-unit-tests:
     runs-on: ubuntu-latest
     needs: unit-tests
@@ -224,8 +230,10 @@ jobs:
           else
             echo "No changes detected"
           fi
+
   needs_e2e_build:
-    uses: ./.github/workflows/needs-e2e-build.yml          
+    uses: ./.github/workflows/needs-e2e-build.yml
+
   component-view-test:
     runs-on: ubuntu-latest
     steps:
@@ -246,6 +254,7 @@ jobs:
       - run: yarn test:view --coverage=false --forceExit --silent
         env:
           NODE_OPTIONS: --max_old_space_size=20480
+
   smart-e2e-selection:
     name: 'Smart E2E Selection'
     runs-on: ubuntu-latest
@@ -264,7 +273,6 @@ jobs:
             .github/actions/smart-e2e-selection
           sparse-checkout-cone-mode: false
           fetch-depth: 1
-
       - name: Run Smart E2E Selection
         id: e2e-selection
         uses: ./.github/actions/smart-e2e-selection
@@ -277,7 +285,7 @@ jobs:
           post-comment: 'true'
 
   # Main E2E tests
-  
+
   build-android-apks:
     name: 'Build Android APKs'
     if: ${{ github.event_name != 'merge_group' && needs.needs_e2e_build.outputs.android_changed == 'true' }}
@@ -336,7 +344,6 @@ jobs:
     secrets: inherit
 
   # Flask E2E tests
-
   build-android-flask-apks:
     name: 'Build Android Flask APKs'
     if: ${{ github.event_name != 'merge_group' && needs.needs_e2e_build.outputs.android_changed == 'true' }}
@@ -380,15 +387,12 @@ jobs:
           command: yarn install --immutable
       - name: Clean state and following up dependencies installation
         run: yarn setup:github-ci --no-build-android
-
       - name: Generate iOS bundle
         run: yarn gen-bundle:ios
         env:
           NODE_OPTIONS: --max_old_space_size=12288
-
       - name: Check bundle size
         run: ./scripts/js-bundle-stats.sh ios/main.jsbundle 52
-
       - name: Upload iOS bundle
         uses: actions/upload-artifact@v4
         with:
@@ -401,13 +405,11 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
-
       - name: Download iOS bundle
         uses: actions/download-artifact@v4
         with:
           name: ios-bundle
           path: ios/main.jsbundle
-
       - name: Push bundle size to mobile_bundlesize_stats repo
         run: ./scripts/push-bundle-size.sh
         env:
@@ -450,13 +452,13 @@ jobs:
           else
             echo "No changes detected"
           fi
-
           # Revert git update-index --no-assume-unchanged for each entry
           echo "Reverting assume unchanged for the following paths:"
           for path in "${EXCLUDES[@]}"; do
             echo "$path"
             git update-index --no-assume-unchanged "$path"
           done
+
   sonar-cloud-quality-gate-status:
     runs-on: ubuntu-latest
     needs: sonar-cloud
@@ -476,32 +478,25 @@ jobs:
             echo "This job only runs for pull requests."
             exit 0
           fi
-
           # Bypass step if skip-sonar-cloud label is found
           LABEL=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
           "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/labels" | \
           jq -r '.[] | select(.name=="skip-sonar-cloud") | .name')
-
           if [[ "$LABEL" == "skip-sonar-cloud" ]]; then
             echo "skip-sonar-cloud label found. Skipping SonarCloud Quality Gate check."
           else
             sleep 30
-
             PROJECT_KEY="metamask-mobile"
             PR_NUMBER="${{ github.event.pull_request.number }}"
             SONAR_TOKEN="${{ secrets.SONAR_TOKEN }}"
-
             if [ -z "$PR_NUMBER" ]; then
               echo "No pull request number found. Failing the check."
               exit 1
             fi
-
             RESPONSE=$(curl -s -u "$SONAR_TOKEN:" \
               "https://sonarcloud.io/api/qualitygates/project_status?projectKey=$PROJECT_KEY&pullRequest=$PR_NUMBER")
             echo "SonarCloud API Response: $RESPONSE"
-
             STATUS=$(echo "$RESPONSE" | jq -r '.projectStatus.status')
-
             if [[ "$STATUS" == "ERROR" ]]; then
               echo "Quality Gate failed."
               exit 1
@@ -512,6 +507,7 @@ jobs:
               exit 1
             fi
           fi
+
   check-workflows:
     name: Check workflows
     runs-on: ubuntu-latest
@@ -524,6 +520,7 @@ jobs:
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color -config-file .github/actionlint.yaml
         shell: bash
+
   all-jobs-pass:
     name: All jobs pass
     runs-on: ubuntu-latest
@@ -543,6 +540,7 @@ jobs:
       - name: Set jobs passed status
         id: jobs-passed-status
         run: echo "ALL_JOBS_PASSED=true" >> "$GITHUB_OUTPUT"
+
   check-all-jobs-pass:
     name: Check all jobs pass
     if: ${{ always() }}
@@ -560,23 +558,21 @@ jobs:
             echo "Non-E2E jobs failed"
             exit 1
           fi
-
           # Check E2E jobs only if they should have run
           if [[ "${{ needs.needs_e2e_build.outputs.builds }}" == "true" ]]; then
-            if [[ "${{ needs.e2e-smoke-tests-android.result }}" == "failure" ]]; then
-              echo "Android E2E tests failed"
+            if [[ "${{ needs.e2e-smoke-tests-android.result }}" != "success" ]]; then
+              echo "Android E2E tests did not succeed (result: ${{ needs.e2e-smoke-tests-android.result }})"
               exit 1
             fi
-            if [[ "${{ needs.e2e-smoke-tests-ios.result }}" == "failure" ]]; then
-              echo "iOS E2E tests failed"
+            if [[ "${{ needs.e2e-smoke-tests-ios.result }}" != "success" ]]; then
+              echo "iOS E2E tests did not succeed (result: ${{ needs.e2e-smoke-tests-ios.result }})"
               exit 1
             fi
-            if [[ "${{ needs.e2e-smoke-tests-android-flask.result }}" == "failure" ]]; then
-              echo "Android Flask E2E tests failed"
+            if [[ "${{ needs.e2e-smoke-tests-android-flask.result }}" != "success" ]]; then
+              echo "Android Flask E2E tests did not succeed (result: ${{ needs.e2e-smoke-tests-android-flask.result }})"
               exit 1
             fi
           fi
-
           echo "All required jobs passed"
 
   log-merge-group-failure:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,16 +560,24 @@ jobs:
           fi
           # Check E2E jobs only if they should have run
           if [[ "${{ needs.needs_e2e_build.outputs.builds }}" == "true" ]]; then
-            if [[ "${{ needs.e2e-smoke-tests-android.result }}" != "success" ]]; then
-              echo "Android E2E tests did not succeed (result: ${{ needs.e2e-smoke-tests-android.result }})"
+            # Accept both 'success' and 'skipped' as valid results
+            # 'skipped' occurs during merge_group events or when jobs are intentionally skipped
+            # Only fail on 'failure' or 'cancelled'
+            ANDROID_RESULT="${{ needs.e2e-smoke-tests-android.result }}"
+            if [[ "$ANDROID_RESULT" == "failure" ]] || [[ "$ANDROID_RESULT" == "cancelled" ]]; then
+              echo "Android E2E tests failed (result: $ANDROID_RESULT)"
               exit 1
             fi
-            if [[ "${{ needs.e2e-smoke-tests-ios.result }}" != "success" ]]; then
-              echo "iOS E2E tests did not succeed (result: ${{ needs.e2e-smoke-tests-ios.result }})"
+            
+            IOS_RESULT="${{ needs.e2e-smoke-tests-ios.result }}"
+            if [[ "$IOS_RESULT" == "failure" ]] || [[ "$IOS_RESULT" == "cancelled" ]]; then
+              echo "iOS E2E tests failed (result: $IOS_RESULT)"
               exit 1
             fi
-            if [[ "${{ needs.e2e-smoke-tests-android-flask.result }}" != "success" ]]; then
-              echo "Android Flask E2E tests did not succeed (result: ${{ needs.e2e-smoke-tests-android-flask.result }})"
+            
+            FLASK_RESULT="${{ needs.e2e-smoke-tests-android-flask.result }}"
+            if [[ "$FLASK_RESULT" == "failure" ]] || [[ "$FLASK_RESULT" == "cancelled" ]]; then
+              echo "Android Flask E2E tests failed (result: $FLASK_RESULT)"
               exit 1
             fi
           fi


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This fix ensures that:

Cancelled E2E tests (like in https://github.com/MetaMask/metamask-extension/actions/runs/19671799841/job/56346000935) will now cause all-jobs-pass to fail
Skipped E2E tests (unexpected) will also cause failures

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Final CI gate now treats cancelled E2E runs as failures while allowing skipped as pass; misc workflow cleanups and non-functional string formatting tweaks.
> 
> - **CI/CD**:
>   - **Final Gate Logic**: In `check-all-jobs-pass`, accept `success` or `skipped` for `e2e-smoke-tests-android`, `e2e-smoke-tests-ios`, and `e2e-smoke-tests-android-flask`; fail on `failure` or `cancelled`.
>   - **Workflow Hygiene**: Minor path/whitespace fixes (e.g., `needs_e2e_build`), consistent steps in bundle size and SonarCloud jobs.
> - **Perps (HyperLiquidProvider)**:
>   - Non-functional template string formatting updates in `ensureUsdhCollateralForOrder` and minimum-order retry message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c49ee40f37ea0a837af1b8c5261eb2d90fe650a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->