### PR TITLE
chore: remove BottomSheetFooter background color

### DIFF
--- a/app/component-library/components/BottomSheets/BottomSheetFooter/BottomSheetFooter.styles.ts
+++ b/app/component-library/components/BottomSheets/BottomSheetFooter/BottomSheetFooter.styles.ts
@@ -22,7 +22,7 @@ const styleSheet = (params: {
   theme: Theme;
   vars: BottomSheetFooterStyleSheetVars;
 }) => {
-  const { vars, theme } = params;
+  const { vars } = params;
   const { style, buttonsAlignment } = vars;
   const buttonStyle: ViewStyle =
     buttonsAlignment === ButtonsAlignment.Horizontal
@@ -32,7 +32,6 @@ const styleSheet = (params: {
   return StyleSheet.create({
     base: Object.assign(
       {
-        backgroundColor: theme.colors.background.default,
         flexDirection:
           buttonsAlignment === ButtonsAlignment.Horizontal ? 'row' : 'column',
         paddingVertical: 4,

--- a/app/component-library/components/BottomSheets/BottomSheetFooter/__snapshots__/BottomSheetFooter.test.tsx.snap
+++ b/app/component-library/components/BottomSheets/BottomSheetFooter/__snapshots__/BottomSheetFooter.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`BottomSheetFooter should render snapshot correctly 1`] = `
 <View
   style={
     {
-      "backgroundColor": "#ffffff",
       "flexDirection": "row",
       "paddingHorizontal": 8,
       "paddingVertical": 4,

--- a/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
@@ -248,7 +248,6 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
         <View
           style={
             {
-              "backgroundColor": "#ffffff",
               "flexDirection": "row",
               "paddingHorizontal": 16,
               "paddingVertical": 20,

--- a/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
@@ -465,7 +465,6 @@ exports[`SlippageModal renders all UI elements with the proper slippage options 
           <View
             style={
               {
-                "backgroundColor": "#ffffff",
                 "flexDirection": "row",
                 "paddingHorizontal": 8,
                 "paddingVertical": 4,

--- a/app/components/UI/ConfirmAddAsset/__snapshots__/ConfirmAddAsset.test.tsx.snap
+++ b/app/components/UI/ConfirmAddAsset/__snapshots__/ConfirmAddAsset.test.tsx.snap
@@ -285,7 +285,6 @@ exports[`ConfirmAddAsset render matches previous snapshot 1`] = `
     <View
       style={
         {
-          "backgroundColor": "#ffffff",
           "flexDirection": "row",
           "paddingHorizontal": 16,
           "paddingVertical": 4,

--- a/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
@@ -607,7 +607,6 @@ exports[`LendingLearnMoreModal render lending history apy chart 1`] = `
         <View
           style={
             {
-              "backgroundColor": "#ffffff",
               "flexDirection": "row",
               "paddingBottom": 16,
               "paddingHorizontal": 16,

--- a/app/components/UI/NetworkModal/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/NetworkModal/__snapshots__/index.test.tsx.snap
@@ -479,7 +479,6 @@ exports[`NetworkDetails renders correctly 1`] = `
               <View
                 style={
                   {
-                    "backgroundColor": "#ffffff",
                     "flexDirection": "row",
                     "paddingHorizontal": 8,
                     "paddingVertical": 4,

--- a/app/components/UI/NetworkVerificationInfo/__snapshots__/NetworkVerificationInfo.test.tsx.snap
+++ b/app/components/UI/NetworkVerificationInfo/__snapshots__/NetworkVerificationInfo.test.tsx.snap
@@ -438,7 +438,6 @@ exports[`NetworkVerificationInfo renders correctly 1`] = `
   <View
     style={
       {
-        "backgroundColor": "#ffffff",
         "flexDirection": "row",
         "paddingHorizontal": 8,
         "paddingVertical": 4,
@@ -932,7 +931,6 @@ exports[`NetworkVerificationInfo renders updated details when isNetworkRpcUpdate
   <View
     style={
       {
-        "backgroundColor": "#ffffff",
         "flexDirection": "row",
         "paddingHorizontal": 8,
         "paddingVertical": 4,

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/__snapshots__/PerpsBottomSheetTooltip.test.tsx.snap
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/__snapshots__/PerpsBottomSheetTooltip.test.tsx.snap
@@ -194,7 +194,6 @@ exports[`PerpsBottomSheetTooltip renders correctly when visible 1`] = `
         <View
           style={
             {
-              "backgroundColor": "#ffffff",
               "flexDirection": "row",
               "paddingHorizontal": 16,
               "paddingVertical": 24,

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -1584,7 +1584,6 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                           <View
                             style={
                               {
-                                "backgroundColor": "#ffffff",
                                 "flexDirection": "column",
                                 "paddingHorizontal": 8,
                                 "paddingVertical": 4,
@@ -5955,7 +5954,6 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                           <View
                             style={
                               {
-                                "backgroundColor": "#ffffff",
                                 "flexDirection": "column",
                                 "paddingHorizontal": 8,
                                 "paddingVertical": 4,

--- a/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
@@ -246,7 +246,6 @@ exports[`GasImpactModal render matches snapshot 1`] = `
           <View
             style={
               {
-                "backgroundColor": "#ffffff",
                 "flexDirection": "row",
                 "paddingBottom": 16,
                 "paddingHorizontal": 8,

--- a/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
@@ -614,7 +614,6 @@ exports[`PoolStakingLearnMoreModal render matches snapshot 1`] = `
         <View
           style={
             {
-              "backgroundColor": "#ffffff",
               "flexDirection": "row",
               "paddingHorizontal": 16,
               "paddingVertical": 16,

--- a/app/components/Views/AccountSelector/__snapshots__/AccountSelector.test.tsx.snap
+++ b/app/components/Views/AccountSelector/__snapshots__/AccountSelector.test.tsx.snap
@@ -939,7 +939,6 @@ exports[`AccountSelector should render correctly 1`] = `
                           <View
                             style={
                               {
-                                "backgroundColor": "#ffffff",
                                 "flexDirection": "row",
                                 "marginHorizontal": 16,
                                 "marginVertical": 16,

--- a/app/components/Views/DataCollectionModal/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/DataCollectionModal/__snapshots__/index.test.tsx.snap
@@ -171,7 +171,6 @@ exports[`DataCollectionModal should render expected snapshot 1`] = `
         <View
           style={
             {
-              "backgroundColor": "#ffffff",
               "flexDirection": "row",
               "paddingHorizontal": 8,
               "paddingVertical": 4,

--- a/app/components/Views/confirmations/legacy/components/Approval/TemplateConfirmation/Templates/__snapshots__/ApprovalResult.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/components/Approval/TemplateConfirmation/Templates/__snapshots__/ApprovalResult.test.tsx.snap
@@ -155,7 +155,6 @@ exports[`ApprovalResult renders approval result with error type 1`] = `
     <View
       style={
         {
-          "backgroundColor": "#ffffff",
           "flexDirection": "row",
           "paddingHorizontal": 8,
           "paddingVertical": 4,
@@ -361,7 +360,6 @@ exports[`ApprovalResult renders approval result with success type 1`] = `
     <View
       style={
         {
-          "backgroundColor": "#ffffff",
           "flexDirection": "row",
           "paddingHorizontal": 8,
           "paddingVertical": 4,

--- a/app/components/Views/confirmations/legacy/components/Approval/TemplateConfirmation/__snapshots__/TemplateConfirmation.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/components/Approval/TemplateConfirmation/__snapshots__/TemplateConfirmation.test.tsx.snap
@@ -41,7 +41,6 @@ exports[`TemplateConfirmation renders content and actions 1`] = `
     <View
       style={
         {
-          "backgroundColor": "#ffffff",
           "flexDirection": "row",
           "paddingHorizontal": 8,
           "paddingVertical": 4,


### PR DESCRIPTION
## **Description**

Removed the default background color from BottomSheetFooter component styles as part of bottom sheet updates. This change removes the explicit `backgroundColor: theme.colors.background.default` from the BottomSheetFooter styles to allow the background color to be controlled at the bottom sheet dialog level.

The changes include:
- Removed `backgroundColor` property from BottomSheetFooter base styles
- Removed unused `theme` parameter from stylesheet function
- Updated 18 snapshot files across various components that use BottomSheetFooter

This follows the same pattern as #23355, which removed the HeaderBase background color.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to #23355 (similar background color removal for HeaderBase)

## **Manual testing steps**

```gherkin
Feature: BottomSheetFooter background color

  Scenario: BottomSheetFooter renders without explicit background color
    Given user is on any screen with bottom sheet components
    When user opens a bottom sheet with a footer
    Then the footer should render without an explicit background color
    And the background should inherit from parent bottom sheet
```

## **Screenshots/Recordings**

N/A - Style-only change, no visual differences expected as background color will inherit from parent

### **Before**

Footer had explicit white background color set

<img width="200" height="846" alt="Screenshot 2025-11-28 at 7 21 46 AM" src="https://github.com/user-attachments/assets/40a57b12-d770-475a-b12c-df84e95eee48" /><img width="200" height="838" alt="Screenshot 2025-11-28 at 7 21 53 AM" src="https://github.com/user-attachments/assets/e1426cd5-f040-46b1-a32f-b495a6d1f33a" />

### **After**

Footer background color controlled by parent bottom sheet dialog

<img width="200" height="846" alt="Screenshot 2025-11-28 at 7 21 46 AM" src="https://github.com/user-attachments/assets/40a57b12-d770-475a-b12c-df84e95eee48" /><img width="200" height="838" alt="Screenshot 2025-11-28 at 7 21 53 AM" src="https://github.com/user-attachments/assets/e1426cd5-f040-46b1-a32f-b495a6d1f33a" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the default background color from BottomSheetFooter and updates dependent snapshots accordingly.
> 
> - **Component Library**:
>   - **BottomSheetFooter**: Remove `backgroundColor` from `base` style in `app/component-library/components/BottomSheets/BottomSheetFooter/BottomSheetFooter.styles.ts` and drop unused `theme` param.
> - **Tests/Snapshots**:
>   - Update snapshots across multiple consumers (e.g., `Bridge/QuoteExpiredModal`, `SlippageModal`, `ConfirmAddAsset`, `Earn/LendingLearnMoreModal`, `NetworkModal`, `NetworkVerificationInfo`, `PerpsBottomSheetTooltip`, `Ramp/Aggregator/Quotes`, `Stake/GasImpactModal`, `Stake/PoolStakingLearnMoreModal`, `AccountSelector`, `DataCollectionModal`, `ApprovalResult`, `TemplateConfirmation`) to reflect footer without explicit background color.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7c23c63e642a9810d1234e09dd02794d279d1ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->