### PR TITLE
feat: cp-7.61.0 add gas fee token metrics

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/utils.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/utils.test.ts
@@ -34,6 +34,11 @@ import {
   TransactionEventHandlerRequest,
   type TransactionMetrics,
 } from './types';
+import { store } from '../../../../store';
+import { NATIVE_TOKEN_ADDRESS } from '../../../../components/Views/confirmations/constants/tokens';
+
+const TOKEN_ADDRESS_MOCK = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const TOKEN_ADDRESS_2_MOCK = '0xdac17f958d2ee523a2206206994597c13d831ec7';
 
 jest.mock('../../../Analytics/MetricsEventBuilder', () => ({
   MetricsEventBuilder: {
@@ -55,6 +60,37 @@ jest.mock('../../../../util/rpc-domain-utils', () => ({
     Unknown: 'unknown',
   },
 }));
+
+jest.mock('../../../../store', () => ({
+  store: {
+    getState: jest.fn(),
+  },
+}));
+
+/**
+ * Helper function to mock native balance for an address on a specific chain
+ */
+function mockNativeBalance(
+  chainId: string,
+  address: string,
+  balance: string | undefined,
+): void {
+  (store.getState as jest.Mock).mockReturnValue({
+    engine: {
+      backgroundState: {
+        AccountTrackerController: {
+          accountsByChainId: {
+            [chainId]: {
+              [address.toLowerCase()]: {
+                balance,
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+}
 
 describe('getTransactionTypeValue', () => {
   it('should return correct string value for snake case conversion cases', () => {
@@ -221,6 +257,8 @@ describe('generateDefaultTransactionMetrics', () => {
     txParams: {
       authorizationList: [],
       from: FROM_ADDRESS_MOCK,
+      gas: '0x1',
+      maxFeePerGas: '0x1',
     },
   };
 
@@ -256,6 +294,8 @@ describe('generateDefaultTransactionMetrics', () => {
     (MetricsEventBuilder.createEventBuilder as jest.Mock).mockReturnValue(
       mockEventBuilder,
     );
+
+    mockNativeBalance('0x1', FROM_ADDRESS_MOCK, '0x0000000000000000000');
   });
 
   it('generates default transaction metrics', async () => {
@@ -267,7 +307,7 @@ describe('generateDefaultTransactionMetrics', () => {
 
     expect(result).toEqual({
       metametricsEvent: mockMetametricsEvent,
-      properties: {
+      properties: expect.objectContaining({
         account_eip7702_upgraded: undefined,
         account_type: 'MetaMask',
         additional_property: 'test_value',
@@ -283,7 +323,7 @@ describe('generateDefaultTransactionMetrics', () => {
         transaction_envelope_type: undefined,
         transaction_internal_id: 'test-id-123',
         transaction_type: 'simple_send',
-      },
+      }),
       sensitiveProperties: {
         sensitive_data: 'sensitive_value',
       },
@@ -305,7 +345,7 @@ describe('generateDefaultTransactionMetrics', () => {
 
     expect(result).toEqual({
       metametricsEvent: mockMetametricsEvent,
-      properties: {
+      properties: expect.objectContaining({
         account_eip7702_upgraded: undefined,
         account_type: 'MetaMask',
         chain_id: '0x1',
@@ -320,7 +360,7 @@ describe('generateDefaultTransactionMetrics', () => {
         transaction_envelope_type: undefined,
         transaction_internal_id: 'test-id-123',
         transaction_type: 'simple_send',
-      },
+      }),
     });
   });
 
@@ -525,6 +565,192 @@ describe('generateDefaultTransactionMetrics', () => {
       expect(result.properties.gas_fee_presented).toEqual(['custom']);
       expect(result.properties.gas_estimation_failed).toBe(true);
     });
+
+    describe('gas payment tokens', () => {
+      it('includes gas_payment_tokens_available when gasFeeTokens are present', async () => {
+        const metaWithGasFeeTokens = {
+          ...mockTransactionMeta,
+          gasFeeTokens: [
+            { symbol: 'USDC', tokenAddress: TOKEN_ADDRESS_MOCK },
+            { symbol: 'USDT', tokenAddress: TOKEN_ADDRESS_2_MOCK },
+          ],
+        };
+
+        const result = await generateDefaultTransactionMetrics(
+          mockMetametricsEvent,
+          metaWithGasFeeTokens as TransactionMeta,
+          mockEventHandlerRequest as TransactionEventHandlerRequest,
+        );
+
+        expect(result.properties.gas_payment_tokens_available).toEqual([
+          'USDC',
+          'USDT',
+        ]);
+      });
+
+      it('includes gas_paid_with when selectedGasFeeToken matches a token', async () => {
+        const metaWithSelectedToken = {
+          ...mockTransactionMeta,
+          gasFeeTokens: [
+            { symbol: 'USDC', tokenAddress: TOKEN_ADDRESS_MOCK },
+            { symbol: 'USDT', tokenAddress: TOKEN_ADDRESS_2_MOCK },
+          ],
+          selectedGasFeeToken: TOKEN_ADDRESS_MOCK,
+        };
+
+        const result = await generateDefaultTransactionMetrics(
+          mockMetametricsEvent,
+          metaWithSelectedToken as TransactionMeta,
+          mockEventHandlerRequest as TransactionEventHandlerRequest,
+        );
+
+        expect(result.properties.gas_paid_with).toBe('USDC');
+      });
+
+      it('sets gas_paid_with to pre-funded_ETH when native token is selected', async () => {
+        const metaWithNativeToken = {
+          ...mockTransactionMeta,
+          gasFeeTokens: [
+            { symbol: 'USDC', tokenAddress: TOKEN_ADDRESS_MOCK },
+            { symbol: 'USDT', tokenAddress: TOKEN_ADDRESS_2_MOCK },
+          ],
+          selectedGasFeeToken: NATIVE_TOKEN_ADDRESS,
+        };
+
+        const result = await generateDefaultTransactionMetrics(
+          mockMetametricsEvent,
+          metaWithNativeToken as TransactionMeta,
+          mockEventHandlerRequest as TransactionEventHandlerRequest,
+        );
+
+        expect(result.properties.gas_paid_with).toBe('pre-funded_ETH');
+      });
+
+      it('handles case-insensitive token address matching', async () => {
+        const metaWithUppercaseAddress = {
+          ...mockTransactionMeta,
+          gasFeeTokens: [
+            { symbol: 'USDC', tokenAddress: TOKEN_ADDRESS_MOCK.toLowerCase() },
+          ],
+          selectedGasFeeToken: TOKEN_ADDRESS_MOCK.toUpperCase(),
+        };
+
+        const result = await generateDefaultTransactionMetrics(
+          mockMetametricsEvent,
+          metaWithUppercaseAddress as TransactionMeta,
+          mockEventHandlerRequest as TransactionEventHandlerRequest,
+        );
+
+        expect(result.properties.gas_paid_with).toBe('USDC');
+      });
+
+      it('sets gas_insufficient_native_asset to false when balance is sufficient', async () => {
+        mockNativeBalance('0x1', FROM_ADDRESS_MOCK, '0x1000000000000000000');
+
+        const metaWithLowGas = {
+          ...mockTransactionMeta,
+          txParams: {
+            ...mockTransactionMeta.txParams,
+            gas: '0x5208',
+            maxFeePerGas: '0x1',
+          },
+        };
+
+        const result = await generateDefaultTransactionMetrics(
+          mockMetametricsEvent,
+          metaWithLowGas as TransactionMeta,
+          mockEventHandlerRequest as TransactionEventHandlerRequest,
+        );
+
+        expect(result.properties.gas_insufficient_native_asset).toBe(false);
+      });
+
+      it('sets gas_insufficient_native_asset to true when balance is insufficient', async () => {
+        mockNativeBalance('0x1', FROM_ADDRESS_MOCK, '0x1');
+
+        const metaWithHighGas = {
+          ...mockTransactionMeta,
+          txParams: {
+            ...mockTransactionMeta.txParams,
+            gas: '0x100000',
+            maxFeePerGas: '0x100000000',
+          },
+        };
+
+        const result = await generateDefaultTransactionMetrics(
+          mockMetametricsEvent,
+          metaWithHighGas as TransactionMeta,
+          mockEventHandlerRequest as TransactionEventHandlerRequest,
+        );
+
+        expect(result.properties.gas_insufficient_native_asset).toBe(true);
+      });
+
+      it('uses gasPrice for max gas cost calculation when maxFeePerGas is not available', async () => {
+        mockNativeBalance('0x1', FROM_ADDRESS_MOCK, '0x1');
+
+        const metaWithGasPrice = {
+          ...mockTransactionMeta,
+          txParams: {
+            ...mockTransactionMeta.txParams,
+            gas: '0x100000',
+            gasPrice: '0x100000000',
+            maxFeePerGas: undefined,
+          },
+        };
+
+        const result = await generateDefaultTransactionMetrics(
+          mockMetametricsEvent,
+          metaWithGasPrice as TransactionMeta,
+          mockEventHandlerRequest as TransactionEventHandlerRequest,
+        );
+
+        expect(result.properties.gas_insufficient_native_asset).toBe(true);
+      });
+
+      it('handles missing account balance gracefully', async () => {
+        mockNativeBalance('0x1', FROM_ADDRESS_MOCK, undefined);
+
+        const result = await generateDefaultTransactionMetrics(
+          mockMetametricsEvent,
+          mockTransactionMeta as TransactionMeta,
+          mockEventHandlerRequest as TransactionEventHandlerRequest,
+        );
+
+        expect(result.properties.gas_insufficient_native_asset).toBe(true);
+      });
+
+      it('returns undefined for gas_paid_with when no token is selected', async () => {
+        const metaWithoutSelectedToken = {
+          ...mockTransactionMeta,
+          gasFeeTokens: [{ symbol: 'USDC', tokenAddress: TOKEN_ADDRESS_MOCK }],
+          selectedGasFeeToken: undefined,
+        };
+
+        const result = await generateDefaultTransactionMetrics(
+          mockMetametricsEvent,
+          metaWithoutSelectedToken as TransactionMeta,
+          mockEventHandlerRequest as TransactionEventHandlerRequest,
+        );
+
+        expect(result.properties.gas_paid_with).toBeUndefined();
+      });
+
+      it('returns undefined for gas_payment_tokens_available when gasFeeTokens is undefined', async () => {
+        const metaWithoutGasFeeTokens = {
+          ...mockTransactionMeta,
+          gasFeeTokens: undefined,
+        };
+
+        const result = await generateDefaultTransactionMetrics(
+          mockMetametricsEvent,
+          metaWithoutGasFeeTokens as TransactionMeta,
+          mockEventHandlerRequest as TransactionEventHandlerRequest,
+        );
+
+        expect(result.properties.gas_payment_tokens_available).toBeUndefined();
+      });
+    });
   });
 
   describe('batch transaction metrics', () => {
@@ -541,27 +767,29 @@ describe('generateDefaultTransactionMetrics', () => {
             }) as RootState,
         } as TransactionEventHandlerRequest,
       );
-      expect(metrics.properties).toStrictEqual({
-        account_eip7702_upgraded: undefined,
-        account_type: 'MetaMask',
-        api_method: 'wallet_sendCalls',
-        batch_transaction_count: 2,
-        batch_transaction_method: 'eip7702',
-        chain_id: '0xaa36a7',
-        dapp_host_name: 'metamask.github.io',
-        eip7702_upgrade_transaction: true,
-        error: undefined,
-        gas_estimation_failed: true,
-        gas_fee_presented: ['custom'],
-        gas_fee_selected: undefined,
-        source: 'MetaMask Mobile',
-        status: 'unapproved',
-        transaction_contract_address: [],
-        transaction_contract_method: [],
-        transaction_envelope_type: '0x4',
-        transaction_internal_id: 'aa0ff2b0-150f-11f0-9325-8f0b8505bc4f',
-        transaction_type: 'batch',
-      });
+      expect(metrics.properties).toEqual(
+        expect.objectContaining({
+          account_eip7702_upgraded: undefined,
+          account_type: 'MetaMask',
+          api_method: 'wallet_sendCalls',
+          batch_transaction_count: 2,
+          batch_transaction_method: 'eip7702',
+          chain_id: '0xaa36a7',
+          dapp_host_name: 'metamask.github.io',
+          eip7702_upgrade_transaction: true,
+          error: undefined,
+          gas_estimation_failed: true,
+          gas_fee_presented: ['custom'],
+          gas_fee_selected: undefined,
+          source: 'MetaMask Mobile',
+          status: 'unapproved',
+          transaction_contract_address: [],
+          transaction_contract_method: [],
+          transaction_envelope_type: '0x4',
+          transaction_internal_id: 'aa0ff2b0-150f-11f0-9325-8f0b8505bc4f',
+          transaction_type: 'batch',
+        }),
+      );
     });
 
     it('generate correct properties for upgrade only request', async () => {
@@ -577,23 +805,25 @@ describe('generateDefaultTransactionMetrics', () => {
             }) as RootState,
         } as TransactionEventHandlerRequest,
       );
-      expect(metrics.properties).toStrictEqual({
-        account_eip7702_upgraded: undefined,
-        account_type: 'MetaMask',
-        chain_id: '0xaa36a7',
-        dapp_host_name: 'metamask',
-        eip7702_upgrade_transaction: true,
-        error: undefined,
-        gas_estimation_failed: true,
-        gas_fee_presented: ['custom'],
-        gas_fee_selected: undefined,
-        source: 'MetaMask Mobile',
-        status: 'unapproved',
-        transaction_contract_method: [],
-        transaction_envelope_type: '0x4',
-        transaction_internal_id: 'aa0ff2b0-150f-11f0-9325-8f0b8505bc4f',
-        transaction_type: 'batch',
-      });
+      expect(metrics.properties).toEqual(
+        expect.objectContaining({
+          account_eip7702_upgraded: undefined,
+          account_type: 'MetaMask',
+          chain_id: '0xaa36a7',
+          dapp_host_name: 'metamask',
+          eip7702_upgrade_transaction: true,
+          error: undefined,
+          gas_estimation_failed: true,
+          gas_fee_presented: ['custom'],
+          gas_fee_selected: undefined,
+          source: 'MetaMask Mobile',
+          status: 'unapproved',
+          transaction_contract_method: [],
+          transaction_envelope_type: '0x4',
+          transaction_internal_id: 'aa0ff2b0-150f-11f0-9325-8f0b8505bc4f',
+          transaction_type: 'batch',
+        }),
+      );
     });
 
     it('generate correct properties for rejected upgrade request', async () => {
@@ -615,24 +845,26 @@ describe('generateDefaultTransactionMetrics', () => {
             }) as RootState,
         } as TransactionEventHandlerRequest,
       );
-      expect(metrics.properties).toStrictEqual({
-        account_eip7702_upgraded: undefined,
-        account_type: 'MetaMask',
-        chain_id: '0xaa36a7',
-        dapp_host_name: 'metamask',
-        eip7702_upgrade_rejection: true,
-        eip7702_upgrade_transaction: true,
-        error: undefined,
-        gas_estimation_failed: true,
-        gas_fee_presented: ['custom'],
-        gas_fee_selected: undefined,
-        source: 'MetaMask Mobile',
-        status: 'rejected',
-        transaction_contract_method: [],
-        transaction_envelope_type: '0x4',
-        transaction_internal_id: 'aa0ff2b0-150f-11f0-9325-8f0b8505bc4f',
-        transaction_type: 'batch',
-      });
+      expect(metrics.properties).toEqual(
+        expect.objectContaining({
+          account_eip7702_upgraded: undefined,
+          account_type: 'MetaMask',
+          chain_id: '0xaa36a7',
+          dapp_host_name: 'metamask',
+          eip7702_upgrade_rejection: true,
+          eip7702_upgrade_transaction: true,
+          error: undefined,
+          gas_estimation_failed: true,
+          gas_fee_presented: ['custom'],
+          gas_fee_selected: undefined,
+          source: 'MetaMask Mobile',
+          status: 'rejected',
+          transaction_contract_method: [],
+          transaction_envelope_type: '0x4',
+          transaction_internal_id: 'aa0ff2b0-150f-11f0-9325-8f0b8505bc4f',
+          transaction_type: 'batch',
+        }),
+      );
     });
 
     it('generate correct properties for batched approval request', async () => {
@@ -648,29 +880,32 @@ describe('generateDefaultTransactionMetrics', () => {
             }) as RootState,
         } as TransactionEventHandlerRequest,
       );
-      expect(metrics.properties).toStrictEqual({
-        account_eip7702_upgraded: '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b',
-        account_type: 'MetaMask',
-        api_method: 'wallet_sendCalls',
-        batch_transaction_count: 2,
-        batch_transaction_method: 'eip7702',
-        chain_id: '0x1',
-        dapp_host_name: 'jumper123.exchange',
-        eip7702_upgrade_transaction: false,
-        error: undefined,
-        gas_estimation_failed: false,
-        gas_fee_presented: ['custom', 'low', 'medium', 'high'],
-        gas_fee_selected: 'medium',
-        source: 'MetaMask Mobile',
-        status: 'unapproved',
-        transaction_contract_address: [
-          '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE',
-        ],
-        transaction_contract_method: [],
-        transaction_envelope_type: '0x2',
-        transaction_internal_id: '00e2c3a0-3537-11f0-a6bc-c5da15141f51',
-        transaction_type: 'batch',
-      });
+      expect(metrics.properties).toEqual(
+        expect.objectContaining({
+          account_eip7702_upgraded:
+            '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b',
+          account_type: 'MetaMask',
+          api_method: 'wallet_sendCalls',
+          batch_transaction_count: 2,
+          batch_transaction_method: 'eip7702',
+          chain_id: '0x1',
+          dapp_host_name: 'jumper123.exchange',
+          eip7702_upgrade_transaction: false,
+          error: undefined,
+          gas_estimation_failed: false,
+          gas_fee_presented: ['custom', 'low', 'medium', 'high'],
+          gas_fee_selected: 'medium',
+          source: 'MetaMask Mobile',
+          status: 'unapproved',
+          transaction_contract_address: [
+            '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE',
+          ],
+          transaction_contract_method: [],
+          transaction_envelope_type: '0x2',
+          transaction_internal_id: '00e2c3a0-3537-11f0-a6bc-c5da15141f51',
+          transaction_type: 'batch',
+        }),
+      );
     });
   });
 });

--- a/app/core/Engine/controllers/transaction-controller/utils.ts
+++ b/app/core/Engine/controllers/transaction-controller/utils.ts
@@ -344,9 +344,9 @@ function getNativeBalance(chainId: string, address: string): BigNumber {
   const state = store.getState();
 
   const accountsByChainId =
-    state.engine.backgroundState.AccountTrackerController.accountsByChainId;
+    state.engine?.backgroundState?.AccountTrackerController?.accountsByChainId;
 
-  const account = accountsByChainId[chainId]?.[address.toLowerCase()];
+  const account = accountsByChainId?.[chainId]?.[address.toLowerCase()];
 
   return new BigNumber((account?.balance as Hex) ?? '0x0');
 }


### PR DESCRIPTION
## **Description**

Add gas fee token properties to transaction events.

- `gas_insufficient_native_asset`
- `gas_paid_with`
- `gas_payment_tokens_available`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #23415 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds gas_insufficient_native_asset, gas_paid_with, and gas_payment_tokens_available to transaction metrics with balance-based evaluation and comprehensive tests.
> 
> - **Engine / Transaction Metrics (`utils.ts`)**:
>   - Add `gas_insufficient_native_asset`, `gas_paid_with`, `gas_payment_tokens_available` to `getGasMetricProperties` output.
>   - Determine native token selection via `getNativeTokenAddress` and compute max gas cost using new helpers `getMaxGasCost` and `getNativeBalance` (reads from `store.engine.backgroundState.AccountTrackerController.accountsByChainId`), using `BigNumber`.
>   - Leverage `txParams.gas`, `maxFeePerGas`/`gasPrice` for insufficiency calculation; support case-insensitive token address match.
> - **Tests (`utils.test.ts`)**:
>   - Mock `store.getState` and add `mockNativeBalance` helper; set `txParams.gas`/`maxFeePerGas` in fixtures.
>   - Add cases covering token list exposure, selected token resolution (including native and case-insensitive match), and native asset sufficiency (including missing balance and gasPrice fallback).
>   - Relax some assertions to `expect.objectContaining` for metric property checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38b9e111e11ec32d09ebb612662ecb43f2146c6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->