### PR TITLE
chore: update network names in swaps source and dest network pickers

### DIFF
--- a/app/components/UI/Bridge/components/BridgeDestNetworkSelector/BridgeDestNetworkSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestNetworkSelector/BridgeDestNetworkSelector.test.tsx
@@ -251,6 +251,6 @@ describe('BridgeDestNetworkSelector - ChainPopularity fallback', () => {
     // Optimism (popularity 10) should appear before Palm and zkSync Era (both Infinity)
     expect(getByText('Optimism')).toBeTruthy();
     expect(getByText('Palm')).toBeTruthy();
-    expect(getByText('zkSync Era')).toBeTruthy();
+    expect(getByText('zkSync')).toBeTruthy();
   });
 });

--- a/app/components/UI/Bridge/components/BridgeDestNetworkSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestNetworkSelector/index.tsx
@@ -18,6 +18,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { selectChainId } from '../../../../../selectors/networkController';
 import { BridgeViewMode } from '../../types';
 import { ChainPopularity } from '../BridgeDestNetworksBar';
+import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../constants/bridge';
 
 export interface BridgeDestNetworkSelectorRouteParams {
   shouldGoToTokens?: boolean;
@@ -80,7 +81,12 @@ export const BridgeDestNetworkSelector: React.FC = () => {
             onPress={() => handleChainSelect(chain.chainId)}
           >
             <ListItem verticalAlignment={VerticalAlignment.Center}>
-              <NetworkRow chainId={chain.chainId} chainName={chain.name} />
+              <NetworkRow
+                chainId={chain.chainId}
+                chainName={
+                  NETWORK_TO_SHORT_NETWORK_NAME_MAP[chain.chainId] ?? chain.name
+                }
+              />
             </ListItem>
           </TouchableOpacity>
         )),

--- a/app/components/UI/Bridge/components/BridgeDestNetworksBar.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestNetworksBar.tsx
@@ -20,6 +20,7 @@ import {
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { NETWORKS_CHAIN_ID } from '../../../../constants/network';
 import { CaipChainId, Hex } from '@metamask/utils';
+import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../constants/bridge';
 import { Box } from '../../Box/Box';
 import { getNetworkImageSource } from '../../../../util/networks';
 import { AlignItems, FlexDirection } from '../../Box/box.types';
@@ -80,10 +81,6 @@ export const ChainPopularity: Record<Hex | CaipChainId, number> = {
   [NETWORKS_CHAIN_ID.MONAD]: 13,
 };
 
-const ShortChainNames: Record<Hex | CaipChainId, string> = {
-  [CHAIN_IDS.MAINNET]: 'Ethereum',
-};
-
 export const BridgeDestNetworksBar = () => {
   const navigation = useNavigation();
   const dispatch = useDispatch();
@@ -140,7 +137,10 @@ export const BridgeDestNetworksBar = () => {
                     size={AvatarSize.Xs}
                   />
                 ) : null}
-                <Text>{ShortChainNames[chain.chainId] ?? chain.name}</Text>
+                <Text>
+                  {NETWORK_TO_SHORT_NETWORK_NAME_MAP[chain.chainId] ??
+                    chain.name}
+                </Text>
               </Box>
             }
             style={

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/BridgeDestTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/BridgeDestTokenSelector.test.tsx
@@ -20,8 +20,6 @@ import {
   ARBITRUM_DISPLAY_NAME,
   AVALANCHE_DISPLAY_NAME,
   BASE_DISPLAY_NAME,
-  BNB_DISPLAY_NAME,
-  OPTIMISM_DISPLAY_NAME,
 } from '../../../../../core/Engine/constants';
 
 const mockNavigate = jest.fn();
@@ -104,7 +102,7 @@ jest.mock('../../../../../util/trace', () => ({
 }));
 
 describe('getNetworkName', () => {
-  it('returns network name from network configurations when available', () => {
+  it('returns short name from NETWORK_TO_SHORT_NETWORK_NAME_MAP when available', () => {
     const chainId = toHex('1') as Hex;
     const networkConfigurations: Record<
       string,
@@ -121,8 +119,9 @@ describe('getNetworkName', () => {
       } as MultichainNetworkConfiguration,
     };
 
+    // NETWORK_TO_SHORT_NETWORK_NAME_MAP takes priority, returning 'Ethereum'
     const result = getNetworkName(chainId, networkConfigurations);
-    expect(result).toBe('Ethereum Mainnet');
+    expect(result).toBe('Ethereum');
   });
 
   it('returns nickname from PopularList when network not in configurations', () => {
@@ -147,15 +146,16 @@ describe('getNetworkName', () => {
     expect(result).toBe(ARBITRUM_DISPLAY_NAME);
   });
 
-  it('returns nickname from PopularList for BNB Smart Chain', () => {
+  it('returns short name from NETWORK_TO_SHORT_NETWORK_NAME_MAP for BNB', () => {
     const chainId = toHex('56') as Hex;
     const networkConfigurations: Record<
       string,
       MultichainNetworkConfiguration
     > = {};
 
+    // NETWORK_TO_SHORT_NETWORK_NAME_MAP returns 'BNB' for this chain
     const result = getNetworkName(chainId, networkConfigurations);
-    expect(result).toBe(BNB_DISPLAY_NAME);
+    expect(result).toBe('BNB');
   });
 
   it('returns nickname from PopularList for Base', () => {
@@ -169,15 +169,16 @@ describe('getNetworkName', () => {
     expect(result).toBe(BASE_DISPLAY_NAME);
   });
 
-  it('returns nickname from PopularList for OP', () => {
+  it('returns short name from NETWORK_TO_SHORT_NETWORK_NAME_MAP for Optimism', () => {
     const chainId = toHex('10') as Hex;
     const networkConfigurations: Record<
       string,
       MultichainNetworkConfiguration
     > = {};
 
+    // NETWORK_TO_SHORT_NETWORK_NAME_MAP returns 'Optimism' for this chain
     const result = getNetworkName(chainId, networkConfigurations);
-    expect(result).toBe(OPTIMISM_DISPLAY_NAME);
+    expect(result).toBe('Optimism');
   });
 
   it('returns "Unknown Network" when network not found anywhere', () => {
@@ -191,7 +192,7 @@ describe('getNetworkName', () => {
     expect(result).toBe('Unknown Network');
   });
 
-  it('prioritizes network configurations over PopularList', () => {
+  it('prioritizes NETWORK_TO_SHORT_NETWORK_NAME_MAP over network configurations', () => {
     const chainId = toHex('43114') as Hex; // Avalanche
     const networkConfigurations: Record<
       string,
@@ -208,30 +209,33 @@ describe('getNetworkName', () => {
       } as MultichainNetworkConfiguration,
     };
 
+    // NETWORK_TO_SHORT_NETWORK_NAME_MAP takes priority over network configurations
     const result = getNetworkName(chainId, networkConfigurations);
-    expect(result).toBe('Custom Avalanche Name');
+    expect(result).toBe('Avalanche');
   });
 
-  it('handles undefined network configurations gracefully', () => {
+  it('returns short name when network configurations is undefined', () => {
     const chainId = toHex('1') as Hex;
     const networkConfigurations = undefined as unknown as Record<
       string,
       MultichainNetworkConfiguration
     >;
 
+    // NETWORK_TO_SHORT_NETWORK_NAME_MAP takes priority, returning 'Ethereum'
     const result = getNetworkName(chainId, networkConfigurations);
-    expect(result).toBe('Unknown Network');
+    expect(result).toBe('Ethereum');
   });
 
-  it('handles null network configurations gracefully', () => {
+  it('returns short name when network configurations is null', () => {
     const chainId = toHex('1') as Hex;
     const networkConfigurations = null as unknown as Record<
       string,
       MultichainNetworkConfiguration
     >;
 
+    // NETWORK_TO_SHORT_NETWORK_NAME_MAP takes priority, returning 'Ethereum'
     const result = getNetworkName(chainId, networkConfigurations);
-    expect(result).toBe('Unknown Network');
+    expect(result).toBe('Ethereum');
   });
 
   it('handles empty string chainId', () => {
@@ -245,7 +249,7 @@ describe('getNetworkName', () => {
     expect(result).toBe('Unknown Network');
   });
 
-  it('handles network configuration without name property', () => {
+  it('returns short name when network configuration lacks name property', () => {
     const chainId = toHex('1') as Hex;
     const networkConfigurations = {
       [chainId]: {
@@ -259,8 +263,9 @@ describe('getNetworkName', () => {
       } as unknown as MultichainNetworkConfiguration,
     };
 
+    // NETWORK_TO_SHORT_NETWORK_NAME_MAP takes priority, returning 'Ethereum'
     const result = getNetworkName(chainId, networkConfigurations);
-    expect(result).toBe('Unknown Network');
+    expect(result).toBe('Ethereum');
   });
 });
 
@@ -372,7 +377,7 @@ describe('BridgeDestTokenSelector', () => {
           symbol: 'HELLO',
           tokenFiatAmount: 200000,
         }),
-        networkName: 'Ethereum Mainnet',
+        networkName: 'Ethereum',
       }),
     });
   });
@@ -522,7 +527,7 @@ describe('BridgeDestTokenSelector', () => {
           token_name: 'Hello Token',
           token_symbol: 'HELLO',
           token_contract: ethToken2Address,
-          chain_name: 'Ethereum Mainnet',
+          chain_name: 'Ethereum',
           chain_id: '0x1',
         },
       );

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/index.tsx
@@ -34,11 +34,13 @@ import Engine from '../../../../../core/Engine';
 import { UnifiedSwapBridgeEventName } from '@metamask/bridge-controller';
 import { MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
 import Routes from '../../../../../constants/navigation/Routes';
+import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../constants/bridge';
 
 export const getNetworkName = (
   chainId: Hex,
   networkConfigurations: Record<string, MultichainNetworkConfiguration>,
 ) =>
+  NETWORK_TO_SHORT_NETWORK_NAME_MAP[chainId] ??
   networkConfigurations?.[chainId as Hex]?.name ??
   PopularList.find((network) => network.chainId === chainId)?.nickname ??
   'Unknown Network';

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/BridgeSourceNetworkSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/BridgeSourceNetworkSelector.test.tsx
@@ -64,7 +64,7 @@ describe('BridgeSourceNetworkSelector', () => {
 
     // Networks should be visible with fiat values
     await waitFor(() => {
-      expect(getByText('Ethereum Mainnet')).toBeTruthy();
+      expect(getByText('Ethereum')).toBeTruthy();
       expect(getByText('Optimism')).toBeTruthy();
 
       // Check for fiat values
@@ -274,7 +274,7 @@ describe('BridgeSourceNetworkSelector', () => {
     );
 
     await waitFor(() => {
-      expect(queryByText('Ethereum Mainnet')).toBeNull();
+      expect(queryByText('Ethereum')).toBeNull();
       expect(getByText('Optimism')).toBeTruthy();
     });
   });
@@ -304,7 +304,7 @@ describe('BridgeSourceNetworkSelector', () => {
       );
 
       await waitFor(() => {
-        expect(getByText('Ethereum Mainnet')).toBeTruthy();
+        expect(getByText('Ethereum')).toBeTruthy();
         expect(getByText('Optimism')).toBeTruthy();
 
         const labels = queryAllByText(strings('networks.no_network_fee'));
@@ -333,7 +333,7 @@ describe('BridgeSourceNetworkSelector', () => {
       );
 
       await waitFor(() => {
-        expect(getByText('Ethereum Mainnet')).toBeTruthy();
+        expect(getByText('Ethereum')).toBeTruthy();
         expect(getByText('Optimism')).toBeTruthy();
         expect(queryByText(strings('networks.no_network_fee'))).toBeNull();
       });

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/__snapshots__/BridgeSourceNetworkSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/__snapshots__/BridgeSourceNetworkSelector.test.tsx.snap
@@ -745,7 +745,7 @@ exports[`BridgeSourceNetworkSelector renders with initial state and displays net
                                                     }
                                                   }
                                                 >
-                                                  Ethereum Mainnet
+                                                  Ethereum
                                                 </Text>
                                               </View>
                                             </View>

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
@@ -33,6 +33,7 @@ import { CaipChainId, Hex } from '@metamask/utils';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import { getNativeSourceToken } from '../../utils/tokenUtils';
 import { getGasFeesSponsoredNetworkEnabled } from '../../../../../selectors/featureFlagController/gasFeesSponsored';
+import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../constants/bridge';
 
 const createStyles = () =>
   StyleSheet.create({
@@ -235,7 +236,9 @@ export const BridgeSourceNetworkSelector: React.FC<
               />
               <NetworkRow
                 chainId={chain.chainId}
-                chainName={chain.name}
+                chainName={
+                  NETWORK_TO_SHORT_NETWORK_NAME_MAP[chain.chainId] ?? chain.name
+                }
                 showNoNetworkFeeLabel={isGasFeesSponsoredNetworkEnabled(
                   chain.chainId as Hex,
                 )}

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/index.tsx
@@ -33,6 +33,7 @@ import { useTokens } from '../../hooks/useTokens';
 import { BridgeToken, BridgeViewMode } from '../../types';
 import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
 import { useNetworkInfo } from '../../../../../selectors/selectedNetworkController';
+import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../constants/bridge';
 
 export const BridgeSourceTokenSelector: React.FC = React.memo(() => {
   const dispatch = useDispatch();
@@ -145,7 +146,9 @@ export const BridgeSourceTokenSelector: React.FC = React.memo(() => {
         return <SkeletonItem />;
       }
 
-      const networkName = allNetworkConfigurations[item.chainId]?.name;
+      const networkName =
+        NETWORK_TO_SHORT_NETWORK_NAME_MAP[item.chainId] ??
+        allNetworkConfigurations[item.chainId]?.name;
 
       return (
         <TokenSelectorItem

--- a/app/constants/bridge.ts
+++ b/app/constants/bridge.ts
@@ -48,7 +48,7 @@ export const NETWORK_TO_SHORT_NETWORK_NAME_MAP: Record<
   [CHAIN_IDS.LINEA_MAINNET]: 'Linea',
   [CHAIN_IDS.POLYGON]: 'Polygon',
   [CHAIN_IDS.AVALANCHE]: 'Avalanche',
-  [CHAIN_IDS.BSC]: 'Binance Smart Chain',
+  [CHAIN_IDS.BSC]: 'BNB',
   [CHAIN_IDS.ARBITRUM]: 'Arbitrum',
   [CHAIN_IDS.OPTIMISM]: 'Optimism',
   [CHAIN_IDS.ZKSYNC_ERA]: 'ZkSync Era',

--- a/app/constants/bridge.ts
+++ b/app/constants/bridge.ts
@@ -51,7 +51,7 @@ export const NETWORK_TO_SHORT_NETWORK_NAME_MAP: Record<
   [CHAIN_IDS.BSC]: 'BNB',
   [CHAIN_IDS.ARBITRUM]: 'Arbitrum',
   [CHAIN_IDS.OPTIMISM]: 'Optimism',
-  [CHAIN_IDS.ZKSYNC_ERA]: 'ZkSync Era',
+  [CHAIN_IDS.ZKSYNC_ERA]: 'zkSync',
   [CHAIN_IDS.BASE]: 'Base',
   [CHAIN_IDS.SEI]: 'Sei',
   [CHAIN_IDS.MONAD]: 'Monad',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR updates the network names in the Swap source and destination network pickers.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated Swap network names

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3278

## **Manual testing steps**

```gherkin
Feature: Updated Swap network names

  Scenario: user wants to swap
    Given user is in Swaps

    When user opens the source or destination network pickers
    Then they see the new network names
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="568" height="1084" alt="Screenshot 2025-12-02 at 11 06 48 PM" src="https://github.com/user-attachments/assets/638add47-2540-4e02-a7f0-d25d2e1732cc" />
<img width="568" height="1084" alt="Screenshot 2025-12-02 at 11 06 52 PM" src="https://github.com/user-attachments/assets/4cbe5b3e-fe2d-4700-b3a7-e22722426137" />
<img width="568" height="1084" alt="Screenshot 2025-12-02 at 11 06 58 PM" src="https://github.com/user-attachments/assets/08e0a849-4f8d-4d5e-bffb-06e99156d9fe" />
<img width="568" height="1084" alt="Screenshot 2025-12-02 at 11 07 02 PM" src="https://github.com/user-attachments/assets/02f3024e-f03a-4734-9a48-0f133e155736" />



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes displayed network names across bridge source/dest selectors and token selectors using a new `NETWORK_TO_SHORT_NETWORK_NAME_MAP`, and updates tests accordingly.
> 
> - **Bridge UI**:
>   - Use `NETWORK_TO_SHORT_NETWORK_NAME_MAP` for display names in `BridgeDestNetworkSelector`, `BridgeDestNetworksBar`, `BridgeSourceNetworkSelector`, and `BridgeSourceTokenSelector`.
>   - Prefer short names (e.g., `Ethereum`, `BNB`, `zkSync`) over longer variants.
>   - Remove ad-hoc `ShortChainNames` in `BridgeDestNetworksBar`.
> - **Token Selector**:
>   - `getNetworkName` now prioritizes `NETWORK_TO_SHORT_NETWORK_NAME_MAP` before configs/popular list in `BridgeDestTokenSelector`.
> - **Tests/Snapshots**:
>   - Update expectations to short names (e.g., `Ethereum`, `BNB`, `zkSync`).
>   - Adjust event payload assertions to new `chain_name` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82923bf8bc7a97dd12736b676de84eeb1b46c1c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->