### PR TITLE
fix: improve import assets UI

### DIFF
--- a/app/components/UI/AddCustomToken/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/AddCustomToken/__snapshots__/index.test.tsx.snap
@@ -189,15 +189,11 @@ exports[`AddCustomToken renders correctly with required props 1`] = `
   </RCTScrollView>
   <View
     style={
-      [
-        {
-          "margin": 16,
-          "paddingVertical": 16,
-        },
-        {
-          "paddingBottom": 0,
-        },
-      ]
+      {
+        "margin": 16,
+        "paddingBottom": 0,
+        "paddingVertical": 16,
+      }
     }
   >
     <TouchableOpacity

--- a/app/components/UI/AddCustomToken/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/AddCustomToken/__snapshots__/index.test.tsx.snap
@@ -187,50 +187,58 @@ exports[`AddCustomToken renders correctly with required props 1`] = `
       </View>
     </View>
   </RCTScrollView>
-  <TouchableOpacity
-    accessibilityRole="button"
-    accessible={true}
-    activeOpacity={1}
-    disabled={true}
-    onPress={[Function]}
-    onPressIn={[Function]}
-    onPressOut={[Function]}
+  <View
     style={
-      {
-        "alignItems": "center",
-        "alignSelf": "center",
-        "backgroundColor": "#121314",
-        "borderRadius": 12,
-        "color": "#4459ff",
-        "flexDirection": "row",
-        "fontFamily": "Geist Regular",
-        "fontSize": 18,
-        "height": 48,
-        "justifyContent": "center",
-        "marginBottom": 16,
-        "opacity": 0.5,
-        "overflow": "hidden",
-        "paddingHorizontal": 16,
-        "position": "relative",
-        "width": "100%",
-      }
+      [
+        {
+          "margin": 16,
+          "paddingVertical": 16,
+        },
+        {
+          "paddingBottom": 0,
+        },
+      ]
     }
-    testID="token-import-next-button"
   >
-    <Text
-      accessibilityRole="text"
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={true}
+      onPress={[Function]}
+      onPressIn={[Function]}
+      onPressOut={[Function]}
       style={
         {
-          "color": "#ffffff",
-          "fontFamily": "Geist Medium",
-          "fontSize": 16,
-          "letterSpacing": 0,
-          "lineHeight": 24,
+          "alignItems": "center",
+          "alignSelf": "stretch",
+          "backgroundColor": "#121314",
+          "borderRadius": 12,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "opacity": 0.5,
+          "overflow": "hidden",
+          "paddingHorizontal": 16,
         }
       }
+      testID="token-import-next-button"
     >
-      Next
-    </Text>
-  </TouchableOpacity>
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#ffffff",
+            "fontFamily": "Geist Medium",
+            "fontSize": 16,
+            "letterSpacing": 0,
+            "lineHeight": 24,
+          }
+        }
+      >
+        Next
+      </Text>
+    </TouchableOpacity>
+  </View>
 </View>
 `;

--- a/app/components/UI/AddCustomToken/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/AddCustomToken/__snapshots__/index.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`AddCustomToken renders correctly with required props 1`] = `
     {
       "backgroundColor": "#ffffff",
       "flex": 1,
+      "paddingHorizontal": 16,
     }
   }
 >

--- a/app/components/UI/AddCustomToken/index.js
+++ b/app/components/UI/AddCustomToken/index.js
@@ -1,5 +1,13 @@
 import React, { PureComponent } from 'react';
-import { Text, TextInput, View, StyleSheet, ScrollView } from 'react-native';
+import {
+  Text,
+  TextInput,
+  View,
+  StyleSheet,
+  ScrollView,
+  Platform,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { fontStyles } from '../../../styles/common';
 import Engine from '../../../core/Engine';
 import PropTypes from 'prop-types';
@@ -24,6 +32,7 @@ import { formatIconUrlWithProxy } from '@metamask/assets-controllers';
 import Button, {
   ButtonSize,
   ButtonVariants,
+  ButtonWidthTypes,
 } from '../../../component-library/components/Buttons/Button';
 import Icon, {
   IconName,
@@ -37,7 +46,7 @@ import CLText from '../../../component-library/components/Texts/Text/Text';
 import Logger from '../../../util/Logger';
 import { endTrace, trace, TraceName } from '../../../util/trace';
 
-const createStyles = (colors) =>
+const createStyles = (colors, bottomInset = 0) =>
   StyleSheet.create({
     wrapper: {
       backgroundColor: colors.background.default,
@@ -57,7 +66,11 @@ const createStyles = (colors) =>
     rowWrapper: {
       paddingHorizontal: 16,
     },
-    buttonWrapper: {},
+    buttonWrapper: {
+      paddingVertical: 16,
+      margin: 16,
+      paddingBottom: bottomInset,
+    },
     textInput: {
       borderWidth: 1,
       borderRadius: 8,
@@ -102,15 +115,6 @@ const createStyles = (colors) =>
     tokenDetectionIcon: {
       paddingTop: 4,
       paddingRight: 8,
-    },
-    import: {
-      fontSize: 18,
-      color: colors.primary.default,
-      ...fontStyles.normal,
-      position: 'relative',
-      width: '100%',
-      alignSelf: 'center',
-      marginBottom: 16,
     },
     textWrapper: {
       padding: 0,
@@ -173,6 +177,11 @@ class AddCustomToken extends PureComponent {
      * The network client ID
      */
     networkClientId: PropTypes.string,
+
+    /**
+     * Safe area insets from react-native-safe-area-context
+     */
+    safeAreaInsets: PropTypes.object,
   };
 
   getTokenAddedAnalyticsParams = () => {
@@ -528,7 +537,9 @@ class AddCustomToken extends PureComponent {
     } = this.state;
     const colors = this.context.colors || mockTheme.colors;
     const themeAppearance = this.context.themeAppearance || 'light';
-    const styles = createStyles(colors);
+    const bottomInset =
+      Platform.OS === 'ios' ? 0 : this.props.safeAreaInsets?.bottom || 0;
+    const styles = createStyles(colors, bottomInset);
     const isDisabled = !symbol || !decimals || !this.props.selectedNetwork;
 
     const addressInputStyle = onFocusAddress
@@ -660,15 +671,17 @@ class AddCustomToken extends PureComponent {
             </View>
           ) : null}
         </ScrollView>
-        <Button
-          variant={ButtonVariants.Primary}
-          size={ButtonSize.Lg}
-          label={strings('transaction.next')}
-          style={styles.import}
-          onPress={this.goToConfirmAddToken}
-          isDisabled={isDisabled}
-          testID={ImportTokenViewSelectorsIDs.NEXT_BUTTON}
-        />
+        <View style={styles.buttonWrapper}>
+          <Button
+            variant={ButtonVariants.Primary}
+            size={ButtonSize.Lg}
+            width={ButtonWidthTypes.Full}
+            label={strings('transaction.next')}
+            onPress={this.goToConfirmAddToken}
+            isDisabled={isDisabled}
+            testID={ImportTokenViewSelectorsIDs.NEXT_BUTTON}
+          />
+        </View>
       </View>
     );
   };
@@ -676,4 +689,10 @@ class AddCustomToken extends PureComponent {
 
 AddCustomToken.contextType = ThemeContext;
 
-export default withMetricsAwareness(AddCustomToken);
+// Wrapper component to inject safe area insets into the class component
+const AddCustomTokenWithInsets = (props) => {
+  const safeAreaInsets = useSafeAreaInsets();
+  return <AddCustomToken {...props} safeAreaInsets={safeAreaInsets} />;
+};
+
+export default withMetricsAwareness(AddCustomTokenWithInsets);

--- a/app/components/UI/AddCustomToken/index.js
+++ b/app/components/UI/AddCustomToken/index.js
@@ -42,6 +42,7 @@ const createStyles = (colors) =>
     wrapper: {
       backgroundColor: colors.background.default,
       flex: 1,
+      paddingHorizontal: 16,
     },
     overlappingAvatarsContainer: {
       flexDirection: 'row',

--- a/app/components/UI/AssetSearch/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/AssetSearch/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,8 @@ exports[`AssetSearch renders correctly with allTokens 1`] = `
     style={
       {
         "color": "#686e7d",
-        "paddingLeft": 20,
+        "left": 16,
+        "position": "absolute",
       }
     }
   >
@@ -44,9 +45,9 @@ exports[`AssetSearch renders correctly with allTokens 1`] = `
       {
         "borderColor": "#2c3dc5",
         "color": "#686e7d",
-        "paddingHorizontal": 12,
+        "paddingHorizontal": 42,
         "paddingVertical": 12,
-        "width": "80%",
+        "width": "100%",
       }
     }
   >
@@ -66,48 +67,6 @@ exports[`AssetSearch renders correctly with allTokens 1`] = `
       testID="input-search-asset"
       value=""
     />
-  </View>
-  <View
-    style={
-      {
-        "color": "#686e7d",
-        "paddingRight": 20,
-      }
-    }
-  >
-    <TouchableOpacity
-      accessible={true}
-      activeOpacity={1}
-      disabled={false}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "borderRadius": 8,
-          "height": 24,
-          "justifyContent": "center",
-          "opacity": 1,
-          "width": 24,
-        }
-      }
-      testID="clear-search-bar"
-    >
-      <SvgMock
-        color="#121314"
-        fill="currentColor"
-        height={16}
-        name="Close"
-        style={
-          {
-            "height": 16,
-            "width": 16,
-          }
-        }
-        width={16}
-      />
-    </TouchableOpacity>
   </View>
 </View>
 `;

--- a/app/components/UI/AssetSearch/index.tsx
+++ b/app/components/UI/AssetSearch/index.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { TextInput, View, StyleSheet, TextStyle } from 'react-native';
+import {
+  TextInput,
+  View,
+  StyleSheet,
+  TextStyle,
+  ViewStyle,
+} from 'react-native';
 import { fontStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
 import { useTheme } from '../../../util/theme';
@@ -13,50 +19,49 @@ import ButtonIcon, {
 } from '../../../component-library/components/Buttons/ButtonIcon';
 import { BridgeToken } from '../Bridge/types';
 import { useTokenSearch } from '../Bridge/hooks/useTokenSearch';
-
-// TODO: Replace "any" with type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const createStyles = (colors: any) =>
-  StyleSheet.create({
-    searchSection: {
-      flexDirection: 'row',
-      justifyContent: 'center',
-      alignItems: 'center',
+import { Colors } from '../../../util/theme/models';
+const createStyles = (colors: Colors) => {
+  const commonSearchStyles = {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 8,
+    borderColor: colors.border.default,
+    color: colors.text.default,
+  };
+  return StyleSheet.create({
+    searchSection: Object.assign({
+      ...commonSearchStyles,
       borderWidth: 1,
-      borderRadius: 8,
-      borderColor: colors.border.default,
-      color: colors.text.default,
-    },
-    searchSectionFocused: {
-      marginBottom: 0,
-      flexDirection: 'row',
-      justifyContent: 'center',
-      alignItems: 'center',
-      borderRadius: 8,
-      color: colors.text.default,
-      borderColor: colors.primary.default,
+    } as ViewStyle),
+    searchSectionFocused: Object.assign({
+      ...commonSearchStyles,
       borderWidth: 2,
-    },
+      borderColor: colors.primary.default,
+    } as ViewStyle),
     textInput: {
       ...fontStyles.normal,
       color: colors.text.default,
     } as TextStyle,
     icon: {
-      paddingLeft: 20,
+      position: 'absolute',
+      left: 16,
       color: colors.icon.alternative,
     },
     iconClose: {
-      paddingRight: 20,
+      position: 'absolute',
+      right: 16,
       color: colors.icon.alternative,
     },
     input: {
-      width: '80%',
-      paddingHorizontal: 12,
+      width: '100%',
       paddingVertical: 12,
+      paddingHorizontal: 42,
       color: colors.icon.alternative,
       borderColor: colors.primary.alternative,
     },
   });
+};
 
 interface Props {
   onSearch: ({
@@ -129,16 +134,18 @@ const AssetSearch = ({ onSearch, onFocus, onBlur, allTokens }: Props) => {
         />
       </View>
 
-      <View style={styles.iconClose}>
-        <ButtonIcon
-          size={ButtonIconSizes.Sm}
-          iconName={IconName.Close}
-          onPress={() => {
-            setSearchString('');
-          }}
-          testID={ImportTokenViewSelectorsIDs.CLEAR_SEARCH_BAR}
-        />
-      </View>
+      {searchString.length > 0 && (
+        <View style={styles.iconClose}>
+          <ButtonIcon
+            size={ButtonIconSizes.Sm}
+            iconName={IconName.Close}
+            onPress={() => {
+              setSearchString('');
+            }}
+            testID={ImportTokenViewSelectorsIDs.CLEAR_SEARCH_BAR}
+          />
+        </View>
+      )}
     </View>
   );
 };

--- a/app/components/UI/SearchTokenAutocomplete/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/SearchTokenAutocomplete/__snapshots__/index.test.tsx.snap
@@ -946,10 +946,15 @@ exports[`SearchTokenAutocomplete renders correctly with selected chain 1`] = `
                       </View>
                       <View
                         style={
-                          {
-                            "margin": 16,
-                            "paddingVertical": 16,
-                          }
+                          [
+                            {
+                              "margin": 16,
+                              "paddingVertical": 16,
+                            },
+                            {
+                              "paddingBottom": 0,
+                            },
+                          ]
                         }
                       >
                         <TouchableOpacity

--- a/app/components/UI/SearchTokenAutocomplete/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/SearchTokenAutocomplete/__snapshots__/index.test.tsx.snap
@@ -946,15 +946,11 @@ exports[`SearchTokenAutocomplete renders correctly with selected chain 1`] = `
                       </View>
                       <View
                         style={
-                          [
-                            {
-                              "margin": 16,
-                              "paddingVertical": 16,
-                            },
-                            {
-                              "paddingBottom": 0,
-                            },
-                          ]
+                          {
+                            "margin": 16,
+                            "paddingBottom": 0,
+                            "paddingVertical": 16,
+                          }
                         }
                       >
                         <TouchableOpacity

--- a/app/components/UI/SearchTokenAutocomplete/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/SearchTokenAutocomplete/__snapshots__/index.test.tsx.snap
@@ -329,7 +329,7 @@ exports[`SearchTokenAutocomplete renders correctly with selected chain 1`] = `
                         <View
                           style={
                             {
-                              "paddingTop": 16,
+                              "margin": 16,
                             }
                           }
                         >
@@ -353,7 +353,8 @@ exports[`SearchTokenAutocomplete renders correctly with selected chain 1`] = `
                               style={
                                 {
                                   "color": "#686e7d",
-                                  "paddingLeft": 20,
+                                  "left": 16,
+                                  "position": "absolute",
                                 }
                               }
                             >
@@ -376,9 +377,9 @@ exports[`SearchTokenAutocomplete renders correctly with selected chain 1`] = `
                                 {
                                   "borderColor": "#2c3dc5",
                                   "color": "#686e7d",
-                                  "paddingHorizontal": 12,
+                                  "paddingHorizontal": 42,
                                   "paddingVertical": 12,
-                                  "width": "80%",
+                                  "width": "100%",
                                 }
                               }
                             >
@@ -398,48 +399,6 @@ exports[`SearchTokenAutocomplete renders correctly with selected chain 1`] = `
                                 testID="input-search-asset"
                                 value=""
                               />
-                            </View>
-                            <View
-                              style={
-                                {
-                                  "color": "#686e7d",
-                                  "paddingRight": 20,
-                                }
-                              }
-                            >
-                              <TouchableOpacity
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "borderRadius": 8,
-                                    "height": 24,
-                                    "justifyContent": "center",
-                                    "opacity": 1,
-                                    "width": 24,
-                                  }
-                                }
-                                testID="clear-search-bar"
-                              >
-                                <SvgMock
-                                  color="#121314"
-                                  fill="currentColor"
-                                  height={16}
-                                  name="Close"
-                                  style={
-                                    {
-                                      "height": 16,
-                                      "width": 16,
-                                    }
-                                  }
-                                  width={16}
-                                />
-                              </TouchableOpacity>
                             </View>
                           </View>
                         </View>
@@ -988,6 +947,7 @@ exports[`SearchTokenAutocomplete renders correctly with selected chain 1`] = `
                       <View
                         style={
                           {
+                            "margin": 16,
                             "paddingVertical": 16,
                           }
                         }

--- a/app/components/UI/SearchTokenAutocomplete/index.tsx
+++ b/app/components/UI/SearchTokenAutocomplete/index.tsx
@@ -5,7 +5,9 @@ import {
   InteractionManager,
   Text,
   LayoutAnimation,
+  Platform,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { strings } from '../../../../locales/i18n';
 import AssetSearch from '../AssetSearch';
 import Engine from '../../../core/Engine';
@@ -42,7 +44,7 @@ import { RootState } from '../../../reducers';
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const createStyles = (colors: any) =>
+const createStyles = (colors: any, bottomInset: number) =>
   StyleSheet.create({
     container: {
       flex: 1,
@@ -71,6 +73,7 @@ const createStyles = (colors: any) =>
     button: {
       paddingVertical: 16,
       margin: 16,
+      paddingBottom: bottomInset,
     },
     searchInput: {
       margin: 16,
@@ -112,7 +115,9 @@ const SearchTokenAutocomplete = ({
   const [isSearchFocused, setIsSearchFocused] = useState(false);
 
   const { colors } = useTheme();
-  const styles = createStyles(colors);
+  const insets = useSafeAreaInsets();
+  const bottomInset = Platform.OS === 'ios' ? 0 : insets.bottom;
+  const styles = createStyles(colors, bottomInset);
 
   const isTokenDetectionEnabled = useSelector(selectUseTokenDetection);
   const ticker = useSelector(selectEvmTicker);

--- a/app/components/UI/SearchTokenAutocomplete/index.tsx
+++ b/app/components/UI/SearchTokenAutocomplete/index.tsx
@@ -70,9 +70,10 @@ const createStyles = (colors: any) =>
     },
     button: {
       paddingVertical: 16,
+      margin: 16,
     },
     searchInput: {
-      paddingTop: 16,
+      margin: 16,
     },
   });
 

--- a/app/components/Views/AddAsset/AddAsset.styles.ts
+++ b/app/components/Views/AddAsset/AddAsset.styles.ts
@@ -29,7 +29,6 @@ const styleSheet = (params: { theme: Theme }) => {
       marginTop: 10,
     },
     tabContainer: {
-      paddingHorizontal: 16,
       flex: 1,
     },
     networkImageContainer: {
@@ -66,6 +65,9 @@ const styleSheet = (params: { theme: Theme }) => {
       justifyContent: 'center',
       alignItems: 'center',
       paddingHorizontal: 16,
+    },
+    networkSelectorAvatarContainer: {
+      marginRight: 8,
     },
   });
 };

--- a/app/components/Views/AddAsset/AddAsset.tsx
+++ b/app/components/Views/AddAsset/AddAsset.tsx
@@ -121,8 +121,6 @@ const AddAsset = () => {
     () => [...(topTokens || []), ...(remainingTokens || [])],
     [topTokens, remainingTokens],
   );
-  // eslint-disable-next-line no-console
-  console.log('allTokens', allTokens);
 
   return (
     <SafeAreaView style={styles.wrapper} testID={`add-${assetType}-screen`}>

--- a/app/components/Views/AddAsset/AddAsset.tsx
+++ b/app/components/Views/AddAsset/AddAsset.tsx
@@ -39,7 +39,9 @@ import Avatar, {
   AvatarSize,
   AvatarVariant,
 } from '../../../component-library/components/Avatars/Avatar';
-import ButtonIcon from '../../../component-library/components/Buttons/ButtonIcon';
+import ButtonIcon, {
+  ButtonIconSizes,
+} from '../../../component-library/components/Buttons/ButtonIcon';
 import {
   IconColor,
   IconName,
@@ -174,13 +176,8 @@ const AddAsset = () => {
               onPress={() => setOpenNetworkSelector(true)}
               onLongPress={() => setOpenNetworkSelector(true)}
             >
-              <Text style={styles.networkSelectorText}>
-                {selectedNetwork
-                  ? networkConfigurations?.[selectedNetwork as Hex]?.name
-                  : strings('networks.select_network')}
-              </Text>
-              <View style={styles.overlappingAvatarsContainer}>
-                {selectedNetwork ? (
+              {selectedNetwork ? (
+                <View style={styles.networkSelectorAvatarContainer}>
                   <Avatar
                     variant={AvatarVariant.Network}
                     size={AvatarSize.Sm}
@@ -194,10 +191,17 @@ const AddAsset = () => {
                     })}
                     testID={ImportTokenViewSelectorsIDs.SELECT_NETWORK_BUTTON}
                   />
-                ) : null}
-
+                </View>
+              ) : null}
+              <Text style={styles.networkSelectorText}>
+                {selectedNetwork
+                  ? networkConfigurations?.[selectedNetwork as Hex]?.name
+                  : strings('networks.select_network')}
+              </Text>
+              <View style={styles.overlappingAvatarsContainer}>
                 <ButtonIcon
                   iconName={IconName.ArrowDown}
+                  size={ButtonIconSizes.Sm}
                   iconColor={IconColor.Default}
                   testID={ImportTokenViewSelectorsIDs.SELECT_NETWORK_BUTTON}
                   onPress={() => setOpenNetworkSelector(true)}

--- a/app/components/Views/AddAsset/AddAsset.tsx
+++ b/app/components/Views/AddAsset/AddAsset.tsx
@@ -121,6 +121,8 @@ const AddAsset = () => {
     () => [...(topTokens || []), ...(remainingTokens || [])],
     [topTokens, remainingTokens],
   );
+  // eslint-disable-next-line no-console
+  console.log('allTokens', allTokens);
 
   return (
     <SafeAreaView style={styles.wrapper} testID={`add-${assetType}-screen`}>

--- a/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
+++ b/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
@@ -821,51 +821,55 @@ exports[`AddAsset component renders token view correctly 1`] = `
           </View>
         </View>
       </RCTScrollView>
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        disabled={true}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+      <View
         style={
           {
-            "alignItems": "center",
-            "alignSelf": "center",
-            "backgroundColor": "#121314",
-            "borderRadius": 12,
-            "color": "#4459ff",
-            "flexDirection": "row",
-            "fontFamily": "Geist Regular",
-            "fontSize": 18,
-            "height": 48,
-            "justifyContent": "center",
-            "marginBottom": 16,
-            "opacity": 0.5,
-            "overflow": "hidden",
-            "paddingHorizontal": 16,
-            "position": "relative",
-            "width": "100%",
+            "margin": 16,
+            "paddingBottom": 0,
+            "paddingVertical": 16,
           }
         }
-        testID="token-import-next-button"
       >
-        <Text
-          accessibilityRole="text"
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessible={true}
+          activeOpacity={1}
+          disabled={true}
+          onPress={[Function]}
+          onPressIn={[Function]}
+          onPressOut={[Function]}
           style={
             {
-              "color": "#ffffff",
-              "fontFamily": "Geist Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
+              "alignItems": "center",
+              "alignSelf": "stretch",
+              "backgroundColor": "#121314",
+              "borderRadius": 12,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "opacity": 0.5,
+              "overflow": "hidden",
+              "paddingHorizontal": 16,
             }
           }
+          testID="token-import-next-button"
         >
-          Next
-        </Text>
-      </TouchableOpacity>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#ffffff",
+                "fontFamily": "Geist Medium",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Next
+          </Text>
+        </TouchableOpacity>
+      </View>
     </View>
   </View>
 </RCTSafeAreaView>

--- a/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
+++ b/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
@@ -529,28 +529,10 @@ exports[`AddAsset component renders token view correctly 1`] = `
           }
         }
       >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#121314",
-              "fontFamily": "Geist Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
-          }
-        >
-          Ethereum
-        </Text>
         <View
           style={
             {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "paddingHorizontal": 16,
-              "position": "absolute",
-              "right": 0,
+              "marginRight": 8,
             }
           }
         >
@@ -581,6 +563,32 @@ exports[`AddAsset component renders token view correctly 1`] = `
               testID="network-avatar-image"
             />
           </View>
+        </View>
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#121314",
+              "fontFamily": "Geist Regular",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Ethereum
+        </Text>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "paddingHorizontal": 16,
+              "position": "absolute",
+              "right": 0,
+            }
+          }
+        >
           <TouchableOpacity
             accessibilityRole="button"
             accessible={true}
@@ -593,10 +601,10 @@ exports[`AddAsset component renders token view correctly 1`] = `
               {
                 "alignItems": "center",
                 "borderRadius": 8,
-                "height": 28,
+                "height": 24,
                 "justifyContent": "center",
                 "opacity": 1,
-                "width": 28,
+                "width": 24,
               }
             }
             testID="select-network-button"
@@ -604,15 +612,15 @@ exports[`AddAsset component renders token view correctly 1`] = `
             <SvgMock
               color="#121314"
               fill="currentColor"
-              height={20}
+              height={16}
               name="ArrowDown"
               style={
                 {
-                  "height": 20,
-                  "width": 20,
+                  "height": 16,
+                  "width": 16,
                 }
               }
-              width={20}
+              width={16}
             />
           </TouchableOpacity>
         </View>
@@ -623,7 +631,6 @@ exports[`AddAsset component renders token view correctly 1`] = `
     style={
       {
         "flex": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="add-asset-tabs-container"
@@ -633,6 +640,7 @@ exports[`AddAsset component renders token view correctly 1`] = `
         {
           "backgroundColor": "#ffffff",
           "flex": 1,
+          "paddingHorizontal": 16,
         }
       }
     >


### PR DESCRIPTION
## **Description**

improve import assets UI
- Move network badge to the left of network picker
- The close icon "X" no longer appears if no search string exists, but it will appear if they do
- Footer button "Next" for Search Tab and Custom Token tab both are aligned and aren't being overlapped with the Android OS navigation bar

Other changes that aren't related to the tickets
- Improve multi selector layout by removing horizontal padding in parent container

## **Changelog**

CHANGELOG entry: Improved import assets UI

## **Related issues**

Fixes:
https://consensyssoftware.atlassian.net/browse/MDP-247
https://consensyssoftware.atlassian.net/browse/MDP-246
https://consensyssoftware.atlassian.net/browse/MDP-594

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

### Main UI Changes

https://consensyssoftware.atlassian.net/browse/MDP-246

| before | after |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/0da6da9a-ac2e-4359-a502-513e9e139404) | ![after](https://github.com/user-attachments/assets/2d15c992-5941-4230-acbe-93d4d88dc49c) |

### Android Button Obstruction Fix - Search Tab

https://consensyssoftware.atlassian.net/browse/MDP-594

| before | after |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/89eec7c6-e031-43eb-871c-dc7f1f8ac7b2) | ![after](https://github.com/user-attachments/assets/7569690c-b3dd-433d-8383-dc05a9d0d096) |

### Android Button Obstruction Fix - Custom Token Tab

https://consensyssoftware.atlassian.net/browse/MDP-594

| before | after |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/74cf6edf-6b58-4b37-9159-cff4943c1249) | ![after](https://github.com/user-attachments/assets/0ea3ec3b-098e-4760-b073-79554e9a77e9) |

### Close icon disappearing and reappearing based on search string

https://consensyssoftware.atlassian.net/browse/MDP-247

https://github.com/user-attachments/assets/1d5d5073-cad5-4d03-989a-b98e1f76e2d5


### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Import Assets screens with left-aligned network picker avatar, conditional clear icon, full-width bottom-aligned Next buttons that respect Android safe-area, and improved search field layout.
> 
> - **Import Token (Custom Token)**:
>   - Apply safe-area insets (Android) to footer; wrap Next button in `buttonWrapper` with margins and full-width `Button`.
>   - Add `paddingHorizontal` to `wrapper` and refactor styles; inject `safeAreaInsets` via HOC.
> - **Search (AssetSearch/SearchTokenAutocomplete)**:
>   - Make search input full-width with absolute `Search`/`Close` icons; show `Close` only when text exists.
>   - Add margins around search input and safe-area-aware padding for footer `Next` button.
> - **Add Asset screen**:
>   - Rework network picker: move network avatar to the left of the label and reduce arrow icon size; add spacing style.
>   - Adjust container padding to align tabs/content; minor style cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d679ae4432baf5fda44c3351efc676464deae520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->