### PR TITLE
feat(snaps): Date/Time Picker

### DIFF
--- a/app/components/Snaps/SnapInterfaceContext.tsx
+++ b/app/components/Snaps/SnapInterfaceContext.tsx
@@ -93,8 +93,8 @@ export const SnapInterfaceContextProvider: FunctionComponent<
         params: {
           event: {
             type: event,
-            name,
-            value,
+            ...(name === undefined ? {} : { name }),
+            ...(value === undefined ? {} : { value }),
           },
           id: interfaceId,
         },

--- a/app/components/Snaps/SnapInterfaceContext.tsx
+++ b/app/components/Snaps/SnapInterfaceContext.tsx
@@ -93,8 +93,8 @@ export const SnapInterfaceContextProvider: FunctionComponent<
         params: {
           event: {
             type: event,
-            ...(name !== undefined && name !== null ? { name } : {}),
-            ...(value !== undefined && value !== null ? { value } : {}),
+            name,
+            value,
           },
           id: interfaceId,
         },

--- a/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.styles.ts
+++ b/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.styles.ts
@@ -1,0 +1,34 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../util/theme/models';
+import Device from '../../../util/device';
+
+/**
+ *
+ * @param params Style sheet params.
+ * @param params.theme App theme from ThemeContext.
+ * @returns StyleSheet object.
+ */
+const styleSheet = (params: {
+  theme: Theme;
+  vars: {
+    selected?: boolean;
+    compact?: boolean;
+  };
+}) => {
+  const { theme } = params;
+  const { colors } = theme;
+  return StyleSheet.create({
+    modal: {
+      backgroundColor: colors.background.default,
+      borderTopLeftRadius: 24,
+      borderTopRightRadius: 24,
+      paddingBottom: Device.isIphoneX() ? 20 : 0,
+      alignItems: 'center',
+      gap: 16,
+      paddingLeft: 16,
+      paddingRight: 16,
+    },
+  });
+};
+
+export default styleSheet;

--- a/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.tsx
+++ b/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.tsx
@@ -162,14 +162,23 @@ export const SnapUIDateTimePicker: FunctionComponent<
 
   /**
    * Submits the internal value to the snap.
+   *
+   * @param date - The date to submit.
    */
-  const submitInternalValue = () => {
-    const normalizedDate = normalizeDate(internalValue, type);
+  const submitInternalValue = (date: Date) => {
+    const normalizedDate = normalizeDate(date, type);
     const isoString = DateTime.fromJSDate(normalizedDate).toISO();
 
     setValue(normalizedDate);
     handleInputChange(name, isoString, form);
     setShowDatePicker(false);
+  };
+
+  /**
+   * Handles submission for iOS picker.
+   */
+  const handleIosSubmit = () => {
+    submitInternalValue(internalValue);
   };
 
   /**
@@ -194,11 +203,8 @@ export const SnapUIDateTimePicker: FunctionComponent<
 
     // Handle the second of two-step process for datetime type. (time selection)
     if (type === 'datetime' && androidMode === 'time' && event.type === 'set') {
-      const selectedDate = new Date(internalValue);
-      selectedDate.setTime(date.getTime());
-
-      setInternalValue(selectedDate);
-      submitInternalValue();
+      setInternalValue(date);
+      submitInternalValue(date);
 
       setAndroidMode('date');
       return;
@@ -228,7 +234,7 @@ export const SnapUIDateTimePicker: FunctionComponent<
     // Handle single step date or time selection.
     if (event.type === 'set') {
       setInternalValue(date);
-      submitInternalValue();
+      submitInternalValue(date);
     }
 
     setShowDatePicker(false);
@@ -335,7 +341,7 @@ export const SnapUIDateTimePicker: FunctionComponent<
                 {
                   label: strings('navigation.ok'),
                   variant: ButtonVariants.Primary,
-                  onPress: submitInternalValue,
+                  onPress: handleIosSubmit,
                 },
               ]}
             />

--- a/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.tsx
+++ b/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.tsx
@@ -19,6 +19,8 @@ import ApprovalModal from '../../Approvals/ApprovalModal';
 import BottomSheetFooter from '../../../component-library/components/BottomSheets/BottomSheetFooter';
 import { ButtonVariants } from '../../../component-library/components/Buttons/Button';
 import { useStyles } from '../../hooks/useStyles';
+import Input from '../../../component-library/components/Form/TextField/foundation/Input';
+import { strings } from '../../../../locales/i18n';
 
 /**
  * The props for the SnapUIDateTimePicker component.
@@ -214,9 +216,8 @@ export const SnapUIDateTimePicker: FunctionComponent<
   const handleBlur = () => setCurrentFocusedInput(null);
 
   return (
-    <Box>
+    <Box testID={'snap-ui-renderer__date-time-picker'}>
       {label && <Label variant={TextVariant.BodyMDMedium}>{label}</Label>}
-
       <TextField
         size={TextFieldSize.Lg}
         placeholder={placeholder}
@@ -226,7 +227,7 @@ export const SnapUIDateTimePicker: FunctionComponent<
         onBlur={handleBlur}
         id={name}
         readOnly
-        testID={`${name}-snap-ui-date-time-picker`}
+        pointerEvents="none"
         value={formatDateForDisplay(value, type)}
         inputElement={
           <TouchableOpacity
@@ -237,11 +238,12 @@ export const SnapUIDateTimePicker: FunctionComponent<
             }
             activeOpacity={0.7}
           >
-            <TextInput
+            <Input
+              isStateStylesDisabled
+              readOnly
+              pointerEvents="none"
               value={formatDateForDisplay(value, type)}
               placeholder={placeholder}
-              editable={false}
-              pointerEvents="none"
             />
           </TouchableOpacity>
         }
@@ -281,12 +283,12 @@ export const SnapUIDateTimePicker: FunctionComponent<
             <BottomSheetFooter
               buttonPropsArray={[
                 {
-                  label: 'Cancel',
+                  label: strings('navigation.cancel'),
                   variant: ButtonVariants.Secondary,
                   onPress: handleClosePicker,
                 },
                 {
-                  label: 'OK',
+                  label: strings('navigation.ok'),
                   variant: ButtonVariants.Primary,
                   onPress: submitInternalValue,
                 },

--- a/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.tsx
+++ b/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.tsx
@@ -157,17 +157,17 @@ export const SnapUIDateTimePicker: FunctionComponent<
   ) => {
     if (!date) return;
 
-    const normalizedDate = normalizeDate(date, type);
-    setInternalValue(normalizedDate);
+    setInternalValue(date);
   };
 
   /**
    * Submits the internal value to the snap.
    */
   const submitInternalValue = () => {
-    const isoString = DateTime.fromJSDate(internalValue).toISO();
+    const normalizedDate = normalizeDate(internalValue, type);
+    const isoString = DateTime.fromJSDate(normalizedDate).toISO();
 
-    setValue(internalValue);
+    setValue(normalizedDate);
     handleInputChange(name, isoString, form);
     setShowDatePicker(false);
   };
@@ -197,9 +197,7 @@ export const SnapUIDateTimePicker: FunctionComponent<
       const selectedDate = new Date(internalValue);
       selectedDate.setTime(date.getTime());
 
-      const normalizedDate = normalizeDate(selectedDate, type);
-
-      setInternalValue(normalizedDate);
+      setInternalValue(selectedDate);
       submitInternalValue();
 
       setAndroidMode('date');
@@ -229,9 +227,7 @@ export const SnapUIDateTimePicker: FunctionComponent<
     }
     // Handle single step date or time selection.
     if (event.type === 'set') {
-      const normalizedDate = normalizeDate(date, type);
-
-      setInternalValue(normalizedDate);
+      setInternalValue(date);
       submitInternalValue();
     }
 

--- a/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.tsx
+++ b/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.tsx
@@ -1,0 +1,191 @@
+import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
+import { useSnapInterfaceContext } from '../SnapInterfaceContext';
+import { DateTime } from 'luxon';
+import { Box } from '@metamask/design-system-react-native';
+import Label from '../../../component-library/components/Form/Label';
+import HelpText, {
+  HelpTextSeverity,
+} from '../../../component-library/components/Form/HelpText';
+import { TextVariant } from '../../../component-library/components/Texts/Text';
+import DateTimePicker, {
+  DateTimePickerEvent,
+} from '@react-native-community/datetimepicker';
+import TextField, {
+  TextFieldSize,
+} from '../../../component-library/components/Form/TextField';
+import { Platform, TextInput, TouchableOpacity } from 'react-native';
+import ApprovalModal from '../../Approvals/ApprovalModal';
+import BottomSheetFooter from '../../../component-library/components/BottomSheets/BottomSheetFooter';
+import { ButtonVariants } from '../../../component-library/components/Buttons/Button';
+
+/**
+ * The props for the SnapUIDateTimePicker component.
+ */
+export interface SnapUIDateTimePickerProps {
+  name: string;
+  type: 'date' | 'time' | 'datetime';
+  label?: string;
+  error?: string;
+  placeholder?: string;
+  form?: string;
+  disablePast?: boolean;
+  disableFuture?: boolean;
+  disabled?: boolean;
+}
+
+/**
+ * Styles for the SnapUIDateTimePicker component.
+ */
+
+/**
+ * The SnapUIDateTimePicker component.
+ *
+ * @param props - The component props.
+ * @param props.name - The name of the input.
+ * @param props.type - The type of the picker (date, time, datetime).
+ * @param props.label - The label for the picker.
+ * @param props.form - The form identifier.
+ * @param props.disabled - Whether the picker is disabled.
+ * @param props.error - The error message to display.
+ * @param props.disablePast - Whether to disable past dates (only for date and datetime types).
+ * @param props.disableFuture - Whether to disable future dates (only for date and datetime types).
+ * @param props.placeholder - The placeholder text for the picker.
+ * @returns The DateTimePicker component.
+ */
+export const SnapUIDateTimePicker: FunctionComponent<
+  SnapUIDateTimePickerProps
+> = ({
+  type = 'datetime',
+  label,
+  placeholder,
+  name,
+  form,
+  disabled,
+  error,
+  disablePast = false,
+  disableFuture = false,
+}) => {
+  const { handleInputChange, getValue, setCurrentFocusedInput } =
+    useSnapInterfaceContext();
+
+  const inputRef = useRef<TextInput>(null);
+
+  const initialValue = getValue(name, form) as string;
+
+  const [value, setValue] = useState<Date | null>(
+    initialValue ? new Date(initialValue) : null,
+  );
+
+  const [showDatePicker, setShowDatePicker] = useState(false);
+
+  useEffect(() => {
+    if (initialValue !== undefined && initialValue !== null) {
+      setValue(new Date(initialValue));
+    }
+  }, [initialValue]);
+
+  const handleInternalValueChange = (
+    _event: DateTimePickerEvent,
+    date: Date | undefined,
+  ) => {
+    setValue(date ?? null);
+  };
+
+  const submitInternalValue = () => {
+    const isoString = value ? DateTime.fromJSDate(value).toISO() : null;
+
+    handleInputChange(name, isoString, form);
+  };
+
+  const handleChange = (
+    _event: DateTimePickerEvent,
+    date: Date | undefined,
+  ) => {
+    if (!date) return;
+
+    const isoString = DateTime.fromJSDate(date).toISO();
+
+    setValue(date);
+    handleInputChange(name, isoString, form);
+  };
+
+  const handleOpenPicker = () => {
+    setShowDatePicker(true);
+  };
+
+  const handleClosePicker = () => {
+    setShowDatePicker(false);
+  };
+
+  const handleFocus = () => setCurrentFocusedInput(name);
+  const handleBlur = () => setCurrentFocusedInput(null);
+
+  return (
+    <Box>
+      {label && <Label variant={TextVariant.BodyMDMedium}>{label}</Label>}
+      <TouchableOpacity onPress={handleOpenPicker} activeOpacity={0.7}>
+        <TextField
+          size={TextFieldSize.Lg}
+          placeholder={placeholder}
+          isDisabled={disabled}
+          ref={inputRef}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          id={name}
+          readOnly
+          testID={`${name}-snap-ui-date-time-picker`}
+          value={
+            value
+              ? DateTime.fromJSDate(value).toLocaleString(DateTime.DATETIME_MED)
+              : undefined
+          }
+          // We set a max height of 58px and let the input grow to fill the rest of the height next to a taller sibling element.
+          // eslint-disable-next-line react-native/no-inline-styles
+          style={{ maxHeight: 58, flexGrow: 1 }}
+        />
+      </TouchableOpacity>
+      {Platform.OS === 'android' && showDatePicker && (
+        <DateTimePicker
+          value={value ?? new Date()}
+          mode={type}
+          display="default"
+          onChange={handleChange}
+          maximumDate={disableFuture ? new Date() : undefined}
+          minimumDate={disablePast ? new Date() : undefined}
+        />
+      )}
+
+      {Platform.OS === 'ios' && (
+        <ApprovalModal
+          isVisible={showDatePicker}
+          onCancel={handleClosePicker}
+          avoidKeyboard
+        >
+          <DateTimePicker
+            value={value ?? new Date()}
+            mode={type}
+            display="spinner"
+            onChange={handleInternalValueChange}
+            maximumDate={disableFuture ? new Date() : undefined}
+            minimumDate={disablePast ? new Date() : undefined}
+          />
+          <BottomSheetFooter
+            buttonPropsArray={[
+              {
+                label: 'Cancel',
+                variant: ButtonVariants.Secondary,
+                onPress: handleClosePicker,
+              },
+              {
+                label: 'Confirm',
+                variant: ButtonVariants.Primary,
+                onPress: submitInternalValue,
+              },
+            ]}
+          />
+        </ApprovalModal>
+      )}
+      {error && <HelpText severity={HelpTextSeverity.Error}>{error}</HelpText>}
+    </Box>
+  );
+};

--- a/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.tsx
+++ b/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.tsx
@@ -269,7 +269,6 @@ export const SnapUIDateTimePicker: FunctionComponent<
     <Box testID={'snap-ui-renderer__date-time-picker'}>
       {label && <Label variant={TextVariant.BodyMDMedium}>{label}</Label>}
       <TextField
-        testID="snap-ui-renderer__date-time-picker-input"
         size={TextFieldSize.Lg}
         placeholder={placeholder}
         isDisabled={disabled}
@@ -282,6 +281,7 @@ export const SnapUIDateTimePicker: FunctionComponent<
         value={formatDateForDisplay(value, type)}
         inputElement={
           <TouchableOpacity
+            testID="snap-ui-renderer__date-time-picker-touchable"
             onPress={
               Platform.OS === 'ios'
                 ? handleOpenIosPicker
@@ -290,6 +290,7 @@ export const SnapUIDateTimePicker: FunctionComponent<
             activeOpacity={0.7}
           >
             <Input
+              testID="snap-ui-renderer__date-time-picker-input"
               isStateStylesDisabled
               readOnly
               pointerEvents="none"

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
@@ -29,6 +29,7 @@ exports[`SnapUIRenderer adds a footer if required 1`] = `
           "marginBottom": 80,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -188,6 +189,7 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -346,6 +348,7 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -600,6 +603,7 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -852,6 +856,7 @@ exports[`SnapUIRenderer renders basic UI 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -947,6 +952,7 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
           "marginBottom": 80,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -1465,6 +1471,7 @@ exports[`SnapUIRenderer renders footers 1`] = `
           "marginBottom": 80,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -1724,6 +1731,7 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -2040,6 +2048,7 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -2198,6 +2207,7 @@ exports[`SnapUIRenderer supports the onCancel prop 1`] = `
           "marginBottom": 80,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/account-selector.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/account-selector.test.ts.snap
@@ -29,6 +29,7 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -150,6 +151,7 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/address.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/address.test.ts.snap
@@ -29,6 +29,7 @@ exports[`SnapUIAddress renders Bitcoin address 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -123,6 +124,7 @@ exports[`SnapUIAddress renders Bitcoin address with blockie 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -226,6 +228,7 @@ exports[`SnapUIAddress renders Cosmos address 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -320,6 +323,7 @@ exports[`SnapUIAddress renders Cosmos address with blockie 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -423,6 +427,7 @@ exports[`SnapUIAddress renders Ethereum address 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -517,6 +522,7 @@ exports[`SnapUIAddress renders Ethereum address with blockie 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -620,6 +626,7 @@ exports[`SnapUIAddress renders Hedera address 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -714,6 +721,7 @@ exports[`SnapUIAddress renders Hedera address with blockie 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -817,6 +825,7 @@ exports[`SnapUIAddress renders Polkadot address 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -911,6 +920,7 @@ exports[`SnapUIAddress renders Polkadot address with blockie 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -1014,6 +1024,7 @@ exports[`SnapUIAddress renders Starknet address 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -1108,6 +1119,7 @@ exports[`SnapUIAddress renders Starknet address with blockie 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -1211,6 +1223,7 @@ exports[`SnapUIAddress renders legacy Ethereum address 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/asset-selector.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/asset-selector.test.ts.snap
@@ -29,6 +29,7 @@ exports[`SnapUIAssetSelector should render 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/container.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/container.test.ts.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`container add footer button when useFooter is true and onCancel is provided 1`] = `
+{
+  "children": {
+    "children": {
+      "children": {
+        "children": "navigation.close",
+        "element": "SnapUIFooterButton",
+        "key": "default-button",
+        "props": {
+          "isSnapAction": false,
+          "onCancel": [MockFunction],
+          "testID": "default-snap-footer-button",
+          "variant": "Secondary",
+        },
+      },
+      "element": "Box",
+      "key": "default-footer",
+      "props": {
+        "flexDirection": "row",
+        "gap": 16,
+        "padding": 16,
+        "style": {
+          "alignItems": "center",
+          "bottom": 0,
+          "gap": 16,
+          "height": 80,
+          "justifyContent": "space-evenly",
+          "margin": 16,
+          "paddingVertical": 16,
+          "position": "absolute",
+          "width": "100%",
+        },
+      },
+    },
+    "element": "TouchableHighlight",
+  },
+  "element": "ScrollView",
+  "key": "default-scrollview",
+  "props": {
+    "style": {
+      "marginBottom": 0,
+    },
+    "testID": "snap-ui-renderer__scrollview",
+  },
+}
+`;
+
+exports[`container render basic container with single child 1`] = `
+{
+  "children": [
+    {
+      "children": {
+        "children": {
+          "children": [
+            "Hello",
+          ],
+          "element": "text",
+          "props": {
+            "style": {
+              "gap": 16,
+              "margin": 16,
+            },
+          },
+        },
+        "element": "TouchableHighlight",
+      },
+      "element": "ScrollView",
+      "key": "default-scrollview",
+      "props": {
+        "style": {
+          "marginBottom": 0,
+        },
+        "testID": "snap-ui-renderer__scrollview",
+      },
+    },
+  ],
+  "element": "Box",
+  "props": {
+    "style": {
+      "flexDirection": "column",
+      "flexGrow": 1,
+    },
+  },
+}
+`;

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`SnapUIDateTimePicker can show an error 1`] = `
                   <TouchableOpacity
                     activeOpacity={0.7}
                     onPress={[Function]}
-                    testID="snap-ui-renderer__date-time-picker-touchable"
+                    testID="snap-ui-renderer__date-time-picker--datetime-touchable"
                   >
                     <TextInput
                       autoFocus={true}
@@ -161,7 +161,7 @@ exports[`SnapUIDateTimePicker can show an error 1`] = `
                           "textAlignVertical": "center",
                         }
                       }
-                      testID="snap-ui-renderer__date-time-picker-input"
+                      testID="snap-ui-renderer__date-time-picker--datetime-input"
                     />
                   </TouchableOpacity>
                 </View>
@@ -315,7 +315,7 @@ exports[`SnapUIDateTimePicker renders a date picker 1`] = `
                   <TouchableOpacity
                     activeOpacity={0.7}
                     onPress={[Function]}
-                    testID="snap-ui-renderer__date-time-picker-touchable"
+                    testID="snap-ui-renderer__date-time-picker--date-touchable"
                   >
                     <TextInput
                       autoFocus={true}
@@ -341,7 +341,7 @@ exports[`SnapUIDateTimePicker renders a date picker 1`] = `
                           "textAlignVertical": "center",
                         }
                       }
-                      testID="snap-ui-renderer__date-time-picker-input"
+                      testID="snap-ui-renderer__date-time-picker--date-input"
                     />
                   </TouchableOpacity>
                 </View>
@@ -480,7 +480,7 @@ exports[`SnapUIDateTimePicker renders a date time picker 1`] = `
                   <TouchableOpacity
                     activeOpacity={0.7}
                     onPress={[Function]}
-                    testID="snap-ui-renderer__date-time-picker-touchable"
+                    testID="snap-ui-renderer__date-time-picker--datetime-touchable"
                   >
                     <TextInput
                       autoFocus={true}
@@ -506,7 +506,7 @@ exports[`SnapUIDateTimePicker renders a date time picker 1`] = `
                           "textAlignVertical": "center",
                         }
                       }
-                      testID="snap-ui-renderer__date-time-picker-input"
+                      testID="snap-ui-renderer__date-time-picker--datetime-input"
                     />
                   </TouchableOpacity>
                 </View>
@@ -645,7 +645,7 @@ exports[`SnapUIDateTimePicker renders a time picker 1`] = `
                   <TouchableOpacity
                     activeOpacity={0.7}
                     onPress={[Function]}
-                    testID="snap-ui-renderer__date-time-picker-touchable"
+                    testID="snap-ui-renderer__date-time-picker--time-touchable"
                   >
                     <TextInput
                       autoFocus={true}
@@ -671,7 +671,7 @@ exports[`SnapUIDateTimePicker renders a time picker 1`] = `
                           "textAlignVertical": "center",
                         }
                       }
-                      testID="snap-ui-renderer__date-time-picker-input"
+                      testID="snap-ui-renderer__date-time-picker--time-input"
                     />
                   </TouchableOpacity>
                 </View>
@@ -825,7 +825,7 @@ exports[`SnapUIDateTimePicker renders inside a field 1`] = `
                   <TouchableOpacity
                     activeOpacity={0.7}
                     onPress={[Function]}
-                    testID="snap-ui-renderer__date-time-picker-touchable"
+                    testID="snap-ui-renderer__date-time-picker--datetime-touchable"
                   >
                     <TextInput
                       autoFocus={true}
@@ -851,7 +851,7 @@ exports[`SnapUIDateTimePicker renders inside a field 1`] = `
                           "textAlignVertical": "center",
                         }
                       }
-                      testID="snap-ui-renderer__date-time-picker-input"
+                      testID="snap-ui-renderer__date-time-picker--datetime-input"
                     />
                   </TouchableOpacity>
                 </View>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
@@ -135,6 +135,7 @@ exports[`SnapUIDateTimePicker can show an error 1`] = `
                   <TouchableOpacity
                     activeOpacity={0.7}
                     onPress={[Function]}
+                    testID="snap-ui-renderer__date-time-picker-touchable"
                   >
                     <TextInput
                       autoFocus={true}
@@ -160,7 +161,7 @@ exports[`SnapUIDateTimePicker can show an error 1`] = `
                           "textAlignVertical": "center",
                         }
                       }
-                      testID="input"
+                      testID="snap-ui-renderer__date-time-picker-input"
                     />
                   </TouchableOpacity>
                 </View>
@@ -314,6 +315,7 @@ exports[`SnapUIDateTimePicker renders a date picker 1`] = `
                   <TouchableOpacity
                     activeOpacity={0.7}
                     onPress={[Function]}
+                    testID="snap-ui-renderer__date-time-picker-touchable"
                   >
                     <TextInput
                       autoFocus={true}
@@ -339,7 +341,7 @@ exports[`SnapUIDateTimePicker renders a date picker 1`] = `
                           "textAlignVertical": "center",
                         }
                       }
-                      testID="input"
+                      testID="snap-ui-renderer__date-time-picker-input"
                     />
                   </TouchableOpacity>
                 </View>
@@ -478,6 +480,7 @@ exports[`SnapUIDateTimePicker renders a date time picker 1`] = `
                   <TouchableOpacity
                     activeOpacity={0.7}
                     onPress={[Function]}
+                    testID="snap-ui-renderer__date-time-picker-touchable"
                   >
                     <TextInput
                       autoFocus={true}
@@ -503,7 +506,7 @@ exports[`SnapUIDateTimePicker renders a date time picker 1`] = `
                           "textAlignVertical": "center",
                         }
                       }
-                      testID="input"
+                      testID="snap-ui-renderer__date-time-picker-input"
                     />
                   </TouchableOpacity>
                 </View>
@@ -642,6 +645,7 @@ exports[`SnapUIDateTimePicker renders a time picker 1`] = `
                   <TouchableOpacity
                     activeOpacity={0.7}
                     onPress={[Function]}
+                    testID="snap-ui-renderer__date-time-picker-touchable"
                   >
                     <TextInput
                       autoFocus={true}
@@ -667,7 +671,7 @@ exports[`SnapUIDateTimePicker renders a time picker 1`] = `
                           "textAlignVertical": "center",
                         }
                       }
-                      testID="input"
+                      testID="snap-ui-renderer__date-time-picker-input"
                     />
                   </TouchableOpacity>
                 </View>
@@ -821,6 +825,7 @@ exports[`SnapUIDateTimePicker renders inside a field 1`] = `
                   <TouchableOpacity
                     activeOpacity={0.7}
                     onPress={[Function]}
+                    testID="snap-ui-renderer__date-time-picker-touchable"
                   >
                     <TextInput
                       autoFocus={true}
@@ -846,7 +851,7 @@ exports[`SnapUIDateTimePicker renders inside a field 1`] = `
                           "textAlignVertical": "center",
                         }
                       }
-                      testID="input"
+                      testID="snap-ui-renderer__date-time-picker-input"
                     />
                   </TouchableOpacity>
                 </View>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`SnapUIDateTimePicker can show an error 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -224,6 +225,7 @@ exports[`SnapUIDateTimePicker renders a date picker 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -389,6 +391,7 @@ exports[`SnapUIDateTimePicker renders a date time picker 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -554,6 +557,7 @@ exports[`SnapUIDateTimePicker renders a time picker 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -719,6 +723,7 @@ exports[`SnapUIDateTimePicker renders inside a field 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
@@ -1,0 +1,866 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SnapUIDateTimePicker can show an error 1`] = `
+<View
+  style={
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {},
+        {
+          "flexDirection": "column",
+          "flexGrow": 1,
+        },
+      ]
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <View>
+        <TouchableHighlight>
+          <View
+            color="Default"
+            flexDirection="column"
+            gap={8}
+            justifyContent="flex-start"
+            style={
+              [
+                {
+                  "color": "Default",
+                  "flexDirection": "column",
+                  "gap": 8,
+                  "justifyContent": "flex-start",
+                },
+                {
+                  "gap": 16,
+                  "margin": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                  undefined,
+                ]
+              }
+              testID="snap-ui-renderer__date-time-picker"
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist Medium",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+                testID="label"
+              >
+                Select date and time
+              </Text>
+              <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "#b7bbc8",
+                    "borderRadius": 8,
+                    "borderWidth": 1,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "height": 48,
+                    "maxHeight": 58,
+                    "opacity": 1,
+                    "paddingHorizontal": 16,
+                  }
+                }
+                testID="textfield"
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <TouchableOpacity
+                    activeOpacity={0.7}
+                    onPress={[Function]}
+                  >
+                    <TextInput
+                      autoFocus={true}
+                      editable={true}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      pointerEvents="none"
+                      readOnly={true}
+                      style={
+                        {
+                          "backgroundColor": "#ffffff",
+                          "borderColor": "transparent",
+                          "borderWidth": 1,
+                          "color": "#121314",
+                          "fontFamily": "Geist Regular",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "height": 24,
+                          "letterSpacing": 0,
+                          "lineHeight": 20,
+                          "opacity": 1,
+                          "paddingVertical": 2,
+                          "textAlignVertical": "center",
+                        }
+                      }
+                      testID="input"
+                    />
+                  </TouchableOpacity>
+                </View>
+              </View>
+              <View />
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#ca3542",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 14,
+                    "letterSpacing": 0,
+                    "lineHeight": 22,
+                  }
+                }
+                testID="helptext"
+              >
+                This is an error
+              </Text>
+            </View>
+          </View>
+        </TouchableHighlight>
+      </View>
+    </RCTScrollView>
+  </View>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIDateTimePicker renders a date picker 1`] = `
+<View
+  style={
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {},
+        {
+          "flexDirection": "column",
+          "flexGrow": 1,
+        },
+      ]
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <View>
+        <TouchableHighlight>
+          <View
+            color="Default"
+            flexDirection="column"
+            gap={8}
+            justifyContent="flex-start"
+            style={
+              [
+                {
+                  "color": "Default",
+                  "flexDirection": "column",
+                  "gap": 8,
+                  "justifyContent": "flex-start",
+                },
+                {
+                  "gap": 16,
+                  "margin": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                  undefined,
+                ]
+              }
+              testID="snap-ui-renderer__date-time-picker"
+            >
+              <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "#b7bbc8",
+                    "borderRadius": 8,
+                    "borderWidth": 1,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "height": 48,
+                    "maxHeight": 58,
+                    "opacity": 1,
+                    "paddingHorizontal": 16,
+                  }
+                }
+                testID="textfield"
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <TouchableOpacity
+                    activeOpacity={0.7}
+                    onPress={[Function]}
+                  >
+                    <TextInput
+                      autoFocus={true}
+                      editable={true}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      pointerEvents="none"
+                      readOnly={true}
+                      style={
+                        {
+                          "backgroundColor": "#ffffff",
+                          "borderColor": "transparent",
+                          "borderWidth": 1,
+                          "color": "#121314",
+                          "fontFamily": "Geist Regular",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "height": 24,
+                          "letterSpacing": 0,
+                          "lineHeight": 20,
+                          "opacity": 1,
+                          "paddingVertical": 2,
+                          "textAlignVertical": "center",
+                        }
+                      }
+                      testID="input"
+                    />
+                  </TouchableOpacity>
+                </View>
+              </View>
+              <View />
+            </View>
+          </View>
+        </TouchableHighlight>
+      </View>
+    </RCTScrollView>
+  </View>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIDateTimePicker renders a date time picker 1`] = `
+<View
+  style={
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {},
+        {
+          "flexDirection": "column",
+          "flexGrow": 1,
+        },
+      ]
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <View>
+        <TouchableHighlight>
+          <View
+            color="Default"
+            flexDirection="column"
+            gap={8}
+            justifyContent="flex-start"
+            style={
+              [
+                {
+                  "color": "Default",
+                  "flexDirection": "column",
+                  "gap": 8,
+                  "justifyContent": "flex-start",
+                },
+                {
+                  "gap": 16,
+                  "margin": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                  undefined,
+                ]
+              }
+              testID="snap-ui-renderer__date-time-picker"
+            >
+              <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "#b7bbc8",
+                    "borderRadius": 8,
+                    "borderWidth": 1,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "height": 48,
+                    "maxHeight": 58,
+                    "opacity": 1,
+                    "paddingHorizontal": 16,
+                  }
+                }
+                testID="textfield"
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <TouchableOpacity
+                    activeOpacity={0.7}
+                    onPress={[Function]}
+                  >
+                    <TextInput
+                      autoFocus={true}
+                      editable={true}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      pointerEvents="none"
+                      readOnly={true}
+                      style={
+                        {
+                          "backgroundColor": "#ffffff",
+                          "borderColor": "transparent",
+                          "borderWidth": 1,
+                          "color": "#121314",
+                          "fontFamily": "Geist Regular",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "height": 24,
+                          "letterSpacing": 0,
+                          "lineHeight": 20,
+                          "opacity": 1,
+                          "paddingVertical": 2,
+                          "textAlignVertical": "center",
+                        }
+                      }
+                      testID="input"
+                    />
+                  </TouchableOpacity>
+                </View>
+              </View>
+              <View />
+            </View>
+          </View>
+        </TouchableHighlight>
+      </View>
+    </RCTScrollView>
+  </View>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIDateTimePicker renders a time picker 1`] = `
+<View
+  style={
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {},
+        {
+          "flexDirection": "column",
+          "flexGrow": 1,
+        },
+      ]
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <View>
+        <TouchableHighlight>
+          <View
+            color="Default"
+            flexDirection="column"
+            gap={8}
+            justifyContent="flex-start"
+            style={
+              [
+                {
+                  "color": "Default",
+                  "flexDirection": "column",
+                  "gap": 8,
+                  "justifyContent": "flex-start",
+                },
+                {
+                  "gap": 16,
+                  "margin": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                  undefined,
+                ]
+              }
+              testID="snap-ui-renderer__date-time-picker"
+            >
+              <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "#b7bbc8",
+                    "borderRadius": 8,
+                    "borderWidth": 1,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "height": 48,
+                    "maxHeight": 58,
+                    "opacity": 1,
+                    "paddingHorizontal": 16,
+                  }
+                }
+                testID="textfield"
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <TouchableOpacity
+                    activeOpacity={0.7}
+                    onPress={[Function]}
+                  >
+                    <TextInput
+                      autoFocus={true}
+                      editable={true}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      pointerEvents="none"
+                      readOnly={true}
+                      style={
+                        {
+                          "backgroundColor": "#ffffff",
+                          "borderColor": "transparent",
+                          "borderWidth": 1,
+                          "color": "#121314",
+                          "fontFamily": "Geist Regular",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "height": 24,
+                          "letterSpacing": 0,
+                          "lineHeight": 20,
+                          "opacity": 1,
+                          "paddingVertical": 2,
+                          "textAlignVertical": "center",
+                        }
+                      }
+                      testID="input"
+                    />
+                  </TouchableOpacity>
+                </View>
+              </View>
+              <View />
+            </View>
+          </View>
+        </TouchableHighlight>
+      </View>
+    </RCTScrollView>
+  </View>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIDateTimePicker renders inside a field 1`] = `
+<View
+  style={
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {},
+        {
+          "flexDirection": "column",
+          "flexGrow": 1,
+        },
+      ]
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <View>
+        <TouchableHighlight>
+          <View
+            color="Default"
+            flexDirection="column"
+            gap={8}
+            justifyContent="flex-start"
+            style={
+              [
+                {
+                  "color": "Default",
+                  "flexDirection": "column",
+                  "gap": 8,
+                  "justifyContent": "flex-start",
+                },
+                {
+                  "gap": 16,
+                  "margin": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "display": "flex",
+                  },
+                  undefined,
+                ]
+              }
+              testID="snap-ui-renderer__date-time-picker"
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist Medium",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+                testID="label"
+              >
+                Select date and time
+              </Text>
+              <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "#b7bbc8",
+                    "borderRadius": 8,
+                    "borderWidth": 1,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "height": 48,
+                    "maxHeight": 58,
+                    "opacity": 1,
+                    "paddingHorizontal": 16,
+                  }
+                }
+                testID="textfield"
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <TouchableOpacity
+                    activeOpacity={0.7}
+                    onPress={[Function]}
+                  >
+                    <TextInput
+                      autoFocus={true}
+                      editable={true}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      pointerEvents="none"
+                      readOnly={true}
+                      style={
+                        {
+                          "backgroundColor": "#ffffff",
+                          "borderColor": "transparent",
+                          "borderWidth": 1,
+                          "color": "#121314",
+                          "fontFamily": "Geist Regular",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "height": 24,
+                          "letterSpacing": 0,
+                          "lineHeight": 20,
+                          "opacity": 1,
+                          "paddingVertical": 2,
+                          "textAlignVertical": "center",
+                        }
+                      }
+                      testID="input"
+                    />
+                  </TouchableOpacity>
+                </View>
+              </View>
+              <View />
+            </View>
+          </View>
+        </TouchableHighlight>
+      </View>
+    </RCTScrollView>
+  </View>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -29,6 +29,7 @@ exports[`SnapUIForm will render 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -229,6 +230,7 @@ exports[`SnapUIForm will render with fields 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/input.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/input.test.ts.snap
@@ -29,6 +29,7 @@ exports[`SnapUIInput handles disabled input 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>
@@ -187,6 +188,7 @@ exports[`SnapUIInput renders with initial value 1`] = `
           "marginBottom": 0,
         }
       }
+      testID="snap-ui-renderer__scrollview"
     >
       <View>
         <TouchableHighlight>

--- a/app/components/Snaps/SnapUIRenderer/components/container.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/container.test.ts
@@ -43,43 +43,7 @@ describe('container', () => {
       theme: mockTheme,
     });
 
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "children": [
-          {
-            "children": {
-              "children": {
-                "children": [
-                  "Hello",
-                ],
-                "element": "text",
-                "props": {
-                  "style": {
-                    "gap": 16,
-                    "margin": 16,
-                  },
-                },
-              },
-              "element": "TouchableHighlight",
-            },
-            "element": "ScrollView",
-            "key": "default-scrollview",
-            "props": {
-              "style": {
-                "marginBottom": 0,
-              },
-            },
-          },
-        ],
-        "element": "Box",
-        "props": {
-          "style": {
-            "flexDirection": "column",
-            "flexGrow": 1,
-          },
-        },
-      }
-    `);
+    expect(result).toMatchSnapshot();
   });
 
   it('add footer button when useFooter is true and onCancel is provided', () => {
@@ -97,50 +61,6 @@ describe('container', () => {
 
     expect(Array.isArray(result.children)).toBe(true);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((result.children as any[])[0]).toMatchInlineSnapshot(`
-      {
-        "children": {
-          "children": {
-            "children": {
-              "children": "navigation.close",
-              "element": "SnapUIFooterButton",
-              "key": "default-button",
-              "props": {
-                "isSnapAction": false,
-                "onCancel": [MockFunction],
-                "testID": "default-snap-footer-button",
-                "variant": "Secondary",
-              },
-            },
-            "element": "Box",
-            "key": "default-footer",
-            "props": {
-              "flexDirection": "row",
-              "gap": 16,
-              "padding": 16,
-              "style": {
-                "alignItems": "center",
-                "bottom": 0,
-                "gap": 16,
-                "height": 80,
-                "justifyContent": "space-evenly",
-                "margin": 16,
-                "paddingVertical": 16,
-                "position": "absolute",
-                "width": "100%",
-              },
-            },
-          },
-          "element": "TouchableHighlight",
-        },
-        "element": "ScrollView",
-        "key": "default-scrollview",
-        "props": {
-          "style": {
-            "marginBottom": 0,
-          },
-        },
-      }
-    `);
+    expect((result.children as any[])[0]).toMatchSnapshot();
   });
 });

--- a/app/components/Snaps/SnapUIRenderer/components/container.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/container.ts
@@ -74,6 +74,7 @@ export const container: UIComponentFactory<BoxElement> = ({
       children: styledContent,
     },
     props: {
+      testID: 'snap-ui-renderer__scrollview',
       style: {
         marginBottom: useFooter && footer ? 80 : 0,
       },

--- a/app/components/Snaps/SnapUIRenderer/components/date-time-picker.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/components/date-time-picker.test.tsx
@@ -73,7 +73,7 @@ describe('SnapUIDateTimePicker', () => {
 
     act(() => {
       fireEvent.press(
-        getByTestId('snap-ui-renderer__date-time-picker-touchable'),
+        getByTestId('snap-ui-renderer__date-time-picker--datetime-touchable'),
       );
     });
 
@@ -101,7 +101,8 @@ describe('SnapUIDateTimePicker', () => {
     });
 
     expect(
-      getByTestId('snap-ui-renderer__date-time-picker-input').props.value,
+      getByTestId('snap-ui-renderer__date-time-picker--datetime-input').props
+        .value,
     ).toEqual(
       DateTime.fromJSDate(date).toLocaleString(DateTime.DATETIME_SHORT),
     );
@@ -119,7 +120,7 @@ describe('SnapUIDateTimePicker', () => {
 
     act(() => {
       fireEvent.press(
-        getByTestId('snap-ui-renderer__date-time-picker-touchable'),
+        getByTestId('snap-ui-renderer__date-time-picker--date-touchable'),
       );
     });
 
@@ -147,7 +148,7 @@ describe('SnapUIDateTimePicker', () => {
     });
 
     expect(
-      getByTestId('snap-ui-renderer__date-time-picker-input').props.value,
+      getByTestId('snap-ui-renderer__date-time-picker--date-input').props.value,
     ).toEqual(
       DateTime.fromJSDate(date)
         .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
@@ -167,7 +168,7 @@ describe('SnapUIDateTimePicker', () => {
 
     act(() => {
       fireEvent.press(
-        getByTestId('snap-ui-renderer__date-time-picker-touchable'),
+        getByTestId('snap-ui-renderer__date-time-picker--time-touchable'),
       );
     });
 
@@ -195,7 +196,7 @@ describe('SnapUIDateTimePicker', () => {
     });
 
     expect(
-      getByTestId('snap-ui-renderer__date-time-picker-input').props.value,
+      getByTestId('snap-ui-renderer__date-time-picker--time-input').props.value,
     ).toEqual(
       DateTime.fromJSDate(date)
         .set({ second: 0, millisecond: 0 })

--- a/app/components/Snaps/SnapUIRenderer/components/date-time-picker.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/components/date-time-picker.test.tsx
@@ -1,11 +1,20 @@
 import { Box, DateTimePicker, Field } from '@metamask/snaps-sdk/jsx';
 import { renderInterface } from '../testUtils';
-import { fireEvent } from '@testing-library/react-native';
+import { act, fireEvent, waitFor } from '@testing-library/react-native';
 
 import RNDateTimePicker from '@react-native-community/datetimepicker';
 import { DateTime } from 'luxon';
 
-jest.mock('../../../../core/Engine/Engine');
+jest.mock('../../../../core/Engine/Engine', () => ({
+  controllerMessenger: {
+    call: jest.fn(),
+  },
+  context: {
+    SnapInterfaceController: {
+      updateInterfaceState: jest.fn(),
+    },
+  },
+}));
 
 describe('SnapUIDateTimePicker', () => {
   it('renders a date time picker', () => {
@@ -52,8 +61,8 @@ describe('SnapUIDateTimePicker', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('can select a date and time', () => {
-    const { getByTestId, UNSAFE_getByType } = renderInterface(
+  it('can select a date and time', async () => {
+    const { getByTestId, UNSAFE_getByType, getByText } = renderInterface(
       Box({
         children: DateTimePicker({
           name: 'date-time-picker',
@@ -62,25 +71,135 @@ describe('SnapUIDateTimePicker', () => {
       }),
     );
 
+    act(() => {
+      fireEvent.press(
+        getByTestId('snap-ui-renderer__date-time-picker-touchable'),
+      );
+    });
+
+    await waitFor(() => UNSAFE_getByType(RNDateTimePicker));
+
     const date = new Date('2024-12-25T15:30:00Z');
 
-    fireEvent(
-      UNSAFE_getByType(RNDateTimePicker),
-      'onChange',
-      {
-        type: 'set',
-        nativeEvent: {
-          timestamp: date.getTime(),
-          utcOffset: 0,
+    act(() => {
+      fireEvent(
+        UNSAFE_getByType(RNDateTimePicker),
+        'onChange',
+        {
+          type: 'set',
+          nativeEvent: {
+            timestamp: date.getTime(),
+            utcOffset: 0,
+          },
         },
-      },
-      date,
-    );
+        date,
+      );
+    });
+
+    act(() => {
+      fireEvent.press(getByText('OK'));
+    });
 
     expect(
       getByTestId('snap-ui-renderer__date-time-picker-input').props.value,
     ).toEqual(
       DateTime.fromJSDate(date).toLocaleString(DateTime.DATETIME_SHORT),
+    );
+  });
+
+  it('can select a date', async () => {
+    const { getByTestId, UNSAFE_getByType, getByText } = renderInterface(
+      Box({
+        children: DateTimePicker({
+          name: 'date-picker',
+          type: 'date',
+        }),
+      }),
+    );
+
+    act(() => {
+      fireEvent.press(
+        getByTestId('snap-ui-renderer__date-time-picker-touchable'),
+      );
+    });
+
+    await waitFor(() => UNSAFE_getByType(RNDateTimePicker));
+
+    const date = new Date('2024-12-25T15:30:00Z');
+
+    act(() => {
+      fireEvent(
+        UNSAFE_getByType(RNDateTimePicker),
+        'onChange',
+        {
+          type: 'set',
+          nativeEvent: {
+            timestamp: date.getTime(),
+            utcOffset: 0,
+          },
+        },
+        date,
+      );
+    });
+
+    act(() => {
+      fireEvent.press(getByText('OK'));
+    });
+
+    expect(
+      getByTestId('snap-ui-renderer__date-time-picker-input').props.value,
+    ).toEqual(
+      DateTime.fromJSDate(date)
+        .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+        .toLocaleString(DateTime.DATE_SHORT),
+    );
+  });
+
+  it('can select a time', async () => {
+    const { getByTestId, UNSAFE_getByType, getByText } = renderInterface(
+      Box({
+        children: DateTimePicker({
+          name: 'time-picker',
+          type: 'time',
+        }),
+      }),
+    );
+
+    act(() => {
+      fireEvent.press(
+        getByTestId('snap-ui-renderer__date-time-picker-touchable'),
+      );
+    });
+
+    await waitFor(() => UNSAFE_getByType(RNDateTimePicker));
+
+    const date = new Date('2024-12-25T15:30:00Z');
+
+    act(() => {
+      fireEvent(
+        UNSAFE_getByType(RNDateTimePicker),
+        'onChange',
+        {
+          type: 'set',
+          nativeEvent: {
+            timestamp: date.getTime(),
+            utcOffset: 0,
+          },
+        },
+        date,
+      );
+    });
+
+    act(() => {
+      fireEvent.press(getByText('OK'));
+    });
+
+    expect(
+      getByTestId('snap-ui-renderer__date-time-picker-input').props.value,
+    ).toEqual(
+      DateTime.fromJSDate(date)
+        .set({ second: 0, millisecond: 0 })
+        .toLocaleString(DateTime.TIME_SIMPLE),
     );
   });
 

--- a/app/components/Snaps/SnapUIRenderer/components/date-time-picker.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/components/date-time-picker.test.tsx
@@ -1,0 +1,86 @@
+import { Box, DateTimePicker, Field } from '@metamask/snaps-sdk/jsx';
+import { renderInterface } from '../testUtils';
+
+jest.mock('../../../../core/Engine/Engine');
+
+describe('SnapUIDateTimePicker', () => {
+  it('renders a date time picker', () => {
+    const { toJSON, getByTestId } = renderInterface(
+      Box({
+        children: DateTimePicker({
+          name: 'date-time-picker',
+        }),
+      }),
+    );
+
+    expect(getByTestId('snap-ui-renderer__date-time-picker')).toBeTruthy();
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('renders a date picker', () => {
+    const { toJSON, getByTestId } = renderInterface(
+      Box({
+        children: DateTimePicker({
+          name: 'date-picker',
+          type: 'date',
+        }),
+      }),
+    );
+
+    expect(getByTestId('snap-ui-renderer__date-time-picker')).toBeTruthy();
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('renders a time picker', () => {
+    const { toJSON, getByTestId } = renderInterface(
+      Box({
+        children: DateTimePicker({
+          name: 'time-picker',
+          type: 'time',
+        }),
+      }),
+    );
+
+    expect(getByTestId('snap-ui-renderer__date-time-picker')).toBeTruthy();
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('renders inside a field', () => {
+    const { toJSON, getByText, getByTestId } = renderInterface(
+      Box({
+        children: Field({
+          label: 'Select date and time',
+          children: DateTimePicker({
+            name: 'date-time-picker',
+          }),
+        }),
+      }),
+    );
+
+    expect(getByText('Select date and time')).toBeTruthy();
+    expect(getByTestId('snap-ui-renderer__date-time-picker')).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('can show an error', () => {
+    const { toJSON, getByText, getByTestId } = renderInterface(
+      Box({
+        children: Field({
+          label: 'Select date and time',
+          error: 'This is an error',
+          children: DateTimePicker({
+            name: 'date-time-picker',
+          }),
+        }),
+      }),
+    );
+
+    expect(getByText('Select date and time')).toBeTruthy();
+    expect(getByText('This is an error')).toBeTruthy();
+    expect(getByTestId('snap-ui-renderer__date-time-picker')).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
+  });
+});

--- a/app/components/Snaps/SnapUIRenderer/components/date-time-picker.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/components/date-time-picker.test.tsx
@@ -1,5 +1,9 @@
 import { Box, DateTimePicker, Field } from '@metamask/snaps-sdk/jsx';
 import { renderInterface } from '../testUtils';
+import { fireEvent } from '@testing-library/react-native';
+
+import RNDateTimePicker from '@react-native-community/datetimepicker';
+import { DateTime } from 'luxon';
 
 jest.mock('../../../../core/Engine/Engine');
 
@@ -46,6 +50,38 @@ describe('SnapUIDateTimePicker', () => {
     expect(getByTestId('snap-ui-renderer__date-time-picker')).toBeTruthy();
 
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('can select a date and time', () => {
+    const { getByTestId, UNSAFE_getByType } = renderInterface(
+      Box({
+        children: DateTimePicker({
+          name: 'date-time-picker',
+          type: 'datetime',
+        }),
+      }),
+    );
+
+    const date = new Date('2024-12-25T15:30:00Z');
+
+    fireEvent(
+      UNSAFE_getByType(RNDateTimePicker),
+      'onChange',
+      {
+        type: 'set',
+        nativeEvent: {
+          timestamp: date.getTime(),
+          utcOffset: 0,
+        },
+      },
+      date,
+    );
+
+    expect(
+      getByTestId('snap-ui-renderer__date-time-picker-input').props.value,
+    ).toEqual(
+      DateTime.fromJSDate(date).toLocaleString(DateTime.DATETIME_SHORT),
+    );
   });
 
   it('renders inside a field', () => {

--- a/app/components/Snaps/SnapUIRenderer/components/date-time-picker.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/date-time-picker.ts
@@ -1,0 +1,18 @@
+import { DateTimePickerElement } from '@metamask/snaps-sdk/jsx';
+import { UIComponentFactory } from './types';
+
+export const dateTimePicker: UIComponentFactory<DateTimePickerElement> = ({
+  element: e,
+  form,
+}) => ({
+  element: 'SnapUIDateTimePicker',
+  props: {
+    form,
+    type: e.props.type,
+    name: e.props.name,
+    placeholder: e.props.placeholder,
+    disabled: e.props.disabled,
+    disablePast: e.props.disablePast,
+    disableFuture: e.props.disableFuture,
+  },
+});

--- a/app/components/Snaps/SnapUIRenderer/components/field.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/field.ts
@@ -9,6 +9,7 @@ import {
   AccountSelectorElement,
   DropdownElement,
   RadioGroupElement,
+  DateTimePickerElement,
 } from '@metamask/snaps-sdk/jsx';
 import { getJsxChildren } from '@metamask/snaps-utils';
 import { getPrimaryChildElementIndex, mapToTemplate } from '../utils';
@@ -20,6 +21,7 @@ import { assetSelector as assetSelectorFn } from './asset-selector';
 import { accountSelector as accountSelectorFn } from './account-selector';
 import { dropdown as dropdownFn } from './dropdown';
 import { radioGroup as radioGroupFn } from './radioGroup';
+import { dateTimePicker as dateTimePickerFn } from './date-time-picker';
 
 export const field: UIComponentFactory<FieldElement> = ({
   element: e,
@@ -236,6 +238,24 @@ export const field: UIComponentFactory<FieldElement> = ({
           id: radioGroup.props.name,
           label: e.props.label,
           name: radioGroup.props.name,
+          form,
+          error: e.props.error,
+          disabled: child.props.disabled,
+        },
+      };
+    }
+
+    case 'DateTimePicker': {
+      const dateTimePicker = child as DateTimePickerElement;
+      const dateTimePickerMapped = dateTimePickerFn({
+        element: dateTimePicker,
+      } as UIComponentParams<DateTimePickerElement>);
+      return {
+        ...dateTimePickerMapped,
+        element: 'SnapUIDateTimePicker',
+        props: {
+          ...dateTimePickerMapped.props,
+          label: e.props.label,
           form,
           error: e.props.error,
           disabled: child.props.disabled,

--- a/app/components/Snaps/SnapUIRenderer/components/index.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/index.ts
@@ -28,6 +28,7 @@ import { copyable } from './copyable';
 import { accountSelector } from './account-selector';
 import { dropdown } from './dropdown';
 import { radioGroup } from './radioGroup';
+import { dateTimePicker } from './date-time-picker';
 
 export const COMPONENT_MAPPING = {
   Box: box,
@@ -60,4 +61,5 @@ export const COMPONENT_MAPPING = {
   AccountSelector: accountSelector,
   Dropdown: dropdown,
   RadioGroup: radioGroup,
+  DateTimePicker: dateTimePicker,
 };

--- a/app/components/Snaps/SnapUIRenderer/utils.ts
+++ b/app/components/Snaps/SnapUIRenderer/utils.ts
@@ -46,6 +46,7 @@ export const FIELD_ELEMENT_TYPES = [
   'AddressInput',
   'AssetSelector',
   'AccountSelector',
+  'DateTimePicker',
 ];
 
 /**

--- a/app/components/UI/TemplateRenderer/SafeComponentList.ts
+++ b/app/components/UI/TemplateRenderer/SafeComponentList.ts
@@ -38,6 +38,7 @@ import { SnapUIAssetSelector } from '../../Snaps/SnapUIAssetSelector/SnapUIAsset
 import { SnapUICopyable } from '../../Snaps/SnapUICopyable/SnapUICopyable';
 import { SnapUIAccountSelector } from '../../Snaps/SnapUIAccountSelector/SnapUIAccountSelector';
 import { SnapUIRadioGroup } from '../../Snaps/SnapUIRadioGroup/SnapUIRadioGroup';
+import { SnapUIDateTimePicker } from '../../Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker';
 
 export const safeComponentList = {
   BottomSheetFooter,
@@ -72,6 +73,7 @@ export const safeComponentList = {
   SnapUISpinner,
   SnapUIInfoRow,
   SnapUIAccountSelector,
+  SnapUIDateTimePicker,
   RNText,
   ScrollView,
   SnapUITooltip,

--- a/app/core/Engine/controllers/snaps/snap-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.ts
@@ -47,6 +47,8 @@ export const snapControllerInit: ControllerInitFunction<
   SnapControllerMessenger,
   SnapControllerInitMessenger
 > = ({ initMessenger, controllerMessenger, persistedState }) => {
+  // eslint-disable-next-line no-console
+  console.log('Initializing SnapController:', process.env.METAMASK_BUILD_TYPE);
   const requireAllowlist = process.env.METAMASK_BUILD_TYPE !== 'flask';
   const disableSnapInstallation = process.env.METAMASK_BUILD_TYPE !== 'flask';
   const allowLocalSnaps = process.env.METAMASK_BUILD_TYPE === 'flask';

--- a/app/core/Engine/controllers/snaps/snap-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.ts
@@ -47,8 +47,6 @@ export const snapControllerInit: ControllerInitFunction<
   SnapControllerMessenger,
   SnapControllerInitMessenger
 > = ({ initMessenger, controllerMessenger, persistedState }) => {
-  // eslint-disable-next-line no-console
-  console.log('Initializing SnapController:', process.env.METAMASK_BUILD_TYPE);
   const requireAllowlist = process.env.METAMASK_BUILD_TYPE !== 'flask';
   const disableSnapInstallation = process.env.METAMASK_BUILD_TYPE !== 'flask';
   const allowLocalSnaps = process.env.METAMASK_BUILD_TYPE === 'flask';

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -86,6 +86,7 @@ class TestSnaps {
   get snapUIRendererScrollView(): Promise<Detox.NativeMatcher> {
     return Matchers.getIdentifier('snap-ui-renderer__scrollview');
   }
+
   async checkResultSpan(
     selector: keyof typeof TestSnapResultSelectorWebIDS,
     expectedMessage: string,

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -356,6 +356,11 @@ class TestSnaps {
     await Gestures.waitAndTap(this.dateTimePickerTouchable);
 
     await Gestures.waitAndTap(this.dateTimePickerOkButton);
+
+    // Android date and time picker is a two-step process, so we need to tap OK again
+    if (device.getPlatform() === 'android') {
+      await Gestures.waitAndTap(this.dateTimePickerOkButton);
+    }
   }
 
   async selectDateInDatePicker() {

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -24,7 +24,7 @@ import { RetryOptions } from '../../framework';
 import { Json } from '@metamask/utils';
 
 export const TEST_SNAPS_URL =
-  'https://metamask.github.io/snaps/test-snaps/2.28.1/';
+  'https://metamask.github.io/snaps/test-snaps/3.1.0/';
 
 class TestSnaps {
   get getConnectSnapButton(): DetoxElement {
@@ -61,6 +61,31 @@ class TestSnaps {
     return Matchers.getElementByID('snap-ui-renderer__checkbox');
   }
 
+  get dateTimePickerTouchable(): DetoxElement {
+    return Matchers.getElementByID(
+      'snap-ui-renderer__date-time-picker--datetime-touchable',
+    );
+  }
+
+  get datePickerTouchable(): DetoxElement {
+    return Matchers.getElementByID(
+      'snap-ui-renderer__date-time-picker--date-touchable',
+    );
+  }
+
+  get timePickerTouchable(): DetoxElement {
+    return Matchers.getElementByID(
+      'snap-ui-renderer__date-time-picker--time-touchable',
+    );
+  }
+
+  get dateTimePickerOkButton(): DetoxElement {
+    return Matchers.getElementByText('OK');
+  }
+
+  get snapUIRendererScrollView(): Promise<Detox.NativeMatcher> {
+    return Matchers.getIdentifier('snap-ui-renderer__scrollview');
+  }
   async checkResultSpan(
     selector: keyof typeof TestSnapResultSelectorWebIDS,
     expectedMessage: string,
@@ -320,6 +345,29 @@ class TestSnaps {
 
   async tapCheckbox() {
     await Gestures.tap(this.checkboxElement);
+  }
+
+  async selectDateInDateTimePicker() {
+    await Gestures.scrollToElement(
+      this.timePickerTouchable,
+      this.snapUIRendererScrollView,
+    );
+
+    await Gestures.waitAndTap(this.dateTimePickerTouchable);
+
+    await Gestures.waitAndTap(this.dateTimePickerOkButton);
+  }
+
+  async selectDateInDatePicker() {
+    await Gestures.waitAndTap(this.datePickerTouchable);
+
+    await Gestures.waitAndTap(this.dateTimePickerOkButton);
+  }
+
+  async selectTimeInTimePicker() {
+    await Gestures.waitAndTap(this.timePickerTouchable);
+
+    await Gestures.waitAndTap(this.dateTimePickerOkButton);
   }
 
   async installSnap(

--- a/e2e/specs/snaps/test-snap-interactive-ui.spec.ts
+++ b/e2e/specs/snaps/test-snap-interactive-ui.spec.ts
@@ -98,6 +98,11 @@ describe(FlaskBuildTests('Interactive UI Snap Tests'), () => {
         await Assertions.checkIfDisabled(
           Matchers.getElementByID('snap-ui-renderer__selector'),
         );
+
+        await Assertions.checkIfDisabled(TestSnaps.dateTimePickerTouchable);
+        await Assertions.checkIfDisabled(TestSnaps.datePickerTouchable);
+        await Assertions.checkIfDisabled(TestSnaps.timePickerTouchable);
+
         await Assertions.checkIfDisabled(Matchers.getElementByText('Submit'));
 
         await TestSnaps.tapCancelButton();

--- a/e2e/specs/snaps/test-snap-interactive-ui.spec.ts
+++ b/e2e/specs/snaps/test-snap-interactive-ui.spec.ts
@@ -6,6 +6,7 @@ import TabBarComponent from '../../pages/wallet/TabBarComponent';
 import TestSnaps from '../../pages/Browser/TestSnaps';
 import { Assertions } from '../../framework';
 import Matchers from '../../framework/Matchers';
+import { DateTime } from 'luxon';
 
 jest.setTimeout(150_000);
 
@@ -36,11 +37,18 @@ describe(FlaskBuildTests('Interactive UI Snap Tests'), () => {
       async () => {
         await TestSnaps.tapButton('createDialogButton');
 
+        // Create the expected date when the pickers are mounted.
+        // This is needed to compare later with the values submitted by the snap.
+        const dateTimePickerDate = DateTime.now();
+
         await TestSnaps.fillInput('example-input', 'foo bar');
         await TestSnaps.selectInNativeDropdown('snapUIDropdown', 'Option 2');
         await TestSnaps.selectRadioButton('Option 1');
         await TestSnaps.tapCheckbox();
         await TestSnaps.selectInNativeDropdown('snapUISelector', 'Option 3');
+        await TestSnaps.selectDateInDateTimePicker();
+        await TestSnaps.selectDateInDatePicker();
+        await TestSnaps.selectTimeInTimePicker();
         await TestSnaps.tapSubmitButton();
 
         await Assertions.expectTextDisplayed('foo bar');
@@ -48,6 +56,17 @@ describe(FlaskBuildTests('Interactive UI Snap Tests'), () => {
         await Assertions.expectTextDisplayed('option1');
         await Assertions.expectTextDisplayed('true');
         await Assertions.expectTextDisplayed('option3');
+        await Assertions.expectTextDisplayed(
+          dateTimePickerDate.set({ second: 0, millisecond: 0 }).toISO(),
+        );
+        await Assertions.expectTextDisplayed(
+          dateTimePickerDate
+            .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+            .toISO(),
+        );
+        await Assertions.expectTextDisplayed(
+          dateTimePickerDate.set({ second: 0, millisecond: 0 }).toISO(),
+        );
 
         await TestSnaps.tapOkButton();
       },

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2529,7 +2529,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNDateTimePicker (8.3.0):
+  - RNDateTimePicker (8.5.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3572,7 +3572,7 @@ SPEC CHECKSUMS:
   RNCCheckbox: 33b44487ca8008394ce658cc32b26eab04f426ef
   RNCClipboard: f1fe5a8005c651c204e60b43cf0cd67e2244ab70
   RNCMaskedView: b3aee2f4fa81807ec035be51c057aa2eed166173
-  RNDateTimePicker: 96559f666636a8326e862024103eab77a6950625
+  RNDateTimePicker: 68da7b6d5749731f6c5ee407b278c0019f01319c
   RNDefaultPreference: 36fe31684af1f2d14e0664aa9a816d0ec6149cc1
   RNDeviceInfo: e5219d380b51ddb7f97e650ab99a518476b90203
   RNFBApp: 0e66b9f844efdf2ac3fa2b30e64c9db41a263b3d

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "@expo/fingerprint": "^0.15.0",
     "appwright@^0.1.45": "patch:appwright@npm%3A0.1.45#./.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch",
     "@scure/bip32": "1.7.0",
+    "js-sha3": "0.9.3",
     "@metamask/snaps-sdk": "^10.2.0",
     "react-native@0.76.9": "patch:react-native@npm%3A0.76.9#./.yarn/patches/react-native-npm-0.76.9-1c25352097.patch",
     "@ethereumjs/util@npm:^9.0.3": "patch:@ethereumjs/util@npm%3A9.1.0#~/.yarn/patches/@ethereumjs-util-npm-9.1.0-7e85509408.patch",

--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
     "@react-native-community/cli-platform-android": "15.0.1",
     "@react-native-community/cli-platform-ios": "15.0.1",
     "@react-native-community/cli-server-api": "^17.0.0",
-    "@react-native-community/datetimepicker": "^8.3.0",
+    "@react-native-community/datetimepicker": "^8.5.0",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-native-community/slider": "^4.4.3",
     "@react-native-cookies/cookies": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
     "@expo/fingerprint": "^0.15.0",
     "appwright@^0.1.45": "patch:appwright@npm%3A0.1.45#./.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch",
     "@scure/bip32": "1.7.0",
-    "js-sha3": "0.9.3",
     "@metamask/snaps-sdk": "^10.2.0",
     "react-native@0.76.9": "patch:react-native@npm%3A0.76.9#./.yarn/patches/react-native-npm-0.76.9-1c25352097.patch",
     "@ethereumjs/util@npm:^9.0.3": "patch:@ethereumjs/util@npm%3A9.1.0#~/.yarn/patches/@ethereumjs-util-npm-9.1.0-7e85509408.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11866,13 +11866,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-community/datetimepicker@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "@react-native-community/datetimepicker@npm:8.3.0"
+"@react-native-community/datetimepicker@npm:^8.5.0":
+  version: 8.5.0
+  resolution: "@react-native-community/datetimepicker@npm:8.5.0"
   dependencies:
     invariant: "npm:^2.2.4"
   peerDependencies:
-    expo: ">=50.0.0"
+    expo: ">=52.0.0"
     react: "*"
     react-native: "*"
     react-native-windows: "*"
@@ -11881,7 +11881,7 @@ __metadata:
       optional: true
     react-native-windows:
       optional: true
-  checksum: 10/69adaaadbd8b57d1c049d0ca92dddad62b5c8dfba50e4660303c30746d39e9e976d6d61f59f001d5df15f25832dc740225fe394c667bd3a76dc42b66efc061d9
+  checksum: 10/e7268c9f74aaf8b2ec7e14ea6ba916a6dc32df1d54d5371a1cf3a731b9ae1e2694a3ed70a1ab642694f5ade171d721464ca93dd0fa0aa11208dd1cce5f25f46a
   languageName: node
   linkType: hard
 
@@ -34119,7 +34119,7 @@ __metadata:
     "@react-native-community/cli-platform-android": "npm:15.0.1"
     "@react-native-community/cli-platform-ios": "npm:15.0.1"
     "@react-native-community/cli-server-api": "npm:^17.0.0"
-    "@react-native-community/datetimepicker": "npm:^8.3.0"
+    "@react-native-community/datetimepicker": "npm:^8.5.0"
     "@react-native-community/netinfo": "npm:^11.4.1"
     "@react-native-community/slider": "npm:^4.4.3"
     "@react-native-cookies/cookies": "npm:^6.2.1"


### PR DESCRIPTION
## **Description**

This RP adds a date/time picker to Snaps UI.

## **Changelog**

CHANGELOG entry: Add Snaps UI date/time picker

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="500" height="935" alt="Screenshot 2025-12-01 at 15 07 30" src="https://github.com/user-attachments/assets/7cdd6608-ace1-48df-ad62-9b268c5b603a" />
<img width="500" height="935" alt="Screenshot 2025-12-01 at 15 07 38" src="https://github.com/user-attachments/assets/62c2cf70-a9d8-4cc8-b42a-2a6b90c44aa2" />
<img width="500" height="935" alt="Screenshot 2025-12-01 at 15 07 46" src="https://github.com/user-attachments/assets/41aab971-1d94-40dd-8e34-131722c290ea" />
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-12-01 at 15 45 06" src="https://github.com/user-attachments/assets/d7ac5c45-d2fc-47b2-9b62-582ccb1df362" />
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-12-01 at 15 45 12" src="https://github.com/user-attachments/assets/c94a4225-fff2-41cb-82ff-fa1bd61e08d7" />
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-12-01 at 15 45 18" src="https://github.com/user-attachments/assets/d52677a7-0b1c-401c-b95b-b65761bd558f" />
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-12-01 at 15 45 23" src="https://github.com/user-attachments/assets/d80c27dc-a2ae-412f-94cb-5e72b6ec5562" />
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-12-01 at 15 45 33" src="https://github.com/user-attachments/assets/7963a6c5-d90e-4649-bf93-119752a6d66c" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `SnapUIDateTimePicker` with iOS/Android flows, integrates it into the Snaps UI renderer/field system, adds tests and e2e coverage, and bumps `@react-native-community/datetimepicker` to 8.5.0.
> 
> - **Snaps UI**:
>   - Add `SnapUIDateTimePicker` component (iOS bottom sheet confirm, Android two-step date→time) with styles and state integration via `SnapInterfaceContext`.
>   - Map new `DateTimePicker` JSX element in `components/index.ts`, `components/field.ts`, and `components/date-time-picker.ts`.
>   - Expose component in `SafeComponentList`.
>   - Add `testID` to `ScrollView` in container and propagate in snapshots.
> - **State/Event handling**:
>   - Update `SnapInterfaceContext` to include `name`/`value` when not `undefined`.
> - **Testing**:
>   - Add unit tests and snapshots for Date/Time Picker; refactor container tests to external snapshots.
>   - Update multiple renderer snapshots for new `testID` and components.
> - **E2E**:
>   - Extend TestSnaps to interact with date, time, and datetime pickers; validate submitted ISO values and disabled states.
>   - Update Test Snaps URL to `3.1.0`.
> - **Dependencies**:
>   - Bump `@react-native-community/datetimepicker` to `^8.5.0` (Pods updated accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb87d5ba03c4c1c8c48b9886ed29bb3788eac72d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->