### PR TITLE
fix: Disappearing candles on Perps chart cp-7.61.0

### DIFF
--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
@@ -981,4 +981,80 @@ describe('CandleStreamChannel', () => {
       expect(subscriber).not.toHaveBeenCalled();
     });
   });
+
+  describe('Always Uses Maximum Duration', () => {
+    it('always uses YEAR_TO_DATE duration when subscribing regardless of requested duration', () => {
+      mockSubscribeToCandles.mockImplementation(({ duration }) => {
+        // Verify YEAR_TO_DATE is always used
+        expect(duration).toBe(TimeDuration.YEAR_TO_DATE);
+        return jest.fn();
+      });
+
+      // Subscribe with ONE_DAY - should still use YEAR_TO_DATE internally
+      channel.subscribe({
+        coin: 'BTC',
+        interval: CandlePeriod.ONE_HOUR,
+        duration: TimeDuration.ONE_DAY,
+        callback: jest.fn(),
+      });
+
+      expect(mockSubscribeToCandles).toHaveBeenCalledTimes(1);
+    });
+
+    it('shares WebSocket connection when subscribers use different durations for same coin+interval', () => {
+      mockSubscribeToCandles.mockReturnValue(jest.fn());
+
+      // First subscriber with ONE_DAY
+      channel.subscribe({
+        coin: 'BTC',
+        interval: CandlePeriod.ONE_HOUR,
+        duration: TimeDuration.ONE_DAY,
+        callback: jest.fn(),
+      });
+
+      // Second subscriber with YEAR_TO_DATE (different duration, same coin+interval)
+      channel.subscribe({
+        coin: 'BTC',
+        interval: CandlePeriod.ONE_HOUR,
+        duration: TimeDuration.YEAR_TO_DATE,
+        callback: jest.fn(),
+      });
+
+      // WebSocket subscription created only once (connection is shared)
+      expect(mockSubscribeToCandles).toHaveBeenCalledTimes(1);
+    });
+
+    it('second subscriber receives cached data immediately', () => {
+      let capturedCallback: ((data: CandleData) => void) | undefined;
+      const firstCallback = jest.fn();
+      const secondCallback = jest.fn();
+
+      mockSubscribeToCandles.mockImplementation(({ callback }) => {
+        capturedCallback = callback;
+        return jest.fn();
+      });
+
+      // First subscriber
+      channel.subscribe({
+        coin: 'BTC',
+        interval: CandlePeriod.ONE_HOUR,
+        duration: TimeDuration.YEAR_TO_DATE,
+        callback: firstCallback,
+      });
+
+      // Simulate initial data load
+      capturedCallback?.(mockCandleData);
+
+      // Second subscriber
+      channel.subscribe({
+        coin: 'BTC',
+        interval: CandlePeriod.ONE_HOUR,
+        duration: TimeDuration.ONE_DAY,
+        callback: secondCallback,
+      });
+
+      // Second callback receives cached data immediately
+      expect(secondCallback).toHaveBeenCalledWith(mockCandleData);
+    });
+  });
 });

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
@@ -113,7 +113,9 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
   }
 
   /**
-   * Subscribe to candle updates for a specific coin and interval
+   * Subscribe to candle updates for a specific coin and interval.
+   * Note: The duration parameter is accepted for API compatibility but ignored -
+   * we always fetch maximum candles (YEAR_TO_DATE = 500) to avoid complex caching issues.
    */
   public subscribe(params: {
     coin: string;
@@ -123,13 +125,13 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
     throttleMs?: number;
     onError?: (error: Error) => void;
   }): () => void {
-    const { coin, interval, duration, callback, throttleMs, onError } = params;
+    const { coin, interval, callback, throttleMs, onError } = params;
     const cacheKey = this.getCacheKey(coin, interval);
     const id = Math.random().toString(36);
 
     const subscription: StreamSubscription<CandleData> = {
       id,
-      cacheKey, // Store cacheKey to filter subscribers by their subscription
+      cacheKey,
       callback,
       throttleMs,
       hasReceivedFirstUpdate: false,
@@ -145,7 +147,7 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
     }
 
     // Ensure WebSocket connected for this coin+interval
-    this.connect(coin, interval, duration, cacheKey);
+    this.connect(coin, interval, cacheKey);
 
     // Return unsubscribe function
     return () => {
@@ -165,9 +167,7 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
       if (remainingForThisKey === 0) {
         DevLogger.log(
           'CandleStreamChannel: Disconnecting WebSocket (no subscribers)',
-          {
-            cacheKey,
-          },
+          { cacheKey },
         );
         this.disconnect(cacheKey);
       }
@@ -175,12 +175,13 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
   }
 
   /**
-   * Connect to WebSocket for specific coin and interval
+   * Connect to WebSocket for specific coin and interval.
+   * Always uses YEAR_TO_DATE duration to fetch maximum candles (500) on initial load.
+   * This ensures all subscribers get the full dataset regardless of their individual duration needs.
    */
   private connect(
     coin: string,
     interval: CandlePeriod,
-    duration: TimeDuration,
     cacheKey: string,
   ): void {
     // Skip if already connected for this coin+interval
@@ -198,17 +199,18 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
 
         // Only reconnect if subscribers still exist and no connection established
         if (hasActiveSubscribers && !this.wsSubscriptions.has(cacheKey)) {
-          this.connect(coin, interval, duration, cacheKey);
+          this.connect(coin, interval, cacheKey);
         }
       }, PERPS_CONSTANTS.RECONNECTION_CLEANUP_DELAY_MS);
       return;
     }
 
     // Subscribe to candle updates via controller
+    // Always use YEAR_TO_DATE to fetch maximum candles (500) regardless of subscriber's duration
     const unsubscribe = Engine.context.PerpsController.subscribeToCandles({
       coin,
       interval,
-      duration,
+      duration: TimeDuration.YEAR_TO_DATE, // Always fetch max candles
       callback: (candleData: CandleData) => {
         // Update cache
         this.cache.set(cacheKey, candleData);


### PR DESCRIPTION
## **Description**

There was a caching conflict in the `CandleStreamChannel` between the `usePerpsMarketStats` and `usePerpsLiveCandles` hooks on the asset details page.

`usePerpsMarketStats` always subscribes to 1-hour candles, regardless of what interval the chart is displaying. This is because it calculates 24-hour high/low and volume, which requires 24 one-hour candles.

However, this would cause a conflict in the cache key that would also cause the chart to render only 24 candles, rather than the full 500 in data set.

This was only apparent for the `1h` duration:

When viewing 15m chart:
Stats subscribes to BTC-1h (24 candles)
Chart subscribes to BTC-15m (500 candles)
Different cache keys, no conflict

When viewing 4h chart:
Stats subscribes to BTC-1h (24 candles)
Chart subscribes to BTC-4h (500 candles)
Different cache keys, no conflict

When viewing 1h chart:
Stats subscribes to BTC-1h (24 candles) ← first
Chart subscribes to BTC-1h (500 candles) ← same key!
Same cache key, conflict

The 1h interval was the only one where both components competed for the same `coin-interval` cache entry. Causing the chart to not render the full data set.

The solution I opted for was to simply always fetch 500 candles. The component that needs less data can just use what it needs from the larger dataset. This way, everyone gets enough data regardless of subscription order. The performance to fetch this amount of data seems negligible.

## **Changelog**

CHANGELOG entry: fix 1h candle period on perps chart not displaying full dataset

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2197

## **Manual testing steps**

```gherkin
Feature: Perps chart candle display

  Scenario: user views 1h candles on market chart
    Given user is on the market details view

    When user selects the 1h candle period
    Then the chart displays several weeks of historical candles
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/9c5e9bae-85ad-43a7-85b9-81f7dc33ed55

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Force `CandleStreamChannel` to always fetch max candles (`YEAR_TO_DATE`) and ignore requested duration; update tests to validate shared connections and caching.
> 
> - **Perps Candle Streaming**:
>   - Always use `TimeDuration.YEAR_TO_DATE` when subscribing in `CandleStreamChannel` to fetch max candles (500), ignoring requested `duration`.
>   - Simplify API: remove `duration` from internal `connect(...)` and from subscriber handling; cache key remains `coin-interval`.
>   - Maintain shared WebSocket per `coin+interval`; disconnect when no subscribers remain; unchanged throttling/cache behaviors.
> - **Tests** (`app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts`):
>   - Add specs ensuring `YEAR_TO_DATE` is always used, connections are shared across different requested durations, and second subscribers receive cached data immediately.
>   - Existing tests continue to validate caching, throttling, pause/resume, disconnect, and historical fetch/merge behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3856ceff7d8d9a5cb2f921fd72bbfb8a2ecfce8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->