### PR TITLE
fix: cp-7.61.0 prevent infinite quote requests when user selected max balance

### DIFF
--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import Engine from '../../../../../core/Engine';
 import { type GenericQuoteRequest } from '@metamask/bridge-controller';
 import { useSelector } from 'react-redux';
@@ -50,6 +50,13 @@ export const useBridgeQuoteRequest = () => {
     selectGasIncludedQuoteParams,
   );
 
+  // Prevents infinite requests when user select max balance on
+  // source token input.
+  const insufficientBalRef = useRef(insufficientBal);
+  useEffect(() => {
+    insufficientBalRef.current = insufficientBal;
+  }, [insufficientBal]);
+
   /**
    * Updates quote parameters in the bridge controller
    */
@@ -83,7 +90,7 @@ export const useBridgeQuoteRequest = () => {
       destWalletAddress: destAddress ?? walletAddress,
       gasIncluded,
       gasIncluded7702,
-      insufficientBal,
+      insufficientBal: insufficientBalRef.current,
     };
 
     await Engine.context.BridgeController.updateBridgeQuoteRequestParams(
@@ -101,7 +108,6 @@ export const useBridgeQuoteRequest = () => {
     context,
     gasIncluded,
     gasIncluded7702,
-    insufficientBal,
   ]);
 
   // Create a stable debounced function that persists across renders


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When pressing the max button on the source token (or input max balance by hand), infinite quote requests were triggered due to a circular dependency: the updateQuoteParams callback in useBridgeQuoteRequest had insufficientBal in its dependency array, and useIsInsufficientBalance recalculates this value using gas fees from the returned quote (bestQuote?.gasFee?.effective?.amount), causing the callback to be recreated after each quote response, which recreated the debounced function, triggering another quote request in an endless loop. The fix uses a ref (insufficientBalRef) to store the latest insufficientBal value (updated via useEffect) and accesses it inside updateQuoteParams instead of closing over the value directly, removing insufficientBal from the dependency array—this ensures the latest value is always used when making requests while keeping the debounced function stable across renders.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: prevent infinite quote requests when max balance is selected in swaps

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/23523
 
## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents infinite bridge quote requests when selecting max balance by reading `insufficientBal` via a ref and removing it from callback deps to keep the debounced updater stable.
> 
> - **Bridge Quote Request Hook** (`app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts`):
>   - Use `useRef` + `useEffect` to track `insufficientBal` and read it via `insufficientBalRef.current` in `updateQuoteParams`.
>   - Remove `insufficientBal` from `updateQuoteParams` dependency array to avoid recreating the debounced updater.
>   - Pass `insufficientBalRef.current` in `GenericQuoteRequest` params.
>   - Minor import additions for `useEffect` and `useRef`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 270caf9a7749dc76219a1e770343a9ef44df6736. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->