### PR TITLE
fix(ramp): align Aggregator UI with design system cp-7.61.0

### DIFF
--- a/app/components/Base/SelectorButton.tsx
+++ b/app/components/Base/SelectorButton.tsx
@@ -6,7 +6,11 @@ import {
   TouchableOpacityProps,
   GestureResponderEvent,
 } from 'react-native';
-import Icon from 'react-native-vector-icons/FontAwesome';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../component-library/components/Icons/Icon';
 import { useTheme } from '../../util/theme';
 import { Theme } from '@metamask/design-tokens';
 
@@ -19,7 +23,7 @@ interface SelectorButtonProps {
 const createStyles = (colors: Theme['colors']) =>
   StyleSheet.create({
     container: {
-      backgroundColor: colors.background.alternative,
+      backgroundColor: colors.background.muted,
       paddingVertical: 8,
       paddingHorizontal: 10,
       borderRadius: 100,
@@ -28,10 +32,7 @@ const createStyles = (colors: Theme['colors']) =>
       justifyContent: 'center',
     },
     caretDown: {
-      textAlign: 'right',
-      color: colors.text.alternative,
-      marginLeft: 10,
-      marginRight: 5,
+      marginHorizontal: 5,
     },
   });
 
@@ -48,7 +49,12 @@ const SelectorButton: React.FC<SelectorButtonProps & TouchableOpacityProps> = ({
     <TouchableOpacity onPress={onPress} disabled={disabled} {...props}>
       <View style={styles.container}>
         <>{children}</>
-        <Icon name="caret-down" size={18} style={styles.caretDown} />
+        <Icon
+          name={IconName.ArrowDown}
+          size={IconSize.Sm}
+          color={IconColor.Alternative}
+          style={styles.caretDown}
+        />
       </View>
     </TouchableOpacity>
   );

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.styles.ts
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.styles.ts
@@ -23,7 +23,7 @@ const styleSheet = (params: { theme: Theme }) => {
       left: 0,
       right: 0,
       paddingBottom: 50,
-      backgroundColor: colors.background.alternative,
+      backgroundColor: colors.background.section,
     },
     keypad: {
       paddingHorizontal: 16,

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -31,7 +31,6 @@ import useAddressBalance from '../../../../../hooks/useAddressBalance/useAddress
 import { Asset } from '../../../../../hooks/useAddressBalance/useAddressBalance.types';
 
 import BaseSelectorButton from '../../../../../Base/SelectorButton';
-import StyledButton from '../../../../StyledButton';
 
 import ScreenLayout from '../../components/ScreenLayout';
 import Row from '../../components/Row';
@@ -92,6 +91,11 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../../component-library/components/Buttons/Button';
 import { BuildQuoteSelectors } from '../../../../../../../e2e/selectors/Ramps/BuildQuote.selectors';
 
 import { isNonEvmAddress } from '../../../../../../core/Multichain/utils';
@@ -1101,15 +1105,15 @@ const BuildQuote = () => {
       <ScreenLayout.Footer>
         <ScreenLayout.Content>
           <Row style={styles.cta}>
-            <StyledButton
-              type="confirm"
+            <Button
+              size={ButtonSize.Lg}
               onPress={handleGetQuotePress}
+              label={strings('fiat_on_ramp_aggregator.get_quotes')}
+              variant={ButtonVariants.Primary}
+              width={ButtonWidthTypes.Full}
+              isDisabled={amountNumber <= 0 || isFetching}
               accessibilityRole="button"
-              accessible
-              disabled={amountNumber <= 0 || isFetching}
-            >
-              {strings('fiat_on_ramp_aggregator.get_quotes')}
-            </StyledButton>
+            />
           </Row>
         </ScreenLayout.Content>
       </ScreenLayout.Footer>
@@ -1137,14 +1141,14 @@ const BuildQuote = () => {
           }
         />
         <ScreenLayout.Content>
-          <StyledButton
-            type="confirm"
+          <Button
+            size={ButtonSize.Lg}
             onPress={handleKeypadDone}
+            label={strings('fiat_on_ramp_aggregator.done')}
+            variant={ButtonVariants.Primary}
+            width={ButtonWidthTypes.Full}
             accessibilityRole="button"
-            accessible
-          >
-            {strings('fiat_on_ramp_aggregator.done')}
-          </StyledButton>
+          />
         </ScreenLayout.Content>
       </Animated.View>
     </ScreenLayout>

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -630,7 +630,7 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -676,32 +676,20 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                         }
                                       }
                                     />
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                                 <View
@@ -721,7 +709,7 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -746,32 +734,20 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                     >
                                       🇨🇱
                                     </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                               </View>
@@ -801,9 +777,8 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -1019,117 +994,46 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                           }
                                           testID="listitemcolumn"
                                         >
-                                          <View>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "display": "flex",
+                                                  "flexDirection": "row",
+                                                },
+                                                undefined,
+                                              ]
+                                            }
+                                          >
                                             <Text
+                                              accessibilityRole="text"
                                               style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "Geist Bold",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
                                               }
                                             >
-                                              <Text
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#121314",
-                                                      "fontFamily": "Geist Regular",
-                                                      "fontSize": 30,
-                                                      "marginVertical": 2,
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "fontFamily": "Geist Bold",
-                                                    },
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                ETH
-                                              </Text>
-                                                
-                                              <Text
-                                                allowFontScaling={false}
-                                                selectable={false}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": undefined,
-                                                      "fontSize": 16,
-                                                    },
-                                                    {
-                                                      "color": "#121314",
-                                                      "marginLeft": 10,
-                                                    },
-                                                    {
-                                                      "fontFamily": "Entypo",
-                                                      "fontStyle": "normal",
-                                                      "fontWeight": "normal",
-                                                    },
-                                                    {},
-                                                  ]
-                                                }
-                                              >
-                                                
-                                              </Text>
+                                              ETH
                                             </Text>
+                                            <SvgMock
+                                              color="#686e7d"
+                                              fill="currentColor"
+                                              height={16}
+                                              name="ArrowDown"
+                                              style={
+                                                {
+                                                  "height": 16,
+                                                  "marginLeft": 8,
+                                                  "width": 16,
+                                                }
+                                              }
+                                              width={16}
+                                            />
                                           </View>
                                         </View>
                                       </View>
@@ -1192,9 +1096,8 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -1297,117 +1200,46 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                           onPress={[Function]}
                                           testID="select-currency"
                                         >
-                                          <View>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "display": "flex",
+                                                  "flexDirection": "row",
+                                                },
+                                                undefined,
+                                              ]
+                                            }
+                                          >
                                             <Text
+                                              accessibilityRole="text"
                                               style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "Geist Bold",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
                                               }
                                             >
-                                              <Text
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#121314",
-                                                      "fontFamily": "Geist Regular",
-                                                      "fontSize": 30,
-                                                      "marginVertical": 2,
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "fontFamily": "Geist Bold",
-                                                    },
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                USD
-                                              </Text>
-                                                
-                                              <Text
-                                                allowFontScaling={false}
-                                                selectable={false}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": undefined,
-                                                      "fontSize": 16,
-                                                    },
-                                                    {
-                                                      "color": "#121314",
-                                                      "marginLeft": 10,
-                                                    },
-                                                    {
-                                                      "fontFamily": "Entypo",
-                                                      "fontStyle": "normal",
-                                                      "fontWeight": "normal",
-                                                    },
-                                                    {},
-                                                  ]
-                                                }
-                                              >
-                                                
-                                              </Text>
+                                              USD
                                             </Text>
+                                            <SvgMock
+                                              color="#686e7d"
+                                              fill="currentColor"
+                                              height={16}
+                                              name="ArrowDown"
+                                              style={
+                                                {
+                                                  "height": 16,
+                                                  "marginLeft": 8,
+                                                  "width": 16,
+                                                }
+                                              }
+                                              width={16}
+                                            />
                                           </View>
                                         </TouchableOpacity>
                                       </View>
@@ -1484,9 +1316,8 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                     style={
                                       [
                                         {
-                                          "borderColor": "#b7bbc8",
+                                          "backgroundColor": "#3c4d9d0f",
                                           "borderRadius": 8,
-                                          "borderWidth": 1.5,
                                           "padding": 16,
                                         },
                                         undefined,
@@ -1586,117 +1417,46 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                           }
                                           testID="listitem-gap"
                                         />
-                                        <View>
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "alignItems": "center",
+                                                "display": "flex",
+                                                "flexDirection": "row",
+                                              },
+                                              undefined,
+                                            ]
+                                          }
+                                        >
                                           <Text
+                                            accessibilityRole="text"
                                             style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist Regular",
-                                                  "fontSize": 30,
-                                                  "marginVertical": 2,
-                                                },
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                {
-                                                  "color": "#121314",
-                                                },
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                {
-                                                  "color": "#121314",
-                                                },
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                              ]
+                                              {
+                                                "color": "#121314",
+                                                "fontFamily": "Geist Bold",
+                                                "fontSize": 16,
+                                                "letterSpacing": 0,
+                                                "lineHeight": 24,
+                                              }
                                             }
                                           >
-                                            <Text
-                                              style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "fontFamily": "Geist Bold",
-                                                  },
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
-                                              }
-                                            >
-                                              Change
-                                            </Text>
-                                              
-                                            <Text
-                                              allowFontScaling={false}
-                                              selectable={false}
-                                              style={
-                                                [
-                                                  {
-                                                    "color": undefined,
-                                                    "fontSize": 16,
-                                                  },
-                                                  {
-                                                    "color": "#121314",
-                                                    "marginLeft": 10,
-                                                  },
-                                                  {
-                                                    "fontFamily": "Entypo",
-                                                    "fontStyle": "normal",
-                                                    "fontWeight": "normal",
-                                                  },
-                                                  {},
-                                                ]
-                                              }
-                                            >
-                                              
-                                            </Text>
+                                            Change
                                           </Text>
+                                          <SvgMock
+                                            color="#686e7d"
+                                            fill="currentColor"
+                                            height={16}
+                                            name="ArrowDown"
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "marginLeft": 8,
+                                                "width": 16,
+                                              }
+                                            }
+                                            width={16}
+                                          />
                                         </View>
                                       </View>
                                     </View>
@@ -1799,53 +1559,34 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                 accessible={true}
                                 activeOpacity={1}
                                 disabled={true}
+                                onPress={[Function]}
+                                onPressIn={[Function]}
+                                onPressOut={[Function]}
                                 style={
-                                  [
-                                    [
-                                      {
-                                        "borderRadius": 12,
-                                        "justifyContent": "center",
-                                        "padding": 15,
-                                      },
-                                      {
-                                        "backgroundColor": "#4459ff",
-                                        "minHeight": 50,
-                                      },
-                                      undefined,
-                                    ],
-                                    {
-                                      "opacity": 0.6,
-                                    },
-                                  ]
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "stretch",
+                                    "backgroundColor": "#121314",
+                                    "borderRadius": 12,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "opacity": 0.5,
+                                    "overflow": "hidden",
+                                    "paddingHorizontal": 16,
+                                  }
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
-                                    [
-                                      {
-                                        "color": "#007aff",
-                                        "fontSize": 17,
-                                        "fontWeight": "500",
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#dcdcdc",
-                                      },
-                                      [
-                                        {
-                                          "fontFamily": "Geist Bold",
-                                          "fontSize": 14,
-                                          "textAlign": "center",
-                                        },
-                                        {
-                                          "color": "#ffffff",
-                                        },
-                                        undefined,
-                                      ],
-                                      {
-                                        "opacity": 0.6,
-                                      },
-                                    ]
+                                    {
+                                      "color": "#ffffff",
+                                      "fontFamily": "Geist Medium",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
                                   }
                                 >
                                   Get quotes
@@ -1887,8 +1628,8 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                             <RCTScrollView
                               contentContainerStyle={
                                 {
-                                  "paddingLeft": 25,
-                                  "paddingRight": 25,
+                                  "paddingLeft": 16,
+                                  "paddingRight": 16,
                                 }
                               }
                               horizontal={true}
@@ -1898,62 +1639,38 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $100
@@ -1962,62 +1679,38 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $500
@@ -2026,62 +1719,38 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $1000
@@ -2798,49 +2467,34 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                             <TouchableOpacity
                               accessibilityRole="button"
                               accessible={true}
-                              activeOpacity={0.2}
+                              activeOpacity={1}
                               onPress={[Function]}
+                              onPressIn={[Function]}
+                              onPressOut={[Function]}
                               style={
-                                [
-                                  [
-                                    {
-                                      "borderRadius": 12,
-                                      "justifyContent": "center",
-                                      "padding": 15,
-                                    },
-                                    {
-                                      "backgroundColor": "#4459ff",
-                                      "minHeight": 50,
-                                    },
-                                    undefined,
-                                  ],
-                                  null,
-                                ]
+                                {
+                                  "alignItems": "center",
+                                  "alignSelf": "stretch",
+                                  "backgroundColor": "#121314",
+                                  "borderRadius": 12,
+                                  "flexDirection": "row",
+                                  "height": 48,
+                                  "justifyContent": "center",
+                                  "overflow": "hidden",
+                                  "paddingHorizontal": 16,
+                                }
                               }
                             >
                               <Text
+                                accessibilityRole="text"
                                 style={
-                                  [
-                                    {
-                                      "color": "#007aff",
-                                      "fontSize": 17,
-                                      "fontWeight": "500",
-                                      "textAlign": "center",
-                                    },
-                                    null,
-                                    [
-                                      {
-                                        "fontFamily": "Geist Bold",
-                                        "fontSize": 14,
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#ffffff",
-                                      },
-                                      undefined,
-                                    ],
-                                    null,
-                                  ]
+                                  {
+                                    "color": "#ffffff",
+                                    "fontFamily": "Geist Medium",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
                                 }
                               >
                                 Done
@@ -3556,49 +3210,34 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Change payment method
@@ -4219,49 +3858,34 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Change cash destination
@@ -4979,49 +4603,34 @@ exports[`BuildQuote View Crypto Currency Data renders an error page when there i
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Try again
@@ -5675,7 +5284,7 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -5721,32 +5330,20 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                         }
                                       }
                                     />
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                                 <View
@@ -5766,7 +5363,7 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -5791,32 +5388,20 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                     >
                                       🇨🇱
                                     </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                               </View>
@@ -5844,9 +5429,8 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -5889,12 +5473,12 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                               [
                                                 {
                                                   "alignItems": "center",
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 9999,
-                                                  "height": 40,
+                                                  "height": 48,
                                                   "justifyContent": "center",
                                                   "overflow": "hidden",
-                                                  "width": 40,
+                                                  "width": 48,
                                                 },
                                                 undefined,
                                               ]
@@ -5922,7 +5506,7 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -5967,7 +5551,7 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -6012,7 +5596,7 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                   style={
                                     [
                                       {
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#858b9a14",
                                         "borderRadius": 30,
                                         "padding": 14,
                                       },
@@ -6062,9 +5646,8 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -6167,117 +5750,46 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                           onPress={[Function]}
                                           testID="select-currency"
                                         >
-                                          <View>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "display": "flex",
+                                                  "flexDirection": "row",
+                                                },
+                                                undefined,
+                                              ]
+                                            }
+                                          >
                                             <Text
+                                              accessibilityRole="text"
                                               style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "Geist Bold",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
                                               }
                                             >
-                                              <Text
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#121314",
-                                                      "fontFamily": "Geist Regular",
-                                                      "fontSize": 30,
-                                                      "marginVertical": 2,
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "fontFamily": "Geist Bold",
-                                                    },
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                USD
-                                              </Text>
-                                                
-                                              <Text
-                                                allowFontScaling={false}
-                                                selectable={false}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": undefined,
-                                                      "fontSize": 16,
-                                                    },
-                                                    {
-                                                      "color": "#121314",
-                                                      "marginLeft": 10,
-                                                    },
-                                                    {
-                                                      "fontFamily": "Entypo",
-                                                      "fontStyle": "normal",
-                                                      "fontWeight": "normal",
-                                                    },
-                                                    {},
-                                                  ]
-                                                }
-                                              >
-                                                
-                                              </Text>
+                                              USD
                                             </Text>
+                                            <SvgMock
+                                              color="#686e7d"
+                                              fill="currentColor"
+                                              height={16}
+                                              name="ArrowDown"
+                                              style={
+                                                {
+                                                  "height": 16,
+                                                  "marginLeft": 8,
+                                                  "width": 16,
+                                                }
+                                              }
+                                              width={16}
+                                            />
                                           </View>
                                         </TouchableOpacity>
                                       </View>
@@ -6352,9 +5864,8 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                     style={
                                       [
                                         {
-                                          "borderColor": "#b7bbc8",
+                                          "backgroundColor": "#3c4d9d0f",
                                           "borderRadius": 8,
-                                          "borderWidth": 1.5,
                                           "padding": 16,
                                         },
                                         undefined,
@@ -6395,7 +5906,7 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -6440,7 +5951,7 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -6486,7 +5997,7 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                         style={
                                           [
                                             {
-                                              "backgroundColor": "#f3f5f9",
+                                              "backgroundColor": "#858b9a14",
                                               "borderRadius": 30,
                                               "padding": 14,
                                             },
@@ -6548,53 +6059,34 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                 accessible={true}
                                 activeOpacity={1}
                                 disabled={true}
+                                onPress={[Function]}
+                                onPressIn={[Function]}
+                                onPressOut={[Function]}
                                 style={
-                                  [
-                                    [
-                                      {
-                                        "borderRadius": 12,
-                                        "justifyContent": "center",
-                                        "padding": 15,
-                                      },
-                                      {
-                                        "backgroundColor": "#4459ff",
-                                        "minHeight": 50,
-                                      },
-                                      undefined,
-                                    ],
-                                    {
-                                      "opacity": 0.6,
-                                    },
-                                  ]
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "stretch",
+                                    "backgroundColor": "#121314",
+                                    "borderRadius": 12,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "opacity": 0.5,
+                                    "overflow": "hidden",
+                                    "paddingHorizontal": 16,
+                                  }
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
-                                    [
-                                      {
-                                        "color": "#007aff",
-                                        "fontSize": 17,
-                                        "fontWeight": "500",
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#dcdcdc",
-                                      },
-                                      [
-                                        {
-                                          "fontFamily": "Geist Bold",
-                                          "fontSize": 14,
-                                          "textAlign": "center",
-                                        },
-                                        {
-                                          "color": "#ffffff",
-                                        },
-                                        undefined,
-                                      ],
-                                      {
-                                        "opacity": 0.6,
-                                      },
-                                    ]
+                                    {
+                                      "color": "#ffffff",
+                                      "fontFamily": "Geist Medium",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
                                   }
                                 >
                                   Get quotes
@@ -6636,8 +6128,8 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                             <RCTScrollView
                               contentContainerStyle={
                                 {
-                                  "paddingLeft": 25,
-                                  "paddingRight": 25,
+                                  "paddingLeft": 16,
+                                  "paddingRight": 16,
                                 }
                               }
                               horizontal={true}
@@ -6647,62 +6139,38 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $100
@@ -6711,62 +6179,38 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $500
@@ -6775,62 +6219,38 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $1000
@@ -7547,49 +6967,34 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                             <TouchableOpacity
                               accessibilityRole="button"
                               accessible={true}
-                              activeOpacity={0.2}
+                              activeOpacity={1}
                               onPress={[Function]}
+                              onPressIn={[Function]}
+                              onPressOut={[Function]}
                               style={
-                                [
-                                  [
-                                    {
-                                      "borderRadius": 12,
-                                      "justifyContent": "center",
-                                      "padding": 15,
-                                    },
-                                    {
-                                      "backgroundColor": "#4459ff",
-                                      "minHeight": 50,
-                                    },
-                                    undefined,
-                                  ],
-                                  null,
-                                ]
+                                {
+                                  "alignItems": "center",
+                                  "alignSelf": "stretch",
+                                  "backgroundColor": "#121314",
+                                  "borderRadius": 12,
+                                  "flexDirection": "row",
+                                  "height": 48,
+                                  "justifyContent": "center",
+                                  "overflow": "hidden",
+                                  "paddingHorizontal": 16,
+                                }
                               }
                             >
                               <Text
+                                accessibilityRole="text"
                                 style={
-                                  [
-                                    {
-                                      "color": "#007aff",
-                                      "fontSize": 17,
-                                      "fontWeight": "500",
-                                      "textAlign": "center",
-                                    },
-                                    null,
-                                    [
-                                      {
-                                        "fontFamily": "Geist Bold",
-                                        "fontSize": 14,
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#ffffff",
-                                      },
-                                      undefined,
-                                    ],
-                                    null,
-                                  ]
+                                  {
+                                    "color": "#ffffff",
+                                    "fontFamily": "Geist Medium",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
                                 }
                               >
                                 Done
@@ -8305,49 +7710,34 @@ exports[`BuildQuote View Fiat Currency Data renders an error page when there is 
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Try again
@@ -9001,7 +8391,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -9047,32 +8437,20 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                         }
                                       }
                                     />
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                                 <View
@@ -9092,7 +8470,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -9117,32 +8495,20 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                     >
                                       🇨🇱
                                     </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                               </View>
@@ -9170,9 +8536,8 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -9215,12 +8580,12 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                               [
                                                 {
                                                   "alignItems": "center",
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 9999,
-                                                  "height": 40,
+                                                  "height": 48,
                                                   "justifyContent": "center",
                                                   "overflow": "hidden",
-                                                  "width": 40,
+                                                  "width": 48,
                                                 },
                                                 undefined,
                                               ]
@@ -9248,7 +8613,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -9293,7 +8658,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -9338,7 +8703,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                   style={
                                     [
                                       {
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#858b9a14",
                                         "borderRadius": 30,
                                         "padding": 14,
                                       },
@@ -9388,9 +8753,8 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -9445,7 +8809,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -9492,7 +8856,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                           style={
                                             [
                                               {
-                                                "backgroundColor": "#f3f5f9",
+                                                "backgroundColor": "#858b9a14",
                                                 "borderRadius": 30,
                                                 "padding": 14,
                                               },
@@ -9587,9 +8951,8 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                     style={
                                       [
                                         {
-                                          "borderColor": "#b7bbc8",
+                                          "backgroundColor": "#3c4d9d0f",
                                           "borderRadius": 8,
-                                          "borderWidth": 1.5,
                                           "padding": 16,
                                         },
                                         undefined,
@@ -9630,7 +8993,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -9675,7 +9038,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -9721,7 +9084,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                         style={
                                           [
                                             {
-                                              "backgroundColor": "#f3f5f9",
+                                              "backgroundColor": "#858b9a14",
                                               "borderRadius": 30,
                                               "padding": 14,
                                             },
@@ -9783,53 +9146,34 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                 accessible={true}
                                 activeOpacity={1}
                                 disabled={true}
+                                onPress={[Function]}
+                                onPressIn={[Function]}
+                                onPressOut={[Function]}
                                 style={
-                                  [
-                                    [
-                                      {
-                                        "borderRadius": 12,
-                                        "justifyContent": "center",
-                                        "padding": 15,
-                                      },
-                                      {
-                                        "backgroundColor": "#4459ff",
-                                        "minHeight": 50,
-                                      },
-                                      undefined,
-                                    ],
-                                    {
-                                      "opacity": 0.6,
-                                    },
-                                  ]
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "stretch",
+                                    "backgroundColor": "#121314",
+                                    "borderRadius": 12,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "opacity": 0.5,
+                                    "overflow": "hidden",
+                                    "paddingHorizontal": 16,
+                                  }
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
-                                    [
-                                      {
-                                        "color": "#007aff",
-                                        "fontSize": 17,
-                                        "fontWeight": "500",
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#dcdcdc",
-                                      },
-                                      [
-                                        {
-                                          "fontFamily": "Geist Bold",
-                                          "fontSize": 14,
-                                          "textAlign": "center",
-                                        },
-                                        {
-                                          "color": "#ffffff",
-                                        },
-                                        undefined,
-                                      ],
-                                      {
-                                        "opacity": 0.6,
-                                      },
-                                    ]
+                                    {
+                                      "color": "#ffffff",
+                                      "fontFamily": "Geist Medium",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
                                   }
                                 >
                                   Get quotes
@@ -9871,8 +9215,8 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                             <RCTScrollView
                               contentContainerStyle={
                                 {
-                                  "paddingLeft": 25,
-                                  "paddingRight": 25,
+                                  "paddingLeft": 16,
+                                  "paddingRight": 16,
                                 }
                               }
                               horizontal={true}
@@ -9882,62 +9226,38 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $100
@@ -9946,62 +9266,38 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $500
@@ -10010,62 +9306,38 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $1000
@@ -10782,49 +10054,34 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                             <TouchableOpacity
                               accessibilityRole="button"
                               accessible={true}
-                              activeOpacity={0.2}
+                              activeOpacity={1}
                               onPress={[Function]}
+                              onPressIn={[Function]}
+                              onPressOut={[Function]}
                               style={
-                                [
-                                  [
-                                    {
-                                      "borderRadius": 12,
-                                      "justifyContent": "center",
-                                      "padding": 15,
-                                    },
-                                    {
-                                      "backgroundColor": "#4459ff",
-                                      "minHeight": 50,
-                                    },
-                                    undefined,
-                                  ],
-                                  null,
-                                ]
+                                {
+                                  "alignItems": "center",
+                                  "alignSelf": "stretch",
+                                  "backgroundColor": "#121314",
+                                  "borderRadius": 12,
+                                  "flexDirection": "row",
+                                  "height": 48,
+                                  "justifyContent": "center",
+                                  "overflow": "hidden",
+                                  "paddingHorizontal": 16,
+                                }
                               }
                             >
                               <Text
+                                accessibilityRole="text"
                                 style={
-                                  [
-                                    {
-                                      "color": "#007aff",
-                                      "fontSize": 17,
-                                      "fontWeight": "500",
-                                      "textAlign": "center",
-                                    },
-                                    null,
-                                    [
-                                      {
-                                        "fontFamily": "Geist Bold",
-                                        "fontSize": 14,
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#ffffff",
-                                      },
-                                      undefined,
-                                    ],
-                                    null,
-                                  ]
+                                  {
+                                    "color": "#ffffff",
+                                    "fontFamily": "Geist Medium",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
                                 }
                               >
                                 Done
@@ -11540,49 +10797,34 @@ exports[`BuildQuote View Payment Method Data renders an error page when there is
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Try again
@@ -12236,7 +11478,7 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -12282,32 +11524,20 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                         }
                                       }
                                     />
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                                 <View
@@ -12327,7 +11557,7 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -12352,32 +11582,20 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                     >
                                       🇨🇱
                                     </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                               </View>
@@ -12407,9 +11625,8 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -12625,117 +11842,46 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                           }
                                           testID="listitemcolumn"
                                         >
-                                          <View>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "display": "flex",
+                                                  "flexDirection": "row",
+                                                },
+                                                undefined,
+                                              ]
+                                            }
+                                          >
                                             <Text
+                                              accessibilityRole="text"
                                               style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "Geist Bold",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
                                               }
                                             >
-                                              <Text
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#121314",
-                                                      "fontFamily": "Geist Regular",
-                                                      "fontSize": 30,
-                                                      "marginVertical": 2,
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "fontFamily": "Geist Bold",
-                                                    },
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                ETH
-                                              </Text>
-                                                
-                                              <Text
-                                                allowFontScaling={false}
-                                                selectable={false}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": undefined,
-                                                      "fontSize": 16,
-                                                    },
-                                                    {
-                                                      "color": "#121314",
-                                                      "marginLeft": 10,
-                                                    },
-                                                    {
-                                                      "fontFamily": "Entypo",
-                                                      "fontStyle": "normal",
-                                                      "fontWeight": "normal",
-                                                    },
-                                                    {},
-                                                  ]
-                                                }
-                                              >
-                                                
-                                              </Text>
+                                              ETH
                                             </Text>
+                                            <SvgMock
+                                              color="#686e7d"
+                                              fill="currentColor"
+                                              height={16}
+                                              name="ArrowDown"
+                                              style={
+                                                {
+                                                  "height": 16,
+                                                  "marginLeft": 8,
+                                                  "width": 16,
+                                                }
+                                              }
+                                              width={16}
+                                            />
                                           </View>
                                         </View>
                                       </View>
@@ -12798,9 +11944,8 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -12903,117 +12048,46 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                           onPress={[Function]}
                                           testID="select-currency"
                                         >
-                                          <View>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "display": "flex",
+                                                  "flexDirection": "row",
+                                                },
+                                                undefined,
+                                              ]
+                                            }
+                                          >
                                             <Text
+                                              accessibilityRole="text"
                                               style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "Geist Bold",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
                                               }
                                             >
-                                              <Text
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#121314",
-                                                      "fontFamily": "Geist Regular",
-                                                      "fontSize": 30,
-                                                      "marginVertical": 2,
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "fontFamily": "Geist Bold",
-                                                    },
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                USD
-                                              </Text>
-                                                
-                                              <Text
-                                                allowFontScaling={false}
-                                                selectable={false}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": undefined,
-                                                      "fontSize": 16,
-                                                    },
-                                                    {
-                                                      "color": "#121314",
-                                                      "marginLeft": 10,
-                                                    },
-                                                    {
-                                                      "fontFamily": "Entypo",
-                                                      "fontStyle": "normal",
-                                                      "fontWeight": "normal",
-                                                    },
-                                                    {},
-                                                  ]
-                                                }
-                                              >
-                                                
-                                              </Text>
+                                              USD
                                             </Text>
+                                            <SvgMock
+                                              color="#686e7d"
+                                              fill="currentColor"
+                                              height={16}
+                                              name="ArrowDown"
+                                              style={
+                                                {
+                                                  "height": 16,
+                                                  "marginLeft": 8,
+                                                  "width": 16,
+                                                }
+                                              }
+                                              width={16}
+                                            />
                                           </View>
                                         </TouchableOpacity>
                                       </View>
@@ -13090,9 +12164,8 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                     style={
                                       [
                                         {
-                                          "borderColor": "#b7bbc8",
+                                          "backgroundColor": "#3c4d9d0f",
                                           "borderRadius": 8,
-                                          "borderWidth": 1.5,
                                           "padding": 16,
                                         },
                                         undefined,
@@ -13192,117 +12265,46 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                           }
                                           testID="listitem-gap"
                                         />
-                                        <View>
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "alignItems": "center",
+                                                "display": "flex",
+                                                "flexDirection": "row",
+                                              },
+                                              undefined,
+                                            ]
+                                          }
+                                        >
                                           <Text
+                                            accessibilityRole="text"
                                             style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist Regular",
-                                                  "fontSize": 30,
-                                                  "marginVertical": 2,
-                                                },
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                {
-                                                  "color": "#121314",
-                                                },
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                {
-                                                  "color": "#121314",
-                                                },
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                              ]
+                                              {
+                                                "color": "#121314",
+                                                "fontFamily": "Geist Bold",
+                                                "fontSize": 16,
+                                                "letterSpacing": 0,
+                                                "lineHeight": 24,
+                                              }
                                             }
                                           >
-                                            <Text
-                                              style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "fontFamily": "Geist Bold",
-                                                  },
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
-                                              }
-                                            >
-                                              Change
-                                            </Text>
-                                              
-                                            <Text
-                                              allowFontScaling={false}
-                                              selectable={false}
-                                              style={
-                                                [
-                                                  {
-                                                    "color": undefined,
-                                                    "fontSize": 16,
-                                                  },
-                                                  {
-                                                    "color": "#121314",
-                                                    "marginLeft": 10,
-                                                  },
-                                                  {
-                                                    "fontFamily": "Entypo",
-                                                    "fontStyle": "normal",
-                                                    "fontWeight": "normal",
-                                                  },
-                                                  {},
-                                                ]
-                                              }
-                                            >
-                                              
-                                            </Text>
+                                            Change
                                           </Text>
+                                          <SvgMock
+                                            color="#686e7d"
+                                            fill="currentColor"
+                                            height={16}
+                                            name="ArrowDown"
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "marginLeft": 8,
+                                                "width": 16,
+                                              }
+                                            }
+                                            width={16}
+                                          />
                                         </View>
                                       </View>
                                     </View>
@@ -13362,53 +12364,34 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                 accessible={true}
                                 activeOpacity={1}
                                 disabled={true}
+                                onPress={[Function]}
+                                onPressIn={[Function]}
+                                onPressOut={[Function]}
                                 style={
-                                  [
-                                    [
-                                      {
-                                        "borderRadius": 12,
-                                        "justifyContent": "center",
-                                        "padding": 15,
-                                      },
-                                      {
-                                        "backgroundColor": "#4459ff",
-                                        "minHeight": 50,
-                                      },
-                                      undefined,
-                                    ],
-                                    {
-                                      "opacity": 0.6,
-                                    },
-                                  ]
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "stretch",
+                                    "backgroundColor": "#121314",
+                                    "borderRadius": 12,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "opacity": 0.5,
+                                    "overflow": "hidden",
+                                    "paddingHorizontal": 16,
+                                  }
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
-                                    [
-                                      {
-                                        "color": "#007aff",
-                                        "fontSize": 17,
-                                        "fontWeight": "500",
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#dcdcdc",
-                                      },
-                                      [
-                                        {
-                                          "fontFamily": "Geist Bold",
-                                          "fontSize": 14,
-                                          "textAlign": "center",
-                                        },
-                                        {
-                                          "color": "#ffffff",
-                                        },
-                                        undefined,
-                                      ],
-                                      {
-                                        "opacity": 0.6,
-                                      },
-                                    ]
+                                    {
+                                      "color": "#ffffff",
+                                      "fontFamily": "Geist Medium",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
                                   }
                                 >
                                   Get quotes
@@ -13450,8 +12433,8 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                             <RCTScrollView
                               contentContainerStyle={
                                 {
-                                  "paddingLeft": 25,
-                                  "paddingRight": 25,
+                                  "paddingLeft": 16,
+                                  "paddingRight": 16,
                                 }
                               }
                               horizontal={true}
@@ -13461,62 +12444,38 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $100
@@ -13525,62 +12484,38 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $500
@@ -13589,62 +12524,38 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $1000
@@ -14361,49 +13272,34 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                             <TouchableOpacity
                               accessibilityRole="button"
                               accessible={true}
-                              activeOpacity={0.2}
+                              activeOpacity={1}
                               onPress={[Function]}
+                              onPressIn={[Function]}
+                              onPressOut={[Function]}
                               style={
-                                [
-                                  [
-                                    {
-                                      "borderRadius": 12,
-                                      "justifyContent": "center",
-                                      "padding": 15,
-                                    },
-                                    {
-                                      "backgroundColor": "#4459ff",
-                                      "minHeight": 50,
-                                    },
-                                    undefined,
-                                  ],
-                                  null,
-                                ]
+                                {
+                                  "alignItems": "center",
+                                  "alignSelf": "stretch",
+                                  "backgroundColor": "#121314",
+                                  "borderRadius": 12,
+                                  "flexDirection": "row",
+                                  "height": 48,
+                                  "justifyContent": "center",
+                                  "overflow": "hidden",
+                                  "paddingHorizontal": 16,
+                                }
                               }
                             >
                               <Text
+                                accessibilityRole="text"
                                 style={
-                                  [
-                                    {
-                                      "color": "#007aff",
-                                      "fontSize": 17,
-                                      "fontWeight": "500",
-                                      "textAlign": "center",
-                                    },
-                                    null,
-                                    [
-                                      {
-                                        "fontFamily": "Geist Bold",
-                                        "fontSize": 14,
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#ffffff",
-                                      },
-                                      undefined,
-                                    ],
-                                    null,
-                                  ]
+                                  {
+                                    "color": "#ffffff",
+                                    "fontFamily": "Geist Medium",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
                                 }
                               >
                                 Done
@@ -15055,7 +13951,7 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -15101,32 +13997,20 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                         }
                                       }
                                     />
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                                 <View
@@ -15146,7 +14030,7 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -15171,32 +14055,20 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                     >
                                       🇨🇱
                                     </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                               </View>
@@ -15226,9 +14098,8 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -15444,117 +14315,46 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                           }
                                           testID="listitemcolumn"
                                         >
-                                          <View>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "display": "flex",
+                                                  "flexDirection": "row",
+                                                },
+                                                undefined,
+                                              ]
+                                            }
+                                          >
                                             <Text
+                                              accessibilityRole="text"
                                               style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "Geist Bold",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
                                               }
                                             >
-                                              <Text
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#121314",
-                                                      "fontFamily": "Geist Regular",
-                                                      "fontSize": 30,
-                                                      "marginVertical": 2,
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "fontFamily": "Geist Bold",
-                                                    },
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                ETH
-                                              </Text>
-                                                
-                                              <Text
-                                                allowFontScaling={false}
-                                                selectable={false}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": undefined,
-                                                      "fontSize": 16,
-                                                    },
-                                                    {
-                                                      "color": "#121314",
-                                                      "marginLeft": 10,
-                                                    },
-                                                    {
-                                                      "fontFamily": "Entypo",
-                                                      "fontStyle": "normal",
-                                                      "fontWeight": "normal",
-                                                    },
-                                                    {},
-                                                  ]
-                                                }
-                                              >
-                                                
-                                              </Text>
+                                              ETH
                                             </Text>
+                                            <SvgMock
+                                              color="#686e7d"
+                                              fill="currentColor"
+                                              height={16}
+                                              name="ArrowDown"
+                                              style={
+                                                {
+                                                  "height": 16,
+                                                  "marginLeft": 8,
+                                                  "width": 16,
+                                                }
+                                              }
+                                              width={16}
+                                            />
                                           </View>
                                         </View>
                                       </View>
@@ -15617,9 +14417,8 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -15722,117 +14521,46 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                           onPress={[Function]}
                                           testID="select-currency"
                                         >
-                                          <View>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "display": "flex",
+                                                  "flexDirection": "row",
+                                                },
+                                                undefined,
+                                              ]
+                                            }
+                                          >
                                             <Text
+                                              accessibilityRole="text"
                                               style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "Geist Bold",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
                                               }
                                             >
-                                              <Text
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#121314",
-                                                      "fontFamily": "Geist Regular",
-                                                      "fontSize": 30,
-                                                      "marginVertical": 2,
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "fontFamily": "Geist Bold",
-                                                    },
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                USD
-                                              </Text>
-                                                
-                                              <Text
-                                                allowFontScaling={false}
-                                                selectable={false}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": undefined,
-                                                      "fontSize": 16,
-                                                    },
-                                                    {
-                                                      "color": "#121314",
-                                                      "marginLeft": 10,
-                                                    },
-                                                    {
-                                                      "fontFamily": "Entypo",
-                                                      "fontStyle": "normal",
-                                                      "fontWeight": "normal",
-                                                    },
-                                                    {},
-                                                  ]
-                                                }
-                                              >
-                                                
-                                              </Text>
+                                              USD
                                             </Text>
+                                            <SvgMock
+                                              color="#686e7d"
+                                              fill="currentColor"
+                                              height={16}
+                                              name="ArrowDown"
+                                              style={
+                                                {
+                                                  "height": 16,
+                                                  "marginLeft": 8,
+                                                  "width": 16,
+                                                }
+                                              }
+                                              width={16}
+                                            />
                                           </View>
                                         </TouchableOpacity>
                                       </View>
@@ -15907,9 +14635,8 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                     style={
                                       [
                                         {
-                                          "borderColor": "#b7bbc8",
+                                          "backgroundColor": "#3c4d9d0f",
                                           "borderRadius": 8,
-                                          "borderWidth": 1.5,
                                           "padding": 16,
                                         },
                                         undefined,
@@ -15950,7 +14677,7 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -15995,7 +14722,7 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -16041,7 +14768,7 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                         style={
                                           [
                                             {
-                                              "backgroundColor": "#f3f5f9",
+                                              "backgroundColor": "#858b9a14",
                                               "borderRadius": 30,
                                               "padding": 14,
                                             },
@@ -16103,53 +14830,34 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                 accessible={true}
                                 activeOpacity={1}
                                 disabled={true}
+                                onPress={[Function]}
+                                onPressIn={[Function]}
+                                onPressOut={[Function]}
                                 style={
-                                  [
-                                    [
-                                      {
-                                        "borderRadius": 12,
-                                        "justifyContent": "center",
-                                        "padding": 15,
-                                      },
-                                      {
-                                        "backgroundColor": "#4459ff",
-                                        "minHeight": 50,
-                                      },
-                                      undefined,
-                                    ],
-                                    {
-                                      "opacity": 0.6,
-                                    },
-                                  ]
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "stretch",
+                                    "backgroundColor": "#121314",
+                                    "borderRadius": 12,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "opacity": 0.5,
+                                    "overflow": "hidden",
+                                    "paddingHorizontal": 16,
+                                  }
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
-                                    [
-                                      {
-                                        "color": "#007aff",
-                                        "fontSize": 17,
-                                        "fontWeight": "500",
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#dcdcdc",
-                                      },
-                                      [
-                                        {
-                                          "fontFamily": "Geist Bold",
-                                          "fontSize": 14,
-                                          "textAlign": "center",
-                                        },
-                                        {
-                                          "color": "#ffffff",
-                                        },
-                                        undefined,
-                                      ],
-                                      {
-                                        "opacity": 0.6,
-                                      },
-                                    ]
+                                    {
+                                      "color": "#ffffff",
+                                      "fontFamily": "Geist Medium",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
                                   }
                                 >
                                   Get quotes
@@ -16191,8 +14899,8 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                             <RCTScrollView
                               contentContainerStyle={
                                 {
-                                  "paddingLeft": 25,
-                                  "paddingRight": 25,
+                                  "paddingLeft": 16,
+                                  "paddingRight": 16,
                                 }
                               }
                               horizontal={true}
@@ -16202,62 +14910,38 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $100
@@ -16266,62 +14950,38 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $500
@@ -16330,62 +14990,38 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $1000
@@ -17102,49 +15738,34 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                             <TouchableOpacity
                               accessibilityRole="button"
                               accessible={true}
-                              activeOpacity={0.2}
+                              activeOpacity={1}
                               onPress={[Function]}
+                              onPressIn={[Function]}
+                              onPressOut={[Function]}
                               style={
-                                [
-                                  [
-                                    {
-                                      "borderRadius": 12,
-                                      "justifyContent": "center",
-                                      "padding": 15,
-                                    },
-                                    {
-                                      "backgroundColor": "#4459ff",
-                                      "minHeight": 50,
-                                    },
-                                    undefined,
-                                  ],
-                                  null,
-                                ]
+                                {
+                                  "alignItems": "center",
+                                  "alignSelf": "stretch",
+                                  "backgroundColor": "#121314",
+                                  "borderRadius": 12,
+                                  "flexDirection": "row",
+                                  "height": 48,
+                                  "justifyContent": "center",
+                                  "overflow": "hidden",
+                                  "paddingHorizontal": 16,
+                                }
                               }
                             >
                               <Text
+                                accessibilityRole="text"
                                 style={
-                                  [
-                                    {
-                                      "color": "#007aff",
-                                      "fontSize": 17,
-                                      "fontWeight": "500",
-                                      "textAlign": "center",
-                                    },
-                                    null,
-                                    [
-                                      {
-                                        "fontFamily": "Geist Bold",
-                                        "fontSize": 14,
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#ffffff",
-                                      },
-                                      undefined,
-                                    ],
-                                    null,
-                                  ]
+                                  {
+                                    "color": "#ffffff",
+                                    "fontFamily": "Geist Medium",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
                                 }
                               >
                                 Done
@@ -17860,49 +16481,34 @@ exports[`BuildQuote View Regions data renders an error page when there is a regi
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Try again
@@ -18556,7 +17162,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -18602,32 +17208,20 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                         }
                                       }
                                     />
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                                 <View
@@ -18641,7 +17235,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                   style={
                                     [
                                       {
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#858b9a14",
                                         "borderRadius": 30,
                                         "padding": 14,
                                       },
@@ -18689,9 +17283,8 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -18734,12 +17327,12 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                               [
                                                 {
                                                   "alignItems": "center",
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 9999,
-                                                  "height": 40,
+                                                  "height": 48,
                                                   "justifyContent": "center",
                                                   "overflow": "hidden",
-                                                  "width": 40,
+                                                  "width": 48,
                                                 },
                                                 undefined,
                                               ]
@@ -18767,7 +17360,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -18812,7 +17405,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -18857,7 +17450,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                   style={
                                     [
                                       {
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#858b9a14",
                                         "borderRadius": 30,
                                         "padding": 14,
                                       },
@@ -18907,9 +17500,8 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -18964,7 +17556,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -19011,7 +17603,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                           style={
                                             [
                                               {
-                                                "backgroundColor": "#f3f5f9",
+                                                "backgroundColor": "#858b9a14",
                                                 "borderRadius": 30,
                                                 "padding": 14,
                                               },
@@ -19106,9 +17698,8 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                     style={
                                       [
                                         {
-                                          "borderColor": "#b7bbc8",
+                                          "backgroundColor": "#3c4d9d0f",
                                           "borderRadius": 8,
-                                          "borderWidth": 1.5,
                                           "padding": 16,
                                         },
                                         undefined,
@@ -19149,7 +17740,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -19194,7 +17785,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                             style={
                                               [
                                                 {
-                                                  "backgroundColor": "#f3f5f9",
+                                                  "backgroundColor": "#858b9a14",
                                                   "borderRadius": 30,
                                                   "padding": 14,
                                                 },
@@ -19240,7 +17831,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                         style={
                                           [
                                             {
-                                              "backgroundColor": "#f3f5f9",
+                                              "backgroundColor": "#858b9a14",
                                               "borderRadius": 30,
                                               "padding": 14,
                                             },
@@ -19302,53 +17893,34 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                 accessible={true}
                                 activeOpacity={1}
                                 disabled={true}
+                                onPress={[Function]}
+                                onPressIn={[Function]}
+                                onPressOut={[Function]}
                                 style={
-                                  [
-                                    [
-                                      {
-                                        "borderRadius": 12,
-                                        "justifyContent": "center",
-                                        "padding": 15,
-                                      },
-                                      {
-                                        "backgroundColor": "#4459ff",
-                                        "minHeight": 50,
-                                      },
-                                      undefined,
-                                    ],
-                                    {
-                                      "opacity": 0.6,
-                                    },
-                                  ]
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "stretch",
+                                    "backgroundColor": "#121314",
+                                    "borderRadius": 12,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "opacity": 0.5,
+                                    "overflow": "hidden",
+                                    "paddingHorizontal": 16,
+                                  }
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
-                                    [
-                                      {
-                                        "color": "#007aff",
-                                        "fontSize": 17,
-                                        "fontWeight": "500",
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#dcdcdc",
-                                      },
-                                      [
-                                        {
-                                          "fontFamily": "Geist Bold",
-                                          "fontSize": 14,
-                                          "textAlign": "center",
-                                        },
-                                        {
-                                          "color": "#ffffff",
-                                        },
-                                        undefined,
-                                      ],
-                                      {
-                                        "opacity": 0.6,
-                                      },
-                                    ]
+                                    {
+                                      "color": "#ffffff",
+                                      "fontFamily": "Geist Medium",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
                                   }
                                 >
                                   Get quotes
@@ -19390,8 +17962,8 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                             <RCTScrollView
                               contentContainerStyle={
                                 {
-                                  "paddingLeft": 25,
-                                  "paddingRight": 25,
+                                  "paddingLeft": 16,
+                                  "paddingRight": 16,
                                 }
                               }
                               horizontal={true}
@@ -19401,62 +17973,38 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $100
@@ -19465,62 +18013,38 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $500
@@ -19529,62 +18053,38 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $1000
@@ -20301,49 +18801,34 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                             <TouchableOpacity
                               accessibilityRole="button"
                               accessible={true}
-                              activeOpacity={0.2}
+                              activeOpacity={1}
                               onPress={[Function]}
+                              onPressIn={[Function]}
+                              onPressOut={[Function]}
                               style={
-                                [
-                                  [
-                                    {
-                                      "borderRadius": 12,
-                                      "justifyContent": "center",
-                                      "padding": 15,
-                                    },
-                                    {
-                                      "backgroundColor": "#4459ff",
-                                      "minHeight": 50,
-                                    },
-                                    undefined,
-                                  ],
-                                  null,
-                                ]
+                                {
+                                  "alignItems": "center",
+                                  "alignSelf": "stretch",
+                                  "backgroundColor": "#121314",
+                                  "borderRadius": 12,
+                                  "flexDirection": "row",
+                                  "height": 48,
+                                  "justifyContent": "center",
+                                  "overflow": "hidden",
+                                  "paddingHorizontal": 16,
+                                }
                               }
                             >
                               <Text
+                                accessibilityRole="text"
                                 style={
-                                  [
-                                    {
-                                      "color": "#007aff",
-                                      "fontSize": 17,
-                                      "fontWeight": "500",
-                                      "textAlign": "center",
-                                    },
-                                    null,
-                                    [
-                                      {
-                                        "fontFamily": "Geist Bold",
-                                        "fontSize": 14,
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#ffffff",
-                                      },
-                                      undefined,
-                                    ],
-                                    null,
-                                  ]
+                                  {
+                                    "color": "#ffffff",
+                                    "fontFamily": "Geist Medium",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
                                 }
                               >
                                 Done
@@ -20995,7 +19480,7 @@ exports[`BuildQuote View renders correctly 1`] = `
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -21041,32 +19526,20 @@ exports[`BuildQuote View renders correctly 1`] = `
                                         }
                                       }
                                     />
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                                 <View
@@ -21086,7 +19559,7 @@ exports[`BuildQuote View renders correctly 1`] = `
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -21111,32 +19584,20 @@ exports[`BuildQuote View renders correctly 1`] = `
                                     >
                                       🇨🇱
                                     </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                               </View>
@@ -21166,9 +19627,8 @@ exports[`BuildQuote View renders correctly 1`] = `
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -21384,117 +19844,46 @@ exports[`BuildQuote View renders correctly 1`] = `
                                           }
                                           testID="listitemcolumn"
                                         >
-                                          <View>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "display": "flex",
+                                                  "flexDirection": "row",
+                                                },
+                                                undefined,
+                                              ]
+                                            }
+                                          >
                                             <Text
+                                              accessibilityRole="text"
                                               style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "Geist Bold",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
                                               }
                                             >
-                                              <Text
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#121314",
-                                                      "fontFamily": "Geist Regular",
-                                                      "fontSize": 30,
-                                                      "marginVertical": 2,
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "fontFamily": "Geist Bold",
-                                                    },
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                ETH
-                                              </Text>
-                                                
-                                              <Text
-                                                allowFontScaling={false}
-                                                selectable={false}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": undefined,
-                                                      "fontSize": 16,
-                                                    },
-                                                    {
-                                                      "color": "#121314",
-                                                      "marginLeft": 10,
-                                                    },
-                                                    {
-                                                      "fontFamily": "Entypo",
-                                                      "fontStyle": "normal",
-                                                      "fontWeight": "normal",
-                                                    },
-                                                    {},
-                                                  ]
-                                                }
-                                              >
-                                                
-                                              </Text>
+                                              ETH
                                             </Text>
+                                            <SvgMock
+                                              color="#686e7d"
+                                              fill="currentColor"
+                                              height={16}
+                                              name="ArrowDown"
+                                              style={
+                                                {
+                                                  "height": 16,
+                                                  "marginLeft": 8,
+                                                  "width": 16,
+                                                }
+                                              }
+                                              width={16}
+                                            />
                                           </View>
                                         </View>
                                       </View>
@@ -21557,9 +19946,8 @@ exports[`BuildQuote View renders correctly 1`] = `
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -21662,117 +20050,46 @@ exports[`BuildQuote View renders correctly 1`] = `
                                           onPress={[Function]}
                                           testID="select-currency"
                                         >
-                                          <View>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "display": "flex",
+                                                  "flexDirection": "row",
+                                                },
+                                                undefined,
+                                              ]
+                                            }
+                                          >
                                             <Text
+                                              accessibilityRole="text"
                                               style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "Geist Bold",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
                                               }
                                             >
-                                              <Text
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#121314",
-                                                      "fontFamily": "Geist Regular",
-                                                      "fontSize": 30,
-                                                      "marginVertical": 2,
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "fontFamily": "Geist Bold",
-                                                    },
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                USD
-                                              </Text>
-                                                
-                                              <Text
-                                                allowFontScaling={false}
-                                                selectable={false}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": undefined,
-                                                      "fontSize": 16,
-                                                    },
-                                                    {
-                                                      "color": "#121314",
-                                                      "marginLeft": 10,
-                                                    },
-                                                    {
-                                                      "fontFamily": "Entypo",
-                                                      "fontStyle": "normal",
-                                                      "fontWeight": "normal",
-                                                    },
-                                                    {},
-                                                  ]
-                                                }
-                                              >
-                                                
-                                              </Text>
+                                              USD
                                             </Text>
+                                            <SvgMock
+                                              color="#686e7d"
+                                              fill="currentColor"
+                                              height={16}
+                                              name="ArrowDown"
+                                              style={
+                                                {
+                                                  "height": 16,
+                                                  "marginLeft": 8,
+                                                  "width": 16,
+                                                }
+                                              }
+                                              width={16}
+                                            />
                                           </View>
                                         </TouchableOpacity>
                                       </View>
@@ -21849,9 +20166,8 @@ exports[`BuildQuote View renders correctly 1`] = `
                                     style={
                                       [
                                         {
-                                          "borderColor": "#b7bbc8",
+                                          "backgroundColor": "#3c4d9d0f",
                                           "borderRadius": 8,
-                                          "borderWidth": 1.5,
                                           "padding": 16,
                                         },
                                         undefined,
@@ -21951,117 +20267,46 @@ exports[`BuildQuote View renders correctly 1`] = `
                                           }
                                           testID="listitem-gap"
                                         />
-                                        <View>
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "alignItems": "center",
+                                                "display": "flex",
+                                                "flexDirection": "row",
+                                              },
+                                              undefined,
+                                            ]
+                                          }
+                                        >
                                           <Text
+                                            accessibilityRole="text"
                                             style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist Regular",
-                                                  "fontSize": 30,
-                                                  "marginVertical": 2,
-                                                },
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                {
-                                                  "color": "#121314",
-                                                },
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                {
-                                                  "color": "#121314",
-                                                },
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                              ]
+                                              {
+                                                "color": "#121314",
+                                                "fontFamily": "Geist Bold",
+                                                "fontSize": 16,
+                                                "letterSpacing": 0,
+                                                "lineHeight": 24,
+                                              }
                                             }
                                           >
-                                            <Text
-                                              style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "fontFamily": "Geist Bold",
-                                                  },
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
-                                              }
-                                            >
-                                              Change
-                                            </Text>
-                                              
-                                            <Text
-                                              allowFontScaling={false}
-                                              selectable={false}
-                                              style={
-                                                [
-                                                  {
-                                                    "color": undefined,
-                                                    "fontSize": 16,
-                                                  },
-                                                  {
-                                                    "color": "#121314",
-                                                    "marginLeft": 10,
-                                                  },
-                                                  {
-                                                    "fontFamily": "Entypo",
-                                                    "fontStyle": "normal",
-                                                    "fontWeight": "normal",
-                                                  },
-                                                  {},
-                                                ]
-                                              }
-                                            >
-                                              
-                                            </Text>
+                                            Change
                                           </Text>
+                                          <SvgMock
+                                            color="#686e7d"
+                                            fill="currentColor"
+                                            height={16}
+                                            name="ArrowDown"
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "marginLeft": 8,
+                                                "width": 16,
+                                              }
+                                            }
+                                            width={16}
+                                          />
                                         </View>
                                       </View>
                                     </View>
@@ -22164,53 +20409,34 @@ exports[`BuildQuote View renders correctly 1`] = `
                                 accessible={true}
                                 activeOpacity={1}
                                 disabled={true}
+                                onPress={[Function]}
+                                onPressIn={[Function]}
+                                onPressOut={[Function]}
                                 style={
-                                  [
-                                    [
-                                      {
-                                        "borderRadius": 12,
-                                        "justifyContent": "center",
-                                        "padding": 15,
-                                      },
-                                      {
-                                        "backgroundColor": "#4459ff",
-                                        "minHeight": 50,
-                                      },
-                                      undefined,
-                                    ],
-                                    {
-                                      "opacity": 0.6,
-                                    },
-                                  ]
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "stretch",
+                                    "backgroundColor": "#121314",
+                                    "borderRadius": 12,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "opacity": 0.5,
+                                    "overflow": "hidden",
+                                    "paddingHorizontal": 16,
+                                  }
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
-                                    [
-                                      {
-                                        "color": "#007aff",
-                                        "fontSize": 17,
-                                        "fontWeight": "500",
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#dcdcdc",
-                                      },
-                                      [
-                                        {
-                                          "fontFamily": "Geist Bold",
-                                          "fontSize": 14,
-                                          "textAlign": "center",
-                                        },
-                                        {
-                                          "color": "#ffffff",
-                                        },
-                                        undefined,
-                                      ],
-                                      {
-                                        "opacity": 0.6,
-                                      },
-                                    ]
+                                    {
+                                      "color": "#ffffff",
+                                      "fontFamily": "Geist Medium",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
                                   }
                                 >
                                   Get quotes
@@ -22252,8 +20478,8 @@ exports[`BuildQuote View renders correctly 1`] = `
                             <RCTScrollView
                               contentContainerStyle={
                                 {
-                                  "paddingLeft": 25,
-                                  "paddingRight": 25,
+                                  "paddingLeft": 16,
+                                  "paddingRight": 16,
                                 }
                               }
                               horizontal={true}
@@ -22263,62 +20489,38 @@ exports[`BuildQuote View renders correctly 1`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $100
@@ -22327,62 +20529,38 @@ exports[`BuildQuote View renders correctly 1`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $500
@@ -22391,62 +20569,38 @@ exports[`BuildQuote View renders correctly 1`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     $1000
@@ -23163,49 +21317,34 @@ exports[`BuildQuote View renders correctly 1`] = `
                             <TouchableOpacity
                               accessibilityRole="button"
                               accessible={true}
-                              activeOpacity={0.2}
+                              activeOpacity={1}
                               onPress={[Function]}
+                              onPressIn={[Function]}
+                              onPressOut={[Function]}
                               style={
-                                [
-                                  [
-                                    {
-                                      "borderRadius": 12,
-                                      "justifyContent": "center",
-                                      "padding": 15,
-                                    },
-                                    {
-                                      "backgroundColor": "#4459ff",
-                                      "minHeight": 50,
-                                    },
-                                    undefined,
-                                  ],
-                                  null,
-                                ]
+                                {
+                                  "alignItems": "center",
+                                  "alignSelf": "stretch",
+                                  "backgroundColor": "#121314",
+                                  "borderRadius": 12,
+                                  "flexDirection": "row",
+                                  "height": 48,
+                                  "justifyContent": "center",
+                                  "overflow": "hidden",
+                                  "paddingHorizontal": 16,
+                                }
                               }
                             >
                               <Text
+                                accessibilityRole="text"
                                 style={
-                                  [
-                                    {
-                                      "color": "#007aff",
-                                      "fontSize": 17,
-                                      "fontWeight": "500",
-                                      "textAlign": "center",
-                                    },
-                                    null,
-                                    [
-                                      {
-                                        "fontFamily": "Geist Bold",
-                                        "fontSize": 14,
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#ffffff",
-                                      },
-                                      undefined,
-                                    ],
-                                    null,
-                                  ]
+                                  {
+                                    "color": "#ffffff",
+                                    "fontFamily": "Geist Medium",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
                                 }
                               >
                                 Done
@@ -23760,7 +21899,7 @@ exports[`BuildQuote View renders correctly 2`] = `
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -23806,32 +21945,20 @@ exports[`BuildQuote View renders correctly 2`] = `
                                         }
                                       }
                                     />
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                                 <View
@@ -23851,7 +21978,7 @@ exports[`BuildQuote View renders correctly 2`] = `
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -23876,32 +22003,20 @@ exports[`BuildQuote View renders correctly 2`] = `
                                     >
                                       🇨🇱
                                     </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                                 <View
@@ -23920,7 +22035,7 @@ exports[`BuildQuote View renders correctly 2`] = `
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "backgroundColor": "#f3f5f9",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 100,
                                         "flexDirection": "row",
                                         "justifyContent": "center",
@@ -23943,32 +22058,20 @@ exports[`BuildQuote View renders correctly 2`] = `
                                     >
                                       USD
                                     </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      selectable={false}
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="ArrowDown"
                                       style={
-                                        [
-                                          {
-                                            "color": undefined,
-                                            "fontSize": 18,
-                                          },
-                                          {
-                                            "color": "#686e7d",
-                                            "marginLeft": 10,
-                                            "marginRight": 5,
-                                            "textAlign": "right",
-                                          },
-                                          {
-                                            "fontFamily": "FontAwesome",
-                                            "fontStyle": "normal",
-                                            "fontWeight": "normal",
-                                          },
-                                          {},
-                                        ]
+                                        {
+                                          "height": 16,
+                                          "marginHorizontal": 5,
+                                          "width": 16,
+                                        }
                                       }
-                                    >
-                                      
-                                    </Text>
+                                      width={16}
+                                    />
                                   </View>
                                 </TouchableOpacity>
                               </View>
@@ -23998,9 +22101,8 @@ exports[`BuildQuote View renders correctly 2`] = `
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -24216,117 +22318,46 @@ exports[`BuildQuote View renders correctly 2`] = `
                                           }
                                           testID="listitemcolumn"
                                         >
-                                          <View>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "display": "flex",
+                                                  "flexDirection": "row",
+                                                },
+                                                undefined,
+                                              ]
+                                            }
+                                          >
                                             <Text
+                                              accessibilityRole="text"
                                               style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "Geist Bold",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
                                               }
                                             >
-                                              <Text
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#121314",
-                                                      "fontFamily": "Geist Regular",
-                                                      "fontSize": 30,
-                                                      "marginVertical": 2,
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "fontFamily": "Geist Bold",
-                                                    },
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                ETH
-                                              </Text>
-                                                
-                                              <Text
-                                                allowFontScaling={false}
-                                                selectable={false}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": undefined,
-                                                      "fontSize": 16,
-                                                    },
-                                                    {
-                                                      "color": "#121314",
-                                                      "marginLeft": 10,
-                                                    },
-                                                    {
-                                                      "fontFamily": "Entypo",
-                                                      "fontStyle": "normal",
-                                                      "fontWeight": "normal",
-                                                    },
-                                                    {},
-                                                  ]
-                                                }
-                                              >
-                                                
-                                              </Text>
+                                              ETH
                                             </Text>
+                                            <SvgMock
+                                              color="#686e7d"
+                                              fill="currentColor"
+                                              height={16}
+                                              name="ArrowDown"
+                                              style={
+                                                {
+                                                  "height": 16,
+                                                  "marginLeft": 8,
+                                                  "width": 16,
+                                                }
+                                              }
+                                              width={16}
+                                            />
                                           </View>
                                         </View>
                                       </View>
@@ -24389,9 +22420,8 @@ exports[`BuildQuote View renders correctly 2`] = `
                                   style={
                                     [
                                       {
-                                        "borderColor": "#b7bbc8",
+                                        "backgroundColor": "#3c4d9d0f",
                                         "borderRadius": 8,
-                                        "borderWidth": 1.5,
                                         "padding": 16,
                                       },
                                       undefined,
@@ -24530,9 +22560,8 @@ exports[`BuildQuote View renders correctly 2`] = `
                                     style={
                                       [
                                         {
-                                          "borderColor": "#b7bbc8",
+                                          "backgroundColor": "#3c4d9d0f",
                                           "borderRadius": 8,
-                                          "borderWidth": 1.5,
                                           "padding": 16,
                                         },
                                         undefined,
@@ -24632,117 +22661,46 @@ exports[`BuildQuote View renders correctly 2`] = `
                                           }
                                           testID="listitem-gap"
                                         />
-                                        <View>
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "alignItems": "center",
+                                                "display": "flex",
+                                                "flexDirection": "row",
+                                              },
+                                              undefined,
+                                            ]
+                                          }
+                                        >
                                           <Text
+                                            accessibilityRole="text"
                                             style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist Regular",
-                                                  "fontSize": 30,
-                                                  "marginVertical": 2,
-                                                },
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                {
-                                                  "color": "#121314",
-                                                },
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                {
-                                                  "color": "#121314",
-                                                },
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                                undefined,
-                                              ]
+                                              {
+                                                "color": "#121314",
+                                                "fontFamily": "Geist Bold",
+                                                "fontSize": 16,
+                                                "letterSpacing": 0,
+                                                "lineHeight": 24,
+                                              }
                                             }
                                           >
-                                            <Text
-                                              style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "fontFamily": "Geist Bold",
-                                                  },
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
-                                              }
-                                            >
-                                              Change
-                                            </Text>
-                                              
-                                            <Text
-                                              allowFontScaling={false}
-                                              selectable={false}
-                                              style={
-                                                [
-                                                  {
-                                                    "color": undefined,
-                                                    "fontSize": 16,
-                                                  },
-                                                  {
-                                                    "color": "#121314",
-                                                    "marginLeft": 10,
-                                                  },
-                                                  {
-                                                    "fontFamily": "Entypo",
-                                                    "fontStyle": "normal",
-                                                    "fontWeight": "normal",
-                                                  },
-                                                  {},
-                                                ]
-                                              }
-                                            >
-                                              
-                                            </Text>
+                                            Change
                                           </Text>
+                                          <SvgMock
+                                            color="#686e7d"
+                                            fill="currentColor"
+                                            height={16}
+                                            name="ArrowDown"
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "marginLeft": 8,
+                                                "width": 16,
+                                              }
+                                            }
+                                            width={16}
+                                          />
                                         </View>
                                       </View>
                                     </View>
@@ -24845,53 +22803,34 @@ exports[`BuildQuote View renders correctly 2`] = `
                                 accessible={true}
                                 activeOpacity={1}
                                 disabled={true}
+                                onPress={[Function]}
+                                onPressIn={[Function]}
+                                onPressOut={[Function]}
                                 style={
-                                  [
-                                    [
-                                      {
-                                        "borderRadius": 12,
-                                        "justifyContent": "center",
-                                        "padding": 15,
-                                      },
-                                      {
-                                        "backgroundColor": "#4459ff",
-                                        "minHeight": 50,
-                                      },
-                                      undefined,
-                                    ],
-                                    {
-                                      "opacity": 0.6,
-                                    },
-                                  ]
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "stretch",
+                                    "backgroundColor": "#121314",
+                                    "borderRadius": 12,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "opacity": 0.5,
+                                    "overflow": "hidden",
+                                    "paddingHorizontal": 16,
+                                  }
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
-                                    [
-                                      {
-                                        "color": "#007aff",
-                                        "fontSize": 17,
-                                        "fontWeight": "500",
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#dcdcdc",
-                                      },
-                                      [
-                                        {
-                                          "fontFamily": "Geist Bold",
-                                          "fontSize": 14,
-                                          "textAlign": "center",
-                                        },
-                                        {
-                                          "color": "#ffffff",
-                                        },
-                                        undefined,
-                                      ],
-                                      {
-                                        "opacity": 0.6,
-                                      },
-                                    ]
+                                    {
+                                      "color": "#ffffff",
+                                      "fontFamily": "Geist Medium",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
                                   }
                                 >
                                   Get quotes
@@ -24933,8 +22872,8 @@ exports[`BuildQuote View renders correctly 2`] = `
                             <RCTScrollView
                               contentContainerStyle={
                                 {
-                                  "paddingLeft": 25,
-                                  "paddingRight": 25,
+                                  "paddingLeft": 16,
+                                  "paddingRight": 16,
                                 }
                               }
                               horizontal={true}
@@ -24944,62 +22883,38 @@ exports[`BuildQuote View renders correctly 2`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     25%
@@ -25008,62 +22923,38 @@ exports[`BuildQuote View renders correctly 2`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     50%
@@ -25072,62 +22963,38 @@ exports[`BuildQuote View renders correctly 2`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     75%
@@ -25136,62 +23003,38 @@ exports[`BuildQuote View renders correctly 2`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
                                     {
-                                      "borderColor": "#b7bbc8",
-                                      "borderRadius": 999,
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "marginRight": 5,
                                       "minWidth": 78,
-                                      "padding": 7,
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
                                     }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "Geist Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#686e7d",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "fontSize": 12,
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "marginVertical": 0,
-                                        },
-                                        undefined,
-                                      ]
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     MAX
@@ -25908,49 +23751,34 @@ exports[`BuildQuote View renders correctly 2`] = `
                             <TouchableOpacity
                               accessibilityRole="button"
                               accessible={true}
-                              activeOpacity={0.2}
+                              activeOpacity={1}
                               onPress={[Function]}
+                              onPressIn={[Function]}
+                              onPressOut={[Function]}
                               style={
-                                [
-                                  [
-                                    {
-                                      "borderRadius": 12,
-                                      "justifyContent": "center",
-                                      "padding": 15,
-                                    },
-                                    {
-                                      "backgroundColor": "#4459ff",
-                                      "minHeight": 50,
-                                    },
-                                    undefined,
-                                  ],
-                                  null,
-                                ]
+                                {
+                                  "alignItems": "center",
+                                  "alignSelf": "stretch",
+                                  "backgroundColor": "#121314",
+                                  "borderRadius": 12,
+                                  "flexDirection": "row",
+                                  "height": 48,
+                                  "justifyContent": "center",
+                                  "overflow": "hidden",
+                                  "paddingHorizontal": 16,
+                                }
                               }
                             >
                               <Text
+                                accessibilityRole="text"
                                 style={
-                                  [
-                                    {
-                                      "color": "#007aff",
-                                      "fontSize": 17,
-                                      "fontWeight": "500",
-                                      "textAlign": "center",
-                                    },
-                                    null,
-                                    [
-                                      {
-                                        "fontFamily": "Geist Bold",
-                                        "fontSize": 14,
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "color": "#ffffff",
-                                      },
-                                      undefined,
-                                    ],
-                                    null,
-                                  ]
+                                  {
+                                    "color": "#ffffff",
+                                    "fontFamily": "Geist Medium",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
                                 }
                               >
                                 Done
@@ -26666,49 +24494,34 @@ exports[`BuildQuote View renders correctly when sdkError is present 1`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Return to Home Screen
@@ -27329,49 +25142,34 @@ exports[`BuildQuote View renders correctly when sdkError is present 2`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Return to Home Screen

--- a/app/components/UI/Ramp/Aggregator/Views/Checkout/__snapshots__/Checkout.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Checkout/__snapshots__/Checkout.test.tsx.snap
@@ -1925,49 +1925,34 @@ exports[`Checkout displays sdkError when present 1`] = `
                                       <TouchableOpacity
                                         accessibilityRole="button"
                                         accessible={true}
-                                        activeOpacity={0.2}
+                                        activeOpacity={1}
                                         onPress={[Function]}
+                                        onPressIn={[Function]}
+                                        onPressOut={[Function]}
                                         style={
-                                          [
-                                            [
-                                              {
-                                                "borderRadius": 12,
-                                                "justifyContent": "center",
-                                                "padding": 15,
-                                              },
-                                              {
-                                                "backgroundColor": "#4459ff",
-                                                "minHeight": 50,
-                                              },
-                                              undefined,
-                                            ],
-                                            null,
-                                          ]
+                                          {
+                                            "alignItems": "center",
+                                            "alignSelf": "stretch",
+                                            "backgroundColor": "#121314",
+                                            "borderRadius": 12,
+                                            "flexDirection": "row",
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "overflow": "hidden",
+                                            "paddingHorizontal": 16,
+                                          }
                                         }
                                       >
                                         <Text
+                                          accessibilityRole="text"
                                           style={
-                                            [
-                                              {
-                                                "color": "#007aff",
-                                                "fontSize": 17,
-                                                "fontWeight": "500",
-                                                "textAlign": "center",
-                                              },
-                                              null,
-                                              [
-                                                {
-                                                  "fontFamily": "Geist Bold",
-                                                  "fontSize": 14,
-                                                  "textAlign": "center",
-                                                },
-                                                {
-                                                  "color": "#ffffff",
-                                                },
-                                                undefined,
-                                              ],
-                                              null,
-                                            ]
+                                            {
+                                              "color": "#ffffff",
+                                              "fontFamily": "Geist Medium",
+                                              "fontSize": 16,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
+                                            }
                                           }
                                         >
                                           Return to Home Screen
@@ -3223,49 +3208,34 @@ exports[`Checkout handles get order error gracefully 1`] = `
                                       <TouchableOpacity
                                         accessibilityRole="button"
                                         accessible={true}
-                                        activeOpacity={0.2}
+                                        activeOpacity={1}
                                         onPress={[Function]}
+                                        onPressIn={[Function]}
+                                        onPressOut={[Function]}
                                         style={
-                                          [
-                                            [
-                                              {
-                                                "borderRadius": 12,
-                                                "justifyContent": "center",
-                                                "padding": 15,
-                                              },
-                                              {
-                                                "backgroundColor": "#4459ff",
-                                                "minHeight": 50,
-                                              },
-                                              undefined,
-                                            ],
-                                            null,
-                                          ]
+                                          {
+                                            "alignItems": "center",
+                                            "alignSelf": "stretch",
+                                            "backgroundColor": "#121314",
+                                            "borderRadius": 12,
+                                            "flexDirection": "row",
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "overflow": "hidden",
+                                            "paddingHorizontal": 16,
+                                          }
                                         }
                                       >
                                         <Text
+                                          accessibilityRole="text"
                                           style={
-                                            [
-                                              {
-                                                "color": "#007aff",
-                                                "fontSize": 17,
-                                                "fontWeight": "500",
-                                                "textAlign": "center",
-                                              },
-                                              null,
-                                              [
-                                                {
-                                                  "fontFamily": "Geist Bold",
-                                                  "fontSize": 14,
-                                                  "textAlign": "center",
-                                                },
-                                                {
-                                                  "color": "#ffffff",
-                                                },
-                                                undefined,
-                                              ],
-                                              null,
-                                            ]
+                                            {
+                                              "color": "#ffffff",
+                                              "fontFamily": "Geist Medium",
+                                              "fontSize": 16,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
+                                            }
                                           }
                                         >
                                           Try again
@@ -3978,49 +3948,34 @@ exports[`Checkout handles undefined order gracefully 1`] = `
                                       <TouchableOpacity
                                         accessibilityRole="button"
                                         accessible={true}
-                                        activeOpacity={0.2}
+                                        activeOpacity={1}
                                         onPress={[Function]}
+                                        onPressIn={[Function]}
+                                        onPressOut={[Function]}
                                         style={
-                                          [
-                                            [
-                                              {
-                                                "borderRadius": 12,
-                                                "justifyContent": "center",
-                                                "padding": 15,
-                                              },
-                                              {
-                                                "backgroundColor": "#4459ff",
-                                                "minHeight": 50,
-                                              },
-                                              undefined,
-                                            ],
-                                            null,
-                                          ]
+                                          {
+                                            "alignItems": "center",
+                                            "alignSelf": "stretch",
+                                            "backgroundColor": "#121314",
+                                            "borderRadius": 12,
+                                            "flexDirection": "row",
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "overflow": "hidden",
+                                            "paddingHorizontal": 16,
+                                          }
                                         }
                                       >
                                         <Text
+                                          accessibilityRole="text"
                                           style={
-                                            [
-                                              {
-                                                "color": "#007aff",
-                                                "fontSize": 17,
-                                                "fontWeight": "500",
-                                                "textAlign": "center",
-                                              },
-                                              null,
-                                              [
-                                                {
-                                                  "fontFamily": "Geist Bold",
-                                                  "fontSize": 14,
-                                                  "textAlign": "center",
-                                                },
-                                                {
-                                                  "color": "#ffffff",
-                                                },
-                                                undefined,
-                                              ],
-                                              null,
-                                            ]
+                                            {
+                                              "color": "#ffffff",
+                                              "fontFamily": "Geist Medium",
+                                              "fontSize": 16,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
+                                            }
                                           }
                                         >
                                           Try again
@@ -5276,49 +5231,34 @@ exports[`Checkout sets and displays error on http error in WebView 1`] = `
                                       <TouchableOpacity
                                         accessibilityRole="button"
                                         accessible={true}
-                                        activeOpacity={0.2}
+                                        activeOpacity={1}
                                         onPress={[Function]}
+                                        onPressIn={[Function]}
+                                        onPressOut={[Function]}
                                         style={
-                                          [
-                                            [
-                                              {
-                                                "borderRadius": 12,
-                                                "justifyContent": "center",
-                                                "padding": 15,
-                                              },
-                                              {
-                                                "backgroundColor": "#4459ff",
-                                                "minHeight": 50,
-                                              },
-                                              undefined,
-                                            ],
-                                            null,
-                                          ]
+                                          {
+                                            "alignItems": "center",
+                                            "alignSelf": "stretch",
+                                            "backgroundColor": "#121314",
+                                            "borderRadius": 12,
+                                            "flexDirection": "row",
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "overflow": "hidden",
+                                            "paddingHorizontal": 16,
+                                          }
                                         }
                                       >
                                         <Text
+                                          accessibilityRole="text"
                                           style={
-                                            [
-                                              {
-                                                "color": "#007aff",
-                                                "fontSize": 17,
-                                                "fontWeight": "500",
-                                                "textAlign": "center",
-                                              },
-                                              null,
-                                              [
-                                                {
-                                                  "fontFamily": "Geist Bold",
-                                                  "fontSize": 14,
-                                                  "textAlign": "center",
-                                                },
-                                                {
-                                                  "color": "#ffffff",
-                                                },
-                                                undefined,
-                                              ],
-                                              null,
-                                            ]
+                                            {
+                                              "color": "#ffffff",
+                                              "fontFamily": "Geist Medium",
+                                              "fontSize": 16,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
+                                            }
                                           }
                                         >
                                           Try again
@@ -6031,49 +5971,34 @@ exports[`Checkout sets and displays error on http error in WebView for callback 
                                       <TouchableOpacity
                                         accessibilityRole="button"
                                         accessible={true}
-                                        activeOpacity={0.2}
+                                        activeOpacity={1}
                                         onPress={[Function]}
+                                        onPressIn={[Function]}
+                                        onPressOut={[Function]}
                                         style={
-                                          [
-                                            [
-                                              {
-                                                "borderRadius": 12,
-                                                "justifyContent": "center",
-                                                "padding": 15,
-                                              },
-                                              {
-                                                "backgroundColor": "#4459ff",
-                                                "minHeight": 50,
-                                              },
-                                              undefined,
-                                            ],
-                                            null,
-                                          ]
+                                          {
+                                            "alignItems": "center",
+                                            "alignSelf": "stretch",
+                                            "backgroundColor": "#121314",
+                                            "borderRadius": 12,
+                                            "flexDirection": "row",
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "overflow": "hidden",
+                                            "paddingHorizontal": 16,
+                                          }
                                         }
                                       >
                                         <Text
+                                          accessibilityRole="text"
                                           style={
-                                            [
-                                              {
-                                                "color": "#007aff",
-                                                "fontSize": 17,
-                                                "fontWeight": "500",
-                                                "textAlign": "center",
-                                              },
-                                              null,
-                                              [
-                                                {
-                                                  "fontFamily": "Geist Bold",
-                                                  "fontSize": 14,
-                                                  "textAlign": "center",
-                                                },
-                                                {
-                                                  "color": "#ffffff",
-                                                },
-                                                undefined,
-                                              ],
-                                              null,
-                                            ]
+                                            {
+                                              "color": "#ffffff",
+                                              "fontFamily": "Geist Medium",
+                                              "fontSize": 16,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
+                                            }
                                           }
                                         >
                                           Try again
@@ -6786,49 +6711,34 @@ exports[`Checkout sets error when handling url navigation state change and selec
                                       <TouchableOpacity
                                         accessibilityRole="button"
                                         accessible={true}
-                                        activeOpacity={0.2}
+                                        activeOpacity={1}
                                         onPress={[Function]}
+                                        onPressIn={[Function]}
+                                        onPressOut={[Function]}
                                         style={
-                                          [
-                                            [
-                                              {
-                                                "borderRadius": 12,
-                                                "justifyContent": "center",
-                                                "padding": 15,
-                                              },
-                                              {
-                                                "backgroundColor": "#4459ff",
-                                                "minHeight": 50,
-                                              },
-                                              undefined,
-                                            ],
-                                            null,
-                                          ]
+                                          {
+                                            "alignItems": "center",
+                                            "alignSelf": "stretch",
+                                            "backgroundColor": "#121314",
+                                            "borderRadius": 12,
+                                            "flexDirection": "row",
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "overflow": "hidden",
+                                            "paddingHorizontal": 16,
+                                          }
                                         }
                                       >
                                         <Text
+                                          accessibilityRole="text"
                                           style={
-                                            [
-                                              {
-                                                "color": "#007aff",
-                                                "fontSize": 17,
-                                                "fontWeight": "500",
-                                                "textAlign": "center",
-                                              },
-                                              null,
-                                              [
-                                                {
-                                                  "fontFamily": "Geist Bold",
-                                                  "fontSize": 14,
-                                                  "textAlign": "center",
-                                                },
-                                                {
-                                                  "color": "#ffffff",
-                                                },
-                                                undefined,
-                                              ],
-                                              null,
-                                            ]
+                                            {
+                                              "color": "#ffffff",
+                                              "fontFamily": "Geist Medium",
+                                              "fontSize": 16,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
+                                            }
                                           }
                                         >
                                           Try again

--- a/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
@@ -10,7 +10,11 @@ import useThunkDispatch from '../../../../../hooks/useThunkDispatch';
 import ScreenLayout from '../../components/ScreenLayout';
 import OrderDetail from '../../components/OrderDetails';
 import Row from '../../components/Row';
-import StyledButton from '../../../../StyledButton';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../../component-library/components/Buttons/Button';
 import {
   FiatOrder,
   getOrderById,
@@ -262,27 +266,29 @@ const OrderDetails = () => {
             !order.sellTxHash &&
             order.state === FIAT_ORDER_STATES.CREATED ? (
               <Row>
-                <StyledButton
-                  type="confirm"
+                <Button
+                  size={ButtonSize.Lg}
                   onPress={navigateToSendTransaction}
-                >
-                  {strings(
+                  label={strings(
                     'fiat_on_ramp_aggregator.order_details.continue_order',
                   )}
-                </StyledButton>
+                  variant={ButtonVariants.Primary}
+                  width={ButtonWidthTypes.Full}
+                />
               </Row>
             ) : null}
 
             {order.state !== FIAT_ORDER_STATES.CREATED &&
               order.state !== FIAT_ORDER_STATES.PENDING && (
-                <StyledButton
-                  type="confirm"
+                <Button
+                  size={ButtonSize.Lg}
                   onPress={handleMakeAnotherPurchase}
-                >
-                  {strings(
+                  label={strings(
                     'fiat_on_ramp_aggregator.order_details.start_new_order',
                   )}
-                </StyledButton>
+                  variant={ButtonVariants.Primary}
+                  width={ButtonWidthTypes.Full}
+                />
               )}
           </ScreenLayout.Content>
         </ScreenLayout.Footer>

--- a/app/components/UI/Ramp/Aggregator/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
@@ -603,9 +603,8 @@ exports[`OrderDetails renders a cancelled order 1`] = `
                                         style={
                                           [
                                             {
-                                              "borderColor": "#b7bbc8",
+                                              "backgroundColor": "#3c4d9d0f",
                                               "borderRadius": 8,
-                                              "borderWidth": 1.5,
                                               "padding": 16,
                                             },
                                             {
@@ -1429,49 +1428,34 @@ exports[`OrderDetails renders a cancelled order 1`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Start a new order
@@ -2116,9 +2100,8 @@ exports[`OrderDetails renders a completed order 1`] = `
                                         style={
                                           [
                                             {
-                                              "borderColor": "#b7bbc8",
+                                              "backgroundColor": "#3c4d9d0f",
                                               "borderRadius": 8,
-                                              "borderWidth": 1.5,
                                               "padding": 16,
                                             },
                                             {
@@ -2942,49 +2925,34 @@ exports[`OrderDetails renders a completed order 1`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Start a new order
@@ -3644,9 +3612,8 @@ exports[`OrderDetails renders a created order 1`] = `
                                         style={
                                           [
                                             {
-                                              "borderColor": "#b7bbc8",
+                                              "backgroundColor": "#3c4d9d0f",
                                               "borderRadius": 8,
-                                              "borderWidth": 1.5,
                                               "padding": 16,
                                             },
                                             {
@@ -5087,9 +5054,8 @@ exports[`OrderDetails renders a failed order 1`] = `
                                         style={
                                           [
                                             {
-                                              "borderColor": "#b7bbc8",
+                                              "backgroundColor": "#3c4d9d0f",
                                               "borderRadius": 8,
-                                              "borderWidth": 1.5,
                                               "padding": 16,
                                             },
                                             {
@@ -5913,49 +5879,34 @@ exports[`OrderDetails renders a failed order 1`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Start a new order
@@ -6615,9 +6566,8 @@ exports[`OrderDetails renders a pending order 1`] = `
                                         style={
                                           [
                                             {
-                                              "borderColor": "#b7bbc8",
+                                              "backgroundColor": "#3c4d9d0f",
                                               "borderRadius": 8,
-                                              "borderWidth": 1.5,
                                               "padding": 16,
                                             },
                                             {
@@ -8511,49 +8461,34 @@ exports[`OrderDetails renders an error screen if a CREATED order cannot be polle
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Try again
@@ -9228,9 +9163,8 @@ exports[`OrderDetails renders non-transacted orders 1`] = `
                                         style={
                                           [
                                             {
-                                              "borderColor": "#b7bbc8",
+                                              "backgroundColor": "#3c4d9d0f",
                                               "borderRadius": 8,
-                                              "borderWidth": 1.5,
                                               "padding": 16,
                                             },
                                             {
@@ -10066,49 +10000,34 @@ exports[`OrderDetails renders non-transacted orders 1`] = `
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    activeOpacity={0.2}
+                                    activeOpacity={1}
                                     onPress={[Function]}
+                                    onPressIn={[Function]}
+                                    onPressOut={[Function]}
                                     style={
-                                      [
-                                        [
-                                          {
-                                            "borderRadius": 12,
-                                            "justifyContent": "center",
-                                            "padding": 15,
-                                          },
-                                          {
-                                            "backgroundColor": "#4459ff",
-                                            "minHeight": 50,
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "alignItems": "center",
+                                        "alignSelf": "stretch",
+                                        "backgroundColor": "#121314",
+                                        "borderRadius": 12,
+                                        "flexDirection": "row",
+                                        "height": 48,
+                                        "justifyContent": "center",
+                                        "overflow": "hidden",
+                                        "paddingHorizontal": 16,
+                                      }
                                     }
                                   >
                                     <Text
+                                      accessibilityRole="text"
                                       style={
-                                        [
-                                          {
-                                            "color": "#007aff",
-                                            "fontSize": 17,
-                                            "fontWeight": "500",
-                                            "textAlign": "center",
-                                          },
-                                          null,
-                                          [
-                                            {
-                                              "fontFamily": "Geist Bold",
-                                              "fontSize": 14,
-                                              "textAlign": "center",
-                                            },
-                                            {
-                                              "color": "#ffffff",
-                                            },
-                                            undefined,
-                                          ],
-                                          null,
-                                        ]
+                                        {
+                                          "color": "#ffffff",
+                                          "fontFamily": "Geist Medium",
+                                          "fontSize": 16,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                        }
                                       }
                                     >
                                       Continue this order
@@ -10781,9 +10700,8 @@ exports[`OrderDetails renders the support links if the provider has them 1`] = `
                                         style={
                                           [
                                             {
-                                              "borderColor": "#b7bbc8",
+                                              "backgroundColor": "#3c4d9d0f",
                                               "borderRadius": 8,
-                                              "borderWidth": 1.5,
                                               "padding": 16,
                                             },
                                             {
@@ -11626,49 +11544,34 @@ exports[`OrderDetails renders the support links if the provider has them 1`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Start a new order
@@ -12328,9 +12231,8 @@ exports[`OrderDetails renders transacted orders that do not have timeDescription
                                         style={
                                           [
                                             {
-                                              "borderColor": "#b7bbc8",
+                                              "backgroundColor": "#3c4d9d0f",
                                               "borderRadius": 8,
-                                              "borderWidth": 1.5,
                                               "padding": 16,
                                             },
                                             {
@@ -13819,9 +13721,8 @@ exports[`OrderDetails renders transacted orders that have timeDescriptionPending
                                         style={
                                           [
                                             {
-                                              "borderColor": "#b7bbc8",
+                                              "backgroundColor": "#3c4d9d0f",
                                               "borderRadius": 8,
-                                              "borderWidth": 1.5,
                                               "padding": 16,
                                             },
                                             {

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.styles.ts
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.styles.ts
@@ -6,7 +6,7 @@ const styleSheet = (params: { theme: Theme }) => {
   const { colors } = theme;
   return StyleSheet.create({
     timerWrapper: {
-      backgroundColor: colors.background.alternative,
+      backgroundColor: colors.background.muted,
       borderRadius: 20,
       marginBottom: 8,
       paddingVertical: 4,

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -24,9 +24,8 @@ exports[`LoadingQuotes component renders correctly 1`] = `
         style={
           [
             {
-              "borderColor": "#b7bbc8",
+              "backgroundColor": "#3c4d9d0f",
               "borderRadius": 8,
-              "borderWidth": 1.5,
               "padding": 16,
             },
             undefined,
@@ -67,7 +66,7 @@ exports[`LoadingQuotes component renders correctly 1`] = `
                 style={
                   [
                     {
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 30,
                       "padding": 14,
                     },
@@ -113,7 +112,7 @@ exports[`LoadingQuotes component renders correctly 1`] = `
                 style={
                   [
                     {
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 30,
                       "padding": 14,
                     },
@@ -168,7 +167,7 @@ exports[`LoadingQuotes component renders correctly 1`] = `
                 style={
                   [
                     {
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 30,
                       "padding": 14,
                     },
@@ -214,7 +213,7 @@ exports[`LoadingQuotes component renders correctly 1`] = `
                 style={
                   [
                     {
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 30,
                       "padding": 14,
                     },
@@ -265,9 +264,8 @@ exports[`LoadingQuotes component renders correctly 1`] = `
         style={
           [
             {
-              "borderColor": "#b7bbc8",
+              "backgroundColor": "#3c4d9d0f",
               "borderRadius": 8,
-              "borderWidth": 1.5,
               "padding": 16,
             },
             undefined,
@@ -308,7 +306,7 @@ exports[`LoadingQuotes component renders correctly 1`] = `
                 style={
                   [
                     {
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 30,
                       "padding": 14,
                     },
@@ -354,7 +352,7 @@ exports[`LoadingQuotes component renders correctly 1`] = `
                 style={
                   [
                     {
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 30,
                       "padding": 14,
                     },
@@ -403,9 +401,8 @@ exports[`LoadingQuotes component renders correctly 1`] = `
         style={
           [
             {
-              "borderColor": "#b7bbc8",
+              "backgroundColor": "#3c4d9d0f",
               "borderRadius": 8,
-              "borderWidth": 1.5,
               "padding": 16,
             },
             undefined,
@@ -446,7 +443,7 @@ exports[`LoadingQuotes component renders correctly 1`] = `
                 style={
                   [
                     {
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 30,
                       "padding": 14,
                     },
@@ -492,7 +489,7 @@ exports[`LoadingQuotes component renders correctly 1`] = `
                 style={
                   [
                     {
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 30,
                       "padding": 14,
                     },
@@ -1257,7 +1254,7 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                               {
                                 "alignItems": "center",
                                 "alignSelf": "center",
-                                "backgroundColor": "#f3f5f9",
+                                "backgroundColor": "#3c4d9d0f",
                                 "borderRadius": 20,
                                 "flexDirection": "row",
                                 "marginBottom": 8,
@@ -1402,9 +1399,8 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                                       style={
                                         [
                                           {
-                                            "borderColor": "#b7bbc8",
+                                            "backgroundColor": "#3c4d9d0f",
                                             "borderRadius": 8,
-                                            "borderWidth": 1.5,
                                             "padding": 16,
                                           },
                                           undefined,
@@ -1523,49 +1519,36 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                                               <TouchableOpacity
                                                 accessibilityRole="button"
                                                 accessible={true}
-                                                activeOpacity={0.2}
+                                                activeOpacity={1}
                                                 disabled={false}
+                                                loading={false}
                                                 onPress={[Function]}
+                                                onPressIn={[Function]}
+                                                onPressOut={[Function]}
                                                 style={
-                                                  [
-                                                    [
-                                                      {
-                                                        "borderRadius": 12,
-                                                        "justifyContent": "center",
-                                                        "padding": 15,
-                                                      },
-                                                      {
-                                                        "backgroundColor": "#4459ff",
-                                                      },
-                                                      undefined,
-                                                    ],
-                                                    null,
-                                                  ]
+                                                  {
+                                                    "alignItems": "center",
+                                                    "alignSelf": "stretch",
+                                                    "backgroundColor": "#121314",
+                                                    "borderRadius": 12,
+                                                    "flexDirection": "row",
+                                                    "height": 48,
+                                                    "justifyContent": "center",
+                                                    "overflow": "hidden",
+                                                    "paddingHorizontal": 16,
+                                                  }
                                                 }
                                               >
                                                 <Text
+                                                  accessibilityRole="text"
                                                   style={
-                                                    [
-                                                      {
-                                                        "color": "#007aff",
-                                                        "fontSize": 17,
-                                                        "fontWeight": "500",
-                                                        "textAlign": "center",
-                                                      },
-                                                      null,
-                                                      [
-                                                        {
-                                                          "fontFamily": "Geist Bold",
-                                                          "fontSize": 14,
-                                                          "textAlign": "center",
-                                                        },
-                                                        {
-                                                          "color": "#ffffff",
-                                                        },
-                                                        undefined,
-                                                      ],
-                                                      null,
-                                                    ]
+                                                    {
+                                                      "color": "#ffffff",
+                                                      "fontFamily": "Geist Medium",
+                                                      "fontSize": 16,
+                                                      "letterSpacing": 0,
+                                                      "lineHeight": 24,
+                                                    }
                                                   }
                                                 >
                                                   Continue with Paypal (Staging)
@@ -3588,7 +3571,7 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                     {
                                       "alignItems": "center",
                                       "alignSelf": "center",
-                                      "backgroundColor": "#f3f5f9",
+                                      "backgroundColor": "#3c4d9d0f",
                                       "borderRadius": 20,
                                       "flexDirection": "row",
                                       "marginBottom": 8,
@@ -3824,9 +3807,8 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                               style={
                                                 [
                                                   {
-                                                    "borderColor": "#b7bbc8",
+                                                    "backgroundColor": "#3c4d9d0f",
                                                     "borderRadius": 8,
-                                                    "borderWidth": 1.5,
                                                     "padding": 16,
                                                   },
                                                   undefined,
@@ -4052,49 +4034,36 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                                       <TouchableOpacity
                                                         accessibilityRole="button"
                                                         accessible={true}
-                                                        activeOpacity={0.2}
+                                                        activeOpacity={1}
                                                         disabled={false}
+                                                        loading={false}
                                                         onPress={[Function]}
+                                                        onPressIn={[Function]}
+                                                        onPressOut={[Function]}
                                                         style={
-                                                          [
-                                                            [
-                                                              {
-                                                                "borderRadius": 12,
-                                                                "justifyContent": "center",
-                                                                "padding": 15,
-                                                              },
-                                                              {
-                                                                "backgroundColor": "#4459ff",
-                                                              },
-                                                              undefined,
-                                                            ],
-                                                            null,
-                                                          ]
+                                                          {
+                                                            "alignItems": "center",
+                                                            "alignSelf": "stretch",
+                                                            "backgroundColor": "#121314",
+                                                            "borderRadius": 12,
+                                                            "flexDirection": "row",
+                                                            "height": 48,
+                                                            "justifyContent": "center",
+                                                            "overflow": "hidden",
+                                                            "paddingHorizontal": 16,
+                                                          }
                                                         }
                                                       >
                                                         <Text
+                                                          accessibilityRole="text"
                                                           style={
-                                                            [
-                                                              {
-                                                                "color": "#007aff",
-                                                                "fontSize": 17,
-                                                                "fontWeight": "500",
-                                                                "textAlign": "center",
-                                                              },
-                                                              null,
-                                                              [
-                                                                {
-                                                                  "fontFamily": "Geist Bold",
-                                                                  "fontSize": 14,
-                                                                  "textAlign": "center",
-                                                                },
-                                                                {
-                                                                  "color": "#ffffff",
-                                                                },
-                                                                undefined,
-                                                              ],
-                                                              null,
-                                                            ]
+                                                            {
+                                                              "color": "#ffffff",
+                                                              "fontFamily": "Geist Medium",
+                                                              "fontSize": 16,
+                                                              "letterSpacing": 0,
+                                                              "lineHeight": 24,
+                                                            }
                                                           }
                                                         >
                                                           Continue with Banxa (Staging)
@@ -4140,9 +4109,8 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                               style={
                                                 [
                                                   {
-                                                    "borderColor": "#b7bbc8",
+                                                    "backgroundColor": "#3c4d9d0f",
                                                     "borderRadius": 8,
-                                                    "borderWidth": 1.5,
                                                     "padding": 16,
                                                   },
                                                   undefined,
@@ -4397,49 +4365,36 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                                       <TouchableOpacity
                                                         accessibilityRole="button"
                                                         accessible={true}
-                                                        activeOpacity={0.2}
+                                                        activeOpacity={1}
                                                         disabled={false}
+                                                        loading={false}
                                                         onPress={[Function]}
+                                                        onPressIn={[Function]}
+                                                        onPressOut={[Function]}
                                                         style={
-                                                          [
-                                                            [
-                                                              {
-                                                                "borderRadius": 12,
-                                                                "justifyContent": "center",
-                                                                "padding": 15,
-                                                              },
-                                                              {
-                                                                "backgroundColor": "#4459ff",
-                                                              },
-                                                              undefined,
-                                                            ],
-                                                            null,
-                                                          ]
+                                                          {
+                                                            "alignItems": "center",
+                                                            "alignSelf": "stretch",
+                                                            "backgroundColor": "#121314",
+                                                            "borderRadius": 12,
+                                                            "flexDirection": "row",
+                                                            "height": 48,
+                                                            "justifyContent": "center",
+                                                            "overflow": "hidden",
+                                                            "paddingHorizontal": 16,
+                                                          }
                                                         }
                                                       >
                                                         <Text
+                                                          accessibilityRole="text"
                                                           style={
-                                                            [
-                                                              {
-                                                                "color": "#007aff",
-                                                                "fontSize": 17,
-                                                                "fontWeight": "500",
-                                                                "textAlign": "center",
-                                                              },
-                                                              null,
-                                                              [
-                                                                {
-                                                                  "fontFamily": "Geist Bold",
-                                                                  "fontSize": 14,
-                                                                  "textAlign": "center",
-                                                                },
-                                                                {
-                                                                  "color": "#ffffff",
-                                                                },
-                                                                undefined,
-                                                              ],
-                                                              null,
-                                                            ]
+                                                            {
+                                                              "color": "#ffffff",
+                                                              "fontFamily": "Geist Medium",
+                                                              "fontSize": 16,
+                                                              "letterSpacing": 0,
+                                                              "lineHeight": 24,
+                                                            }
                                                           }
                                                         >
                                                           Continue with MoonPay (Staging)
@@ -4485,9 +4440,8 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                               style={
                                                 [
                                                   {
-                                                    "borderColor": "#b7bbc8",
+                                                    "backgroundColor": "#3c4d9d0f",
                                                     "borderRadius": 8,
-                                                    "borderWidth": 1.5,
                                                     "padding": 16,
                                                   },
                                                   undefined,
@@ -4667,49 +4621,36 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                                       <TouchableOpacity
                                                         accessibilityRole="button"
                                                         accessible={true}
-                                                        activeOpacity={0.2}
+                                                        activeOpacity={1}
                                                         disabled={false}
+                                                        loading={false}
                                                         onPress={[Function]}
+                                                        onPressIn={[Function]}
+                                                        onPressOut={[Function]}
                                                         style={
-                                                          [
-                                                            [
-                                                              {
-                                                                "borderRadius": 12,
-                                                                "justifyContent": "center",
-                                                                "padding": 15,
-                                                              },
-                                                              {
-                                                                "backgroundColor": "#4459ff",
-                                                              },
-                                                              undefined,
-                                                            ],
-                                                            null,
-                                                          ]
+                                                          {
+                                                            "alignItems": "center",
+                                                            "alignSelf": "stretch",
+                                                            "backgroundColor": "#121314",
+                                                            "borderRadius": 12,
+                                                            "flexDirection": "row",
+                                                            "height": 48,
+                                                            "justifyContent": "center",
+                                                            "overflow": "hidden",
+                                                            "paddingHorizontal": 16,
+                                                          }
                                                         }
                                                       >
                                                         <Text
+                                                          accessibilityRole="text"
                                                           style={
-                                                            [
-                                                              {
-                                                                "color": "#007aff",
-                                                                "fontSize": 17,
-                                                                "fontWeight": "500",
-                                                                "textAlign": "center",
-                                                              },
-                                                              null,
-                                                              [
-                                                                {
-                                                                  "fontFamily": "Geist Bold",
-                                                                  "fontSize": 14,
-                                                                  "textAlign": "center",
-                                                                },
-                                                                {
-                                                                  "color": "#ffffff",
-                                                                },
-                                                                undefined,
-                                                              ],
-                                                              null,
-                                                            ]
+                                                            {
+                                                              "color": "#ffffff",
+                                                              "fontFamily": "Geist Medium",
+                                                              "fontSize": 16,
+                                                              "letterSpacing": 0,
+                                                              "lineHeight": 24,
+                                                            }
                                                           }
                                                         >
                                                           Continue with Transak (Staging)
@@ -5477,7 +5418,7 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                               {
                                 "alignItems": "center",
                                 "alignSelf": "center",
-                                "backgroundColor": "#f3f5f9",
+                                "backgroundColor": "#3c4d9d0f",
                                 "borderRadius": 20,
                                 "flexDirection": "row",
                                 "marginBottom": 8,
@@ -5632,9 +5573,8 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                                         style={
                                           [
                                             {
-                                              "borderColor": "#b7bbc8",
+                                              "backgroundColor": "#3c4d9d0f",
                                               "borderRadius": 8,
-                                              "borderWidth": 1.5,
                                               "padding": 16,
                                             },
                                             undefined,
@@ -5892,49 +5832,36 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                                                 <TouchableOpacity
                                                   accessibilityRole="button"
                                                   accessible={true}
-                                                  activeOpacity={0.2}
+                                                  activeOpacity={1}
                                                   disabled={false}
+                                                  loading={false}
                                                   onPress={[Function]}
+                                                  onPressIn={[Function]}
+                                                  onPressOut={[Function]}
                                                   style={
-                                                    [
-                                                      [
-                                                        {
-                                                          "borderRadius": 12,
-                                                          "justifyContent": "center",
-                                                          "padding": 15,
-                                                        },
-                                                        {
-                                                          "backgroundColor": "#4459ff",
-                                                        },
-                                                        undefined,
-                                                      ],
-                                                      null,
-                                                    ]
+                                                    {
+                                                      "alignItems": "center",
+                                                      "alignSelf": "stretch",
+                                                      "backgroundColor": "#121314",
+                                                      "borderRadius": 12,
+                                                      "flexDirection": "row",
+                                                      "height": 48,
+                                                      "justifyContent": "center",
+                                                      "overflow": "hidden",
+                                                      "paddingHorizontal": 16,
+                                                    }
                                                   }
                                                 >
                                                   <Text
+                                                    accessibilityRole="text"
                                                     style={
-                                                      [
-                                                        {
-                                                          "color": "#007aff",
-                                                          "fontSize": 17,
-                                                          "fontWeight": "500",
-                                                          "textAlign": "center",
-                                                        },
-                                                        null,
-                                                        [
-                                                          {
-                                                            "fontFamily": "Geist Bold",
-                                                            "fontSize": 14,
-                                                            "textAlign": "center",
-                                                          },
-                                                          {
-                                                            "color": "#ffffff",
-                                                          },
-                                                          undefined,
-                                                        ],
-                                                        null,
-                                                      ]
+                                                      {
+                                                        "color": "#ffffff",
+                                                        "fontFamily": "Geist Medium",
+                                                        "fontSize": 16,
+                                                        "letterSpacing": 0,
+                                                        "lineHeight": 24,
+                                                      }
                                                     }
                                                   >
                                                     Continue with MoonPay (Staging)
@@ -6790,49 +6717,34 @@ exports[`Quotes renders correctly after animation without quotes 1`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Try again
@@ -7631,49 +7543,34 @@ exports[`Quotes renders correctly when fetching quotes errors 1`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Try again
@@ -8472,49 +8369,34 @@ exports[`Quotes renders correctly with sdkError 1`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Return to Home Screen
@@ -9313,49 +9195,34 @@ exports[`Quotes renders quotes expired screen 1`] = `
                                 <TouchableOpacity
                                   accessibilityRole="button"
                                   accessible={true}
-                                  activeOpacity={0.2}
+                                  activeOpacity={1}
                                   onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
                                   style={
-                                    [
-                                      [
-                                        {
-                                          "borderRadius": 12,
-                                          "justifyContent": "center",
-                                          "padding": 15,
-                                        },
-                                        {
-                                          "backgroundColor": "#4459ff",
-                                          "minHeight": 50,
-                                        },
-                                        undefined,
-                                      ],
-                                      null,
-                                    ]
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "stretch",
+                                      "backgroundColor": "#121314",
+                                      "borderRadius": 12,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
-                                      [
-                                        {
-                                          "color": "#007aff",
-                                          "fontSize": 17,
-                                          "fontWeight": "500",
-                                          "textAlign": "center",
-                                        },
-                                        null,
-                                        [
-                                          {
-                                            "fontFamily": "Geist Bold",
-                                            "fontSize": 14,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "color": "#ffffff",
-                                          },
-                                          undefined,
-                                        ],
-                                        null,
-                                      ]
+                                      {
+                                        "color": "#ffffff",
+                                        "fontFamily": "Geist Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
                                     }
                                   >
                                     Get new quotes
@@ -9385,7 +9252,7 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
     {
       "alignItems": "center",
       "alignSelf": "center",
-      "backgroundColor": "#f3f5f9",
+      "backgroundColor": "#3c4d9d0f",
       "borderRadius": 20,
       "flexDirection": "row",
       "marginBottom": 8,
@@ -9495,7 +9362,7 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
     {
       "alignItems": "center",
       "alignSelf": "center",
-      "backgroundColor": "#f3f5f9",
+      "backgroundColor": "#3c4d9d0f",
       "borderRadius": 20,
       "flexDirection": "row",
       "marginBottom": 8,
@@ -9605,7 +9472,7 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
     {
       "alignItems": "center",
       "alignSelf": "center",
-      "backgroundColor": "#f3f5f9",
+      "backgroundColor": "#3c4d9d0f",
       "borderRadius": 20,
       "flexDirection": "row",
       "marginBottom": 8,
@@ -9715,7 +9582,7 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
     {
       "alignItems": "center",
       "alignSelf": "center",
-      "backgroundColor": "#f3f5f9",
+      "backgroundColor": "#3c4d9d0f",
       "borderRadius": 20,
       "flexDirection": "row",
       "marginBottom": 8,
@@ -9825,7 +9692,7 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
     {
       "alignItems": "center",
       "alignSelf": "center",
-      "backgroundColor": "#f3f5f9",
+      "backgroundColor": "#3c4d9d0f",
       "borderRadius": 20,
       "flexDirection": "row",
       "marginBottom": 8,
@@ -9935,7 +9802,7 @@ exports[`Timer component renders correctly with isFetchingQuotes=true, pollingCy
     {
       "alignItems": "center",
       "alignSelf": "center",
-      "backgroundColor": "#f3f5f9",
+      "backgroundColor": "#3c4d9d0f",
       "borderRadius": 20,
       "flexDirection": "row",
       "marginBottom": 8,
@@ -9995,7 +9862,7 @@ exports[`Timer component renders correctly with isFetchingQuotes=true, pollingCy
     {
       "alignItems": "center",
       "alignSelf": "center",
-      "backgroundColor": "#f3f5f9",
+      "backgroundColor": "#3c4d9d0f",
       "borderRadius": 20,
       "flexDirection": "row",
       "marginBottom": 8,
@@ -10055,7 +9922,7 @@ exports[`Timer component renders correctly with isFetchingQuotes=true, pollingCy
     {
       "alignItems": "center",
       "alignSelf": "center",
-      "backgroundColor": "#f3f5f9",
+      "backgroundColor": "#3c4d9d0f",
       "borderRadius": 20,
       "flexDirection": "row",
       "marginBottom": 8,
@@ -10115,7 +9982,7 @@ exports[`Timer component renders correctly with isFetchingQuotes=true, pollingCy
     {
       "alignItems": "center",
       "alignSelf": "center",
-      "backgroundColor": "#f3f5f9",
+      "backgroundColor": "#3c4d9d0f",
       "borderRadius": 20,
       "flexDirection": "row",
       "marginBottom": 8,

--- a/app/components/UI/Ramp/Aggregator/components/AssetSelectorButton.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/AssetSelectorButton.tsx
@@ -48,7 +48,10 @@ const AssetSelectorButton: React.FC<Props> = ({
       {loading ? (
         <ListItem>
           <ListItemColumn>
-            <AvatarToken size={AvatarTokenSize.Lg} />
+            <AvatarToken
+              size={AvatarTokenSize.Xl}
+              twClassName="bg-background-hover"
+            />
           </ListItemColumn>
           <ListItemColumn widthType={WidthType.Fill}>
             <SkeletonText small />

--- a/app/components/UI/Ramp/Aggregator/components/Box.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/Box.tsx
@@ -14,8 +14,7 @@ const createStyles = (colors: Colors) =>
   StyleSheet.create({
     wrapper: {
       padding: 16,
-      borderWidth: 1.5,
-      borderColor: colors.border.default,
+      backgroundColor: colors.background.muted,
       borderRadius: 8,
     },
     label: {

--- a/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.test.tsx
@@ -84,7 +84,7 @@ describe('CustomAction Component', () => {
   });
 
   it('shows loading indicator when isLoading is true', () => {
-    const { getByTestId } = renderWithProvider(
+    const { toJSON } = renderWithProvider(
       <CustomAction
         customAction={mockCustomAction}
         showInfo={jest.fn()}
@@ -93,7 +93,7 @@ describe('CustomAction Component', () => {
       { state: defaultState },
     );
 
-    expect(getByTestId('buy-button-loading')).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('displays previously used provider tag', () => {

--- a/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  View,
-  TouchableOpacity,
-  LayoutChangeEvent,
-  ActivityIndicator,
-} from 'react-native';
+import { View, TouchableOpacity, LayoutChangeEvent } from 'react-native';
 import Feather from 'react-native-vector-icons/Feather';
 import Animated, {
   Easing,
@@ -17,7 +12,11 @@ import Animated, {
 import { PaymentCustomAction } from '@consensys/on-ramp-sdk/dist/API';
 import Box from '../Box';
 import Title from '../../../../../Base/Title';
-import StyledButton from '../../../../StyledButton';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../../component-library/components/Buttons/Button';
 import { strings } from '../../../../../../../locales/i18n';
 import RemoteImage from '../../../../../Base/RemoteImage';
 import TagColored from '../../../../../../component-library/components-temp/TagColored';
@@ -51,7 +50,7 @@ const CustomAction: React.FC<Props> = ({
 }: Props) => {
   const {
     styles,
-    theme: { colors, themeAppearance },
+    theme: { themeAppearance },
   } = useStyles(styleSheet, {});
   const {
     buy: { provider },
@@ -140,23 +139,17 @@ const CustomAction: React.FC<Props> = ({
               testID="animated-view-height"
             >
               <View style={styles.buyButton}>
-                <StyledButton
-                  type={'blue'}
-                  onPress={onPressCTA}
-                  disabled={isLoading}
-                >
-                  {isLoading ? (
-                    <ActivityIndicator
-                      testID="buy-button-loading"
-                      size={'small'}
-                      color={colors.primary.inverse}
-                    />
-                  ) : (
-                    strings('fiat_on_ramp_aggregator.continue_with', {
-                      provider: provider.name,
-                    })
-                  )}
-                </StyledButton>
+                <Button
+                  size={ButtonSize.Lg}
+                  onPress={() => onPressCTA?.()}
+                  label={strings('fiat_on_ramp_aggregator.continue_with', {
+                    provider: provider.name,
+                  })}
+                  variant={ButtonVariants.Primary}
+                  width={ButtonWidthTypes.Full}
+                  isDisabled={isLoading}
+                  loading={isLoading}
+                />
               </View>
             </Animated.View>
           }

--- a/app/components/UI/Ramp/Aggregator/components/CustomAction/__snapshots__/CustomAction.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/CustomAction/__snapshots__/CustomAction.test.tsx.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CustomAction Component shows loading indicator when isLoading is true 1`] = `
+<View
+  style={
+    {
+      "opacity": 0,
+    }
+  }
+  testID="animated-view-opacity"
+>
+  <TouchableOpacity
+    accessibilityLabel="Paypal (Staging)"
+    accessible={true}
+    activeOpacity={0.8}
+    disabled={true}
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#3c4d9d0f",
+            "borderRadius": 8,
+            "padding": 16,
+          },
+          undefined,
+          undefined,
+          {
+            "padding": 0,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessibilityRole="none"
+        accessible={true}
+        style={
+          {
+            "padding": 16,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "marginBottom": 8,
+            }
+          }
+        >
+          <TouchableOpacity
+            accessibilityHint="Shows provider details"
+            accessibilityLabel="Paypal (Staging) logo"
+            disabled={true}
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                source={
+                  {
+                    "uri": "https://on-ramp.dev-api.cx.metamask.io/assets/providers/paypal_light.png",
+                  }
+                }
+                style={
+                  {
+                    "height": 24,
+                    "width": 65,
+                  }
+                }
+              />
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": undefined,
+                      "fontSize": 12,
+                    },
+                    {
+                      "color": "#686e7d",
+                      "marginLeft": 8,
+                    },
+                    {
+                      "fontFamily": "Feather",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </TouchableOpacity>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+            }
+          }
+        />
+        <View
+          style={
+            {
+              "marginTop": 0,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              [
+                {
+                  "marginTop": 4,
+                  "overflow": "hidden",
+                },
+                {},
+              ]
+            }
+            testID="animated-view-height"
+          >
+            <View
+              style={
+                {
+                  "marginTop": 10,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                accessible={true}
+                activeOpacity={1}
+                disabled={true}
+                loading={true}
+                onPress={[Function]}
+                onPressIn={[Function]}
+                onPressOut={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "alignSelf": "stretch",
+                    "backgroundColor": "#121314",
+                    "borderRadius": 12,
+                    "flexDirection": "row",
+                    "height": 48,
+                    "justifyContent": "center",
+                    "opacity": 0.5,
+                    "overflow": "hidden",
+                    "paddingHorizontal": 16,
+                  }
+                }
+              >
+                <ActivityIndicator
+                  color="#ffffff"
+                  size="small"
+                />
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </TouchableOpacity>
+</View>
+`;

--- a/app/components/UI/Ramp/Aggregator/components/DownChevronText.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/DownChevronText.tsx
@@ -1,15 +1,26 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
-import Entypo from 'react-native-vector-icons/Entypo';
-import Text from '../../../../Base/Text';
+import { StyleSheet } from 'react-native';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../../component-library/components/Icons/Icon';
+import Text, {
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
 import { useTheme } from '../../../../../util/theme';
 import { Colors } from '../../../../../util/theme/models';
 
-const createStyles = (colors: Colors) =>
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+} from '@metamask/design-system-react-native';
+
+const createStyles = (_colors: Colors) =>
   StyleSheet.create({
     chevron: {
-      marginLeft: 10,
-      color: colors.icon.default,
+      marginLeft: 8,
     },
   });
 
@@ -21,15 +32,19 @@ const DownChevronText = ({ text, ...props }: Props) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
   return (
-    <View {...props}>
-      <Text black>
-        <Text black bold>
-          {text}
-        </Text>
-        {'  '}
-        <Entypo name="chevron-down" size={16} style={styles.chevron} />
-      </Text>
-    </View>
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      {...props}
+    >
+      <Text variant={TextVariant.BodyMDBold}>{text}</Text>
+      <Icon
+        name={IconName.ArrowDown}
+        size={IconSize.Sm}
+        color={IconColor.Alternative}
+        style={styles.chevron}
+      />
+    </Box>
   );
 };
 

--- a/app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
@@ -4,7 +4,11 @@ import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityI
 import { useTheme } from '../../../../../util/theme';
 import Title from '../../../../Base/Title';
 import Text from '../../../../Base/Text';
-import StyledButton from '../../../StyledButton';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../component-library/components/Buttons/Button';
 import { strings } from '../../../../../../locales/i18n';
 import { Colors } from '../../../../../util/theme/models';
 import { ScreenLocation } from '../types';
@@ -154,9 +158,13 @@ function ErrorView({
 
         {ctaOnPress && (
           <View style={styles.ctaContainer}>
-            <StyledButton type="confirm" onPress={ctaOnPressCallback}>
-              {ctaLabel || strings('fiat_on_ramp_aggregator.try_again')}
-            </StyledButton>
+            <Button
+              size={ButtonSize.Lg}
+              onPress={ctaOnPressCallback}
+              label={ctaLabel || strings('fiat_on_ramp_aggregator.try_again')}
+              variant={ButtonVariants.Primary}
+              width={ButtonWidthTypes.Full}
+            />
           </View>
         )}
       </View>

--- a/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -554,9 +554,8 @@ exports[`PaymentMethodSelectorModal renders correctly 1`] = `
                                       style={
                                         [
                                           {
-                                            "borderColor": "#b7bbc8",
+                                            "backgroundColor": "#3c4d9d0f",
                                             "borderRadius": 8,
-                                            "borderWidth": 1.5,
                                             "padding": 16,
                                           },
                                           undefined,
@@ -838,9 +837,8 @@ exports[`PaymentMethodSelectorModal renders correctly 1`] = `
                                       style={
                                         [
                                           {
-                                            "borderColor": "#b7bbc8",
+                                            "backgroundColor": "#3c4d9d0f",
                                             "borderRadius": 8,
-                                            "borderWidth": 1.5,
                                             "padding": 16,
                                           },
                                           undefined,
@@ -1699,9 +1697,8 @@ exports[`PaymentMethodSelectorModal renders for sell flow 1`] = `
                                       style={
                                         [
                                           {
-                                            "borderColor": "#b7bbc8",
+                                            "backgroundColor": "#3c4d9d0f",
                                             "borderRadius": 8,
-                                            "borderWidth": 1.5,
                                             "padding": 16,
                                           },
                                           undefined,
@@ -1983,9 +1980,8 @@ exports[`PaymentMethodSelectorModal renders for sell flow 1`] = `
                                       style={
                                         [
                                           {
-                                            "borderColor": "#b7bbc8",
+                                            "backgroundColor": "#3c4d9d0f",
                                             "borderRadius": 8,
-                                            "borderWidth": 1.5,
                                             "padding": 16,
                                           },
                                           undefined,
@@ -2844,9 +2840,8 @@ exports[`PaymentMethodSelectorModal renders without disclaimer when selected pay
                                       style={
                                         [
                                           {
-                                            "borderColor": "#b7bbc8",
+                                            "backgroundColor": "#3c4d9d0f",
                                             "borderRadius": 8,
-                                            "borderWidth": 1.5,
                                             "padding": 16,
                                           },
                                           undefined,
@@ -3126,9 +3121,8 @@ exports[`PaymentMethodSelectorModal renders without disclaimer when selected pay
                                       style={
                                         [
                                           {
-                                            "borderColor": "#b7bbc8",
+                                            "backgroundColor": "#3c4d9d0f",
                                             "borderRadius": 8,
-                                            "borderWidth": 1.5,
                                             "padding": 16,
                                           },
                                           undefined,

--- a/app/components/UI/Ramp/Aggregator/components/QuickAmounts.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/QuickAmounts.tsx
@@ -1,31 +1,24 @@
 import React, { useCallback } from 'react';
-import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
-import Icon, {
-  IconName,
-  IconSize,
-  IconColor,
-} from '../../../../../component-library/components/Icons/Icon';
-import Text from '../../../../Base/Text';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { IconName } from '../../../../../component-library/components/Icons/Icon';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+} from '../../../../../component-library/components/Buttons/Button';
 import { useTheme } from '../../../../../util/theme';
 import { Colors } from '../../../../../util/theme/models';
 import { QuickAmount } from '../types';
 
-const INSET = 25;
+const INSET = 16;
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
     content: {
-      backgroundColor: colors.background.alternative,
+      backgroundColor: colors.background.section,
       paddingVertical: 12,
     },
     amount: {
-      borderRadius: 999,
-      borderWidth: 1,
-      borderColor: colors.border.default,
       marginRight: 5,
       minWidth: 78,
-      padding: 7,
-      flexDirection: 'row',
-      justifyContent: 'center',
     },
   });
 
@@ -38,7 +31,7 @@ interface AmountProps {
   disabled?: boolean;
 }
 
-const Amount = ({ amount, onPress, isBuy, ...props }: AmountProps) => {
+const Amount = ({ amount, onPress, isBuy, disabled }: AmountProps) => {
   const { value, isNative, label } = amount;
   const { colors } = useTheme();
   const styles = createStyles(colors);
@@ -46,29 +39,18 @@ const Amount = ({ amount, onPress, isBuy, ...props }: AmountProps) => {
     onPress(amount);
   }, [onPress, amount]);
 
+  const showSparkleIcon = !isBuy && value === 1 && isNative;
+
   return (
-    <TouchableOpacity
-      style={styles.amount}
+    <Button
+      variant={ButtonVariants.Secondary}
+      size={ButtonSize.Sm}
+      label={label}
       onPress={handlePress}
-      accessibilityRole="button"
-      accessible
-      {...props}
-    >
-      {/*
-        We need to show the sparkle icon only when the value is 1 (100%) and is native token
-        to account for the gas estimation
-      */}
-      {!isBuy && value === 1 && isNative ? (
-        <Icon
-          name={IconName.Sparkle}
-          color={IconColor.Alternative}
-          size={IconSize.Sm}
-        />
-      ) : null}
-      <Text grey small centered noMargin>
-        {label}
-      </Text>
-    </TouchableOpacity>
+      style={styles.amount}
+      startIconName={showSparkleIcon ? IconName.Sparkle : undefined}
+      isDisabled={disabled}
+    />
   );
 };
 
@@ -81,13 +63,7 @@ interface Props {
   onAmountPress: (amount: QuickAmount) => any;
 }
 
-const QuickAmounts = ({
-  amounts,
-  onAmountPress,
-  isBuy,
-  disabled,
-  ...props
-}: Props) => {
+const QuickAmounts = ({ amounts, onAmountPress, isBuy, disabled }: Props) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
   return (
@@ -104,7 +80,6 @@ const QuickAmounts = ({
             onPress={onAmountPress}
             key={index}
             disabled={disabled}
-            {...props}
           />
         ))}
       </ScrollView>

--- a/app/components/UI/Ramp/Aggregator/components/Quote/Quote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/Quote/Quote.test.tsx
@@ -124,7 +124,7 @@ describe('Quote Component', () => {
   });
 
   it('shows loading indicator when isLoading is true', () => {
-    const { getByTestId } = renderWithProvider(
+    const { toJSON } = renderWithProvider(
       <Quote
         quote={mockQuote}
         isLoading
@@ -134,7 +134,7 @@ describe('Quote Component', () => {
       { state: defaultState },
     );
 
-    expect(getByTestId('buy-button-loading')).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('displays previously used provider tag', () => {

--- a/app/components/UI/Ramp/Aggregator/components/Quote/Quote.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/Quote/Quote.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  View,
-  TouchableOpacity,
-  LayoutChangeEvent,
-  ActivityIndicator,
-} from 'react-native';
+import { View, TouchableOpacity, LayoutChangeEvent } from 'react-native';
 import Feather from 'react-native-vector-icons/Feather';
 import Animated, {
   Easing,
@@ -18,7 +13,6 @@ import { QuoteResponse, SellQuoteResponse } from '@consensys/on-ramp-sdk';
 import { ProviderEnvironmentTypeEnum } from '@consensys/on-ramp-sdk/dist/API';
 import Box from '../Box';
 import Title from '../../../../../Base/Title';
-import StyledButton from '../../../../StyledButton';
 import {
   renderFiat,
   renderFromTokenMinimalUnit,
@@ -41,6 +35,11 @@ import ListItemColumn, {
 import Text, {
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../../component-library/components/Buttons/Button';
 
 interface Props {
   quote: QuoteResponse | SellQuoteResponse;
@@ -70,7 +69,7 @@ const Quote: React.FC<Props> = ({
 }: Props) => {
   const {
     styles,
-    theme: { colors, themeAppearance },
+    theme: { themeAppearance },
   } = useStyles(styleSheet, {});
   const {
     networkFee = 0,
@@ -197,23 +196,17 @@ const Quote: React.FC<Props> = ({
                     }${strings('fiat_on_ramp_aggregator.pay_with')}`}
                   />
                 ) : (
-                  <StyledButton
-                    type={'blue'}
-                    onPress={onPressCTA}
-                    disabled={isLoading}
-                  >
-                    {isLoading ? (
-                      <ActivityIndicator
-                        testID="buy-button-loading"
-                        size={'small'}
-                        color={colors.primary.inverse}
-                      />
-                    ) : (
-                      strings('fiat_on_ramp_aggregator.continue_with', {
-                        provider: provider.name,
-                      })
-                    )}
-                  </StyledButton>
+                  <Button
+                    size={ButtonSize.Lg}
+                    onPress={() => onPressCTA?.()}
+                    label={strings('fiat_on_ramp_aggregator.continue_with', {
+                      provider: provider.name,
+                    })}
+                    variant={ButtonVariants.Primary}
+                    width={ButtonWidthTypes.Full}
+                    isDisabled={isLoading}
+                    loading={isLoading}
+                  />
                 )}
               </View>
             </Animated.View>

--- a/app/components/UI/Ramp/Aggregator/components/Quote/__snapshots__/Quote.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/Quote/__snapshots__/Quote.test.tsx.snap
@@ -1,0 +1,311 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Quote Component shows loading indicator when isLoading is true 1`] = `
+<View
+  style={
+    {
+      "opacity": 0,
+    }
+  }
+  testID="animated-view-opacity"
+>
+  <TouchableOpacity
+    accessibilityLabel="Mock Provider"
+    accessible={true}
+    activeOpacity={0.8}
+    disabled={true}
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#3c4d9d0f",
+            "borderRadius": 8,
+            "padding": 16,
+          },
+          undefined,
+          undefined,
+          {
+            "padding": 0,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessibilityRole="none"
+        accessible={true}
+        style={
+          {
+            "padding": 16,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "marginBottom": 8,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "display": "flex",
+                "flexDirection": "row",
+                "gap": 8,
+                "marginBottom": 8,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "alignSelf": "flex-start",
+                  "backgroundColor": "#4459ff1a",
+                  "borderRadius": 4,
+                  "height": 20,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 8,
+                }
+              }
+              testID="tagcolored"
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#4459ff",
+                    "fontFamily": "Geist Bold",
+                    "fontSize": 12,
+                    "fontWeight": "bold",
+                    "letterSpacing": 0.25,
+                    "lineHeight": 20,
+                    "textTransform": "uppercase",
+                  }
+                }
+                testID="tagcolored-text"
+              >
+                Most reliable
+              </Text>
+            </View>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "alignSelf": "flex-start",
+                  "backgroundColor": "#457a391a",
+                  "borderRadius": 4,
+                  "height": 20,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 8,
+                }
+              }
+              testID="tagcolored"
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#457a39",
+                    "fontFamily": "Geist Bold",
+                    "fontSize": 12,
+                    "fontWeight": "bold",
+                    "letterSpacing": 0.25,
+                    "lineHeight": 20,
+                    "textTransform": "uppercase",
+                  }
+                }
+                testID="tagcolored-text"
+              >
+                Best rate
+              </Text>
+            </View>
+          </View>
+          <TouchableOpacity
+            accessibilityHint="Shows provider details"
+            accessibilityLabel="Mock Provider logo"
+            disabled={true}
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                source={
+                  {
+                    "uri": "logo-url",
+                  }
+                }
+                style={
+                  {
+                    "height": 50,
+                    "width": 50,
+                  }
+                }
+              />
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": undefined,
+                      "fontSize": 12,
+                    },
+                    {
+                      "color": "#686e7d",
+                      "marginLeft": 8,
+                    },
+                    {
+                      "fontFamily": "Feather",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </TouchableOpacity>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "flex": 1,
+              }
+            }
+            testID="listitemcolumn"
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 18,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              0.005
+               
+              ETH
+            </Text>
+          </View>
+          <View
+            accessible={false}
+            style={
+              {
+                "width": 16,
+              }
+            }
+            testID="listitem-gap"
+          />
+          <View
+            style={
+              {
+                "flex": -1,
+              }
+            }
+            testID="listitemcolumn"
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 18,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              ≈ 
+              $
+               
+              98 USD
+            </Text>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "marginTop": 0,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              [
+                {
+                  "marginTop": 4,
+                  "overflow": "hidden",
+                },
+                {},
+              ]
+            }
+            testID="animated-view-height"
+          >
+            <View
+              style={
+                {
+                  "marginTop": 10,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                accessible={true}
+                activeOpacity={1}
+                disabled={true}
+                loading={true}
+                onPress={[Function]}
+                onPressIn={[Function]}
+                onPressOut={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "alignSelf": "stretch",
+                    "backgroundColor": "#121314",
+                    "borderRadius": 12,
+                    "flexDirection": "row",
+                    "height": 48,
+                    "justifyContent": "center",
+                    "opacity": 0.5,
+                    "overflow": "hidden",
+                    "paddingHorizontal": 16,
+                  }
+                }
+              >
+                <ActivityIndicator
+                  color="#ffffff"
+                  size="small"
+                />
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </TouchableOpacity>
+</View>
+`;

--- a/app/components/UI/Ramp/Aggregator/components/SkeletonBox.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/SkeletonBox.tsx
@@ -8,7 +8,7 @@ const createStyles = (colors: Colors) =>
     wrapper: {
       padding: 18,
       borderRadius: 6,
-      backgroundColor: colors.background.alternative,
+      backgroundColor: colors.background.hover,
     },
   });
 

--- a/app/components/UI/Ramp/Aggregator/components/SkeletonText.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/SkeletonText.tsx
@@ -8,7 +8,7 @@ const createStyles = (colors: Colors) =>
     wrapper: {
       padding: 14,
       borderRadius: 30,
-      backgroundColor: colors.background.alternative,
+      backgroundColor: colors.background.hover,
     },
     thin: {
       padding: 8,

--- a/app/components/UI/Ramp/Aggregator/components/__snapshots__/AccountSelector.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/__snapshots__/AccountSelector.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`AccountSelector renders correctly with selected address 1`] = `
     style={
       {
         "alignItems": "center",
-        "backgroundColor": "#f3f5f9",
+        "backgroundColor": "#3c4d9d0f",
         "borderRadius": 100,
         "flexDirection": "row",
         "justifyContent": "center",
@@ -62,32 +62,20 @@ exports[`AccountSelector renders correctly with selected address 1`] = `
     >
       Test Account
     </Text>
-    <Text
-      allowFontScaling={false}
-      selectable={false}
+    <SvgMock
+      color="#686e7d"
+      fill="currentColor"
+      height={16}
+      name="ArrowDown"
       style={
-        [
-          {
-            "color": undefined,
-            "fontSize": 18,
-          },
-          {
-            "color": "#686e7d",
-            "marginLeft": 10,
-            "marginRight": 5,
-            "textAlign": "right",
-          },
-          {
-            "fontFamily": "FontAwesome",
-            "fontStyle": "normal",
-            "fontWeight": "normal",
-          },
-          {},
-        ]
+        {
+          "height": 16,
+          "marginHorizontal": 5,
+          "width": 16,
+        }
       }
-    >
-      
-    </Text>
+      width={16}
+    />
   </View>
 </TouchableOpacity>
 `;

--- a/app/components/UI/Ramp/Aggregator/components/__snapshots__/AmountInput.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/__snapshots__/AmountInput.test.tsx.snap
@@ -26,9 +26,8 @@ exports[`AmountInput renders correctly 1`] = `
       style={
         [
           {
-            "borderColor": "#b7bbc8",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 8,
-            "borderWidth": 1.5,
             "padding": 16,
           },
           undefined,
@@ -130,9 +129,8 @@ exports[`AmountInput renders correctly with currency selector 1`] = `
       style={
         [
           {
-            "borderColor": "#b7bbc8",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 8,
-            "borderWidth": 1.5,
             "padding": 16,
           },
           undefined,
@@ -234,117 +232,46 @@ exports[`AmountInput renders correctly with currency selector 1`] = `
               onPress={[MockFunction]}
               testID="select-currency"
             >
-              <View>
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "display": "flex",
+                      "flexDirection": "row",
+                    },
+                    undefined,
+                  ]
+                }
+              >
                 <Text
+                  accessibilityRole="text"
                   style={
-                    [
-                      {
-                        "color": "#121314",
-                        "fontFamily": "Geist Regular",
-                        "fontSize": 30,
-                        "marginVertical": 2,
-                      },
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      {
-                        "color": "#121314",
-                      },
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      {
-                        "color": "#121314",
-                      },
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                    ]
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist Bold",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    }
                   }
                 >
-                  <Text
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "fontFamily": "Geist Regular",
-                          "fontSize": 30,
-                          "marginVertical": 2,
-                        },
-                        undefined,
-                        undefined,
-                        {
-                          "fontFamily": "Geist Bold",
-                        },
-                        undefined,
-                        {
-                          "color": "#121314",
-                        },
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        {
-                          "color": "#121314",
-                        },
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                      ]
-                    }
-                  >
-                    USD
-                  </Text>
-                    
-                  <Text
-                    allowFontScaling={false}
-                    selectable={false}
-                    style={
-                      [
-                        {
-                          "color": undefined,
-                          "fontSize": 16,
-                        },
-                        {
-                          "color": "#121314",
-                          "marginLeft": 10,
-                        },
-                        {
-                          "fontFamily": "Entypo",
-                          "fontStyle": "normal",
-                          "fontWeight": "normal",
-                        },
-                        {},
-                      ]
-                    }
-                  >
-                    
-                  </Text>
+                  USD
                 </Text>
+                <SvgMock
+                  color="#686e7d"
+                  fill="currentColor"
+                  height={16}
+                  name="ArrowDown"
+                  style={
+                    {
+                      "height": 16,
+                      "marginLeft": 8,
+                      "width": 16,
+                    }
+                  }
+                  width={16}
+                />
               </View>
             </TouchableOpacity>
           </View>
@@ -381,9 +308,8 @@ exports[`AmountInput renders loading state correctly 1`] = `
       style={
         [
           {
-            "borderColor": "#b7bbc8",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 8,
-            "borderWidth": 1.5,
             "padding": 16,
           },
           undefined,
@@ -437,7 +363,7 @@ exports[`AmountInput renders loading state correctly 1`] = `
                 style={
                   [
                     {
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 30,
                       "padding": 14,
                     },
@@ -495,9 +421,8 @@ exports[`AmountInput renders loading state correctly with currency selector 1`] 
       style={
         [
           {
-            "borderColor": "#b7bbc8",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 8,
-            "borderWidth": 1.5,
             "padding": 16,
           },
           undefined,
@@ -551,7 +476,7 @@ exports[`AmountInput renders loading state correctly with currency selector 1`] 
                 style={
                   [
                     {
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 30,
                       "padding": 14,
                     },
@@ -598,7 +523,7 @@ exports[`AmountInput renders loading state correctly with currency selector 1`] 
               style={
                 [
                   {
-                    "backgroundColor": "#f3f5f9",
+                    "backgroundColor": "#858b9a14",
                     "borderRadius": 30,
                     "padding": 14,
                   },

--- a/app/components/UI/Ramp/Aggregator/components/__snapshots__/AssetSelectorButton.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/__snapshots__/AssetSelectorButton.test.tsx.snap
@@ -26,9 +26,8 @@ exports[`AssetSelectorButton renders correctly 1`] = `
       style={
         [
           {
-            "borderColor": "#b7bbc8",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 8,
-            "borderWidth": 1.5,
             "padding": 16,
           },
           undefined,
@@ -125,117 +124,46 @@ exports[`AssetSelectorButton renders correctly 1`] = `
               }
               testID="listitemcolumn"
             >
-              <View>
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "display": "flex",
+                      "flexDirection": "row",
+                    },
+                    undefined,
+                  ]
+                }
+              >
                 <Text
+                  accessibilityRole="text"
                   style={
-                    [
-                      {
-                        "color": "#121314",
-                        "fontFamily": "Geist Regular",
-                        "fontSize": 30,
-                        "marginVertical": 2,
-                      },
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      {
-                        "color": "#121314",
-                      },
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      {
-                        "color": "#121314",
-                      },
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                    ]
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist Bold",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    }
                   }
                 >
-                  <Text
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "fontFamily": "Geist Regular",
-                          "fontSize": 30,
-                          "marginVertical": 2,
-                        },
-                        undefined,
-                        undefined,
-                        {
-                          "fontFamily": "Geist Bold",
-                        },
-                        undefined,
-                        {
-                          "color": "#121314",
-                        },
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        {
-                          "color": "#121314",
-                        },
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                      ]
-                    }
-                  >
-                    ETH
-                  </Text>
-                    
-                  <Text
-                    allowFontScaling={false}
-                    selectable={false}
-                    style={
-                      [
-                        {
-                          "color": undefined,
-                          "fontSize": 16,
-                        },
-                        {
-                          "color": "#121314",
-                          "marginLeft": 10,
-                        },
-                        {
-                          "fontFamily": "Entypo",
-                          "fontStyle": "normal",
-                          "fontWeight": "normal",
-                        },
-                        {},
-                      ]
-                    }
-                  >
-                    
-                  </Text>
+                  ETH
                 </Text>
+                <SvgMock
+                  color="#686e7d"
+                  fill="currentColor"
+                  height={16}
+                  name="ArrowDown"
+                  style={
+                    {
+                      "height": 16,
+                      "marginLeft": 8,
+                      "width": 16,
+                    }
+                  }
+                  width={16}
+                />
               </View>
             </View>
           </View>
@@ -272,9 +200,8 @@ exports[`AssetSelectorButton renders correctly without icon 1`] = `
       style={
         [
           {
-            "borderColor": "#b7bbc8",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 8,
-            "borderWidth": 1.5,
             "padding": 16,
           },
           undefined,
@@ -346,117 +273,46 @@ exports[`AssetSelectorButton renders correctly without icon 1`] = `
               }
               testID="listitemcolumn"
             >
-              <View>
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "display": "flex",
+                      "flexDirection": "row",
+                    },
+                    undefined,
+                  ]
+                }
+              >
                 <Text
+                  accessibilityRole="text"
                   style={
-                    [
-                      {
-                        "color": "#121314",
-                        "fontFamily": "Geist Regular",
-                        "fontSize": 30,
-                        "marginVertical": 2,
-                      },
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      {
-                        "color": "#121314",
-                      },
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      {
-                        "color": "#121314",
-                      },
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                    ]
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist Bold",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    }
                   }
                 >
-                  <Text
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "fontFamily": "Geist Regular",
-                          "fontSize": 30,
-                          "marginVertical": 2,
-                        },
-                        undefined,
-                        undefined,
-                        {
-                          "fontFamily": "Geist Bold",
-                        },
-                        undefined,
-                        {
-                          "color": "#121314",
-                        },
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        {
-                          "color": "#121314",
-                        },
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                      ]
-                    }
-                  >
-                    ETH
-                  </Text>
-                    
-                  <Text
-                    allowFontScaling={false}
-                    selectable={false}
-                    style={
-                      [
-                        {
-                          "color": undefined,
-                          "fontSize": 16,
-                        },
-                        {
-                          "color": "#121314",
-                          "marginLeft": 10,
-                        },
-                        {
-                          "fontFamily": "Entypo",
-                          "fontStyle": "normal",
-                          "fontWeight": "normal",
-                        },
-                        {},
-                      ]
-                    }
-                  >
-                    
-                  </Text>
+                  ETH
                 </Text>
+                <SvgMock
+                  color="#686e7d"
+                  fill="currentColor"
+                  height={16}
+                  name="ArrowDown"
+                  style={
+                    {
+                      "height": 16,
+                      "marginLeft": 8,
+                      "width": 16,
+                    }
+                  }
+                  width={16}
+                />
               </View>
             </View>
           </View>
@@ -493,9 +349,8 @@ exports[`AssetSelectorButton renders loading state correctly 1`] = `
       style={
         [
           {
-            "borderColor": "#b7bbc8",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 8,
-            "borderWidth": 1.5,
             "padding": 16,
           },
           undefined,
@@ -538,12 +393,12 @@ exports[`AssetSelectorButton renders loading state correctly 1`] = `
                   [
                     {
                       "alignItems": "center",
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 9999,
-                      "height": 40,
+                      "height": 48,
                       "justifyContent": "center",
                       "overflow": "hidden",
-                      "width": 40,
+                      "width": 48,
                     },
                     undefined,
                   ]
@@ -571,7 +426,7 @@ exports[`AssetSelectorButton renders loading state correctly 1`] = `
                 style={
                   [
                     {
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 30,
                       "padding": 14,
                     },
@@ -616,7 +471,7 @@ exports[`AssetSelectorButton renders loading state correctly 1`] = `
                 style={
                   [
                     {
-                      "backgroundColor": "#f3f5f9",
+                      "backgroundColor": "#858b9a14",
                       "borderRadius": 30,
                       "padding": 14,
                     },

--- a/app/components/UI/Ramp/Aggregator/components/__snapshots__/PaymentMethodSelector.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/__snapshots__/PaymentMethodSelector.test.tsx.snap
@@ -26,9 +26,8 @@ exports[`PaymentMethodSelector renders correctly 1`] = `
       style={
         [
           {
-            "borderColor": "#b7bbc8",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 8,
-            "borderWidth": 1.5,
             "padding": 16,
           },
           undefined,
@@ -114,117 +113,46 @@ exports[`PaymentMethodSelector renders correctly 1`] = `
             }
             testID="listitem-gap"
           />
-          <View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexDirection": "row",
+                },
+                undefined,
+              ]
+            }
+          >
             <Text
+              accessibilityRole="text"
               style={
-                [
-                  {
-                    "color": "#121314",
-                    "fontFamily": "Geist Regular",
-                    "fontSize": 30,
-                    "marginVertical": 2,
-                  },
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  {
-                    "color": "#121314",
-                  },
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  {
-                    "color": "#121314",
-                  },
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                ]
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Bold",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
               }
             >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#121314",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 30,
-                      "marginVertical": 2,
-                    },
-                    undefined,
-                    undefined,
-                    {
-                      "fontFamily": "Geist Bold",
-                    },
-                    undefined,
-                    {
-                      "color": "#121314",
-                    },
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    {
-                      "color": "#121314",
-                    },
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                  ]
-                }
-              >
-                Change
-              </Text>
-                
-              <Text
-                allowFontScaling={false}
-                selectable={false}
-                style={
-                  [
-                    {
-                      "color": undefined,
-                      "fontSize": 16,
-                    },
-                    {
-                      "color": "#121314",
-                      "marginLeft": 10,
-                    },
-                    {
-                      "fontFamily": "Entypo",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    {},
-                  ]
-                }
-              >
-                
-              </Text>
+              Change
             </Text>
+            <SvgMock
+              color="#686e7d"
+              fill="currentColor"
+              height={16}
+              name="ArrowDown"
+              style={
+                {
+                  "height": 16,
+                  "marginLeft": 8,
+                  "width": 16,
+                }
+              }
+              width={16}
+            />
           </View>
         </View>
       </View>
@@ -306,9 +234,8 @@ exports[`PaymentMethodSelector renders correctly if there are no icons 1`] = `
       style={
         [
           {
-            "borderColor": "#b7bbc8",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 8,
-            "borderWidth": 1.5,
             "padding": 16,
           },
           undefined,
@@ -394,117 +321,46 @@ exports[`PaymentMethodSelector renders correctly if there are no icons 1`] = `
             }
             testID="listitem-gap"
           />
-          <View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexDirection": "row",
+                },
+                undefined,
+              ]
+            }
+          >
             <Text
+              accessibilityRole="text"
               style={
-                [
-                  {
-                    "color": "#121314",
-                    "fontFamily": "Geist Regular",
-                    "fontSize": 30,
-                    "marginVertical": 2,
-                  },
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  {
-                    "color": "#121314",
-                  },
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  {
-                    "color": "#121314",
-                  },
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                ]
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Bold",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
               }
             >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#121314",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 30,
-                      "marginVertical": 2,
-                    },
-                    undefined,
-                    undefined,
-                    {
-                      "fontFamily": "Geist Bold",
-                    },
-                    undefined,
-                    {
-                      "color": "#121314",
-                    },
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    {
-                      "color": "#121314",
-                    },
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                  ]
-                }
-              >
-                Change
-              </Text>
-                
-              <Text
-                allowFontScaling={false}
-                selectable={false}
-                style={
-                  [
-                    {
-                      "color": undefined,
-                      "fontSize": 16,
-                    },
-                    {
-                      "color": "#121314",
-                      "marginLeft": 10,
-                    },
-                    {
-                      "fontFamily": "Entypo",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    {},
-                  ]
-                }
-              >
-                
-              </Text>
+              Change
             </Text>
+            <SvgMock
+              color="#686e7d"
+              fill="currentColor"
+              height={16}
+              name="ArrowDown"
+              style={
+                {
+                  "height": 16,
+                  "marginLeft": 8,
+                  "width": 16,
+                }
+              }
+              width={16}
+            />
           </View>
         </View>
       </View>
@@ -557,9 +413,8 @@ exports[`PaymentMethodSelector renders loading state correctly 1`] = `
       style={
         [
           {
-            "borderColor": "#b7bbc8",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 8,
-            "borderWidth": 1.5,
             "padding": 16,
           },
           undefined,
@@ -600,7 +455,7 @@ exports[`PaymentMethodSelector renders loading state correctly 1`] = `
               style={
                 [
                   {
-                    "backgroundColor": "#f3f5f9",
+                    "backgroundColor": "#858b9a14",
                     "borderRadius": 30,
                     "padding": 14,
                   },
@@ -645,7 +500,7 @@ exports[`PaymentMethodSelector renders loading state correctly 1`] = `
               style={
                 [
                   {
-                    "backgroundColor": "#f3f5f9",
+                    "backgroundColor": "#858b9a14",
                     "borderRadius": 30,
                     "padding": 14,
                   },
@@ -691,7 +546,7 @@ exports[`PaymentMethodSelector renders loading state correctly 1`] = `
           style={
             [
               {
-                "backgroundColor": "#f3f5f9",
+                "backgroundColor": "#858b9a14",
                 "borderRadius": 30,
                 "padding": 14,
               },

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -583,7 +583,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -2459,7 +2459,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -4335,7 +4335,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -6211,7 +6211,7 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -8026,7 +8026,7 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -9840,7 +9840,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -11655,7 +11655,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -13563,7 +13563,7 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -15333,7 +15333,7 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -17148,7 +17148,7 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -18963,7 +18963,7 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -20778,7 +20778,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -22593,7 +22593,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -24501,7 +24501,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -26314,7 +26314,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -28220,7 +28220,7 @@ exports[`BuildQuote Component User Details Error displays user details error ale
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,
@@ -30128,7 +30128,7 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
-                                    "backgroundColor": "#ffffff",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
                                     "borderWidth": 1,

--- a/app/components/UI/Ramp/Deposit/components/AccountSelector/AccountSelector.styles.ts
+++ b/app/components/UI/Ramp/Deposit/components/AccountSelector/AccountSelector.styles.ts
@@ -10,7 +10,7 @@ const stylesheet = (params: { theme: Theme }) => {
       justifyContent: 'space-between',
       gap: 10,
       alignItems: 'center',
-      backgroundColor: theme.colors.background.default,
+      backgroundColor: theme.colors.background.muted,
       borderRadius: 12,
       padding: 8,
       borderWidth: 1,


### PR DESCRIPTION

## **Description**

This PR aligns Aggregator screens with the current design system components and styles as part of **Unified Buy Phase 1** ([#23636](https://github.com/MetaMask/metamask-mobile/issues/23636)). 

The Ramp components were originally created before the design system existed. These refinements reduce visual noise and inconsistencies, making the experience feel more modern, trustworthy, and consistent with the rest of the app.

### Changes:
- **Inputs**: Removed borders and applied muted background (borderless input style)
- **Primary CTA**: Updated buttons to design system `Button` component (Primary variant)
- **Quotes list**: Updated quote cards to borderless boxes with muted background
- **Account & region selectors**: Updated to muted background style to match new inputs
- **Keypad**: Set keypad container background to `background.section`
- **Quick amounts**: Set background to `background.section`, migrated to `Button` (Secondary variant)
- **Icons**: Replaced FontAwesome/Entypo icons with component-library `Icon` (ArrowDown)
- **Skeleton components**: Updated background color to `background.hover`

**Note**: Visual-only changes; no behavioral changes expected.

## **Changelog**

CHANGELOG entry: Refined Buy/Sell UI inputs and buttons to match design system

## **Related issues**

Fixes: #23636

## **Manual testing steps**

```gherkin
Feature: Buy UI Design System Alignment

  Scenario: User views the Build Quote screen
    Given the user is on the Buy flow
    When user navigates to the Build Quote screen
    Then the inputs should have muted backgrounds without borders
    And the "Get quotes" button should use the Primary button style
    And the keypad container should have a section background
    And the quick amount buttons should use Secondary button style

  Scenario: User views the Quotes list
    Given the user has entered an amount to buy
    When user views the list of quotes
    Then the quote cards should have muted backgrounds without borders
    And the "Continue with [provider]" buttons should show loading spinner when pressed

  Scenario: User views Order Details
    Given the user has completed an order
    When user views the order details screen
    Then the action buttons should use the Primary button style

  Scenario: User toggles between light and dark theme
    Given the user is on any Ramp screen
    When user switches between light and dark theme
    Then all components should render correctly in both themes
```

## **Screenshots/Recordings**












### **Before**

#### Light Theme

https://github.com/user-attachments/assets/f99f11cb-c21d-48be-afb8-4e2e2870d155


#### Dark Theme

https://github.com/user-attachments/assets/832268cd-5330-48fb-9877-a57d5686e5db


### **After**

#### Light Theme

https://github.com/user-attachments/assets/be3400df-07d7-4db9-b1c9-df4d246e4480


#### Dark Theme

https://github.com/user-attachments/assets/5f5450f8-cb12-4dee-8957-ce52e26098ce




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 7c91a7560cd6df77264bcba0edb9d14aff72142c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->