### PR TITLE
fix(ramp): experience switcher text cp-7.61.0

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/SettingsModal.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/SettingsModal.test.tsx
@@ -100,11 +100,11 @@ describe('SettingsModal', () => {
     expect(getByText('View order history')).toBeTruthy();
   });
 
-  it('displays use new buy experience menu item', () => {
+  it('displays more ways to buy menu item', () => {
     const { getByText } = render();
 
-    expect(getByText('Use new buy experience')).toBeTruthy();
-    expect(getByText('Try new native on ramp')).toBeTruthy();
+    expect(getByText('More ways to buy')).toBeTruthy();
+    expect(getByText('Switch to the new version')).toBeTruthy();
   });
 
   it('navigates to transactions view when view order history is pressed', () => {
@@ -121,11 +121,11 @@ describe('SettingsModal', () => {
     });
   });
 
-  it('navigates to deposit when use new buy experience is pressed', () => {
+  it('navigates to deposit when more ways to buy is pressed', () => {
     const { getByText } = render();
-    const newBuyExperienceButton = getByText('Use new buy experience');
+    const moreWaysToBuyButton = getByText('More ways to buy');
 
-    fireEvent.press(newBuyExperienceButton);
+    fireEvent.press(moreWaysToBuyButton);
 
     expect(mockDangerouslyGetParent).toHaveBeenCalled();
     expect(mockGoToDeposit).toHaveBeenCalled();
@@ -140,9 +140,9 @@ describe('SettingsModal', () => {
     });
 
     const { getByText } = render();
-    const newBuyExperienceButton = getByText('Use new buy experience');
+    const moreWaysToBuyButton = getByText('More ways to buy');
 
-    fireEvent.press(newBuyExperienceButton);
+    fireEvent.press(moreWaysToBuyButton);
 
     expect(mockParentGoBack).toHaveBeenCalled();
   });
@@ -162,10 +162,10 @@ describe('SettingsModal', () => {
       expect(getByText('View order history')).toBeTruthy();
     });
 
-    it('renders add icon for new buy experience', () => {
+    it('renders add icon for more ways to buy', () => {
       const { getByText } = render();
 
-      expect(getByText('Use new buy experience')).toBeTruthy();
+      expect(getByText('More ways to buy')).toBeTruthy();
     });
   });
 
@@ -179,9 +179,9 @@ describe('SettingsModal', () => {
 
     it('tracks event when deposit is pressed', () => {
       const { getByText } = render();
-      const newBuyExperienceButton = getByText('Use new buy experience');
+      const moreWaysToBuyButton = getByText('More ways to buy');
 
-      fireEvent.press(newBuyExperienceButton);
+      fireEvent.press(moreWaysToBuyButton);
 
       expect(mockTrackEvent).toHaveBeenCalledWith('RAMPS_BUTTON_CLICKED', {
         location: 'Buy Settings Modal',

--- a/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/__snapshots__/SettingsModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/__snapshots__/SettingsModal.test.tsx.snap
@@ -691,7 +691,7 @@ exports[`SettingsModal renders snapshot correctly 1`] = `
                                       }
                                     }
                                   >
-                                    Use new buy experience
+                                    More ways to buy
                                   </Text>
                                   <Text
                                     accessibilityRole="text"
@@ -705,7 +705,7 @@ exports[`SettingsModal renders snapshot correctly 1`] = `
                                       }
                                     }
                                   >
-                                    Try new native on ramp
+                                    Switch to the new version
                                   </Text>
                                 </View>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/__snapshots__/ConfigurationModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/__snapshots__/ConfigurationModal.test.tsx.snap
@@ -792,7 +792,7 @@ exports[`ConfigurationModal render matches snapshot 1`] = `
                                       }
                                     }
                                   >
-                                    Use a different payment provider
+                                    Switch to the classic version
                                   </Text>
                                 </View>
                               </View>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -701,7 +701,7 @@
       "error_sdk_not_initialized": "SDK not initialized",
       "logged_out_error": "Error logging out",
       "more_ways_to_buy": "More ways to buy",
-      "more_ways_to_buy_description": "Use a different payment provider"
+      "more_ways_to_buy_description": "Switch to the classic version"
     },
     "region_modal": {
       "select_a_region": "Select a region",
@@ -4684,8 +4684,8 @@
     "webview_error_no_address_provided": "No wallet address was provided to continue",
     "settings_modal": {
       "title": "Settings",
-      "use_new_buy_experience": "Use new buy experience",
-      "use_new_buy_experience_description": "Try new native on ramp"
+      "use_new_buy_experience": "More ways to buy",
+      "use_new_buy_experience_description": "Switch to the new version"
     },
     "onboarding": {
       "what_to_expect": "What to Expect",


### PR DESCRIPTION
## **Description**

This PR updates the copy text in the "escape hatch" modals that allow users to switch between the Aggregator (classic) and Deposit (new) buy experiences.

**Reason for change:**
The current copy text ("Use new buy experience" / "Try new native on ramp" and "More ways to buy" / "Use a different payment provider") was confusing users about the action being performed. Users didn't realize they were switching to a completely different feature/experience.

**Solution:**
Updated the modal copy to be clearer about switching between versions:
- **Aggregator → Native (Deposit):** "More ways to buy" / "Switch to the new version"
- **Native (Deposit) → Aggregator:** "More ways to buy" / "Switch to the classic version"

## **Changelog**

CHANGELOG entry: Improved clarity of the "More ways to buy" modal copy when switching between buy experiences

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-2858 
Fixes https://github.com/MetaMask/metamask-mobile/issues/23716 

## **Manual testing steps**

```gherkin
Feature: More ways to buy escape hatch copy

  Scenario: user views escape hatch modal from Aggregator (classic) experience
    Given user is in the Aggregator buy flow
    When user opens the settings modal
    Then user sees "More ways to buy" with description "Switch to the new version"

  Scenario: user views escape hatch modal from Deposit (new) experience
    Given user is in the Deposit buy flow
    When user opens the configuration modal
    Then user sees "More ways to buy" with description "Switch to the classic version"
```

## **Screenshots/Recordings**

### **Before**

| Aggregator | Deposit |
|:--:|:--:|
| <img width="299" alt="before_agg" src="https://github.com/user-attachments/assets/5a01ef8b-7cad-4c2e-a149-c43cc4b6aec2" /> | <img width="299" alt="before_deposit" src="https://github.com/user-attachments/assets/f4f88802-f42d-4cf6-ae2f-61e95ad9dbae" /> |

### **After**

| Aggregator | Deposit |
|:--:|:--:|
| <img width="299" alt="after_agg" src="https://github.com/user-attachments/assets/9b05bdb7-bae8-427c-bc3d-153fb82d895c" /> | <img width="299" alt="after_deposit" src="https://github.com/user-attachments/assets/9ec3e323-0e58-4c98-875d-219cdddba271" /> |


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

You can drop your 4 screenshots in the Before/After sections where I've left the placeholders!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates copy and tests for the buy experience switcher: “More ways to buy” with “Switch to the new version” (Aggregator) and “Switch to the classic version” (Deposit).
> 
> - **UI copy updates**
>   - `fiat_on_ramp_aggregator.settings_modal`:
>     - `use_new_buy_experience` → `More ways to buy`
>     - Description → `Switch to the new version`
>   - `deposit.configuration_modal`:
>     - `more_ways_to_buy_description` → `Switch to the classic version`
> - **Tests & snapshots**
>   - Update `SettingsModal.test.tsx` and related snapshots to assert new labels and descriptions.
>   - Update `ConfigurationModal` snapshot to reflect new description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faecee2f253379f7312cf6a105c685f0b8249909. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->