### PR TITLE
feat(predict): add sports market sorting and improve market parsing cp-7.61.0

### DIFF
--- a/app/components/UI/Predict/components/PredictMarketOutcomeResolved/PredictMarketOutcomeResolved.tsx
+++ b/app/components/UI/Predict/components/PredictMarketOutcomeResolved/PredictMarketOutcomeResolved.tsx
@@ -55,7 +55,7 @@ const PredictMarketOutcomeResolved: React.FC<
             numberOfLines={1}
             ellipsizeMode="tail"
           >
-            {outcome.groupItemTitle}
+            {outcome.groupItemTitle ?? outcome.title}
           </Text>
           <Text
             variant={TextVariant.BodySMMedium}

--- a/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
@@ -282,7 +282,13 @@ describe('PredictPositionDetail', () => {
   });
 
   it('renders initial value line and avgPrice cents', () => {
-    renderComponent({ initialValue: 50, outcome: 'No', avgPrice: 0.7 });
+    renderComponent({
+      initialValue: 50,
+      outcome: 'No',
+      avgPrice: 0.7,
+      outcomeId: 'outcome-2',
+      outcomeTokenId: '1',
+    });
 
     expect(screen.getByText('Group')).toBeOnTheScreen();
     expect(

--- a/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.tsx
+++ b/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.tsx
@@ -100,6 +100,14 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
     (o) => o.id === currentPosition.outcomeId && o.groupItemTitle,
   )?.groupItemTitle;
 
+  const outcomeToken = market?.outcomes
+    .find(
+      (o) =>
+        o.id === currentPosition.outcomeId &&
+        o.tokens.find((t) => t.id === currentPosition.outcomeTokenId),
+    )
+    ?.tokens.find((t) => t.id === currentPosition.outcomeTokenId);
+
   const onCashOut = () => {
     executeGuardedAction(
       () => {
@@ -175,7 +183,7 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
               initialValue: formatPrice(initialValue, {
                 maximumDecimals: 2,
               }),
-              outcome,
+              outcome: outcomeToken?.title ?? outcome,
               shares: formatPrice(size, {
                 maximumDecimals: 2,
               }),

--- a/app/components/UI/Predict/providers/polymarket/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/types.ts
@@ -130,8 +130,11 @@ export interface PolymarketApiMarket {
   icon: string;
   image: string;
   groupItemTitle: string;
+  groupItemThreshold?: number;
+  sportsMarketType?: string;
   status: 'open' | 'closed' | 'resolved';
   volumeNum: number;
+  liquidity: number;
   negRisk: boolean;
   clobTokenIds: string;
   outcomes: string;
@@ -142,6 +145,7 @@ export interface PolymarketApiMarket {
   orderPriceMinTickSize: number;
   events?: PolymarketApiEvent[];
   umaResolutionStatus: string;
+  line?: number;
 }
 
 export interface PolymarketApiSeries {
@@ -174,6 +178,7 @@ export interface PolymarketApiEvent {
   tags: PolymarketApiTag[];
   liquidity: number;
   volume: number;
+  sortBy?: 'price' | 'ascending' | 'descending';
 }
 
 export interface PolymarketApiActivity {

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -1965,6 +1965,18 @@ describe('polymarket utils', () => {
       expect(result.groupItemTitle).toBe('Team A 3.5');
     });
 
+    it('formats spread market groupItemTitle preserving dashes in team names', () => {
+      const market = createMarket({
+        sportsMarketType: 'spreads',
+        groupItemTitle: 'FC-Dallas -3.5',
+      });
+      const event = createTestEvent({ title: 'FC-Dallas vs. St.-Louis' });
+
+      const result = parsePolymarketMarket(market, event);
+
+      expect(result.groupItemTitle).toBe('FC-Dallas 3.5');
+    });
+
     it('formats spread market outcome titles with line values', () => {
       const market = createMarket({
         sportsMarketType: 'spreads',
@@ -1989,8 +2001,8 @@ describe('polymarket utils', () => {
 
       const result = parsePolymarketMarket(market, event);
 
-      expect(result.tokens[0].title).toBe('Team A ');
-      expect(result.tokens[1].title).toBe('Team B ');
+      expect(result.tokens[0].title).toBe('Team A');
+      expect(result.tokens[1].title).toBe('Team B');
     });
 
     it('handles undefined volumeNum as 0', () => {

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -66,6 +66,12 @@ import {
   roundOrderAmount,
   previewOrder,
   getAllowanceCalls,
+  isSportEvent,
+  isSpreadMarket,
+  sortSportMarkets,
+  sortMarketsByField,
+  sortMarkets,
+  parsePolymarketMarket,
 } from './utils';
 
 // Mock external dependencies
@@ -953,6 +959,7 @@ describe('polymarket utils', () => {
           groupItemTitle: 'Weather',
           closed: false,
           volumeNum: 1000,
+          liquidity: 500,
           clobTokenIds: '["token-1", "token-2"]',
           outcomes: '["Yes", "No"]',
           outcomePrices: '["0.6", "0.4"]',
@@ -1102,7 +1109,7 @@ describe('polymarket utils', () => {
       ]);
     });
 
-    it('sort markets by price in descending order', () => {
+    it('sorts markets by price in descending order when sortMarketsBy is price', () => {
       const eventWithMultipleMarkets = {
         ...mockEvent,
         markets: [
@@ -1127,6 +1134,7 @@ describe('polymarket utils', () => {
       const result = parsePolymarketEvents(
         [eventWithMultipleMarkets],
         mockCategory,
+        'price',
       );
 
       expect(result[0].outcomes).toHaveLength(3);
@@ -1137,7 +1145,7 @@ describe('polymarket utils', () => {
       ]);
     });
 
-    it('handle markets with null outcomePrices in sorting', () => {
+    it('handles markets with null outcomePrices in sorting when sortMarketsBy is price', () => {
       const eventWithNullPrices = {
         ...mockEvent,
         markets: [
@@ -1154,15 +1162,19 @@ describe('polymarket utils', () => {
         ],
       };
 
-      const result = parsePolymarketEvents([eventWithNullPrices], mockCategory);
+      const result = parsePolymarketEvents(
+        [eventWithNullPrices],
+        mockCategory,
+        'price',
+      );
 
       expect(result[0].outcomes).toHaveLength(2);
-      // Market with price should come first (0.6 > 0)
+      // Market with price comes first (0.6 > 0)
       expect(result[0].outcomes[0].id).toBe('market-with-price');
       expect(result[0].outcomes[1].id).toBe('market-without-price');
     });
 
-    it('handle markets with undefined outcomePrices in sorting', () => {
+    it('handles markets with undefined outcomePrices in sorting when sortMarketsBy is price', () => {
       const eventWithUndefinedPrices = {
         ...mockEvent,
         markets: [
@@ -1182,15 +1194,16 @@ describe('polymarket utils', () => {
       const result = parsePolymarketEvents(
         [eventWithUndefinedPrices],
         mockCategory,
+        'price',
       );
 
       expect(result[0].outcomes).toHaveLength(2);
-      // Market with price should come first (0.3 > 0)
+      // Market with price comes first (0.3 > 0)
       expect(result[0].outcomes[0].id).toBe('market-with-price');
       expect(result[0].outcomes[1].id).toBe('market-without-price');
     });
 
-    it('handle markets with empty outcomePrices string in sorting', () => {
+    it('handles markets with empty outcomePrices string in sorting when sortMarketsBy is price', () => {
       const eventWithEmptyPrices = {
         ...mockEvent,
         markets: [
@@ -1210,10 +1223,11 @@ describe('polymarket utils', () => {
       const result = parsePolymarketEvents(
         [eventWithEmptyPrices],
         mockCategory,
+        'price',
       );
 
       expect(result[0].outcomes).toHaveLength(2);
-      // Market with price should come first (0.4 > 0)
+      // Market with price comes first (0.4 > 0)
       expect(result[0].outcomes[0].id).toBe('market-with-price');
       expect(result[0].outcomes[1].id).toBe('market-with-empty-price');
     });
@@ -1255,7 +1269,7 @@ describe('polymarket utils', () => {
       expect(result[0].outcomes[0].resolvedBy).toBeUndefined();
     });
 
-    it('handle complex sorting with mixed price scenarios', () => {
+    it('handles complex sorting with mixed price scenarios when sortMarketsBy is price', () => {
       const eventWithComplexPrices = {
         ...mockEvent,
         markets: [
@@ -1285,6 +1299,7 @@ describe('polymarket utils', () => {
       const result = parsePolymarketEvents(
         [eventWithComplexPrices],
         mockCategory,
+        'price',
       );
 
       expect(result[0].outcomes).toHaveLength(4);
@@ -1294,6 +1309,672 @@ describe('polymarket utils', () => {
         'market-zero', // 0
         'market-null', // 0 (default)
       ]);
+    });
+
+    it('preserves market order when no sortMarketsBy is provided for non-sport events', () => {
+      const eventWithMultipleMarkets = {
+        ...mockEvent,
+        markets: [
+          {
+            ...mockEvent.markets[0],
+            conditionId: 'market-first',
+            outcomePrices: '["0.3", "0.7"]',
+          },
+          {
+            ...mockEvent.markets[0],
+            conditionId: 'market-second',
+            outcomePrices: '["0.8", "0.2"]',
+          },
+          {
+            ...mockEvent.markets[0],
+            conditionId: 'market-third',
+            outcomePrices: '["0.5", "0.5"]',
+          },
+        ],
+      };
+
+      const result = parsePolymarketEvents(
+        [eventWithMultipleMarkets],
+        mockCategory,
+      );
+
+      expect(result[0].outcomes).toHaveLength(3);
+      expect(result[0].outcomes.map((outcome) => outcome.id)).toEqual([
+        'market-first',
+        'market-second',
+        'market-third',
+      ]);
+    });
+  });
+
+  describe('isSportEvent', () => {
+    it('returns true when event has sports tag', () => {
+      const sportEvent: PolymarketApiEvent = {
+        id: 'sport-event-1',
+        slug: 'sport-event',
+        title: 'Sport Event',
+        description: 'A sport event',
+        icon: 'https://example.com/icon.png',
+        closed: false,
+        tags: [{ id: '1', label: 'Sports', slug: 'sports' }],
+        series: [],
+        markets: [],
+        liquidity: 1000,
+        volume: 5000,
+      };
+
+      const result = isSportEvent(sportEvent);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when event has no sports tag', () => {
+      const nonSportEvent: PolymarketApiEvent = {
+        id: 'non-sport-event-1',
+        slug: 'non-sport-event',
+        title: 'Non Sport Event',
+        description: 'A non-sport event',
+        icon: 'https://example.com/icon.png',
+        closed: false,
+        tags: [{ id: '2', label: 'Politics', slug: 'politics' }],
+        series: [],
+        markets: [],
+        liquidity: 1000,
+        volume: 5000,
+      };
+
+      const result = isSportEvent(nonSportEvent);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when event has empty tags', () => {
+      const eventWithNoTags: PolymarketApiEvent = {
+        id: 'event-no-tags',
+        slug: 'event-no-tags',
+        title: 'Event No Tags',
+        description: 'An event with no tags',
+        icon: 'https://example.com/icon.png',
+        closed: false,
+        tags: [],
+        series: [],
+        markets: [],
+        liquidity: 1000,
+        volume: 5000,
+      };
+
+      const result = isSportEvent(eventWithNoTags);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isSpreadMarket', () => {
+    it('returns true when sportsMarketType contains spread', () => {
+      const spreadMarket: PolymarketApiMarket = {
+        conditionId: 'spread-market',
+        question: 'Spread market?',
+        description: 'A spread market',
+        icon: 'https://example.com/icon.png',
+        image: 'https://example.com/image.png',
+        groupItemTitle: 'Team A -3.5',
+        sportsMarketType: 'spreads',
+        status: 'open',
+        volumeNum: 1000,
+        liquidity: 500,
+        negRisk: false,
+        clobTokenIds: '["token-1", "token-2"]',
+        outcomes: '["Yes", "No"]',
+        outcomePrices: '["0.5", "0.5"]',
+        closed: false,
+        active: true,
+        resolvedBy: '',
+        orderPriceMinTickSize: 0.01,
+        umaResolutionStatus: 'unresolved',
+      };
+
+      const result = isSpreadMarket(spreadMarket);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true when sportsMarketType is spread (case insensitive)', () => {
+      const spreadMarket: PolymarketApiMarket = {
+        conditionId: 'spread-market',
+        question: 'Spread market?',
+        description: 'A spread market',
+        icon: 'https://example.com/icon.png',
+        image: 'https://example.com/image.png',
+        groupItemTitle: 'Team A -3.5',
+        sportsMarketType: 'Spreads',
+        status: 'open',
+        volumeNum: 1000,
+        liquidity: 500,
+        negRisk: false,
+        clobTokenIds: '["token-1", "token-2"]',
+        outcomes: '["Yes", "No"]',
+        outcomePrices: '["0.5", "0.5"]',
+        closed: false,
+        active: true,
+        resolvedBy: '',
+        orderPriceMinTickSize: 0.01,
+        umaResolutionStatus: 'unresolved',
+      };
+
+      const result = isSpreadMarket(spreadMarket);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when sportsMarketType is moneyline', () => {
+      const moneylineMarket: PolymarketApiMarket = {
+        conditionId: 'moneyline-market',
+        question: 'Moneyline market?',
+        description: 'A moneyline market',
+        icon: 'https://example.com/icon.png',
+        image: 'https://example.com/image.png',
+        groupItemTitle: 'Team A',
+        sportsMarketType: 'moneyline',
+        status: 'open',
+        volumeNum: 1000,
+        liquidity: 500,
+        negRisk: false,
+        clobTokenIds: '["token-1", "token-2"]',
+        outcomes: '["Yes", "No"]',
+        outcomePrices: '["0.5", "0.5"]',
+        closed: false,
+        active: true,
+        resolvedBy: '',
+        orderPriceMinTickSize: 0.01,
+        umaResolutionStatus: 'unresolved',
+      };
+
+      const result = isSpreadMarket(moneylineMarket);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when sportsMarketType is undefined', () => {
+      const marketWithoutType: PolymarketApiMarket = {
+        conditionId: 'market-no-type',
+        question: 'Market?',
+        description: 'A market without type',
+        icon: 'https://example.com/icon.png',
+        image: 'https://example.com/image.png',
+        groupItemTitle: 'Team A',
+        status: 'open',
+        volumeNum: 1000,
+        liquidity: 500,
+        negRisk: false,
+        clobTokenIds: '["token-1", "token-2"]',
+        outcomes: '["Yes", "No"]',
+        outcomePrices: '["0.5", "0.5"]',
+        closed: false,
+        active: true,
+        resolvedBy: '',
+        orderPriceMinTickSize: 0.01,
+        umaResolutionStatus: 'unresolved',
+      };
+
+      const result = isSpreadMarket(marketWithoutType);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('sortSportMarkets', () => {
+    const createSportMarket = (
+      id: string,
+      sportsMarketType: string,
+      liquidity: number,
+      volume: number,
+    ): PolymarketApiMarket => ({
+      conditionId: id,
+      question: `Market ${id}?`,
+      description: `Description ${id}`,
+      icon: 'https://example.com/icon.png',
+      image: 'https://example.com/image.png',
+      groupItemTitle: `Group ${id}`,
+      sportsMarketType,
+      status: 'open',
+      volumeNum: volume,
+      liquidity,
+      negRisk: false,
+      clobTokenIds: '["token-1", "token-2"]',
+      outcomes: '["Yes", "No"]',
+      outcomePrices: '["0.5", "0.5"]',
+      closed: false,
+      active: true,
+      resolvedBy: '',
+      orderPriceMinTickSize: 0.01,
+      umaResolutionStatus: 'unresolved',
+    });
+
+    it('groups markets by sportsMarketType with moneyline first, spreads second, totals third', () => {
+      const markets = [
+        createSportMarket('totals-1', 'totals', 100, 100),
+        createSportMarket('moneyline-1', 'moneyline', 100, 100),
+        createSportMarket('spreads-1', 'spreads', 100, 100),
+      ];
+
+      const result = sortSportMarkets(markets);
+
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'moneyline-1',
+        'spreads-1',
+        'totals-1',
+      ]);
+    });
+
+    it('sorts alphabetically for unknown market types', () => {
+      const markets = [
+        createSportMarket('zebra-1', 'zebra', 100, 100),
+        createSportMarket('alpha-1', 'alpha', 100, 100),
+        createSportMarket('moneyline-1', 'moneyline', 100, 100),
+      ];
+
+      const result = sortSportMarkets(markets);
+
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'moneyline-1',
+        'alpha-1',
+        'zebra-1',
+      ]);
+    });
+
+    it('sorts markets within same group by liquidity + volume descending', () => {
+      const markets = [
+        createSportMarket('moneyline-low', 'moneyline', 100, 100), // score: 200
+        createSportMarket('moneyline-high', 'moneyline', 500, 500), // score: 1000
+        createSportMarket('moneyline-medium', 'moneyline', 300, 200), // score: 500
+      ];
+
+      const result = sortSportMarkets(markets);
+
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'moneyline-high',
+        'moneyline-medium',
+        'moneyline-low',
+      ]);
+    });
+
+    it('handles markets with undefined sportsMarketType as other', () => {
+      const markets = [
+        createSportMarket('other-1', undefined as any, 100, 100),
+        createSportMarket('moneyline-1', 'moneyline', 100, 100),
+      ];
+
+      const result = sortSportMarkets(markets);
+
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'moneyline-1',
+        'other-1',
+      ]);
+    });
+
+    it('maintains group ordering with multiple markets per group', () => {
+      const markets = [
+        createSportMarket('totals-low', 'totals', 50, 50),
+        createSportMarket('spreads-high', 'spreads', 500, 500),
+        createSportMarket('moneyline-low', 'moneyline', 100, 100),
+        createSportMarket('totals-high', 'totals', 300, 300),
+        createSportMarket('spreads-low', 'spreads', 100, 100),
+        createSportMarket('moneyline-high', 'moneyline', 400, 400),
+      ];
+
+      const result = sortSportMarkets(markets);
+
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'moneyline-high',
+        'moneyline-low',
+        'spreads-high',
+        'spreads-low',
+        'totals-high',
+        'totals-low',
+      ]);
+    });
+  });
+
+  describe('sortMarketsByField', () => {
+    const createMarketForSorting = (
+      id: string,
+      price: string,
+      threshold?: number,
+    ): PolymarketApiMarket => ({
+      conditionId: id,
+      question: `Market ${id}?`,
+      description: `Description ${id}`,
+      icon: 'https://example.com/icon.png',
+      image: 'https://example.com/image.png',
+      groupItemTitle: `Group ${id}`,
+      groupItemThreshold: threshold,
+      status: 'open',
+      volumeNum: 1000,
+      liquidity: 500,
+      negRisk: false,
+      clobTokenIds: '["token-1", "token-2"]',
+      outcomes: '["Yes", "No"]',
+      outcomePrices: price,
+      closed: false,
+      active: true,
+      resolvedBy: '',
+      orderPriceMinTickSize: 0.01,
+      umaResolutionStatus: 'unresolved',
+    });
+
+    it('sorts by price descending', () => {
+      const markets = [
+        createMarketForSorting('low', '["0.3", "0.7"]'),
+        createMarketForSorting('high', '["0.9", "0.1"]'),
+        createMarketForSorting('medium', '["0.5", "0.5"]'),
+      ];
+
+      const result = sortMarketsByField(markets, 'price');
+
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'high',
+        'medium',
+        'low',
+      ]);
+    });
+
+    it('sorts by groupItemThreshold ascending', () => {
+      const markets = [
+        createMarketForSorting('high', '["0.5", "0.5"]', 100),
+        createMarketForSorting('low', '["0.5", "0.5"]', 10),
+        createMarketForSorting('medium', '["0.5", "0.5"]', 50),
+      ];
+
+      const result = sortMarketsByField(markets, 'ascending');
+
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'low',
+        'medium',
+        'high',
+      ]);
+    });
+
+    it('sorts by groupItemThreshold descending', () => {
+      const markets = [
+        createMarketForSorting('high', '["0.5", "0.5"]', 100),
+        createMarketForSorting('low', '["0.5", "0.5"]', 10),
+        createMarketForSorting('medium', '["0.5", "0.5"]', 50),
+      ];
+
+      const result = sortMarketsByField(markets, 'descending');
+
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'high',
+        'medium',
+        'low',
+      ]);
+    });
+
+    it('handles undefined groupItemThreshold as 0 for ascending', () => {
+      const markets = [
+        createMarketForSorting('with-threshold', '["0.5", "0.5"]', 50),
+        createMarketForSorting('without-threshold', '["0.5", "0.5"]'),
+      ];
+
+      const result = sortMarketsByField(markets, 'ascending');
+
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'without-threshold',
+        'with-threshold',
+      ]);
+    });
+
+    it('handles null outcomePrices as 0 for price sorting', () => {
+      const markets = [
+        createMarketForSorting('with-price', '["0.6", "0.4"]'),
+        {
+          ...createMarketForSorting('null-price', ''),
+          outcomePrices: null as any,
+        },
+      ];
+
+      const result = sortMarketsByField(markets, 'price');
+
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'with-price',
+        'null-price',
+      ]);
+    });
+  });
+
+  describe('sortMarkets', () => {
+    const createEvent = (
+      tags: { id: string; label: string; slug: string }[],
+      markets: PolymarketApiMarket[],
+      sortBy?: 'price' | 'ascending' | 'descending',
+    ): PolymarketApiEvent => ({
+      id: 'event-1',
+      slug: 'test-event',
+      title: 'Test Event',
+      description: 'A test event',
+      icon: 'https://example.com/icon.png',
+      closed: false,
+      tags,
+      series: [],
+      markets,
+      liquidity: 1000,
+      volume: 5000,
+      sortBy,
+    });
+
+    const createMarket = (
+      id: string,
+      price: string,
+      liquidity: number,
+      volume: number,
+      sportsMarketType?: string,
+    ): PolymarketApiMarket => ({
+      conditionId: id,
+      question: `Market ${id}?`,
+      description: `Description ${id}`,
+      icon: 'https://example.com/icon.png',
+      image: 'https://example.com/image.png',
+      groupItemTitle: `Group ${id}`,
+      sportsMarketType,
+      status: 'open',
+      volumeNum: volume,
+      liquidity,
+      negRisk: false,
+      clobTokenIds: '["token-1", "token-2"]',
+      outcomes: '["Yes", "No"]',
+      outcomePrices: price,
+      closed: false,
+      active: true,
+      resolvedBy: '',
+      orderPriceMinTickSize: 0.01,
+      umaResolutionStatus: 'unresolved',
+    });
+
+    it('uses sortBy parameter when provided', () => {
+      const markets = [
+        createMarket('low', '["0.3", "0.7"]', 100, 100),
+        createMarket('high', '["0.9", "0.1"]', 100, 100),
+      ];
+      const event = createEvent([], markets);
+
+      const result = sortMarkets(event, 'price');
+
+      expect(result.map((m) => m.conditionId)).toEqual(['high', 'low']);
+    });
+
+    it('uses sortSportMarkets for sport events when no sortBy parameter', () => {
+      const markets = [
+        createMarket('totals-1', '["0.5", "0.5"]', 100, 100, 'totals'),
+        createMarket('moneyline-1', '["0.5", "0.5"]', 100, 100, 'moneyline'),
+      ];
+      const sportTags = [{ id: '1', label: 'Sports', slug: 'sports' }];
+      const event = createEvent(sportTags, markets);
+
+      const result = sortMarkets(event);
+
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'moneyline-1',
+        'totals-1',
+      ]);
+    });
+
+    it('uses event.sortBy for non-sport events when no sortBy parameter', () => {
+      const markets = [
+        createMarket('low', '["0.3", "0.7"]', 100, 100),
+        createMarket('high', '["0.9", "0.1"]', 100, 100),
+      ];
+      const event = createEvent([], markets, 'price');
+
+      const result = sortMarkets(event);
+
+      expect(result.map((m) => m.conditionId)).toEqual(['high', 'low']);
+    });
+
+    it('returns markets unchanged when no sorting specified for non-sport events', () => {
+      const markets = [
+        createMarket('first', '["0.3", "0.7"]', 100, 100),
+        createMarket('second', '["0.9", "0.1"]', 100, 100),
+      ];
+      const event = createEvent([], markets);
+
+      const result = sortMarkets(event);
+
+      expect(result.map((m) => m.conditionId)).toEqual(['first', 'second']);
+    });
+
+    it('prioritizes sortBy parameter over sport event sorting', () => {
+      const markets = [
+        createMarket('totals-low-price', '["0.3", "0.7"]', 100, 100, 'totals'),
+        createMarket(
+          'moneyline-high-price',
+          '["0.9", "0.1"]',
+          100,
+          100,
+          'moneyline',
+        ),
+      ];
+      const sportTags = [{ id: '1', label: 'Sports', slug: 'sports' }];
+      const event = createEvent(sportTags, markets);
+
+      const result = sortMarkets(event, 'price');
+
+      // Price sorting overrides sport sorting
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'moneyline-high-price',
+        'totals-low-price',
+      ]);
+    });
+  });
+
+  describe('parsePolymarketMarket', () => {
+    const createMarket = (
+      overrides: Partial<PolymarketApiMarket> = {},
+    ): PolymarketApiMarket => ({
+      conditionId: 'market-1',
+      question: 'Will it rain?',
+      description: 'Weather prediction',
+      icon: 'https://example.com/icon.png',
+      image: 'https://example.com/image.png',
+      groupItemTitle: 'Weather',
+      status: 'open',
+      volumeNum: 1000,
+      liquidity: 500,
+      negRisk: false,
+      clobTokenIds: '["token-1", "token-2"]',
+      outcomes: '["Yes", "No"]',
+      outcomePrices: '["0.6", "0.4"]',
+      closed: false,
+      active: true,
+      resolvedBy: '0x123',
+      orderPriceMinTickSize: 0.01,
+      umaResolutionStatus: 'unresolved',
+      ...overrides,
+    });
+
+    it('parses market to PredictOutcome correctly', () => {
+      const market = createMarket();
+
+      const result = parsePolymarketMarket(market, 'event-1');
+
+      expect(result).toEqual({
+        id: 'market-1',
+        providerId: 'polymarket',
+        marketId: 'event-1',
+        title: 'Will it rain?',
+        description: 'Weather prediction',
+        image: 'https://example.com/icon.png',
+        groupItemTitle: 'Weather',
+        status: 'open',
+        volume: 1000,
+        tokens: [
+          { id: 'token-1', title: 'Yes', price: 0.6 },
+          { id: 'token-2', title: 'No', price: 0.4 },
+        ],
+        negRisk: false,
+        tickSize: '0.01',
+        resolvedBy: '0x123',
+        resolutionStatus: 'unresolved',
+      });
+    });
+
+    it('uses image when icon is not available', () => {
+      const market = createMarket({ icon: undefined as any });
+
+      const result = parsePolymarketMarket(market, 'event-1');
+
+      expect(result.image).toBe('https://example.com/image.png');
+    });
+
+    it('returns closed status for closed markets', () => {
+      const market = createMarket({ closed: true });
+
+      const result = parsePolymarketMarket(market, 'event-1');
+
+      expect(result.status).toBe('closed');
+    });
+
+    it('formats spread market groupItemTitle by removing dash', () => {
+      const market = createMarket({
+        sportsMarketType: 'spreads',
+        groupItemTitle: 'Team A -3.5',
+      });
+
+      const result = parsePolymarketMarket(market, 'event-1');
+
+      expect(result.groupItemTitle).toBe('Team A 3.5');
+    });
+
+    it('formats spread market outcome titles with line values', () => {
+      const market = createMarket({
+        sportsMarketType: 'spreads',
+        line: 3.5,
+        outcomes: '["Team A", "Team B"]',
+      });
+
+      const result = parsePolymarketMarket(market, 'event-1');
+
+      expect(result.tokens[0].title).toBe('Team A -3.5');
+      expect(result.tokens[1].title).toBe('Team B +3.5');
+    });
+
+    it('handles spread markets without line value', () => {
+      const market = createMarket({
+        sportsMarketType: 'spreads',
+        outcomes: '["Team A", "Team B"]',
+      });
+
+      const result = parsePolymarketMarket(market, 'event-1');
+
+      expect(result.tokens[0].title).toBe('Team A ');
+      expect(result.tokens[1].title).toBe('Team B ');
+    });
+
+    it('handles undefined volumeNum as 0', () => {
+      const market = createMarket({ volumeNum: undefined as any });
+
+      const result = parsePolymarketMarket(market, 'event-1');
+
+      expect(result.volume).toBe(0);
     });
   });
 
@@ -1500,6 +2181,7 @@ describe('polymarket utils', () => {
           groupItemTitle: 'Weather',
           closed: false,
           volumeNum: 1000,
+          liquidity: 500,
           clobTokenIds: '["token-1", "token-2"]',
           outcomes: '["Yes", "No"]',
           outcomePrices: '["0.6", "0.4"]',
@@ -1614,6 +2296,7 @@ describe('polymarket utils', () => {
       groupItemTitle: 'Weather',
       closed: false,
       volumeNum: 1000,
+      liquidity: 500,
       clobTokenIds: '["token-1", "token-2"]',
       outcomes: '["Yes", "No"]',
       outcomePrices: '["0.6", "0.4"]',

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -417,7 +417,9 @@ const getSportsMarketTypePriority = (type: string): number => {
 
 const formatMarketGroupItemTitle = (market: PolymarketApiMarket): string => {
   if (isSpreadMarket(market)) {
-    return market.groupItemTitle.replace('-', '');
+    // Remove the dash before the spread number (e.g., "FC-Dallas -3.5" → "FC-Dallas 3.5")
+    // Uses negative lookahead to target dash followed by digit, not dashes in team names
+    return market.groupItemTitle.replace(/-(?=\d)/, '');
   }
   return market.groupItemTitle;
 };
@@ -426,9 +428,8 @@ const formatOutcomeTitles = (market: PolymarketApiMarket): string[] => {
   const outcomes = market.outcomes ? JSON.parse(market.outcomes) : [];
   if (isSpreadMarket(market)) {
     const line = market.line ? Math.abs(market.line) : 0;
-    return outcomes.map(
-      (outcome: string, index: number) =>
-        `${outcome} ${line ? (index > 0 ? `+${line}` : `-${line}`) : ''}`,
+    return outcomes.map((outcome: string, index: number) =>
+      line ? `${outcome} ${index > 0 ? `+${line}` : `-${line}`}` : outcome,
     );
   }
   return outcomes;

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
@@ -55,16 +55,14 @@ const PredictSellPreview = () => {
     useRoute<RouteProp<PredictNavigationParamList, 'PredictSellPreview'>>();
   const { market, position, outcome, entryPoint } = route.params;
 
-  const {
-    icon,
-    title,
-    outcome: outcomeSideText,
-    initialValue,
-    size,
-  } = position;
+  const { icon, title, initialValue, size } = position;
 
   const outcomeGroupTitle = outcome?.groupItemTitle ?? '';
   const outcomeTitle = title;
+  const outcomeToken = outcome?.tokens.find(
+    (t) => t.id === position.outcomeTokenId,
+  );
+  const outcomeSideText = outcomeToken?.title ?? position.outcome;
 
   // Prepare analytics properties for sell/cash-out action
   const analyticsProperties = useMemo(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add support for sports betting markets with proper sorting and formatting:

- Detect sports events via tags and handle spread markets specially
- Sort sports markets by type priority (moneyline > spreads > totals)
- Within each type group, sort by liquidity + volume descending
- Format spread market titles with line values (e.g., "Team -5", "Team +5")
- Sort outcome tokens to show team A first for spread markets

Add flexible market sorting based on event configuration:
- Support sortBy field on events ('price', 'ascending', 'descending')
- Sort by outcome price, or groupItemThreshold ascending/descending
- Default to price sorting for non-sports markets

Improve outcome title display across components:
- Derive outcome side text from token title instead of position field
- Fall back to outcome.title when groupItemTitle is undefined
- Ensures displayed outcome matches actual token held by user

Update Polymarket API types with new fields:
- groupItemThreshold, sportsMarketType, line for market sorting
- sortBy for event-level sort configuration
- liquidity on market for sorting calculations

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-329

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

https://www.loom.com/share/c8a9e862aa9e4b3eb151d6601412c385

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds sports-aware market sorting/grouping and enhanced Polymarket parsing, while UI derives outcome side from token titles and falls back to outcome title when needed.
> 
> - **Predict utils (Polymarket)**:
>   - Add sports detection/sorting: `isSportEvent`, `isSpreadMarket`, `sortSportMarkets` (moneyline > spreads > totals; rank by liquidity+volume).
>   - Add flexible sorting: `sortMarketsByField('price'|'ascending'|'descending')`, `sortMarkets`; honor `event.sortBy`; default to price sorting in fetch.
>   - New parsing helpers: `parsePolymarketMarket` (formats spreads, orders tokens, image fallback), internal outcome formatting/sorting.
>   - Update `parsePolymarketEvents` to use new sort/parse pipeline.
> - **Types**:
>   - Extend `PolymarketApiMarket` with `liquidity`, `groupItemThreshold?`, `sportsMarketType?`, `line?`.
>   - Extend `PolymarketApiEvent` with `sortBy?`.
> - **UI**:
>   - Resolved outcome header shows `outcome.groupItemTitle ?? outcome.title`.
>   - Position detail and sell preview derive outcome side from matching token title; keep group title fallback.
> - **Tests**:
>   - Add/expand unit tests covering sports sorting, field-based sorting, market parsing (spreads/ordering), and updated UI behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1db3f1e05e6f48cb1c1e8f408cc801aa106d291c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->