### PR TITLE
chore(infra): revert Android E2E runner from xl to lg instance

### DIFF
--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -33,7 +33,7 @@ jobs:
   build-android-apks:
     name: Build Android E2E APKs
     runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg # Using lg runner with optimized Gradle memory settings (see gradle.properties.github)
-    timeout-minutes: 40
+    timeout-minutes: 60  # Increased from 40 to accommodate lg runner's reduced parallelism
     env:
       GRADLE_USER_HOME: /home/admin/_work/.gradle
       CACHE_GENERATION: v1 # Increment this to bust the cache (v1, v2, v3, etc.)

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -32,8 +32,7 @@ on:
 jobs:
   build-android-apks:
     name: Build Android E2E APKs
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg # Using lg runner with optimized Gradle memory settings (see gradle.properties.github)
-    timeout-minutes: 60  # Increased from 40 to accommodate lg runner's reduced parallelism
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg # Bumped from lg to xl to prevent Daemon disappearance issue (Daemon OOM issue in CI)
     env:
       GRADLE_USER_HOME: /home/admin/_work/.gradle
       CACHE_GENERATION: v1 # Increment this to bust the cache (v1, v2, v3, etc.)

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -32,7 +32,8 @@ on:
 jobs:
   build-android-apks:
     name: Build Android E2E APKs
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg # Bumped from lg to xl to prevent Daemon disappearance issue (Daemon OOM issue in CI)
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg
+    timeout-minutes: 60
     env:
       GRADLE_USER_HOME: /home/admin/_work/.gradle
       CACHE_GENERATION: v1 # Increment this to bust the cache (v1, v2, v3, etc.)

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -138,7 +138,7 @@ jobs:
         if: ${{ steps.apk-cache-restore.outputs.cache-hit != 'true' }}
         run: |
           echo "🏗 Building Android E2E APKs..."
-          export NODE_OPTIONS="--max-old-space-size=8192"
+          export NODE_OPTIONS="--max-old-space-size=6144"
           # Use E2E gradle properties for GitHub Actions builds (gradle.properties.github)
           cp android/gradle.properties.github android/gradle.properties
           yarn build:android:${{ inputs.build_type }}:e2e
@@ -152,7 +152,7 @@ jobs:
           IGNORE_BOXLOGS_DEVELOPMENT: true
           GITHUB_CI: 'true'
           CI: 'true'
-          NODE_OPTIONS: '--max-old-space-size=8192'
+          NODE_OPTIONS: '--max-old-space-size=6144'
           BRIDGE_USE_DEV_APIS: 'true'
           RAMP_INTERNAL_BUILD: 'true'
           SEEDLESS_ONBOARDING_ENABLED: 'true'
@@ -201,7 +201,7 @@ jobs:
           IGNORE_BOXLOGS_DEVELOPMENT: true
           GITHUB_CI: 'true'
           CI: 'true'
-          NODE_OPTIONS: '--max-old-space-size=8192'
+          NODE_OPTIONS: '--max-old-space-size=6144'
           BRIDGE_USE_DEV_APIS: 'true'
           RAMP_INTERNAL_BUILD: 'true'
           SEEDLESS_ONBOARDING_ENABLED: 'true'

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   build-android-apks:
     name: Build Android E2E APKs
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg # Bumped from lg to xl to prevent Daemon disappearance issue (Daemon OOM issue in CI)
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg # Using lg runner with optimized Gradle memory settings (see gradle.properties.github)
     timeout-minutes: 40
     env:
       GRADLE_USER_HOME: /home/admin/_work/.gradle

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   build-android-apks:
     name: Build Android E2E APKs
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-xl # Bumped from lg to xl to prevent Daemon disappearance issue (Daemon OOM issue in CI)
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg # Bumped from lg to xl to prevent Daemon disappearance issue (Daemon OOM issue in CI)
     timeout-minutes: 40
     env:
       GRADLE_USER_HOME: /home/admin/_work/.gradle

--- a/android/gradle.properties.github
+++ b/android/gradle.properties.github
@@ -1,16 +1,17 @@
 # GitHub Actions-specific Gradle settings
 # Optimized for E2E builds on GitHub Actions runners
 
-# JVM configuration - balanced settings to avoid OOM while maintaining performance
-# Using 16GB heap to leave room for parallel workers and native memory
-org.gradle.jvmargs=-Xmx16g -XX:MaxMetaspaceSize=1g -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:+UseStringDeduplication -XX:+OptimizeStringConcat
+# JVM configuration - optimized for lg runner (16GB RAM) to avoid OOM
+# Using 8GB heap to leave room for Node.js (8GB) and OS overhead on 16GB runners
+# For xl runners (32GB), these settings can be increased
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:G1HeapRegionSize=8m -XX:+UseStringDeduplication -XX:+OptimizeStringConcat
 
-# Enable performance optimizations but limit parallelism to prevent OOM
+# Enable performance optimizations but limit parallelism to prevent OOM on lg runners
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.caching=true
 org.gradle.daemon=true
-org.gradle.workers.max=6
+org.gradle.workers.max=4
 org.gradle.vfs.watch=false
 
 # CI-specific optimizations - enabled for GitHub Actions

--- a/android/gradle.properties.github
+++ b/android/gradle.properties.github
@@ -2,9 +2,9 @@
 # Optimized for E2E builds on GitHub Actions runners
 
 # JVM configuration - optimized for lg runner (16GB RAM) to avoid OOM
-# Using 8GB heap to leave room for Node.js (8GB) and OS overhead on 16GB runners
-# For xl runners (32GB), these settings can be increased
-org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:G1HeapRegionSize=8m -XX:+UseStringDeduplication -XX:+OptimizeStringConcat
+# Memory budget: Gradle 6GB + Node.js 6GB = 12GB, leaving 4GB for OS/SDK tools
+# For xl runners (32GB), these settings can be increased to 12GB each
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:G1HeapRegionSize=8m -XX:+UseStringDeduplication -XX:+OptimizeStringConcat
 
 # Enable performance optimizations but limit parallelism to prevent OOM on lg runners
 org.gradle.parallel=true


### PR DESCRIPTION
## **Description**

Revert Android E2E runner from `xl` (32GB) to `lg` (16GB) with optimized memory settings to reduce CI costs.

### Root Cause Analysis

The `xl` runner was introduced in [PR #23418](https://github.com/MetaMask/metamask-mobile/pull/23418) as a **workaround** for Gradle OOM issues. Investigation revealed the actual problem was **memory over-commitment**:

| Date | Commit | Change | Memory Config | Result |
|------|--------|--------|---------------|--------|
| Oct 20 | [d2a007d14](https://github.com/MetaMask/metamask-mobile/commit/d2a007d1409339cc011cfc978a58edd4ed229ebe) | Runner xl→lg | 32GB Gradle on 16GB runner | ❌ OOM |
| Nov 10 | [fbc08a68f](https://github.com/MetaMask/metamask-mobile/commit/fbc08a68fec866a939e23fe03da26847eb0e538f) | Reduced Gradle | 16GB+8GB = 24GB on 16GB | ❌ OOM |
| Nov 20 | [2b1a33a1b](https://github.com/MetaMask/metamask-mobile/commit/2b1a33a1b73) | Added 40min timeout | Based on xl reference (19min) | ⚠️ |
| Nov 28 | [ffba0b05e](https://github.com/MetaMask/metamask-mobile/commit/ffba0b05e702a4842d10f6910d7c9d636a04b959) | Runner lg→xl | 16GB+8GB = 24GB on 32GB | ✅ |

### The Fix

Proper memory allocation for 16GB `lg` runner:

```
Before (broken):     Gradle 16GB + Node.js 8GB = 24GB > 16GB ❌
After (optimized):   Gradle 6GB  + Node.js 6GB = 12GB + 4GB OS headroom ✅
```

| Setting | xl (workaround) | lg (this PR) |
|---------|-----------------|--------------|
| Runner RAM | 32GB | 16GB |
| Gradle JVM (`-Xmx`) | 16GB | **6GB** |
| Node.js (`--max-old-space-size`) | 8GB | **6GB** |
| Gradle workers | 6 | **4** |
| Timeout | 40 min | **60 min** |

### Why Explicit `timeout-minutes: 60`?

⚠️ **Important:** GitHub Actions and Cirrus CI have different default timeouts:

| Platform | Default Timeout |
|----------|----------------|
| **Cirrus CI** | 60 minutes |
| **GitHub Actions** | **360 minutes (6 hours)** |

This workflow runs on **GitHub Actions** using Cirrus Labs *runners* (not Cirrus CI itself). Without an explicit `timeout-minutes`, GitHub Actions defaults to 6 hours. During testing, removing the timeout caused a build to run for [~6 hours](https://productionresultssa9.blob.core.windows.net/actions-results/26167ef1-558a-47e5-b2c2-232af23fabfd/workflow-job-run-a4a72ee1-8b27-5462-be0d-c991ef4725fb/logs/job/job-logs.txt) due to a hung process.

The explicit `timeout-minutes: 60` ensures:
- Stuck builds fail fast instead of running for 6 hours
- Cost savings by not wasting runner time on hung jobs
- Provides 38 minutes of headroom beyond the typical ~22 minute build

### Validation

✅ **Build succeeded** on `lg` runner in **~22 minutes** (full Gradle build, no APK cache):
- [Build log](https://github.com/MetaMask/metamask-mobile/actions/runs/12245073844)
- Only ~3 min slower than `xl` reference (19 min)
- 60 min timeout provides 38 min headroom for longer builds

### Why 4GB OS Headroom?

The JVM consumes memory beyond the `-Xmx` heap setting. Additional memory is needed for:

- **JVM non-heap memory**: Metaspace (capped at 512MB), thread stacks (~1MB per thread), native memory, code cache
- **Forked processes**: Kotlin daemon may spawn separately, AAPT2 and D8/R8 can fork during compilation
- **Linux kernel + system processes**: Essential OS overhead
- **File system cache**: Linux uses free RAM to cache I/O, improving build performance

The exact memory usage of these components varies and is not well-documented. We chose **4GB as a conservative buffer** to ensure stability. Initial tests with only 8GB+8GB=16GB (zero headroom) resulted in builds that timed out due to memory pressure causing slowdowns.

A tighter 2GB headroom might work but carries higher risk of OOM under peak load. The 4GB buffer has been **validated empirically** with a successful 22-minute build.

### Impact

- ✅ Only `build-android-e2e.yml` affected
- ✅ iOS builds unaffected (different runner, no Gradle)
- ✅ E2E test runs unaffected (use pre-built APKs)
- ✅ Cost savings: 16GB runner vs 32GB runner

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3174](https://consensyssoftware.atlassian.net/browse/INFRA-3174)

## **Manual testing steps**

```gherkin
Feature: Android E2E APK Build on lg Runner

  Scenario: Build completes successfully with optimized memory settings
    Given the build-android-e2e workflow is triggered on a PR
    And the runner is ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg (16GB RAM)

    When the Gradle build runs with 6GB heap and 4 workers
    And Node.js runs with 6GB max-old-space-size

    Then the build completes without OOM errors
    And the build finishes within 60 minutes
    And APK artifacts are uploaded successfully
```

## **Screenshots/Recordings**

### **Before**

N/A - CI/CD workflow change, no UI changes.

### **After**

N/A - CI/CD workflow change, no UI changes.

Build evidence: [Successful build log](https://github.com/MetaMask/metamask-mobile/actions/runs/12245073844) (~22 minutes on lg runner)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[INFRA-3174]: https://consensyssoftware.atlassian.net/browse/INFRA-3174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ