### PR TITLE
fix: [Trending] inconsistencies in results

### DIFF
--- a/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.tsx
+++ b/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.tsx
@@ -25,16 +25,6 @@ export enum NetworkOption {
   AllNetworks = 'all',
 }
 
-/**
- * List of CAIP chain IDs to exclude from the network selection list
- */
-const EXCLUDED_NETWORKS: CaipChainId[] = [
-  'eip155:11297108109', // Palm
-  'eip155:999', // Hyper EVM
-  'eip155:143', // Monad
-  'bip122:000000000019d6689c085ae165831e93', // btc mainnet
-];
-
 export interface TrendingTokenNetworkBottomSheetProps {
   isVisible: boolean;
   onClose: () => void;
@@ -61,11 +51,7 @@ const TrendingTokenNetworkBottomSheet: React.FC<
 }) => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const { colors } = useTheme();
-  const popularNetworks = usePopularNetworks();
-  // exclude Palm and hyper EVM from networks list and call it networksPopular
-  const networks = popularNetworks.filter(
-    (network) => !EXCLUDED_NETWORKS.includes(network.caipChainId),
-  );
+  const networks = usePopularNetworks();
 
   // Default to "All networks" if no selection
   const [selectedNetwork, setSelectedNetwork] = useState<

--- a/app/components/UI/Trending/hooks/usePopularNetworks/usePopularNetworks.test.ts
+++ b/app/components/UI/Trending/hooks/usePopularNetworks/usePopularNetworks.test.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { CaipChainId } from '@metamask/utils';
 import { BtcScope, SolScope } from '@metamask/keyring-api';
 import { isTestNet } from '../../../../../util/networks';
-import { usePopularNetworks } from './usePopularNetworks';
+import { usePopularNetworks, EXCLUDED_NETWORKS } from './usePopularNetworks';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -250,6 +250,50 @@ describe('usePopularNetworks', () => {
       expect(
         result.current.some((network) => network.caipChainId === 'eip155:1'),
       ).toBe(true);
+    });
+  });
+
+  describe('excluded networks filtering', () => {
+    it('filters out all excluded networks from networkConfigurations', () => {
+      const mockNetworkConfigurations = {
+        'eip155:1': {
+          caipChainId: 'eip155:1' as CaipChainId,
+          name: 'Ethereum Mainnet',
+        },
+        'eip155:11297108109': {
+          caipChainId: 'eip155:11297108109' as CaipChainId,
+          name: 'Palm',
+        },
+        'eip155:999': {
+          caipChainId: 'eip155:999' as CaipChainId,
+          name: 'Hyper EVM',
+        },
+        'eip155:143': {
+          caipChainId: 'eip155:143' as CaipChainId,
+          name: 'Monad',
+        },
+        'bip122:000000000019d6689c085ae165831e93': {
+          caipChainId: 'bip122:000000000019d6689c085ae165831e93' as CaipChainId,
+          name: 'Bitcoin Mainnet',
+        },
+        'eip155:137': {
+          caipChainId: 'eip155:137' as CaipChainId,
+          name: 'Polygon',
+        },
+      };
+
+      mockUseSelector.mockReturnValue(mockNetworkConfigurations);
+
+      const { result } = renderHook(() => usePopularNetworks());
+
+      const resultChainIds = result.current.map((n) => n.caipChainId);
+      EXCLUDED_NETWORKS.forEach((excludedChainId) => {
+        expect(resultChainIds).not.toContain(excludedChainId);
+      });
+      expect(result.current.some((n) => n.name === 'Ethereum Mainnet')).toBe(
+        true,
+      );
+      expect(result.current.some((n) => n.name === 'Polygon')).toBe(true);
     });
   });
 

--- a/app/components/UI/Trending/hooks/usePopularNetworks/usePopularNetworks.test.ts
+++ b/app/components/UI/Trending/hooks/usePopularNetworks/usePopularNetworks.test.ts
@@ -144,11 +144,6 @@ describe('usePopularNetworks', () => {
 
     it('filters out Bitcoin testnets from networkConfigurations', () => {
       const mockNetworkConfigurations = {
-        // Bitcoin mainnet example
-        [BtcScope.Mainnet]: {
-          caipChainId: BtcScope.Mainnet as CaipChainId,
-          name: 'Bitcoin',
-        },
         // Bitcoin testnet variants using full CAIP IDs from BtcScope
         [BtcScope.Testnet]: {
           caipChainId: BtcScope.Testnet as CaipChainId,
@@ -172,7 +167,6 @@ describe('usePopularNetworks', () => {
 
       const { result } = renderHook(() => usePopularNetworks());
 
-      expect(result.current.some((n) => n.name === 'Bitcoin')).toBe(true);
       expect(result.current.some((n) => n.name === 'Bitcoin Testnet')).toBe(
         false,
       );

--- a/app/components/UI/Trending/hooks/usePopularNetworks/usePopularNetworks.ts
+++ b/app/components/UI/Trending/hooks/usePopularNetworks/usePopularNetworks.ts
@@ -16,7 +16,7 @@ import { PopularList } from '../../../../../util/networks/customNetworks';
  * List of CAIP chain IDs to exclude from the popular networks list
  * These networks are not supported for trending/filtering features
  */
-const EXCLUDED_NETWORKS: CaipChainId[] = [
+export const EXCLUDED_NETWORKS: CaipChainId[] = [
   'eip155:11297108109', // Palm
   'eip155:999', // Hyper EVM
   'eip155:143', // Monad

--- a/app/components/UI/Trending/hooks/usePopularNetworks/usePopularNetworks.ts
+++ b/app/components/UI/Trending/hooks/usePopularNetworks/usePopularNetworks.ts
@@ -13,8 +13,19 @@ import { ProcessedNetwork } from '../../../../hooks/useNetworksByNamespace/useNe
 import { PopularList } from '../../../../../util/networks/customNetworks';
 
 /**
+ * List of CAIP chain IDs to exclude from the popular networks list
+ * These networks are not supported for trending/filtering features
+ */
+const EXCLUDED_NETWORKS: CaipChainId[] = [
+  'eip155:11297108109', // Palm
+  'eip155:999', // Hyper EVM
+  'eip155:143', // Monad
+  'bip122:000000000019d6689c085ae165831e93', // Bitcoin Mainnet
+];
+
+/**
  * Hook to get popular networks, combining networks from Redux state and PopularList.
- * Filters out testnets and ensures Ethereum Mainnet and Linea Mainnet appear first.
+ * Filters out testnets, excluded networks, and ensures Ethereum Mainnet and Linea Mainnet appear first.
  * The selector selectNetworkConfigurationsByCaipChainId is affected by whether the user has removed or added a network.
  * This hook will return all popular networks regardless of whether the user has removed or added a network.
  *
@@ -105,8 +116,13 @@ export const usePopularNetworks = (): ProcessedNetwork[] => {
       }
     }
 
+    // Filter out excluded networks
+    const filteredNetworks = processedNetworks.filter(
+      (network) => !EXCLUDED_NETWORKS.includes(network.caipChainId),
+    );
+
     // Sort networks so Ethereum Mainnet and Linea Mainnet appear first
-    return processedNetworks.sort((a, b) => {
+    return filteredNetworks.sort((a, b) => {
       const ethereumMainnet = 'eip155:1';
       const lineaMainnet = 'eip155:59144';
 

--- a/app/components/UI/Trending/hooks/useSearchRequest/useSearchRequest.test.ts
+++ b/app/components/UI/Trending/hooks/useSearchRequest/useSearchRequest.test.ts
@@ -4,10 +4,26 @@ import { act, waitFor } from '@testing-library/react-native';
 import { CaipChainId } from '@metamask/utils';
 // eslint-disable-next-line import/no-namespace
 import * as assetsControllers from '@metamask/assets-controllers';
+import { usePopularNetworks } from '../usePopularNetworks/usePopularNetworks';
+
+jest.mock('../usePopularNetworks/usePopularNetworks');
+
+const mockUsePopularNetworks = usePopularNetworks as jest.MockedFunction<
+  typeof usePopularNetworks
+>;
 
 describe('useSearchRequest', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUsePopularNetworks.mockReturnValue([
+      {
+        id: 'eip155:1',
+        name: 'Ethereum Mainnet',
+        caipChainId: 'eip155:1' as CaipChainId,
+        isSelected: false,
+        imageSource: { uri: 'ethereum' },
+      },
+    ]);
   });
 
   it('returns search results when search succeeds', async () => {

--- a/app/components/UI/Trending/hooks/useSearchRequest/useSearchRequest.ts
+++ b/app/components/UI/Trending/hooks/useSearchRequest/useSearchRequest.ts
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useState, useRef } from 'react';
+import { useCallback, useEffect, useState, useRef, useMemo } from 'react';
 import { CaipChainId } from '@metamask/utils';
 import { searchTokens } from '@metamask/assets-controllers';
 import { useStableArray } from '../../../Perps/hooks/useStableArray';
+import type { ProcessedNetwork } from '../../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
+import { usePopularNetworks } from '../usePopularNetworks/usePopularNetworks';
 
 /**
  * Hook for handling search tokens request
@@ -12,7 +14,20 @@ export const useSearchRequest = (options: {
   query: string;
   limit: number;
 }) => {
-  const { chainIds = [], query, limit } = options;
+  const { chainIds: providedChainIds = [], query, limit } = options;
+
+  // Get popular networks for filtering
+  const popularNetworks = usePopularNetworks();
+
+  // Use provided chainIds or default to popular networks
+  const chainIds = useMemo((): CaipChainId[] => {
+    if (providedChainIds.length > 0) {
+      return providedChainIds;
+    }
+    return popularNetworks.map(
+      (network: ProcessedNetwork) => network.caipChainId,
+    );
+  }, [providedChainIds, popularNetworks]);
   const [results, setResults] = useState<unknown[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);

--- a/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.test.ts
+++ b/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.test.ts
@@ -3,32 +3,14 @@ import { renderHookWithProvider } from '../../../../../util/test/renderWithProvi
 import { act, waitFor } from '@testing-library/react-native';
 // eslint-disable-next-line import/no-namespace
 import * as assetsControllers from '@metamask/assets-controllers';
-import {
-  ProcessedNetwork,
-  useNetworksByNamespace,
-} from '../../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
-import { useNetworksToUse } from '../../../../hooks/useNetworksToUse/useNetworksToUse';
+import type { ProcessedNetwork } from '../../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
+import { usePopularNetworks } from '../usePopularNetworks/usePopularNetworks';
+import { CaipChainId } from '@metamask/utils';
 
-// Mock the network hooks
-jest.mock(
-  '../../../../hooks/useNetworksByNamespace/useNetworksByNamespace',
-  () => ({
-    useNetworksByNamespace: jest.fn(),
-    NetworkType: {
-      Popular: 'popular',
-      Custom: 'custom',
-    },
-  }),
-);
+jest.mock('../usePopularNetworks/usePopularNetworks');
 
-jest.mock('../../../../hooks/useNetworksToUse/useNetworksToUse', () => ({
-  useNetworksToUse: jest.fn(),
-}));
-
-const mockUseNetworksByNamespace =
-  useNetworksByNamespace as jest.MockedFunction<typeof useNetworksByNamespace>;
-const mockUseNetworksToUse = useNetworksToUse as jest.MockedFunction<
-  typeof useNetworksToUse
+const mockUsePopularNetworks = usePopularNetworks as jest.MockedFunction<
+  typeof usePopularNetworks
 >;
 
 // Default mock networks
@@ -36,14 +18,14 @@ const mockDefaultNetworks: ProcessedNetwork[] = [
   {
     id: '1',
     name: 'Ethereum Mainnet',
-    caipChainId: 'eip155:1' as const,
+    caipChainId: 'eip155:1' as CaipChainId,
     isSelected: true,
     imageSource: { uri: 'ethereum' },
   },
   {
     id: '137',
     name: 'Polygon',
-    caipChainId: 'eip155:137' as const,
+    caipChainId: 'eip155:137' as CaipChainId,
     isSelected: true,
     imageSource: { uri: 'polygon' },
   },
@@ -52,26 +34,7 @@ const mockDefaultNetworks: ProcessedNetwork[] = [
 describe('useTrendingRequest', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Set up default mocks for network hooks
-    mockUseNetworksByNamespace.mockReturnValue({
-      networks: mockDefaultNetworks,
-      selectedNetworks: mockDefaultNetworks,
-      areAllNetworksSelected: true,
-      areAnyNetworksSelected: true,
-      networkCount: mockDefaultNetworks.length,
-      selectedCount: mockDefaultNetworks.length,
-    });
-    mockUseNetworksToUse.mockReturnValue({
-      networksToUse: mockDefaultNetworks,
-      evmNetworks: mockDefaultNetworks,
-      solanaNetworks: [],
-      selectedEvmAccount: null,
-      selectedSolanaAccount: null,
-      isMultichainAccountsState2Enabled: false,
-      areAllNetworksSelectedCombined: true,
-      areAllEvmNetworksSelected: true,
-      areAllSolanaNetworksSelected: false,
-    } as unknown as ReturnType<typeof useNetworksToUse>);
+    mockUsePopularNetworks.mockReturnValue(mockDefaultNetworks);
   });
 
   it('returns trending tokens results when fetch succeeds', async () => {
@@ -257,13 +220,7 @@ describe('useTrendingRequest', () => {
         expect(spyGetTrendingTokens).toHaveBeenCalledTimes(1);
       });
 
-      expect(mockUseNetworksByNamespace).toHaveBeenCalledWith({
-        networkType: 'popular',
-      });
-      expect(mockUseNetworksToUse).toHaveBeenCalledWith({
-        networks: mockDefaultNetworks,
-        networkType: 'popular',
-      });
+      expect(mockUsePopularNetworks).toHaveBeenCalled();
       expect(spyGetTrendingTokens).toHaveBeenCalledWith(
         expect.objectContaining({
           chainIds: ['eip155:1', 'eip155:137'],

--- a/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
+++ b/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
@@ -5,12 +5,8 @@ import {
   SortTrendingBy,
 } from '@metamask/assets-controllers';
 import { useStableArray } from '../../../Perps/hooks/useStableArray';
-import {
-  NetworkType,
-  useNetworksByNamespace,
-  ProcessedNetwork,
-} from '../../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
-import { useNetworksToUse } from '../../../../hooks/useNetworksToUse/useNetworksToUse';
+import type { ProcessedNetwork } from '../../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
+import { usePopularNetworks } from '../usePopularNetworks/usePopularNetworks';
 
 /**
  * Hook for handling trending tokens request
@@ -35,25 +31,18 @@ export const useTrendingRequest = (options: {
     maxMarketCap,
   } = options;
 
-  // Get default networks when chainIds is empty
-  const { networks } = useNetworksByNamespace({
-    networkType: NetworkType.Popular,
-  });
-
-  const { networksToUse } = useNetworksToUse({
-    networks,
-    networkType: NetworkType.Popular,
-  });
+  // Get popular networks for filtering
+  const popularNetworks = usePopularNetworks();
 
   // Use provided chainIds or default to popular networks
   const chainIds = useMemo((): CaipChainId[] => {
     if (providedChainIds.length > 0) {
       return providedChainIds;
     }
-    return networksToUse.map(
+    return popularNetworks.map(
       (network: ProcessedNetwork) => network.caipChainId,
     );
-  }, [providedChainIds, networksToUse]);
+  }, [providedChainIds, popularNetworks]);
 
   // Track the current request ID to prevent stale results from overwriting current ones
   const requestIdRef = useRef(0);

--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
@@ -22,6 +22,7 @@ export const useTrendingSearch = (
     useSearchRequest({
       query: searchQuery || '',
       limit: 20,
+      chainIds: chainIds ?? undefined,
     });
 
   const {

--- a/app/components/Views/TrendingView/TrendingView.test.tsx
+++ b/app/components/Views/TrendingView/TrendingView.test.tsx
@@ -31,6 +31,7 @@ import {
   selectChainId,
   selectPopularNetworkConfigurationsByCaipChainId,
   selectCustomNetworkConfigurationsByCaipChainId,
+  selectNetworkConfigurationsByCaipChainId,
 } from '../../../selectors/networkController';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 import { selectEnabledNetworksByNamespace } from '../../../selectors/networkEnablementController';
@@ -106,12 +107,33 @@ describe('TrendingView', () => {
     typeof useSelector
   >;
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockIsEnabled.mockReturnValue(true);
-    mockAddListener.mockReturnValue(jest.fn());
+  /**
+   * Helper function to create mock selector implementation with optional overrides
+   */
+  const createMockSelectorImplementation =
+    (
+      overrides: {
+        browserTabsCount?: number;
+        multichainEnabled?: boolean;
+        basicFunctionalityEnabled?: boolean;
+      } = {},
+    ) =>
+    (selector: unknown) => {
+      // Handle browser tabs count selector
+      if (typeof selector === 'function') {
+        const selectorStr = selector.toString();
+        if (selectorStr.includes('browser') && selectorStr.includes('tabs')) {
+          return overrides.browserTabsCount ?? 0;
+        }
+        // Handle selectSelectedInternalAccountByScope which is a selector factory
+        if (
+          selectorStr.includes('selectSelectedInternalAccountByScope') ||
+          selectorStr.includes('SelectedInternalAccountByScope')
+        ) {
+          return (_scope: string) => null;
+        }
+      }
 
-    mockUseSelector.mockImplementation((selector) => {
       // Compare selectors by reference for memoized selectors
       if (selector === selectChainId) {
         return '0x1';
@@ -126,97 +148,41 @@ describe('TrendingView', () => {
           },
         };
       }
+      if (selector === selectNetworkConfigurationsByCaipChainId) {
+        return {};
+      }
       if (selector === selectPopularNetworkConfigurationsByCaipChainId) {
-        // Return empty array to prevent Object.entries() error
         return [];
       }
       if (selector === selectCustomNetworkConfigurationsByCaipChainId) {
-        // Return empty array to prevent Object.entries() error
         return [];
       }
       if (selector === selectMultichainAccountsState2Enabled) {
-        // Return false to use default networks behavior
-        return false;
+        return overrides.multichainEnabled ?? false;
       }
       if (selector === selectBasicFunctionalityEnabled) {
-        // Return true by default (enabled)
-        return true;
+        return overrides.basicFunctionalityEnabled ?? true;
       }
-      // Handle selectSelectedInternalAccountByScope which is a selector factory
-      // It returns a function that takes a scope and returns an account
       if (selector === selectSelectedInternalAccountByScope) {
-        // Return a function that returns null (no account selected)
         return (_scope: string) => null;
       }
-      // Fallback: if selector is a function and might be a selector factory, return a function
-      if (typeof selector === 'function') {
-        const selectorStr = selector.toString();
-        if (
-          selectorStr.includes('selectSelectedInternalAccountByScope') ||
-          selectorStr.includes('SelectedInternalAccountByScope')
-        ) {
-          return (_scope: string) => null;
-        }
-      }
+
       return undefined;
-    });
-  });
+    };
 
-  it('renders browser button in header', () => {
-    const { getByTestId } = render(
-      <NavigationContainer>
-        <TrendingView />
-      </NavigationContainer>,
-    );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsEnabled.mockReturnValue(true);
+    mockAddListener.mockReturnValue(jest.fn());
 
-    const browserButton = getByTestId('trending-view-browser-button');
-
-    expect(browserButton).toBeDefined();
+    mockUseSelector.mockImplementation(createMockSelectorImplementation());
   });
 
   describe('browser button states', () => {
     it('displays add icon when no browser tabs are open', () => {
-      mockUseSelector.mockImplementation((selector) => {
-        // Handle browser tabs count selector
-        if (typeof selector === 'function') {
-          const selectorStr = selector.toString();
-          if (selectorStr.includes('browser') && selectorStr.includes('tabs')) {
-            return 0;
-          }
-        }
-        // Return default mock values for other selectors
-        if (selector === selectChainId) {
-          return '0x1';
-        }
-        if (selector === selectIsEvmNetworkSelected) {
-          return true;
-        }
-        if (selector === selectEnabledNetworksByNamespace) {
-          return { eip155: { '0x1': true } };
-        }
-        if (selector === selectPopularNetworkConfigurationsByCaipChainId) {
-          return [];
-        }
-        if (selector === selectCustomNetworkConfigurationsByCaipChainId) {
-          return [];
-        }
-        if (selector === selectMultichainAccountsState2Enabled) {
-          return false;
-        }
-        if (selector === selectSelectedInternalAccountByScope) {
-          return (_scope: string) => null;
-        }
-        if (typeof selector === 'function') {
-          const selectorStr = selector.toString();
-          if (
-            selectorStr.includes('selectSelectedInternalAccountByScope') ||
-            selectorStr.includes('SelectedInternalAccountByScope')
-          ) {
-            return (_scope: string) => null;
-          }
-        }
-        return undefined;
-      });
+      mockUseSelector.mockImplementation(
+        createMockSelectorImplementation({ browserTabsCount: 0 }),
+      );
 
       const { getByTestId, queryByText } = render(
         <NavigationContainer>
@@ -225,53 +191,14 @@ describe('TrendingView', () => {
       );
 
       const browserButton = getByTestId('trending-view-browser-button');
-
-      expect(browserButton).toBeDefined();
+      expect(browserButton).toBeOnTheScreen();
       expect(queryByText(/^\d+$/)).toBeNull();
     });
 
     it('displays tab count when one browser tab is open', () => {
-      mockUseSelector.mockImplementation((selector) => {
-        // Handle browser tabs count selector
-        if (typeof selector === 'function') {
-          const selectorStr = selector.toString();
-          if (selectorStr.includes('browser') && selectorStr.includes('tabs')) {
-            return 1;
-          }
-        }
-        // Return default mock values for other selectors
-        if (selector === selectChainId) {
-          return '0x1';
-        }
-        if (selector === selectIsEvmNetworkSelected) {
-          return true;
-        }
-        if (selector === selectEnabledNetworksByNamespace) {
-          return { eip155: { '0x1': true } };
-        }
-        if (selector === selectPopularNetworkConfigurationsByCaipChainId) {
-          return [];
-        }
-        if (selector === selectCustomNetworkConfigurationsByCaipChainId) {
-          return [];
-        }
-        if (selector === selectMultichainAccountsState2Enabled) {
-          return false;
-        }
-        if (selector === selectSelectedInternalAccountByScope) {
-          return (_scope: string) => null;
-        }
-        if (typeof selector === 'function') {
-          const selectorStr = selector.toString();
-          if (
-            selectorStr.includes('selectSelectedInternalAccountByScope') ||
-            selectorStr.includes('SelectedInternalAccountByScope')
-          ) {
-            return (_scope: string) => null;
-          }
-        }
-        return undefined;
-      });
+      mockUseSelector.mockImplementation(
+        createMockSelectorImplementation({ browserTabsCount: 1 }),
+      );
 
       const { getByText } = render(
         <NavigationContainer>
@@ -279,51 +206,13 @@ describe('TrendingView', () => {
         </NavigationContainer>,
       );
 
-      expect(getByText('1')).toBeDefined();
+      expect(getByText('1')).toBeOnTheScreen();
     });
 
     it('displays tab count when multiple browser tabs are open', () => {
-      mockUseSelector.mockImplementation((selector) => {
-        // Handle browser tabs count selector
-        if (typeof selector === 'function') {
-          const selectorStr = selector.toString();
-          if (selectorStr.includes('browser') && selectorStr.includes('tabs')) {
-            return 5;
-          }
-        }
-        // Return default mock values for other selectors
-        if (selector === selectChainId) {
-          return '0x1';
-        }
-        if (selector === selectIsEvmNetworkSelected) {
-          return true;
-        }
-        if (selector === selectEnabledNetworksByNamespace) {
-          return { eip155: { '0x1': true } };
-        }
-        if (selector === selectPopularNetworkConfigurationsByCaipChainId) {
-          return [];
-        }
-        if (selector === selectCustomNetworkConfigurationsByCaipChainId) {
-          return [];
-        }
-        if (selector === selectMultichainAccountsState2Enabled) {
-          return false;
-        }
-        if (selector === selectSelectedInternalAccountByScope) {
-          return (_scope: string) => null;
-        }
-        if (typeof selector === 'function') {
-          const selectorStr = selector.toString();
-          if (
-            selectorStr.includes('selectSelectedInternalAccountByScope') ||
-            selectorStr.includes('SelectedInternalAccountByScope')
-          ) {
-            return (_scope: string) => null;
-          }
-        }
-        return undefined;
-      });
+      mockUseSelector.mockImplementation(
+        createMockSelectorImplementation({ browserTabsCount: 5 }),
+      );
 
       const { getByText } = render(
         <NavigationContainer>
@@ -331,51 +220,13 @@ describe('TrendingView', () => {
         </NavigationContainer>,
       );
 
-      expect(getByText('5')).toBeDefined();
+      expect(getByText('5')).toBeOnTheScreen();
     });
 
     it('displays tab count when many browser tabs are open', () => {
-      mockUseSelector.mockImplementation((selector) => {
-        // Handle browser tabs count selector
-        if (typeof selector === 'function') {
-          const selectorStr = selector.toString();
-          if (selectorStr.includes('browser') && selectorStr.includes('tabs')) {
-            return 99;
-          }
-        }
-        // Return default mock values for other selectors
-        if (selector === selectChainId) {
-          return '0x1';
-        }
-        if (selector === selectIsEvmNetworkSelected) {
-          return true;
-        }
-        if (selector === selectEnabledNetworksByNamespace) {
-          return { eip155: { '0x1': true } };
-        }
-        if (selector === selectPopularNetworkConfigurationsByCaipChainId) {
-          return [];
-        }
-        if (selector === selectCustomNetworkConfigurationsByCaipChainId) {
-          return [];
-        }
-        if (selector === selectMultichainAccountsState2Enabled) {
-          return false;
-        }
-        if (selector === selectSelectedInternalAccountByScope) {
-          return (_scope: string) => null;
-        }
-        if (typeof selector === 'function') {
-          const selectorStr = selector.toString();
-          if (
-            selectorStr.includes('selectSelectedInternalAccountByScope') ||
-            selectorStr.includes('SelectedInternalAccountByScope')
-          ) {
-            return (_scope: string) => null;
-          }
-        }
-        return undefined;
-      });
+      mockUseSelector.mockImplementation(
+        createMockSelectorImplementation({ browserTabsCount: 99 }),
+      );
 
       const { getByText } = render(
         <NavigationContainer>
@@ -383,7 +234,7 @@ describe('TrendingView', () => {
         </NavigationContainer>,
       );
 
-      expect(getByText('99')).toBeDefined();
+      expect(getByText('99')).toBeOnTheScreen();
     });
 
     it('navigates to TrendingBrowser when button is pressed', () => {
@@ -413,7 +264,7 @@ describe('TrendingView', () => {
       </NavigationContainer>,
     );
 
-    expect(getByText('Explore')).toBeDefined();
+    expect(getByText('Explore')).toBeOnTheScreen();
   });
 
   it('renders search bar button', () => {
@@ -425,7 +276,7 @@ describe('TrendingView', () => {
 
     const searchButton = getByTestId('explore-view-search-button');
 
-    expect(searchButton).toBeDefined();
+    expect(searchButton).toBeOnTheScreen();
   });
 
   it('navigates to ExploreSearch route when search bar is pressed', () => {
@@ -436,7 +287,6 @@ describe('TrendingView', () => {
     );
 
     const searchButton = getByTestId('explore-view-search-button');
-
     fireEvent.press(searchButton);
 
     expect(mockNavigate).toHaveBeenCalledWith('ExploreSearch');
@@ -444,12 +294,9 @@ describe('TrendingView', () => {
 
   describe('basic functionality toggle', () => {
     it('displays empty state when basic functionality is disabled', () => {
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectBasicFunctionalityEnabled) {
-          return false;
-        }
-        return undefined;
-      });
+      mockUseSelector.mockImplementation(
+        createMockSelectorImplementation({ basicFunctionalityEnabled: false }),
+      );
 
       const { getByTestId } = render(
         <NavigationContainer>
@@ -457,7 +304,7 @@ describe('TrendingView', () => {
         </NavigationContainer>,
       );
 
-      expect(getByTestId('basic-functionality-empty-state')).toBeDefined();
+      expect(getByTestId('basic-functionality-empty-state')).toBeOnTheScreen();
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The trending tokens feature had the following issues:
- Trending results were not scoped to popular networks which led to having some results from chains which we could not even filter on
- Search API results were never scoped to some specific chains -> Now we scope to only popular chains
- Filtering logi was not centralized

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix trending tokens inconsistencies in search results

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-1866

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="209" height="413" alt="image" src="https://github.com/user-attachments/assets/47c424cb-f03a-40a8-9c88-d4f0a67fb0eb" />


<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes trending and search to popular networks using a centralized filter (with explicit exclusions) and updates UI/tests accordingly.
> 
> - **Hooks**:
>   - **`usePopularNetworks`**:
>     - Adds `EXCLUDED_NETWORKS` and filters out unsupported/testnet/custom networks; ensures Ethereum then Linea ordering.
>   - **`useTrendingRequest` / `useSearchRequest`**:
>     - Default `chainIds` to `usePopularNetworks()` when not provided; stabilize requests and states.
>   - **`useTrendingSearch`**:
>     - Passes `chainIds` through to both search and trending requests.
> - **UI**:
>   - **`TrendingTokenNetworkBottomSheet`**: Uses `usePopularNetworks()` directly (removes local exclusions).
> - **Tests**:
>   - Expand coverage for excluded networks and defaults; mock `usePopularNetworks`; streamline `TrendingView` tests with selector helper and updated assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a2981d6729dc01cc2032fe753145163746e3bd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->