### PR TITLE
fix: truncate text in predict claim confirmation

### DIFF
--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.styles.ts
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.styles.ts
@@ -22,6 +22,10 @@ const styleSheet = (params: { theme: Theme }) =>
     bottom: {
       textAlign: 'center',
     },
+
+    textContainer: {
+      flex: 1,
+    },
   });
 
 export default styleSheet;

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
@@ -70,6 +70,7 @@ export function PredictClaimFooter({ onPress }: PredictClaimFooterProps) {
 }
 
 function SingleWin({ wonPositions }: { wonPositions: PredictPosition[] }) {
+  const { styles } = useStyles(styleSheet, {});
   const formatFiat = useFiatFormatter({ currency: 'usd' });
 
   const position = wonPositions[0];
@@ -91,9 +92,15 @@ function SingleWin({ wonPositions }: { wonPositions: PredictPosition[] }) {
         imageSource={{ uri: position.icon }}
         size={AvatarSize.Lg}
       />
-      <Box flexDirection={FlexDirection.Column}>
-        <Text variant={TextVariant.BodyMDMedium}>{position.title}</Text>
-        <Text variant={TextVariant.BodySMMedium} color={TextColor.Alternative}>
+      <Box flexDirection={FlexDirection.Column} style={styles.textContainer}>
+        <Text variant={TextVariant.BodyMDMedium} numberOfLines={1}>
+          {position.title}
+        </Text>
+        <Text
+          variant={TextVariant.BodySMMedium}
+          color={TextColor.Alternative}
+          numberOfLines={1}
+        >
           {amountFormatted} on {position.outcome}
         </Text>
       </Box>


### PR DESCRIPTION
## **Description**

Truncate long titles and options in Predict claim confirmations, when claiming a single position.

## **Changelog**

CHANGELOG entry: Truncate long titles in Predict claim confirmations

## **Related issues**

Fixes: #23212 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="300" alt="Truncate" src="https://github.com/user-attachments/assets/1dc869f0-4c79-407f-9471-41c183e3e4ea" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Truncates long title/outcome text in the single-win Predict claim footer and adds a flex text container to enable proper ellipsis.
> 
> - **Predict Claim Footer (`predict-claim-footer.tsx`)**
>   - Single-win layout: apply `numberOfLines={1}` to `Text` for `position.title` and amount/outcome line to truncate overflow.
>   - Use `styles.textContainer` on the text column to constrain width next to the avatar.
>   - Initialize `useStyles` in `SingleWin` to access styles.
> - **Styles (`predict-claim-footer.styles.ts`)**
>   - Add `textContainer` style with `flex: 1` to allow text truncation within the row.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26dbf37fc4ab635d3ca2d1cfb57e1d0b89207dc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->