### PR TITLE
fix(perps): remove DEX prefix from limit price modal ticker display

### DIFF
--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.tsx
@@ -27,6 +27,7 @@ import {
   PERPS_CONSTANTS,
   LIMIT_PRICE_CONFIG,
 } from '../../constants/perpsConfig';
+import { getPerpsDisplaySymbol } from '../../utils/marketUtils';
 import { BigNumber } from 'bignumber.js';
 
 interface PerpsLimitPriceBottomSheetProps {
@@ -325,7 +326,7 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
         )}
         {/* Current market price below input */}
         <Text style={styles.marketPriceText}>
-          {asset}-USD{' '}
+          {getPerpsDisplaySymbol(asset)}-USD{' '}
           {currentPrice !== undefined && currentPrice !== null
             ? formatPerpsFiat(currentPrice, {
                 ranges: PRICE_RANGES_UNIVERSAL,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes a display issue in the "Set Limit Price" modal/bottom sheet where HIP-3 asset tickers were showing with their DEX prefix (e.g., "xyz:GOOGL-USD" instead of "GOOGL-USD").

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed ticker display in limit price modal to remove DEX prefix from asset symbols

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2107

## **Manual testing steps**

```gherkin

Feature: Limit Price Modal Ticker Display

  Scenario: User views limit price modal for HIP-3 asset
    Given the user is on the Perps order screen
    And the user has selected a HIP-3 asset (e.g., "xyz:GOOGL")
    And the user taps on the limit price field

    When the limit price modal/bottom sheet opens
    Then the ticker should display as "GOOGL-USD" (without the "xyz:" prefix)
    And the current market price should be displayed correctly below the input field

  Scenario: User views limit price modal for regular asset
    Given the user is on the Perps order screen
    And the user has selected a regular asset (e.g., "BTC")
    And the user taps on the limit price field

    When the limit price modal/bottom sheet opens
    Then the ticker should display as "BTC-USD" (unchanged, as it has no prefix)
    And the current market price should be displayed correctly below the input field
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
xyz prefix is displayed

https://consensys.slack.com/archives/C08U6DYNJ1G/p1763984319853539

<!-- [screenshots/recordings] -->

### **After**
xyz prefix is hidden
<!-- [screenshots/recordings] -->
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-12-01 at 12 40 36" src="https://github.com/user-attachments/assets/9d2e0ffb-3f77-4d1b-b0c1-218acb553f91" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace raw asset with display symbol in the limit price modal ticker to hide DEX prefixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8f912e92b0c148626a15fdb94447e008306887a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->