### PR TITLE
feat: Add "Inaccurate fee" alert in Confirmations

### DIFF
--- a/app/components/Views/confirmations/constants/alerts.ts
+++ b/app/components/Views/confirmations/constants/alerts.ts
@@ -5,6 +5,7 @@ export enum AlertKeys {
   Blockaid = 'blockaid',
   BurnAddress = 'burn_address',
   DomainMismatch = 'domain_mismatch',
+  GasEstimateFailed = 'gas_estimate_failed',
   InsufficientBalance = 'insufficient_balance',
   InsufficientPayTokenBalance = 'insufficient_pay_token_balance',
   InsufficientPayTokenNative = 'insufficient_pay_token_native',

--- a/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.test.ts
@@ -20,8 +20,10 @@ import { useBurnAddressAlert } from './useBurnAddressAlert';
 import { useTokenTrustSignalAlerts } from './useTokenTrustSignalAlerts';
 import { useAddressTrustSignalAlerts } from './useAddressTrustSignalAlerts';
 import { useOriginTrustSignalAlerts } from './useOriginTrustSignalAlerts';
+import { useGasEstimateFailedAlert } from './useGasEstimateFailedAlert';
 
 jest.mock('./useBlockaidAlerts');
+jest.mock('./useGasEstimateFailedAlert');
 jest.mock('./useDomainMismatchAlerts');
 jest.mock('./useInsufficientBalanceAlert');
 jest.mock('./useAccountTypeUpgrade');
@@ -168,6 +170,7 @@ describe('useConfirmationAlerts', () => {
     jest.clearAllMocks();
     (useBlockaidAlerts as jest.Mock).mockReturnValue([]);
     (useDomainMismatchAlerts as jest.Mock).mockReturnValue([]);
+    (useGasEstimateFailedAlert as jest.Mock).mockReturnValue([]);
     (useInsufficientBalanceAlert as jest.Mock).mockReturnValue([]);
     (useAccountTypeUpgrade as jest.Mock).mockReturnValue([]);
     (useSignedOrSubmittedAlert as jest.Mock).mockReturnValue([]);

--- a/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import useBlockaidAlerts from './useBlockaidAlerts';
 import useDomainMismatchAlerts from './useDomainMismatchAlerts';
+import { useGasEstimateFailedAlert } from './useGasEstimateFailedAlert';
 import { useInsufficientBalanceAlert } from './useInsufficientBalanceAlert';
 import { useAccountTypeUpgrade } from './useAccountTypeUpgrade';
 import { useSignedOrSubmittedAlert } from './useSignedOrSubmittedAlert';
@@ -22,6 +23,7 @@ function useSignatureAlerts(): Alert[] {
 }
 
 function useTransactionAlerts(): Alert[] {
+  const gasEstimateFailedAlert = useGasEstimateFailedAlert();
   const insufficientBalanceAlert = useInsufficientBalanceAlert();
   const signedOrSubmittedAlert = useSignedOrSubmittedAlert();
   const pendingTransactionAlert = usePendingTransactionAlert();
@@ -35,6 +37,7 @@ function useTransactionAlerts(): Alert[] {
 
   return useMemo(
     () => [
+      ...gasEstimateFailedAlert,
       ...insufficientBalanceAlert,
       ...batchedUnusedApprovalsAlert,
       ...pendingTransactionAlert,
@@ -46,6 +49,7 @@ function useTransactionAlerts(): Alert[] {
       ...tokenTrustSignalAlerts,
     ],
     [
+      gasEstimateFailedAlert,
       insufficientBalanceAlert,
       batchedUnusedApprovalsAlert,
       pendingTransactionAlert,

--- a/app/components/Views/confirmations/hooks/alerts/useDomainMismatchAlerts.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useDomainMismatchAlerts.test.ts
@@ -14,7 +14,8 @@ describe('useDomainMismatchAlerts', () => {
   const ALERT_MOCK = {
     field: RowAlertKey.RequestFrom,
     key: AlertKeys.DomainMismatch,
-    message: `The site making the request is not the site you’re signing into. This could be an attempt to steal your login credentials.`,
+    message:
+      "The site making the request is not the site you're signing into. This could be an attempt to steal your login credentials.",
     title: 'Suspicious sign-in request',
     severity: Severity.Danger,
   };

--- a/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.test.ts
@@ -1,5 +1,4 @@
 import {
-  SimulationErrorCode,
   TransactionStatus,
   TransactionType,
   TransactionMeta,
@@ -16,32 +15,16 @@ const MOCK_TRANSACTION_META = {
   status: TransactionStatus.unapproved,
   type: TransactionType.contractInteraction,
   chainId: '0x1',
-  simulationData: undefined,
+  simulationFails: undefined,
 } as unknown as TransactionMeta;
 
-const MOCK_TRANSACTION_META_WITH_REVERTED_SIMULATION = {
+const MOCK_TRANSACTION_META_WITH_SIMULATION_FAILS = {
   id: '2',
   status: TransactionStatus.unapproved,
   type: TransactionType.contractInteraction,
   chainId: '0x1',
-  simulationData: {
-    error: {
-      code: SimulationErrorCode.Reverted,
-      message: 'execution reverted',
-    },
-  },
-} as unknown as TransactionMeta;
-
-const MOCK_TRANSACTION_META_WITH_OTHER_SIMULATION_ERROR = {
-  id: '3',
-  status: TransactionStatus.unapproved,
-  type: TransactionType.contractInteraction,
-  chainId: '0x1',
-  simulationData: {
-    error: {
-      code: SimulationErrorCode.InvalidResponse,
-      message: 'invalid response',
-    },
+  simulationFails: {
+    reason: 'execution reverted',
   },
 } as unknown as TransactionMeta;
 
@@ -56,9 +39,9 @@ describe('useGasEstimateFailedAlert', () => {
     jest.clearAllMocks();
   });
 
-  it('returns alert when simulation is reverted', () => {
+  it('returns alert when simulationFails is truthy', () => {
     mockUseTransactionMetadataRequest.mockReturnValue(
-      MOCK_TRANSACTION_META_WITH_REVERTED_SIMULATION,
+      MOCK_TRANSACTION_META_WITH_SIMULATION_FAILS,
     );
 
     const { result } = renderHookWithProvider(() =>
@@ -75,7 +58,7 @@ describe('useGasEstimateFailedAlert', () => {
     });
   });
 
-  it('returns empty array when simulation has no error', () => {
+  it('returns empty array when simulationFails is undefined', () => {
     mockUseTransactionMetadataRequest.mockReturnValue(MOCK_TRANSACTION_META);
 
     const { result } = renderHookWithProvider(() =>
@@ -95,21 +78,9 @@ describe('useGasEstimateFailedAlert', () => {
     expect(result.current).toEqual([]);
   });
 
-  it('returns empty array when simulation error is not Reverted', () => {
-    mockUseTransactionMetadataRequest.mockReturnValue(
-      MOCK_TRANSACTION_META_WITH_OTHER_SIMULATION_ERROR,
-    );
-
-    const { result } = renderHookWithProvider(() =>
-      useGasEstimateFailedAlert(),
-    );
-
-    expect(result.current).toEqual([]);
-  });
-
   it('returns alert with correct message content', () => {
     mockUseTransactionMetadataRequest.mockReturnValue(
-      MOCK_TRANSACTION_META_WITH_REVERTED_SIMULATION,
+      MOCK_TRANSACTION_META_WITH_SIMULATION_FAILS,
     );
 
     const { result } = renderHookWithProvider(() =>
@@ -123,7 +94,7 @@ describe('useGasEstimateFailedAlert', () => {
 
   it('returns non-blocking alert', () => {
     mockUseTransactionMetadataRequest.mockReturnValue(
-      MOCK_TRANSACTION_META_WITH_REVERTED_SIMULATION,
+      MOCK_TRANSACTION_META_WITH_SIMULATION_FAILS,
     );
 
     const { result } = renderHookWithProvider(() =>

--- a/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.test.ts
@@ -1,0 +1,110 @@
+import {
+  TransactionStatus,
+  TransactionType,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useGasEstimateFailedAlert } from './useGasEstimateFailedAlert';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { AlertKeys } from '../../constants/alerts';
+import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
+import { Severity } from '../../types/alerts';
+
+const MOCK_TRANSACTION_META = {
+  id: '1',
+  status: TransactionStatus.unapproved,
+  type: TransactionType.contractInteraction,
+  chainId: '0x1',
+  simulationFails: undefined,
+} as unknown as TransactionMeta;
+
+const MOCK_TRANSACTION_META_WITH_SIMULATION_FAILS = {
+  id: '2',
+  status: TransactionStatus.unapproved,
+  type: TransactionType.contractInteraction,
+  chainId: '0x1',
+  simulationFails: {
+    reason: 'execution reverted',
+    debug: {
+      blockNumber: '0x123',
+      blockGasLimit: '0x456',
+    },
+  },
+} as unknown as TransactionMeta;
+
+jest.mock('../transactions/useTransactionMetadataRequest');
+
+describe('useGasEstimateFailedAlert', () => {
+  const mockUseTransactionMetadataRequest = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns alert when transaction has simulationFails', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue(
+      MOCK_TRANSACTION_META_WITH_SIMULATION_FAILS,
+    );
+
+    const { result } = renderHookWithProvider(() =>
+      useGasEstimateFailedAlert(),
+    );
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toMatchObject({
+      isBlocking: false,
+      key: AlertKeys.GasEstimateFailed,
+      field: RowAlertKey.EstimatedFee,
+      severity: Severity.Warning,
+      title: 'Inaccurate fee',
+    });
+  });
+
+  it('returns empty array when transaction has no simulationFails', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue(MOCK_TRANSACTION_META);
+
+    const { result } = renderHookWithProvider(() =>
+      useGasEstimateFailedAlert(),
+    );
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns empty array when transaction metadata is undefined', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue(undefined);
+
+    const { result } = renderHookWithProvider(() =>
+      useGasEstimateFailedAlert(),
+    );
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns alert with correct message content', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue(
+      MOCK_TRANSACTION_META_WITH_SIMULATION_FAILS,
+    );
+
+    const { result } = renderHookWithProvider(() =>
+      useGasEstimateFailedAlert(),
+    );
+
+    expect(result.current[0].message).toBe(
+      "We're unable to provide an accurate fee and this estimate might be high. We suggest you to input a custom gas limit, but there's a risk the transaction will still fail.",
+    );
+  });
+
+  it('returns non-blocking alert', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue(
+      MOCK_TRANSACTION_META_WITH_SIMULATION_FAILS,
+    );
+
+    const { result } = renderHookWithProvider(() =>
+      useGasEstimateFailedAlert(),
+    );
+
+    expect(result.current[0].isBlocking).toBe(false);
+  });
+});

--- a/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.test.ts
@@ -91,16 +91,4 @@ describe('useGasEstimateFailedAlert', () => {
       "We're unable to provide an accurate fee and this estimate might be high. We suggest you to input a custom gas limit, but there's a risk the transaction will still fail.",
     );
   });
-
-  it('returns non-blocking alert', () => {
-    mockUseTransactionMetadataRequest.mockReturnValue(
-      MOCK_TRANSACTION_META_WITH_SIMULATION_FAILS,
-    );
-
-    const { result } = renderHookWithProvider(() =>
-      useGasEstimateFailedAlert(),
-    );
-
-    expect(result.current[0].isBlocking).toBe(false);
-  });
 });

--- a/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+
+import { strings } from '../../../../../../locales/i18n';
+import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
+import { AlertKeys } from '../../constants/alerts';
+import { Alert, Severity } from '../../types/alerts';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+
+export const useGasEstimateFailedAlert = (): Alert[] => {
+  const transactionMeta = useTransactionMetadataRequest();
+
+  const estimationFailed = Boolean(transactionMeta?.simulationFails);
+
+  return useMemo(() => {
+    if (!estimationFailed) {
+      return [];
+    }
+
+    return [
+      {
+        isBlocking: false,
+        key: AlertKeys.GasEstimateFailed,
+        field: RowAlertKey.EstimatedFee,
+        message: strings('alert_system.gas_estimate_failed.message'),
+        title: strings('alert_system.gas_estimate_failed.title'),
+        severity: Severity.Warning,
+      },
+    ];
+  }, [estimationFailed]);
+};

--- a/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.ts
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { SimulationErrorCode } from '@metamask/transaction-controller';
 
 import { strings } from '../../../../../../locales/i18n';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
@@ -10,12 +9,10 @@ import { useTransactionMetadataRequest } from '../transactions/useTransactionMet
 export const useGasEstimateFailedAlert = (): Alert[] => {
   const transactionMeta = useTransactionMetadataRequest();
 
-  const simulationError = transactionMeta?.simulationData?.error;
-  const isSimulationReverted =
-    simulationError?.code === SimulationErrorCode.Reverted;
+  const estimationFailed = Boolean(transactionMeta?.simulationFails);
 
   return useMemo(() => {
-    if (!isSimulationReverted) {
+    if (!estimationFailed) {
       return [];
     }
 
@@ -29,5 +26,5 @@ export const useGasEstimateFailedAlert = (): Alert[] => {
         severity: Severity.Warning,
       },
     ];
-  }, [isSimulationReverted]);
+  }, [estimationFailed]);
 };

--- a/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { SimulationErrorCode } from '@metamask/transaction-controller';
 
 import { strings } from '../../../../../../locales/i18n';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
@@ -9,10 +10,12 @@ import { useTransactionMetadataRequest } from '../transactions/useTransactionMet
 export const useGasEstimateFailedAlert = (): Alert[] => {
   const transactionMeta = useTransactionMetadataRequest();
 
-  const estimationFailed = Boolean(transactionMeta?.simulationFails);
+  const simulationError = transactionMeta?.simulationData?.error;
+  const isSimulationReverted =
+    simulationError?.code === SimulationErrorCode.Reverted;
 
   return useMemo(() => {
-    if (!estimationFailed) {
+    if (!isSimulationReverted) {
       return [];
     }
 
@@ -26,5 +29,5 @@ export const useGasEstimateFailedAlert = (): Alert[] => {
         severity: Severity.Warning,
       },
     ];
-  }, [estimationFailed]);
+  }, [isSimulationReverted]);
 };

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationAlertMetrics.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationAlertMetrics.ts
@@ -112,6 +112,7 @@ const ALERTS_NAME_METRICS: AlertNameMetrics = {
   [AlertKeys.Blockaid]: 'blockaid',
   [AlertKeys.BurnAddress]: 'burn_address',
   [AlertKeys.DomainMismatch]: 'domain_mismatch',
+  [AlertKeys.GasEstimateFailed]: 'gas_estimate_failed',
   [AlertKeys.InsufficientBalance]: 'insufficient_balance',
   [AlertKeys.InsufficientPayTokenBalance]: 'insufficient_funds',
   [AlertKeys.InsufficientPayTokenFees]: 'insufficient_funds_for_fees',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -52,7 +52,11 @@
     },
     "domain_mismatch": {
       "title": "Suspicious sign-in request",
-      "message": "The site making the request is not the site you’re signing into. This could be an attempt to steal your login credentials."
+      "message": "The site making the request is not the site you're signing into. This could be an attempt to steal your login credentials."
+    },
+    "gas_estimate_failed": {
+      "title": "Inaccurate fee",
+      "message": "We're unable to provide an accurate fee and this estimate might be high. We suggest you to input a custom gas limit, but there's a risk the transaction will still fail."
     },
     "insufficient_balance": {
       "title": "Insufficient funds",


### PR DESCRIPTION
## **Description**
Adds "Inaccurate fee" alert in Confirmations.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds "Inaccurate fee" alert in Confirmations

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5597

Related PR in the extension: https://github.com/MetaMask/metamask-extension/pull/25174/files

## **Manual testing steps**

1. Go to test dapp
2. Deploy failing contract
3. Trigger failing transaction
4. Notice the "Inaccurate fee" alert on mobile in the Network fee row

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="386" height="739" alt="image" src="https://github.com/user-attachments/assets/551d77b8-3f89-4799-9ee4-a76940b3eb0d" />

<img width="400" height="744" alt="image" src="https://github.com/user-attachments/assets/4371df77-89d7-41f9-989c-80a57a7596cc" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a non-blocking "Inaccurate fee" alert on confirmations when gas simulation fails, and wires up metrics, i18n, and tests.
> 
> - **Alerts**:
>   - Add `useGasEstimateFailedAlert` to surface `Severity.Warning` "Inaccurate fee" (`AlertKeys.GasEstimateFailed`) on `RowAlertKey.EstimatedFee` when `simulationFails` is truthy.
>   - Include this alert in transaction alerts aggregation in `useConfirmationAlerts`.
> - **Constants & Metrics**:
>   - Extend `AlertKeys` with `gas_estimate_failed`.
>   - Map to metrics in `useConfirmationAlertMetrics`.
> - **i18n**:
>   - Add `alert_system.gas_estimate_failed.{title,message}` strings; normalize apostrophe in `domain_mismatch` message.
> - **Tests**:
>   - New `useGasEstimateFailedAlert.test.ts` covering trigger and content.
>   - Update `useConfirmationAlerts.test.ts` to mock new hook.
>   - Adjust `useDomainMismatchAlerts.test.ts` expected copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ece41c6edf5bc93efd2b6915e4138056c23a9386. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->