### PR TITLE
fix: stale swap quote data when changing destination token

### DIFF
--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
@@ -11,7 +11,8 @@ import {
   selectIsSolanaSwap,
   selectIsSolanaToNonSolana,
 } from '../../../../../core/redux/slices/bridge';
-import { RequestStatus, isNonEvmChainId } from '@metamask/bridge-controller';
+import { RequestStatus } from '@metamask/bridge-controller';
+import { areAddressesEqual } from '../../../../../util/address';
 import { useCallback, useMemo, useEffect, useState, useRef } from 'react';
 import {
   fromTokenMinimalUnit,
@@ -93,11 +94,7 @@ export const useBridgeQuoteData = ({
     if (!activeQuote || !destToken) return false;
     const quoteDestAddress = activeQuote.quote.destAsset.address;
     const selectedDestAddress = destToken.address;
-    // Solana addresses are case-sensitive, EVM addresses are not
-    if (isNonEvmChainId(destToken.chainId)) {
-      return quoteDestAddress === selectedDestAddress;
-    }
-    return quoteDestAddress.toLowerCase() === selectedDestAddress.toLowerCase();
+    return areAddressesEqual(quoteDestAddress, selectedDestAddress);
   })();
 
   const destTokenAmount =

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
@@ -101,8 +101,19 @@ describe('useBridgeQuoteData', () => {
       quoteFetchError: null,
     };
 
+    // destToken must match the quote's destAsset for destTokenAmount to be calculated
+    const bridgeReducerOverrides = {
+      destToken: {
+        symbol: 'USDC',
+        chainId: SolScope.Mainnet,
+        address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        decimals: 6,
+      },
+    };
+
     const testState = createBridgeTestState({
       bridgeControllerOverrides,
+      bridgeReducerOverrides,
     });
 
     const { result } = renderHookWithProvider(() => useBridgeQuoteData(), {
@@ -212,6 +223,45 @@ describe('useBridgeQuoteData', () => {
       shouldShowPriceImpactWarning: false,
       quotesLoadingStatus: RequestStatus.FETCHED,
     });
+  });
+
+  it('returns undefined destTokenAmount when quote destAsset does not match selected destToken', () => {
+    // Set up mock with a quote for a different destination token (ETH) than what's selected (USDC)
+    (selectBridgeQuotes as unknown as jest.Mock).mockImplementation(() => ({
+      recommendedQuote: mockQuoteWithMetadata, // This quote is for Solana USDC
+      alternativeQuotes: [],
+    }));
+
+    const bridgeControllerOverrides = {
+      quotes: mockQuotes as unknown as QuoteResponse[],
+      quotesLoadingStatus: null,
+      quoteFetchError: null,
+    };
+
+    // Selected destToken is ETH on mainnet, which doesn't match the quote's destAsset (Solana USDC)
+    // This simulates the race condition when user changes destination token
+    const bridgeReducerOverrides = {
+      destToken: {
+        symbol: 'ETH',
+        chainId: CHAIN_IDS.MAINNET,
+        address: '0x0000000000000000000000000000000000000000',
+        decimals: 18,
+      },
+    };
+
+    const testState = createBridgeTestState({
+      bridgeControllerOverrides,
+      bridgeReducerOverrides,
+    });
+
+    const { result } = renderHookWithProvider(() => useBridgeQuoteData(), {
+      state: testState,
+    });
+
+    // destTokenAmount should be undefined because quote's destAsset doesn't match selected destToken
+    // This prevents showing incorrect amounts when switching destination tokens
+    expect(result.current.activeQuote).toEqual(mockQuoteWithMetadata);
+    expect(result.current.destTokenAmount).toBeUndefined();
   });
 
   it('handles expired quotes correctly', () => {

--- a/app/components/UI/Bridge/hooks/useInitialDestToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useInitialDestToken/index.ts
@@ -34,6 +34,11 @@ export const useInitialDestToken = (
   const prevInitialDestToken = usePrevious(initialDestToken);
 
   useEffect(() => {
+    // If dest token is already set in Redux (pre-populated before navigation), skip initialization
+    if (destToken && !initialDestToken) {
+      return;
+    }
+
     if (initialDestToken && prevInitialDestToken !== initialDestToken) {
       dispatch(setDestToken(initialDestToken));
       return;

--- a/app/components/UI/Bridge/hooks/useInitialSourceToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useInitialSourceToken/index.ts
@@ -20,8 +20,10 @@ import {
   selectIsEvmNetworkSelected,
   selectSelectedNonEvmNetworkChainId,
 } from '../../../../../selectors/multichainNetworkController';
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { getNativeSourceToken } from '../../utils/tokenUtils';
+import { CaipChainId, Hex } from '@metamask/utils';
+import { NetworkConfiguration } from '@metamask/network-controller';
 
 /**
  *
@@ -59,7 +61,51 @@ export const useInitialSourceToken = (
     ? selectedEvmChainId
     : selectedNonEvmNetworkChainId;
 
+  /**
+   * Switches to the appropriate network if the token's chain differs from current chain.
+   * @returns true if network switch was initiated, false otherwise
+   */
+  const handleNetworkSwitch = useCallback(
+    (tokenChainId: Hex | CaipChainId): boolean => {
+      const tokenCaipChainId = formatChainIdToCaip(tokenChainId);
+      const currentCaipChainId = formatChainIdToCaip(chainId);
+
+      if (tokenCaipChainId !== currentCaipChainId) {
+        if (isNonEvmChainId(tokenCaipChainId)) {
+          onNonEvmNetworkChange(tokenCaipChainId);
+          return true;
+        }
+
+        const hexChainId = formatChainIdToHex(tokenCaipChainId);
+        onSetRpcTarget(
+          evmNetworkConfigurations[hexChainId] as NetworkConfiguration,
+        );
+        return true;
+      }
+      return false;
+    },
+    [chainId, evmNetworkConfigurations, onNonEvmNetworkChange, onSetRpcTarget],
+  );
+
   useEffect(() => {
+    // If initial source token is already set in Redux (pre-populated before navigation),
+    // only handle network switching if needed
+    if (
+      initialSourceToken &&
+      sourceToken?.address === initialSourceToken.address
+    ) {
+      // Set source amount if provided
+      if (initialSourceAmount) {
+        dispatch(setSourceAmount(initialSourceAmount));
+      }
+
+      // Change network if necessary
+      if (initialSourceToken.chainId) {
+        handleNetworkSwitch(initialSourceToken.chainId);
+      }
+      return;
+    }
+
     // If no initial source token is provided,
     // set the source token to the bip44 default pair (preferred) or the native token of the current chain
     if (!initialSourceToken && !sourceToken) {
@@ -92,30 +138,16 @@ export const useInitialSourceToken = (
 
     // Change network if necessary
     if (initialSourceToken?.chainId) {
-      // Convert both chain IDs to CAIP format for accurate comparison
-      const sourceCaipChainId = formatChainIdToCaip(initialSourceToken.chainId);
-      const currentCaipChainId = formatChainIdToCaip(chainId);
-
-      if (sourceCaipChainId !== currentCaipChainId) {
-        if (isNonEvmChainId(sourceCaipChainId)) {
-          onNonEvmNetworkChange(sourceCaipChainId);
-          return;
-        }
-
-        const hexChainId = formatChainIdToHex(sourceCaipChainId);
-        onSetRpcTarget(evmNetworkConfigurations[hexChainId]);
-      }
+      handleNetworkSwitch(initialSourceToken.chainId);
     }
   }, [
     initialSourceToken,
     sourceToken,
-    evmNetworkConfigurations,
     chainId,
-    onSetRpcTarget,
-    onNonEvmNetworkChange,
     dispatch,
     initialSourceAmount,
     prevInitialSourceToken,
     bip44DefaultPair,
+    handleNetworkSwitch,
   ]);
 };

--- a/app/components/UI/Bridge/hooks/useInitialSourceToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useInitialSourceToken/index.ts
@@ -90,10 +90,15 @@ export const useInitialSourceToken = (
 
   useEffect(() => {
     // If initial source token is already set in Redux (pre-populated before navigation),
-    // only handle network switching if needed
+    // only handle network switching if needed.
+    // Must compare both address AND chainId since native tokens on different chains
+    // share the same zero address (0x0000...0000)
     if (
       initialSourceToken &&
-      areAddressesEqual(sourceToken?.address ?? '', initialSourceToken.address)
+      sourceToken?.chainId &&
+      areAddressesEqual(sourceToken.address, initialSourceToken.address) &&
+      formatChainIdToCaip(sourceToken.chainId) ===
+        formatChainIdToCaip(initialSourceToken.chainId)
     ) {
       // Set source amount if provided
       if (initialSourceAmount) {

--- a/app/components/UI/Bridge/hooks/useInitialSourceToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useInitialSourceToken/index.ts
@@ -10,10 +10,11 @@ import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selector
 import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
 import { useNetworkInfo } from '../../../../../selectors/selectedNetworkController';
 import {
-  isNonEvmChainId,
   formatChainIdToCaip,
   formatChainIdToHex,
+  isNonEvmChainId,
 } from '@metamask/bridge-controller';
+import { areAddressesEqual } from '../../../../../util/address';
 import { constants } from 'ethers';
 import usePrevious from '../../../../hooks/usePrevious';
 import {
@@ -92,7 +93,7 @@ export const useInitialSourceToken = (
     // only handle network switching if needed
     if (
       initialSourceToken &&
-      sourceToken?.address === initialSourceToken.address
+      areAddressesEqual(sourceToken?.address ?? '', initialSourceToken.address)
     ) {
       // Set source amount if provided
       if (initialSourceAmount) {

--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
@@ -32,6 +32,7 @@ import {
   getNativeSourceToken,
   getDefaultDestToken,
 } from '../../utils/tokenUtils';
+import { areAddressesEqual } from '../../../../../util/address';
 
 export enum SwapBridgeNavigationLocation {
   TabBar = 'TabBar',
@@ -129,43 +130,17 @@ export const useSwapBridgeNavigation = ({
       // Pre-populate Redux state before navigation to prevent empty button flash
       dispatch(setSourceToken(sourceToken));
 
-      // Helper to compare addresses with proper case sensitivity
-      // Solana addresses are case-sensitive, EVM addresses are not
-      const areAddressesEqual = (
-        addr1: string | undefined,
-        addr2: string | undefined,
-        chainId: Hex | CaipChainId,
-      ): boolean => {
-        if (!addr1 || !addr2) return false;
-        if (isNonEvmChainId(chainId)) {
-          // Solana addresses are case-sensitive
-          return addr1 === addr2;
-        }
-        // EVM addresses are case-insensitive
-        return addr1.toLowerCase() === addr2.toLowerCase();
-      };
-
       const defaultDestToken = getDefaultDestToken(sourceToken.chainId);
       // Make sure source and dest tokens are different
       if (
         defaultDestToken &&
-        !areAddressesEqual(
-          sourceToken.address,
-          defaultDestToken.address,
-          sourceToken.chainId,
-        )
+        !areAddressesEqual(sourceToken.address, defaultDestToken.address)
       ) {
         dispatch(setDestToken(defaultDestToken));
       } else {
         // Fall back to native token if default dest is same as source
         const nativeDestToken = getNativeSourceToken(sourceToken.chainId);
-        if (
-          !areAddressesEqual(
-            sourceToken.address,
-            nativeDestToken.address,
-            sourceToken.chainId,
-          )
-        ) {
+        if (!areAddressesEqual(sourceToken.address, nativeDestToken.address)) {
           dispatch(setDestToken(nativeDestToken));
         }
       }

--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
@@ -129,20 +129,42 @@ export const useSwapBridgeNavigation = ({
       // Pre-populate Redux state before navigation to prevent empty button flash
       dispatch(setSourceToken(sourceToken));
 
+      // Helper to compare addresses with proper case sensitivity
+      // Solana addresses are case-sensitive, EVM addresses are not
+      const areAddressesEqual = (
+        addr1: string | undefined,
+        addr2: string | undefined,
+        chainId: Hex | CaipChainId,
+      ): boolean => {
+        if (!addr1 || !addr2) return false;
+        if (isNonEvmChainId(chainId)) {
+          // Solana addresses are case-sensitive
+          return addr1 === addr2;
+        }
+        // EVM addresses are case-insensitive
+        return addr1.toLowerCase() === addr2.toLowerCase();
+      };
+
       const defaultDestToken = getDefaultDestToken(sourceToken.chainId);
       // Make sure source and dest tokens are different
       if (
         defaultDestToken &&
-        sourceToken.address?.toLowerCase() !==
-          defaultDestToken.address?.toLowerCase()
+        !areAddressesEqual(
+          sourceToken.address,
+          defaultDestToken.address,
+          sourceToken.chainId,
+        )
       ) {
         dispatch(setDestToken(defaultDestToken));
       } else {
         // Fall back to native token if default dest is same as source
         const nativeDestToken = getNativeSourceToken(sourceToken.chainId);
         if (
-          sourceToken.address?.toLowerCase() !==
-          nativeDestToken.address?.toLowerCase()
+          !areAddressesEqual(
+            sourceToken.address,
+            nativeDestToken.address,
+            sourceToken.chainId,
+          )
         ) {
           dispatch(setDestToken(nativeDestToken));
         }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

In the latest 7.61.0 (3242) build on TestFlight, there's a momentary flash of a huge destination amount when changing the destination asset from ETH to USDC on Ethereum before the quote refetches. This issue is also observed in the 7.62.0 (3239) build. 

Additionally, the 'Swap From' and 'Swap To' buttons appear empty momentarily upon entering the swap flow before being pre-filled. This issue is only observed in the 7.62.0 build.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where stale quote data remained momentarily when changing swap destination token

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents stale quote amounts when changing destination token, pre-fills swap tokens prior to navigation, and refactors initial source token network switching.
> 
> - **Bridge quotes (`useBridgeQuoteData`)**:
>   - Validate quote `destAsset` matches selected `destToken` before computing `destTokenAmount`; hide amount on mismatch to avoid stale values.
>   - Add tests covering matching/mismatching dest tokens and related states.
> - **Navigation (`useSwapBridgeNavigation`)**:
>   - Pre-dispatch `setSourceToken` and `setDestToken` before navigating; select a default dest token distinct from source to prevent empty button flash.
> - **Initialization hooks**:
>   - `useInitialDestToken`: Skip initialization when `destToken` is already set in Redux.
>   - `useInitialSourceToken`: Extract `handleNetworkSwitch`, compare address+chainId to detect pre-set token, set initial amount, and switch networks when needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd1c7a6fd66ee25ce65c9ca07209399e097448f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->