### PR TITLE
refactor: update network switching metrics to include chain ID and custom network status

### DIFF
--- a/app/components/Views/AccountPermissions/NetworkPermissionsConnected/NetworkPermissionsConnected.tsx
+++ b/app/components/Views/AccountPermissions/NetworkPermissionsConnected/NetworkPermissionsConnected.tsx
@@ -11,8 +11,6 @@ import { AccountPermissionsScreens } from '../AccountPermissions.types';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import Routes from '../../../../constants/navigation/Routes';
 import {
-  selectProviderConfig,
-  ProviderConfig,
   selectEvmChainId,
   selectEvmNetworkConfigurationsByChainId,
 } from '../../../../selectors/networkController';
@@ -48,6 +46,7 @@ import { getCaip25Caveat } from '../../../../core/Permissions';
 import { getPermittedEthChainIds } from '@metamask/chain-agnostic-permission';
 import { toHex } from '@metamask/controller-utils';
 import { parseCaipChainId } from '@metamask/utils';
+import { POPULAR_NETWORK_CHAIN_IDS } from '../../../../constants/popular-networks';
 
 // Needs to be updated to handle non-evm
 const NetworkPermissionsConnected = ({
@@ -59,7 +58,6 @@ const NetworkPermissionsConnected = ({
   const { navigate } = useNavigation();
   const { trackEvent, createEventBuilder } = useMetrics();
 
-  const providerConfig: ProviderConfig = useSelector(selectProviderConfig);
   const evmChainId = useSelector(selectEvmChainId);
   const evmCaipChainId = `eip155:${parseInt(evmChainId, 16)}`;
 
@@ -141,12 +139,15 @@ const NetworkPermissionsConnected = ({
             const theNetworkName = handleNetworkSwitch(reference);
 
             if (theNetworkName) {
+              const targetChainId = toHex(reference);
               trackEvent(
                 createEventBuilder(MetaMetricsEvents.NETWORK_SWITCHED)
                   .addProperties({
                     chain_id: reference,
-                    from_network: providerConfig?.nickname || theNetworkName,
-                    to_network: theNetworkName,
+                    from_network: evmChainId,
+                    to_network: targetChainId,
+                    custom_network:
+                      !POPULAR_NETWORK_CHAIN_IDS.has(targetChainId),
                   })
                   .build(),
               );

--- a/app/components/Views/NetworkSelector/useSwitchNetworks.ts
+++ b/app/components/Views/NetworkSelector/useSwitchNetworks.ts
@@ -66,7 +66,6 @@ export function useSwitchNetworks({
   domainIsConnectedDapp = false,
   origin = '',
   selectedChainId,
-  selectedNetworkName,
   dismissModal,
   closeRpcModal,
   parentSpan,
@@ -109,12 +108,8 @@ export function useSwitchNetworks({
 
       const { MultichainNetworkController, SelectedNetworkController } =
         Engine.context;
-      const {
-        name: nickname,
-        chainId,
-        rpcEndpoints,
-        defaultRpcEndpointIndex,
-      } = networkConfiguration;
+      const { chainId, rpcEndpoints, defaultRpcEndpointIndex } =
+        networkConfiguration;
 
       const networkConfigurationId =
         rpcEndpoints[defaultRpcEndpointIndex].networkClientId;
@@ -154,8 +149,9 @@ export function useSwitchNetworks({
         createEventBuilder(MetaMetricsEvents.NETWORK_SWITCHED)
           .addProperties({
             chain_id: getDecimalChainId(chainId),
-            from_network: selectedNetworkName,
-            to_network: nickname,
+            from_network: selectedChainId,
+            to_network: chainId,
+            custom_network: !POPULAR_NETWORK_CHAIN_IDS.has(chainId),
           })
           .build(),
       );
@@ -163,7 +159,7 @@ export function useSwitchNetworks({
     [
       domainIsConnectedDapp,
       origin,
-      selectedNetworkName,
+      selectedChainId,
       trackEvent,
       createEventBuilder,
       parentSpan,
@@ -225,12 +221,14 @@ export function useSwitchNetworks({
       endTrace({ name: TraceName.SwitchBuiltInNetwork });
       endTrace({ name: TraceName.NetworkSwitch });
 
+      const toChainId = BUILT_IN_NETWORKS[type].chainId;
       trackEvent(
         createEventBuilder(MetaMetricsEvents.NETWORK_SWITCHED)
           .addProperties({
-            chain_id: getDecimalChainId(selectedChainId),
-            from_network: selectedNetworkName,
-            to_network: type,
+            chain_id: getDecimalChainId(toChainId),
+            from_network: selectedChainId,
+            to_network: toChainId,
+            custom_network: !POPULAR_NETWORK_CHAIN_IDS.has(toChainId),
           })
           .build(),
       );
@@ -241,7 +239,6 @@ export function useSwitchNetworks({
       networkConfigurations,
       setTokenNetworkFilter,
       selectedChainId,
-      selectedNetworkName,
       trackEvent,
       createEventBuilder,
       parentSpan,

--- a/app/core/RPCMethods/lib/ethereum-chain-utils.js
+++ b/app/core/RPCMethods/lib/ethereum-chain-utils.js
@@ -15,6 +15,7 @@ import { MetaMetrics, MetaMetricsEvents } from '../../../core/Analytics';
 import { MetricsEventBuilder } from '../../../core/Analytics/MetricsEventBuilder';
 import Engine from '../../Engine';
 import { isSnapId } from '@metamask/snaps-utils';
+import { POPULAR_NETWORK_CHAIN_IDS } from '../../../constants/popular-networks';
 
 const EVM_NATIVE_TOKEN_DECIMALS = 18;
 
@@ -278,10 +279,14 @@ export async function switchToNetwork({
     networkClientId,
   );
 
+  const fromChainId = hooks.fromNetworkConfiguration?.chainId;
   const analyticsParams = {
     chain_id: getDecimalChainId(chainId),
     source: 'Custom Network API',
     symbol: nativeCurrency || 'ETH',
+    from_network: fromChainId,
+    to_network: chainId,
+    custom_network: !POPULAR_NETWORK_CHAIN_IDS.has(chainId),
     ...analytics,
   };
 

--- a/app/core/RPCMethods/lib/ethereum-chain-utils.test.ts
+++ b/app/core/RPCMethods/lib/ethereum-chain-utils.test.ts
@@ -39,12 +39,14 @@ describe('switchToNetwork', () => {
       build: jest.fn().mockReturnValue(mockMetricsBuilderBuild),
     });
 
+    const fromChainId = '0x89';
     const mockHooks = {
       getCaveat: jest
         .fn()
         .mockReturnValue({ value: getDefaultCaip25CaveatValue() }),
       requestPermittedChainsPermissionIncrementalForOrigin: jest.fn(),
       hasApprovalRequestsForOrigin: jest.fn(),
+      fromNetworkConfiguration: { chainId: fromChainId },
     };
 
     const chainId = '0x1';
@@ -82,6 +84,9 @@ describe('switchToNetwork', () => {
       chain_id: '1',
       source: 'Custom Network API',
       symbol: 'ETH',
+      from_network: fromChainId,
+      to_network: chainId,
+      custom_network: false,
       test: 'test',
     });
     expect(mockTrackEvent).toHaveBeenCalledWith(mockMetricsBuilderBuild);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds additional properties to the NETWORK_SWITCHED analytics event to improve network switching tracking. The changes include:

1. Adding from_network and to_network as chain IDs (hex format) instead of network names
2. Adding custom_network boolean flag to indicate if the target network is a custom (non-popular) network
Removing the selectedNetworkName parameter from useSwitchNetworks hook as it's no longer needed

These changes apply to network switching from:

- Network Selector modal
- Network Permissions Connected component (dApp permission flow)
- RPC method calls (wallet_switchEthereumChain)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
3. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-213

## **Manual testing steps**

```gherkin
Feature: Network Switched Analytics Event

  Scenario: user switches network from Network Selector
    Given user is on any screen with network selector accessible
    
    When user opens the network selector and switches to a different network
    Then the NETWORK_SWITCHED event should contain chain_id, from_network, to_network, and custom_network properties

  Scenario: user switches network via dApp permission
    Given user is connected to a dApp with network permissions
    
    When user switches network through the network permissions modal
    Then the NETWORK_SWITCHED event should contain chain_id, from_network (hex), to_network (hex), and custom_network (boolean)

  Scenario: dApp requests network switch via RPC
    Given user is connected to a dApp
    
    When the dApp calls wallet_switchEthereumChain
    Then the NETWORK_SWITCHED event should include from_network, to_network, and custom_network properties
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies NETWORK_SWITCHED analytics to report from/to chain IDs and a custom_network flag across UI flows and RPC, with tests updated accordingly.
> 
> - **Analytics/metrics**
>   - Standardize `MetaMetricsEvents.NETWORK_SWITCHED` properties across network switching flows:
>     - `from_network` and `to_network` now use chain IDs (hex) instead of names.
>     - Add `custom_network` boolean based on `POPULAR_NETWORK_CHAIN_IDS`.
>     - Ensure `chain_id` reflects the target chain (decimal where applicable).
>   - Apply changes in:
>     - `app/components/Views/AccountPermissions/.../NetworkPermissionsConnected.tsx` (remove `selectProviderConfig`; track using `evmChainId` → `targetChainId`).
>     - `app/components/Views/NetworkSelector/useSwitchNetworks.ts` (remove `selectedNetworkName`; track with `selectedChainId` → `chainId`/built-ins; add popularity check).
>     - `app/core/RPCMethods/lib/ethereum-chain-utils.js` (include `from_network`, `to_network`, `custom_network`).
> - **Tests**
>   - Update `ethereum-chain-utils.test.ts` to assert new analytics fields (`from_network`, `to_network`, `custom_network`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df07c0be25e78345a74fd581f815662cb198e523. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->