### PR TITLE
feat: Add Snaps debug information to the about page

### DIFF
--- a/app/components/Views/Settings/AppInformation/index.js
+++ b/app/components/Views/Settings/AppInformation/index.js
@@ -270,7 +270,7 @@ class AppInformation extends PureComponent {
                 )}
 
                 {this.props.preinstalledSnaps.map((snap) => (
-                  <Text style={styles.branchInfo}>
+                  <Text key={snap.name} style={styles.branchInfo}>
                     {snap.name}: {snap.version} ({snap.status})
                   </Text>
                 ))}

--- a/app/components/Views/Settings/AppInformation/index.js
+++ b/app/components/Views/Settings/AppInformation/index.js
@@ -24,6 +24,7 @@ import {
   updateId,
   checkAutomatically,
 } from 'expo-updates';
+import { connect } from 'react-redux';
 import { PROJECT_ID, getFullVersion } from '../../../../constants/ota';
 import { fontStyles } from '../../../../styles/common';
 import PropTypes from 'prop-types';
@@ -37,6 +38,7 @@ import {
   getFeatureFlagAppDistribution,
   getFeatureFlagAppEnvironment,
 } from '../../../../core/Engine/controllers/remote-feature-flag-controller/utils';
+import { getPreinstalledSnapsMetadata } from '../../../../selectors/snaps';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -102,12 +104,13 @@ const foxImage = require('../../../../images/branding/fox.png'); // eslint-disab
 /**
  * View that contains app information
  */
-export default class AppInformation extends PureComponent {
+class AppInformation extends PureComponent {
   static propTypes = {
     /**
     /* navigation object required to push new views
     */
     navigation: PropTypes.object,
+    preinstalledSnaps: PropTypes.array,
   };
 
   state = {
@@ -265,6 +268,12 @@ export default class AppInformation extends PureComponent {
                     </Text>
                   </>
                 )}
+
+                {this.props.preinstalledSnaps.map((snap) => (
+                  <Text style={styles.branchInfo}>
+                    {snap.name}: {snap.version} ({snap.status})
+                  </Text>
+                ))}
               </>
             )}
           </View>
@@ -311,3 +320,9 @@ export default class AppInformation extends PureComponent {
 }
 
 AppInformation.contextType = ThemeContext;
+
+const mapStateToProps = (state) => ({
+  preinstalledSnaps: getPreinstalledSnapsMetadata(state),
+});
+
+export default connect(mapStateToProps)(AppInformation);

--- a/app/components/Views/Settings/AppInformation/index.test.tsx
+++ b/app/components/Views/Settings/AppInformation/index.test.tsx
@@ -1,8 +1,12 @@
 import { waitFor, fireEvent } from '@testing-library/react-native';
 import { Image, TouchableOpacity } from 'react-native';
-import { renderScreen } from '../../../../util/test/renderWithProvider';
+import {
+  DeepPartial,
+  renderScreen,
+} from '../../../../util/test/renderWithProvider';
 import AppInformation from './';
 import { AboutMetaMaskSelectorsIDs } from '../../../../../e2e/selectors/Settings/AboutMetaMask.selectors';
+import { RootState } from '../../../../reducers';
 
 // Mock device info
 const mockGetApplicationName = jest.fn();
@@ -32,6 +36,28 @@ jest.mock(
   }),
 );
 
+const MOCK_STATE = {
+  engine: {
+    backgroundState: {
+      SnapController: {
+        snaps: {
+          'npm:@metamask/solana-snap': {
+            id: 'npm:@metamask/solana-snap',
+            enabled: true,
+            version: '1.7.0',
+            status: 'running',
+            manifest: {
+              proposedName: 'Solana',
+              description: 'Manage Solana using MetaMask',
+            },
+            preinstalled: true,
+          },
+        },
+      },
+    },
+  },
+} as DeepPartial<RootState>;
+
 describe('AppInformation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -47,7 +73,7 @@ describe('AppInformation', () => {
     const { toJSON } = renderScreen(
       AppInformation,
       { name: 'AppInformation' },
-      { state: {} },
+      { state: MOCK_STATE },
     );
     expect(toJSON()).toMatchSnapshot();
   });
@@ -56,7 +82,7 @@ describe('AppInformation', () => {
     const { getByTestId } = renderScreen(
       AppInformation,
       { name: 'AppInformation' },
-      { state: {} },
+      { state: MOCK_STATE },
     );
 
     expect(getByTestId(AboutMetaMaskSelectorsIDs.CONTAINER)).toBeTruthy();
@@ -66,7 +92,7 @@ describe('AppInformation', () => {
     const { getByText } = renderScreen(
       AppInformation,
       { name: 'AppInformation' },
-      { state: {} },
+      { state: MOCK_STATE },
     );
 
     // Given the device info is mocked
@@ -82,7 +108,7 @@ describe('AppInformation', () => {
       const { getByText } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       // Given the component is rendered
@@ -100,7 +126,7 @@ describe('AppInformation', () => {
       const { getByText } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       expect(getByText(/Links/)).toBeTruthy();
@@ -109,7 +135,11 @@ describe('AppInformation', () => {
 
   describe('Component Lifecycle', () => {
     it('fetches device info on mount', async () => {
-      renderScreen(AppInformation, { name: 'AppInformation' }, { state: {} });
+      renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
 
       // Given the component is mounted
       // When the componentDidMount lifecycle method runs
@@ -129,7 +159,7 @@ describe('AppInformation', () => {
       const { getByText } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       // Given device info returns specific values
@@ -146,7 +176,7 @@ describe('AppInformation', () => {
       const { UNSAFE_getAllByType } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       // Given the component is rendered
@@ -173,7 +203,7 @@ describe('AppInformation', () => {
       const { queryByText } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       // When the component renders
@@ -192,7 +222,7 @@ describe('AppInformation', () => {
       const { getByText, UNSAFE_getAllByType } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       // When the user long-presses the fox icon
@@ -213,6 +243,7 @@ describe('AppInformation', () => {
         expect(
           getByText('Remote Feature Flag Distribution: main'),
         ).toBeTruthy();
+        expect(getByText('Solana: 1.7.0 (running)')).toBeTruthy();
       });
     });
 
@@ -225,7 +256,7 @@ describe('AppInformation', () => {
       const { queryByText, getByText, UNSAFE_getAllByType } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       // When initially rendered
@@ -262,7 +293,7 @@ describe('AppInformation', () => {
       const { getByText } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       // When the component renders
@@ -284,7 +315,7 @@ describe('AppInformation', () => {
       const { UNSAFE_getAllByType } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       // Given the component is rendered
@@ -308,7 +339,7 @@ describe('AppInformation', () => {
       const { queryByText, getByText, UNSAFE_getAllByType } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       // Given environment info is initially hidden
@@ -342,7 +373,7 @@ describe('AppInformation', () => {
       const { getByText, queryByText, UNSAFE_getAllByType } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       // Given environment info is initially hidden
@@ -384,7 +415,7 @@ describe('AppInformation', () => {
       const { getByText, UNSAFE_getAllByType } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       // When the fox icon is long-pressed
@@ -412,7 +443,7 @@ describe('AppInformation', () => {
       const { queryByText } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       expect(queryByText(/Expo Project ID:/)).toBeNull();
@@ -428,7 +459,7 @@ describe('AppInformation', () => {
       const { getByText, UNSAFE_getAllByType } = renderScreen(
         AppInformation,
         { name: 'AppInformation' },
-        { state: {} },
+        { state: MOCK_STATE },
       );
 
       const touchableOpacities = UNSAFE_getAllByType(TouchableOpacity);

--- a/app/selectors/snaps/snapController.ts
+++ b/app/selectors/snaps/snapController.ts
@@ -18,7 +18,16 @@ export const selectSnapsMetadata = createDeepEqualSelector(
   selectSnaps,
   (snaps) =>
     Object.values(snaps).reduce<
-      Record<string, { name: string; description: string }>
+      Record<
+        string,
+        {
+          name: string;
+          description: string;
+          version: string;
+          status: string;
+          preinstalled?: boolean;
+        }
+      >
     >((snapsMetadata, snap) => {
       const snapId = snap.id;
       const manifest = snap.localizationFiles
@@ -33,9 +42,17 @@ export const selectSnapsMetadata = createDeepEqualSelector(
       snapsMetadata[snapId] = {
         name: manifest.proposedName,
         description: manifest.description,
+        version: snap.version,
+        status: snap.status,
+        preinstalled: snap.preinstalled,
       };
       return snapsMetadata;
     }, {}),
+);
+
+export const getPreinstalledSnapsMetadata = createDeepEqualSelector(
+  selectSnapsMetadata,
+  (metadata) => Object.values(metadata).filter((snap) => snap.preinstalled),
 );
 
 export const getEnabledSnaps = createDeepEqualSelector(selectSnaps, (snaps) =>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add Snaps debugging information to the hidden menu on the about page.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Manual testing steps**

1. Long press the fox icon on the about screen

## **Screenshots/Recordings**

### **After**
<img width="300" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-12-02 at 12 23 24" src="https://github.com/user-attachments/assets/dd84e477-82a5-45f0-85f5-60bfcd35f86b" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Connects About screen to Redux to show preinstalled Snaps (name, version, status) in the hidden debug section, with new selector support and updated tests.
> 
> - **Settings/About (`app/components/Views/Settings/AppInformation`)**:
>   - Connects component to Redux and injects `preinstalledSnaps` via `getPreinstalledSnapsMetadata`.
>   - Displays each preinstalled Snap as `name: version (status)` in the hidden environment info (long-press fox).
> - **Selectors (`app/selectors/snaps/snapController.ts`)**:
>   - Extends `selectSnapsMetadata` to include `version`, `status`, and `preinstalled`.
>   - Adds `getPreinstalledSnapsMetadata` to filter preinstalled Snaps.
> - **Tests (`index.test.tsx`)**:
>   - Provide mock state with a preinstalled Snap; assert its display in the debug section.
>   - Update utilities/types imports to support mocked Redux state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3767b00fa54afac9998af1fa407f443178e20343. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->