### PR TITLE
chore: simplify detection stage of bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -52,14 +52,11 @@ body:
  - type: dropdown
    id: stage
    attributes:
-     label: Detection stage
-     description: At what stage was the bug detected?
+     label: Where was this bug found?
+     description: Help us understand where this bug was encountered.
      options:
-       - In production (default)
-       - In public beta
-       - During release testing
-       - On main branch
-       - On a feature branch
+       - Live version (from official store)
+       - Internal release testing
    validations:
      required: true
  - type: input

--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -239,21 +239,15 @@ function extractTemplateTypeFromBody(body: string): TemplateType {
 function extractRegressionStageFromBugReportIssueBody(
   body: string,
 ): RegressionStage | undefined {
-  const detectionStageRegex = /### Detection stage\s*\n\s*(.*)/i;
+  const detectionStageRegex = /### Where was this bug found\?\s*\n\s*(.*)/i;
   const match = body.match(detectionStageRegex);
   const extractedAnswer = match ? match[1].trim() : undefined;
 
   switch (extractedAnswer) {
-    case 'On a feature branch':
-      return RegressionStage.DevelopmentFeature;
-    case 'On main branch':
-      return RegressionStage.DevelopmentMain;
-    case 'During release testing':
-      return RegressionStage.Testing;
-    case 'In public beta':
-      return RegressionStage.Beta;
-    case 'In production (default)':
+    case 'Live version (from official store)':
       return RegressionStage.Production;
+    case 'Internal release testing':
+      return RegressionStage.Testing;
     default:
       return undefined;
   }

--- a/.github/scripts/shared/label.ts
+++ b/.github/scripts/shared/label.ts
@@ -3,8 +3,6 @@ import { GitHub } from '@actions/github/lib/utils';
 import { retrieveRepo } from './repo';
 
 export enum RegressionStage {
-  DevelopmentFeature,
-  DevelopmentMain,
   Testing,
   Beta,
   Production
@@ -54,21 +52,7 @@ export const invalidPullRequestTemplateLabel: Label = {
 
 // This function crafts appropriate label, corresponding to regression stage and release version.
 export function craftRegressionLabel(regressionStage: RegressionStage | undefined, releaseVersion: string | undefined): Label {
-  switch (regressionStage) {
-    case RegressionStage.DevelopmentFeature:
-      return {
-        name: `feature-branch-bug`,
-        color: '5319E7', // violet
-        description: `bug that was found on a feature branch, but not yet merged in main branch`,
-      };
-
-    case RegressionStage.DevelopmentMain:
-      return {
-        name: `regression-main`,
-        color: '5319E7', // violet
-        description: `Regression bug that was found on main branch, but not yet present in production`,
-      };
-
+  switch (regressionStage) { 
     case RegressionStage.Testing:
       return {
         name: `regression-RC-${releaseVersion || '*'}`,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Renames and simplifies the bug report stage dropdown:

before:
```
label: Detection stage
description: At what stage was the bug detected?
options:
   - In production (default)
   - In public beta
   - During release testing
   - On main branch
   - On a feature branch
```
New:
```
 label: Where was this bug found?
 description: Help us understand where this bug was encountered.
 options:
    - Live version (from official store)
    - Internal release testing
```

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames and simplifies the bug report stage dropdown and updates action scripts to parse the new field and map to streamlined regression labels.
> 
> - **Issue Template (`.github/ISSUE_TEMPLATE/bug-report.yml`)**:
>   - Rename `Detection stage` to `Where was this bug found?`; reword description.
>   - Reduce options to `Live version (from official store)` and `Internal release testing`.
> - **Actions Script (`.github/scripts/check-template-and-add-labels.ts`)**:
>   - Update regex to match new stage heading and parse answers.
>   - Map `Live version...` -> `Production`, `Internal release testing` -> `Testing`; remove other mappings.
> - **Labeling (`.github/scripts/shared/label.ts`)**:
>   - Remove `DevelopmentFeature` and `DevelopmentMain` from `RegressionStage`.
>   - Drop related cases in `craftRegressionLabel`; keep `Testing`, `Beta`, `Production` and default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d283c269ede68c71c5b55763a8860a120fcab1e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->