### PR TITLE
chore: extract MusdTag component logic from RewardsTag logic

### DIFF
--- a/app/components/UI/Earn/components/OutputAmountTag/OutputAmountTag.test.tsx
+++ b/app/components/UI/Earn/components/OutputAmountTag/OutputAmountTag.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import OutputAmountTag, { OUTPUT_AMOUNT_TAG_SELECTOR } from './OutputAmountTag';
+
+describe('OutputAmountTag', () => {
+  it('renders correctly with amount and symbol', () => {
+    const { getByTestId, getByText } = renderWithProvider(
+      <OutputAmountTag amount="10" symbol="mUSD" />,
+    );
+
+    expect(getByTestId(OUTPUT_AMOUNT_TAG_SELECTOR)).toBeOnTheScreen();
+    expect(getByText('10 mUSD')).toBeOnTheScreen();
+  });
+
+  it('renders correctly with custom symbol', () => {
+    const { getByText } = renderWithProvider(
+      <OutputAmountTag amount="25" symbol="USDC" />,
+    );
+
+    expect(getByText('25 USDC')).toBeOnTheScreen();
+  });
+
+  it('renders amount without symbol when symbol not provided', () => {
+    const { getByText } = renderWithProvider(<OutputAmountTag amount="100" />);
+
+    expect(getByText('100')).toBeOnTheScreen();
+  });
+
+  it('renders without background when showBackground is false', () => {
+    const { getByText } = renderWithProvider(
+      <OutputAmountTag amount="10" symbol="mUSD" showBackground={false} />,
+    );
+
+    expect(getByText('10 mUSD')).toBeOnTheScreen();
+  });
+
+  it('uses custom testID when provided', () => {
+    const customTestID = 'custom-output-tag';
+    const { getByTestId } = renderWithProvider(
+      <OutputAmountTag amount="50" symbol="ETH" testID={customTestID} />,
+    );
+
+    expect(getByTestId(customTestID)).toBeOnTheScreen();
+  });
+
+  it('renders correctly with 0 amount', () => {
+    const { getByText } = renderWithProvider(
+      <OutputAmountTag amount="0" symbol="mUSD" />,
+    );
+
+    expect(getByText('0 mUSD')).toBeOnTheScreen();
+  });
+
+  it('renders correctly with large amount', () => {
+    const { getByText } = renderWithProvider(
+      <OutputAmountTag amount="1,500" symbol="USDT" />,
+    );
+
+    expect(getByText('1,500 USDT')).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Earn/components/OutputAmountTag/OutputAmountTag.test.tsx
+++ b/app/components/UI/Earn/components/OutputAmountTag/OutputAmountTag.test.tsx
@@ -26,12 +26,16 @@ describe('OutputAmountTag', () => {
     expect(getByText('100')).toBeOnTheScreen();
   });
 
-  it('renders without background when showBackground is false', () => {
-    const { getByText } = renderWithProvider(
+  it('sets backgroundColor to transparent when showBackground is false', () => {
+    const { getByTestId } = renderWithProvider(
       <OutputAmountTag amount="10" symbol="mUSD" showBackground={false} />,
     );
 
-    expect(getByText('10 mUSD')).toBeOnTheScreen();
+    const tagElement = getByTestId(OUTPUT_AMOUNT_TAG_SELECTOR);
+
+    expect(tagElement.props.style).toEqual(
+      expect.objectContaining({ backgroundColor: 'transparent' }),
+    );
   });
 
   it('uses custom testID when provided', () => {

--- a/app/components/UI/Earn/components/OutputAmountTag/OutputAmountTag.tsx
+++ b/app/components/UI/Earn/components/OutputAmountTag/OutputAmountTag.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import TagBase, {
+  TagSeverity,
+  TagShape,
+} from '../../../../../component-library/base-components/TagBase';
+import { TextVariant } from '../../../../../component-library/components/Texts/Text';
+import { useStyles } from '../../../../../component-library/hooks';
+import { useTheme } from '../../../../../util/theme';
+
+export const OUTPUT_AMOUNT_TAG_SELECTOR = 'output-amount-tag';
+
+interface OutputAmountTagProps {
+  /**
+   * Amount to display
+   */
+  amount: string;
+  /**
+   * Token symbol to display after the amount
+   */
+  symbol?: string;
+  /**
+   * Whether to show the background color
+   * @default true
+   */
+  showBackground?: boolean;
+  /**
+   * Optional test ID for the component
+   */
+  testID?: string;
+}
+
+const createStyles = () =>
+  StyleSheet.create({
+    wrapper: {
+      marginBottom: 6,
+    },
+  });
+
+/**
+ * Generic tag component that displays an output amount with symbol.
+ * Used in conversion flows to show the expected output amount.
+ */
+const OutputAmountTag: React.FC<OutputAmountTagProps> = ({
+  amount,
+  symbol,
+  showBackground = true,
+  testID,
+}) => {
+  const { colors } = useTheme();
+  const { styles } = useStyles(createStyles, {});
+
+  const tagStyle = {
+    backgroundColor: showBackground ? colors.background.section : 'transparent',
+    paddingHorizontal: 16,
+    paddingTop: 6,
+    paddingBottom: 6,
+  };
+
+  const displayText = symbol ? `${amount} ${symbol}` : amount;
+
+  return (
+    <View style={styles.wrapper}>
+      <TagBase
+        shape={TagShape.Pill}
+        includesBorder={false}
+        textProps={{
+          variant: TextVariant.BodySMMedium,
+        }}
+        severity={TagSeverity.Neutral}
+        testID={testID || OUTPUT_AMOUNT_TAG_SELECTOR}
+        gap={6}
+        style={tagStyle}
+      >
+        {displayText}
+      </TagBase>
+    </View>
+  );
+};
+
+export default OutputAmountTag;

--- a/app/components/UI/Earn/components/OutputAmountTag/index.ts
+++ b/app/components/UI/Earn/components/OutputAmountTag/index.ts
@@ -1,0 +1,2 @@
+export { default } from './OutputAmountTag';
+export { OUTPUT_AMOUNT_TAG_SELECTOR } from './OutputAmountTag';

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -17,15 +17,21 @@ import { useTransactionCustomAmountAlerts } from '../../../hooks/transactions/us
 import { useAccountTokens } from '../../../hooks/send/useAccountTokens';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 import { AssetType } from '../../../types/token';
-import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import {
+  useTransactionPayRequiredTokens,
+  useIsTransactionPayLoading,
+} from '../../../hooks/pay/useTransactionPayData';
 import { strings } from '../../../../../../../locales/i18n';
 import { Hex } from '@metamask/utils';
 import { TransactionPayRequiredToken } from '@metamask/transaction-pay-controller';
 import { fireEvent } from '@testing-library/react-native';
 import { TransactionType } from '@metamask/transaction-controller';
 import { useTransactionConfirm } from '../../../hooks/transactions/useTransactionConfirm';
+import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
+import { useTokenFiatRates } from '../../../hooks/tokens/useTokenFiatRates';
 
 jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe');
+jest.mock('../../../hooks/tokens/useTokenFiatRates');
 jest.mock('../../../hooks/pay/useAutomaticTransactionPayToken');
 jest.mock('../../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../hooks/transactions/useTransactionCustomAmount');
@@ -37,6 +43,7 @@ jest.mock('../../../hooks/send/useAccountTokens');
 jest.mock('../../../hooks/pay/useTransactionPayAvailableTokens');
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../../hooks/transactions/useTransactionConfirm');
+jest.mock('../../../hooks/transactions/useTransactionMetadataRequest');
 jest.mock('../../../hooks/metrics/useConfirmationAlertMetrics', () => ({
   useConfirmationAlertMetrics: () => ({
     trackInlineAlertClicked: jest.fn(),
@@ -51,6 +58,15 @@ jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: jest.fn(),
 }));
+
+jest.mock('react-native-safe-area-context', () => {
+  const inset = { top: 0, right: 0, bottom: 0, left: 0 };
+  return {
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+    useSafeAreaInsets: () => inset,
+    useSafeAreaFrame: () => ({ x: 0, y: 0, width: 390, height: 844 }),
+  };
+});
 
 jest.mock('../../../../../UI/Ramp/hooks/useRampNavigation', () => ({
   ...jest.requireActual('../../../../../UI/Ramp/hooks/useRampNavigation'),
@@ -105,6 +121,10 @@ describe('CustomAmountInfo', () => {
     useTransactionPayAvailableTokens,
   );
 
+  const useIsTransactionPayLoadingMock = jest.mocked(
+    useIsTransactionPayLoading,
+  );
+
   const useTransactionCustomAmountAlertsMock = jest.mocked(
     useTransactionCustomAmountAlerts,
   );
@@ -112,6 +132,12 @@ describe('CustomAmountInfo', () => {
   const useTransactionCustomAmountMock = jest.mocked(
     useTransactionCustomAmount,
   );
+
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+
+  const useTokenFiatRatesMock = jest.mocked(useTokenFiatRates);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -160,6 +186,12 @@ describe('CustomAmountInfo', () => {
     useTransactionPayAvailableTokensMock.mockReturnValue([{}] as AssetType[]);
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
     useTransactionConfirmMock.mockReturnValue({} as never);
+    useIsTransactionPayLoadingMock.mockReturnValue(false);
+    useTokenFiatRatesMock.mockReturnValue([1, 1]);
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.contractInteraction,
+      txParams: { from: '0x123' },
+    } as never);
   });
 
   it('renders amount', () => {
@@ -234,7 +266,12 @@ describe('CustomAmountInfo', () => {
   });
 
   it('renders alternate confirm label if predict withdraw', async () => {
-    const { getByText } = render({
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.predictWithdraw,
+      txParams: { from: '0x123' },
+    } as never);
+
+    const { getByText, findByText } = render({
       transactionType: TransactionType.predictWithdraw,
     });
 
@@ -243,7 +280,30 @@ describe('CustomAmountInfo', () => {
     });
 
     expect(
-      getByText(strings('confirm.deposit_edit_amount_predict_withdraw')),
+      await findByText(strings('confirm.deposit_edit_amount_predict_withdraw')),
     ).toBeDefined();
+  });
+
+  it('calls overrideContent with amountHuman and hides default content', () => {
+    const mockOverrideContent = jest.fn().mockReturnValue(null);
+
+    useTransactionCustomAmountMock.mockReturnValue({
+      amountFiat: '123.45',
+      amountHuman: '0.5',
+      amountHumanDebounced: '0.5',
+      hasInput: true,
+      isInputChanged: false,
+      updatePendingAmount: noop,
+      updatePendingAmountPercentage: noop,
+      updateTokenAmount: noop,
+    });
+
+    const { queryByText } = render({ overrideContent: mockOverrideContent });
+
+    expect(mockOverrideContent).toHaveBeenCalledWith('0.5');
+    expect(queryByText('0 TST')).toBeNull();
+    expect(
+      queryByText(new RegExp(strings('confirm.label.pay_with'))),
+    ).toBeNull();
   });
 });

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -59,10 +59,22 @@ export interface CustomAmountInfoProps {
   disablePay?: boolean;
   hasMax?: boolean;
   preferredToken?: SetPayTokenRequest;
+  /**
+   * Optional render function that overrides the default content.
+   * When set, automatically hides PayTokenAmount, PayWithRow, and children.
+   */
+  overrideContent?: (amountHuman: string) => ReactNode;
 }
 
 export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
-  ({ children, currency, disablePay, hasMax, preferredToken }) => {
+  ({
+    children,
+    currency,
+    disablePay,
+    hasMax,
+    preferredToken,
+    overrideContent,
+  }) => {
     useClearConfirmationOnBackSwipe();
     useAutomaticTransactionPayToken({
       disable: disablePay,
@@ -116,11 +128,20 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             onPress={handleAmountPress}
             disabled={!hasTokens}
           />
-          {disablePay !== true && (
-            <PayTokenAmount amountHuman={amountHuman} disabled={!hasTokens} />
+          {overrideContent ? (
+            overrideContent(amountHuman)
+          ) : (
+            <>
+              {disablePay !== true && (
+                <PayTokenAmount
+                  amountHuman={amountHuman}
+                  disabled={!hasTokens}
+                />
+              )}
+              {children}
+              {disablePay !== true && hasTokens && <PayWithRow />}
+            </>
           )}
-          {children}
-          {disablePay !== true && hasTokens && <PayWithRow />}
         </Box>
         <Box gap={25}>
           <AlertMessage alertMessage={alertMessage} />

--- a/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
@@ -6,9 +6,11 @@ import { useAddToken } from '../../../hooks/tokens/useAddToken';
 import { useRoute } from '@react-navigation/native';
 import { CustomAmountInfo } from '../custom-amount-info';
 import { useCustomAmount } from '../../../hooks/earn/useCustomAmount';
+import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 
 jest.mock('../../../hooks/tokens/useAddToken');
 jest.mock('../../../hooks/earn/useCustomAmount');
+jest.mock('../../../hooks/pay/useTransactionPayAvailableTokens');
 
 jest.mock('../custom-amount-info', () => ({
   CustomAmountInfo: jest.fn(() => null),
@@ -36,6 +38,9 @@ describe('MusdConversionInfo', () => {
   const mockUseAddToken = jest.mocked(useAddToken);
   const mockUseRoute = jest.mocked(useRoute);
   const mockUseCustomAmount = jest.mocked(useCustomAmount);
+  const mockUseTransactionPayAvailableTokens = jest.mocked(
+    useTransactionPayAvailableTokens,
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -44,6 +49,7 @@ describe('MusdConversionInfo', () => {
       outputAmount: null,
       outputSymbol: null,
     });
+    mockUseTransactionPayAvailableTokens.mockReturnValue([]);
   });
 
   afterEach(() => {
@@ -137,6 +143,27 @@ describe('MusdConversionInfo', () => {
         }),
         expect.anything(),
       );
+    });
+  });
+
+  describe('useTransactionPayAvailableTokens', () => {
+    it('calls useTransactionPayAvailableTokens in override content', () => {
+      mockRoute.params = {
+        outputChainId: '0x1' as Hex,
+      };
+
+      mockUseRoute.mockReturnValue(mockRoute);
+      mockUseTransactionPayAvailableTokens.mockReturnValue([
+        { address: '0x123' },
+      ] as never);
+
+      renderWithProvider(<MusdConversionInfo />, {
+        state: {},
+      });
+
+      // The hook is called when MusdOverrideContent renders
+      // We verify the mock was set up correctly
+      expect(mockUseTransactionPayAvailableTokens).toBeDefined();
     });
   });
 });

--- a/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
@@ -5,11 +5,17 @@ import { MusdConversionInfo } from './musd-conversion-info';
 import { useAddToken } from '../../../hooks/tokens/useAddToken';
 import { useRoute } from '@react-navigation/native';
 import { CustomAmountInfo } from '../custom-amount-info';
+import { useCustomAmount } from '../../../hooks/earn/useCustomAmount';
 
 jest.mock('../../../hooks/tokens/useAddToken');
+jest.mock('../../../hooks/earn/useCustomAmount');
 
 jest.mock('../custom-amount-info', () => ({
   CustomAmountInfo: jest.fn(() => null),
+}));
+
+jest.mock('../../rows/pay-with-row', () => ({
+  PayWithRow: jest.fn(() => null),
 }));
 
 const mockRoute = {
@@ -29,9 +35,15 @@ jest.mock('@react-navigation/native', () => {
 describe('MusdConversionInfo', () => {
   const mockUseAddToken = jest.mocked(useAddToken);
   const mockUseRoute = jest.mocked(useRoute);
+  const mockUseCustomAmount = jest.mocked(useCustomAmount);
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseCustomAmount.mockReturnValue({
+      shouldShowOutputAmountTag: false,
+      outputAmount: null,
+      outputSymbol: null,
+    });
   });
 
   afterEach(() => {
@@ -101,6 +113,27 @@ describe('MusdConversionInfo', () => {
       expect(CustomAmountInfo).toHaveBeenCalledWith(
         expect.objectContaining({
           preferredToken: preferredPaymentToken,
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('overrideContent', () => {
+    it('passes overrideContent function to CustomAmountInfo', () => {
+      mockRoute.params = {
+        outputChainId: '0x1' as Hex,
+      };
+
+      mockUseRoute.mockReturnValue(mockRoute);
+
+      renderWithProvider(<MusdConversionInfo />, {
+        state: {},
+      });
+
+      expect(CustomAmountInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          overrideContent: expect.any(Function),
         }),
         expect.anything(),
       );

--- a/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
@@ -146,8 +146,8 @@ describe('MusdConversionInfo', () => {
     });
   });
 
-  describe('useTransactionPayAvailableTokens', () => {
-    it('calls useTransactionPayAvailableTokens in override content', () => {
+  describe('MusdOverrideContent', () => {
+    it('calls useTransactionPayAvailableTokens when rendered', () => {
       mockRoute.params = {
         outputChainId: '0x1' as Hex,
       };
@@ -161,9 +161,15 @@ describe('MusdConversionInfo', () => {
         state: {},
       });
 
-      // The hook is called when MusdOverrideContent renders
-      // We verify the mock was set up correctly
-      expect(mockUseTransactionPayAvailableTokens).toBeDefined();
+      const mockCustomAmountInfo = jest.mocked(CustomAmountInfo);
+      const overrideContent = mockCustomAmountInfo.mock.calls[0][0]
+        .overrideContent as (amountHuman: string) => React.ReactNode;
+
+      renderWithProvider(<>{overrideContent('100')}</>, {
+        state: {},
+      });
+
+      expect(mockUseTransactionPayAvailableTokens).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
+++ b/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
@@ -1,12 +1,39 @@
-import React from 'react';
-import { CustomAmountInfo } from '../custom-amount-info';
+import React, { useCallback } from 'react';
+import { useParams } from '../../../../../../util/navigation/navUtils';
+import OutputAmountTag from '../../../../../UI/Earn/components/OutputAmountTag';
 import {
   MUSD_TOKEN,
   MUSD_TOKEN_ADDRESS_BY_CHAIN,
 } from '../../../../../UI/Earn/constants/musd';
-import { useAddToken } from '../../../hooks/tokens/useAddToken';
 import { MusdConversionConfig } from '../../../../../UI/Earn/hooks/useMusdConversion';
-import { useParams } from '../../../../../../util/navigation/navUtils';
+import { useCustomAmount } from '../../../hooks/earn/useCustomAmount';
+import { useAddToken } from '../../../hooks/tokens/useAddToken';
+import { PayWithRow } from '../../rows/pay-with-row';
+import { CustomAmountInfo } from '../custom-amount-info';
+
+interface MusdOverrideContentProps {
+  amountHuman: string;
+}
+
+const MusdOverrideContent: React.FC<MusdOverrideContentProps> = ({
+  amountHuman,
+}) => {
+  const { shouldShowOutputAmountTag, outputAmount, outputSymbol } =
+    useCustomAmount({ amountHuman });
+
+  return (
+    <>
+      {shouldShowOutputAmountTag && outputAmount !== null && (
+        <OutputAmountTag
+          amount={outputAmount}
+          symbol={outputSymbol ?? undefined}
+          showBackground={false}
+        />
+      )}
+      <PayWithRow />
+    </>
+  );
+};
 
 export const MusdConversionInfo = () => {
   const { outputChainId, preferredPaymentToken } =
@@ -30,5 +57,15 @@ export const MusdConversionInfo = () => {
     tokenAddress: tokenToAddAddress,
   });
 
-  return <CustomAmountInfo preferredToken={preferredPaymentToken} />;
+  const renderOverrideContent = useCallback(
+    (amountHuman: string) => <MusdOverrideContent amountHuman={amountHuman} />,
+    [],
+  );
+
+  return (
+    <CustomAmountInfo
+      preferredToken={preferredPaymentToken}
+      overrideContent={renderOverrideContent}
+    />
+  );
 };

--- a/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
+++ b/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
@@ -10,6 +10,7 @@ import { useCustomAmount } from '../../../hooks/earn/useCustomAmount';
 import { useAddToken } from '../../../hooks/tokens/useAddToken';
 import { PayWithRow } from '../../rows/pay-with-row';
 import { CustomAmountInfo } from '../custom-amount-info';
+import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 
 interface MusdOverrideContentProps {
   amountHuman: string;
@@ -21,6 +22,9 @@ const MusdOverrideContent: React.FC<MusdOverrideContentProps> = ({
   const { shouldShowOutputAmountTag, outputAmount, outputSymbol } =
     useCustomAmount({ amountHuman });
 
+  const availableTokens = useTransactionPayAvailableTokens();
+  const hasTokens = availableTokens.length > 0;
+
   return (
     <>
       {shouldShowOutputAmountTag && outputAmount !== null && (
@@ -30,7 +34,7 @@ const MusdOverrideContent: React.FC<MusdOverrideContentProps> = ({
           showBackground={false}
         />
       )}
-      <PayWithRow />
+      {hasTokens && <PayWithRow />}
     </>
   );
 };

--- a/app/components/Views/confirmations/hooks/earn/useCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/earn/useCustomAmount.test.ts
@@ -1,0 +1,140 @@
+import { renderHook } from '@testing-library/react-native';
+import { TransactionType } from '@metamask/transaction-controller';
+import { useSelector } from 'react-redux';
+import { useCustomAmount } from './useCustomAmount';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { selectIsMusdConversionFlowEnabledFlag } from '../../../../UI/Earn/selectors/featureFlags';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+jest.mock('../transactions/useTransactionMetadataRequest');
+jest.mock('../../../../UI/Earn/selectors/featureFlags');
+
+const mockUseSelector = jest.mocked(useSelector);
+const mockUseTransactionMetadataRequest = jest.mocked(
+  useTransactionMetadataRequest,
+);
+
+describe('useCustomAmount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectIsMusdConversionFlowEnabledFlag) {
+        return true;
+      }
+      return undefined;
+    });
+  });
+
+  describe('non-mUSD transactions', () => {
+    it('returns shouldShowOutputAmountTag false for non-mUSD transaction types', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue({
+        type: TransactionType.perpsDeposit,
+      } as ReturnType<typeof useTransactionMetadataRequest>);
+
+      const { result } = renderHook(() =>
+        useCustomAmount({ amountHuman: '100' }),
+      );
+
+      expect(result.current.shouldShowOutputAmountTag).toBe(false);
+      expect(result.current.outputAmount).toBeNull();
+      expect(result.current.outputSymbol).toBeNull();
+    });
+
+    it('returns shouldShowOutputAmountTag false for predictDeposit transaction', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue({
+        type: TransactionType.predictDeposit,
+      } as ReturnType<typeof useTransactionMetadataRequest>);
+
+      const { result } = renderHook(() =>
+        useCustomAmount({ amountHuman: '500' }),
+      );
+
+      expect(result.current.shouldShowOutputAmountTag).toBe(false);
+      expect(result.current.outputAmount).toBeNull();
+      expect(result.current.outputSymbol).toBeNull();
+    });
+
+    it('returns shouldShowOutputAmountTag false when transaction is undefined', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue(undefined);
+
+      const { result } = renderHook(() =>
+        useCustomAmount({ amountHuman: '100' }),
+      );
+
+      expect(result.current.shouldShowOutputAmountTag).toBe(false);
+      expect(result.current.outputAmount).toBeNull();
+      expect(result.current.outputSymbol).toBeNull();
+    });
+
+    it('returns shouldShowOutputAmountTag false when mUSD feature flag is disabled', () => {
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectIsMusdConversionFlowEnabledFlag) {
+          return false;
+        }
+        return undefined;
+      });
+      mockUseTransactionMetadataRequest.mockReturnValue({
+        type: TransactionType.musdConversion,
+      } as ReturnType<typeof useTransactionMetadataRequest>);
+
+      const { result } = renderHook(() =>
+        useCustomAmount({ amountHuman: '100' }),
+      );
+
+      expect(result.current.shouldShowOutputAmountTag).toBe(false);
+    });
+  });
+
+  describe('output amount tag', () => {
+    describe('mUSD conversion transactions', () => {
+      beforeEach(() => {
+        mockUseTransactionMetadataRequest.mockReturnValue({
+          type: TransactionType.musdConversion,
+        } as ReturnType<typeof useTransactionMetadataRequest>);
+      });
+
+      it('returns shouldShowOutputAmountTag true for mUSD conversion', () => {
+        const { result } = renderHook(() =>
+          useCustomAmount({ amountHuman: '100' }),
+        );
+
+        expect(result.current.shouldShowOutputAmountTag).toBe(true);
+      });
+
+      it('returns formatted outputAmount with 2 decimal places', () => {
+        const { result } = renderHook(() =>
+          useCustomAmount({ amountHuman: '100.5678' }),
+        );
+
+        expect(result.current.outputAmount).toBe('100.57');
+      });
+
+      it('returns outputAmount for whole numbers', () => {
+        const { result } = renderHook(() =>
+          useCustomAmount({ amountHuman: '250' }),
+        );
+
+        expect(result.current.outputAmount).toBe('250');
+      });
+
+      it('returns 0 outputAmount for empty string', () => {
+        const { result } = renderHook(() =>
+          useCustomAmount({ amountHuman: '' }),
+        );
+
+        expect(result.current.outputAmount).toBe('0');
+      });
+
+      it('returns mUSD as outputSymbol for mUSD conversion', () => {
+        const { result } = renderHook(() =>
+          useCustomAmount({ amountHuman: '100' }),
+        );
+
+        expect(result.current.outputSymbol).toBe('mUSD');
+      });
+    });
+  });
+});

--- a/app/components/Views/confirmations/hooks/earn/useCustomAmount.tsx
+++ b/app/components/Views/confirmations/hooks/earn/useCustomAmount.tsx
@@ -1,0 +1,68 @@
+import { TransactionType } from '@metamask/transaction-controller';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { limitToMaximumDecimalPlaces } from '../../../../../util/number';
+import { selectIsMusdConversionFlowEnabledFlag } from '../../../../UI/Earn/selectors/featureFlags';
+import { hasTransactionType } from '../../utils/transaction';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+
+export interface UseCustomAmountParams {
+  /**
+   * The human-readable amount (e.g., "100.50")
+   * Used to calculate output amount display
+   */
+  amountHuman: string;
+}
+
+export interface UseCustomAmountResult {
+  /** Whether to show an output amount tag instead of PayTokenAmount */
+  shouldShowOutputAmountTag: boolean;
+  /** Output amount for the tag (formatted, null when not applicable) */
+  outputAmount: string | null;
+  /** Symbol for the output amount (null when not applicable) */
+  outputSymbol: string | null;
+}
+
+/**
+ * Hook for managing custom amount logic in custom amount flows.
+ * Encapsulates transaction type detection, points calculation, and tooltip state.
+ *
+ * @param params - Hook parameters including the amount for points calculation
+ * @returns Custom amount state and callbacks for UI integration
+ */
+export const useCustomAmount = ({
+  amountHuman,
+}: UseCustomAmountParams): UseCustomAmountResult => {
+  const isMusdConversionFlowEnabled = useSelector(
+    selectIsMusdConversionFlowEnabledFlag,
+  );
+
+  const transactionMeta = useTransactionMetadataRequest();
+  const isMusdConversion =
+    isMusdConversionFlowEnabled &&
+    hasTransactionType(transactionMeta, [TransactionType.musdConversion]);
+
+  // Output amount tag logic - currently for mUSD conversion only
+  const shouldShowOutputAmountTag = isMusdConversion;
+
+  const outputAmount = useMemo(() => {
+    if (!shouldShowOutputAmountTag) {
+      return null;
+    }
+    return limitToMaximumDecimalPlaces(parseFloat(amountHuman) || 0, 2);
+  }, [shouldShowOutputAmountTag, amountHuman]);
+
+  const outputSymbol = useMemo(() => {
+    if (!shouldShowOutputAmountTag) {
+      return null;
+    }
+    // For mUSD conversion, the output symbol is always mUSD
+    return 'mUSD';
+  }, [shouldShowOutputAmountTag]);
+
+  return {
+    shouldShowOutputAmountTag,
+    outputAmount,
+    outputSymbol,
+  };
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR extracts the `OutputAmountTag` component for mUSD conversion flows, separating it from [rewards-related functionality](https://github.com/MetaMask/metamask-mobile/pull/23145) that has a blocker.

**Changes included:**

1. **OutputAmountTag component** - A standalone generic tag component that displays output amounts with symbols in conversion flows (e.g., "100.57 mUSD")

2. **useCustomAmount hook** - Simplified hook that only handles output amount logic for mUSD conversions:
   - `shouldShowOutputAmountTag` - Whether to display the tag
   - `outputAmount` - Formatted amount with 2 decimal places
   - `outputSymbol` - Token symbol (mUSD)

3. **Removed rewards-related code** that had a blocker:
   - Removed `RewardsTag` component (empty directory cleaned up)
   - Removed `RewardsTooltipBottomSheet` component (empty directory cleaned up)
   - Removed `useRewardsAccountOptedIn` hook
   - Removed `useCustomAmountRewards` hook
   - Removed rewards-related properties from tests (`shouldShowRewardsTag`, `estimatedPoints`, `onRewardsTagPress`, `renderRewardsTooltip`)

4. **Test cleanup** - Updated test files to remove references to non-existent rewards functionality:
   - `useCustomAmount.test.ts` - Removed rewards opt-in tests, points calculation tests, and tooltip tests
   - `musd-conversion-info.test.tsx` - Fixed import names and mock values

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-101

## **Manual testing steps**

```gherkin
Feature: mUSD Conversion Output Amount Display

  Scenario: user views output amount during mUSD conversion
    Given user is on the mUSD conversion confirmation screen
    And mUSD feature flag is enabled

    When user enters an amount to convert
    Then the OutputAmountTag displays the formatted output amount with "mUSD" symbol## **Screenshots/Recordings**
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="120" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-05 at 12 45 45" src="https://github.com/user-attachments/assets/056d19c6-d039-4b2c-8cd4-2c9760e8a3a1" />
<img width="120" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-05 at 12 45 37" src="https://github.com/user-attachments/assets/1953feed-1b35-4995-a370-94face16305d" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces OutputAmountTag and useCustomAmount, and integrates them into mUSD conversion via a new overrideContent in CustomAmountInfo with accompanying tests.
> 
> - **UI/Components**:
>   - **OutputAmountTag** (`app/components/UI/Earn/components/OutputAmountTag`): New pill tag to display formatted `amount` with optional `symbol` and background.
>   - **CustomAmountInfo**: Adds `overrideContent(amountHuman)` prop to replace default content (hides `PayTokenAmount`, `PayWithRow`, and `children`).
>   - **MusdConversionInfo**: Renders `MusdOverrideContent` using `useCustomAmount` to show `OutputAmountTag` (mUSD) and conditionally `PayWithRow`; ensures mUSD token is added per `outputChainId`.
> - **Hooks**:
>   - **useCustomAmount** (`hooks/earn`): Determines when to show output tag for `musdConversion`, formats amount to 2 decimals, and sets `mUSD` symbol based on feature flag and transaction type.
> - **Tests**:
>   - Adds tests for `OutputAmountTag` and `useCustomAmount`.
>   - Updates `custom-amount-info` and `musd-conversion-info` tests to validate `overrideContent`, labels, and token availability behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9b4de8811722e958ddbc56ccbb2e1909a045163. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->