### PR TITLE
fix(perps): buttons colors for abtest cp-7.61.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -1132,7 +1132,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
               <View style={styles.actionButtonWrapper}>
                 {buttonColorVariant === 'monochrome' ? (
                   <Button
-                    variant={ButtonVariants.Secondary}
+                    variant={ButtonVariants.Primary}
                     size={ButtonSize.Lg}
                     width={ButtonWidthTypes.Full}
                     label={strings('perps.market.long')}
@@ -1157,7 +1157,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
               <View style={styles.actionButtonWrapper}>
                 {buttonColorVariant === 'monochrome' ? (
                   <Button
-                    variant={ButtonVariants.Secondary}
+                    variant={ButtonVariants.Primary}
                     size={ButtonSize.Lg}
                     width={ButtonWidthTypes.Full}
                     label={strings('perps.market.short')}

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.styles.ts
@@ -72,7 +72,7 @@ const styleSheet = (params: { theme: Theme }) => {
       right: 0,
       paddingHorizontal: 16,
       paddingTop: 12,
-      paddingBottom: 24,
+      // paddingBottom is calculated dynamically in component with safe area insets
       backgroundColor: colors.background.default,
       borderTopWidth: 1,
       borderTopColor: colors.border.muted,

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
@@ -19,11 +19,15 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
+import { ButtonSize as ButtonSizeRNDesignSystem } from '@metamask/design-system-react-native';
 import Button, {
   ButtonVariants,
   ButtonWidthTypes,
   ButtonSize,
 } from '../../../../../component-library/components/Buttons/Button';
+import ButtonSemantic, {
+  ButtonSemanticSeverity,
+} from '../../../../../component-library/components-temp/Buttons/ButtonSemantic';
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../component-library/components/Buttons/ButtonIcon';
@@ -68,6 +72,9 @@ import {
   calculateAggregationParams,
   MAX_ORDER_BOOK_LEVELS,
 } from '../../utils/orderBookGrouping';
+import { usePerpsABTest } from '../../utils/abTesting/usePerpsABTest';
+import { BUTTON_COLOR_TEST } from '../../utils/abTesting/tests';
+import { selectPerpsButtonColorTestVariant } from '../../selectors/featureFlags';
 
 const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
   testID = PerpsOrderBookViewSelectorsIDs.CONTAINER,
@@ -79,6 +86,12 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
   const { styles } = useStyles(styleSheet, {});
   const { navigateToOrder } = usePerpsNavigation();
   const { track } = usePerpsEventTracking();
+
+  // A/B Testing: Button color test (TAT-1937)
+  const { variantName: buttonColorVariant } = usePerpsABTest({
+    test: BUTTON_COLOR_TEST,
+    featureFlagSelector: selectPerpsButtonColorTestVariant,
+  });
 
   // Get market data for the header
   const { markets } = usePerpsMarkets();
@@ -445,25 +458,49 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
         {/* Action Buttons */}
         <View style={styles.actionsContainer}>
           <View style={styles.actionButtonWrapper}>
-            <Button
-              variant={ButtonVariants.Secondary}
-              size={ButtonSize.Lg}
-              width={ButtonWidthTypes.Full}
-              label={strings('perps.market.long')}
-              onPress={handleLongPress}
-              testID={PerpsOrderBookViewSelectorsIDs.LONG_BUTTON}
-            />
+            {buttonColorVariant === 'monochrome' ? (
+              <Button
+                variant={ButtonVariants.Primary}
+                size={ButtonSize.Lg}
+                width={ButtonWidthTypes.Full}
+                label={strings('perps.market.long')}
+                onPress={handleLongPress}
+                testID={PerpsOrderBookViewSelectorsIDs.LONG_BUTTON}
+              />
+            ) : (
+              <ButtonSemantic
+                severity={ButtonSemanticSeverity.Success}
+                onPress={handleLongPress}
+                isFullWidth
+                size={ButtonSizeRNDesignSystem.Lg}
+                testID={PerpsOrderBookViewSelectorsIDs.LONG_BUTTON}
+              >
+                {strings('perps.market.long')}
+              </ButtonSemantic>
+            )}
           </View>
 
           <View style={styles.actionButtonWrapper}>
-            <Button
-              variant={ButtonVariants.Secondary}
-              size={ButtonSize.Lg}
-              width={ButtonWidthTypes.Full}
-              label={strings('perps.market.short')}
-              onPress={handleShortPress}
-              testID={PerpsOrderBookViewSelectorsIDs.SHORT_BUTTON}
-            />
+            {buttonColorVariant === 'monochrome' ? (
+              <Button
+                variant={ButtonVariants.Primary}
+                size={ButtonSize.Lg}
+                width={ButtonWidthTypes.Full}
+                label={strings('perps.market.short')}
+                onPress={handleShortPress}
+                testID={PerpsOrderBookViewSelectorsIDs.SHORT_BUTTON}
+              />
+            ) : (
+              <ButtonSemantic
+                severity={ButtonSemanticSeverity.Danger}
+                onPress={handleShortPress}
+                isFullWidth
+                size={ButtonSizeRNDesignSystem.Lg}
+                testID={PerpsOrderBookViewSelectorsIDs.SHORT_BUTTON}
+              >
+                {strings('perps.market.short')}
+              </ButtonSemantic>
+            )}
           </View>
         </View>
       </View>

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
@@ -14,7 +14,10 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import { PerpsOrderBookViewSelectorsIDs } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
 import { strings } from '../../../../../../locales/i18n';
 import ButtonSemantic, {
@@ -86,6 +89,7 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
   const { styles } = useStyles(styleSheet, {});
   const { navigateToOrder } = usePerpsNavigation();
   const { track } = usePerpsEventTracking();
+  const insets = useSafeAreaInsets();
 
   // A/B Testing: Button color test (TAT-1937)
   const {
@@ -220,6 +224,12 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
     if (currentGrouping === null) return '—';
     return formatGroupingLabel(currentGrouping);
   }, [currentGrouping]);
+
+  // Dynamic footer style with safe area insets
+  const footerStyle = useMemo(
+    () => [styles.footer, { paddingBottom: 16 + insets.bottom }],
+    [styles.footer, insets.bottom],
+  );
 
   // Handle grouping dropdown press
   const handleDepthBandPress = useCallback(() => {
@@ -449,7 +459,7 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
       </ScrollView>
 
       {/* Footer with Spread and Actions */}
-      <View style={styles.footer}>
+      <View style={footerStyle}>
         {/* Spread Row */}
         {orderBook && (
           <View style={styles.spreadContainer}>

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -262,7 +262,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   const { isAtCap: isAtOICap } = usePerpsOICap(orderForm.asset);
 
   // A/B Testing: Button color test (TAT-1937)
-  const { variantName: buttonColorVariant } = usePerpsABTest({
+  const {
+    variantName: buttonColorVariant,
+    isEnabled: isButtonColorTestEnabled,
+  } = usePerpsABTest({
     test: BUTTON_COLOR_TEST,
     featureFlagSelector: selectPerpsButtonColorTestVariant,
   });
@@ -307,6 +310,9 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
         orderForm.direction === 'long'
           ? PerpsEventValues.DIRECTION.LONG
           : PerpsEventValues.DIRECTION.SHORT,
+      ...(isButtonColorTestEnabled && {
+        [PerpsEventProperties.AB_TEST_BUTTON_COLOR]: buttonColorVariant,
+      }),
     },
   });
 
@@ -710,6 +716,20 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
 
     orderStartTimeRef.current = Date.now();
 
+    // Track Place Order button press with A/B test context
+    if (isButtonColorTestEnabled) {
+      track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
+        [PerpsEventProperties.INTERACTION_TYPE]:
+          PerpsEventValues.INTERACTION_TYPE.TAP,
+        [PerpsEventProperties.ASSET]: orderForm.asset,
+        [PerpsEventProperties.DIRECTION]:
+          orderForm.direction === 'long'
+            ? PerpsEventValues.DIRECTION.LONG
+            : PerpsEventValues.DIRECTION.SHORT,
+        [PerpsEventProperties.AB_TEST_BUTTON_COLOR]: buttonColorVariant,
+      });
+    }
+
     try {
       // Validation errors are shown in the UI
       if (!orderValidation.isValid) {
@@ -871,6 +891,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     feeResults.metamaskFeeRate,
     feeResults.feeDiscountPercentage,
     feeResults.estimatedPoints,
+    isButtonColorTestEnabled,
+    buttonColorVariant,
   ]);
 
   // Memoize the tooltip handlers to prevent recreating them on every render

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -1307,7 +1307,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
 
           {buttonColorVariant === 'monochrome' ? (
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariants.Primary}
               size={ButtonSize.Lg}
               width={ButtonWidthTypes.Full}
               label={placeOrderLabel}

--- a/docs/perps/perps-metametrics-reference.md
+++ b/docs/perps/perps-metametrics-reference.md
@@ -100,7 +100,7 @@ MetaMetrics.getInstance().trackEvent(
 - `input_method` (optional): How value was entered: `'slider' | 'keyboard' | 'preset' | 'manual' | 'percentage_button'`
 - `candle_period` (optional): Selected candle period
 - `favorites_count` (optional): Total number of markets in watchlist after toggle (number, used with `favorite_toggled`)
-- `ab_test_button_color` (optional): Button color test variant (`'control' | 'monochrome'`), only included when test is enabled and user taps Long/Short button (for engagement tracking)
+- `ab_test_button_color` (optional): Button color test variant (`'control' | 'monochrome'`), only included when test is enabled and user taps Long/Short or Place Order button (for engagement tracking)
 - Future AB tests: `ab_test_{test_name}` (see [Multiple Concurrent Tests](#multiple-concurrent-tests))
 
 ### 3. PERPS_TRADE_TRANSACTION
@@ -287,7 +287,7 @@ usePerpsEventTracking({
    - Required to calculate engagement rate
 
 2. **PERPS_UI_INTERACTION** (engagement):
-   - Include `ab_test_button_color` when user taps Long/Short button
+   - Include `ab_test_button_color` when user taps Long/Short or Place Order button
    - Only sent when test is enabled
    - Measures which variant drives more button presses
 


### PR DESCRIPTION
## **Description**

Fixes TAT-2134: Incorrect color for Long/Short buttons in A/B test.

1. **Added A/B test support to PerpsOrderBookView**: The Long/Short buttons in `PerpsOrderBookView.tsx` were always rendering as monochrome, ignoring the A/B test configuration. Added the same `usePerpsABTest` hook and conditional rendering that exists in `PerpsMarketDetailsView.tsx` and `PerpsOrderView.tsx`.

2. **Fixed dark/light mode theming for monochrome variant**: Changed monochrome buttons from `ButtonVariants.Secondary` to `ButtonVariants.Primary` across all three views. This provides proper theme-aware styling:
   - Dark mode: White/light buttons with dark text
   - Light mode: Dark buttons with light text

   This matches the styling of the "Set leverage" button in `PerpsLeverageBottomSheet.tsx`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2134
-  https://github.com/MetaMask/metamask-mobile/issues/23804 

## **Manual testing steps**

```gherkin
Feature: A/B Test Button Colors Consistency

  Scenario: User sees consistent button colors across all Perps trading screens
    Given user has Perps feature enabled
    And A/B test is configured in LaunchDarkly

    When user navigates to PerpsMarketDetailsView
    Then Long/Short buttons match the assigned A/B test variant (colored or monochrome)

    When user navigates to PerpsOrderBookView
    Then Long/Short buttons match the same A/B test variant as PerpsMarketDetailsView

    When user navigates to PerpsOrderView
    Then Place Order button matches the same A/B test variant

  Scenario: Monochrome buttons have correct dark mode styling
    Given user has dark mode enabled
    And A/B test assigns "monochrome" variant

    When user views any Perps trading screen with Long/Short buttons
    Then buttons should have white/light background with dark text
    And buttons should be clearly visible against dark background
```

## **Screenshots/Recordings**

### **Before**

- Monochrome buttons showed dark background on dark mode (low contrast)
- PerpsOrderBookView always showed secondary buttons regardless of A/B test

### **After**

- Monochrome buttons show white/light background on dark mode (proper contrast)
- All three views (PerpsMarketDetailsView, PerpsOrderView, PerpsOrderBookView) respect A/B test variant

https://github.com/user-attachments/assets/d17cfd45-2a03-479c-8cc2-d9022001fa53


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## MetaMetrics Integration (A/B Test Tracking)

The button color A/B test (TAT-1937) is connected to MetaMetrics via the `ab_test_button_color` property.

### Property to Validate

| Property | Values | Description |
|----------|--------|-------------|
| `ab_test_button_color` | `'control'` \| `'monochrome'` | Variant assigned by LaunchDarkly |

### Events That Include This Property

1. **`PERPS_SCREEN_VIEWED`** (baseline exposure)
   - Sent when user views `PerpsMarketDetailsView` (asset details screen)
   - Includes `ab_test_button_color` when test is enabled
   - Used to count how many users were exposed to each variant

2. **`PERPS_UI_INTERACTION`** (engagement)
   - Sent when user taps Long/Short button
   - Includes `ab_test_button_color` + `interaction_type: 'tap'` + `direction: 'long'|'short'`
   - Used to measure which variant drives more button presses

### How to Validate in Analytics (Amplitude/Segment)

```
Engagement Rate = Count(PERPS_UI_INTERACTION where ab_test_button_color = 'X')
                  / Count(PERPS_SCREEN_VIEWED where ab_test_button_color = 'X')
```

Compare engagement rates between `control` (green/red buttons) and `monochrome` (white buttons) variants.

### Code References

- Property constant: `PerpsEventProperties.AB_TEST_BUTTON_COLOR` in `app/components/UI/Perps/constants/eventNames.ts:111`
- Screen view tracking: `PerpsMarketDetailsView.tsx:454-467`
- LaunchDarkly flag: `perps-abtest-button-color` → Redux: `perpsAbtestButtonColor`

---

## Files Changed

- `app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx` - Changed monochrome Long/Short buttons from `ButtonVariants.Secondary` to `ButtonVariants.Primary`
- `app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx` - Changed monochrome Place Order button from `ButtonVariants.Secondary` to `ButtonVariants.Primary`
- `app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx` - Added A/B test support and changed monochrome Long/Short buttons from `ButtonVariants.Secondary` to `ButtonVariants.Primary`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches monochrome CTA buttons to `Primary`, adds button-color A/B test with tracking to Order Book and Place Order, adjusts Order Book footer for safe area, and updates MetaMetrics docs.
> 
> - **UI**
>   - `PerpsMarketDetailsView.tsx`: Monochrome `Long/Short` buttons now use `ButtonVariants.Primary`.
>   - `PerpsOrderBookView.tsx`:
>     - Adds button-color A/B test (`usePerpsABTest`); conditionally renders `Button` vs `ButtonSemantic` for `Long/Short`.
>     - Monochrome variant uses `ButtonVariants.Primary`.
>     - Footer `paddingBottom` computed with safe area insets.
>   - `PerpsOrderBookView.styles.ts`: Moves footer `paddingBottom` to be dynamic (via component).
>   - `PerpsOrderView.tsx`: Monochrome `Place Order` uses `ButtonVariants.Primary`; integrates A/B test context.
> - **Analytics**
>   - Tracks `ab_test_button_color` on `Long/Short` and `Place Order` taps; includes on relevant screen views where enabled.
> - **Docs**
>   - Updates `perps-metametrics-reference.md` to include `ab_test_button_color` for `Long/Short` and `Place Order` engagement and dual-tracking guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a5c8c2aaea7a464bba66d6c2ac732c4ab7560fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->