### PR TITLE
chore: update biometric settings to accept any on device to avoid locking users out

### DIFF
--- a/app/core/SecureKeychain.test.ts
+++ b/app/core/SecureKeychain.test.ts
@@ -79,7 +79,7 @@ describe('SecureKeychain - setGenericPassword', () => {
       'metamask-user',
       expect.any(String),
       expect.objectContaining({
-        accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
+        accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_ANY,
       }),
     );
     expect(StorageWrapper.setItem).toHaveBeenCalledWith(BIOMETRY_CHOICE, TRUE);

--- a/app/core/SecureKeychain.ts
+++ b/app/core/SecureKeychain.ts
@@ -187,7 +187,7 @@ const SecureKeychain = {
 
     const metrics = MetaMetrics.getInstance();
     if (type === this.TYPES.BIOMETRICS) {
-      authOptions.accessControl = Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET;
+      authOptions.accessControl = Keychain.ACCESS_CONTROL.BIOMETRY_ANY;
 
       await metrics.addTraitsToUser({
         [UserProfileProperty.AUTHENTICATION_TYPE]:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR allows users to change their biometrics on the OS without impacting the MetaMask application login logic. 

Mitigation:

- The OS update requires the user to know their pin-code and validate depending on the platform(iOS) provide current biometric before it is changed on the device. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updates biometric capabilities

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch biometric keychain access control from BIOMETRY_CURRENT_SET to BIOMETRY_ANY and update tests accordingly.
> 
> - **Core**:
>   - Update `SecureKeychain.setGenericPassword` to use `Keychain.ACCESS_CONTROL.BIOMETRY_ANY` for `BIOMETRICS` auth type.
> - **Tests**:
>   - Adjust expectation in `app/core/SecureKeychain.test.ts` to assert `accessControl: BIOMETRY_ANY`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a3b4e0eb885a2c1098f640f173c69959d8b108d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->