### PR TITLE
fix(predict): Resolves sporadic re-render issue with chart when selecting MAX

### DIFF
--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -2193,14 +2193,19 @@ describe('PredictMarketDetails', () => {
       it('requests higher fidelity when MAX history span is shorter than a month', async () => {
         const shortRangeHistory = buildPriceHistory(12 * 60 * 60 * 1000); // 12 hours
 
-        setupPredictMarketDetailsTest(
-          { status: 'closed' },
-          {},
-          { priceHistory: { priceHistories: shortRangeHistory } },
-        );
-
         const { usePredictPriceHistory } = jest.requireMock(
           '../../hooks/usePredictPriceHistory',
+        );
+
+        const { rerender } = setupPredictMarketDetailsTest(
+          { status: 'closed' },
+          {},
+          {
+            priceHistory: {
+              priceHistories: shortRangeHistory,
+              isFetching: true,
+            },
+          },
         );
 
         await waitFor(() => {
@@ -2209,17 +2214,37 @@ describe('PredictMarketDetails', () => {
               call[0]?.interval === PredictPriceHistoryInterval.MAX,
           );
           expect(maxCalls.length).toBeGreaterThan(0);
-          expect(
-            maxCalls.some(
-              (call: [UsePredictPriceHistoryOptions]) =>
-                call[0]?.fidelity === SHORT_RANGE_FIDELITY,
-            ),
-          ).toBe(true);
         });
-      });
+
+        usePredictPriceHistory.mockReturnValue({
+          priceHistories: shortRangeHistory,
+          isFetching: false,
+          errors: [],
+          refetch: jest.fn().mockResolvedValue(undefined),
+        });
+
+        await act(async () => {
+          rerender(<PredictMarketDetails />);
+        });
+        await waitFor(
+          () => {
+            const maxCalls = usePredictPriceHistory.mock.calls.filter(
+              (call: [UsePredictPriceHistoryOptions]) =>
+                call[0]?.interval === PredictPriceHistoryInterval.MAX,
+            );
+            expect(
+              maxCalls.some(
+                (call: [UsePredictPriceHistoryOptions]) =>
+                  call[0]?.fidelity === SHORT_RANGE_FIDELITY,
+              ),
+            ).toBe(true);
+          },
+          { timeout: 10000 },
+        );
+      }, 15000);
 
       it('keeps default MAX fidelity when history span exceeds the threshold', async () => {
-        const longRangeHistory = buildPriceHistory(45 * 24 * 60 * 60 * 1000); // 45 days
+        const longRangeHistory = buildPriceHistory(45 * 24 * 60 * 60 * 1000);
 
         setupPredictMarketDetailsTest(
           { status: 'closed' },
@@ -2237,6 +2262,37 @@ describe('PredictMarketDetails', () => {
               call[0]?.interval === PredictPriceHistoryInterval.MAX,
           );
           expect(maxCalls.length).toBeGreaterThan(0);
+          expect(
+            maxCalls.every(
+              (call: [UsePredictPriceHistoryOptions]) =>
+                call[0]?.fidelity === MAX_DEFAULT_FIDELITY,
+            ),
+          ).toBe(true);
+        });
+      });
+
+      it('handles empty price history gracefully', async () => {
+        // Empty price history should not cause errors
+        // The effect should wait for valid data before making fidelity decisions
+        setupPredictMarketDetailsTest(
+          { status: 'closed' },
+          {},
+          { priceHistory: { priceHistories: [[], []], isFetching: false } },
+        );
+
+        const { usePredictPriceHistory } = jest.requireMock(
+          '../../hooks/usePredictPriceHistory',
+        );
+
+        // omponent should still render and make MAX interval calls
+        // but fidelity adjustment won't happen until valid data is available
+        await waitFor(() => {
+          const maxCalls = usePredictPriceHistory.mock.calls.filter(
+            (call: [UsePredictPriceHistoryOptions]) =>
+              call[0]?.interval === PredictPriceHistoryInterval.MAX,
+          );
+          expect(maxCalls.length).toBeGreaterThan(0);
+          // Should use default MAX fidelity since no valid range data available
           expect(
             maxCalls.every(
               (call: [UsePredictPriceHistoryOptions]) =>

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -4,7 +4,13 @@ import {
   useNavigation,
   useRoute,
 } from '@react-navigation/native';
-import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import React, {
+  useMemo,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+} from 'react';
 import {
   Image,
   InteractionManager,
@@ -114,9 +120,13 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     useRoute<RouteProp<PredictNavigationParamList, 'PredictMarketDetails'>>();
   const tw = useTailwind();
   const [selectedTimeframe, setSelectedTimeframe] =
-    useState<PredictPriceHistoryInterval>(PredictPriceHistoryInterval.ONE_DAY);
+    useState<PredictPriceHistoryInterval>(
+      PredictPriceHistoryInterval.ONE_MONTH,
+    );
   const [maxIntervalAdaptiveFidelity, setMaxIntervalAdaptiveFidelity] =
     useState<number | null>(null);
+  const maxFidelityLockedRef = useRef<boolean>(false);
+  const prevTimeframeRef = useRef<PredictPriceHistoryInterval | null>(null);
   const [activeTab, setActiveTab] = useState<number | null>(null);
   const [userSelectedTab, setUserSelectedTab] = useState<boolean>(false);
   const insets = useSafeAreaInsets();
@@ -350,49 +360,75 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     enabled: chartOutcomeTokenIds.length > 0,
   });
 
-  const maxIntervalRangeMs = useMemo(() => {
+  const primaryMaxIntervalRangeMs = useMemo(() => {
     if (selectedTimeframe !== PredictPriceHistoryInterval.MAX) {
       return null;
     }
 
-    const timestamps = priceHistories.flatMap((history) =>
-      history.map((point) => getTimestampInMs(point.timestamp)),
-    );
-
-    if (!timestamps.length) {
+    const primaryHistory = priceHistories[0] ?? [];
+    if (primaryHistory.length === 0) {
       return null;
     }
+
+    const timestamps = primaryHistory.map((point) =>
+      getTimestampInMs(point.timestamp),
+    );
 
     return Math.max(...timestamps) - Math.min(...timestamps);
   }, [priceHistories, selectedTimeframe]);
 
   useEffect(() => {
+    const prevTimeframe = prevTimeframeRef.current;
+    const justSwitchedToMax =
+      selectedTimeframe === PredictPriceHistoryInterval.MAX &&
+      prevTimeframe !== PredictPriceHistoryInterval.MAX;
+
+    // update the ref for next render
+    prevTimeframeRef.current = selectedTimeframe;
+
+    // when switching away from MAX, reset the fidelity and unlock for next MAX selection
     if (selectedTimeframe !== PredictPriceHistoryInterval.MAX) {
       if (maxIntervalAdaptiveFidelity !== null) {
         setMaxIntervalAdaptiveFidelity(null);
       }
+      maxFidelityLockedRef.current = false;
       return;
     }
 
-    if (
-      typeof maxIntervalRangeMs === 'number' &&
-      maxIntervalRangeMs > 0 &&
-      maxIntervalRangeMs < MAX_INTERVAL_SHORT_RANGE_MS
-    ) {
-      if (maxIntervalAdaptiveFidelity !== MAX_INTERVAL_SHORT_RANGE_FIDELITY) {
-        setMaxIntervalAdaptiveFidelity(MAX_INTERVAL_SHORT_RANGE_FIDELITY);
-      }
+    // skip if already locked to prevent feedback loop
+    if (maxFidelityLockedRef.current) {
       return;
     }
 
-    if (
-      maxIntervalAdaptiveFidelity !== null &&
-      (maxIntervalRangeMs === null ||
-        maxIntervalRangeMs >= MAX_INTERVAL_SHORT_RANGE_MS)
-    ) {
-      setMaxIntervalAdaptiveFidelity(null);
+    // wait for fetch to complete before making decisions
+    if (isPriceHistoryFetching) {
+      return;
     }
-  }, [maxIntervalRangeMs, maxIntervalAdaptiveFidelity, selectedTimeframe]);
+
+    // skip if just switched to MAX - data is still from previous timeframe
+    if (justSwitchedToMax) {
+      return;
+    }
+
+    // wait for valid range data before making a decision
+    if (
+      typeof primaryMaxIntervalRangeMs !== 'number' ||
+      primaryMaxIntervalRangeMs <= 0
+    ) {
+      return;
+    }
+
+    // make one-shot fidelity decision and lock to prevent re-evaluation
+    if (primaryMaxIntervalRangeMs < MAX_INTERVAL_SHORT_RANGE_MS) {
+      setMaxIntervalAdaptiveFidelity(MAX_INTERVAL_SHORT_RANGE_FIDELITY);
+    }
+    maxFidelityLockedRef.current = true;
+  }, [
+    primaryMaxIntervalRangeMs,
+    maxIntervalAdaptiveFidelity,
+    selectedTimeframe,
+    isPriceHistoryFetching,
+  ]);
 
   const chartData: ChartSeries[] = useMemo(() => {
     const palette = [


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Resolves a sporadic re-render issue on the market details chart when a user selects `MAX`
- Sets the default selected timeframe to `1M` 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-34](https://consensyssoftware.atlassian.net/browse/PRED-341)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="420" alt="image" src="https://github.com/user-attachments/assets/0fb58841-bb0d-4af2-9554-f867f13f0fbe" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes MAX timeframe chart updates with a one-shot adaptive fidelity flow and switches default timeframe to 1M, with tests covering fidelity scenarios and empty histories.
> 
> - **UI (PredictMarketDetails)**:
>   - Default `selectedTimeframe` set to `ONE_MONTH`.
>   - MAX interval fidelity made one-shot and stable using `useRef` locks (`maxFidelityLockedRef`, `prevTimeframeRef`):
>     - Reset fidelity when leaving `MAX`; wait for fetch completion; ignore immediate switch-to-MAX; compute range from primary history only.
>   - Renames `maxIntervalRangeMs` to `primaryMaxIntervalRangeMs` and refines range calculation.
> - **Tests (PredictMarketDetails.test.tsx)**:
>   - Add coverage for MAX fidelity behavior:
>     - Requests higher fidelity for short spans; keeps default for long spans; handles empty histories gracefully.
>   - Utilize rerender and mocked `usePredictPriceHistory` to assert interval/fidelity calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3d8fbbee801d772d8cfb5c5756366ee994bfd2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->