### PR TITLE
test: disable predict feature flag globally and only enable in predict tests

### DIFF
--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -183,6 +183,7 @@ jobs:
           GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
           GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+          MM_PREDICT_GTM_MODAL_ENABLED: 'false'
 
       - name: Repack APK with JS updates using @expo/repack-app
         if: ${{ steps.apk-cache-restore.outputs.cache-hit == 'true' }}

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -48,6 +48,7 @@ jobs:
       GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
       GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
       MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+      MM_PREDICT_GTM_MODAL_ENABLED: 'false'
 
     steps:
       # Get the source code from the repository

--- a/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
+++ b/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
@@ -271,6 +271,12 @@ const DEFAULT_FEATURE_FLAGS_ARRAY: Record<string, unknown>[] = [
     },
   },
   {
+    predictGtmOnboardingModalEnabled: {
+      enabled: false,
+      minimumVersion: '7.60.0',
+    },
+  },
+  {
     additionalNetworksBlacklist: [], // Empty by default, can be overridden in tests
   },
   {

--- a/e2e/api-mocking/mock-responses/feature-flags-mocks.ts
+++ b/e2e/api-mocking/mock-responses/feature-flags-mocks.ts
@@ -150,6 +150,10 @@ export const remoteFeatureFlagPredictEnabled = (enabled = true) => ({
     enabled,
     minimumVersion: '7.60.0',
   },
+  predictGtmOnboardingModalEnabled: {
+    enabled: false,
+    minimumVersion: '7.60.0',
+  },
 });
 
 export const remoteFeatureFlagSendRedesignDisabled = {

--- a/e2e/framework/fixtures/FixtureBuilder.ts
+++ b/e2e/framework/fixtures/FixtureBuilder.ts
@@ -579,6 +579,14 @@ class FixtureBuilder {
                   featureVersion: null,
                   minimumVersion: null,
                 },
+                predictTradingEnabled: {
+                  enabled: false,
+                  minimumVersion: '7.60.0',
+                },
+                predictGtmOnboardingModalEnabled: {
+                  enabled: false,
+                  minimumVersion: '7.60.0',
+                },
               },
             },
           },

--- a/e2e/framework/fixtures/FixtureBuilder.ts
+++ b/e2e/framework/fixtures/FixtureBuilder.ts
@@ -579,14 +579,6 @@ class FixtureBuilder {
                   featureVersion: null,
                   minimumVersion: null,
                 },
-                predictTradingEnabled: {
-                  enabled: false,
-                  minimumVersion: '7.60.0',
-                },
-                predictGtmOnboardingModalEnabled: {
-                  enabled: false,
-                  minimumVersion: '7.60.0',
-                },
               },
             },
           },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Disable predict feature in main feature flag mock
- Suppress predict modal as this can cause other tests to fail

<img width="409" height="913" alt="Screenshot 2025-12-05 at 10 27 20" src="https://github.com/user-attachments/assets/001e7b1e-a3f5-4a63-81c1-5cb4086e11fb" />

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a disabled Predict GTM onboarding modal flag to mocks and sets CI env to suppress the modal, keeping Predict trading disabled by default.
> 
> - **E2E API Mocks**:
>   - Add `predictGtmOnboardingModalEnabled` (disabled; `minimumVersion: '7.60.0'`) to `DEFAULT_FEATURE_FLAGS_ARRAY` in `e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts` and to `remoteFeatureFlagPredictEnabled` in `e2e/api-mocking/mock-responses/feature-flags-mocks.ts`.
>   - Ensure `predictTradingEnabled` remains disabled by default in mocks.
> - **CI Workflows**:
>   - Set `MM_PREDICT_GTM_MODAL_ENABLED: 'false'` in `/.github/workflows/build-android-e2e.yml` and `/.github/workflows/build-ios-e2e.yml` to suppress the modal during E2E builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a737aac971ba7d903f7b5fc622b75d6bb568665a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->