### PR TITLE
feat(perps): design spacing consistency

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
@@ -303,7 +303,7 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
             </Button>
           </Box>
         ) : (
-          <Box twClassName="px-4 pt-4 pb-2">
+          <Box twClassName="px-4 pt-4 pb-4">
             <Animated.View style={[getBalanceAnimatedStyle]}>
               <Text
                 variant={TextVariant.DisplayMD}


### PR DESCRIPTION
## **Description**

Adds consistent padding between the balance section and content sections on the Perps home screen. Changed bottom padding from 8px to 16px for visual consistency with spacing between other sections.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2173

## **Manual testing steps**

```gherkin
Feature: Perps Home Padding

  Scenario: user views Perps home screen with balance
    Given user has funds in their Perps account

    When user views the Perps home screen
    Then spacing between balance and first section matches spacing between other sections
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="419" height="875" alt="image" src="https://github.com/user-attachments/assets/cb2d84ec-9a3a-44a4-bae8-80cd052f65b2" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase bottom padding under the non-empty balance section from 8px to 16px on Perps home for spacing consistency.
> 
> - **UI – Perps Home**:
>   - Increase bottom padding in `PerpsMarketBalanceActions.tsx` non-empty balance container from `pb-2` to `pb-4` to align spacing with other sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23e1951606a32f4b8b18ba31e10e14fc996e8c04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->