### PR TITLE
chore: update claude model and prompt for smart e2e 

### DIFF
--- a/e2e/tools/e2e-ai-analyzer/ai-tools/handlers/grep-codebase.ts
+++ b/e2e/tools/e2e-ai-analyzer/ai-tools/handlers/grep-codebase.ts
@@ -40,7 +40,7 @@ export function handleGrepCodebase(input: ToolInput, baseDir: string): string {
 
     // Use grep -E for extended regex (supports |, +, ?, etc.)
     // -E: extended regex, -r: recursive, -n: line numbers, -i: case insensitive
-    const command = `grep -Erni --include="${filePattern}" "${pattern}" app/ | head -${maxResults}`;
+    const command = `grep -Erni --include="${filePattern}" --exclude-dir=node_modules "${pattern}" app/ e2e/ .github/ scripts/ 2>/dev/null | head -${maxResults}`;
 
     const result = execSync(command, {
       encoding: 'utf-8',

--- a/e2e/tools/e2e-ai-analyzer/config.ts
+++ b/e2e/tools/e2e-ai-analyzer/config.ts
@@ -12,7 +12,7 @@ export const CLAUDE_CONFIG = {
    * Claude model to use for analysis
    * - See available models: https://docs.anthropic.com/en/docs/about-claude/models
    */
-  model: 'claude-sonnet-4-5-20250929' as const,
+  model: 'claude-opus-4-5-20251101' as const,
 
   /**
    * Maximum tokens allowed for the AI response. Controls the length of reasoning and tool calls
@@ -41,7 +41,7 @@ export const CLAUDE_CONFIG = {
    * - Iteration 2: AI investigates dependencies (2-3 tool calls)
    * - Iteration 3: AI calls finalize tool (e.g., finalize_tag_selection) → DONE
    */
-  maxIterations: 15,
+  maxIterations: 20,
 };
 
 /**

--- a/e2e/tools/e2e-ai-analyzer/modes/select-tags/prompt.ts
+++ b/e2e/tools/e2e-ai-analyzer/modes/select-tags/prompt.ts
@@ -67,7 +67,7 @@ export function buildTaskPrompt(
   }
 
   const instruction = `Analyze the changed files and the impacted codebase to select the E2E test tags to run so the changes can be verified safely with minimal risk.`;
-  const tagsSection = `AVAILABLE TEST TAGS (select from these and don't search for additional tags):\n${tagCoverageList}`;
+  const tagsSection = `AVAILABLE TEST TAGS (these are the ONLY valid tags - do NOT search for tags.ts or any tags file, they are already provided here):\n${tagCoverageList}`;
   const filesSection = `CHANGED FILES (${
     allFiles.length
   } total):\n${fileList.join('\n')}`;

--- a/package.json
+++ b/package.json
@@ -477,7 +477,7 @@
     "zxcvbn": "4.4.2"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.63.1",
+    "@anthropic-ai/sdk": "^0.71.0",
     "@babel/core": "^7.25.2",
     "@babel/eslint-parser": "^7.25.1",
     "@babel/preset-env": "^7.25.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,9 +41,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anthropic-ai/sdk@npm:^0.63.1":
-  version: 0.63.1
-  resolution: "@anthropic-ai/sdk@npm:0.63.1"
+"@anthropic-ai/sdk@npm:^0.71.0":
+  version: 0.71.0
+  resolution: "@anthropic-ai/sdk@npm:0.71.0"
   dependencies:
     json-schema-to-ts: "npm:^3.1.1"
   peerDependencies:
@@ -53,7 +53,7 @@ __metadata:
       optional: true
   bin:
     anthropic-ai-sdk: bin/cli
-  checksum: 10/9ce43fd06a7d3fb62e5f51b78cbf74681ed9c5a5770127b2be62a3b392f2e6fa4c9a8fe38e6f43d33198f79ba37a6ab62568bb77fd11bf9842f5a4b0cb4f02db
+  checksum: 10/2c4da293d11e0284fe16f909fb59cbaaabe62014cf5f058e225697e4c0bdc029c05171a7a9d9449cb5535abb4d31d653ab96e0edd2443172fa1b272cfd8afa04
   languageName: node
   linkType: hard
 
@@ -35927,7 +35927,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "metamask@workspace:."
   dependencies:
-    "@anthropic-ai/sdk": "npm:^0.63.1"
+    "@anthropic-ai/sdk": "npm:^0.71.0"
     "@babel/core": "npm:^7.25.2"
     "@babel/eslint-parser": "npm:^7.25.1"
     "@babel/preset-env": "npm:^7.25.3"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
- Small update to prompt to prevent tool from trying to find tags file
- Bumped iterations to cater for complex PRs
- Fixed some found issues with grep_codebase tool which was only looking in app folder
- Use new opus model 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades Claude model and SDK, raises iteration cap, broadens grep search (excluding node_modules), and clarifies the tag selection prompt.
> 
> - **E2E AI Analyzer**:
>   - **Config (`e2e/tools/e2e-ai-analyzer/config.ts`)**: Update `CLAUDE_CONFIG.model` to `claude-opus-4-5-20251101`; increase `maxIterations` to `20`.
>   - **Grep Tool (`ai-tools/handlers/grep-codebase.ts`)**: Expand search to `app/`, `e2e/`, `.github/`, `scripts/`; add `--exclude-dir=node_modules` and suppress stderr (`2>/dev/null`).
>   - **Select Tags Prompt (`modes/select-tags/prompt.ts`)**: Tighten guidance so only provided tags are considered; discourage searching tag files.
> - **Dependencies**:
>   - Bump `@anthropic-ai/sdk` dev dependency to `^0.71.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dcac4c599f46af609f3067a7d7ff221749d50b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->