### PR TITLE
fix: hide trending section if empty

### DIFF
--- a/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
+++ b/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
@@ -48,7 +48,7 @@ export const useTrendingRequest = (options: {
     Awaited<ReturnType<typeof getTrendingTokens>>
   >([]);
 
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   const [error, setError] = useState<Error | null>(null);
 

--- a/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
+++ b/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
@@ -22,7 +22,7 @@ export const useTrendingRequest = (options: {
 }) => {
   const {
     chainIds: providedChainIds = [],
-    sortBy,
+    sortBy = 'h24_trending',
     minLiquidity = 0,
     minVolume24hUsd = 0,
     maxVolume24hUsd,

--- a/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.test.tsx
+++ b/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.test.tsx
@@ -317,11 +317,10 @@ describe('TrendingTokensFullView', () => {
   });
 
   it('displays skeleton loader when loading', () => {
-    mockUseTrendingRequest.mockReturnValue({
-      results: [],
+    mockUseTrendingSearch.mockReturnValue({
+      data: [],
       isLoading: true,
-      error: null,
-      fetch: jest.fn(),
+      refetch: jest.fn(),
     });
 
     const { queryAllByTestId } = renderWithProvider(
@@ -335,23 +334,20 @@ describe('TrendingTokensFullView', () => {
     expect(skeletons[0]).toBeOnTheScreen();
   });
 
-  it('displays skeleton loader when results are empty', () => {
-    mockUseTrendingRequest.mockReturnValue({
-      results: [],
+  it('displays empty error state when results are empty', () => {
+    mockUseTrendingSearch.mockReturnValue({
+      data: [],
       isLoading: false,
-      error: null,
-      fetch: jest.fn(),
+      refetch: jest.fn(),
     });
 
-    const { queryAllByTestId } = renderWithProvider(
+    const { getByText } = renderWithProvider(
       <TrendingTokensFullView />,
       { state: mockState },
       false,
     );
 
-    const skeletons = queryAllByTestId('trending-tokens-skeleton');
-    expect(skeletons.length).toBeGreaterThan(0);
-    expect(skeletons[0]).toBeOnTheScreen();
+    expect(getByText('Trending tokens is not available')).toBeOnTheScreen();
   });
 
   it('displays trending tokens list when data is loaded', () => {

--- a/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.tsx
+++ b/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.tsx
@@ -41,6 +41,7 @@ import {
 } from '../../../UI/Trending/components/TrendingTokensBottomSheet';
 import { sortTrendingTokens } from '../../../UI/Trending/utils/sortTrendingTokens';
 import { useTrendingSearch } from '../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
+import EmptyErrorTrendingState from '../../TrendingView/components/EmptyErrorState/EmptyErrorTrendingState';
 
 interface TrendingTokensNavigationParamList {
   [key: string]: undefined | object;
@@ -112,6 +113,9 @@ const createStyles = (theme: Theme) =>
       fontWeight: '600',
       lineHeight: 19.6, // 140% of 14px
       fontStyle: 'normal',
+    },
+    controlButtonDisabled: {
+      opacity: 0.5,
     },
   });
 
@@ -312,8 +316,12 @@ const TrendingTokensFullView = () => {
             <TouchableOpacity
               testID="price-change-button"
               onPress={handlePriceChangePress}
-              style={styles.controlButton}
+              style={[
+                styles.controlButton,
+                searchResults.length === 0 && styles.controlButtonDisabled,
+              ]}
               activeOpacity={0.2}
+              disabled={searchResults.length === 0}
             >
               <View style={styles.controlButtonContent}>
                 <Text style={styles.controlButtonText}>
@@ -366,12 +374,14 @@ const TrendingTokensFullView = () => {
         </View>
       ) : null}
 
-      {isLoading || (searchResults as TrendingAsset[]).length === 0 ? (
+      {isLoading ? (
         <View style={styles.listContainer}>
           {Array.from({ length: 12 }).map((_, index) => (
             <TrendingTokensSkeleton key={index} />
           ))}
         </View>
+      ) : (searchResults as TrendingAsset[]).length === 0 ? (
+        <EmptyErrorTrendingState onRetry={handleRefresh} />
       ) : (
         <View style={styles.listContainer}>
           <TrendingTokensList

--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -172,7 +172,7 @@ const TrendingFeed: React.FC = () => {
             />
           }
         >
-          <QuickActions />
+          <QuickActions emptySections={emptySections} />
 
           {HOME_SECTIONS_ARRAY.map((section) => {
             // Hide section visually but keep mounted so it can report when data arrives
@@ -186,7 +186,7 @@ const TrendingFeed: React.FC = () => {
                 <SectionHeader sectionId={section.id} />
                 <section.Section
                   refreshTrigger={refreshTrigger}
-                  onEmptyChange={sectionEmptyCallbacks[section.id]}
+                  toggleSectionEmptyState={sectionEmptyCallbacks[section.id]}
                 />
               </Box>
             );

--- a/app/components/Views/TrendingView/components/EmptyErrorState/EmptyErrorTrendingState.test.tsx
+++ b/app/components/Views/TrendingView/components/EmptyErrorState/EmptyErrorTrendingState.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import EmptyErrorTrendingState from './EmptyErrorTrendingState';
+
+describe('EmptyErrorTrendingState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders empty state', () => {
+    const { getByText } = render(
+      <EmptyErrorTrendingState onRetry={() => true} />,
+    );
+
+    expect(getByText('Trending tokens is not available')).toBeDefined();
+    expect(getByText("We can't fetch this page right now")).toBeDefined();
+    expect(getByText('Try again')).toBeDefined();
+  });
+
+  it('calls onRetry when button is pressed', () => {
+    const mockOnRetry = jest.fn();
+    const { getByText } = render(
+      <EmptyErrorTrendingState onRetry={mockOnRetry} />,
+    );
+
+    const retryButton = getByText('Try again');
+
+    fireEvent.press(retryButton);
+
+    expect(mockOnRetry).toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/TrendingView/components/EmptyErrorState/EmptyErrorTrendingState.tsx
+++ b/app/components/Views/TrendingView/components/EmptyErrorState/EmptyErrorTrendingState.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {
+  Box,
+  Text,
+  TextVariant,
+  Button,
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+
+interface EmptyErrorTrendingStateProps {
+  onRetry?: () => void;
+}
+
+const EmptyErrorTrendingState: React.FC<EmptyErrorTrendingStateProps> = ({
+  onRetry,
+}) => (
+  <Box
+    testID="empty-error-trending-state"
+    twClassName="flex-col pt-9 pb-24 justify-center items-center gap-3 flex-1"
+  >
+    <Box twClassName="flex-col w-[337px] items-stretch">
+      <Text
+        variant={TextVariant.HeadingSm}
+        twClassName="text-default text-center self-stretch mb-2"
+      >
+        {strings('trending.empty_error_trending_state.title')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        twClassName="text-alternative text-center self-stretch font-medium"
+      >
+        {strings('trending.empty_error_trending_state.description')}
+      </Text>
+      {onRetry && (
+        <Button
+          variant={ButtonVariant.Primary}
+          twClassName="self-stretch mt-6"
+          onPress={onRetry}
+        >
+          {strings('trending.empty_error_trending_state.try_again')}
+        </Button>
+      )}
+    </Box>
+  </Box>
+);
+
+export default EmptyErrorTrendingState;

--- a/app/components/Views/TrendingView/components/QuickActions/QuickActions.tsx
+++ b/app/components/Views/TrendingView/components/QuickActions/QuickActions.tsx
@@ -10,22 +10,31 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { SECTIONS_ARRAY } from '../../config/sections.config';
+import { SECTIONS_ARRAY, SectionId } from '../../config/sections.config';
+
+interface QuickActionsProps {
+  /** Set of section IDs that have empty data and should be hidden */
+  emptySections?: Set<SectionId>;
+}
 
 /**
  * A dynamic component that automatically generates action buttons based on the
  * centralized sections configuration. When a new section is added to SECTIONS_CONFIG,
  * a corresponding button will automatically appear here.
  */
-const QuickActions: React.FC = () => {
+const QuickActions: React.FC<QuickActionsProps> = ({ emptySections }) => {
   const navigation = useNavigation();
   const tw = useTailwind();
+
+  const visibleSections = emptySections
+    ? SECTIONS_ARRAY.filter((s) => !emptySections.has(s.id))
+    : SECTIONS_ARRAY;
 
   return (
     <Box twClassName="mt-1 mb-4">
       <ScrollView horizontal showsHorizontalScrollIndicator={false}>
         <Box twClassName="flex-row gap-2">
-          {SECTIONS_ARRAY.map((section) => (
+          {visibleSections.map((section) => (
             <TouchableOpacity
               key={section.id}
               onPress={() => section.viewAllAction(navigation)}

--- a/app/components/Views/TrendingView/components/QuickActions/QuickActions.tsx
+++ b/app/components/Views/TrendingView/components/QuickActions/QuickActions.tsx
@@ -14,7 +14,7 @@ import { SECTIONS_ARRAY, SectionId } from '../../config/sections.config';
 
 interface QuickActionsProps {
   /** Set of section IDs that have empty data and should be hidden */
-  emptySections?: Set<SectionId>;
+  emptySections: Set<SectionId>;
 }
 
 /**
@@ -26,9 +26,9 @@ const QuickActions: React.FC<QuickActionsProps> = ({ emptySections }) => {
   const navigation = useNavigation();
   const tw = useTailwind();
 
-  const visibleSections = emptySections
-    ? SECTIONS_ARRAY.filter((s) => !emptySections.has(s.id))
-    : SECTIONS_ARRAY;
+  const visibleSections = SECTIONS_ARRAY.filter(
+    (s) => !emptySections.has(s.id),
+  );
 
   return (
     <Box twClassName="mt-1 mb-4">

--- a/app/components/Views/TrendingView/components/SectionCard/SectionCard.tsx
+++ b/app/components/Views/TrendingView/components/SectionCard/SectionCard.tsx
@@ -21,11 +21,14 @@ const createStyles = (theme: Theme) =>
 interface SectionCardProps {
   sectionId: SectionId;
   refreshTrigger?: number;
+  /** Callback when data empty state changes (only called after loading completes) */
+  onEmptyChange?: (isEmpty: boolean) => void;
 }
 
 const SectionCard: React.FC<SectionCardProps> = ({
   sectionId,
   refreshTrigger,
+  onEmptyChange,
 }) => {
   const navigation = useNavigation();
   const theme = useAppThemeFromContext();
@@ -33,6 +36,13 @@ const SectionCard: React.FC<SectionCardProps> = ({
 
   const section = SECTIONS_CONFIG[sectionId];
   const { data, isLoading, refetch } = section.useSectionData();
+
+  // Notify parent when data empty state changes (only after loading completes)
+  useEffect(() => {
+    if (!isLoading && onEmptyChange) {
+      onEmptyChange(data.length === 0);
+    }
+  }, [data.length, isLoading, onEmptyChange]);
 
   useEffect(() => {
     if (refreshTrigger && refreshTrigger > 0 && refetch) {

--- a/app/components/Views/TrendingView/components/SectionCard/SectionCard.tsx
+++ b/app/components/Views/TrendingView/components/SectionCard/SectionCard.tsx
@@ -22,13 +22,13 @@ interface SectionCardProps {
   sectionId: SectionId;
   refreshTrigger?: number;
   /** Callback when data empty state changes (only called after loading completes) */
-  onEmptyChange?: (isEmpty: boolean) => void;
+  toggleSectionEmptyState?: (isEmpty: boolean) => void;
 }
 
 const SectionCard: React.FC<SectionCardProps> = ({
   sectionId,
   refreshTrigger,
-  onEmptyChange,
+  toggleSectionEmptyState,
 }) => {
   const navigation = useNavigation();
   const theme = useAppThemeFromContext();
@@ -39,10 +39,10 @@ const SectionCard: React.FC<SectionCardProps> = ({
 
   // Notify parent when data empty state changes (only after loading completes)
   useEffect(() => {
-    if (!isLoading && onEmptyChange) {
-      onEmptyChange(data.length === 0);
+    if (!isLoading && toggleSectionEmptyState) {
+      toggleSectionEmptyState(data.length === 0);
     }
-  }, [data.length, isLoading, onEmptyChange]);
+  }, [data.length, isLoading, toggleSectionEmptyState]);
 
   useEffect(() => {
     if (refreshTrigger && refreshTrigger > 0 && refetch) {

--- a/app/components/Views/TrendingView/components/SectionCarrousel/SectionCarrousel.tsx
+++ b/app/components/Views/TrendingView/components/SectionCarrousel/SectionCarrousel.tsx
@@ -14,11 +14,13 @@ const CARD_HEIGHT = 220;
 export interface SectionCarrouselProps {
   sectionId: SectionId;
   refreshTrigger?: number;
+  toggleSectionEmptyState?: (isEmpty: boolean) => void;
 }
 
 const SectionCarrousel: React.FC<SectionCarrouselProps> = ({
   sectionId,
   refreshTrigger,
+  toggleSectionEmptyState,
 }) => {
   const navigation = useNavigation();
   const tw = useTailwind();
@@ -26,6 +28,13 @@ const SectionCarrousel: React.FC<SectionCarrouselProps> = ({
 
   const section = SECTIONS_CONFIG[sectionId];
   const { data, isLoading, refetch } = section.useSectionData();
+
+  // Notify parent when data empty state changes (only after loading completes)
+  useEffect(() => {
+    if (!isLoading && toggleSectionEmptyState) {
+      toggleSectionEmptyState(data.length === 0);
+    }
+  }, [data.length, isLoading, toggleSectionEmptyState]);
 
   useEffect(() => {
     if (refreshTrigger && refreshTrigger > 0 && refetch) {

--- a/app/components/Views/TrendingView/config/sections.config.tsx
+++ b/app/components/Views/TrendingView/config/sections.config.tsx
@@ -49,7 +49,7 @@ interface SectionConfig {
   Skeleton: React.ComponentType;
   Section: React.ComponentType<{
     refreshTrigger?: number;
-    onEmptyChange?: (isEmpty: boolean) => void;
+    toggleSectionEmptyState?: (isEmpty: boolean) => void;
   }>;
   useSectionData: (searchQuery?: string) => {
     data: unknown[];
@@ -86,11 +86,11 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
       <TrendingTokenRowItem token={item as TrendingAsset} />
     ),
     Skeleton: () => <TrendingTokensSkeleton />,
-    Section: ({ refreshTrigger, onEmptyChange }) => (
+    Section: ({ refreshTrigger, toggleSectionEmptyState }) => (
       <SectionCard
         sectionId="tokens"
         refreshTrigger={refreshTrigger}
-        onEmptyChange={onEmptyChange}
+        toggleSectionEmptyState={toggleSectionEmptyState}
       />
     ),
     useSectionData: (searchQuery) => {
@@ -127,10 +127,14 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
     ),
     // Using trending skeleton cause PerpsMarketRowSkeleton has too much spacing
     Skeleton: () => <TrendingTokensSkeleton />,
-    Section: ({ refreshTrigger }) => (
+    Section: ({ refreshTrigger, toggleSectionEmptyState }) => (
       <PerpsConnectionProvider>
         <PerpsStreamProvider>
-          <SectionCard sectionId="perps" refreshTrigger={refreshTrigger} />
+          <SectionCard
+            sectionId="perps"
+            refreshTrigger={refreshTrigger}
+            toggleSectionEmptyState={toggleSectionEmptyState}
+          />
         </PerpsStreamProvider>
       </PerpsConnectionProvider>
     ),
@@ -166,10 +170,11 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
       <PredictMarketRowItem market={item as PredictMarketType} />
     ),
     Skeleton: () => <PredictMarketSkeleton isCarousel />,
-    Section: ({ refreshTrigger }) => (
+    Section: ({ refreshTrigger, toggleSectionEmptyState }) => (
       <SectionCarrousel
         sectionId="predictions"
         refreshTrigger={refreshTrigger}
+        toggleSectionEmptyState={toggleSectionEmptyState}
       />
     ),
     useSectionData: (searchQuery) => {
@@ -193,8 +198,12 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
       <SiteRowItemWrapper site={item as SiteData} navigation={navigation} />
     ),
     Skeleton: () => <SiteSkeleton />,
-    Section: ({ refreshTrigger }) => (
-      <SectionCard sectionId="sites" refreshTrigger={refreshTrigger} />
+    Section: ({ refreshTrigger, toggleSectionEmptyState }) => (
+      <SectionCard
+        sectionId="sites"
+        refreshTrigger={refreshTrigger}
+        toggleSectionEmptyState={toggleSectionEmptyState}
+      />
     ),
     useSectionData: (searchQuery) => {
       const { sites, isLoading, refetch } = useSitesData(searchQuery, 100);

--- a/app/components/Views/TrendingView/config/sections.config.tsx
+++ b/app/components/Views/TrendingView/config/sections.config.tsx
@@ -47,7 +47,10 @@ interface SectionConfig {
     navigation: NavigationProp<ParamListBase>;
   }>;
   Skeleton: React.ComponentType;
-  Section: React.ComponentType<{ refreshTrigger?: number }>;
+  Section: React.ComponentType<{
+    refreshTrigger?: number;
+    onEmptyChange?: (isEmpty: boolean) => void;
+  }>;
   useSectionData: (searchQuery?: string) => {
     data: unknown[];
     isLoading: boolean;
@@ -83,8 +86,12 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
       <TrendingTokenRowItem token={item as TrendingAsset} />
     ),
     Skeleton: () => <TrendingTokensSkeleton />,
-    Section: ({ refreshTrigger }) => (
-      <SectionCard sectionId="tokens" refreshTrigger={refreshTrigger} />
+    Section: ({ refreshTrigger, onEmptyChange }) => (
+      <SectionCard
+        sectionId="tokens"
+        refreshTrigger={refreshTrigger}
+        onEmptyChange={onEmptyChange}
+      />
     ),
     useSectionData: (searchQuery) => {
       const { data, isLoading, refetch } = useTrendingSearch(searchQuery);

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7214,6 +7214,11 @@
     "search_sites": "Search sites",
     "enable_basic_functionality": "Enable basic functionality",
     "basic_functionality_disabled_title": "Explore is not available",
-    "basic_functionality_disabled_description": "We can't fetch the required metadata when basic functionality is disabled."
+    "basic_functionality_disabled_description": "We can't fetch the required metadata when basic functionality is disabled.",
+    "empty_error_trending_state": {
+      "title": "Trending tokens is not available",
+      "description": "We can't fetch this page right now",
+      "try_again": "Try again"
+    }
   }
 }


### PR DESCRIPTION
## **Description**

This PR hides trending tokens section if empty.

The UI needs to show again the tokens section if it gets data on refresh

To test this; i updated the useTrendingRequest hook:

```
const isFirstCall = currentRequestId === 1;
const resultsToStore = isFirstCall
  ? []
  : await getTrendingTokens({
      chainIds: stableChainIds,
      sortBy,
      minLiquidity,
      minVolume24hUsd,
      maxVolume24hUsd,
      minMarketCap,
      maxMarketCap,
    });
```

Result:

https://github.com/user-attachments/assets/9247e4ba-fc3e-458d-a5a7-206bdd427de4


## **Changelog**

CHANGELOG entry: Hides trending section if empty

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/8010c17a-4079-4de3-a4d2-14ca887176bc


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hides empty Explore sections and shows an empty error state for Trending Tokens, while defaulting trending fetch to loading with 24h trending sort.
> 
> - **Trending View (Explore)**:
>   - Hide sections with empty data via `emptySections` state; keep components mounted to detect new data.
>   - Pass `toggleSectionEmptyState` to each section (`SectionCard`, `SectionCarrousel`) and wire through `sections.config`.
>   - Update `QuickActions` to only show visible sections.
> - **Trending Tokens Full View**:
>   - Show skeletons only while `isLoading`; when no results, render `EmptyErrorTrendingState` with retry.
>   - Disable Price Change control when no results.
> - **Hook**:
>   - `useTrendingRequest`: default `sortBy` to `h24_trending`; initial `isLoading` set to `true`.
> - **New Component**:
>   - `EmptyErrorTrendingState` with tests and localized strings.
> - **Tests & i18n**:
>   - Update tests to use `useTrendingSearch` and validate new empty/error state and controls.
>   - Add `trending.empty_error_trending_state.*` strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e96b2f05c1f6f4b047a4e5c703b08f1168c0ca97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->