### PR TITLE
fix: Format addresses in address list

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRowsList/MultichainAddressRowsList.utils.test.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRowsList/MultichainAddressRowsList.utils.test.ts
@@ -243,25 +243,24 @@ describe('MultichainAddressRowsList Utils', () => {
       expect(result[0].address).toBe(testAddress);
     });
 
-    it('formats EVM addresses with proper checksumming', () => {
-      // Use a valid lowercase EVM address
+    it('converts lowercase EVM address to checksummed format', () => {
       const lowercaseEvmAddress = '0xc4955c0d639d99699bfd7ec54d9fafee40e4d272';
       const expectedChecksummed = '0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272';
       const account = createMockAccount(lowercaseEvmAddress, ['eip155:0x1']);
+
       const result = getCompatibleNetworksForAccount(account, mockNetworks);
 
       expect(result[0].address).toBe(expectedChecksummed);
     });
 
-    it('preserves non-EVM addresses without modification', () => {
-      // Use a Solana address (base58 format)
+    it('returns unmodified address for non-EVM networks', () => {
       const solanaAddress = 'DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy';
       const account = createMockAccount(solanaAddress, [
         'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
       ]);
+
       const result = getCompatibleNetworksForAccount(account, mockNetworks);
 
-      // Non-EVM addresses should remain unchanged
       expect(result[0].address).toBe(solanaAddress);
     });
   });

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRowsList/MultichainAddressRowsList.utils.test.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRowsList/MultichainAddressRowsList.utils.test.ts
@@ -242,5 +242,27 @@ describe('MultichainAddressRowsList Utils', () => {
 
       expect(result[0].address).toBe(testAddress);
     });
+
+    it('formats EVM addresses with proper checksumming', () => {
+      // Use a valid lowercase EVM address
+      const lowercaseEvmAddress = '0xc4955c0d639d99699bfd7ec54d9fafee40e4d272';
+      const expectedChecksummed = '0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272';
+      const account = createMockAccount(lowercaseEvmAddress, ['eip155:0x1']);
+      const result = getCompatibleNetworksForAccount(account, mockNetworks);
+
+      expect(result[0].address).toBe(expectedChecksummed);
+    });
+
+    it('preserves non-EVM addresses without modification', () => {
+      // Use a Solana address (base58 format)
+      const solanaAddress = 'DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy';
+      const account = createMockAccount(solanaAddress, [
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      ]);
+      const result = getCompatibleNetworksForAccount(account, mockNetworks);
+
+      // Non-EVM addresses should remain unchanged
+      expect(result[0].address).toBe(solanaAddress);
+    });
   });
 });

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRowsList/MultichainAddressRowsList.utils.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRowsList/MultichainAddressRowsList.utils.ts
@@ -4,6 +4,7 @@ import { SolScope, BtcScope, TrxScope } from '@metamask/keyring-api';
 import { CaipChainId } from '@metamask/utils';
 import { TEST_NETWORK_IDS } from '../../../../constants/network';
 import { PopularList } from '../../../../util/networks/customNetworks';
+import { toFormattedAddress } from '../../../../util/address';
 
 export interface NetworkAddressItem {
   chainId: CaipChainId;
@@ -89,13 +90,14 @@ export const sortNetworkAddressItems = (
 
 /**
  * Creates a NetworkAddressItem from chain ID, network config, and address
+ * Ensures addresses are properly formatted: checksummed for EVM, raw for non-EVM
  *
  * @param chainId - Chain ID
  * @param network - Network configuration
  * @param network.name - Network name
  * @param network.chainId - Network chain ID
  * @param address - Address to associate with the network
- * @returns NetworkAddressItem object
+ * @returns NetworkAddressItem object with properly formatted address
  */
 const createNetworkAddressItem = (
   chainId: CaipChainId,
@@ -104,7 +106,7 @@ const createNetworkAddressItem = (
 ): NetworkAddressItem => ({
   chainId,
   networkName: network.name,
-  address,
+  address: toFormattedAddress(address),
 });
 
 /**

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
@@ -8,6 +8,7 @@ import renderWithProvider from '../../../../util/test/renderWithProvider';
 
 import { AddressList } from './AddressList';
 import { MULTICHAIN_ADDRESS_ROW_QR_BUTTON_TEST_ID } from '../../../../component-library/components-temp/MultichainAccounts/MultichainAddressRow';
+import { toFormattedAddress } from '../../../../util/address';
 
 const ACCOUNT_WALLET_ID = 'entropy:wallet-id-1' as AccountWalletId;
 const ACCOUNT_GROUP_ID = 'entropy:wallet-id-1/1' as AccountGroupId;
@@ -208,7 +209,7 @@ describe('AddressList', () => {
       {
         screen: 'ShareAddressQR',
         params: {
-          address: mockEthEoaAccount.address,
+          address: toFormattedAddress(mockEthEoaAccount.address),
           networkName: 'Ethereum',
           chainId: 'eip155:1',
           groupId: ACCOUNT_GROUP_ID,

--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
@@ -139,7 +139,7 @@ export const PrivateKeyList = () => {
           password,
           account.address,
         );
-        privateKeyMap[account.address] = pk;
+        privateKeyMap[account.id] = pk;
       }),
     );
 
@@ -188,7 +188,7 @@ export const PrivateKeyList = () => {
           ),
           callback: async () => {
             await ClipboardManager.setStringExpire(
-              privateKeys[item.account.address],
+              privateKeys[item.account.id],
             );
           },
         }}

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { AccountGroupId } from '@metamask/account-api';
 import BottomSheet, {
@@ -32,6 +32,7 @@ import { getNetworkImageSource } from '../../../../../util/networks';
 import { ShareAddressQRIds } from '../../../../../../e2e/selectors/MultichainAccounts/ShareAddressQR.selectors';
 import { selectAccountGroupById } from '../../../../../selectors/multichainAccounts/accountTreeController';
 import { RootState } from '../../../../../reducers';
+import { toFormattedAddress } from '../../../../../util/address';
 
 interface RootNavigationParamList extends ParamListBase {
   ShareAddressQR: {
@@ -61,13 +62,19 @@ export const ShareAddressQR = () => {
   const { toBlockExplorer, getBlockExplorerName } = useBlockExplorer(chainId);
   const networkImageSource = getNetworkImageSource({ chainId });
 
+  // Format address: checksummed for EVM, raw for non-EVM
+  const formattedAddress = useMemo(
+    () => toFormattedAddress(address),
+    [address],
+  );
+
   const handleOnBack = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
 
   const handleViewOnBlockExplorer = useCallback(() => {
-    toBlockExplorer(address);
-  }, [address, toBlockExplorer]);
+    toBlockExplorer(formattedAddress);
+  }, [formattedAddress, toBlockExplorer]);
 
   return (
     <BottomSheet ref={sheetRef}>
@@ -81,7 +88,7 @@ export const ShareAddressQR = () => {
       >
         <Box twClassName="p-6 border border-muted rounded-2xl">
           <QRCode
-            value={address}
+            value={formattedAddress}
             size={200}
             logo={networkImageSource}
             logoSize={32}
@@ -90,7 +97,7 @@ export const ShareAddressQR = () => {
         </Box>
         <Box twClassName="mt-6 mb-4">
           <QRAccountDisplay
-            accountAddress={address}
+            accountAddress={formattedAddress}
             label={strings('multichain_accounts.share_address_qr.title', {
               networkName,
             })}

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { AccountGroupId } from '@metamask/account-api';
 import BottomSheet, {
@@ -32,7 +32,6 @@ import { getNetworkImageSource } from '../../../../../util/networks';
 import { ShareAddressQRIds } from '../../../../../../e2e/selectors/MultichainAccounts/ShareAddressQR.selectors';
 import { selectAccountGroupById } from '../../../../../selectors/multichainAccounts/accountTreeController';
 import { RootState } from '../../../../../reducers';
-import { toFormattedAddress } from '../../../../../util/address';
 
 interface RootNavigationParamList extends ParamListBase {
   ShareAddressQR: {
@@ -62,19 +61,13 @@ export const ShareAddressQR = () => {
   const { toBlockExplorer, getBlockExplorerName } = useBlockExplorer(chainId);
   const networkImageSource = getNetworkImageSource({ chainId });
 
-  // Format address: checksummed for EVM, raw for non-EVM
-  const formattedAddress = useMemo(
-    () => toFormattedAddress(address),
-    [address],
-  );
-
   const handleOnBack = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
 
   const handleViewOnBlockExplorer = useCallback(() => {
-    toBlockExplorer(formattedAddress);
-  }, [formattedAddress, toBlockExplorer]);
+    toBlockExplorer(address);
+  }, [address, toBlockExplorer]);
 
   return (
     <BottomSheet ref={sheetRef}>
@@ -88,7 +81,7 @@ export const ShareAddressQR = () => {
       >
         <Box twClassName="p-6 border border-muted rounded-2xl">
           <QRCode
-            value={formattedAddress}
+            value={address}
             size={200}
             logo={networkImageSource}
             logoSize={32}
@@ -97,7 +90,7 @@ export const ShareAddressQR = () => {
         </Box>
         <Box twClassName="mt-6 mb-4">
           <QRAccountDisplay
-            accountAddress={formattedAddress}
+            accountAddress={address}
             label={strings('multichain_accounts.share_address_qr.title', {
               networkName,
             })}

--- a/app/selectors/multichainAccounts/accounts.ts
+++ b/app/selectors/multichainAccounts/accounts.ts
@@ -22,6 +22,7 @@ import {
 import { TEST_NETWORK_IDS } from '../../constants/network';
 import type { AccountGroupWithInternalAccounts } from './accounts.type';
 import { sortNetworkAddressItems } from '../../component-library/components-temp/MultichainAccounts/MultichainAddressRowsList/MultichainAddressRowsList.utils';
+import { toFormattedAddress } from '../../util/address';
 
 /**
  * Extracts the wallet ID from an account group ID.
@@ -289,12 +290,14 @@ export const selectInternalAccountListSpreadByScopesByGroupId =
             account.type === EthAccountType.Eoa
               ? ethereumNetworkIds
               : account.scopes || [];
+          // Format address once: checksummed for EVM, raw for non-EVM
+          const formattedAddress = toFormattedAddress(account.address);
           // Filter out testnets from scopes and map each scope to an account-scope object
           return filterTestnets(
             scopes as CaipChainId[],
             networkConfigurations,
           ).map((scope: CaipChainId) => ({
-            account,
+            account: { ...account, address: formattedAddress },
             scope,
             networkName:
               networkConfigurations[scope]?.name || 'Unknown Network',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**


1. What is the reason for the change?
- EVM addresses should always be checksummed. Non evm addresses should not.
- Our addresses were formatted correctly on the list view but not in the QR modal
- This fix ensures that all the addresses being rendered on that screen have the proper formatting
2. What is the improvement/solution?
- call toFormattedAddress before passing it as a prop.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed bug where the EVM addresses were not checksummed

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1327

## **Manual testing steps**
1. create or import a wallet
2. con the home page click the receive button
3. it should open the address list
4. then, look at your EVM addresses and ensure that the shortened versions are checksummed
5. copy the address and ensure that the address is checksummed
6. click on the QR modal and ensure that the address is checksummed
7. scan the qr code and verify that the address is checksummed
8. look at your Bitcoin address, it should not be checksummed.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-12-04 at 16 42 28" src="https://github.com/user-attachments/assets/33e47a72-9f11-42a3-9efd-3a3fea271953" />

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-12-04 at 16 42 12" src="https://github.com/user-attachments/assets/c9162dfe-b619-44e4-9fa4-8dd86f935e70" />


### **After**

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-12-04 at 16 33 52" src="https://github.com/user-attachments/assets/a2feb119-0a07-4010-a220-95b70bcbaf5c" />

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-12-04 at 16 33 48" src="https://github.com/user-attachments/assets/4ea253ae-9953-4f77-a623-7ec739aa286d" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Checksums EVM addresses (leaves non‑EVM raw) across address list/QR and selectors, and switches PrivateKeyList to store private keys by account id; adds tests.
> 
> - **Address formatting**
>   - Use `toFormattedAddress` in `MultichainAddressRowsList.utils` when creating `NetworkAddressItem`.
>   - Format addresses in selector `selectInternalAccountListSpreadByScopesByGroupId` before mapping items.
>   - Pass formatted address to QR navigation in `AddressList.test.tsx`.
> - **Private keys**
>   - Store exported private keys by `account.id` instead of `account.address` in `PrivateKeyList.tsx` and update copy callback usage.
> - **Tests**
>   - Add assertions for checksummed EVM addresses and unmodified non‑EVM addresses in `MultichainAddressRowsList.utils.test.ts`.
>   - Update QR expectation to use formatted address in `AddressList.test.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c35634f4188e125a398f18be69806ff1cbf25d31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->