### PR TITLE
chore: Add missing properties for transaction events

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.ts
+++ b/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.ts
@@ -20,6 +20,7 @@ import type {
   TransactionMetricsBuilder,
 } from '../types';
 import { getMetaMaskPayProperties } from '../event_properties/metamask-pay';
+import { getSimulationValuesProperties } from '../event_properties/simulation-values';
 import Engine from '../../../Engine';
 import { createProjectLogger } from '@metamask/utils';
 
@@ -27,6 +28,7 @@ const log = createProjectLogger('transaction-metrics');
 
 const METRICS_BUILDERS: TransactionMetricsBuilder[] = [
   getMetaMaskPayProperties,
+  getSimulationValuesProperties,
 ];
 
 // Generic handler for simple transaction events

--- a/app/core/Engine/controllers/transaction-controller/event_properties/simulation-values.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/event_properties/simulation-values.test.ts
@@ -1,0 +1,120 @@
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { getSimulationValuesProperties } from './simulation-values';
+import { TransactionMetricsBuilder } from '../types';
+
+describe('getSimulationValuesProperties', () => {
+  const getStateMock: jest.MockedFn<
+    Parameters<TransactionMetricsBuilder>[0]['getState']
+  > = jest.fn();
+
+  const getUIMetricsMock: jest.MockedFn<
+    Parameters<TransactionMetricsBuilder>[0]['getUIMetrics']
+  > = jest.fn();
+
+  let request: Parameters<TransactionMetricsBuilder>[0];
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    request = {
+      transactionMeta: {
+        id: 'tx-1',
+        txParams: { nonce: '0x1' },
+      } as TransactionMeta,
+      allTransactions: [],
+      getUIMetrics: getUIMetricsMock,
+      getState: getStateMock,
+    };
+  });
+
+  it('returns empty properties when assetsFiatValues is not present', () => {
+    request.transactionMeta.type = TransactionType.swap;
+
+    const result = getSimulationValuesProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: {},
+      sensitiveProperties: {},
+    });
+  });
+
+  it('returns both sending and receiving values when present', () => {
+    request.transactionMeta = {
+      ...request.transactionMeta,
+      assetsFiatValues: {
+        sending: '100.50',
+        receiving: '99.75',
+      },
+    } as TransactionMeta;
+
+    const result = getSimulationValuesProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: {
+        simulation_sending_assets_total_value: '100.50',
+        simulation_receiving_assets_total_value: '99.75',
+      },
+      sensitiveProperties: {},
+    });
+  });
+
+  it('returns only sending value when receiving is not provided', () => {
+    request.transactionMeta = {
+      ...request.transactionMeta,
+      assetsFiatValues: {
+        sending: '50',
+      },
+    } as TransactionMeta;
+
+    const result = getSimulationValuesProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: {
+        simulation_sending_assets_total_value: '50',
+      },
+      sensitiveProperties: {},
+    });
+  });
+
+  it('returns only receiving value when sending is not provided', () => {
+    request.transactionMeta = {
+      ...request.transactionMeta,
+      assetsFiatValues: {
+        receiving: '75.25',
+      },
+    } as TransactionMeta;
+
+    const result = getSimulationValuesProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: {
+        simulation_receiving_assets_total_value: '75.25',
+      },
+      sensitiveProperties: {},
+    });
+  });
+
+  it('returns values regardless of transaction type', () => {
+    request.transactionMeta = {
+      ...request.transactionMeta,
+      type: TransactionType.simpleSend,
+      assetsFiatValues: {
+        sending: '100',
+        receiving: '100',
+      },
+    } as TransactionMeta;
+
+    const result = getSimulationValuesProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: {
+        simulation_sending_assets_total_value: '100',
+        simulation_receiving_assets_total_value: '100',
+      },
+      sensitiveProperties: {},
+    });
+  });
+});

--- a/app/core/Engine/controllers/transaction-controller/event_properties/simulation-values.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/event_properties/simulation-values.test.ts
@@ -54,8 +54,8 @@ describe('getSimulationValuesProperties', () => {
 
     expect(result).toStrictEqual({
       properties: {
-        simulation_sending_assets_total_value: '100.50',
-        simulation_receiving_assets_total_value: '99.75',
+        simulation_sending_assets_total_value: 100.5,
+        simulation_receiving_assets_total_value: 99.75,
       },
       sensitiveProperties: {},
     });
@@ -73,7 +73,7 @@ describe('getSimulationValuesProperties', () => {
 
     expect(result).toStrictEqual({
       properties: {
-        simulation_sending_assets_total_value: '50',
+        simulation_sending_assets_total_value: 50,
       },
       sensitiveProperties: {},
     });
@@ -91,7 +91,7 @@ describe('getSimulationValuesProperties', () => {
 
     expect(result).toStrictEqual({
       properties: {
-        simulation_receiving_assets_total_value: '75.25',
+        simulation_receiving_assets_total_value: 75.25,
       },
       sensitiveProperties: {},
     });
@@ -111,8 +111,8 @@ describe('getSimulationValuesProperties', () => {
 
     expect(result).toStrictEqual({
       properties: {
-        simulation_sending_assets_total_value: '100',
-        simulation_receiving_assets_total_value: '100',
+        simulation_sending_assets_total_value: 100,
+        simulation_receiving_assets_total_value: 100,
       },
       sensitiveProperties: {},
     });

--- a/app/core/Engine/controllers/transaction-controller/event_properties/simulation-values.ts
+++ b/app/core/Engine/controllers/transaction-controller/event_properties/simulation-values.ts
@@ -19,12 +19,15 @@ export const getSimulationValuesProperties: TransactionMetricsBuilder = ({
   }
 
   if (assetsFiatValues.sending !== undefined) {
-    properties.simulation_sending_assets_total_value = assetsFiatValues.sending;
+    properties.simulation_sending_assets_total_value = Number(
+      assetsFiatValues.sending,
+    );
   }
 
   if (assetsFiatValues.receiving !== undefined) {
-    properties.simulation_receiving_assets_total_value =
-      assetsFiatValues.receiving;
+    properties.simulation_receiving_assets_total_value = Number(
+      assetsFiatValues.receiving,
+    );
   }
 
   return { properties, sensitiveProperties };

--- a/app/core/Engine/controllers/transaction-controller/event_properties/simulation-values.ts
+++ b/app/core/Engine/controllers/transaction-controller/event_properties/simulation-values.ts
@@ -1,0 +1,31 @@
+import { TransactionMetricsBuilder } from '../types';
+import { JsonMap } from '../../../../Analytics/MetaMetrics.types';
+
+/**
+ * Gets simulation asset fiat values for transaction metrics from TransactionMeta.assetsFiatValues.
+ *
+ * @param transactionMeta - The transaction metadata
+ * @returns Object with simulation_sending_assets_total_value and simulation_receiving_assets_total_value properties
+ */
+export const getSimulationValuesProperties: TransactionMetricsBuilder = ({
+  transactionMeta,
+}) => {
+  const properties: JsonMap = {};
+  const sensitiveProperties: JsonMap = {};
+  const { assetsFiatValues } = transactionMeta;
+
+  if (!assetsFiatValues) {
+    return { properties, sensitiveProperties };
+  }
+
+  if (assetsFiatValues.sending !== undefined) {
+    properties.simulation_sending_assets_total_value = assetsFiatValues.sending;
+  }
+
+  if (assetsFiatValues.receiving !== undefined) {
+    properties.simulation_receiving_assets_total_value =
+      assetsFiatValues.receiving;
+  }
+
+  return { properties, sensitiveProperties };
+};


### PR DESCRIPTION
## **Description**
Adds missing properties for transaction events.

Similar thing was implemented in the extension before, so we are just bringing it to mobile as well: https://github.com/MetaMask/metamask-extension/pull/35196

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds 2 missing properties for transaction events

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4138

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds metrics for simulation sending/receiving fiat values and integrates them into transaction event tracking with unit tests.
> 
> - **Transaction metrics**:
>   - Add `getSimulationValuesProperties` to emit `simulation_sending_assets_total_value` and `simulation_receiving_assets_total_value` from `TransactionMeta.assetsFiatValues`.
>   - Integrate builder into `METRICS_BUILDERS` in `event-handlers/metrics.ts` for all transaction events.
> - **Tests**:
>   - Add unit tests in `event_properties/simulation-values.test.ts` covering presence/absence of sending/receiving values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34b804092b637dc2587223ea3ddcbce4c7641883. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->