### PR TITLE
feat: Add Intercom support integration for beta builds

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -181,3 +181,11 @@ export MM_CARD_BAANX_API_CLIENT_KEY_DEV=""
 
 ## PNA25 (Privacy Notice)
 export MM_EXTENSION_UX_PNA25=""
+
+## Intercom Customer Support (Beta Only)
+export MM_INTERCOM_ENABLED="false"
+
+# Intercom API credentials (get from Intercom dashboard)
+export MM_INTERCOM_API_KEY_IOS=""
+export MM_INTERCOM_API_KEY_ANDROID=""
+export MM_INTERCOM_APP_ID=""

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -360,6 +360,11 @@ android {
       it.buildConfigField 'String', 'IS_RAMP_UAT', "\"$System.env.RAMP_INTERNAL_BUILD\""
       // Used to point to dev environment API for ramp
       it.buildConfigField 'String', 'IS_RAMP_DEV', "\"$System.env.RAMP_DEV_BUILD\""
+      // Intercom configuration (beta only)
+      it.buildConfigField 'String', 'MM_INTERCOM_ENABLED', "\"$System.env.MM_INTERCOM_ENABLED\""
+      it.buildConfigField 'String', 'METAMASK_ENVIRONMENT', "\"$System.env.METAMASK_ENVIRONMENT\""
+      it.buildConfigField 'String', 'MM_INTERCOM_API_KEY_ANDROID', "\"$System.env.MM_INTERCOM_API_KEY_ANDROID\""
+      it.buildConfigField 'String', 'MM_INTERCOM_APP_ID', "\"$System.env.MM_INTERCOM_APP_ID\""
     }
 
     buildFeatures {

--- a/android/app/src/main/java/io/metamask/MainApplication.kt
+++ b/android/app/src/main/java/io/metamask/MainApplication.kt
@@ -30,6 +30,7 @@ import io.metamask.nativeModules.RCTMinimizerPackage
 import io.metamask.nativesdk.NativeSDKPackage
 import io.metamask.nativeModules.RNTar.RNTarPackage
 import io.metamask.nativeModules.NotificationPackage
+import com.intercom.reactnative.IntercomModule
 
 class MainApplication : Application(), ShareApplication, ReactApplication {
 
@@ -72,6 +73,17 @@ class MainApplication : Application(), ShareApplication, ReactApplication {
 
     override fun onCreate() {
         super.onCreate()
+        
+        // Initialize Intercom SDK (beta only, privacy-first)
+        // SDK loads but no user data sent until they click the support button
+        if (BuildConfig.MM_INTERCOM_ENABLED == "true" && BuildConfig.METAMASK_ENVIRONMENT == "beta") {
+            val apiKey = BuildConfig.MM_INTERCOM_API_KEY_ANDROID
+            val appId = BuildConfig.MM_INTERCOM_APP_ID
+            
+            if (apiKey.isNotEmpty() && appId.isNotEmpty()) {
+                IntercomModule.initialize(this, apiKey, appId)
+            }
+        }
         
         // Initialize Branch
         RNBranchModule.getAutoInstance(this)

--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -90,6 +90,7 @@ import { selectIsSeedlessPasswordOutdated } from '../../../selectors/seedlessOnb
 import { Authentication } from '../../../core';
 import { IconName } from '../../../component-library/components/Icons/Icon';
 import Routes from '../../../constants/navigation/Routes';
+import IntercomButton from '../../UI/IntercomButton';
 import { useCompletedOnboardingEffect } from '../../../util/onboarding/hooks/useCompletedOnboardingEffect';
 import {
   useNetworksByNamespace,
@@ -122,6 +123,11 @@ const Main = (props) => {
   const backgroundMode = useRef(false);
   const locale = useRef(I18n.locale);
   const removeConnectionStatusListener = useRef();
+
+  // Intercom integration - only enabled on beta builds with feature flag
+  const INTERCOM_ENABLED =
+    process.env.MM_INTERCOM_ENABLED === 'true' &&
+    process.env.METAMASK_ENVIRONMENT === 'beta';
 
   const isSeedlessPasswordOutdated = useSelector(
     selectIsSeedlessPasswordOutdated,
@@ -460,6 +466,7 @@ const Main = (props) => {
         <ProtectYourWalletModal navigation={props.navigation} />
         <RootRPCMethodsUI navigation={props.navigation} />
         <ProtectWalletMandatoryModal />
+        {INTERCOM_ENABLED && <IntercomButton />}
       </View>
     </React.Fragment>
   );

--- a/app/components/UI/IntercomButton/IntercomButton.styles.ts
+++ b/app/components/UI/IntercomButton/IntercomButton.styles.ts
@@ -1,0 +1,32 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../util/theme/models';
+
+const styleSheet = (params: { theme: Theme }) => {
+  const { theme } = params;
+  const { colors } = theme;
+
+  return StyleSheet.create({
+    intercomButton: {
+      position: 'absolute',
+      top: '39%',
+      right: 0,
+      height: 60,
+      width: 40,
+      backgroundColor: colors.primary.default,
+      borderTopLeftRadius: 30,
+      borderBottomLeftRadius: 30,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingLeft: 8,
+      shadowColor: colors.shadow.default,
+      shadowOffset: { width: -2, height: 0 },
+      shadowOpacity: 0.3,
+      shadowRadius: 4,
+      elevation: 5,
+      zIndex: 10000,
+    },
+  });
+};
+
+export default styleSheet;

--- a/app/components/UI/IntercomButton/IntercomButton.test.tsx
+++ b/app/components/UI/IntercomButton/IntercomButton.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import IntercomButton from './IntercomButton';
+
+jest.mock('../../../util/intercom/IntercomEmailPrompt', () => ({
+  useIntercomInitialization: jest.fn(),
+  useIntercom: () => ({
+    handlePress: jest.fn(),
+    handleLongPress: jest.fn(),
+    EmailPrompt: () => null,
+  }),
+}));
+
+jest.mock('../../hooks/useStyles', () => ({
+  useStyles: () => ({
+    styles: {
+      intercomButton: {},
+    },
+  }),
+}));
+
+describe('IntercomButton', () => {
+  it('renders correctly', () => {
+    const { getByTestId } = render(<IntercomButton />);
+    expect(getByTestId('global-intercom-button')).toBeDefined();
+  });
+});

--- a/app/components/UI/IntercomButton/IntercomButton.tsx
+++ b/app/components/UI/IntercomButton/IntercomButton.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import Icon, {
+  IconName,
+  IconColor,
+  IconSize,
+} from '../../../component-library/components/Icons/Icon';
+import {
+  useIntercom,
+  useIntercomInitialization,
+} from '../../../util/intercom/IntercomEmailPrompt';
+import { useStyles } from '../../hooks/useStyles';
+import styleSheet from './IntercomButton.styles';
+
+const IntercomButton = () => {
+  const { styles } = useStyles(styleSheet, {});
+
+  useIntercomInitialization();
+  const { handlePress, handleLongPress, EmailPrompt } = useIntercom();
+
+  return (
+    <>
+      <Pressable
+        onPress={handlePress}
+        onLongPress={handleLongPress}
+        testID="global-intercom-button"
+        style={styles.intercomButton}
+      >
+        <Icon
+          name={IconName.Tag}
+          color={IconColor.Inverse}
+          size={IconSize.Md}
+        />
+      </Pressable>
+      <EmailPrompt />
+    </>
+  );
+};
+
+export default IntercomButton;

--- a/app/components/UI/IntercomButton/index.ts
+++ b/app/components/UI/IntercomButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './IntercomButton';

--- a/app/util/intercom/IntercomEmailPrompt.js
+++ b/app/util/intercom/IntercomEmailPrompt.js
@@ -57,10 +57,22 @@ const storage = {
 const loginToIntercom = async (email = null) => {
   try {
     if (email) {
-      await Intercom.loginUserWithUserAttributes({ email });
+      await Intercom.loginUserWithUserAttributes({
+        email,
+        customAttributes: {
+          last_platform: Platform.OS,
+        },
+      });
     } else {
       await Intercom.loginUnidentifiedUser();
+      // For unidentified users, update platform after login
+      await Intercom.updateUser({
+        customAttributes: {
+          last_platform: Platform.OS,
+        },
+      });
     }
+    Logger.log(`[Intercom] Login completed with platform: ${Platform.OS}`);
   } catch (error) {
     Logger.error('Intercom login failed:', error);
   }
@@ -222,21 +234,6 @@ export const useIntercom = () => {
         await loginToIntercom(email);
         setIsLoggedIn(true);
       }
-
-      // Update platform in parallel with presenting (non-blocking)
-      Logger.log(`[Intercom] Starting platform update: ${Platform.OS}`);
-      Intercom.updateUser({
-        customAttributes: {
-          last_platform: Platform.OS,
-        },
-      })
-        .then(() => {
-          Logger.log(`[Intercom] Platform update completed: ${Platform.OS}`);
-        })
-        .catch((error) => {
-          Logger.error('[Intercom] Platform update failed:', error);
-        });
-
       Intercom.present();
     } else {
       setShowSheet(true);

--- a/app/util/intercom/IntercomEmailPrompt.js
+++ b/app/util/intercom/IntercomEmailPrompt.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Alert, TextInput } from 'react-native';
+import { Alert, TextInput, Platform } from 'react-native';
 import PropTypes from 'prop-types';
 import Intercom from '@intercom/intercom-react-native';
 import StorageWrapper from '../../store/storage-wrapper';
@@ -62,7 +62,7 @@ const loginToIntercom = async (email = null) => {
       await Intercom.loginUnidentifiedUser();
     }
   } catch (error) {
-    console.error('Intercom login failed:', error);
+    Logger.error('Intercom login failed:', error);
   }
 };
 
@@ -222,6 +222,21 @@ export const useIntercom = () => {
         await loginToIntercom(email);
         setIsLoggedIn(true);
       }
+
+      // Update platform in parallel with presenting (non-blocking)
+      Logger.log(`[Intercom] Starting platform update: ${Platform.OS}`);
+      Intercom.updateUser({
+        customAttributes: {
+          last_platform: Platform.OS,
+        },
+      })
+        .then(() => {
+          Logger.log(`[Intercom] Platform update completed: ${Platform.OS}`);
+        })
+        .catch((error) => {
+          Logger.error('[Intercom] Platform update failed:', error);
+        });
+
       Intercom.present();
     } else {
       setShowSheet(true);
@@ -242,7 +257,7 @@ export const useIntercom = () => {
           try {
             await Intercom.logout();
           } catch (error) {
-            console.error('Intercom logout failed:', error);
+            Logger.error('Intercom logout failed:', error);
           }
         },
       },

--- a/app/util/intercom/IntercomEmailPrompt.js
+++ b/app/util/intercom/IntercomEmailPrompt.js
@@ -1,0 +1,267 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Alert, TextInput } from 'react-native';
+import PropTypes from 'prop-types';
+import Intercom from '@intercom/intercom-react-native';
+import StorageWrapper from '../../store/storage-wrapper';
+import Logger from '../Logger';
+import BottomSheet from '../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheetHeader from '../../component-library/components/BottomSheets/BottomSheetHeader';
+import BottomSheetFooter, {
+  ButtonsAlignment,
+} from '../../component-library/components/BottomSheets/BottomSheetFooter';
+import { Box } from '@metamask/design-system-react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../component-library/components/Texts/Text';
+import {
+  ButtonVariants,
+  ButtonSize,
+} from '../../component-library/components/Buttons/Button';
+import { useTheme } from '../theme';
+import { useStyles } from '../../component-library/hooks';
+
+// Storage key for persisting Intercom email
+const STORAGE_KEY = '@MetaMask:intercomEmail';
+
+// Basic email validation
+const isValidEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+// Email storage wrapper - fails silently to prevent crashes
+const storage = {
+  get: async () => {
+    try {
+      return await StorageWrapper.getItem(STORAGE_KEY);
+    } catch {
+      // Fail silently - storage errors shouldn't crash the app
+      return null;
+    }
+  },
+  save: async (email) => {
+    try {
+      await StorageWrapper.setItem(STORAGE_KEY, email);
+    } catch {
+      // Fail silently - storage errors shouldn't crash the app
+    }
+  },
+  clear: async () => {
+    try {
+      await StorageWrapper.removeItem(STORAGE_KEY);
+    } catch {
+      // Fail silently - storage errors shouldn't crash the app
+    }
+  },
+};
+
+// Login to Intercom - this is when device data is sent to Intercom servers
+const loginToIntercom = async (email = null) => {
+  try {
+    if (email) {
+      await Intercom.loginUserWithUserAttributes({ email });
+    } else {
+      await Intercom.loginUnidentifiedUser();
+    }
+  } catch (error) {
+    console.error('Intercom login failed:', error);
+  }
+};
+
+// Hook to verify Intercom SDK is ready
+// Native initialization happens in AppDelegate.m / MainApplication.kt
+// No user login here - that only happens when button is clicked (privacy-first)
+export const useIntercomInitialization = () => {
+  useEffect(() => {
+    if (
+      process.env.MM_INTERCOM_ENABLED !== 'true' ||
+      process.env.METAMASK_ENVIRONMENT !== 'beta'
+    ) {
+      return;
+    }
+
+    Logger.log('Intercom: SDK ready (login will happen on user interaction)');
+  }, []);
+};
+
+const styleSheet = ({ theme: { colors } }) => ({
+  container: {
+    padding: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border.muted,
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    marginTop: 16,
+    color: colors.text.default,
+    backgroundColor: colors.background.default,
+  },
+  footer: {
+    paddingHorizontal: 16,
+  },
+});
+
+const EmailPromptModal = ({ sheetRef, onSubmit, onSkip, onClose }) => {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const { colors, themeAppearance } = useTheme();
+  const { styles } = useStyles(styleSheet, {});
+
+  const handleContinue = useCallback(() => {
+    const trimmed = email.trim();
+    if (isValidEmail(trimmed)) {
+      setError('');
+      setEmail('');
+      onSubmit(trimmed);
+    } else {
+      setError('Please enter a valid email address');
+    }
+  }, [email, onSubmit]);
+
+  const handleSkip = useCallback(() => {
+    setEmail('');
+    setError('');
+    onSkip();
+  }, [onSkip]);
+
+  return (
+    <BottomSheet ref={sheetRef} onClose={onClose} shouldNavigateBack={false}>
+      <BottomSheetHeader onClose={onClose}>
+        <Text variant={TextVariant.HeadingMD}>Log in</Text>
+      </BottomSheetHeader>
+      <Box style={styles.container}>
+        <Text variant={TextVariant.BodyMD}>
+          Please enter your email address
+        </Text>
+        <TextInput
+          style={styles.input}
+          placeholder="email@example.com"
+          placeholderTextColor={colors.text.muted}
+          keyboardType="email-address"
+          autoCapitalize="none"
+          autoCorrect={false}
+          value={email}
+          onChangeText={(text) => {
+            setEmail(text);
+            setError('');
+          }}
+          onSubmitEditing={handleContinue}
+          keyboardAppearance={themeAppearance}
+          autoFocus
+        />
+        {error ? (
+          <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+            {error}
+          </Text>
+        ) : null}
+      </Box>
+      <BottomSheetFooter
+        style={styles.footer}
+        buttonsAlignment={ButtonsAlignment.Horizontal}
+        buttonPropsArray={[
+          {
+            variant: ButtonVariants.Secondary,
+            label: 'Skip',
+            size: ButtonSize.Lg,
+            onPress: handleSkip,
+          },
+          {
+            variant: ButtonVariants.Primary,
+            label: 'Continue',
+            size: ButtonSize.Lg,
+            onPress: handleContinue,
+          },
+        ]}
+      />
+    </BottomSheet>
+  );
+};
+
+EmailPromptModal.propTypes = {
+  sheetRef: PropTypes.object.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  onSkip: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+// Main hook for Intercom functionality
+export const useIntercom = () => {
+  const [email, setEmail] = useState(null);
+  const [showSheet, setShowSheet] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const sheetRef = useRef(null);
+
+  // Load stored email on mount (but don't login yet - privacy-first)
+  useEffect(() => {
+    (async () => {
+      const stored = await storage.get();
+      if (stored) {
+        setEmail(stored);
+      }
+    })();
+  }, []);
+
+  const handleEmailSubmit = useCallback(async (submittedEmail) => {
+    await storage.save(submittedEmail);
+    setEmail(submittedEmail);
+    setShowSheet(false);
+    await loginToIntercom(submittedEmail);
+    setIsLoggedIn(true);
+    Intercom.present();
+  }, []);
+
+  const handleEmailSkip = useCallback(async () => {
+    setShowSheet(false);
+    await loginToIntercom(null);
+    Intercom.present();
+  }, []);
+
+  const handlePress = useCallback(async () => {
+    if (email) {
+      if (!isLoggedIn) {
+        await loginToIntercom(email);
+        setIsLoggedIn(true);
+      }
+      Intercom.present();
+    } else {
+      setShowSheet(true);
+      setTimeout(() => sheetRef.current?.onOpenBottomSheet(), 100);
+    }
+  }, [email, isLoggedIn]);
+
+  const handleLongPress = useCallback(() => {
+    Alert.alert('Reset email', 'Clear your saved email?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Reset',
+        style: 'destructive',
+        onPress: async () => {
+          await storage.clear();
+          setEmail(null);
+          setIsLoggedIn(false);
+          try {
+            await Intercom.logout();
+          } catch (error) {
+            console.error('Intercom logout failed:', error);
+          }
+        },
+      },
+    ]);
+  }, []);
+
+  const handleSheetClose = useCallback(() => setShowSheet(false), []);
+
+  return {
+    handlePress,
+    handleLongPress,
+    EmailPrompt: () =>
+      showSheet ? (
+        <EmailPromptModal
+          sheetRef={sheetRef}
+          onSubmit={handleEmailSubmit}
+          onSkip={handleEmailSkip}
+          onClose={handleSheetClose}
+        />
+      ) : null,
+  };
+};

--- a/ios/MetaMask/AppDelegate.m
+++ b/ios/MetaMask/AppDelegate.m
@@ -5,6 +5,7 @@
 
 #import <RNBranch/RNBranch.h>
 #import <Firebase.h>
+#import <IntercomModule.h>
 
 
 @implementation AppDelegate
@@ -29,6 +30,20 @@
   // You can add your custom initial props in the dictionary below.
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = @{@"foxCode": foxCode};
+
+  // Initialize Intercom SDK (beta only, privacy-first)
+  // SDK loads but no user data sent until they click the support button
+  NSString *intercomEnabled = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"intercom_enabled"];
+  NSString *metamaskEnvironment = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"metamask_environment"];
+  
+  if ([intercomEnabled isEqualToString:@"true"] && [metamaskEnvironment isEqualToString:@"beta"]) {
+    NSString *apiKey = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"intercom_api_key"];
+    NSString *appId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"intercom_app_id"];
+    
+    if (apiKey && appId && apiKey.length > 0 && appId.length > 0) {
+      [IntercomModule initialize:apiKey withAppId:appId];
+    }
+  }
 
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }

--- a/ios/MetaMask/AppDelegate.mm
+++ b/ios/MetaMask/AppDelegate.mm
@@ -4,6 +4,7 @@
 #import <React/RCTRootView.h>
 
 #import <React/RCTAppSetupUtils.h>
+#import <IntercomModule.h>
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/CoreModulesPlugins.h>
@@ -56,6 +57,21 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
+
+  // Initialize Intercom SDK (beta only, privacy-first)
+  // SDK loads but no user data sent until they click the support button
+  NSString *intercomEnabled = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"intercom_enabled"];
+  NSString *metamaskEnvironment = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"metamask_environment"];
+  
+  if ([intercomEnabled isEqualToString:@"true"] && [metamaskEnvironment isEqualToString:@"beta"]) {
+    NSString *apiKey = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"intercom_api_key"];
+    NSString *appId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"intercom_app_id"];
+    
+    if (apiKey && appId && apiKey.length > 0 && appId.length > 0) {
+      [IntercomModule initialize:apiKey withAppId:appId];
+    }
+  }
+
   return YES;
 }
 

--- a/ios/MetaMask/Info.plist
+++ b/ios/MetaMask/Info.plist
@@ -141,5 +141,13 @@
 	<string>$(MM_FOX_CODE)</string>
 	<key>mixpanel_token</key>
 	<string>$(MM_MIXPANEL_TOKEN)</string>
+	<key>intercom_enabled</key>
+	<string>$(MM_INTERCOM_ENABLED)</string>
+	<key>metamask_environment</key>
+	<string>$(METAMASK_ENVIRONMENT)</string>
+	<key>intercom_api_key</key>
+	<string>$(MM_INTERCOM_API_KEY_IOS)</string>
+	<key>intercom_app_id</key>
+	<string>$(MM_INTERCOM_APP_ID)</string>
 </dict>
 </plist>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -412,6 +412,29 @@ PODS:
   - hermes-engine (0.76.9):
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
+  - Intercom (19.3.4)
+  - intercom-react-native (9.3.4):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - Intercom (~> 19.3.4)
+    - RCT-Folly (= 2024.10.14.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -2955,6 +2978,7 @@ DEPENDENCIES:
   - "GoogleUtilities/NSData+zlib"
   - GzipSwift
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
+  - "intercom-react-native (from `../node_modules/@intercom/intercom-react-native`)"
   - lottie-react-native (from `../node_modules/lottie-react-native`)
   - "NativeUtils (from `../node_modules/@metamask/native-utils`)"
   - NitroModules (from `../node_modules/react-native-nitro-modules`)
@@ -3093,6 +3117,7 @@ SPEC REPOS:
     - GoogleUtilities
     - GZIP
     - GzipSwift
+    - Intercom
     - libavif
     - libdav1d
     - lottie-ios
@@ -3181,6 +3206,8 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-2024-11-12-RNv0.76.2-5b4aa20c719830dcf5684832b89a6edb95ac3d64
+  intercom-react-native:
+    :path: "../node_modules/@intercom/intercom-react-native"
   lottie-react-native:
     :path: "../node_modules/lottie-react-native"
   NativeUtils:
@@ -3468,6 +3495,8 @@ SPEC CHECKSUMS:
   GZIP: 3c0abf794bfce8c7cb34ea05a1837752416c8868
   GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
+  Intercom: 9d89549ab9742b2acece67baeffbb4b1f932ad3d
+  intercom-react-native: 83c0c463474eb1503b3ceef3f32a986ad95f3695
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   lottie-ios: e047b1d2e6239b787cc5e9755b988869cf190494

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "@ethersproject/abi": "^5.7.0",
     "@expo/fingerprint": "^0.15.0",
     "@expo/repack-app": "^0.2.9",
+    "@intercom/intercom-react-native": "^9.3.3",
     "@keystonehq/bc-ur-registry-eth": "^0.21.0",
     "@keystonehq/ur-decoder": "^0.12.2",
     "@lavamoat/react-native-lockdown": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6239,6 +6239,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@intercom/intercom-react-native@npm:^9.3.3":
+  version: 9.3.4
+  resolution: "@intercom/intercom-react-native@npm:9.3.4"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/56dbe262ce9b34467551a715b24df0d34b96ef524b4527cb2c0a7d171fcf82be22ec45111aa8d6528883caeb88b08d98da65ba70813c1ee5fbc6b3f544a6eebe
+  languageName: node
+  linkType: hard
+
 "@ioredis/commands@npm:^1.1.1":
   version: 1.2.0
   resolution: "@ioredis/commands@npm:1.2.0"
@@ -35948,6 +35958,7 @@ __metadata:
     "@img/sharp-libvips-darwin-arm64": "npm:^1.2.1"
     "@img/sharp-libvips-linux-x64": "npm:^1.2.1"
     "@img/sharp-linux-x64": "npm:^0.34.3"
+    "@intercom/intercom-react-native": "npm:^9.3.3"
     "@keystonehq/bc-ur-registry-eth": "npm:^0.21.0"
     "@keystonehq/ur-decoder": "npm:^0.12.2"
     "@lavamoat/allow-scripts": "npm:^3.0.4"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR implements Intercom support integration for MetaMask Mobile, enabling beta users to submit bug issues through an in-app messenger. The implementation follows a privacy-first approach where the SDK loads but no user data is sent to Intercom servers until the user explicitly clicks the support button.

**Key features:**
- Only enabled on beta builds when `MM_INTERCOM_ENABLED=true` environment variable is set
- Privacy-first: SDK initialization happens on app launch, but user login (data transmission) only happens when support button is clicked
- Optional email prompt for identified support sessions
- Long-press button to reset stored email
- Falls back to anonymous support if user skips email entry

**Files changed:**
- `package.json` / `yarn.lock` / `ios/Podfile.lock` - Added `@intercom/intercom-react-native` dependency
- `app/components/UI/IntercomButton/*` - New component for floating support button (component, styles, test, index)
- `app/util/intercom/IntercomEmailPrompt.js` - Intercom integration logic with email prompt modal
- `app/components/Nav/Main/index.js` - Integrated IntercomButton into main navigation
- `.js.env.example` - Added Intercom environment variables documentation
- `ios/MetaMask/AppDelegate.m` / `AppDelegate.mm` - Native iOS SDK initialization
- `android/app/src/main/java/io/metamask/MainApplication.kt` - Native Android SDK initialization
- `android/app/build.gradle` - Added BuildConfig fields for Intercom credentials
- `ios/MetaMask/Info.plist` - Added Intercom configuration keys

## **Changelog**

CHANGELOG entry: Added Intercom support integration for beta builds

## **Related issues**

Fixes: [Add issue number if applicable]

## **Manual testing steps**

Feature: Intercom support

  Scenario: Beta user with feature flag enabled accesses support
    Given user has beta build with MM_INTERCOM_ENABLED=true
    And user is on the main wallet screen
    
    When user taps the floating support button on the right edge
    Then email prompt modal appears
    
    When user enters their email and taps Continue
    Then Intercom messenger opens with identified session
    And email is saved for future sessions

  Scenario: Beta user skips email entry
    Given user has beta build with MM_INTERCOM_ENABLED=true
    And user taps the floating support button
    And email prompt modal appears
    
    When user taps Skip
    Then Intercom messenger opens with anonymous session
    
    When user closes messenger and taps button again
    Then email prompt modal appears again (since no email was saved)

  Scenario: Beta user resets saved email
    Given user has beta build with MM_INTERCOM_ENABLED=true
    And user has previously entered their email
    
    When user long-presses the support button
    Then reset confirmation alert appears
    
    When user taps Reset
    Then saved email is cleared
    And next button tap shows email prompt again

  Scenario: Production build does not show support button
    Given user has production build OR MM_INTERCOM_ENABLED=false
    
    When user is on the main wallet screen
    Then support button is not visible

  Scenario: Dev build does not show support button
    Given user has dev build (not beta)
    
    When user is on the main wallet screen
    Then support button is not visible## **Screenshots/Recordings**

### **Before**
- No customer support integration

### **After**
- Floating support button appears on right edge of main screen (beta only)
- Email prompt modal for identified support sessions
- Intercom messenger for live customer support

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.