### PR TITLE
fix: prevent price diff text wrapping from shifting chart on iOS accessibility scaling

### DIFF
--- a/app/components/UI/AssetOverview/Price/Price.styles.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.styles.tsx
@@ -16,7 +16,13 @@ const styleSheet = (params: {
     wrapper: {
       paddingHorizontal: 16,
     },
+    priceDiffContainer: {
+      flexDirection: 'row',
+      flexWrap: 'nowrap',
+      overflow: 'hidden',
+    },
     priceDiff: {
+      flexShrink: 1,
       color:
         priceDiff > 0
           ? colors.success.default

--- a/app/components/UI/AssetOverview/Price/Price.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.tsx
@@ -136,32 +136,40 @@ const Price = ({
               </SkeletonPlaceholder>
             </View>
           ) : distributedPriceData.length > 0 ? (
-            <Text style={styles.priceDiff} variant={TextVariant.BodyMDMedium}>
-              {
-                <Icon
-                  name={
-                    diff > 0
-                      ? 'trending-up'
-                      : diff < 0
-                        ? 'trending-down'
-                        : 'minus'
-                  }
-                  size={16}
-                  style={styles.priceDiffIcon}
-                />
-              }{' '}
-              {addCurrencySymbol(diff, currentCurrency, true)} (
-              {diff > 0 ? '+' : ''}
-              {diff === 0 ? '0' : ((diff / comparePrice) * 100).toFixed(2)}
-              %){' '}
+            <View style={styles.priceDiffContainer}>
               <Text
-                testID="price-label"
-                color={TextColor.Alternative}
+                style={styles.priceDiff}
                 variant={TextVariant.BodyMDMedium}
+                numberOfLines={1}
+                adjustsFontSizeToFit
+                minimumFontScale={0.5}
               >
-                {date}
+                {
+                  <Icon
+                    name={
+                      diff > 0
+                        ? 'trending-up'
+                        : diff < 0
+                          ? 'trending-down'
+                          : 'minus'
+                    }
+                    size={16}
+                    style={styles.priceDiffIcon}
+                  />
+                }{' '}
+                {addCurrencySymbol(diff, currentCurrency, true)} (
+                {diff > 0 ? '+' : ''}
+                {diff === 0 ? '0' : ((diff / comparePrice) * 100).toFixed(2)}
+                %){' '}
+                <Text
+                  testID="price-label"
+                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMDMedium}
+                >
+                  {date}
+                </Text>
               </Text>
-            </Text>
+            </View>
           ) : null}
         </Text>
       </View>

--- a/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
+++ b/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
@@ -61,64 +61,78 @@ exports[`AssetOverview should render native balances when non evm network is sel
           }
         }
       >
-        <Text
-          accessibilityRole="text"
+        <View
           style={
             {
-              "color": "#457a39",
-              "fontFamily": "Geist Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
+              "flexDirection": "row",
+              "flexWrap": "nowrap",
+              "overflow": "hidden",
             }
           }
         >
           <Text
-            allowFontScaling={false}
-            selectable={false}
-            style={
-              [
-                {
-                  "color": undefined,
-                  "fontSize": 16,
-                },
-                {
-                  "marginTop": 10,
-                },
-                {
-                  "fontFamily": "Feather",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-          >
-            
-          </Text>
-           
-          $151.23
-           (
-          +
-          Infinity
-          %)
-           
-          <Text
             accessibilityRole="text"
+            adjustsFontSizeToFit={true}
+            minimumFontScale={0.5}
+            numberOfLines={1}
             style={
               {
-                "color": "#686e7d",
+                "color": "#457a39",
+                "flexShrink": 1,
                 "fontFamily": "Geist Medium",
                 "fontSize": 16,
                 "letterSpacing": 0,
                 "lineHeight": 24,
               }
             }
-            testID="price-label"
           >
-            Today
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": undefined,
+                    "fontSize": 16,
+                  },
+                  {
+                    "marginTop": 10,
+                  },
+                  {
+                    "fontFamily": "Feather",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+             
+            $151.23
+             (
+            +
+            Infinity
+            %)
+             
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#686e7d",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+              testID="price-label"
+            >
+              Today
+            </Text>
           </Text>
-        </Text>
+        </View>
       </Text>
     </View>
     <View

--- a/app/components/Views/Asset/__snapshots__/index.test.js.snap
+++ b/app/components/Views/Asset/__snapshots__/index.test.js.snap
@@ -857,63 +857,77 @@ exports[`Asset Multichain Functionality should exclude mixed token/SOL transacti
                                           }
                                         }
                                       >
-                                        <Text
-                                          accessibilityRole="text"
+                                        <View
                                           style={
                                             {
-                                              "color": "#686e7d",
-                                              "fontFamily": "Geist Medium",
-                                              "fontSize": 16,
-                                              "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "flexDirection": "row",
+                                              "flexWrap": "nowrap",
+                                              "overflow": "hidden",
                                             }
                                           }
                                         >
                                           <Text
-                                            allowFontScaling={false}
-                                            selectable={false}
-                                            style={
-                                              [
-                                                {
-                                                  "color": undefined,
-                                                  "fontSize": 16,
-                                                },
-                                                {
-                                                  "marginTop": 10,
-                                                },
-                                                {
-                                                  "fontFamily": "Feather",
-                                                  "fontStyle": "normal",
-                                                  "fontWeight": "normal",
-                                                },
-                                                {},
-                                              ]
-                                            }
-                                          >
-                                            
-                                          </Text>
-                                           
-                                          $0
-                                           (
-                                          0
-                                          %)
-                                           
-                                          <Text
                                             accessibilityRole="text"
+                                            adjustsFontSizeToFit={true}
+                                            minimumFontScale={0.5}
+                                            numberOfLines={1}
                                             style={
                                               {
                                                 "color": "#686e7d",
+                                                "flexShrink": 1,
                                                 "fontFamily": "Geist Medium",
                                                 "fontSize": 16,
                                                 "letterSpacing": 0,
                                                 "lineHeight": 24,
                                               }
                                             }
-                                            testID="price-label"
                                           >
-                                            Today
+                                            <Text
+                                              allowFontScaling={false}
+                                              selectable={false}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": undefined,
+                                                    "fontSize": 16,
+                                                  },
+                                                  {
+                                                    "marginTop": 10,
+                                                  },
+                                                  {
+                                                    "fontFamily": "Feather",
+                                                    "fontStyle": "normal",
+                                                    "fontWeight": "normal",
+                                                  },
+                                                  {},
+                                                ]
+                                              }
+                                            >
+                                              
+                                            </Text>
+                                             
+                                            $0
+                                             (
+                                            0
+                                            %)
+                                             
+                                            <Text
+                                              accessibilityRole="text"
+                                              style={
+                                                {
+                                                  "color": "#686e7d",
+                                                  "fontFamily": "Geist Medium",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
+                                              }
+                                              testID="price-label"
+                                            >
+                                              Today
+                                            </Text>
                                           </Text>
-                                        </Text>
+                                        </View>
                                       </Text>
                                     </View>
                                     <View
@@ -2644,63 +2658,77 @@ exports[`Asset Multichain Functionality should exclude transactions with empty a
                                           }
                                         }
                                       >
-                                        <Text
-                                          accessibilityRole="text"
+                                        <View
                                           style={
                                             {
-                                              "color": "#686e7d",
-                                              "fontFamily": "Geist Medium",
-                                              "fontSize": 16,
-                                              "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "flexDirection": "row",
+                                              "flexWrap": "nowrap",
+                                              "overflow": "hidden",
                                             }
                                           }
                                         >
                                           <Text
-                                            allowFontScaling={false}
-                                            selectable={false}
-                                            style={
-                                              [
-                                                {
-                                                  "color": undefined,
-                                                  "fontSize": 16,
-                                                },
-                                                {
-                                                  "marginTop": 10,
-                                                },
-                                                {
-                                                  "fontFamily": "Feather",
-                                                  "fontStyle": "normal",
-                                                  "fontWeight": "normal",
-                                                },
-                                                {},
-                                              ]
-                                            }
-                                          >
-                                            
-                                          </Text>
-                                           
-                                          $0
-                                           (
-                                          0
-                                          %)
-                                           
-                                          <Text
                                             accessibilityRole="text"
+                                            adjustsFontSizeToFit={true}
+                                            minimumFontScale={0.5}
+                                            numberOfLines={1}
                                             style={
                                               {
                                                 "color": "#686e7d",
+                                                "flexShrink": 1,
                                                 "fontFamily": "Geist Medium",
                                                 "fontSize": 16,
                                                 "letterSpacing": 0,
                                                 "lineHeight": 24,
                                               }
                                             }
-                                            testID="price-label"
                                           >
-                                            Today
+                                            <Text
+                                              allowFontScaling={false}
+                                              selectable={false}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": undefined,
+                                                    "fontSize": 16,
+                                                  },
+                                                  {
+                                                    "marginTop": 10,
+                                                  },
+                                                  {
+                                                    "fontFamily": "Feather",
+                                                    "fontStyle": "normal",
+                                                    "fontWeight": "normal",
+                                                  },
+                                                  {},
+                                                ]
+                                              }
+                                            >
+                                              
+                                            </Text>
+                                             
+                                            $0
+                                             (
+                                            0
+                                            %)
+                                             
+                                            <Text
+                                              accessibilityRole="text"
+                                              style={
+                                                {
+                                                  "color": "#686e7d",
+                                                  "fontFamily": "Geist Medium",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
+                                              }
+                                              testID="price-label"
+                                            >
+                                              Today
+                                            </Text>
                                           </Text>
-                                        </Text>
+                                        </View>
                                       </Text>
                                     </View>
                                     <View
@@ -4431,63 +4459,77 @@ exports[`Asset Multichain Functionality should filter SPL token transactions cor
                                           }
                                         }
                                       >
-                                        <Text
-                                          accessibilityRole="text"
+                                        <View
                                           style={
                                             {
-                                              "color": "#686e7d",
-                                              "fontFamily": "Geist Medium",
-                                              "fontSize": 16,
-                                              "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "flexDirection": "row",
+                                              "flexWrap": "nowrap",
+                                              "overflow": "hidden",
                                             }
                                           }
                                         >
                                           <Text
-                                            allowFontScaling={false}
-                                            selectable={false}
-                                            style={
-                                              [
-                                                {
-                                                  "color": undefined,
-                                                  "fontSize": 16,
-                                                },
-                                                {
-                                                  "marginTop": 10,
-                                                },
-                                                {
-                                                  "fontFamily": "Feather",
-                                                  "fontStyle": "normal",
-                                                  "fontWeight": "normal",
-                                                },
-                                                {},
-                                              ]
-                                            }
-                                          >
-                                            
-                                          </Text>
-                                           
-                                          $0
-                                           (
-                                          0
-                                          %)
-                                           
-                                          <Text
                                             accessibilityRole="text"
+                                            adjustsFontSizeToFit={true}
+                                            minimumFontScale={0.5}
+                                            numberOfLines={1}
                                             style={
                                               {
                                                 "color": "#686e7d",
+                                                "flexShrink": 1,
                                                 "fontFamily": "Geist Medium",
                                                 "fontSize": 16,
                                                 "letterSpacing": 0,
                                                 "lineHeight": 24,
                                               }
                                             }
-                                            testID="price-label"
                                           >
-                                            Today
+                                            <Text
+                                              allowFontScaling={false}
+                                              selectable={false}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": undefined,
+                                                    "fontSize": 16,
+                                                  },
+                                                  {
+                                                    "marginTop": 10,
+                                                  },
+                                                  {
+                                                    "fontFamily": "Feather",
+                                                    "fontStyle": "normal",
+                                                    "fontWeight": "normal",
+                                                  },
+                                                  {},
+                                                ]
+                                              }
+                                            >
+                                              
+                                            </Text>
+                                             
+                                            $0
+                                             (
+                                            0
+                                            %)
+                                             
+                                            <Text
+                                              accessibilityRole="text"
+                                              style={
+                                                {
+                                                  "color": "#686e7d",
+                                                  "fontFamily": "Geist Medium",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
+                                              }
+                                              testID="price-label"
+                                            >
+                                              Today
+                                            </Text>
                                           </Text>
-                                        </Text>
+                                        </View>
                                       </Text>
                                     </View>
                                     <View
@@ -6259,63 +6301,77 @@ exports[`Asset Multichain Functionality should filter native SOL transactions co
                                           }
                                         }
                                       >
-                                        <Text
-                                          accessibilityRole="text"
+                                        <View
                                           style={
                                             {
-                                              "color": "#686e7d",
-                                              "fontFamily": "Geist Medium",
-                                              "fontSize": 16,
-                                              "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "flexDirection": "row",
+                                              "flexWrap": "nowrap",
+                                              "overflow": "hidden",
                                             }
                                           }
                                         >
                                           <Text
-                                            allowFontScaling={false}
-                                            selectable={false}
-                                            style={
-                                              [
-                                                {
-                                                  "color": undefined,
-                                                  "fontSize": 16,
-                                                },
-                                                {
-                                                  "marginTop": 10,
-                                                },
-                                                {
-                                                  "fontFamily": "Feather",
-                                                  "fontStyle": "normal",
-                                                  "fontWeight": "normal",
-                                                },
-                                                {},
-                                              ]
-                                            }
-                                          >
-                                            
-                                          </Text>
-                                           
-                                          $0
-                                           (
-                                          0
-                                          %)
-                                           
-                                          <Text
                                             accessibilityRole="text"
+                                            adjustsFontSizeToFit={true}
+                                            minimumFontScale={0.5}
+                                            numberOfLines={1}
                                             style={
                                               {
                                                 "color": "#686e7d",
+                                                "flexShrink": 1,
                                                 "fontFamily": "Geist Medium",
                                                 "fontSize": 16,
                                                 "letterSpacing": 0,
                                                 "lineHeight": 24,
                                               }
                                             }
-                                            testID="price-label"
                                           >
-                                            Today
+                                            <Text
+                                              allowFontScaling={false}
+                                              selectable={false}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": undefined,
+                                                    "fontSize": 16,
+                                                  },
+                                                  {
+                                                    "marginTop": 10,
+                                                  },
+                                                  {
+                                                    "fontFamily": "Feather",
+                                                    "fontStyle": "normal",
+                                                    "fontWeight": "normal",
+                                                  },
+                                                  {},
+                                                ]
+                                              }
+                                            >
+                                              
+                                            </Text>
+                                             
+                                            $0
+                                             (
+                                            0
+                                            %)
+                                             
+                                            <Text
+                                              accessibilityRole="text"
+                                              style={
+                                                {
+                                                  "color": "#686e7d",
+                                                  "fontFamily": "Geist Medium",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
+                                              }
+                                              testID="price-label"
+                                            >
+                                              Today
+                                            </Text>
                                           </Text>
-                                        </Text>
+                                        </View>
                                       </Text>
                                     </View>
                                     <View
@@ -8046,63 +8102,77 @@ exports[`Asset Multichain Functionality should handle state with no multichain t
                                           }
                                         }
                                       >
-                                        <Text
-                                          accessibilityRole="text"
+                                        <View
                                           style={
                                             {
-                                              "color": "#686e7d",
-                                              "fontFamily": "Geist Medium",
-                                              "fontSize": 16,
-                                              "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "flexDirection": "row",
+                                              "flexWrap": "nowrap",
+                                              "overflow": "hidden",
                                             }
                                           }
                                         >
                                           <Text
-                                            allowFontScaling={false}
-                                            selectable={false}
-                                            style={
-                                              [
-                                                {
-                                                  "color": undefined,
-                                                  "fontSize": 16,
-                                                },
-                                                {
-                                                  "marginTop": 10,
-                                                },
-                                                {
-                                                  "fontFamily": "Feather",
-                                                  "fontStyle": "normal",
-                                                  "fontWeight": "normal",
-                                                },
-                                                {},
-                                              ]
-                                            }
-                                          >
-                                            
-                                          </Text>
-                                           
-                                          $0
-                                           (
-                                          0
-                                          %)
-                                           
-                                          <Text
                                             accessibilityRole="text"
+                                            adjustsFontSizeToFit={true}
+                                            minimumFontScale={0.5}
+                                            numberOfLines={1}
                                             style={
                                               {
                                                 "color": "#686e7d",
+                                                "flexShrink": 1,
                                                 "fontFamily": "Geist Medium",
                                                 "fontSize": 16,
                                                 "letterSpacing": 0,
                                                 "lineHeight": 24,
                                               }
                                             }
-                                            testID="price-label"
                                           >
-                                            Today
+                                            <Text
+                                              allowFontScaling={false}
+                                              selectable={false}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": undefined,
+                                                    "fontSize": 16,
+                                                  },
+                                                  {
+                                                    "marginTop": 10,
+                                                  },
+                                                  {
+                                                    "fontFamily": "Feather",
+                                                    "fontStyle": "normal",
+                                                    "fontWeight": "normal",
+                                                  },
+                                                  {},
+                                                ]
+                                              }
+                                            >
+                                              
+                                            </Text>
+                                             
+                                            $0
+                                             (
+                                            0
+                                            %)
+                                             
+                                            <Text
+                                              accessibilityRole="text"
+                                              style={
+                                                {
+                                                  "color": "#686e7d",
+                                                  "fontFamily": "Geist Medium",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
+                                              }
+                                              testID="price-label"
+                                            >
+                                              Today
+                                            </Text>
                                           </Text>
-                                        </Text>
+                                        </View>
                                       </Text>
                                     </View>
                                     <View
@@ -9833,63 +9903,77 @@ exports[`Asset Multichain Functionality should handle unknown SPL token filterin
                                           }
                                         }
                                       >
-                                        <Text
-                                          accessibilityRole="text"
+                                        <View
                                           style={
                                             {
-                                              "color": "#686e7d",
-                                              "fontFamily": "Geist Medium",
-                                              "fontSize": 16,
-                                              "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "flexDirection": "row",
+                                              "flexWrap": "nowrap",
+                                              "overflow": "hidden",
                                             }
                                           }
                                         >
                                           <Text
-                                            allowFontScaling={false}
-                                            selectable={false}
-                                            style={
-                                              [
-                                                {
-                                                  "color": undefined,
-                                                  "fontSize": 16,
-                                                },
-                                                {
-                                                  "marginTop": 10,
-                                                },
-                                                {
-                                                  "fontFamily": "Feather",
-                                                  "fontStyle": "normal",
-                                                  "fontWeight": "normal",
-                                                },
-                                                {},
-                                              ]
-                                            }
-                                          >
-                                            
-                                          </Text>
-                                           
-                                          $0
-                                           (
-                                          0
-                                          %)
-                                           
-                                          <Text
                                             accessibilityRole="text"
+                                            adjustsFontSizeToFit={true}
+                                            minimumFontScale={0.5}
+                                            numberOfLines={1}
                                             style={
                                               {
                                                 "color": "#686e7d",
+                                                "flexShrink": 1,
                                                 "fontFamily": "Geist Medium",
                                                 "fontSize": 16,
                                                 "letterSpacing": 0,
                                                 "lineHeight": 24,
                                               }
                                             }
-                                            testID="price-label"
                                           >
-                                            Today
+                                            <Text
+                                              allowFontScaling={false}
+                                              selectable={false}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": undefined,
+                                                    "fontSize": 16,
+                                                  },
+                                                  {
+                                                    "marginTop": 10,
+                                                  },
+                                                  {
+                                                    "fontFamily": "Feather",
+                                                    "fontStyle": "normal",
+                                                    "fontWeight": "normal",
+                                                  },
+                                                  {},
+                                                ]
+                                              }
+                                            >
+                                              
+                                            </Text>
+                                             
+                                            $0
+                                             (
+                                            0
+                                            %)
+                                             
+                                            <Text
+                                              accessibilityRole="text"
+                                              style={
+                                                {
+                                                  "color": "#686e7d",
+                                                  "fontFamily": "Geist Medium",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
+                                              }
+                                              testID="price-label"
+                                            >
+                                              Today
+                                            </Text>
                                           </Text>
-                                        </Text>
+                                        </View>
                                       </Text>
                                     </View>
                                     <View
@@ -12192,63 +12276,77 @@ exports[`Asset Multichain Functionality should render non-EVM assets with Multic
                                           }
                                         }
                                       >
-                                        <Text
-                                          accessibilityRole="text"
+                                        <View
                                           style={
                                             {
-                                              "color": "#686e7d",
-                                              "fontFamily": "Geist Medium",
-                                              "fontSize": 16,
-                                              "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "flexDirection": "row",
+                                              "flexWrap": "nowrap",
+                                              "overflow": "hidden",
                                             }
                                           }
                                         >
                                           <Text
-                                            allowFontScaling={false}
-                                            selectable={false}
-                                            style={
-                                              [
-                                                {
-                                                  "color": undefined,
-                                                  "fontSize": 16,
-                                                },
-                                                {
-                                                  "marginTop": 10,
-                                                },
-                                                {
-                                                  "fontFamily": "Feather",
-                                                  "fontStyle": "normal",
-                                                  "fontWeight": "normal",
-                                                },
-                                                {},
-                                              ]
-                                            }
-                                          >
-                                            
-                                          </Text>
-                                           
-                                          $0
-                                           (
-                                          0
-                                          %)
-                                           
-                                          <Text
                                             accessibilityRole="text"
+                                            adjustsFontSizeToFit={true}
+                                            minimumFontScale={0.5}
+                                            numberOfLines={1}
                                             style={
                                               {
                                                 "color": "#686e7d",
+                                                "flexShrink": 1,
                                                 "fontFamily": "Geist Medium",
                                                 "fontSize": 16,
                                                 "letterSpacing": 0,
                                                 "lineHeight": 24,
                                               }
                                             }
-                                            testID="price-label"
                                           >
-                                            Today
+                                            <Text
+                                              allowFontScaling={false}
+                                              selectable={false}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": undefined,
+                                                    "fontSize": 16,
+                                                  },
+                                                  {
+                                                    "marginTop": 10,
+                                                  },
+                                                  {
+                                                    "fontFamily": "Feather",
+                                                    "fontStyle": "normal",
+                                                    "fontWeight": "normal",
+                                                  },
+                                                  {},
+                                                ]
+                                              }
+                                            >
+                                              
+                                            </Text>
+                                             
+                                            $0
+                                             (
+                                            0
+                                            %)
+                                             
+                                            <Text
+                                              accessibilityRole="text"
+                                              style={
+                                                {
+                                                  "color": "#686e7d",
+                                                  "fontFamily": "Geist Medium",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
+                                              }
+                                              testID="price-label"
+                                            >
+                                              Today
+                                            </Text>
                                           </Text>
-                                        </Text>
+                                        </View>
                                       </Text>
                                     </View>
                                     <View
@@ -13979,63 +14077,77 @@ exports[`Asset Multichain Functionality should sort filtered transactions by tim
                                           }
                                         }
                                       >
-                                        <Text
-                                          accessibilityRole="text"
+                                        <View
                                           style={
                                             {
-                                              "color": "#686e7d",
-                                              "fontFamily": "Geist Medium",
-                                              "fontSize": 16,
-                                              "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "flexDirection": "row",
+                                              "flexWrap": "nowrap",
+                                              "overflow": "hidden",
                                             }
                                           }
                                         >
                                           <Text
-                                            allowFontScaling={false}
-                                            selectable={false}
-                                            style={
-                                              [
-                                                {
-                                                  "color": undefined,
-                                                  "fontSize": 16,
-                                                },
-                                                {
-                                                  "marginTop": 10,
-                                                },
-                                                {
-                                                  "fontFamily": "Feather",
-                                                  "fontStyle": "normal",
-                                                  "fontWeight": "normal",
-                                                },
-                                                {},
-                                              ]
-                                            }
-                                          >
-                                            
-                                          </Text>
-                                           
-                                          $0
-                                           (
-                                          0
-                                          %)
-                                           
-                                          <Text
                                             accessibilityRole="text"
+                                            adjustsFontSizeToFit={true}
+                                            minimumFontScale={0.5}
+                                            numberOfLines={1}
                                             style={
                                               {
                                                 "color": "#686e7d",
+                                                "flexShrink": 1,
                                                 "fontFamily": "Geist Medium",
                                                 "fontSize": 16,
                                                 "letterSpacing": 0,
                                                 "lineHeight": 24,
                                               }
                                             }
-                                            testID="price-label"
                                           >
-                                            Today
+                                            <Text
+                                              allowFontScaling={false}
+                                              selectable={false}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": undefined,
+                                                    "fontSize": 16,
+                                                  },
+                                                  {
+                                                    "marginTop": 10,
+                                                  },
+                                                  {
+                                                    "fontFamily": "Feather",
+                                                    "fontStyle": "normal",
+                                                    "fontWeight": "normal",
+                                                  },
+                                                  {},
+                                                ]
+                                              }
+                                            >
+                                              
+                                            </Text>
+                                             
+                                            $0
+                                             (
+                                            0
+                                            %)
+                                             
+                                            <Text
+                                              accessibilityRole="text"
+                                              style={
+                                                {
+                                                  "color": "#686e7d",
+                                                  "fontFamily": "Geist Medium",
+                                                  "fontSize": 16,
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
+                                              }
+                                              testID="price-label"
+                                            >
+                                              Today
+                                            </Text>
                                           </Text>
-                                        </Text>
+                                        </View>
                                       </Text>
                                     </View>
                                     <View


### PR DESCRIPTION
## **Description**

Fixed issue where iOS accessibility font scaling caused the price diff text to wrap, pushing the trend chart down and causing it to jump up and down when scanning the chart.

Solution:
- Wrapped text in a flex container with `flexWrap: 'nowrap'` to constrain layout
- Added `numberOfLines={1}`, `adjustsFontSizeToFit`, and `minimumFontScale={0.5}` to
prevent text wrapping while maintaining readability by auto-scaling font size

## **Changelog**

CHANGELOG entry: Fixed chart jumping issues when font accessibility is turned on

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-596

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

`~`

### **Before**

https://github.com/user-attachments/assets/b19c37ba-b732-45d6-aa34-99e788e938e3

### **After**

https://github.com/user-attachments/assets/6156229d-546a-4e18-8348-6ef0a25e5387

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents price diff text from wrapping and shifting the chart by wrapping it in a non-wrapping row container and enabling single-line autoscaling.
> 
> - **Asset Overview Price UI**:
>   - Wrap price diff and date in `priceDiffContainer` (`flexDirection: 'row'`, `flexWrap: 'nowrap'`, `overflow: 'hidden'`).
>   - Add `flexShrink: 1` to `priceDiff` and keep icon styling.
>   - Set `numberOfLines={1}`, `adjustsFontSizeToFit`, `minimumFontScale={0.5}` on the price diff `Text`; nest date `Text` inside.
> - **Tests**:
>   - Update snapshots to reflect new container and text props.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 936949f4fe1cb7b741c0ad92c6912ca8f875569a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->