### PR TITLE
feat(ramps): cp-7.61.0 add ramps analytics data to all fund action menu items

### DIFF
--- a/app/components/UI/FundActionMenu/FundActionMenu.test.tsx
+++ b/app/components/UI/FundActionMenu/FundActionMenu.test.tsx
@@ -493,6 +493,11 @@ describe('FundActionMenu', () => {
           text: 'Buy',
           location: 'FundActionMenu',
           chain_id_destination: 1,
+          region: undefined,
+          ramp_routing: undefined,
+          is_authenticated: false,
+          preferred_provider: undefined,
+          order_count: 0,
         });
         expect(mockTrackEvent).toHaveBeenCalledWith(mockBuild());
       });
@@ -536,6 +541,11 @@ describe('FundActionMenu', () => {
           text: 'Buy',
           location: 'FundActionMenu',
           chain_id_destination: 137,
+          region: undefined,
+          ramp_routing: undefined,
+          is_authenticated: false,
+          preferred_provider: undefined,
+          order_count: 0,
         });
       });
     });

--- a/app/components/UI/FundActionMenu/FundActionMenu.tsx
+++ b/app/components/UI/FundActionMenu/FundActionMenu.tsx
@@ -50,7 +50,7 @@ const FundActionMenu = () => {
   const rampUnifiedV1Enabled = useRampsUnifiedV1Enabled();
   const { goToBuy, goToAggregator, goToSell, goToDeposit } =
     useRampNavigation();
-  const depositButtonClickData = useRampsButtonClickData();
+  const rampsButtonClickData = useRampsButtonClickData();
 
   const closeBottomSheetAndNavigate = useCallback(
     (navigateFunc: () => void) => {
@@ -119,6 +119,10 @@ const FundActionMenu = () => {
             location: 'FundActionMenu',
             chain_id_destination: getChainIdForAsset(),
             region: rampGeodetectedRegion,
+            ramp_routing: rampsButtonClickData.ramp_routing,
+            is_authenticated: rampsButtonClickData.is_authenticated,
+            preferred_provider: rampsButtonClickData.preferred_provider,
+            order_count: rampsButtonClickData.order_count,
           },
           navigationAction: () => {
             if (customOnBuy) {
@@ -142,10 +146,10 @@ const FundActionMenu = () => {
             chain_id_destination: getDecimalChainId(chainId),
             ramp_type: 'DEPOSIT',
             region: rampGeodetectedRegion,
-            ramp_routing: depositButtonClickData.ramp_routing,
-            is_authenticated: depositButtonClickData.is_authenticated,
-            preferred_provider: depositButtonClickData.preferred_provider,
-            order_count: depositButtonClickData.order_count,
+            ramp_routing: rampsButtonClickData.ramp_routing,
+            is_authenticated: rampsButtonClickData.is_authenticated,
+            preferred_provider: rampsButtonClickData.preferred_provider,
+            order_count: rampsButtonClickData.order_count,
           },
           traceName: TraceName.LoadDepositExperience,
           navigationAction: () => goToDeposit(),
@@ -163,6 +167,10 @@ const FundActionMenu = () => {
             location: 'FundActionMenu',
             chain_id_destination: getChainIdForAsset(),
             region: rampGeodetectedRegion,
+            ramp_routing: rampsButtonClickData.ramp_routing,
+            is_authenticated: rampsButtonClickData.is_authenticated,
+            preferred_provider: rampsButtonClickData.preferred_provider,
+            order_count: rampsButtonClickData.order_count,
           },
           traceName: TraceName.LoadRampExperience,
           traceProperties: { tags: { rampType: RampType.BUY } },
@@ -188,6 +196,10 @@ const FundActionMenu = () => {
             location: 'FundActionMenu',
             chain_id_source: getDecimalChainId(chainId),
             region: rampGeodetectedRegion,
+            ramp_routing: rampsButtonClickData.ramp_routing,
+            is_authenticated: rampsButtonClickData.is_authenticated,
+            preferred_provider: rampsButtonClickData.preferred_provider,
+            order_count: rampsButtonClickData.order_count,
           },
           traceName: TraceName.LoadRampExperience,
           traceProperties: { tags: { rampType: RampType.SELL } },
@@ -208,7 +220,7 @@ const FundActionMenu = () => {
       goToAggregator,
       goToSell,
       goToDeposit,
-      depositButtonClickData,
+      rampsButtonClickData,
     ],
   );
 

--- a/app/components/UI/FundActionMenu/FundActionMenu.types.ts
+++ b/app/components/UI/FundActionMenu/FundActionMenu.types.ts
@@ -26,7 +26,7 @@ export interface ActionConfig {
   isVisible: boolean;
   isDisabled?: boolean;
   analyticsEvent: IMetaMetricsEvent;
-  analyticsProperties: Record<string, string | number>;
+  analyticsProperties: Record<string, string | number | boolean | undefined>;
   traceName: TraceName;
   traceProperties?: Record<
     string,


### PR DESCRIPTION
## **Description**

Added ramps analytics data to all FundActionMenu buttons (buy-unified, buy, sell) to match the deposit button's analytics payload. This ensures consistent analytics tracking across all ramp action buttons.

Changes:
- Added `ramp_routing`, `is_authenticated`, `preferred_provider`, and `order_count` to buy-unified, buy, and sell button analytics
- Renamed `depositButtonClickData` to `rampsButtonClickData` to reflect broader usage
- Updated `ActionConfig` type to support boolean and undefined values in analytics properties

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TRAM-2901, https://github.com/MetaMask/metamask-mobile/issues/23777

## **Manual testing steps**

Feature: FundActionMenu Analytics

  Scenario: user taps buy button
    Given the user is on a screen with the FundActionMenu

    When user taps the buy button
    Then analytics event BUY_BUTTON_CLICKED is fired with ramp_routing, is_authenticated, preferred_provider, and order_count properties

  Scenario: user taps sell button
    Given the user is on a screen with the FundActionMenu

    When user taps the sell button
    Then analytics event SELL_BUTTON_CLICKED is fired with ramp_routing, is_authenticated, preferred_provider, and order_count properties## **Screenshots/Recordings**

### **Before**

N/A - Analytics change only

### **After**

N/A - Analytics change only

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies ramp analytics across FundActionMenu actions using shared button click data and updates types/tests accordingly.
> 
> - **UI / FundActionMenu**:
>   - Use `useRampsButtonClickData` and add shared analytics fields (`ramp_routing`, `is_authenticated`, `preferred_provider`, `order_count`) to `buy-unified`, `buy`, and `sell` button events; keep existing `region` and chain ID fields.
>   - Rename `depositButtonClickData` → `rampsButtonClickData`; update memo deps accordingly.
> - **Types**:
>   - Broaden `ActionConfig.analyticsProperties` to accept `boolean` and `undefined`.
> - **Tests**:
>   - Update `FundActionMenu.test.tsx` to mock `RampsButtonClickData` and assert new analytics properties for buy flows; maintain behavior that custom `onBuy` skips analytics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f194d92f959c27af49744e87f49d74a07d5921a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->