### PR TITLE
feat: hide network connection banner immediately when network recovers

### DIFF
--- a/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.test.tsx
+++ b/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.test.tsx
@@ -108,6 +108,10 @@ const mockNetworkController = {
 
 const mockEngine = {
   lookupEnabledNetworks: jest.fn(),
+  controllerMessenger: {
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+  },
   context: {
     NetworkController: mockNetworkController,
   },
@@ -133,6 +137,8 @@ describe('useNetworkConnectionBanner', () => {
 
     // Mock Engine methods directly (safer than spyOn after jest.mock)
     Engine.lookupEnabledNetworks = mockEngine.lookupEnabledNetworks;
+    // @ts-expect-error - Mocking Engine for testing
+    Engine.controllerMessenger = mockEngine.controllerMessenger;
     // @ts-expect-error - Mocking Engine for testing
     Engine.context = mockEngine.context;
 
@@ -894,6 +900,114 @@ describe('useNetworkConnectionBanner', () => {
 
       act(() => {
         jest.advanceTimersByTime(5000);
+      });
+
+      const actions = store.getActions();
+      expect(actions).toHaveLength(0);
+    });
+  });
+
+  describe('NetworkController:rpcEndpointChainAvailable event subscription', () => {
+    it('subscribes to rpcEndpointChainAvailable event on mount', () => {
+      renderHookWithProvider();
+
+      expect(mockEngine.controllerMessenger.subscribe).toHaveBeenCalledWith(
+        'NetworkController:rpcEndpointChainAvailable',
+        expect.any(Function),
+      );
+    });
+
+    it('unsubscribes from rpcEndpointChainAvailable event on unmount', () => {
+      const { unmount } = renderHookWithProvider();
+
+      const subscribeCall = (
+        mockEngine.controllerMessenger.subscribe as jest.Mock
+      ).mock.calls.find(
+        (call) => call[0] === 'NetworkController:rpcEndpointChainAvailable',
+      );
+      const subscribedHandler = subscribeCall?.[1];
+
+      unmount();
+
+      expect(mockEngine.controllerMessenger.unsubscribe).toHaveBeenCalledWith(
+        'NetworkController:rpcEndpointChainAvailable',
+        subscribedHandler,
+      );
+    });
+
+    it('hides banner when rpcEndpointChainAvailable event fires for matching chain', () => {
+      jest.mocked(selectNetworkConnectionBannerState).mockReturnValue({
+        visible: true,
+        chainId: '0x89',
+        status: 'degraded',
+        networkName: 'Polygon Mainnet',
+        rpcUrl: 'https://polygon-rpc.com',
+        isInfuraEndpoint: false,
+      });
+
+      renderHookWithProvider();
+
+      const subscribeCall = (
+        mockEngine.controllerMessenger.subscribe as jest.Mock
+      ).mock.calls.find(
+        (call) => call[0] === 'NetworkController:rpcEndpointChainAvailable',
+      );
+      const subscribedHandler = subscribeCall?.[1];
+
+      act(() => {
+        subscribedHandler({ chainId: '0x89' });
+      });
+
+      const actions = store.getActions();
+      expect(actions).toHaveLength(1);
+      expect(actions[0]).toStrictEqual({
+        type: 'HIDE_NETWORK_CONNECTION_BANNER',
+      });
+    });
+
+    it('does not hide banner when rpcEndpointChainAvailable event fires for different chain', () => {
+      jest.mocked(selectNetworkConnectionBannerState).mockReturnValue({
+        visible: true,
+        chainId: '0x89',
+        status: 'degraded',
+        networkName: 'Polygon Mainnet',
+        rpcUrl: 'https://polygon-rpc.com',
+        isInfuraEndpoint: false,
+      });
+
+      renderHookWithProvider();
+
+      const subscribeCall = (
+        mockEngine.controllerMessenger.subscribe as jest.Mock
+      ).mock.calls.find(
+        (call) => call[0] === 'NetworkController:rpcEndpointChainAvailable',
+      );
+      const subscribedHandler = subscribeCall?.[1];
+
+      act(() => {
+        subscribedHandler({ chainId: '0x1' }); // Different chain
+      });
+
+      const actions = store.getActions();
+      expect(actions).toHaveLength(0);
+    });
+
+    it('does not hide banner when banner is not visible', () => {
+      jest.mocked(selectNetworkConnectionBannerState).mockReturnValue({
+        visible: false,
+      });
+
+      renderHookWithProvider();
+
+      const subscribeCall = (
+        mockEngine.controllerMessenger.subscribe as jest.Mock
+      ).mock.calls.find(
+        (call) => call[0] === 'NetworkController:rpcEndpointChainAvailable',
+      );
+      const subscribedHandler = subscribeCall?.[1];
+
+      act(() => {
+        subscribedHandler({ chainId: '0x89' });
       });
 
       const actions = store.getActions();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

### **Description**

Subscribe to `NetworkController:rpcEndpointChainAvailable` event to immediately hide the network connection banner when a network becomes available again, instead of relying solely on periodic timeout checks.

### Changes

- Subscribe to `NetworkController:rpcEndpointChainAvailable` event in `useNetworkConnectionBanner` hook
- Hide banner when event fires for matching `chainId`

## Behavior

The banner now hides instantly when:
- The event fires for a network that became available
- The `chainId` matches the currently displayed banner
- The banner is currently visible

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: feat: Network connection banner now hides immediately when network becomes available again

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 08a9ff8f22d3be122eba84fae9e42f319942db82. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->