### PR TITLE
fix(ramp): last order provider check cp-7.61.0

### DIFF
--- a/app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts
@@ -745,6 +745,32 @@ describe('useRampsSmartRouting', () => {
         }),
       );
     });
+
+    it('routes to AGGREGATOR when last completed order has legacy provider', async () => {
+      mockApiResponse({
+        deposit: true,
+        aggregator: true,
+        global: true,
+      });
+      // Legacy orders may have deprecated provider values like MOONPAY
+      // These should route to AGGREGATOR since they're not DEPOSIT or Transak via aggregator
+      mockOrders = [
+        createMockOrder({
+          provider: FIAT_ORDER_PROVIDERS.MOONPAY,
+          state: FIAT_ORDER_STATES.COMPLETED,
+          createdAt: 4000,
+        }),
+      ];
+
+      renderHook(() => useRampsSmartRouting());
+
+      await waitFor(() =>
+        expect(mockDispatch).toHaveBeenCalledWith({
+          type: 'FIAT_SET_RAMP_ROUTING_DECISION',
+          payload: UnifiedRampRoutingType.AGGREGATOR,
+        }),
+      );
+    });
   });
 
   describe('Order sorting by timestamp', () => {

--- a/app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts
@@ -17,7 +17,7 @@ const mockUseSelector = jest.fn();
 const mockFetch = jest.fn();
 const mockUseRampsUnifiedV1Enabled = jest.fn();
 
-global.fetch = mockFetch as jest.Mock;
+globalThis.fetch = mockFetch;
 
 const originalMetamaskEnvironment = process.env.METAMASK_ENVIRONMENT;
 
@@ -36,11 +36,20 @@ jest.mock('./useRampsUnifiedV1Enabled', () => ({
 let mockOrders: FiatOrder[] = [];
 let mockDetectedGeolocation: string | undefined;
 
-const createMockOrder = (
-  provider: FIAT_ORDER_PROVIDERS,
-  state: FIAT_ORDER_STATES,
-  createdAt: number,
-): FiatOrder =>
+interface CreateMockOrderOptions {
+  provider: FIAT_ORDER_PROVIDERS;
+  state: FIAT_ORDER_STATES;
+  createdAt: number;
+  /** The nested provider id for aggregator orders (e.g., 'transak', 'moonpay') */
+  dataProviderId?: string;
+}
+
+const createMockOrder = ({
+  provider,
+  state,
+  createdAt,
+  dataProviderId,
+}: CreateMockOrderOptions): FiatOrder =>
   ({
     id: `order-${createdAt}`,
     provider,
@@ -53,8 +62,23 @@ const createMockOrder = (
     network: '1',
     excludeFromPurchases: false,
     orderType: 'BUY',
-    data: {},
+    data: dataProviderId ? { provider: { id: dataProviderId } } : {},
   }) as FiatOrder;
+
+/**
+ * Helper to create an aggregator order with a specific nested provider
+ */
+const createAggregatorOrder = (
+  state: FIAT_ORDER_STATES,
+  createdAt: number,
+  nestedProviderId: string,
+): FiatOrder =>
+  createMockOrder({
+    provider: FIAT_ORDER_PROVIDERS.AGGREGATOR,
+    state,
+    createdAt,
+    dataProviderId: nestedProviderId,
+  });
 
 const mockApiResponse = ({
   deposit,
@@ -260,11 +284,7 @@ describe('useRampsSmartRouting', () => {
         global: false,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
-          FIAT_ORDER_STATES.COMPLETED,
-          1000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 1000, 'transak'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -302,11 +322,7 @@ describe('useRampsSmartRouting', () => {
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
-          FIAT_ORDER_STATES.COMPLETED,
-          1000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 1000, 'transak'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -430,16 +446,8 @@ describe('useRampsSmartRouting', () => {
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.AGGREGATOR,
-          FIAT_ORDER_STATES.PENDING,
-          1000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
-          FIAT_ORDER_STATES.PENDING,
-          2000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.PENDING, 1000, 'moonpay'),
+        createAggregatorOrder(FIAT_ORDER_STATES.PENDING, 2000, 'transak'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -459,16 +467,8 @@ describe('useRampsSmartRouting', () => {
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.AGGREGATOR,
-          FIAT_ORDER_STATES.FAILED,
-          1000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
-          FIAT_ORDER_STATES.FAILED,
-          2000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.FAILED, 1000, 'moonpay'),
+        createAggregatorOrder(FIAT_ORDER_STATES.FAILED, 2000, 'transak'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -488,11 +488,7 @@ describe('useRampsSmartRouting', () => {
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.AGGREGATOR,
-          FIAT_ORDER_STATES.CANCELLED,
-          1000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.CANCELLED, 1000, 'moonpay'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -507,23 +503,15 @@ describe('useRampsSmartRouting', () => {
   });
 
   describe('Provider-based routing with Transak', () => {
-    it('routes to DEPOSIT when last completed order is from Transak', async () => {
+    it('routes to DEPOSIT when last completed order is from Transak via aggregator', async () => {
       mockApiResponse({
         deposit: true,
         aggregator: true,
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
-          FIAT_ORDER_STATES.COMPLETED,
-          5000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.AGGREGATOR,
-          FIAT_ORDER_STATES.COMPLETED,
-          3000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 5000, 'transak'),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 3000, 'moonpay'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -536,18 +524,14 @@ describe('useRampsSmartRouting', () => {
       );
     });
 
-    it('routes to DEPOSIT when only completed order is from Transak', async () => {
+    it('routes to DEPOSIT when only completed order is from Transak via aggregator', async () => {
       mockApiResponse({
         deposit: true,
         aggregator: true,
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
-          FIAT_ORDER_STATES.COMPLETED,
-          1000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 1000, 'transak'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -560,28 +544,16 @@ describe('useRampsSmartRouting', () => {
       );
     });
 
-    it('routes to DEPOSIT when Transak is most recent among mixed states', async () => {
+    it('routes to DEPOSIT when Transak via aggregator is most recent among mixed states', async () => {
       mockApiResponse({
         deposit: true,
         aggregator: true,
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
-          FIAT_ORDER_STATES.COMPLETED,
-          5000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.AGGREGATOR,
-          FIAT_ORDER_STATES.PENDING,
-          6000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.MOONPAY,
-          FIAT_ORDER_STATES.COMPLETED,
-          3000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 5000, 'transak'),
+        createAggregatorOrder(FIAT_ORDER_STATES.PENDING, 6000, 'moonpay'),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 3000, 'moonpay'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -601,16 +573,12 @@ describe('useRampsSmartRouting', () => {
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.DEPOSIT,
-          FIAT_ORDER_STATES.COMPLETED,
-          5000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.AGGREGATOR,
-          FIAT_ORDER_STATES.COMPLETED,
-          3000,
-        ),
+        createMockOrder({
+          provider: FIAT_ORDER_PROVIDERS.DEPOSIT,
+          state: FIAT_ORDER_STATES.COMPLETED,
+          createdAt: 5000,
+        }),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 3000, 'moonpay'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -630,11 +598,55 @@ describe('useRampsSmartRouting', () => {
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.DEPOSIT,
+        createMockOrder({
+          provider: FIAT_ORDER_PROVIDERS.DEPOSIT,
+          state: FIAT_ORDER_STATES.COMPLETED,
+          createdAt: 1000,
+        }),
+      ];
+
+      renderHook(() => useRampsSmartRouting());
+
+      await waitFor(() =>
+        expect(mockDispatch).toHaveBeenCalledWith({
+          type: 'FIAT_SET_RAMP_ROUTING_DECISION',
+          payload: UnifiedRampRoutingType.DEPOSIT,
+        }),
+      );
+    });
+
+    it('routes to DEPOSIT when provider id contains transak substring', async () => {
+      mockApiResponse({
+        deposit: true,
+        aggregator: true,
+        global: true,
+      });
+      mockOrders = [
+        createAggregatorOrder(
           FIAT_ORDER_STATES.COMPLETED,
-          1000,
+          5000,
+          'transak-native',
         ),
+      ];
+
+      renderHook(() => useRampsSmartRouting());
+
+      await waitFor(() =>
+        expect(mockDispatch).toHaveBeenCalledWith({
+          type: 'FIAT_SET_RAMP_ROUTING_DECISION',
+          payload: UnifiedRampRoutingType.DEPOSIT,
+        }),
+      );
+    });
+
+    it('routes to DEPOSIT when provider id is Transak with different casing', async () => {
+      mockApiResponse({
+        deposit: true,
+        aggregator: true,
+        global: true,
+      });
+      mockOrders = [
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 5000, 'TRANSAK'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -649,23 +661,15 @@ describe('useRampsSmartRouting', () => {
   });
 
   describe('Provider-based routing without Transak', () => {
-    it('routes to AGGREGATOR when last completed order is from Aggregator', async () => {
+    it('routes to AGGREGATOR when last completed order is from non-Transak aggregator provider', async () => {
       mockApiResponse({
         deposit: true,
         aggregator: true,
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.AGGREGATOR,
-          FIAT_ORDER_STATES.COMPLETED,
-          5000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
-          FIAT_ORDER_STATES.COMPLETED,
-          3000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 5000, 'moonpay'),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 3000, 'transak'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -678,18 +682,14 @@ describe('useRampsSmartRouting', () => {
       );
     });
 
-    it('routes to AGGREGATOR when last completed order is from MoonPay', async () => {
+    it('routes to AGGREGATOR when last completed order is from MoonPay via aggregator', async () => {
       mockApiResponse({
         deposit: true,
         aggregator: true,
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.MOONPAY,
-          FIAT_ORDER_STATES.COMPLETED,
-          4000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 4000, 'moonpay'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -702,18 +702,38 @@ describe('useRampsSmartRouting', () => {
       );
     });
 
-    it('routes to AGGREGATOR when last completed order is from Wyre', async () => {
+    it('routes to AGGREGATOR when last completed order is from Sardine via aggregator', async () => {
       mockApiResponse({
         deposit: true,
         aggregator: false,
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.WYRE,
-          FIAT_ORDER_STATES.COMPLETED,
-          3000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 3000, 'sardine'),
+      ];
+
+      renderHook(() => useRampsSmartRouting());
+
+      await waitFor(() =>
+        expect(mockDispatch).toHaveBeenCalledWith({
+          type: 'FIAT_SET_RAMP_ROUTING_DECISION',
+          payload: UnifiedRampRoutingType.AGGREGATOR,
+        }),
+      );
+    });
+
+    it('routes to AGGREGATOR when aggregator order has no nested provider id', async () => {
+      mockApiResponse({
+        deposit: true,
+        aggregator: true,
+        global: true,
+      });
+      mockOrders = [
+        createMockOrder({
+          provider: FIAT_ORDER_PROVIDERS.AGGREGATOR,
+          state: FIAT_ORDER_STATES.COMPLETED,
+          createdAt: 4000,
+        }),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -735,21 +755,9 @@ describe('useRampsSmartRouting', () => {
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
-          FIAT_ORDER_STATES.COMPLETED,
-          1000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.MOONPAY,
-          FIAT_ORDER_STATES.COMPLETED,
-          3000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.AGGREGATOR,
-          FIAT_ORDER_STATES.COMPLETED,
-          2000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 1000, 'transak'),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 3000, 'moonpay'),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 2000, 'sardine'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -769,21 +777,9 @@ describe('useRampsSmartRouting', () => {
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.MOONPAY,
-          FIAT_ORDER_STATES.PENDING,
-          9999,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
-          FIAT_ORDER_STATES.COMPLETED,
-          5000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.AGGREGATOR,
-          FIAT_ORDER_STATES.COMPLETED,
-          3000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.PENDING, 9999, 'moonpay'),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 5000, 'transak'),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 3000, 'sardine'),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -832,11 +828,7 @@ describe('useRampsSmartRouting', () => {
 
       mockDispatch.mockClear();
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.AGGREGATOR,
-          FIAT_ORDER_STATES.COMPLETED,
-          1000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 1000, 'moonpay'),
       ];
 
       rerender({});
@@ -894,15 +886,15 @@ describe('useRampsSmartRouting', () => {
       });
       const sameTimestamp = 5000;
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
+        createAggregatorOrder(
           FIAT_ORDER_STATES.COMPLETED,
           sameTimestamp,
+          'transak',
         ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.AGGREGATOR,
+        createAggregatorOrder(
           FIAT_ORDER_STATES.COMPLETED,
           sameTimestamp,
+          'moonpay',
         ),
       ];
 
@@ -923,26 +915,14 @@ describe('useRampsSmartRouting', () => {
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.MOONPAY,
-          FIAT_ORDER_STATES.PENDING,
-          9000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
-          FIAT_ORDER_STATES.COMPLETED,
-          5000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.AGGREGATOR,
-          FIAT_ORDER_STATES.FAILED,
-          8000,
-        ),
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.DEPOSIT,
-          FIAT_ORDER_STATES.CANCELLED,
-          7000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.PENDING, 9000, 'moonpay'),
+        createAggregatorOrder(FIAT_ORDER_STATES.COMPLETED, 5000, 'transak'),
+        createAggregatorOrder(FIAT_ORDER_STATES.FAILED, 8000, 'sardine'),
+        createMockOrder({
+          provider: FIAT_ORDER_PROVIDERS.DEPOSIT,
+          state: FIAT_ORDER_STATES.CANCELLED,
+          createdAt: 7000,
+        }),
       ];
 
       renderHook(() => useRampsSmartRouting());
@@ -962,11 +942,7 @@ describe('useRampsSmartRouting', () => {
         global: true,
       });
       mockOrders = [
-        createMockOrder(
-          FIAT_ORDER_PROVIDERS.TRANSAK,
-          FIAT_ORDER_STATES.CREATED,
-          1000,
-        ),
+        createAggregatorOrder(FIAT_ORDER_STATES.CREATED, 1000, 'transak'),
       ];
 
       renderHook(() => useRampsSmartRouting());


### PR DESCRIPTION

## **Description**

This PR fixes a bug in the ramp smart routing logic. The condition was checking for `FIAT_ORDER_PROVIDERS.TRANSAK` which is a deprecated provider value. The current valid provider values are only `AGGREGATOR` and `DEPOSIT`.

When an order comes from Transak through the aggregator, the correct way to identify it is by checking `order.data.provider.id` for a substring containing "transak" (case-insensitive).

**Changes:**
- Added `isTransakAggregatorOrder` helper function to correctly identify Transak orders from the aggregator
- Updated the routing condition to use the new helper instead of the deprecated `FIAT_ORDER_PROVIDERS.TRANSAK`
- Updated tests to use proper mock data structure with `data.provider.id` instead of deprecated provider enum values

## **Changelog**

CHANGELOG entry: Fixed Buy decision to deposit according to last provider used

## **Related issues**

Fixes:  https://github.com/MetaMask/metamask-mobile/issues/23547

## **Manual testing steps**

```gherkin
Feature: Ramp Smart Routing

  Scenario: user is routed to Deposit when last completed order was from Transak via Aggregator
    Given user has a completed order from Transak via the Aggregator
    And deposit is supported in user's region

    When user opens the Buy flow
    Then user is routed to the Deposit flow

  Scenario: user is routed to Aggregator when last completed order was from non-Transak provider
    Given user has a completed order from MoonPay via the Aggregator
    And deposit is supported in user's region

    When user opens the Buy flow
    Then user is routed to the Aggregator flow
```

## **Screenshots/Recordings**

### **Before**

N/A - Logic change, no UI changes

### **After**

N/A - Logic change, no UI changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes routing by detecting Transak via aggregator using nested provider id and updates tests to reflect the new data shape and scenarios.
> 
> - **Core logic (`app/components/UI/Ramp/hooks/useRampsSmartRouting.ts`)**:
>   - Add `isTransakAggregatorOrder` to detect Transak when `provider === AGGREGATOR` via `order.data.provider.id` (case-insensitive substring match).
>   - Update routing: route to `DEPOSIT` if last completed order is `DEPOSIT` or `isTransakAggregatorOrder(order)`; otherwise `AGGREGATOR`.
> - **Tests (`app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts`)**:
>   - Refactor mocks to include nested provider id; add `createAggregatorOrder` helper.
>   - Update/expand scenarios for Transak via aggregator (including substring and casing), non-Transak aggregator, legacy providers, missing nested provider, sorting/lifecycle, and region/error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcdac284b6c17f4dd665d36d7b656fb551f9d373. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->