### PR TITLE
chore: Fix to only bypass 'Redirect' modal for in-app signed links

### DIFF
--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
@@ -1289,7 +1289,7 @@ describe('handleUniversalLink', () => {
       );
     });
 
-    describe('external sources always show redirect modal', () => {
+    describe('external sources show modal regardless of signature status', () => {
       const sourcesRequiringModal = [AppConstants.DEEPLINKS.ORIGIN_DEEPLINK];
 
       const validSignature = Buffer.from(new Array(64).fill(0)).toString(
@@ -1361,35 +1361,7 @@ describe('handleUniversalLink', () => {
       );
     });
 
-    describe('non-whitelisted sources', () => {
-      it('displays interstitial modal when source is not whitelisted and URL is not whitelisted', async () => {
-        const nonWhitelistedSource = 'external-browser';
-        const nonWhitelistedUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.DAPP}/example.com`;
-        const testUrlObj = {
-          ...urlObj,
-          hostname: AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
-          href: nonWhitelistedUrl,
-          pathname: `/${ACTIONS.DAPP}/example.com`,
-        };
-
-        await handleUniversalLink({
-          instance,
-          handled,
-          urlObj: testUrlObj,
-          browserCallBack: mockBrowserCallBack,
-          url: nonWhitelistedUrl,
-          source: nonWhitelistedSource,
-        });
-
-        expect(mockHandleDeepLinkModalDisplay).toHaveBeenCalledWith({
-          linkType: DeepLinkModalLinkType.PUBLIC,
-          pageTitle: 'Dapp',
-          onContinue: expect.any(Function),
-          onBack: expect.any(Function),
-        });
-        expect(handled).toHaveBeenCalled();
-      });
-
+    describe('sources not in inAppLinkSources', () => {
       it('skips interstitial modal when URL is whitelisted even with non-whitelisted source', async () => {
         const nonWhitelistedSource = 'external-browser';
         const whitelistedUrl =

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
@@ -1217,23 +1217,30 @@ describe('handleUniversalLink', () => {
       expect(handled).toHaveBeenCalled();
     });
 
-    describe('whitelisted sources', () => {
-      const whitelistedSources = [
+    describe('in-app link sources', () => {
+      const inAppSources = [
         AppConstants.DEEPLINKS.ORIGIN_CAROUSEL,
         AppConstants.DEEPLINKS.ORIGIN_NOTIFICATION,
-        AppConstants.DEEPLINKS.ORIGIN_DEEPLINK,
-        AppConstants.DEEPLINKS.ORIGIN_QR_CODE,
         AppConstants.DEEPLINKS.ORIGIN_IN_APP_BROWSER,
+        AppConstants.DEEPLINKS.ORIGIN_QR_CODE,
       ];
 
-      it.each(whitelistedSources)(
-        'skips interstitial modal when source is "%s" with non-whitelisted URL',
+      const validSignature = Buffer.from(new Array(64).fill(0)).toString(
+        'base64',
+      );
+
+      beforeEach(() => {
+        mockSubtle.verify.mockResolvedValue(true);
+      });
+
+      it.each(inAppSources)(
+        'skips modal when source is "%s" with signed (PRIVATE) link',
         async (testSource) => {
-          const nonWhitelistedUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.DAPP}/example.com`;
+          const signedUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.DAPP}/example.com?sig=${validSignature}`;
           const testUrlObj = {
             ...urlObj,
             hostname: AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
-            href: nonWhitelistedUrl,
+            href: signedUrl,
             pathname: `/${ACTIONS.DAPP}/example.com`,
           };
 
@@ -1242,7 +1249,7 @@ describe('handleUniversalLink', () => {
             handled,
             urlObj: testUrlObj,
             browserCallBack: mockBrowserCallBack,
-            url: nonWhitelistedUrl,
+            url: signedUrl,
             source: testSource,
           });
 
@@ -1251,6 +1258,110 @@ describe('handleUniversalLink', () => {
         },
       );
 
+      it.each(inAppSources)(
+        'displays "Proceed with caution" modal when source is "%s" with unsigned (PUBLIC) link',
+        async (testSource) => {
+          const unsignedUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.DAPP}/example.com`;
+          const testUrlObj = {
+            ...urlObj,
+            hostname: AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+            href: unsignedUrl,
+            pathname: `/${ACTIONS.DAPP}/example.com`,
+          };
+
+          await handleUniversalLink({
+            instance,
+            handled,
+            urlObj: testUrlObj,
+            browserCallBack: mockBrowserCallBack,
+            url: unsignedUrl,
+            source: testSource,
+          });
+
+          expect(mockHandleDeepLinkModalDisplay).toHaveBeenCalledWith({
+            linkType: DeepLinkModalLinkType.PUBLIC,
+            pageTitle: 'Dapp',
+            onContinue: expect.any(Function),
+            onBack: expect.any(Function),
+          });
+          expect(handled).toHaveBeenCalled();
+        },
+      );
+    });
+
+    describe('external sources always show redirect modal', () => {
+      const sourcesRequiringModal = [AppConstants.DEEPLINKS.ORIGIN_DEEPLINK];
+
+      const validSignature = Buffer.from(new Array(64).fill(0)).toString(
+        'base64',
+      );
+
+      beforeEach(() => {
+        mockSubtle.verify.mockResolvedValue(true);
+      });
+
+      it.each(sourcesRequiringModal)(
+        'displays "Redirecting you to MetaMask" modal when source is "%s" with signed (PRIVATE) link',
+        async (testSource) => {
+          const signedUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.DAPP}/example.com?sig=${validSignature}`;
+          const testUrlObj = {
+            ...urlObj,
+            hostname: AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+            href: signedUrl,
+            pathname: `/${ACTIONS.DAPP}/example.com`,
+          };
+
+          await handleUniversalLink({
+            instance,
+            handled,
+            urlObj: testUrlObj,
+            browserCallBack: mockBrowserCallBack,
+            url: signedUrl,
+            source: testSource,
+          });
+
+          expect(mockHandleDeepLinkModalDisplay).toHaveBeenCalledWith({
+            linkType: DeepLinkModalLinkType.PRIVATE,
+            pageTitle: 'Dapp',
+            onContinue: expect.any(Function),
+            onBack: expect.any(Function),
+          });
+          expect(handled).toHaveBeenCalled();
+        },
+      );
+
+      it.each(sourcesRequiringModal)(
+        'displays "Proceed with caution" modal when source is "%s" with unsigned (PUBLIC) link',
+        async (testSource) => {
+          const unsignedUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.DAPP}/example.com`;
+          const testUrlObj = {
+            ...urlObj,
+            hostname: AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+            href: unsignedUrl,
+            pathname: `/${ACTIONS.DAPP}/example.com`,
+          };
+
+          await handleUniversalLink({
+            instance,
+            handled,
+            urlObj: testUrlObj,
+            browserCallBack: mockBrowserCallBack,
+            url: unsignedUrl,
+            source: testSource,
+          });
+
+          expect(mockHandleDeepLinkModalDisplay).toHaveBeenCalledWith({
+            linkType: DeepLinkModalLinkType.PUBLIC,
+            pageTitle: 'Dapp',
+            onContinue: expect.any(Function),
+            onBack: expect.any(Function),
+          });
+          expect(handled).toHaveBeenCalled();
+        },
+      );
+    });
+
+    describe('non-whitelisted sources', () => {
       it('displays interstitial modal when source is not whitelisted and URL is not whitelisted', async () => {
         const nonWhitelistedSource = 'external-browser';
         const nonWhitelistedUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.DAPP}/example.com`;

--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -79,13 +79,10 @@ const interstitialWhitelistUrls = [
   `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${SUPPORTED_ACTIONS.PERPS_ASSET}`,
 ] as const;
 
-// remember this is only for the INTERSTITIAL
-// "Redirecting you to MetaMask..." modal
-// NOT THE "proceed with caution" modal
-const interstitialWhitelistSources = [
+// This is used when links originate from within the app itself
+const inAppLinkSources = [
   AppConstants.DEEPLINKS.ORIGIN_CAROUSEL,
   AppConstants.DEEPLINKS.ORIGIN_NOTIFICATION,
-  AppConstants.DEEPLINKS.ORIGIN_DEEPLINK,
   AppConstants.DEEPLINKS.ORIGIN_QR_CODE,
   AppConstants.DEEPLINKS.ORIGIN_IN_APP_BROWSER,
 ] as string[];
@@ -227,14 +224,18 @@ async function handleUniversalLink({
         return;
       }
 
-      // bypass if link originated from within this app
-      if (interstitialWhitelistSources.includes(source)) {
+      // bypass redirect modalif link originated from within this app AND is signed
+      const linkInstanceType = linkType();
+      if (
+        inAppLinkSources.includes(source) &&
+        linkInstanceType === DeepLinkModalLinkType.PRIVATE
+      ) {
         resolve(true);
         return;
       }
 
       handleDeepLinkModalDisplay({
-        linkType: linkType(),
+        linkType: linkInstanceType,
         pageTitle,
         onContinue: () => resolve(true),
         onBack: () => resolve(false),


### PR DESCRIPTION
## **Description**

This PR fixes a security issue where deep link modals were being bypassed incorrectly. Previously, links from certain sources (including external sources like `ORIGIN_DEEPLINK`) would bypass all modals regardless of whether they were signed or unsigned. This created a security risk where malicious external links could bypass user consent modals.

**What changed:**
- Updated modal bypass logic to only skip modals for **signed (PRIVATE) links** from trusted in-app sources (`ORIGIN_CAROUSEL`, `ORIGIN_NOTIFICATION`, `ORIGIN_QR_CODE`, `ORIGIN_IN_APP_BROWSER`)
- Removed `ORIGIN_DEEPLINK` from the bypass list since it represents external links (from Slack, email, etc.) that should always show modals
- Unsigned (PUBLIC) links now always show the "Proceed with caution" modal, even from in-app sources
- External sources (`ORIGIN_DEEPLINK`) always show modals regardless of signature status

**Why:**
- Security: External links should never bypass user consent modals
- User experience: Signed links from trusted in-app sources can bypass the "Redirecting you to MetaMask" modal for seamless UX
- Consistency: Unsigned links always require user confirmation

**Technical details:**
- The bypass check now requires BOTH conditions: source is in `inAppLinkSources` AND `linkType === PRIVATE`
- `linkType()` is computed once and reused to avoid duplicate computation
- Updated tests to reflect the new behavior with proper coverage for all source/link type combinations

## **Changelog**

CHANGELOG entry: Fixed security issue where external deep links could bypass user consent modals. Signed links from in-app sources (carousel, notifications, QR scanner) now bypass the redirect modal, while external links always show appropriate warnings.

## **Related issues**

Fixes: #23559

## **Manual testing steps**

```gherkin
Feature: Deep link modal bypass behavior

  Scenario: Signed link from carousel bypasses modal
    Given user is viewing a carousel banner with a signed deep link
    When user taps the carousel banner link
    Then the link should open directly without showing "Redirecting you to MetaMask" modal

  Scenario: Unsigned link from carousel shows warning modal
    Given user is viewing a carousel banner with an unsigned deep link
    When user taps the carousel banner link
    Then the "Proceed with caution" modal should be displayed

  Scenario: External link always shows modal
    Given user receives a deep link from an external source (email, Slack, etc.)
    When user taps the external link
    Then the appropriate modal should be displayed:
      - "Redirecting you to MetaMask" for signed links
      - "Proceed with caution" for unsigned links

  Scenario: Signed link from notification bypasses modal
    Given user receives a notification with a signed deep link
    When user taps the notification
    Then the link should open directly without showing modal

  Scenario: QR code scan with signed link bypasses modal
    Given user scans a QR code containing a signed deep link
    When the QR code is processed
    Then the link should open directly without showing modal
```

## **Screenshots/Recordings**

<!-- No UI changes - this is a security fix affecting modal display logic -->

### **Before**

Previously, all links from whitelisted sources (including external `ORIGIN_DEEPLINK`) would bypass modals, creating a security vulnerability.

### **After**

- Signed links from trusted in-app sources bypass modals ✅
- Unsigned links always show warnings ✅  
- External links always show modals ✅

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (updated existing tests and added new test cases)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (updated comments)
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts modal bypass to PRIVATE links from in-app sources and ensures external sources always display the appropriate modal, with tests updated accordingly.
> 
> - **Deep link interstitial logic (`handleUniversalLink.ts`)**:
>   - Compute `linkType` once (`linkInstanceType`) and use it for decisions.
>   - Rename `interstitialWhitelistSources` to `inAppLinkSources` and remove `ORIGIN_DEEPLINK` (external).
>   - Only bypass redirect modal when `source ∈ inAppLinkSources` AND `linkType === PRIVATE`.
>   - External sources (e.g., `ORIGIN_DEEPLINK`) always show a modal (PRIVATE → redirect, PUBLIC → caution).
>   - Existing `interstitialWhitelistUrls` behavior preserved.
> - **Tests (`__tests__/handleUniversalLink.test.ts`)**:
>   - Update/expand cases: in-app signed links skip modal; in-app unsigned show PUBLIC modal.
>   - Add external-source cases: always show modal (PRIVATE/PUBLIC).
>   - Rename describe blocks to reflect in-app vs external sources; keep whitelist URL skip behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96f07782bc56b08a1477261f937b99448cb50855. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->