### PR TITLE
ci: Replace use of `github-tools` workflows with versioned actions

### DIFF
--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   add-team-label:
+    name: Add team label
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    uses: metamask/github-tools/.github/workflows/add-team-label.yml@7fe185fdb0e60981c898e88d82e44ff33f604daa
-    secrets:
-      TEAM_LABEL_TOKEN: ${{ secrets.TEAM_LABEL_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add team label
+        uses: MetaMask/github-tools/.github/actions/add-team-label@v1
+        with:
+          team-label-token: ${{ secrets.TEAM_LABEL_TOKEN }}

--- a/.github/workflows/automated-rca.yml
+++ b/.github/workflows/automated-rca.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   issues: write
   contents: read
-‰
+
 jobs:
   automated-rca:
     name: Automated RCA

--- a/.github/workflows/automated-rca.yml
+++ b/.github/workflows/automated-rca.yml
@@ -7,12 +7,17 @@ on:
 permissions:
   issues: write
   contents: read
-
+‰
 jobs:
   automated-rca:
-    uses: MetaMask/github-tools/.github/workflows/post-gh-rca.yml@5da154078ddf6c022ed89dc3dbf378594afb8266
-    with:
-      repo-owner: ${{ github.repository_owner }}
-      repo-name: ${{ github.event.repository.name }}
-      issue-number: ${{ github.event.issue.number }}
-      issue-labels: '["Sev0-urgent", "Sev1-high"]'
+    name: Automated RCA
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automated RCA
+        uses: MetaMask/github-tools/.github/actions/post-gh-rca@v1
+        with:
+          repo-owner: ${{ github.repository_owner }}
+          repo-name: ${{ github.event.repository.name }}
+          issue-number: ${{ github.event.issue.number }}
+          issue-labels: '["Sev0-urgent", "Sev1-high"]'
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -56,7 +56,7 @@ jobs:
           echo "✅ System images installed"
 
       - name: Setup Android Build Environment
-        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@6742ebe1a3541cb13972d65352a0622a6a6677db
+        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1
         with:
           platform: android
           setup-simulator: false

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -67,7 +67,7 @@ jobs:
 
       # Install Node.js, Xcode tools, and other iOS development dependencies
       - name: Installing iOS Environment Setup
-        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@6742ebe1a3541cb13972d65352a0622a6a6677db
+        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1
         with:
           platform: ios
           setup-simulator: false

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,4 +1,4 @@
-name: ChangeLog Check
+name: Check Changelog
 
 on:
   pull_request:
@@ -6,17 +6,18 @@ on:
 
 jobs:
   check-changelog:
+    name: Check Changelog
+    runs-on: ubuntu-latest
     # Asking engineers to update CHANGELOG.md increases the potential for
     # conflicts across all pull requests.
     # Disable this workflow until we can refine the new changelog process.
     if: false
-
-    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@91e349d177db2c569e03c7aa69d2acb404b62f75
-    with:
-      base-branch: ${{ github.event.pull_request.base.ref }}
-      head-ref: ${{ github.head_ref }}
-      labels: ${{ toJSON(github.event.pull_request.labels) }}
-      pr-number: ${{ github.event.pull_request.number }}
-      repo: ${{ github.repository }}
-    secrets:
-      gh-token: ${{ secrets.PR_TOKEN }}
+    steps:
+      - name: Check changelog
+        uses: MetaMask/github-tools/.github/actions/check-changelog@v1
+        with:
+          base-branch: ${{ github.event.pull_request.base.ref }}
+          head-ref: ${{ github.head_ref }}
+          labels: ${{ toJSON(github.event.pull_request.labels) }}
+          pr-number: ${{ github.event.pull_request.number }}
+          repo: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,13 +576,16 @@ jobs:
 
   log-merge-group-failure:
     name: Log merge group failure
+    runs-on: ubuntu-latest
     # Only run this job if the merge group event fails, skip on forks
     if: ${{ github.event_name == 'merge_group' && failure() && !github.event.repository.fork }}
     needs:
       - check-all-jobs-pass
-    uses: metamask/github-tools/.github/workflows/log-merge-group-failure.yml@6bbad335a01fce1a9ec1eabd9515542c225d46c0
-    secrets:
-      GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-      GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-      SPREADSHEET_ID: ${{ secrets.GOOGLE_MERGE_QUEUE_SPREADSHEET_ID }}
-      SHEET_NAME: ${{ secrets.GOOGLE_MERGE_QUEUE_SHEET_NAME }}
+    steps:
+      - name: Log merge group failure to Google Sheets
+        uses: MetaMask/github-tools/.github/actions/log-merge-group-failure@v1
+        with:
+          google-application-credentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          google-service-account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+          spreadsheet-id: ${{ secrets.GOOGLE_MERGE_QUEUE_SPREADSHEET_ID }}
+          sheet-name: ${{ secrets.GOOGLE_MERGE_QUEUE_SHEET_NAME }}

--- a/.github/workflows/create-release-pr-legacy.yml
+++ b/.github/workflows/create-release-pr-legacy.yml
@@ -19,21 +19,24 @@ jobs:
       id-token: write
 
   create-release-pr:
+    name: Create release pull request
+    runs-on: ubuntu-latest
     needs: generate-build-version
-    uses: MetaMask/github-tools/.github/workflows/create-release-pr.yml@fc6fe1a3fb591f6afa61f0dbbe7698bd50fab9c7
-    with:
-      platform: mobile
-      base-branch: ${{ inputs.base-branch }}
-      semver-version: ${{ inputs.semver-version }}
-      previous-version-tag: ${{ inputs.previous-version-tag }}
-      mobile-build-version: ${{ needs.generate-build-version.outputs.build-version }}
-      github-tools-version: fc6fe1a3fb591f6afa61f0dbbe7698bd50fab9c7
-
-    secrets:
-      # This token needs read permissions to metamask-planning & write permissions to metamask-mobile
-      github-token: ${{ secrets.PR_TOKEN }}
-      google-application-creds-base64: ${{ secrets.GCP_RLS_SHEET_ACCOUNT_BASE64 }}
     permissions:
       contents: write
       pull-requests: write
+    steps:
+      - name: Create Release pull request
+        uses: MetaMask/github-tools/.github/actions/create-release-pr@v1
+        with:
+          platform: mobile
+          checkout-base-branch: ${{ inputs.base-branch }}
+          release-pr-base-branch: ${{ inputs.base-branch }}
+          semver-version: ${{ inputs.semver-version }}
+          previous-version-ref: ${{ inputs.previous-version-tag }}
+          mobile-build-version: ${{ needs.generate-build-version.outputs.build-version }}
+          google-application-creds-base64: ${{ secrets.GCP_RLS_SHEET_ACCOUNT_BASE64 }}
+          # This token needs read permissions to metamask-planning & write
+          # permissions to metamask-mobile.
+          github-token: ${{ secrets.PR_TOKEN }}
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -85,7 +85,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Create Release PR
-        uses: MetaMask/github-tools/.github/actions/create-release-pr@v1.1.2
+        uses: MetaMask/github-tools/.github/actions/create-release-pr@v1
         with:
           platform: mobile
           checkout-base-branch: ${{ needs.resolve-bases.outputs.checkout_base }}

--- a/.github/workflows/merge-stable-sync-pr.yml
+++ b/.github/workflows/merge-stable-sync-pr.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER'
       )
-    uses: MetaMask/github-tools/.github/workflows/merge-approved-pr.yml@7c0ab4db1e9c1d5673fe7958e8959f1842edbebd
+    uses: MetaMask/github-tools/.github/workflows/merge-approved-pr.yml@v1
     with:
       pr-number: ${{ github.event.issue.number }}
       # Merge PRs from stable-main-X.Y.Z into main

--- a/.github/workflows/merge-version-bump-pr.yml
+++ b/.github/workflows/merge-version-bump-pr.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER'
       )
-    uses: MetaMask/github-tools/.github/workflows/merge-approved-pr.yml@7c0ab4db1e9c1d5673fe7958e8959f1842edbebd
+    uses: MetaMask/github-tools/.github/workflows/merge-approved-pr.yml@v1
     with:
       pr-number: ${{ github.event.issue.number }}
       # Merge PRs from version-bump/X.Y.Z into main

--- a/.github/workflows/publish-slack-release-testing-status.yml
+++ b/.github/workflows/publish-slack-release-testing-status.yml
@@ -7,15 +7,18 @@ on:
 
 jobs:
   call-publish-slack-release-testing-status:
+    name: Publish Slack release testing status
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    uses: MetaMask/github-tools/.github/workflows/publish-slack-release-testing-status.yml@bce51a03da4736bef72f67b71ca77714a38fc067
-    with:
-      platform: 'mobile'
-      test-only: 'true'
-      google-document-id: '1tsoodlAlyvEUpkkcNcbZ4PM9HuC9cEM80RZeoVv5OCQ'
-    secrets:
-      slack-api-key: ${{ secrets.SLACKBOT_RLS_TOKEN }}
-      github-token: ${{ secrets.PR_TOKEN }}
-      google-application-creds-base64: ${{ secrets.GCP_RLS_SHEET_ACCOUNT_BASE64 }}
+    steps:
+      - name: Publish Slack release testing status
+        uses: MetaMask/github-tools/.github/actions/publish-slack-release-testing-status@v1
+        with:
+          platform: 'mobile'
+          test-only: 'true'
+          google-document-id: '1tsoodlAlyvEUpkkcNcbZ4PM9HuC9cEM80RZeoVv5OCQ'
+          slack-api-key: ${{ secrets.SLACKBOT_RLS_TOKEN }}
+          github-token: ${{ secrets.PR_TOKEN }}
+          google-application-creds-base64: ${{ secrets.GCP_RLS_SHEET_ACCOUNT_BASE64 }}

--- a/.github/workflows/remove-rca-needed-label-sheets.yml
+++ b/.github/workflows/remove-rca-needed-label-sheets.yml
@@ -11,11 +11,13 @@ permissions:
 
 jobs:
   remove-rca-labels:
-    name: Remove RCA-needed Labels
-    uses: MetaMask/github-tools/.github/workflows/remove-rca-needed-label-sheets.yml@d354252842b91355deb6d57c752812f745f99679
-    with:
-      spreadsheet_id: '1Y16QEnDwZuR3DAQIe3T5LTWy1ye07GNYqxIei_cMg24'
-      sheet_name: 'Form Responses 1'
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-      google-application-creds-base64: ${{ secrets.GCP_RLS_SHEET_ACCOUNT_BASE64 }}
+    name: Remove RCA-needed labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove RCA-needed labels
+        uses: MetaMask/github-tools/.github/actions/remove-rca-needed-label-sheets@v1
+        with:
+          spreadsheet-id: '1Y16QEnDwZuR3DAQIe3T5LTWy1ye07GNYqxIei_cMg24'
+          sheet-name: 'Form Responses 1'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          google-application-creds-base64: ${{ secrets.GCP_RLS_SHEET_ACCOUNT_BASE64 }}

--- a/.github/workflows/run-e2e-smoke-tests-android-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android-flask.yml
@@ -42,7 +42,7 @@ jobs:
         run: yarn setup:github-ci --no-build-ios
 
       - name: Configure Keystore
-        uses: MetaMask/github-tools/.github/actions/configure-keystore@0259e8a920318b02a8860e178d79796eaa08de02
+        uses: MetaMask/github-tools/.github/actions/configure-keystore@v1
         with:
           aws-role-to-assume: ${{ secrets.METAMASK_MOBILE_BUILDER_SIGNER_QA }}
           aws-region: us-east-2

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -109,7 +109,7 @@ jobs:
           echo "✅ System images installed"
 
       - name: Set up E2E environment
-        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@6742ebe1a3541cb13972d65352a0622a6a6677db
+        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1
         with:
           platform: ${{ inputs.platform }}
           setup-simulator: ${{ inputs.platform == 'ios' }}

--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -36,12 +36,13 @@ jobs:
 
   run-stable-sync:
     name: Run Stable branch sync
+    runs-on: ubuntu-latest
     needs: get-next-version
-    uses: metamask/github-tools/.github/workflows/stable-sync.yml@701a894f38883ab48560f948e98b76cc6b4d623f
-    secrets:
-      github-token: ${{ secrets.STABLE_SYNC_TOKEN }}
-    with:
-      semver-version: ${{ needs.get-next-version.outputs.next-version }}
-      repo-type: 'mobile' # Accepts 'mobile' or 'extension'
-      github-tools-version: '701a894f38883ab48560f948e98b76cc6b4d623f'
-      stable-branch-name: 'stable'
+    steps:
+      - name: Run stable branch sync
+        uses: MetaMask/github-tools/.github/actions/stable-sync@v1
+        with:
+          semver-version: ${{ needs.get-next-version.outputs.next-version }}
+          repo-type: 'mobile'
+          stable-branch-name: 'stable'
+          github-token: ${{ secrets.STABLE_SYNC_TOKEN }}

--- a/.github/workflows/stale-issue-pr.yml
+++ b/.github/workflows/stale-issue-pr.yml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   stale:
-    uses: metamask/github-tools/.github/workflows/stale-issue-pr.yml@566da3332757544da431707bde71a242b182b3ac
+    name: Close stale issues and PRs
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
+    steps:
+      - name: Close stale issues and PRs
+        uses: MetaMask/github-tools/.github/actions/stale-issue-pr@v1
+

--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           BRANCH_NAME="${{ github.ref_name }}"
           echo "Checking branch: $BRANCH_NAME"
-          
+
           # Validate branch matches release/x.y.z format (semantic versioning)
           if [[ "$BRANCH_NAME" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             VERSION="${BRANCH_NAME#release/}"
@@ -48,11 +48,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Update Release Changelog
-        uses: MetaMask/github-tools/.github/actions/update-release-changelog@v1.1.3
+        uses: MetaMask/github-tools/.github/actions/update-release-changelog@v1
         with:
           release-branch: ${{ github.ref_name }}
           repository-url: ${{ github.server_url }}/${{ github.repository }}
           platform: mobile
           previous-version-ref: 'null'
-          github-tools-version: v1.1.3
           github-token: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This replaces all use of `MetaMask/github-tools` _workflows_, usually referenced by a specific commit hash, with (composite) _actions_, referenced by a version. This has several benefits:

- We can update actions used simply by creating a new release in the `github-tools` repository, propagating the changes to all repositories using the version.
   - Breaking changes can still be made by creating a major release.
- Actions have access to certain variables that workflows don't have access to, letting us omit input options like `github-tools-ref`.
- In cases where we're already running other steps, using an action avoids spinning up a new runner.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces calls to MetaMask/github-tools reusable workflows with versioned composite actions (@v1) across CI/E2E/release/ops workflows, updating refs, steps, and required inputs.
> 
> - **Workflows migrated from reusable workflows to versioned actions (`@v1`)**:
>   - `add-team-label`, `automated-rca` (adds `github-token`), `changelog-check`, `log-merge-group-failure`, `publish-slack-release-testing-status`, `remove-rca-needed-label-sheets`, `stale-issue-pr`, `stable-branch-sync`, `update-release-changelog`.
>   - Release PR workflows: `create-release-pr.yml` (switch to action `create-release-pr@v1`), `create-release-pr-legacy.yml` (adds explicit step with inputs/secrets via action).
>   - E2E build/test: `build-android-e2e.yml`, `build-ios-e2e.yml`, `run-e2e-workflow.yml`, `run-e2e-smoke-tests-android-flask.yml` (use `setup-e2e-env@v1`/`configure-keystore@v1`).
> - **Ref updates/structural changes**:
>   - Replace pinned SHAs with `@v1`; add `runs-on` and explicit `steps` where needed; move secrets to action inputs (`with`) as required.
>   - Merge utilities: update `merge-stable-sync-pr.yml` and `merge-version-bump-pr.yml` refs to `merge-approved-pr@v1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fae9f6e21741bde0d7435afc361913ddbf963963. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->