### PR TITLE
test: use fontStyles from common.ts in BridgeStepDescription test

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/BridgeStepDescription.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BridgeStepDescription.test.tsx
@@ -12,6 +12,7 @@ import {
   TransactionStatus,
   CHAIN_IDS,
 } from '@metamask/transaction-controller';
+import { fontStyles } from '../../../../../styles/common';
 
 describe('BridgeStepDescription', () => {
   const mockStep = {
@@ -128,7 +129,7 @@ describe('BridgeStepDescription', () => {
     const textElement = getByText(/ETH/);
     expect(textElement.props.style).toHaveProperty(
       'fontFamily',
-      'Geist Medium',
+      fontStyles.medium.fontFamily,
     );
   });
 
@@ -157,7 +158,7 @@ describe('BridgeStepDescription', () => {
     expect(textElement.props.style).toHaveProperty('color', '#121314');
     expect(textElement.props.style).toHaveProperty(
       'fontFamily',
-      'Geist Regular',
+      fontStyles.normal.fontFamily,
     );
   });
 
@@ -175,7 +176,7 @@ describe('BridgeStepDescription', () => {
     expect(textElement.props.style).toHaveProperty('color', '#121314');
     expect(textElement.props.style).toHaveProperty(
       'fontFamily',
-      'Geist Regular',
+      fontStyles.normal.fontFamily,
     );
   });
 
@@ -194,7 +195,7 @@ describe('BridgeStepDescription', () => {
     expect(textElement.props.style).toHaveProperty('color', '#121314');
     expect(textElement.props.style).toHaveProperty(
       'fontFamily',
-      'Geist Regular',
+      fontStyles.normal.fontFamily,
     );
   });
 
@@ -215,7 +216,7 @@ describe('BridgeStepDescription', () => {
     expect(textElement.props.style).toHaveProperty('color', '#121314');
     expect(textElement.props.style).toHaveProperty(
       'fontFamily',
-      'Geist Medium',
+      fontStyles.medium.fontFamily,
     );
   });
 
@@ -236,7 +237,7 @@ describe('BridgeStepDescription', () => {
     expect(textElement.props.style).toHaveProperty('color', '#121314');
     expect(textElement.props.style).toHaveProperty(
       'fontFamily',
-      'Geist Medium',
+      fontStyles.medium.fontFamily,
     );
   });
 
@@ -285,7 +286,7 @@ describe('BridgeStepDescription', () => {
     expect(textElement.props.style).toHaveProperty('color', '#686e7d');
     expect(textElement.props.style).toHaveProperty(
       'fontFamily',
-      'Geist Regular',
+      fontStyles.normal.fontFamily,
     );
   });
 
@@ -299,7 +300,7 @@ describe('BridgeStepDescription', () => {
     expect(textElement.props.style).toHaveProperty('color', '#686e7d');
     expect(textElement.props.style).toHaveProperty(
       'fontFamily',
-      'Geist Regular',
+      fontStyles.normal.fontFamily,
     );
   });
 


### PR DESCRIPTION
## **Description**

This PR fixes a test that would fail after the expo-font changes in #23517. The `BridgeStepDescription.test.tsx` file had hardcoded font family assertions (e.g., `'Geist Medium'`, `'Geist Regular'`) that will break when font file names change to hyphenated format (e.g., `'Geist-Medium'`, `'Geist-Regular'`).

Instead of updating to new hardcoded values, this PR references the centralized `fontStyles` definitions from `app/styles/common.ts`, making the test more maintainable and ensuring a single source of truth for font families.

**Changes:**
- Import `fontStyles` from `app/styles/common.ts`
- Replace `'Geist Medium'` assertions with `fontStyles.medium.fontFamily`
- Replace `'Geist Regular'` assertions with `fontStyles.normal.fontFamily`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to #23517 (main expo-font PR)
Related to #23650 (brand font fixes PR)

## **Manual testing steps**

```gherkin
Feature: BridgeStepDescription test suite

  Scenario: developer runs test suite
    Given the font family definitions have been updated to use hyphens
    
    When developer runs yarn jest BridgeStepDescription.test.tsx
    Then all 22 tests should pass successfully
```

## **Screenshots/Recordings**

N/A - Test-only change

### **Before**

Test assertions used hardcoded font family strings that would fail after font renaming.

### **After**

Test assertions reference `fontStyles` from `common.ts` and pass with new font names.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update BridgeStepDescription tests to reference centralized fontStyles instead of hardcoded font family strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b8f8d2b0f236e95652d4d97110a1b15a19f86fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->