### PR TITLE
feat: disable tokens in metamask pay

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
@@ -4,8 +4,10 @@ import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTo
 import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
 import { AssetType, TokenStandard } from '../../types/token';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { getAvailableTokens } from '../../utils/transaction-pay';
 
 jest.mock('../send/useAccountTokens');
+jest.mock('../../utils/transaction-pay');
 
 const TOKEN_MOCK = {
   accountType: EthAccountType.Eoa,
@@ -25,7 +27,8 @@ describe('useTransactionPayAvailableTokens', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    useAccountTokensMock.mockReturnValue([TOKEN_MOCK]);
+    useAccountTokensMock.mockReturnValue([]);
+    jest.mocked(getAvailableTokens).mockReturnValue([TOKEN_MOCK]);
   });
 
   it('returns available tokens', () => {

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -13,6 +13,10 @@ import {
 } from '@metamask/transaction-pay-controller';
 import { BigNumber } from 'bignumber.js';
 import { isTestNet } from '../../../../util/networks';
+import { store } from '../../../../store';
+import { selectGasFeeTokenFlags } from '../../../../selectors/featureFlagController/confirmations';
+import { getNativeTokenAddress } from './asset';
+import { strings } from '../../../../../locales/i18n';
 
 const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
 
@@ -88,6 +92,8 @@ export function getAvailableTokens({
   requiredTokens?: TransactionPayRequiredToken[];
   tokens: AssetType[];
 }): AssetType[] {
+  const supportedGasFeeTokens = getSupportedGasFeeTokens();
+
   return tokens
     .filter((token) => {
       if (
@@ -120,13 +126,50 @@ export function getAvailableTokens({
       return new BigNumber(token.balance).gt(0);
     })
     .map((token) => {
+      const chainId = (token.chainId as Hex) ?? '0x0';
+
+      const nativeToken = tokens.find(
+        (t) =>
+          t.chainId === chainId && t.address === getNativeTokenAddress(chainId),
+      );
+
+      const noNativeBalance =
+        !nativeToken || new BigNumber(nativeToken.balance).isZero();
+
+      const isGasStationSupported = supportedGasFeeTokens[chainId]?.includes(
+        token.address?.toLowerCase() as Hex,
+      );
+
+      const disabled = noNativeBalance && !isGasStationSupported;
+
+      const disabledMessage = disabled
+        ? strings('pay_with_modal.no_gas')
+        : undefined;
+
       const isSelected =
         payToken?.address.toLowerCase() === token.address.toLowerCase() &&
         payToken?.chainId === token.chainId;
 
       return {
         ...token,
+        disabled,
+        disabledMessage,
         isSelected,
       };
     });
+}
+
+function getSupportedGasFeeTokens(): Record<Hex, Hex[]> {
+  const state = store.getState();
+  const { gasFeeTokens } = selectGasFeeTokenFlags(state);
+
+  return Object.keys(gasFeeTokens).reduce(
+    (acc, chainId) => ({
+      ...acc,
+      [chainId]: gasFeeTokens[chainId as Hex].tokens.map(
+        (token) => token.address.toLowerCase() as Hex,
+      ),
+    }),
+    {},
+  );
 }

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
 import { getFeatureFlagValue } from '../env';
-import { Json } from '@metamask/utils';
+import { Hex, Json } from '@metamask/utils';
 
 export const ATTEMPTS_MAX_DEFAULT = 2;
 export const BUFFER_INITIAL_DEFAULT = 0.025;
@@ -31,6 +31,18 @@ export interface MetaMaskPayFlags {
   bufferStep: number;
   bufferSubsequent: number;
   slippage: number;
+}
+
+export interface GasFeeTokenFlags {
+  gasFeeTokens: {
+    [chainId: Hex]: {
+      name: string;
+      tokens: {
+        name: string;
+        address: Hex;
+      }[];
+    };
+  };
 }
 
 /**
@@ -143,18 +155,25 @@ export const selectSendRedesignFlags = createSelector(
 
 export const selectMetaMaskPayFlags = createSelector(
   selectRemoteFeatureFlags,
-  (featureFlags) => {
+  (featureFlags): MetaMaskPayFlags => {
     const metaMaskPayFlags = featureFlags?.confirmation_pay as
       | Record<string, Json>
       | undefined;
 
-    const attemptsMax = metaMaskPayFlags?.attemptsMax ?? ATTEMPTS_MAX_DEFAULT;
+    const attemptsMax =
+      (metaMaskPayFlags?.attemptsMax as number) ?? ATTEMPTS_MAX_DEFAULT;
+
     const bufferInitial =
-      metaMaskPayFlags?.bufferInitial ?? BUFFER_INITIAL_DEFAULT;
-    const bufferStep = metaMaskPayFlags?.bufferStep ?? BUFFER_STEP_DEFAULT;
+      (metaMaskPayFlags?.bufferInitial as number) ?? BUFFER_INITIAL_DEFAULT;
+
+    const bufferStep =
+      (metaMaskPayFlags?.bufferStep as number) ?? BUFFER_STEP_DEFAULT;
+
     const bufferSubsequent =
-      metaMaskPayFlags?.bufferSubsequent ?? BUFFER_SUBSEQUENT_DEFAULT;
-    const slippage = metaMaskPayFlags?.slippage ?? SLIPPAGE_DEFAULT;
+      (metaMaskPayFlags?.bufferSubsequent as number) ??
+      BUFFER_SUBSEQUENT_DEFAULT;
+
+    const slippage = (metaMaskPayFlags?.slippage as number) ?? SLIPPAGE_DEFAULT;
 
     return {
       attemptsMax,
@@ -162,7 +181,7 @@ export const selectMetaMaskPayFlags = createSelector(
       bufferStep,
       bufferSubsequent,
       slippage,
-    } as MetaMaskPayFlags;
+    };
   },
 );
 
@@ -176,4 +195,23 @@ export const selectNonZeroUnusedApprovalsAllowList = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags: ReturnType<typeof selectRemoteFeatureFlags>) =>
     remoteFeatureFlags?.nonZeroUnusedApprovals ?? [],
+);
+
+export const selectGasFeeTokenFlags = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): GasFeeTokenFlags => {
+    const gasFeeTokenFlags =
+      remoteFeatureFlags?.confirmations_gas_fee_tokens as
+        | Record<string, Json>
+        | undefined;
+
+    const gasFeeTokens =
+      (gasFeeTokenFlags?.gasFeeTokens as
+        | GasFeeTokenFlags['gasFeeTokens']
+        | undefined) ?? {};
+
+    return {
+      gasFeeTokens,
+    };
+  },
 );


### PR DESCRIPTION
## **Description**

Disable tokens in asset picker for MetaMask Pay if there is no native balance and gas station is not supported.

## **Changelog**

CHANGELOG entry: Disable token selection in Perps and Predict deposits if no native balance and gas station not supported

## **Related issues**

Fixes: [#6361](https://github.com/MetaMask/MetaMask-planning/issues/6361)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables MetaMask Pay asset-picker tokens when no native balance unless allowed by gas station feature flags, adding selector support and tests.
> 
> - **Confirmations utils**:
>   - Enhance `getAvailableTokens` to mark tokens as `disabled` with `disabledMessage` when no native balance and token isn’t supported by gas station; keep selection/required-token behavior. Uses `store`, new `selectGasFeeTokenFlags`, and `strings('pay_with_modal.no_gas')`.
>   - Add helper to compute supported gas-fee tokens per `chainId`.
> - **Feature flags**:
>   - Add `GasFeeTokenFlags` type and `selectGasFeeTokenFlags` selector in `selectors/featureFlagController/confirmations`.
>   - Strengthen `selectMetaMaskPayFlags` typing.
> - **Tests**:
>   - Update `transaction-pay.test.ts` to cover disabled/enabled cases (native balance present/absent, gas station support) and mock store/selector.
>   - Update `pay-with-modal.test.tsx` to mock `getAvailableTokens` instead of `useAccountTokens` and remove mUSD allowlist token filtering tests.
>   - Update `useTransactionPayAvailableTokens.test.ts` to mock `getAvailableTokens` and expect returned tokens.
>   - Add tests for `selectGasFeeTokenFlags` selector behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 522201267d46d8e1860c6fd8d0e79e7962c95647. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->