### PR TITLE
chore: Update hip3 logo base url

### DIFF
--- a/app/components/UI/Perps/constants/hyperLiquidConfig.ts
+++ b/app/components/UI/Perps/constants/hyperLiquidConfig.ts
@@ -58,10 +58,6 @@ export const HYPERLIQUID_ENDPOINTS: HyperLiquidEndpoints = {
 export const HYPERLIQUID_ASSET_ICONS_BASE_URL =
   'https://app.hyperliquid.xyz/coins/';
 
-// HIP-3 asset icons base URL (for assets with dex:symbol format)
-export const HIP3_ASSET_ICONS_BASE_URL =
-  'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155%3A999/';
-
 // Asset configurations for multichain abstraction
 export const HYPERLIQUID_ASSET_CONFIGS: HyperLiquidAssetConfigs = {
   USDC: {

--- a/app/components/UI/Perps/utils/marketUtils.test.ts
+++ b/app/components/UI/Perps/utils/marketUtils.test.ts
@@ -16,8 +16,6 @@ import { CandlePeriod } from '../constants/chartConfig';
 
 jest.mock('../constants/hyperLiquidConfig', () => ({
   HYPERLIQUID_ASSET_ICONS_BASE_URL: 'https://app.hyperliquid.xyz/coins/',
-  HIP3_ASSET_ICONS_BASE_URL:
-    'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/',
 }));
 
 describe('marketUtils', () => {
@@ -354,24 +352,20 @@ describe('marketUtils', () => {
       expect(result).toBe('https://app.hyperliquid.xyz/coins/BTC.svg');
     });
 
-    it('returns GitHub URL for HIP-3 asset with colon replaced by underscore', () => {
+    it('returns HyperLiquid URL for HIP-3 asset with market:symbol format', () => {
       const symbol = 'xyz:TSLA';
 
       const result = getAssetIconUrl(symbol);
 
-      expect(result).toBe(
-        'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3%3Axyz_TSLA.svg',
-      );
+      expect(result).toBe('https://app.hyperliquid.xyz/coins/xyz:TSLA.svg');
     });
 
-    it('returns GitHub URL for HIP-3 asset with different DEX prefix', () => {
+    it('returns HyperLiquid URL for HIP-3 asset with different DEX prefix', () => {
       const symbol = 'abc:XYZ100';
 
       const result = getAssetIconUrl(symbol);
 
-      expect(result).toBe(
-        'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3%3Aabc_XYZ100.svg',
-      );
+      expect(result).toBe('https://app.hyperliquid.xyz/coins/abc:XYZ100.svg');
     });
 
     it('removes k prefix for specified assets', () => {
@@ -413,9 +407,7 @@ describe('marketUtils', () => {
 
       const result = getAssetIconUrl(symbol);
 
-      expect(result).toBe(
-        'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3%3Axyz_TSLA.svg',
-      );
+      expect(result).toBe('https://app.hyperliquid.xyz/coins/xyz:TSLA.svg');
     });
   });
 

--- a/app/components/UI/Perps/utils/marketUtils.ts
+++ b/app/components/UI/Perps/utils/marketUtils.ts
@@ -1,10 +1,7 @@
 import type { CandleData, CandleStick } from '../types/perps-types';
 import type { PerpsMarketData } from '../controllers/types';
 import type { BadgeType } from '../components/PerpsBadge/PerpsBadge.types';
-import {
-  HYPERLIQUID_ASSET_ICONS_BASE_URL,
-  HIP3_ASSET_ICONS_BASE_URL,
-} from '../constants/hyperLiquidConfig';
+import { HYPERLIQUID_ASSET_ICONS_BASE_URL } from '../constants/hyperLiquidConfig';
 
 /**
  * Maximum length for market filter patterns (prevents DoS attacks)
@@ -449,9 +446,7 @@ export const getAssetIconUrl = (
   // Check for HIP-3 asset (contains colon) BEFORE uppercasing
   if (symbol.includes(':')) {
     const [dex, assetSymbol] = symbol.split(':');
-    // Keep DEX lowercase, uppercase asset: xyz:XYZ100 -> xyz_XYZ100
-    const hip3Symbol = `${dex.toLowerCase()}_${assetSymbol.toUpperCase()}`;
-    return `${HIP3_ASSET_ICONS_BASE_URL}hip3%3A${hip3Symbol}.svg`;
+    return `${HYPERLIQUID_ASSET_ICONS_BASE_URL}${dex.toLowerCase()}:${assetSymbol.toUpperCase()}.svg`;
   }
 
   // For regular assets, uppercase the entire symbol


### PR DESCRIPTION
## **Description**

We initially were hosting the hip3 logos internally via contract metadata while we were developing the hip3 feature. This was because Hyperliquid did not expose this endpoint until the markets went live, and we weren't sure how they would be constructed.

Now that they are live, we can see how the url is constructed, and point to the hyperliquid endpoint just like we do with crypto assets.

The benefits of this approach are:
1. Less overhead for us, since we don't need to keep track of which markets are going live in order to add logos to our internal cdn. It will automatically work as new markets get added.
2. If the logos change in HL, they will automatically change on our end as well.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix new hip3 asset logos not rendering

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2223

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="411" height="835" alt="Screenshot 2025-12-05 at 10 54 25 AM" src="https://github.com/user-attachments/assets/1f2d650b-0adc-4a48-981e-21e4509fdf48" />

### **After**

<img width="413" height="836" alt="Screenshot 2025-12-05 at 10 40 26 AM" src="https://github.com/user-attachments/assets/8018f4a2-fd75-4985-912d-c044a84bc1f7" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches HIP-3 asset icon URLs to HyperLiquid’s `coins` endpoint and updates `getAssetIconUrl` logic and tests accordingly.
> 
> - **Perps UI**
>   - **Asset Icons**:
>     - Remove `HIP3_ASSET_ICONS_BASE_URL` and use `HYPERLIQUID_ASSET_ICONS_BASE_URL` for HIP-3 markets.
>     - Update `getAssetIconUrl` to output `dex:SYMBOL.svg` (DEX lowercase, symbol uppercase) via `https://app.hyperliquid.xyz/coins/`.
>   - **Utils**:
>     - Modify `app/components/UI/Perps/utils/marketUtils.ts` to construct HIP-3 icon URLs from `dex:symbol` and retain existing k-prefix handling for regular assets.
>   - **Tests**:
>     - Adjust mocks and expectations in `app/components/UI/Perps/utils/marketUtils.test.ts` to expect HyperLiquid icon URLs for HIP-3 assets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e20c225166b4701f4c343737c8bd202e37b3768e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->