### PR TITLE
fix(ramp): use case-insensitive comparison for deposit ramp asset IDs cp-7.61.0

### DIFF
--- a/app/components/UI/Ramp/Deposit/hooks/useCryptoCurrencies.ts
+++ b/app/components/UI/Ramp/Deposit/hooks/useCryptoCurrencies.ts
@@ -10,6 +10,7 @@ import { selectNetworkConfigurationsByCaipChainId } from '../../../../../selecto
 import { isCaipChainId } from '@metamask/utils';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import { toHex } from '@metamask/controller-utils';
+import { toLowerCaseEquals } from '../../../../../util/general';
 
 export interface UseCryptoCurrenciesResult {
   cryptoCurrencies: DepositCryptoCurrency[] | null;
@@ -55,8 +56,8 @@ export function useCryptoCurrencies(): UseCryptoCurrenciesResult {
   useEffect(() => {
     if (cryptoCurrencies && cryptoCurrencies.length > 0) {
       if (intent?.assetId) {
-        const intentCrypto = cryptoCurrencies.find(
-          (token) => token.assetId === intent.assetId,
+        const intentCrypto = cryptoCurrencies.find((token) =>
+          toLowerCaseEquals(token.assetId, intent.assetId),
         );
 
         setIntent((prevIntent) =>
@@ -73,8 +74,8 @@ export function useCryptoCurrencies(): UseCryptoCurrenciesResult {
 
       if (selectedCryptoCurrency) {
         newSelectedCrypto =
-          cryptoCurrencies.find(
-            (crypto) => crypto.assetId === selectedCryptoCurrency.assetId,
+          cryptoCurrencies.find((crypto) =>
+            toLowerCaseEquals(crypto.assetId, selectedCryptoCurrency.assetId),
           ) || null;
       }
 


### PR DESCRIPTION
## **Description**

This PR improves the robustness of asset ID matching in the Deposit Ramp flow by implementing case-insensitive comparisons. Previously, asset IDs (which are often Ethereum addresses) were compared using strict equality, which could cause issues when the same address appeared with different casing.

The change uses the existing `toLowerCaseEquals` utility function from `app/util/general` to ensure that asset IDs are compared case-insensitively in two critical places:
1. When matching an intent's asset ID with available cryptocurrencies
2. When matching the selected cryptocurrency with the updated list of available cryptocurrencies

This ensures that the same Ethereum address with different casing (e.g., `0xabc...` vs `0xABC...`) will be correctly identified as the same asset.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/23441

## **Manual testing steps**

```gherkin
Feature: Deposit Ramp Asset Selection

  Scenario: user selects a cryptocurrency with asset ID in different casing
    Given user has navigated to the Deposit Ramp screen
    And there is an intent with an assetId in lowercase
    And the available cryptocurrencies list contains the same asset with uppercase casing

    When the hook processes the cryptocurrencies list
    Then the correct cryptocurrency should be matched and selected
    And the asset should not be treated as missing
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/5445df8c-8cfb-4168-8666-c79934d0b8ad

### **After**






## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use case-insensitive comparisons for `assetId` when resolving intent and maintaining selected crypto in `useCryptoCurrencies`.
> 
> - **Hooks**
>   - `app/components/UI/Ramp/Deposit/hooks/useCryptoCurrencies.ts`:
>     - Use `toLowerCaseEquals` for case-insensitive `assetId` matching when:
>       - Finding intent crypto in `cryptoCurrencies`.
>       - Reconciling `selectedCryptoCurrency` with updated `cryptoCurrencies` list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 298dc33c50f4c0dff490889ce021e621d7d1b150. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->