### PR TITLE
chore: fix E2E test run flakiness

### DIFF
--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -106,8 +106,33 @@ jobs:
         if: ${{ inputs.platform == 'android' }}
         run: |
           echo "📱 Installing Android system images for E2E tests..."
-          "$ANDROID_SDK_ROOT"/cmdline-tools/latest/bin/sdkmanager "system-images;android-34;google_apis;x86_64"
-          echo "✅ System images installed"
+          
+          # Accept licenses first
+          yes | "$ANDROID_SDK_ROOT"/cmdline-tools/latest/bin/sdkmanager --licenses || true
+          
+          # Clear any corrupted cache
+          rm -rf "$ANDROID_SDK_ROOT/.downloadIntermediates" 2>/dev/null || true
+          
+          # Install with retry logic
+          MAX_RETRIES=3
+          RETRY_COUNT=0
+          
+          until [ $RETRY_COUNT -ge $MAX_RETRIES ]
+          do
+            echo "Attempt $((RETRY_COUNT + 1)) of $MAX_RETRIES"
+            if "$ANDROID_SDK_ROOT"/cmdline-tools/latest/bin/sdkmanager --install "system-images;android-34;google_apis;x86_64"; then
+              echo "✅ System images installed successfully"
+              exit 0
+            fi
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+            echo "⚠️ Installation failed, cleaning up and retrying..."
+            rm -rf "$ANDROID_SDK_ROOT/system-images/android-34" 2>/dev/null || true
+            rm -rf "$ANDROID_SDK_ROOT/.downloadIntermediates" 2>/dev/null || true
+            sleep 5
+          done
+          
+          echo "❌ Failed to install system images after $MAX_RETRIES attempts"
+          exit 1
 
       - name: Set up E2E environment
         uses: MetaMask/github-tools/.github/actions/setup-e2e-env@6742ebe1a3541cb13972d65352a0622a6a6677db


### PR DESCRIPTION
## **Description**

The Android E2E workflow was failing with `Error on ZipFile unknown archive` when downloading system images. This is a known transient issue with the Android SDK Manager where downloads can get corrupted mid-stream.

**What changed:**
- Added retry logic (up to 3 attempts) for installing Android system images
- Added license acceptance step to avoid interactive prompts
- Added cleanup of corrupted cache files (`.downloadIntermediates`) between retries
- Added cleanup of partially downloaded system images between retries

**Why:**
The `sdkmanager` download can fail due to network issues on CI runners, resulting in corrupted zip files. Retrying the download typically succeeds on subsequent attempts.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A - Infrastructure fix for flaky CI

## **Manual testing steps**

```gherkin
Feature: Android E2E CI stability

  Scenario: Android system image installation succeeds with retry
    Given the Android E2E workflow runs on CI

    When the system image download encounters a transient error
    Then the workflow retries the download up to 3 times
    And succeeds on a subsequent attempt
```

## **Screenshots/Recordings**

### **Before**

N/A - CI workflow change

### **After**

N/A - CI workflow change

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds license acceptance and a retry-with-cleanup loop for Android system image installation in the E2E GitHub Actions workflow.
> 
> - **CI Workflow** (`.github/workflows/run-e2e-workflow.yml`)
>   - **Android system image install**: 
>     - Accepts SDK licenses via `sdkmanager --licenses`.
>     - Clears corrupted cache (`$ANDROID_SDK_ROOT/.downloadIntermediates`).
>     - Adds retry loop (3 attempts) using `sdkmanager --install "system-images;android-34;google_apis;x86_64"`.
>     - Cleans partial installs (`system-images/android-34`) and cache between attempts; exits on repeated failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66434dee909b694747d682786028b236b37084a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->