### PR TITLE
fix: update MM Sans and MM Poly fonts to use PostScript names

### DIFF
--- a/app/components/UI/DeleteWalletModal/styles.ts
+++ b/app/components/UI/DeleteWalletModal/styles.ts
@@ -80,7 +80,7 @@ export const createStyles = (colors: any) =>
     warningText: {
       textAlign: 'left',
       width: '100%',
-      fontFamily: 'Geist Medium',
+      fontFamily: 'Geist-Medium',
     },
     warningTextContainer: {
       flexDirection: 'column',

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.styles.ts
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.styles.ts
@@ -1,4 +1,4 @@
-import { Platform, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import type { Theme } from '../../../../../util/theme/models';
 
 export const styleSheet = (params: { theme: Theme }) => {
@@ -24,8 +24,7 @@ export const styleSheet = (params: { theme: Theme }) => {
     },
     heading: {
       marginBottom: 8,
-      fontFamily:
-        Platform.OS === 'android' ? 'MM Sans Regular' : 'MMSans-Regular',
+      fontFamily: 'MMSans-Regular',
     },
     bodyText: {
       marginBottom: 32,

--- a/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.styles.ts
+++ b/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.styles.ts
@@ -78,9 +78,7 @@ const createStyles = (
         ? Platform.OS === 'ios'
           ? 'System'
           : 'Roboto'
-        : Platform.OS === 'ios'
-          ? 'MM Poly'
-          : 'MM Poly Regular',
+        : 'MMPoly-Regular',
       fontWeight: useSystemFont
         ? '700'
         : Platform.OS === 'ios'

--- a/app/components/UI/Predict/components/PredictGTMModal/PredictGTMModal.styles.ts
+++ b/app/components/UI/Predict/components/PredictGTMModal/PredictGTMModal.styles.ts
@@ -75,7 +75,7 @@ const createStyles = (theme: Theme) =>
       flex: 1,
     },
     title: {
-      fontFamily: Platform.OS === 'ios' ? 'MM Poly' : 'MM Poly Regular',
+      fontFamily: 'MMPoly-Regular',
       fontWeight: '400',
       // make it smaller on smaller screens
       fontSize:

--- a/app/components/UI/ReviewModal/styles.ts
+++ b/app/components/UI/ReviewModal/styles.ts
@@ -20,7 +20,7 @@ export const createStyles = (colors: any) =>
     optionIcon: { fontSize: 24 },
     optionLabel: {
       fontSize: 14,
-      fontFamily: 'Geist Regular',
+      fontFamily: 'Geist-Regular',
       color: colors.primary.default,
     },
     helpOption: { marginVertical: 12 },
@@ -29,14 +29,14 @@ export const createStyles = (colors: any) =>
     questionLabel: {
       fontSize: 18,
       paddingHorizontal: 30,
-      fontFamily: 'Geist Bold',
+      fontFamily: 'Geist-Bold',
       textAlign: 'center',
       color: colors.text.default,
       lineHeight: 26,
     },
     description: {
       fontSize: 14,
-      fontFamily: 'Geist Regular',
+      fontFamily: 'Geist-Regular',
       color: colors.text.alternative,
       textAlign: 'center',
       lineHeight: 20,

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Image, ImageBackground, Platform, Text as RNText } from 'react-native';
+import { Image, ImageBackground, Text as RNText } from 'react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -318,7 +318,7 @@ const OnboardingIntroStep: React.FC<{
             tw.style('text-center text-white text-12 leading-1 pt-1'),
             // eslint-disable-next-line react-native/no-inline-styles
             {
-              fontFamily: Platform.OS === 'ios' ? 'MM Poly' : 'MM Poly Regular',
+              fontFamily: 'MMPoly-Regular',
             },
           ]}
         >

--- a/app/components/Views/Onboarding/styles.ts
+++ b/app/components/Views/Onboarding/styles.ts
@@ -1,4 +1,4 @@
-import { StyleSheet, Platform } from 'react-native';
+import { StyleSheet } from 'react-native';
 import Device from '../../../util/device';
 import { colors as importedColors } from '../../../styles/common';
 import type { Theme } from '../../../util/theme/models';
@@ -64,8 +64,7 @@ export const createStyles = (colors: Theme['colors']) =>
       lineHeight: Device.isMediumDevice() ? 30 : 40,
       textAlign: 'center',
       paddingHorizontal: Device.isMediumDevice() ? 40 : 60,
-      fontFamily:
-        Platform.OS === 'android' ? 'MM Sans Regular' : 'MMSans-Regular',
+      fontFamily: 'MMSans-Regular',
       color: importedColors.gettingStartedTextColor,
       width: '100%',
       marginVertical: 16,

--- a/app/components/Views/OnboardingSuccess/index.styles.ts
+++ b/app/components/Views/OnboardingSuccess/index.styles.ts
@@ -1,4 +1,4 @@
-import { StyleSheet, Platform } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { ThemeColors } from '@metamask/design-tokens';
 
 const createStyles = (colors: ThemeColors) =>
@@ -26,8 +26,7 @@ const createStyles = (colors: ThemeColors) =>
       marginBottom: 16,
       marginHorizontal: 16,
       textAlign: 'center',
-      fontFamily:
-        Platform.OS === 'android' ? 'MM Sans Regular' : 'MMSans-Regular',
+      fontFamily: 'MMSans-Regular',
     },
     footerLink: {
       paddingVertical: 8,

--- a/app/components/Views/confirmations/components/send/amount/amount.styles.ts
+++ b/app/components/Views/confirmations/components/send/amount/amount.styles.ts
@@ -64,7 +64,7 @@ export const styleSheet = (params: {
     inputText: {
       fontSize: getFontSizeForInputLength(contentLength),
       lineHeight: 75,
-      fontFamily: 'Geist Medium',
+      fontFamily: 'Geist-Medium',
     },
     inputWrapper: {
       alignItems: 'center',


### PR DESCRIPTION
Dependency https://github.com/MetaMask/metamask-mobile/pull/23517 (merged)

## **Description**

This PR is a **fast-follow to #23517 (expo-font implementation)** that isolates brand font changes (MM Sans and MM Poly) requiring review from code owners outside the mobile-platform and design-system teams.

### Strategy
By splitting these changes into a separate PR, we can:
- Avoid #23517 becoming stale while waiting for reviews from multiple code owners
- Get brand font updates reviewed and merged independently 
- Reduce merge conflicts and review complexity

### Changes
Updates MM Sans and MM Poly font references to use PostScript names with hyphens instead of spaces:
- `'MM Sans Regular'` → `'MMSans-Regular'`
- `'MM Poly'` / `'MM Poly Regular'` → `'MMPoly-Regular'`

Removes platform-specific `Platform.select` wrappers since PostScript names work consistently across iOS and Android.

### Why PostScript Names?
iOS requires the PostScript name from font file metadata (not the Full Name or filename). By using PostScript names and naming our font files to match, both platforms can reference fonts consistently.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to: #23517

## **Manual testing steps**

```gherkin
Feature: Brand font rendering

  Scenario: user views screens with MM Sans and MM Poly fonts
    Given the app is built and installed on a device
    When user navigates to onboarding screens
    And user views Perps GTM modal
    And user views Predict GTM modal  
    And user views Rewards onboarding
    And user views Earn education views
    Then MM Sans and MM Poly fonts render correctly without fallback to system fonts
```

## **Screenshots/Recordings**

### **Before**
Brand fonts(MM Poly and MM Sans) will be currently broken

### **After**
Screenshots and recordings taken from original PR https://github.com/MetaMask/metamask-mobile/pull/23517 which these changes were broken out from.

**iOS**

https://github.com/user-attachments/assets/d73b1049-b5d4-43e9-9aea-2273e216e549

Key screens:
- MM Sans & MM Poly working
- Tabs built with `@metamask/design-system-react-native` working

<img width="398" height="259" alt="Screenshot 2025-12-10 at 8 41 08 AM" src="https://github.com/user-attachments/assets/d5a11151-19b9-455c-86b7-c69531239054" />
<img width="427" height="291" alt="Screenshot 2025-12-10 at 8 41 14 AM" src="https://github.com/user-attachments/assets/54d64ffe-5410-4c86-b2a7-30ed19b898df" />
<img width="412" height="120" alt="Screenshot 2025-12-10 at 8 41 23 AM" src="https://github.com/user-attachments/assets/56734145-114a-443c-a4de-ed1274cfb2e5" />

**Android**

https://github.com/user-attachments/assets/1d14744b-0d2c-4aaa-b18b-9eb5175a6af6

Key screens:
- MM Sans & MM Poly working
- Tabs built with `@metamask/design-system-react-native` working

<img width="442" height="362" alt="Screenshot 2025-12-10 at 8 31 02 AM" src="https://github.com/user-attachments/assets/3ef52f3c-0ae9-46ed-aca8-cab75d3b1666" />
<img width="413" height="183" alt="Screenshot 2025-12-10 at 8 31 06 AM" src="https://github.com/user-attachments/assets/e1e69c06-e3cd-4e27-96f9-f9e0a607e798" />
<img width="318" height="127" alt="Screenshot 2025-12-10 at 8 30 33 AM" src="https://github.com/user-attachments/assets/8b683b25-f87c-4bab-b395-f6555cc05467" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces MM Sans, MM Poly, and Geist font references with PostScript names and removes platform-specific font handling across onboarding, modals, rewards, and confirmations.
> 
> - **Fonts**:
>   - Switch to PostScript names: `MMSans-Regular`, `MMPoly-Regular`, and `Geist-*` (`Geist-Regular`, `Geist-Medium`, `Geist-Bold`).
>   - Remove platform-specific `Platform` font branching where applicable.
> - **Affected areas**:
>   - `UI/Perps/PerpsGTMModal.styles.ts`: unify title font to `MMPoly-Regular`; keep system font fallback logic.
>   - `UI/Predict/PredictGTMModal.styles.ts`: set title font to `MMPoly-Regular`; keep system font for description.
>   - `UI/Earn/...EarnMusdConversionEducationView.styles.ts`: heading uses `MMSans-Regular`.
>   - `Views/Onboarding/styles.ts` and `Views/OnboardingSuccess/index.styles.ts`: titles use `MMSans-Regular`.
>   - `UI/Rewards/.../OnboardingIntroStep.tsx`: title text uses `MMPoly-Regular`.
>   - `UI/ReviewModal/styles.ts` and `UI/DeleteWalletModal/styles.ts`: replace Geist families with `Geist-*`.
>   - `Views/confirmations/.../amount.styles.ts`: input text uses `Geist-Medium`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6630d20465ce19a964b554d44cdce97039dca20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->