### PR TITLE
fix(perps): open_position event should be numeric rather than boolean cp-7.61.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -429,7 +429,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       [PerpsEventProperties.ASSET]: market?.symbol || '',
       [PerpsEventProperties.SOURCE]:
         source || PerpsEventValues.SOURCE.PERP_MARKETS,
-      [PerpsEventProperties.OPEN_POSITION]: !!existingPosition,
+      [PerpsEventProperties.OPEN_POSITION]: existingPosition ? 1 : 0,
       // A/B Test context (TAT-1937) - for baseline exposure tracking
       ...(isButtonColorTestEnabled && {
         [PerpsEventProperties.AB_TEST_BUTTON_COLOR]: buttonColorVariant,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixed incorrect data type for the `OPEN_POSITION` analytics property in the Perps Market Details view. The property was incorrectly sending a boolean value (`!!existingPosition`) instead of a numeric value, which is inconsistent with other usages across the codebase and breaks analytics data type expectations.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes https://github.com/MetaMask/metamask-mobile/issues/23592
Slack Conversation: https://consensys.slack.com/archives/C092T3GPHQD/p1764662917780139

## **Manual testing steps**

```gherkin
Feature: Perps Market Details Analytics

  Scenario: user views market details with existing position
    Given user has an open position in a perps market
    
    When user navigates to the market details view
    Then the OPEN_POSITION analytics property should be sent as number 1

  Scenario: user views market details without existing position
    Given user has no open position in a perps market
    
    When user navigates to the market details view
    Then the OPEN_POSITION analytics property should be sent as number 0
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

No Visual Changes

### **After**

No Visual Changes

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change OPEN_POSITION analytics property to 1/0 instead of boolean in Perps Market Details screen event.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ff0f75c277053bb5c42c0f89c6aecb9afe14e09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->