### PR TITLE
fix(predict): cp-7.61.0 improve bet amount validation with fee-adjusted calculations

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictOrderPreview.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderPreview.test.ts
@@ -25,6 +25,7 @@ describe('usePredictOrderPreview', () => {
       metamaskFee: 1,
       providerFee: 1,
       totalFee: 2,
+      totalFeePercentage: 4,
     },
   };
 

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -740,6 +740,7 @@ describe('PolymarketProvider', () => {
         metamaskFee: 0.02,
         providerFee: 0.02,
         totalFee: 0.04,
+        totalFeePercentage: 0.04,
       },
       ...overrides,
     };
@@ -1358,7 +1359,12 @@ describe('PolymarketProvider', () => {
       const { provider, mockSigner } = setupPlaceOrderTest();
       const preview = createMockOrderPreview({
         side: Side.BUY,
-        fees: { metamaskFee: 0.02, providerFee: 0.02, totalFee: 0.04 },
+        fees: {
+          metamaskFee: 0.02,
+          providerFee: 0.02,
+          totalFee: 0.04,
+          totalFeePercentage: 0.04,
+        },
       });
       const orderParams: PlaceOrderParams = {
         providerId: 'polymarket',
@@ -1374,7 +1380,12 @@ describe('PolymarketProvider', () => {
       const { provider, mockSigner } = setupPlaceOrderTest();
       const preview = createMockOrderPreview({
         side: Side.BUY,
-        fees: { metamaskFee: 0.02, providerFee: 0.02, totalFee: 0.04 },
+        fees: {
+          metamaskFee: 0.02,
+          providerFee: 0.02,
+          totalFee: 0.04,
+          totalFeePercentage: 0.04,
+        },
       });
       const orderParams: PlaceOrderParams = {
         providerId: 'polymarket',
@@ -1395,7 +1406,12 @@ describe('PolymarketProvider', () => {
       const { provider, mockSigner } = setupPlaceOrderTest();
       const preview = createMockOrderPreview({
         side: Side.BUY,
-        fees: { metamaskFee: 0.02, providerFee: 0.02, totalFee: 0.04 },
+        fees: {
+          metamaskFee: 0.02,
+          providerFee: 0.02,
+          totalFee: 0.04,
+          totalFeePercentage: 0.04,
+        },
       });
       const orderParams: PlaceOrderParams = {
         providerId: 'polymarket',
@@ -1416,7 +1432,12 @@ describe('PolymarketProvider', () => {
       const { provider, mockSigner } = setupPlaceOrderTest();
       const preview = createMockOrderPreview({
         side: Side.BUY,
-        fees: { metamaskFee: 0.02, providerFee: 0.02, totalFee: 0.04 },
+        fees: {
+          metamaskFee: 0.02,
+          providerFee: 0.02,
+          totalFee: 0.04,
+          totalFeePercentage: 0.04,
+        },
       });
       const orderParams: PlaceOrderParams = {
         providerId: 'polymarket',
@@ -1447,7 +1468,12 @@ describe('PolymarketProvider', () => {
       const { provider, mockSigner } = setupPlaceOrderTest();
       const preview = createMockOrderPreview({
         side: Side.BUY,
-        fees: { metamaskFee: 0.02, providerFee: 0.02, totalFee: 0.04 },
+        fees: {
+          metamaskFee: 0.02,
+          providerFee: 0.02,
+          totalFee: 0.04,
+          totalFeePercentage: 0.04,
+        },
       });
       const orderParams: PlaceOrderParams = {
         providerId: 'polymarket',
@@ -1472,7 +1498,12 @@ describe('PolymarketProvider', () => {
       const { provider, mockSigner } = setupPlaceOrderTest();
       const preview = createMockOrderPreview({
         side: Side.BUY,
-        fees: { metamaskFee: 0, providerFee: 0, totalFee: 0 },
+        fees: {
+          metamaskFee: 0,
+          providerFee: 0,
+          totalFee: 0,
+          totalFeePercentage: 0,
+        },
       });
 
       await provider.placeOrder({

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -1832,6 +1832,7 @@ describe('polymarket utils', () => {
       expect(fees.totalFee).toBe(expectedTotal);
       expect(fees.providerFee).toBe(expectedEach);
       expect(fees.metamaskFee).toBe(expectedEach);
+      expect(fees.totalFeePercentage).toBe(FEE_PERCENTAGE);
     });
 
     it('calculates fees correctly for various amounts', async () => {
@@ -1845,6 +1846,7 @@ describe('polymarket utils', () => {
       expect(fees.providerFee).toBeGreaterThanOrEqual(0);
       expect(fees.metamaskFee).toBeGreaterThanOrEqual(0);
       expect(fees.totalFee).toBeGreaterThanOrEqual(0);
+      expect(fees.totalFeePercentage).toBe(FEE_PERCENTAGE);
     });
 
     it('handles large amounts correctly', async () => {
@@ -1860,6 +1862,7 @@ describe('polymarket utils', () => {
       expect(fees.totalFee).toBe(expectedTotal);
       expect(fees.providerFee).toBe(expectedEach);
       expect(fees.metamaskFee).toBe(expectedEach);
+      expect(fees.totalFeePercentage).toBe(FEE_PERCENTAGE);
     });
 
     it('handles small amounts correctly', async () => {
@@ -1878,6 +1881,7 @@ describe('polymarket utils', () => {
       expect(fees.totalFee).toBe(expectedTotal);
       expect(fees.providerFee).toBe(expectedEach);
       expect(fees.metamaskFee).toBe(expectedEach);
+      expect(fees.totalFeePercentage).toBe(FEE_PERCENTAGE);
     });
 
     it('waives fees for markets with middle-east tag', async () => {
@@ -1899,6 +1903,7 @@ describe('polymarket utils', () => {
       expect(fees.providerFee).toBe(0);
       expect(fees.metamaskFee).toBe(0);
       expect(fees.totalFee).toBe(0);
+      expect(fees.totalFeePercentage).toBe(0);
     });
   });
 

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -755,6 +755,7 @@ export async function calculateFees({
       metamaskFee: 0,
       providerFee: 0,
       totalFee: 0,
+      totalFeePercentage: 0,
     };
   }
 
@@ -773,6 +774,7 @@ export async function calculateFees({
     metamaskFee,
     providerFee,
     totalFee,
+    totalFeePercentage: FEE_PERCENTAGE,
   };
 }
 

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -72,6 +72,7 @@ export interface PredictFees {
   metamaskFee: number;
   providerFee: number;
   totalFee: number;
+  totalFeePercentage: number;
 }
 
 export interface GeoBlockResponse {

--- a/app/components/UI/Predict/utils/orders.test.ts
+++ b/app/components/UI/Predict/utils/orders.test.ts
@@ -1,0 +1,87 @@
+import { calculateMaxBetAmount, generateOrderId } from './orders';
+
+// Mock react-native-quick-crypto
+jest.mock('react-native-quick-crypto', () => ({
+  randomUUID: jest.fn(() => 'mock-uuid-1234-5678-9012'),
+}));
+
+describe('orders utils', () => {
+  describe('generateOrderId', () => {
+    it('returns a UUID string', () => {
+      const orderId = generateOrderId();
+
+      expect(typeof orderId).toBe('string');
+      expect(orderId).toBe('mock-uuid-1234-5678-9012');
+    });
+  });
+
+  describe('calculateMaxBetAmount', () => {
+    it('returns the original amount when totalFeePercentage is 0', () => {
+      const result = calculateMaxBetAmount(100, 0);
+
+      expect(result).toBe(100);
+    });
+
+    it('returns reduced amount when totalFeePercentage is applied', () => {
+      const result = calculateMaxBetAmount(100, 4);
+
+      expect(result).toBe(96);
+    });
+
+    it('rounds result to 4 decimal places', () => {
+      const result = calculateMaxBetAmount(100, 3.333);
+
+      // 100 * (1 - 3.333/100) = 100 * 0.96667 = 96.667
+      // Rounded to 4 decimals = 96.667
+      expect(result).toBe(96.667);
+    });
+
+    it('handles small amounts correctly', () => {
+      const result = calculateMaxBetAmount(1, 4);
+
+      // 1 * (1 - 4/100) = 1 * 0.96 = 0.96
+      expect(result).toBe(0.96);
+    });
+
+    it('handles very small fee percentages', () => {
+      const result = calculateMaxBetAmount(100, 0.1);
+
+      // 100 * (1 - 0.1/100) = 100 * 0.999 = 99.9
+      expect(result).toBe(99.9);
+    });
+
+    it('handles large fee percentages', () => {
+      const result = calculateMaxBetAmount(100, 50);
+
+      // 100 * (1 - 50/100) = 100 * 0.5 = 50
+      expect(result).toBe(50);
+    });
+
+    it('handles decimal amounts', () => {
+      const result = calculateMaxBetAmount(50.5, 4);
+
+      // 50.5 * (1 - 4/100) = 50.5 * 0.96 = 48.48
+      expect(result).toBe(48.48);
+    });
+
+    it('handles edge case with 100% fee', () => {
+      const result = calculateMaxBetAmount(100, 100);
+
+      // 100 * (1 - 100/100) = 100 * 0 = 0
+      expect(result).toBe(0);
+    });
+
+    it('handles zero amount', () => {
+      const result = calculateMaxBetAmount(0, 4);
+
+      expect(result).toBe(0);
+    });
+
+    it('preserves precision for amounts with many decimal places', () => {
+      const result = calculateMaxBetAmount(100.123456, 4);
+
+      // 100.123456 * 0.96 = 96.11851776, rounded to 4 decimals = 96.1185
+      expect(result).toBe(96.1185);
+    });
+  });
+});

--- a/app/components/UI/Predict/utils/orders.ts
+++ b/app/components/UI/Predict/utils/orders.ts
@@ -7,3 +7,15 @@ import QuickCrypto from 'react-native-quick-crypto';
 export function generateOrderId(): string {
   return QuickCrypto.randomUUID();
 }
+
+export function calculateMaxBetAmount(
+  amount: number,
+  totalFeePercentage: number,
+): number {
+  if (totalFeePercentage === 0) {
+    return amount;
+  }
+  const maxBetAmount = amount * (1 - totalFeePercentage / 100);
+  // Round to 4 decimals (same as calculateFees in polymarket/utils.ts)
+  return Math.round(maxBetAmount * 10000) / 10000;
+}

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -53,6 +53,7 @@ jest.mock('../../hooks/usePredictPlaceOrder', () => ({
 let mockExpectedAmount = 120;
 let mockMetamaskFee = 0.5;
 let mockProviderFee = 1.0;
+let mockTotalFeePercentage = 4;
 jest.mock('../../hooks/usePredictOrderPreview', () => ({
   usePredictOrderPreview: () => ({
     preview: {
@@ -72,6 +73,7 @@ jest.mock('../../hooks/usePredictOrderPreview', () => ({
         metamaskFee: mockMetamaskFee,
         providerFee: mockProviderFee,
         totalFee: mockMetamaskFee + mockProviderFee,
+        totalFeePercentage: mockTotalFeePercentage,
       },
     },
     isCalculating: false,
@@ -240,6 +242,7 @@ describe('PredictBuyPreview', () => {
     mockBalanceLoading = false;
     mockMetamaskFee = 0.5;
     mockProviderFee = 1.0;
+    mockTotalFeePercentage = 4;
     mockRewardsEnabled = false;
     mockRewardsLoading = false;
     mockAccountOptedIn = null;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2115,6 +2115,7 @@
       "order_failed": "Order failed",
       "payments_made_in_usdc": "All payments are made in USDC",
       "prediction_insufficient_funds": "Not enough funds. You can use up to {{amount}}.",
+      "no_funds_enough": "Not enough funds.",
       "prediction_minimum_bet": "Minimum amount is {{amount}}",
       "to_win": "To win",
       "order_failed_generic": "Transaction failed. Please try again."


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add fee percentage tracking and fix max bet amount calculations to
properly account for fees in the prediction betting system.

Changes:
- Add totalFeePercentage field to PredictFees interface
- Implement calculateMaxBetAmount utility to account for fees
- Update calculateFees to return totalFeePercentage (0 or FEE_PERCENTAGE)
- Fix minimum bet validation to include fees (minimumBetWithFees)
- Improve error messaging for insufficient funds vs below minimum
- Add conditional error message when balance is below minimum bet
- Export MINIMUM_BET constant for reusability

Test coverage:
- Add comprehensive tests for calculateMaxBetAmount utility
- Update all existing tests to include totalFeePercentage in mock fees
- Add assertions for totalFeePercentage in fee calculation tests

This ensures users can accurately see their maximum bet amount after
fees are deducted, preventing order failures due to insufficient funds
when fees are applied.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-342?atlOrigin=eyJpIjoiMzU5NTJmY2I2NjM5NGQ5ZGIyYmFhMzJjM2VhNTY1ZWQiLCJwIjoiaiJ9

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

https://www.loom.com/share/05f87ae8888c4e739819a2b5bdc6c4a5

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track fee percentage in previews, compute fee-adjusted min/max bet amounts, update UI/error messages, and expand tests accordingly.
> 
> - **Predict UI**:
>   - Add `MINIMUM_BET` constant and compute `minimumBetWithFees` using `fees.totalFeePercentage`.
>   - Use new `calculateMaxBetAmount` to determine available amount; refine insufficient-funds vs below-minimum messaging.
>   - Update `PredictBuyPreview` logic and tests for fee-adjusted validation and display.
> - **Utils**:
>   - New `orders.ts`: `generateOrderId`, `calculateMaxBetAmount` (+ comprehensive tests).
>   - `polymarket/utils.ts`: `calculateFees` now returns `totalFeePercentage`; waive fees sets it to `0`.
> - **Types & Providers**:
>   - Extend `PredictFees` with `totalFeePercentage` and propagate through previews/tests.
> - **Localization**:
>   - Add `predict.order.no_funds_enough` message.
> - **Tests**:
>   - Update/expand unit tests across hooks, provider, utils, and view to include fee percentage and new validation paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92a617eb793fdb7dbeda008eddf041137ffc65d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->