### PR TITLE
fix(SDKConnectV2): address connection failure toast on MMConnect interaction

### DIFF
--- a/app/core/SDKConnectV2/adapters/host-application-adapter.test.ts
+++ b/app/core/SDKConnectV2/adapters/host-application-adapter.test.ts
@@ -136,6 +136,40 @@ describe('HostApplicationAdapter', () => {
     });
   });
 
+  describe('showConfirmationRejectionError', () => {
+    it('dispatches a rejection error notification with connection info', () => {
+      adapter.showConfirmationRejectionError(
+        createMockConnectionInfo('session-123', 'Test DApp'),
+      );
+
+      expect(showSimpleNotification).toHaveBeenCalledTimes(1);
+      expect(showSimpleNotification).toHaveBeenCalledWith({
+        id: 'session-123',
+        autodismiss: 5000,
+        title: 'sdk_connect_v2.show_rejection.title',
+        description: 'sdk_connect_v2.show_rejection.description',
+        status: 'error',
+      });
+      expect(store.dispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches a rejection error notification without connection info', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1234567890);
+
+      adapter.showConfirmationRejectionError();
+
+      expect(showSimpleNotification).toHaveBeenCalledTimes(1);
+      expect(showSimpleNotification).toHaveBeenCalledWith({
+        id: '1234567890',
+        autodismiss: 5000,
+        title: 'sdk_connect_v2.show_rejection.title',
+        description: 'sdk_connect_v2.show_rejection.description',
+        status: 'error',
+      });
+      expect(store.dispatch).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('showReturnToApp', () => {
     it('dispatches a success notification prompting user to return to app', () => {
       adapter.showReturnToApp(

--- a/app/core/SDKConnectV2/adapters/host-application-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/host-application-adapter.ts
@@ -45,6 +45,18 @@ export class HostApplicationAdapter implements IHostApplicationAdapter {
     );
   }
 
+  showConfirmationRejectionError(conninfo?: ConnectionInfo): void {
+    store.dispatch(
+      showSimpleNotification({
+        id: conninfo?.id || Date.now().toString(),
+        autodismiss: 5000,
+        title: strings('sdk_connect_v2.show_rejection.title'),
+        description: strings('sdk_connect_v2.show_rejection.description'),
+        status: 'error',
+      }),
+    );
+  }
+
   showReturnToApp(conninfo: ConnectionInfo): void {
     store.dispatch(
       showSimpleNotification({

--- a/app/core/SDKConnectV2/services/connection.test.ts
+++ b/app/core/SDKConnectV2/services/connection.test.ts
@@ -13,6 +13,7 @@ import { KVStore } from '../store/kv-store';
 import { RPCBridgeAdapter } from '../adapters/rpc-bridge-adapter';
 import { ConnectionInfo } from '../types/connection-info';
 import { HostApplicationAdapter } from '../adapters/host-application-adapter';
+import { errorCodes } from '@metamask/rpc-errors';
 
 jest.mock('@metamask/mobile-wallet-protocol-wallet-client');
 jest.mock('@metamask/mobile-wallet-protocol-core', () => ({
@@ -60,6 +61,7 @@ const mockHostApp: jest.Mocked<HostApplicationAdapter> = {
   showConnectionLoading: jest.fn(),
   hideConnectionLoading: jest.fn(),
   showConnectionError: jest.fn(),
+  showConfirmationRejectionError: jest.fn(),
   showReturnToApp: jest.fn(),
   syncConnectionList: jest.fn(),
   revokePermissions: jest.fn(),
@@ -365,6 +367,45 @@ describe('Connection', () => {
       expect(mockWalletClientInstance.sendResponse).toHaveBeenCalledTimes(1);
       expect(mockWalletClientInstance.sendResponse).toHaveBeenCalledWith(
         errorResponsePayload,
+      );
+    });
+
+    it('shows confirmation rejection error toast when bridge response includes user rejected request error', async () => {
+      await Connection.create(
+        mockConnectionInfo,
+        mockKeyManager,
+        RELAY_URL,
+        mockHostApp,
+      );
+
+      const userRejectedErrorResponsePayload = {
+        data: {
+          id: 1,
+          jsonrpc: '2.0',
+          error: {
+            code: errorCodes.provider.userRejectedRequest,
+            message: 'User rejected the request',
+          },
+        },
+      };
+
+      // Simulate the RPCBridgeAdapter emitting a user rejected error response
+      onBridgeResponseCallback(userRejectedErrorResponsePayload);
+
+      // Should show confirmation rejection error toast, not generic error toast
+      expect(mockHostApp.showConfirmationRejectionError).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(mockHostApp.showConfirmationRejectionError).toHaveBeenCalledWith(
+        mockConnectionInfo,
+      );
+      expect(mockHostApp.showConnectionError).not.toHaveBeenCalled();
+      expect(mockHostApp.showReturnToApp).not.toHaveBeenCalled();
+
+      // And still send the error response to the client
+      expect(mockWalletClientInstance.sendResponse).toHaveBeenCalledTimes(1);
+      expect(mockWalletClientInstance.sendResponse).toHaveBeenCalledWith(
+        userRejectedErrorResponsePayload,
       );
     });
 

--- a/app/core/SDKConnectV2/services/connection.ts
+++ b/app/core/SDKConnectV2/services/connection.ts
@@ -13,6 +13,7 @@ import { RPCBridgeAdapter } from '../adapters/rpc-bridge-adapter';
 import { ConnectionInfo } from '../types/connection-info';
 import logger from './logger';
 import { IHostApplicationAdapter } from '../types/host-application-adapter';
+import { errorCodes } from '@metamask/rpc-errors';
 
 /**
  * Connection is a live, runtime representation of a dApp connection.
@@ -52,7 +53,13 @@ export class Connection {
           'error' in responseData && responseData.error !== undefined;
 
         if (isError) {
-          this.hostApp.showConnectionError(this.info);
+          if (
+            responseData.error.code === errorCodes.provider.userRejectedRequest
+          ) {
+            this.hostApp.showConfirmationRejectionError(this.info);
+          } else {
+            this.hostApp.showConnectionError(this.info);
+          }
         } else {
           this.hostApp.showReturnToApp(this.info);
         }

--- a/app/core/SDKConnectV2/types/host-application-adapter.ts
+++ b/app/core/SDKConnectV2/types/host-application-adapter.ts
@@ -26,6 +26,11 @@ export interface IHostApplicationAdapter {
   showConnectionError(conninfo?: ConnectionInfo): void;
 
   /**
+   * Displays a global, non-interactive confirmation rejection modal.
+   */
+  showConfirmationRejectionError(conninfo?: ConnectionInfo): void;
+
+  /**
    * Displays a "Return to App" toast notification for successful requests.
    */
   showReturnToApp(conninfo: ConnectionInfo): void;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7208,7 +7208,7 @@
       "description": "Failed to establish connection. Please try again."
     },
     "show_rejection": {
-      "title": "Connection Rejected",
+      "title": "Approval Rejected",
       "description": "User rejected the request."
     },
     "show_return_to_app": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7207,6 +7207,10 @@
       "title": "Connection Error",
       "description": "Failed to establish connection. Please try again."
     },
+    "show_rejection": {
+      "title": "Connection Rejected",
+      "description": "User rejected the request."
+    },
     "show_return_to_app": {
       "title": "Success",
       "description": "Return to the app to continue."


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR addresses an issue where rejecting a MMConnect/SDKConnectV2 confirmation results in a connection failure toast (rather than a error toast) in the wallet.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix issue where rejecting a MMConnect confirmation results in a connection failure toast (rather than a error toast) in the wallet.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: SDKConnectV2 connection rejection modal

  Scenario: user reject SDKConnectV2 connection
    Given no permission exists

    When user attempts to connect via native browser (using Metamask Connect integrated dApp)
    Then rejecting connection show render an error toast with a user rejected connection message
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/aae60e47-5a45-44cf-b786-077ba9086274

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handles userRejectedRequest errors by showing an "Approval Rejected" toast, adding adapter support, tests, and i18n strings.
> 
> - **SDKConnectV2 behavior**:
>   - On bridge responses with `error.code === errorCodes.provider.userRejectedRequest`, call `hostApp.showConfirmationRejectionError` instead of `showConnectionError` in `app/core/SDKConnectV2/services/connection.ts`.
> - **Host application adapter**:
>   - Add `showConfirmationRejectionError(conninfo?)` to `HostApplicationAdapter` with error toast dispatch in `app/core/SDKConnectV2/adapters/host-application-adapter.ts`.
>   - Extend `IHostApplicationAdapter` interface to include `showConfirmationRejectionError` in `app/core/SDKConnectV2/types/host-application-adapter.ts`.
> - **Tests**:
>   - Add unit tests for rejection toast behavior in `connection.test.ts` and adapter tests in `host-application-adapter.test.ts`.
> - **Localization**:
>   - Add `sdk_connect_v2.show_rejection.{title,description}` strings in `locales/languages/en.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c617f577c6724ea7dac33199be971d929e64e579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->