### PR TITLE
fix: Prevent interstitial from appearing on barebones deeplinks cp-7.60.3

### DIFF
--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
@@ -15,6 +15,8 @@ import handleUniversalLink from '../handleUniversalLink';
 import handleDeepLinkModalDisplay from '../handleDeepLinkModalDisplay';
 import { DeepLinkModalLinkType } from '../../../../../components/UI/DeepLinkModal';
 import handleMetaMaskDeeplink from '../handleMetaMaskDeeplink';
+// eslint-disable-next-line import/no-namespace
+import * as signatureUtils from '../../../utils/verifySignature';
 
 jest.mock('../handleMetaMaskDeeplink');
 jest.mock('../../../../SDKConnect/handlers/handleDeeplink');
@@ -53,7 +55,7 @@ const mockSubtle = QuickCrypto.webcrypto.subtle as jest.Mocked<
   verify: jest.Mock<Promise<boolean>>;
 };
 
-describe('handleUniversalLinks', () => {
+describe('handleUniversalLink', () => {
   const mockParse = jest.fn();
   const mockNavigation = { navigate: jest.fn() };
   const mockConnectToChannel = jest.fn();
@@ -62,7 +64,6 @@ describe('handleUniversalLinks', () => {
   const mockReconnect = jest.fn();
   const mockWC2ManagerConnect = jest.fn();
   const mockBindAndroidSDK = jest.fn();
-
   const mockHandleDeeplink = handleDeeplink as jest.Mock;
   const mockHandleMetaMaskDeeplink =
     handleMetaMaskDeeplink as jest.MockedFunction<
@@ -1301,6 +1302,66 @@ describe('handleUniversalLinks', () => {
 
         expect(mockHandleDeepLinkModalDisplay).not.toHaveBeenCalled();
         expect(handled).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('should skip handling deeplinks without pathname and query params', () => {
+    // Link cases to test for skipping handling
+    const testLinkCases = [
+      {
+        link: 'metamask://',
+        shouldSkip: true,
+      },
+      {
+        link: 'https://link.metamask.io/',
+        shouldSkip: true,
+      },
+      {
+        link: 'https://link.metamask.io',
+        shouldSkip: true,
+      },
+      {
+        link: 'https://link.metamask.io/action',
+        shouldSkip: false,
+      },
+      {
+        link: 'https://link.metamask.io/action?query=value',
+        shouldSkip: false,
+      },
+      {
+        link: 'metamask://action',
+        shouldSkip: false,
+      },
+      {
+        link: 'metamask://action?query=value',
+        shouldSkip: false,
+      },
+    ];
+
+    testLinkCases.forEach((testCase) => {
+      it(`should ${testCase.shouldSkip ? 'skip' : 'NOT skip'} handling ${testCase.link}`, async () => {
+        const hasSignatureSpy = jest.spyOn(signatureUtils, 'hasSignature');
+
+        const mappedUrl = testCase.link.replace(
+          `${PROTOCOLS.METAMASK}://`,
+          `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/`,
+        );
+        const { urlObj } = extractURLParams(mappedUrl);
+        await handleUniversalLink({
+          instance,
+          handled,
+          urlObj,
+          browserCallBack: mockBrowserCallBack,
+          url: mappedUrl,
+          source: 'origin',
+        });
+
+        if (testCase.shouldSkip) {
+          expect(hasSignatureSpy).not.toHaveBeenCalled();
+        } else {
+          expect(hasSignatureSpy).toHaveBeenCalled();
+        }
       });
     });
   });

--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -115,6 +115,13 @@ async function handleUniversalLink({
     throw new Error('Invalid hostname');
   }
 
+  // Skip handling deeplinks that do not have a pathname or query
+  // Ex. It's common for third party apps to open MetaMask using only the scheme (metamask://)
+  if (!validatedUrl.pathname.replace('/', '') && !validatedUrl.search) {
+    handled();
+    return;
+  }
+
   let isPrivateLink = false;
   let isInvalidLink = false;
 


### PR DESCRIPTION
## **Description**

This PR fixes an issue where the deeplink interstitial modal was incorrectly appearing when barebones deeplinks (links without pathnames and query parameters) opened the MetaMask app. 

**Problem:**
Third-party applications, especially those using WalletConnect, commonly deeplink back into MetaMask using barebones URLs like `metamask://` or `link.metamask.io/`. These links are intentionally minimal and serve only to open the app without navigating to a specific action. However, the current implementation was processing these links through the full deeplink handling flow, which triggered the interstitial modal and signature verification checks unnecessarily.

**Solution:**
Added an early return in `handleUniversalLink` to skip processing when a validated URL has no pathname and no query parameters. This prevents the interstitial modal from appearing and avoids unnecessary signature verification for these barebones deeplinks, providing a smoother user experience when third-party apps redirect users back to MetaMask.

**Technical Changes:**
- Added early return logic in `handleUniversalLink` to detect and skip barebones deeplinks
- Updated tests to verify skip behavior for links without pathname/query params
- Ensured `hasSignature` is not called when processing is skipped

## **Changelog**

CHANGELOG entry: Fixed unexpected interstitial modal from appearing for barebones deeplinks

## **Related issues**

Fixes: #23641

This fix prevents the deeplink interstitial from appearing when barebones (links without pathnames and query params) deeplinks opens the app. This is a common use case from third party apps especially when using WC. Apps usually deeplink back into metamask via `metamask://`

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
From @v-goyal  - https://consensys.slack.com/archives/C8RSKCNCD/p1764729786354199?thread_ts=1764724329.879139&cid=C8RSKCNCD

### **After**

<!-- [screenshots/recordings] -->
This video shows the fix using the Interface app and includes a smoke test with a few other deeplinks
https://github.com/user-attachments/assets/c5eeb33b-4523-4f6a-b90d-0d94608e55a9

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skip handling deeplinks with no pathname or query (e.g., metamask://, link.metamask.io[/]) to prevent interstitial and signature checks; add targeted tests.
> 
> - **Core – Deeplink handling**:
>   - In `app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts`, add early return to `handled()` and skip processing when the validated URL has no pathname and no query, preventing interstitial/signature flows for barebones links.
> - **Tests**:
>   - In `__tests__/handleUniversalLink.test.ts`:
>     - Import `verifySignature` namespace to spy on `hasSignature`.
>     - Add cases verifying skip behavior for links without path/query and that `hasSignature` is not called when skipped.
>     - Minor: update `describe` name to `handleUniversalLink`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d09a02fd3f659576315f80e1aabe798d599603b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->