### PR TITLE
chore: update github-tools to v1.1.3

### DIFF
--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -48,11 +48,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Update Release Changelog
-        uses: MetaMask/github-tools/.github/actions/update-release-changelog@v1.1.2
+        uses: MetaMask/github-tools/.github/actions/update-release-changelog@v1.1.3
         with:
           release-branch: ${{ github.ref_name }}
           repository-url: ${{ github.server_url }}/${{ github.repository }}
           platform: mobile
           previous-version-ref: 'null'
-          github-tools-version: v1.1.2
+          github-tools-version: v1.1.3
           github-token: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION
## **Description**

Updates `github-tools` to v1.1.3 in release workflows.

### Changes

- Updated `update-release-changelog.yml` to use `github-tools@v1.1.3`

### What's included in v1.1.3

- **Fixed**: Prevent changelog PR creation when branches are in sync ([#177](https://github.com/MetaMask/github-tools/pull/177))

See [github-tools v1.1.3 release notes](https://github.com/MetaMask/github-tools/releases/tag/v1.1.3).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/INFRA-3167

## **Manual testing steps**

```gherkin
Feature: Release changelog workflow

  Scenario: Workflow uses updated github-tools version
    Given the workflow configuration is updated

    When a release branch receives a push
    Then the workflow uses github-tools v1.1.3
```

## **Screenshots/Recordings**

N/A - workflow configuration change only

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.