### PR TITLE
chore: Bypass interstitial modal for URLs that originate from within app

### DIFF
--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -59,7 +59,7 @@ enum SUPPORTED_ACTIONS {
 }
 
 /**
- * Actions that should not show the deep link modal
+ * Actions that should not show the deep link INTERSTITIAL modal
  */
 const WHITELISTED_ACTIONS: SUPPORTED_ACTIONS[] = [
   SUPPORTED_ACTIONS.WC,
@@ -75,9 +75,20 @@ const METAMASK_SDK_ACTIONS: SUPPORTED_ACTIONS[] = [
   SUPPORTED_ACTIONS.MMSDK,
 ];
 
-const interstitialWhitelist = [
+const interstitialWhitelistUrls = [
   `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${SUPPORTED_ACTIONS.PERPS_ASSET}`,
 ] as const;
+
+// remember this is only for the INTERSTITIAL
+// "Redirecting you to MetaMask..." modal
+// NOT THE "proceed with caution" modal
+const interstitialWhitelistSources = [
+  AppConstants.DEEPLINKS.ORIGIN_CAROUSEL,
+  AppConstants.DEEPLINKS.ORIGIN_NOTIFICATION,
+  AppConstants.DEEPLINKS.ORIGIN_DEEPLINK,
+  AppConstants.DEEPLINKS.ORIGIN_QR_CODE,
+  AppConstants.DEEPLINKS.ORIGIN_IN_APP_BROWSER,
+] as string[];
 
 async function handleUniversalLink({
   instance,
@@ -195,13 +206,22 @@ async function handleUniversalLink({
   const shouldProceed =
     WHITELISTED_ACTIONS.includes(action) ||
     (await new Promise<boolean>((resolve) => {
+      // async because app may wait for user to dismiss modal
       const [, actionName] = validatedUrl.pathname.split('/');
       const sanitizedAction = actionName?.replace(/-/g, ' ');
       const pageTitle: string =
         capitalize(sanitizedAction?.toLowerCase()) || '';
 
       const validatedUrlString = validatedUrl.toString();
-      if (interstitialWhitelist.some((u) => validatedUrlString.startsWith(u))) {
+      if (
+        interstitialWhitelistUrls.some((u) => validatedUrlString.startsWith(u))
+      ) {
+        resolve(true);
+        return;
+      }
+
+      // if link origin is ORIGIN_CAROUSEL
+      if (interstitialWhitelistSources.includes(source)) {
         resolve(true);
         return;
       }

--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -220,7 +220,7 @@ async function handleUniversalLink({
         return;
       }
 
-      // if link origin is ORIGIN_CAROUSEL
+      // bypass if link originated from within this app
       if (interstitialWhitelistSources.includes(source)) {
         resolve(true);
         return;


### PR DESCRIPTION
## **Description**

This PR adds functionality to bypass the interstitial modal ("Redirecting you to MetaMask...") for deeplinks originating from trusted internal sources within the MetaMask Mobile app.

**What changed:**
1. Added `interstitialWhitelistSources` array containing trusted internal sources: carousel, notifications, QR codes, in-app browser, and deeplinks
2. Updated `handleUniversalLink` to check if the link's `source` parameter is in the whitelist before showing the interstitial modal
3. Renamed `interstitialWhitelist` to `interstitialWhitelistUrls` for clarity (distinguishing URL-based vs source-based whitelisting)
4. Added unit tests covering all whitelisted sources, negative cases, and edge cases

**Why this change:**
When users interact with deeplinks from within the app (e.g., tapping a carousel card or notification), showing the interstitial modal is unnecessary and creates a poor UX. This change allows trusted internal sources to bypass the interstitial while maintaining security for external sources.

**How it works:**
The logic checks two independent whitelists in order:
1. URL whitelist (`interstitialWhitelistUrls`) - checks if the URL starts with a whitelisted prefix
2. Source whitelist (`interstitialWhitelistSources`) - checks if the `source` parameter matches a trusted internal source

If either check passes, the interstitial modal is bypassed and the deeplink proceeds directly.

## **Changelog**

CHANGELOG entry: Added URLs originating from within app to whitelist to bypass the interstitial modal

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/23559

## **Manual testing steps**

```gherkin
Feature: Interstitial bypass for internal deeplink sources

  Scenario: User taps deeplink from carousel
    Given the user is viewing the wallet home screen with carousel cards
    When user taps a carousel card that contains a deeplink
    Then the deeplink opens directly without showing the "Redirecting you to MetaMask..." interstitial modal

  Scenario: User taps deeplink from notification
    Given the user receives a push notification containing a deeplink
    When user taps the notification
    Then the deeplink opens directly without showing the interstitial modal

  Scenario: User scans QR code from within app
    Given the user is in the QR code scanner within the app
    When user scans a MetaMask deeplink QR code
    Then the deeplink opens directly without showing the interstitial modal

  Scenario: User taps deeplink from external source
    Given the user receives a deeplink from an external source (e.g., email, browser)
    When user taps the deeplink
    Then the interstitial modal is shown before proceeding
```

## **Screenshots/Recordings**

### **Before**
Note: **PLEASE NOTE THAT THE SOLANA BANNER ITEM USUALLY DOESN'T LEAD TO THE PERPS TAB
THIS IS JUST A DEMO OF THE FUNCTIONALITY**

https://github.com/user-attachments/assets/d66fdf18-00aa-4485-8a5e-a6bd0725e6e7

### **After**

https://github.com/user-attachments/assets/307861b0-06b7-48ec-8672-f3ebe22c27ed

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

> [!NOTE]
> Skips the "Redirecting..." interstitial when deeplink source is trusted or URL is whitelisted, and adds unit tests covering these paths.
> 
> - **Core**:
>   - `handleUniversalLink`:
>     - Add `interstitialWhitelistSources` and check `source` against it to bypass interstitial.
>     - Rename `interstitialWhitelist` to `interstitialWhitelistUrls` and check URL prefix before showing modal.
>     - Keep `WHITELISTED_ACTIONS` behavior; resolve modal decision asynchronously via promise.
> - **Tests**:
>   - `__tests__/handleUniversalLink.test.ts`:
>     - Add cases for all whitelisted `source`s skipping the interstitial.
>     - Verify non-whitelisted `source` shows the interstitial for non-whitelisted URLs.
>     - Confirm whitelisted URLs bypass interstitial regardless of `source`.
>     - Ensure existing flows (e.g., `wc`) still bypass modal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f86d364ce0d0d172d819436e9e22fda8e71e80d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->