### PR TITLE
fix(perps): display internal transfers in perps deposits

### DIFF
--- a/app/components/UI/Perps/utils/hyperLiquidAdapter.test.ts
+++ b/app/components/UI/Perps/utils/hyperLiquidAdapter.test.ts
@@ -12,6 +12,8 @@ import {
   formatHyperLiquidPrice,
   formatHyperLiquidSize,
   calculatePositionSize,
+  adaptHyperLiquidLedgerUpdateToUserHistoryItem,
+  type RawHyperLiquidLedgerUpdate,
 } from './hyperLiquidAdapter';
 import type { OrderParams } from '../controllers/types';
 import type {
@@ -1112,6 +1114,113 @@ describe('hyperLiquidAdapter', () => {
       });
 
       expect(result).toBe(100000000000); // (1000000 * 100) / 0.001
+    });
+  });
+
+  describe('adaptHyperLiquidLedgerUpdateToUserHistoryItem', () => {
+    it('includes deposit type in filtered results', () => {
+      const rawLedgerUpdates: RawHyperLiquidLedgerUpdate[] = [
+        {
+          hash: '0x001',
+          time: 1000,
+          delta: { type: 'deposit', usdc: '100' },
+        },
+      ];
+
+      const result =
+        adaptHyperLiquidLedgerUpdateToUserHistoryItem(rawLedgerUpdates);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('includes withdraw type in filtered results', () => {
+      const rawLedgerUpdates: RawHyperLiquidLedgerUpdate[] = [
+        {
+          hash: '0x002',
+          time: 2000,
+          delta: { type: 'withdraw', usdc: '-50' },
+        },
+      ];
+
+      const result =
+        adaptHyperLiquidLedgerUpdateToUserHistoryItem(rawLedgerUpdates);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('includes internalTransfer type in filtered results', () => {
+      const rawLedgerUpdates: RawHyperLiquidLedgerUpdate[] = [
+        {
+          hash: '0x003',
+          time: 3000,
+          delta: { type: 'internalTransfer', usdc: '25' },
+        },
+      ];
+
+      const result =
+        adaptHyperLiquidLedgerUpdateToUserHistoryItem(rawLedgerUpdates);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('excludes unsupported types from filtered results', () => {
+      const rawLedgerUpdates: RawHyperLiquidLedgerUpdate[] = [
+        {
+          hash: '0x004',
+          time: 4000,
+          delta: { type: 'trade', usdc: '10' },
+        },
+        {
+          hash: '0x005',
+          time: 5000,
+          delta: { type: 'liquidation', usdc: '20' },
+        },
+        {
+          hash: '0x006',
+          time: 6000,
+          delta: { type: 'funding', usdc: '5' },
+        },
+      ];
+
+      const result =
+        adaptHyperLiquidLedgerUpdateToUserHistoryItem(rawLedgerUpdates);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('filters mixed types keeping only supported ones', () => {
+      const rawLedgerUpdates: RawHyperLiquidLedgerUpdate[] = [
+        {
+          hash: '0x007',
+          time: 7000,
+          delta: { type: 'deposit', usdc: '100' },
+        },
+        {
+          hash: '0x008',
+          time: 8000,
+          delta: { type: 'trade', usdc: '50' },
+        },
+        {
+          hash: '0x009',
+          time: 9000,
+          delta: { type: 'withdraw', usdc: '-75' },
+        },
+        {
+          hash: '0x010',
+          time: 10000,
+          delta: { type: 'liquidation', usdc: '25' },
+        },
+        {
+          hash: '0x011',
+          time: 11000,
+          delta: { type: 'internalTransfer', usdc: '30' },
+        },
+      ];
+
+      const result =
+        adaptHyperLiquidLedgerUpdateToUserHistoryItem(rawLedgerUpdates);
+
+      expect(result).toHaveLength(3);
     });
   });
 });

--- a/app/components/UI/Perps/utils/hyperLiquidAdapter.test.ts
+++ b/app/components/UI/Perps/utils/hyperLiquidAdapter.test.ts
@@ -1118,109 +1118,66 @@ describe('hyperLiquidAdapter', () => {
   });
 
   describe('adaptHyperLiquidLedgerUpdateToUserHistoryItem', () => {
-    it('includes deposit type in filtered results', () => {
-      const rawLedgerUpdates: RawHyperLiquidLedgerUpdate[] = [
-        {
-          hash: '0x001',
-          time: 1000,
-          delta: { type: 'deposit', usdc: '100' },
-        },
-      ];
-
-      const result =
-        adaptHyperLiquidLedgerUpdateToUserHistoryItem(rawLedgerUpdates);
-
-      expect(result).toHaveLength(1);
+    // Helper function to create test ledger updates
+    const createLedgerUpdate = (
+      type: string,
+      hash = '0x123',
+    ): RawHyperLiquidLedgerUpdate => ({
+      hash,
+      time: 1000,
+      delta: { type, usdc: '100' },
     });
 
-    it('includes withdraw type in filtered results', () => {
-      const rawLedgerUpdates: RawHyperLiquidLedgerUpdate[] = [
-        {
-          hash: '0x002',
-          time: 2000,
-          delta: { type: 'withdraw', usdc: '-50' },
-        },
-      ];
+    describe('filtering by delta type', () => {
+      it('includes deposit type', () => {
+        const updates = [createLedgerUpdate('deposit')];
 
-      const result =
-        adaptHyperLiquidLedgerUpdateToUserHistoryItem(rawLedgerUpdates);
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
 
-      expect(result).toHaveLength(1);
-    });
+        expect(result).toHaveLength(1);
+      });
 
-    it('includes internalTransfer type in filtered results', () => {
-      const rawLedgerUpdates: RawHyperLiquidLedgerUpdate[] = [
-        {
-          hash: '0x003',
-          time: 3000,
-          delta: { type: 'internalTransfer', usdc: '25' },
-        },
-      ];
+      it('includes withdraw type', () => {
+        const updates = [createLedgerUpdate('withdraw')];
 
-      const result =
-        adaptHyperLiquidLedgerUpdateToUserHistoryItem(rawLedgerUpdates);
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
 
-      expect(result).toHaveLength(1);
-    });
+        expect(result).toHaveLength(1);
+      });
 
-    it('excludes unsupported types from filtered results', () => {
-      const rawLedgerUpdates: RawHyperLiquidLedgerUpdate[] = [
-        {
-          hash: '0x004',
-          time: 4000,
-          delta: { type: 'trade', usdc: '10' },
-        },
-        {
-          hash: '0x005',
-          time: 5000,
-          delta: { type: 'liquidation', usdc: '20' },
-        },
-        {
-          hash: '0x006',
-          time: 6000,
-          delta: { type: 'funding', usdc: '5' },
-        },
-      ];
+      it('includes internalTransfer type', () => {
+        const updates = [createLedgerUpdate('internalTransfer')];
 
-      const result =
-        adaptHyperLiquidLedgerUpdateToUserHistoryItem(rawLedgerUpdates);
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
 
-      expect(result).toHaveLength(0);
-    });
+        expect(result).toHaveLength(1);
+      });
 
-    it('filters mixed types keeping only supported ones', () => {
-      const rawLedgerUpdates: RawHyperLiquidLedgerUpdate[] = [
-        {
-          hash: '0x007',
-          time: 7000,
-          delta: { type: 'deposit', usdc: '100' },
-        },
-        {
-          hash: '0x008',
-          time: 8000,
-          delta: { type: 'trade', usdc: '50' },
-        },
-        {
-          hash: '0x009',
-          time: 9000,
-          delta: { type: 'withdraw', usdc: '-75' },
-        },
-        {
-          hash: '0x010',
-          time: 10000,
-          delta: { type: 'liquidation', usdc: '25' },
-        },
-        {
-          hash: '0x011',
-          time: 11000,
-          delta: { type: 'internalTransfer', usdc: '30' },
-        },
-      ];
+      it('excludes unsupported types', () => {
+        const updates = [
+          createLedgerUpdate('trade', '0x001'),
+          createLedgerUpdate('liquidation', '0x002'),
+          createLedgerUpdate('funding', '0x003'),
+        ];
 
-      const result =
-        adaptHyperLiquidLedgerUpdateToUserHistoryItem(rawLedgerUpdates);
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
 
-      expect(result).toHaveLength(3);
+        expect(result).toHaveLength(0);
+      });
+
+      it('filters mixed array keeping only supported types', () => {
+        const updates = [
+          createLedgerUpdate('deposit', '0x001'),
+          createLedgerUpdate('trade', '0x002'),
+          createLedgerUpdate('withdraw', '0x003'),
+          createLedgerUpdate('liquidation', '0x004'),
+          createLedgerUpdate('internalTransfer', '0x005'),
+        ];
+
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
+
+        expect(result).toHaveLength(3);
+      });
     });
   });
 });

--- a/app/components/UI/Perps/utils/hyperLiquidAdapter.test.ts
+++ b/app/components/UI/Perps/utils/hyperLiquidAdapter.test.ts
@@ -1179,5 +1179,139 @@ describe('hyperLiquidAdapter', () => {
         expect(result).toHaveLength(3);
       });
     });
+
+    describe('internalTransfer USDC amount validation', () => {
+      it('includes internalTransfer with positive USDC amount', () => {
+        const updates: RawHyperLiquidLedgerUpdate[] = [
+          {
+            hash: '0x001',
+            time: 1000,
+            delta: { type: 'internalTransfer', usdc: '100.50' },
+          },
+        ];
+
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
+
+        expect(result).toHaveLength(1);
+      });
+
+      it('excludes internalTransfer with zero USDC amount', () => {
+        const updates: RawHyperLiquidLedgerUpdate[] = [
+          {
+            hash: '0x002',
+            time: 2000,
+            delta: { type: 'internalTransfer', usdc: '0' },
+          },
+        ];
+
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
+
+        expect(result).toHaveLength(0);
+      });
+
+      it('excludes internalTransfer with negative USDC amount', () => {
+        const updates: RawHyperLiquidLedgerUpdate[] = [
+          {
+            hash: '0x003',
+            time: 3000,
+            delta: { type: 'internalTransfer', usdc: '-50.25' },
+          },
+        ];
+
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
+
+        expect(result).toHaveLength(0);
+      });
+
+      it('excludes internalTransfer with invalid USDC value', () => {
+        const updates: RawHyperLiquidLedgerUpdate[] = [
+          {
+            hash: '0x004',
+            time: 4000,
+            delta: { type: 'internalTransfer', usdc: 'invalid' },
+          },
+        ];
+
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
+
+        expect(result).toHaveLength(0);
+      });
+
+      it('excludes internalTransfer with missing USDC field', () => {
+        const updates: RawHyperLiquidLedgerUpdate[] = [
+          {
+            hash: '0x005',
+            time: 5000,
+            delta: { type: 'internalTransfer' },
+          },
+        ];
+
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
+
+        expect(result).toHaveLength(0);
+      });
+
+      it('excludes internalTransfer with undefined USDC value', () => {
+        const updates: RawHyperLiquidLedgerUpdate[] = [
+          {
+            hash: '0x006',
+            time: 6000,
+            delta: { type: 'internalTransfer', usdc: undefined },
+          },
+        ];
+
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
+
+        expect(result).toHaveLength(0);
+      });
+
+      it('includes internalTransfer with small positive decimal amount', () => {
+        const updates: RawHyperLiquidLedgerUpdate[] = [
+          {
+            hash: '0x007',
+            time: 7000,
+            delta: { type: 'internalTransfer', usdc: '0.01' },
+          },
+        ];
+
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
+
+        expect(result).toHaveLength(1);
+      });
+
+      it('filters mixed internalTransfer entries keeping only valid positive amounts', () => {
+        const updates: RawHyperLiquidLedgerUpdate[] = [
+          {
+            hash: '0x008',
+            time: 8000,
+            delta: { type: 'internalTransfer', usdc: '100' },
+          },
+          {
+            hash: '0x009',
+            time: 9000,
+            delta: { type: 'internalTransfer', usdc: '0' },
+          },
+          {
+            hash: '0x010',
+            time: 10000,
+            delta: { type: 'internalTransfer', usdc: '-50' },
+          },
+          {
+            hash: '0x011',
+            time: 11000,
+            delta: { type: 'internalTransfer', usdc: 'invalid' },
+          },
+          {
+            hash: '0x012',
+            time: 12000,
+            delta: { type: 'internalTransfer', usdc: '25.50' },
+          },
+        ];
+
+        const result = adaptHyperLiquidLedgerUpdateToUserHistoryItem(updates);
+
+        expect(result).toHaveLength(2);
+      });
+    });
   });
 });

--- a/app/components/UI/Perps/utils/hyperLiquidAdapter.ts
+++ b/app/components/UI/Perps/utils/hyperLiquidAdapter.ts
@@ -505,7 +505,7 @@ export interface RawHyperLiquidLedgerUpdate {
 
 /**
  * Transform raw HyperLiquid ledger updates to UserHistoryItem format
- * Filters for deposits and withdrawals only, extracting amount and asset information
+ * Filters for deposits, withdrawals, and internal transfers only, extracting amount and asset information
  * @param rawLedgerUpdates - Array of raw ledger updates from HyperLiquid SDK
  * @returns Array of UserHistoryItem objects
  */
@@ -515,8 +515,10 @@ export function adaptHyperLiquidLedgerUpdateToUserHistoryItem(
   return (rawLedgerUpdates || [])
     .filter(
       (update) =>
-        // Only include deposits and withdrawals, skip other types
-        update.delta.type === 'deposit' || update.delta.type === 'withdraw',
+        // Only include deposits, withdrawals, and internal transfers, skip other types
+        update.delta.type === 'deposit' ||
+        update.delta.type === 'withdraw' ||
+        update.delta.type === 'internalTransfer',
     )
     .map((update) => {
       // Extract amount and asset based on delta type

--- a/app/components/UI/Perps/utils/hyperLiquidAdapter.ts
+++ b/app/components/UI/Perps/utils/hyperLiquidAdapter.ts
@@ -513,12 +513,18 @@ export function adaptHyperLiquidLedgerUpdateToUserHistoryItem(
   rawLedgerUpdates: RawHyperLiquidLedgerUpdate[],
 ): UserHistoryItem[] {
   return (rawLedgerUpdates || [])
-    .filter(
-      (update) =>
-        // Only include deposits, withdrawals, and internal transfers, skip other types
-        update.delta.type === 'deposit' ||
-        update.delta.type === 'withdraw' ||
-        update.delta.type === 'internalTransfer',
+    .filter((update) =>
+      // Only include deposits, withdrawals, and positive internal transfers, skip other types
+      {
+        if (update.delta.type === 'deposit') return true;
+        if (update.delta.type === 'withdraw') return true;
+        if (update.delta.type === 'internalTransfer') {
+          const usdc = Number.parseFloat(update.delta.usdc ?? '0');
+          if (Number.isNaN(usdc)) return false;
+          return usdc > 0;
+        }
+        return false;
+      },
     )
     .map((update) => {
       // Extract amount and asset based on delta type


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes an issue where internal transfers were not being displayed in the perps transaction history. The `adaptHyperLiquidLedgerUpdateToUserHistoryItem` function was only filtering for deposits and withdrawals, but was excluding internal transfers which are also relevant transaction events that users need to see.

The fix adds `internalTransfer` to the filter condition in the HyperLiquid adapter, ensuring that internal transfers are now included in the user's transaction history alongside deposits and withdrawals.


## **Changelog**

CHANGELOG entry: Fixed internal transfers not appearing in perps transaction history


## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2067

## **Manual testing steps**

```gherkin
Feature: Perps transaction history

  Scenario: user views deposits in Perps
    Given the user has performed deposit using ETH
    
    Then the transaction should be displayed under deposits
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://consensys.slack.com/archives/C09T0L3SHCY/p1762982300776619

### **After**

<!-- [screenshots/recordings] -->
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-28 at 11 18 34" src="https://github.com/user-attachments/assets/a278fc24-748b-4d17-88d4-0bc39d28ffda" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-28 at 11 18 30" src="https://github.com/user-attachments/assets/e2517e40-603a-42ea-a6a3-61dd21d4d4af" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Include positive `internalTransfer` ledger updates in perps deposit history and add comprehensive tests for filtering and amount validation.
> 
> - **Perps adapter (`hyperLiquidAdapter.ts`)**:
>   - Extend `adaptHyperLiquidLedgerUpdateToUserHistoryItem` to include `internalTransfer` updates when `usdc > 0`; ignore zero, negative, or invalid `usdc` values.
> - **Tests (`hyperLiquidAdapter.test.ts`)**:
>   - Add test suite for `adaptHyperLiquidLedgerUpdateToUserHistoryItem` covering supported/unsupported types and strict `internalTransfer` USDC validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 236053b7e979405e5efd053b800c6b0b05819688. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->