### PR TITLE
feat: added support for progressive rollout in trending

### DIFF
--- a/app/selectors/featureFlagController/assetsTrendingTokens/index.test.ts
+++ b/app/selectors/featureFlagController/assetsTrendingTokens/index.test.ts
@@ -20,10 +20,14 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
+// Type for progressive rollout format with value property
+type ProgressiveRolloutFlag =
+  | { value: AssetsTrendingTokensFeatureFlag | boolean }
+  | AssetsTrendingTokensFeatureFlag
+  | boolean;
+
 // Helper function to create mock state with assetsTrendingTokensEnabled flag
-function mockStateWith(
-  trendingTokens: AssetsTrendingTokensFeatureFlag | boolean,
-) {
+function mockStateWith(trendingTokens: ProgressiveRolloutFlag) {
   return {
     engine: {
       backgroundState: {
@@ -72,6 +76,45 @@ describe('Assets Trending Tokens Feature Flag Selector', () => {
 
     it('returns false when flag is simple boolean false', () => {
       const mockedState = mockStateWith(false);
+
+      const result = selectAssetsTrendingTokensEnabled(mockedState);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true when flag has value property with enabled flag', () => {
+      const mockedState = mockStateWith({
+        value: {
+          enabled: true,
+          minimumVersion: '1.0.0',
+        },
+      });
+
+      const result = selectAssetsTrendingTokensEnabled(mockedState);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when flag has value property with disabled flag', () => {
+      const mockedState = mockStateWith({
+        value: {
+          enabled: false,
+          minimumVersion: '1.0.0',
+        },
+      });
+
+      const result = selectAssetsTrendingTokensEnabled(mockedState);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when flag has value property but version is too low', () => {
+      const mockedState = mockStateWith({
+        value: {
+          enabled: true,
+          minimumVersion: '999.999.999',
+        },
+      });
 
       const result = selectAssetsTrendingTokensEnabled(mockedState);
 
@@ -157,6 +200,26 @@ describe('Assets Trending Tokens Feature Flag Selector', () => {
 
       expect(result).toBe(false);
     });
+
+    it('returns true when flag has value property with boolean true', () => {
+      const mockedState = mockStateWith({
+        value: true,
+      });
+
+      const result = selectAssetsTrendingTokensEnabled(mockedState);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when flag has value property with boolean false', () => {
+      const mockedState = mockStateWith({
+        value: false,
+      });
+
+      const result = selectAssetsTrendingTokensEnabled(mockedState);
+
+      expect(result).toBe(false);
+    });
   });
 
   describe('isAssetsTrendingTokensFeatureEnabled with override', () => {
@@ -202,41 +265,20 @@ describe('Assets Trending Tokens Feature Flag Selector', () => {
       expect(result).toBe(true);
     });
 
-    it('uses remote flag when envOverride is empty string', () => {
-      const result = isAssetsTrendingTokensFeatureEnabled(
-        {
-          enabled: true,
-          minimumVersion: '1.0.0',
-        },
-        '',
-      );
+    it.each(['', 'something-else', 'invalid'])(
+      'uses remote flag when envOverride is non-boolean string: "%s"',
+      (envOverride) => {
+        const result = isAssetsTrendingTokensFeatureEnabled(
+          {
+            enabled: true,
+            minimumVersion: '1.0.0',
+          },
+          envOverride,
+        );
 
-      expect(result).toBe(true);
-    });
-
-    it('uses remote flag when envOverride is other string value', () => {
-      const result = isAssetsTrendingTokensFeatureEnabled(
-        {
-          enabled: true,
-          minimumVersion: '1.0.0',
-        },
-        'something-else',
-      );
-
-      expect(result).toBe(true);
-    });
-
-    it('returns false when envOverride is "false" and remote flag would return true', () => {
-      const result = isAssetsTrendingTokensFeatureEnabled(
-        {
-          enabled: true,
-          minimumVersion: '1.0.0',
-        },
-        'false',
-      );
-
-      expect(result).toBe(false);
-    });
+        expect(result).toBe(true);
+      },
+    );
   });
 
   describe('isAssetsTrendingTokensFeatureEnabled edge cases', () => {

--- a/app/selectors/featureFlagController/assetsTrendingTokens/index.ts
+++ b/app/selectors/featureFlagController/assetsTrendingTokens/index.ts
@@ -93,8 +93,16 @@ export const selectAssetsTrendingTokensEnabled = createSelector(
     const envOverride =
       process.env.OVERRIDE_REMOTE_FEATURE_FLAGS &&
       process.env.ASSETS_TRENDING_TOKENS_ENABLED;
+
+    const value =
+      assetsTrendingTokensEnabled &&
+      typeof assetsTrendingTokensEnabled === 'object' &&
+      'value' in assetsTrendingTokensEnabled
+        ? assetsTrendingTokensEnabled.value
+        : assetsTrendingTokensEnabled;
+
     return isAssetsTrendingTokensFeatureEnabled(
-      assetsTrendingTokensEnabled,
+      value,
       envOverride || undefined,
     );
   },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
I have changed the configuration in LD to have these two flags:

`[Progressive Rollout] 0% of users - Minimum Version 7.61.0`
```json
[
  {
    "name": "feature is ON",
    "scope": {
      "type": "threshold",
      "value": 0
    },
    "value": {
      "enabled": true,
      "minimumVersion": "7.61.0"
    }
  },
  {
    "name": "feature is OFF",
    "scope": {
      "type": "threshold",
      "value": 1
    },
    "value": {
      "enabled": false,
      "minimumVersion": "7.61.0"
    }
  }
]
```

`[Progressive Rollout] 100% of users - Minimum Version 7.61.0`
```json
[
  {
    "name": "feature is ON",
    "scope": {
      "type": "threshold",
      "value": 1
    },
    "value": {
      "enabled": true,
      "minimumVersion": "7.61.0"
    }
  },
  {
    "name": "feature is OFF",
    "scope": {
      "type": "threshold",
      "value": 1
    },
    "value": {
      "enabled": false,
      "minimumVersion": "7.61.0"
    }
  }
]
```

This PR focuses on enbling the use of those FFs on the mobile app
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add support for progressive rollout FF

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-1838

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for progressive-rollout flags that wrap `trendingTokens` in a `value` field and updates tests accordingly.
> 
> - **Feature Flags**:
>   - `selectAssetsTrendingTokensEnabled` now handles progressive rollout format by unwrapping `trendingTokens.value` when present before evaluation.
> - **Tests**:
>   - Extend cases to cover `{ value: { enabled, minimumVersion } }` and `{ value: boolean }` inputs.
>   - Consolidate env override non-boolean string cases using `it.each` and remove redundant tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0242e11c299e068a5c98eeb0bab6a3426fc501c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->