### PR TITLE
feat: Sync destination swap asset when source network is changed

### DIFF
--- a/app/components/UI/Bridge/_mocks_/bridgeReducerState.ts
+++ b/app/components/UI/Bridge/_mocks_/bridgeReducerState.ts
@@ -33,4 +33,5 @@ export const mockBridgeReducerState: BridgeState = {
   isGasIncluded7702Supported: false,
   bridgeViewMode: BridgeViewMode.Bridge,
   isSelectingRecipient: false,
+  isDestTokenManuallySet: false,
 };

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/BridgeDestTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/BridgeDestTokenSelector.test.tsx
@@ -9,6 +9,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import {
   selectBridgeViewMode,
   setDestToken,
+  setIsDestTokenManuallySet,
 } from '../../../../../core/redux/slices/bridge';
 import { cloneDeep } from 'lodash';
 import { BridgeViewMode } from '../../types';
@@ -42,6 +43,7 @@ jest.mock('../../../../../core/redux/slices/bridge', () => {
     ...actual,
     default: actual.default,
     setDestToken: jest.fn(actual.setDestToken),
+    setIsDestTokenManuallySet: jest.fn(actual.setIsDestTokenManuallySet),
     selectBridgeViewMode: jest.fn().mockReturnValue('Bridge'),
   };
 });
@@ -304,7 +306,8 @@ describe('BridgeDestTokenSelector', () => {
 
   // TODO: Fix flaky test - timing issue with debounced token selection (500ms)
   // Test fails intermittently due to race condition between waitFor and debounce
-  it.skip('handles token selection correctly', async () => {
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('handles token selection correctly and marks dest token as manually set', async () => {
     // Arrange
     const { getByText } = renderScreen(
       BridgeDestTokenSelector,
@@ -325,7 +328,7 @@ describe('BridgeDestTokenSelector', () => {
       jest.advanceTimersByTime(500);
     });
 
-    // Assert - check that actions were called
+    // Assert - check that setDestToken was called with the selected token
     expect(setDestToken).toHaveBeenCalledWith(
       expect.objectContaining({
         address: ethToken2Address,
@@ -337,6 +340,8 @@ describe('BridgeDestTokenSelector', () => {
         symbol: 'HELLO',
       }),
     );
+    // Also verify the manual flag was set
+    expect(setIsDestTokenManuallySet).toHaveBeenCalledWith(true);
     expect(mockGoBack).toHaveBeenCalled();
   });
 

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/index.tsx
@@ -10,6 +10,7 @@ import {
   selectSelectedDestChainId,
   selectSourceToken,
   setDestToken,
+  setIsDestTokenManuallySet,
 } from '../../../../../core/redux/slices/bridge';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import { TokenSelectorItem } from '../TokenSelectorItem';
@@ -78,7 +79,9 @@ export const BridgeDestTokenSelector: React.FC = React.memo(() => {
 
   const handleTokenPress = useCallback(
     (token: BridgeToken) => {
+      // Mark as manually set to prevent auto-updating dest when source chain changes
       dispatch(setDestToken(token));
+      dispatch(setIsDestTokenManuallySet(true));
       navigation.goBack();
     },
     [dispatch, navigation],

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/BridgeSourceNetworkSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/BridgeSourceNetworkSelector.test.tsx
@@ -6,7 +6,10 @@ import { BridgeSourceNetworkSelector } from '.';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import { Hex } from '@metamask/utils';
-import { setSelectedSourceChainIds } from '../../../../../core/redux/slices/bridge';
+import {
+  setSelectedSourceChainIds,
+  setSourceToken,
+} from '../../../../../core/redux/slices/bridge';
 import { BridgeSourceNetworkSelectorSelectorsIDs } from '../../../../../../e2e/selectors/Bridge/BridgeSourceNetworkSelector.selectors';
 import { cloneDeep } from 'lodash';
 import { MultichainNetwork } from '@metamask/multichain-transactions-controller';
@@ -35,11 +38,23 @@ jest.mock('../../../../../core/redux/slices/bridge', () => {
   };
 });
 
+const mockOnSetRpcTarget = jest.fn().mockResolvedValue(undefined);
+const mockOnNonEvmNetworkChange = jest.fn().mockResolvedValue(undefined);
+
 jest.mock('../../../../Views/NetworkSelector/useSwitchNetworks', () => ({
   useSwitchNetworks: jest.fn(() => ({
-    onSetRpcTarget: jest.fn().mockResolvedValue(undefined),
+    onSetRpcTarget: mockOnSetRpcTarget,
     onNetworkChange: jest.fn(),
+    onNonEvmNetworkChange: mockOnNonEvmNetworkChange,
   })),
+}));
+
+const mockAutoUpdateDestToken = jest.fn();
+
+jest.mock('../../hooks/useAutoUpdateDestToken', () => ({
+  useAutoUpdateDestToken: () => ({
+    autoUpdateDestToken: mockAutoUpdateDestToken,
+  }),
 }));
 
 describe('BridgeSourceNetworkSelector', () => {
@@ -48,6 +63,9 @@ describe('BridgeSourceNetworkSelector', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockOnSetRpcTarget.mockResolvedValue(undefined);
+    mockOnNonEvmNetworkChange.mockResolvedValue(undefined);
+    mockAutoUpdateDestToken.mockClear();
   });
 
   it('renders with initial state and displays networks', async () => {
@@ -221,6 +239,183 @@ describe('BridgeSourceNetworkSelector', () => {
       BridgeSourceNetworkSelectorSelectorsIDs.APPLY_BUTTON,
     );
     expect(applyButton.props.disabled).toBe(true);
+  });
+
+  describe('handleApply', () => {
+    it('calls onApply callback when provided instead of dispatching actions', async () => {
+      const mockOnApply = jest.fn();
+      const { getAllByTestId, getByText } = renderScreen(
+        () => <BridgeSourceNetworkSelector onApply={mockOnApply} />,
+        {
+          name: Routes.BRIDGE.MODALS.SOURCE_NETWORK_SELECTOR,
+        },
+        { state: initialState },
+      );
+
+      // Uncheck Ethereum to have only Optimism selected
+      const ethereumCheckbox = getAllByTestId(`checkbox-${mockChainId}`)[0];
+      fireEvent.press(ethereumCheckbox);
+
+      // Click Apply button
+      const applyButton = getByText('Apply');
+      fireEvent.press(applyButton);
+
+      await waitFor(() => {
+        expect(mockOnApply).toHaveBeenCalledWith([
+          optimismChainId,
+          SolScope.Mainnet,
+          BtcScope.Mainnet,
+          TrxScope.Mainnet,
+        ]);
+        expect(mockGoBack).not.toHaveBeenCalled();
+        expect(setSelectedSourceChainIds).not.toHaveBeenCalled();
+      });
+    });
+
+    it('sets source token to native token when single EVM network is selected', async () => {
+      const { getAllByTestId, getByText } = renderScreen(
+        BridgeSourceNetworkSelector,
+        {
+          name: Routes.BRIDGE.MODALS.SOURCE_NETWORK_SELECTOR,
+        },
+        { state: initialState },
+      );
+
+      // Deselect all first
+      const deselectAllButton = getByText('Deselect all');
+      fireEvent.press(deselectAllButton);
+
+      // Select only Ethereum
+      const ethereumCheckbox = getAllByTestId(`checkbox-${mockChainId}`)[0];
+      fireEvent.press(ethereumCheckbox);
+
+      // Click Apply
+      const applyButton = getByText('Apply');
+      fireEvent.press(applyButton);
+
+      await waitFor(() => {
+        expect(setSourceToken).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chainId: mockChainId,
+            symbol: 'ETH',
+          }),
+        );
+      });
+    });
+
+    it('calls autoUpdateDestToken when single network is selected', async () => {
+      const { getAllByTestId, getByText } = renderScreen(
+        BridgeSourceNetworkSelector,
+        {
+          name: Routes.BRIDGE.MODALS.SOURCE_NETWORK_SELECTOR,
+        },
+        { state: initialState },
+      );
+
+      // Deselect all first
+      const deselectAllButton = getByText('Deselect all');
+      fireEvent.press(deselectAllButton);
+
+      // Select only Optimism
+      const optimismCheckbox = getAllByTestId(`checkbox-${optimismChainId}`)[0];
+      fireEvent.press(optimismCheckbox);
+
+      // Click Apply
+      const applyButton = getByText('Apply');
+      fireEvent.press(applyButton);
+
+      await waitFor(() => {
+        expect(mockAutoUpdateDestToken).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chainId: optimismChainId,
+          }),
+        );
+      });
+    });
+
+    it('calls onSetRpcTarget when single EVM network is selected', async () => {
+      const { getAllByTestId, getByText } = renderScreen(
+        BridgeSourceNetworkSelector,
+        {
+          name: Routes.BRIDGE.MODALS.SOURCE_NETWORK_SELECTOR,
+        },
+        { state: initialState },
+      );
+
+      // Deselect all first
+      const deselectAllButton = getByText('Deselect all');
+      fireEvent.press(deselectAllButton);
+
+      // Select only Ethereum
+      const ethereumCheckbox = getAllByTestId(`checkbox-${mockChainId}`)[0];
+      fireEvent.press(ethereumCheckbox);
+
+      // Click Apply
+      const applyButton = getByText('Apply');
+      fireEvent.press(applyButton);
+
+      await waitFor(() => {
+        expect(mockOnSetRpcTarget).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chainId: mockChainId,
+          }),
+        );
+      });
+    });
+
+    it('calls onNonEvmNetworkChange when single non-EVM network is selected', async () => {
+      const { getAllByTestId, getByText } = renderScreen(
+        BridgeSourceNetworkSelector,
+        {
+          name: Routes.BRIDGE.MODALS.SOURCE_NETWORK_SELECTOR,
+        },
+        { state: initialState },
+      );
+
+      // Deselect all first
+      const deselectAllButton = getByText('Deselect all');
+      fireEvent.press(deselectAllButton);
+
+      // Select only Solana
+      const solanaCheckbox = getAllByTestId(`checkbox-${SolScope.Mainnet}`)[0];
+      fireEvent.press(solanaCheckbox);
+
+      // Click Apply
+      const applyButton = getByText('Apply');
+      fireEvent.press(applyButton);
+
+      await waitFor(() => {
+        expect(mockOnNonEvmNetworkChange).toHaveBeenCalledWith(
+          SolScope.Mainnet,
+        );
+        expect(mockOnSetRpcTarget).not.toHaveBeenCalled();
+      });
+    });
+
+    it('does not set source token or switch network when multiple networks are selected', async () => {
+      const { getByText } = renderScreen(
+        BridgeSourceNetworkSelector,
+        {
+          name: Routes.BRIDGE.MODALS.SOURCE_NETWORK_SELECTOR,
+        },
+        { state: initialState },
+      );
+
+      // Keep all networks selected and click Apply
+      const applyButton = getByText('Apply');
+      fireEvent.press(applyButton);
+
+      await waitFor(() => {
+        expect(setSelectedSourceChainIds).toHaveBeenCalled();
+        expect(mockGoBack).toHaveBeenCalled();
+      });
+
+      // These should NOT be called when multiple networks are selected
+      expect(setSourceToken).not.toHaveBeenCalled();
+      expect(mockAutoUpdateDestToken).not.toHaveBeenCalled();
+      expect(mockOnSetRpcTarget).not.toHaveBeenCalled();
+      expect(mockOnNonEvmNetworkChange).not.toHaveBeenCalled();
+    });
   });
 
   it('networks should be sorted by fiat value in descending order', async () => {

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
@@ -34,6 +34,7 @@ import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selector
 import { getNativeSourceToken } from '../../utils/tokenUtils';
 import { getGasFeesSponsoredNetworkEnabled } from '../../../../../selectors/featureFlagController/gasFeesSponsored';
 import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../constants/bridge';
+import { useAutoUpdateDestToken } from '../../hooks/useAutoUpdateDestToken';
 
 const createStyles = () =>
   StyleSheet.create({
@@ -96,6 +97,7 @@ export const BridgeSourceNetworkSelector: React.FC<
   const isGasFeesSponsoredNetworkEnabled = useSelector(
     getGasFeesSponsoredNetworkEnabled,
   );
+  const { autoUpdateDestToken } = useAutoUpdateDestToken();
 
   // Local state for candidate network selections
   const [candidateSourceChainIds, setCandidateSourceChainIds] = useState<
@@ -141,14 +143,16 @@ export const BridgeSourceNetworkSelector: React.FC<
 
     // If there's only 1 network selected, set the source token to native token of that chain and switch chains
     if (newSelectedSourceChainids.length === 1) {
+      const newSourceChainId = newSelectedSourceChainids[0] as
+        | Hex
+        | CaipChainId;
+      const newSourceToken = getNativeSourceToken(newSourceChainId);
+
       // Reset the source token
-      dispatch(
-        setSourceToken(
-          getNativeSourceToken(
-            newSelectedSourceChainids[0] as Hex | CaipChainId,
-          ),
-        ),
-      );
+      dispatch(setSourceToken(newSourceToken));
+
+      // Auto-update destination token when source chain changes AND dest wasn't manually set
+      autoUpdateDestToken(newSourceToken);
 
       const evmNetworkConfiguration =
         evmNetworkConfigurations[newSelectedSourceChainids[0] as Hex];
@@ -171,6 +175,7 @@ export const BridgeSourceNetworkSelector: React.FC<
     enabledSourceChainIds,
     evmNetworkConfigurations,
     onSetRpcTarget,
+    autoUpdateDestToken,
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     onNonEvmNetworkChange,
     ///: END:ONLY_INCLUDE_IF

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/index.tsx
@@ -34,6 +34,7 @@ import { BridgeToken, BridgeViewMode } from '../../types';
 import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
 import { useNetworkInfo } from '../../../../../selectors/selectedNetworkController';
 import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../constants/bridge';
+import { useAutoUpdateDestToken } from '../../hooks/useAutoUpdateDestToken';
 
 export const BridgeSourceTokenSelector: React.FC = React.memo(() => {
   const dispatch = useDispatch();
@@ -50,6 +51,7 @@ export const BridgeSourceTokenSelector: React.FC = React.memo(() => {
   const selectedSourceToken = useSelector(selectSourceToken);
   const selectedDestToken = useSelector(selectDestToken);
   const selectedChainId = useSelector(selectChainId);
+  const { autoUpdateDestToken } = useAutoUpdateDestToken();
 
   const {
     chainId: selectedEvmChainId, // Will be the most recently selected EVM chain if you are on Solana
@@ -99,6 +101,8 @@ export const BridgeSourceTokenSelector: React.FC = React.memo(() => {
       // and also the next time you open up the token selector to fetch top tokens for the right chain
       navigation.goBack();
       dispatch(setSourceToken(token));
+      // Auto-update destination token when source chain changes AND dest wasn't manually set
+      autoUpdateDestToken(token);
 
       // Switch to the chain of the selected token
       const evmNetworkConfiguration =
@@ -119,6 +123,7 @@ export const BridgeSourceTokenSelector: React.FC = React.memo(() => {
       dispatch,
       evmNetworkConfigurations,
       onSetRpcTarget,
+      autoUpdateDestToken,
       ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       onNonEvmNetworkChange,
       ///: END:ONLY_INCLUDE_IF

--- a/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/index.ts
@@ -1,0 +1,78 @@
+import { useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { BtcScope, EthScope } from '@metamask/keyring-api';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
+import {
+  setDestToken,
+  selectDestToken,
+  selectIsDestTokenManuallySet,
+} from '../../../../../core/redux/slices/bridge';
+import {
+  getDefaultDestToken,
+  getNativeSourceToken,
+} from '../../utils/tokenUtils';
+import { areAddressesEqual } from '../../../../../util/address';
+import { BridgeToken } from '../../types';
+
+/**
+ * Hook that provides a function to auto-update the destination token when the source chain changes.
+ * Assume same-chain swap when user hasn't explicitly set dest.
+ *
+ * The dest token is only updated if:
+ * 1. The source chain has changed (new source is on different chain than current dest, works for flip button too)
+ * 2. The user hasn't manually selected a destination token
+ *
+ * Special cases:
+ * - Bitcoin source: defaults to ETH on Ethereum (same-chain swaps don't make sense for BTC)
+ * - If default dest token equals source token: Not currently possible as we filter out that
+ * token from the asset list, but the default case would be to fall back into native token.
+ */
+export const useAutoUpdateDestToken = () => {
+  const dispatch = useDispatch();
+  const selectedDestToken = useSelector(selectDestToken);
+  const isDestTokenManuallySet = useSelector(selectIsDestTokenManuallySet);
+
+  const autoUpdateDestToken = useCallback(
+    (newSourceToken: BridgeToken) => {
+      // Check if source chain has changed from current dest chain
+      const sourceChainChanged =
+        selectedDestToken?.chainId &&
+        formatChainIdToCaip(newSourceToken.chainId) !==
+          formatChainIdToCaip(selectedDestToken.chainId);
+
+      // Only auto-update if chain changed AND dest wasn't manually set by user
+      if (!sourceChainChanged || isDestTokenManuallySet) {
+        return;
+      }
+
+      // For Bitcoin source, default to ETH on Ethereum
+      // (same-chain swaps don't make sense for BTC)
+      if (newSourceToken.chainId === BtcScope.Mainnet) {
+        dispatch(setDestToken(getNativeSourceToken(EthScope.Mainnet)));
+        return;
+      }
+
+      // For other chains, get the default dest token for the new source chain
+      let defaultDestToken = getDefaultDestToken(newSourceToken.chainId);
+
+      // Make sure source and dest tokens are different
+      if (
+        defaultDestToken &&
+        areAddressesEqual(newSourceToken.address, defaultDestToken.address)
+      ) {
+        // Fall back to native token if default dest is same as source
+        defaultDestToken = getNativeSourceToken(newSourceToken.chainId);
+      }
+
+      if (
+        defaultDestToken &&
+        !areAddressesEqual(newSourceToken.address, defaultDestToken.address)
+      ) {
+        dispatch(setDestToken(defaultDestToken));
+      }
+    },
+    [dispatch, selectedDestToken, isDestTokenManuallySet],
+  );
+
+  return { autoUpdateDestToken };
+};

--- a/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/index.ts
@@ -15,17 +15,18 @@ import { areAddressesEqual } from '../../../../../util/address';
 import { BridgeToken } from '../../types';
 
 /**
- * Hook that provides a function to auto-update the destination token when the source chain changes.
+ * Hook that provides a function to auto-update the destination token when the source changes.
  * Assume same-chain swap when user hasn't explicitly set dest.
  *
- * The dest token is only updated if:
- * 1. The source chain has changed (new source is on different chain than current dest, works for flip button too)
- * 2. The user hasn't manually selected a destination token
+ * The dest token is updated if:
+ * 1. The source chain has changed (new source is on different chain than current dest)
+ * 2. Same-chain but dest needs correction (e.g., dest is native fallback but source no longer conflicts with default dest, or source now conflicts with current dest)
+ * 3. The user hasn't manually selected a destination token
  *
  * Special cases:
  * - Bitcoin source: defaults to ETH on Ethereum (same-chain swaps don't make sense for BTC)
- * - If default dest token equals source token: Not currently possible as we filter out that
- * token from the asset list, but the default case would be to fall back into native token.
+ * - If default dest token equals source token: falls back to native token
+ * - If no default dest exists for chain: falls back to native token
  */
 export const useAutoUpdateDestToken = () => {
   const dispatch = useDispatch();
@@ -34,41 +35,64 @@ export const useAutoUpdateDestToken = () => {
 
   const autoUpdateDestToken = useCallback(
     (newSourceToken: BridgeToken) => {
-      // Check if source chain has changed from current dest chain
-      const sourceChainChanged =
-        selectedDestToken?.chainId &&
-        formatChainIdToCaip(newSourceToken.chainId) !==
-          formatChainIdToCaip(selectedDestToken.chainId);
+      // Never auto-update if dest was manually set by user
+      if (isDestTokenManuallySet) {
+        return;
+      }
 
-      // Only auto-update if chain changed AND dest wasn't manually set by user
-      if (!sourceChainChanged || isDestTokenManuallySet) {
+      // No dest token set yet, nothing to update from
+      if (!selectedDestToken?.chainId) {
         return;
       }
 
       // For Bitcoin source, default to ETH on Ethereum
       // (same-chain swaps don't make sense for BTC)
       if (newSourceToken.chainId === BtcScope.Mainnet) {
-        dispatch(setDestToken(getNativeSourceToken(EthScope.Mainnet)));
+        if (
+          !areAddressesEqual(
+            selectedDestToken.address,
+            getNativeSourceToken(EthScope.Mainnet).address,
+          ) ||
+          selectedDestToken.chainId !== EthScope.Mainnet
+        ) {
+          dispatch(setDestToken(getNativeSourceToken(EthScope.Mainnet)));
+        }
         return;
       }
 
-      // For other chains, get the default dest token for the new source chain
-      let defaultDestToken = getDefaultDestToken(newSourceToken.chainId);
+      // Calculate what the dest token should be based on the new source
+      const defaultDestToken = getDefaultDestToken(newSourceToken.chainId);
+      const nativeToken = getNativeSourceToken(newSourceToken.chainId);
 
-      // Make sure source and dest tokens are different
-      if (
-        defaultDestToken &&
-        areAddressesEqual(newSourceToken.address, defaultDestToken.address)
-      ) {
-        // Fall back to native token if default dest is same as source
-        defaultDestToken = getNativeSourceToken(newSourceToken.chainId);
-      }
+      let expectedDestToken: BridgeToken | undefined;
 
+      // Determine expected dest token
       if (
         defaultDestToken &&
         !areAddressesEqual(newSourceToken.address, defaultDestToken.address)
       ) {
-        dispatch(setDestToken(defaultDestToken));
+        // Default dest is valid (doesn't conflict with source)
+        expectedDestToken = defaultDestToken;
+      } else if (
+        !areAddressesEqual(newSourceToken.address, nativeToken.address)
+      ) {
+        // Fall back to native token if:
+        // 1. No default dest token exists for this chain, OR
+        // 2. Default dest equals source token
+        expectedDestToken = nativeToken;
+      }
+
+      // Only dispatch if expected dest is different from current dest
+      if (
+        expectedDestToken &&
+        (!areAddressesEqual(
+          selectedDestToken.address,
+          expectedDestToken.address,
+        ) ||
+          formatChainIdToCaip(selectedDestToken.chainId) !==
+            formatChainIdToCaip(expectedDestToken.chainId))
+      ) {
+        dispatch(setDestToken(expectedDestToken));
       }
     },
     [dispatch, selectedDestToken, isDestTokenManuallySet],

--- a/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/index.ts
@@ -53,7 +53,7 @@ export const useAutoUpdateDestToken = () => {
             selectedDestToken.address,
             getNativeSourceToken(EthScope.Mainnet).address,
           ) ||
-          selectedDestToken.chainId !== EthScope.Mainnet
+          formatChainIdToCaip(selectedDestToken.chainId) !== EthScope.Mainnet
         ) {
           dispatch(setDestToken(getNativeSourceToken(EthScope.Mainnet)));
         }

--- a/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/useAutoUpdateDestToken.test.ts
+++ b/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/useAutoUpdateDestToken.test.ts
@@ -1,0 +1,301 @@
+import {
+  initialState,
+  ethChainId,
+  optimismChainId,
+} from '../../_mocks_/initialState';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useAutoUpdateDestToken } from '.';
+import { BridgeToken } from '../../types';
+import { Hex } from '@metamask/utils';
+import { BtcScope, SolScope } from '@metamask/keyring-api';
+// eslint-disable-next-line import/no-namespace
+import * as bridgeSlice from '../../../../../core/redux/slices/bridge';
+
+describe('useAutoUpdateDestToken', () => {
+  const mockEthToken: BridgeToken = {
+    address: '0x0000000000000000000000000000000000000001',
+    symbol: 'TOKEN',
+    name: 'Test Token',
+    decimals: 18,
+    chainId: ethChainId,
+  };
+
+  const mockOptimismToken: BridgeToken = {
+    address: '0x0000000000000000000000000000000000000002',
+    symbol: 'OP_TOKEN',
+    name: 'Optimism Token',
+    decimals: 18,
+    chainId: optimismChainId,
+  };
+
+  const mockPolygonToken: BridgeToken = {
+    address: '0x0000000000000000000000000000000000000003',
+    symbol: 'MATIC_TOKEN',
+    name: 'Polygon Token',
+    decimals: 18,
+    chainId: '0x89' as Hex,
+  };
+
+  const mockBtcToken: BridgeToken = {
+    address: '0x0000000000000000000000000000000000000000',
+    symbol: 'BTC',
+    name: 'Bitcoin',
+    decimals: 8,
+    chainId: BtcScope.Mainnet,
+  };
+
+  const mockSolToken: BridgeToken = {
+    address: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+    symbol: 'SOL',
+    name: 'Solana',
+    decimals: 9,
+    chainId: SolScope.Mainnet,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when source chain changes and dest was not manually set', () => {
+    it('updates dest token to default for new source chain', () => {
+      const setDestTokenSpy = jest.spyOn(bridgeSlice, 'setDestToken');
+
+      const { result } = renderHookWithProvider(
+        () => useAutoUpdateDestToken(),
+        {
+          state: {
+            ...initialState,
+            bridge: {
+              ...initialState.bridge,
+              destToken: mockEthToken,
+              isDestTokenManuallySet: false,
+            },
+          },
+        },
+      );
+
+      // Change source to Optimism (different chain from dest)
+      result.current.autoUpdateDestToken(mockOptimismToken);
+
+      // Dest should be updated to Optimism's default (USDC)
+      expect(setDestTokenSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chainId: optimismChainId,
+        }),
+      );
+    });
+
+    it('sets ETH on Ethereum as dest when source is Bitcoin', () => {
+      const setDestTokenSpy = jest.spyOn(bridgeSlice, 'setDestToken');
+
+      const { result } = renderHookWithProvider(
+        () => useAutoUpdateDestToken(),
+        {
+          state: {
+            ...initialState,
+            bridge: {
+              ...initialState.bridge,
+              destToken: mockSolToken, // Currently on Solana
+              isDestTokenManuallySet: false,
+            },
+          },
+        },
+      );
+
+      // Change source to Bitcoin
+      result.current.autoUpdateDestToken(mockBtcToken);
+
+      // Dest should be ETH on Ethereum (0x1)
+      expect(setDestTokenSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          symbol: 'ETH',
+          chainId: '0x1',
+          address: '0x0000000000000000000000000000000000000000',
+        }),
+      );
+    });
+  });
+
+  describe('when dest was manually set', () => {
+    it('does not update dest token when source chain changes', () => {
+      const setDestTokenSpy = jest.spyOn(bridgeSlice, 'setDestToken');
+
+      const { result } = renderHookWithProvider(
+        () => useAutoUpdateDestToken(),
+        {
+          state: {
+            ...initialState,
+            bridge: {
+              ...initialState.bridge,
+              destToken: mockEthToken,
+              isDestTokenManuallySet: true, // User manually selected dest
+            },
+          },
+        },
+      );
+
+      // Change source to Optimism (different chain from dest)
+      result.current.autoUpdateDestToken(mockOptimismToken);
+
+      // Dest should NOT be updated because it was manually set
+      expect(setDestTokenSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when source chain has not changed', () => {
+    it('does not update dest token when source is on same chain as dest', () => {
+      const setDestTokenSpy = jest.spyOn(bridgeSlice, 'setDestToken');
+
+      const anotherEthToken: BridgeToken = {
+        ...mockEthToken,
+        address: '0x0000000000000000000000000000000000000099',
+        symbol: 'ANOTHER',
+      };
+
+      const { result } = renderHookWithProvider(
+        () => useAutoUpdateDestToken(),
+        {
+          state: {
+            ...initialState,
+            bridge: {
+              ...initialState.bridge,
+              destToken: mockEthToken,
+              isDestTokenManuallySet: false,
+            },
+          },
+        },
+      );
+
+      // Change source to another token on same chain (Ethereum)
+      result.current.autoUpdateDestToken(anotherEthToken);
+
+      // Dest should NOT be updated because source chain didn't change
+      expect(setDestTokenSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when there is no current dest token', () => {
+    it('does not update dest token when destToken is undefined', () => {
+      const setDestTokenSpy = jest.spyOn(bridgeSlice, 'setDestToken');
+
+      const { result } = renderHookWithProvider(
+        () => useAutoUpdateDestToken(),
+        {
+          state: {
+            ...initialState,
+            bridge: {
+              ...initialState.bridge,
+              destToken: undefined,
+              isDestTokenManuallySet: false,
+            },
+          },
+        },
+      );
+
+      result.current.autoUpdateDestToken(mockOptimismToken);
+
+      // Dest should NOT be updated because there's no current dest to compare
+      expect(setDestTokenSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when default dest token equals source token', () => {
+    it('falls back to native token for the chain', () => {
+      const setDestTokenSpy = jest.spyOn(bridgeSlice, 'setDestToken');
+
+      // Mock a source token that matches the default dest token address
+      // For Ethereum mainnet, the default dest is mUSD at 0xaca92e438df0b2401ff60da7e4337b687a2435da
+      const sourceTokenMatchingDefault: BridgeToken = {
+        address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+        symbol: 'mUSD',
+        name: 'MetaMask USD',
+        decimals: 6,
+        chainId: ethChainId,
+      };
+
+      const { result } = renderHookWithProvider(
+        () => useAutoUpdateDestToken(),
+        {
+          state: {
+            ...initialState,
+            bridge: {
+              ...initialState.bridge,
+              destToken: mockPolygonToken, // Currently on Polygon
+              isDestTokenManuallySet: false,
+            },
+          },
+        },
+      );
+
+      // Change source to Ethereum with a token that matches default dest
+      result.current.autoUpdateDestToken(sourceTokenMatchingDefault);
+
+      // Should fall back to native ETH since default dest (mUSD) matches source
+      expect(setDestTokenSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          symbol: 'ETH',
+          chainId: ethChainId,
+          address: '0x0000000000000000000000000000000000000000',
+        }),
+      );
+    });
+  });
+
+  describe('cross-chain scenarios', () => {
+    it('updates dest when switching from EVM to Solana source', () => {
+      const setDestTokenSpy = jest.spyOn(bridgeSlice, 'setDestToken');
+
+      const { result } = renderHookWithProvider(
+        () => useAutoUpdateDestToken(),
+        {
+          state: {
+            ...initialState,
+            bridge: {
+              ...initialState.bridge,
+              destToken: mockEthToken, // Currently on Ethereum
+              isDestTokenManuallySet: false,
+            },
+          },
+        },
+      );
+
+      // Change source to Solana
+      result.current.autoUpdateDestToken(mockSolToken);
+
+      // Dest should be updated to Solana's default (USDC)
+      expect(setDestTokenSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chainId: SolScope.Mainnet,
+        }),
+      );
+    });
+
+    it('updates dest when switching from Solana to EVM source', () => {
+      const setDestTokenSpy = jest.spyOn(bridgeSlice, 'setDestToken');
+
+      const { result } = renderHookWithProvider(
+        () => useAutoUpdateDestToken(),
+        {
+          state: {
+            ...initialState,
+            bridge: {
+              ...initialState.bridge,
+              destToken: mockSolToken, // Currently on Solana
+              isDestTokenManuallySet: false,
+            },
+          },
+        },
+      );
+
+      // Change source to Ethereum
+      result.current.autoUpdateDestToken(mockEthToken);
+
+      // Dest should be updated to Ethereum's default (mUSD)
+      expect(setDestTokenSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chainId: ethChainId,
+        }),
+      );
+    });
+  });
+});

--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
@@ -24,6 +24,7 @@ import {
   selectIsBridgeEnabledSourceFactory,
   setSourceToken,
   setDestToken,
+  setIsDestTokenManuallySet,
 } from '../../../../../core/redux/slices/bridge';
 import { trace, TraceName } from '../../../../../util/trace';
 import { useCurrentNetworkInfo } from '../../../../hooks/useCurrentNetworkInfo';
@@ -126,6 +127,11 @@ export const useSwapBridgeNavigation = ({
         // fallback to ETH on mainnet
         sourceToken = getNativeSourceToken(EthScope.Mainnet);
       }
+
+      // Reset the manual dest token flag on navigation so auto-update works correctly
+      // This ensures if user previously manually set dest, then closed and reopened the app,
+      // changing source token will still auto-update the dest token
+      dispatch(setIsDestTokenManuallySet(false));
 
       // Pre-populate Redux state before navigation to prevent empty button flash
       dispatch(setSourceToken(sourceToken));

--- a/app/components/UI/Bridge/hooks/useSwitchTokens/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwitchTokens/index.ts
@@ -6,6 +6,7 @@ import {
   selectSourceToken,
   setSelectedDestChainId,
   setSourceAmount,
+  setIsDestTokenManuallySet,
 } from '../../../../../core/redux/slices/bridge';
 import { useNetworkInfo } from '../../../../../selectors/selectedNetworkController';
 import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
@@ -48,6 +49,8 @@ export const useSwitchTokens = () => {
     if (sourceToken && destToken) {
       dispatch(setSourceToken(destToken));
       dispatch(setDestToken(sourceToken));
+      // Mark dest as manually set since user explicitly chose to flip
+      dispatch(setIsDestTokenManuallySet(true));
       // Swap amounts
       dispatch(setSourceAmount(destTokenAmount));
 

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -9,6 +9,8 @@ import reducer, {
   setBridgeViewMode,
   selectBridgeViewMode,
   setDestToken,
+  setIsDestTokenManuallySet,
+  selectIsDestTokenManuallySet,
   selectBip44DefaultPair,
   selectGasIncludedQuoteParams,
 } from '.';
@@ -44,7 +46,7 @@ describe('bridge slice', () => {
   };
 
   describe('initial state', () => {
-    it('should have the correct initial state', () => {
+    it('has correct initial state', () => {
       expect(initialState).toEqual({
         bridgeViewMode: undefined,
         sourceAmount: undefined,
@@ -60,6 +62,7 @@ describe('bridge slice', () => {
         isSubmittingTx: false,
         isSelectingRecipient: false,
         isMaxSourceAmount: false,
+        isDestTokenManuallySet: false,
       });
     });
   });
@@ -170,12 +173,70 @@ describe('bridge slice', () => {
   });
 
   describe('setDestToken', () => {
-    it('should set the destination token and update selectedDestChainId', () => {
+    it('sets the destination token and updates selectedDestChainId', () => {
       const action = setDestToken(mockDestToken);
       const state = reducer(initialState, action);
 
       expect(state.destToken).toBe(mockDestToken);
       expect(state.selectedDestChainId).toBe(mockDestToken.chainId);
+    });
+
+    it('does not modify isDestTokenManuallySet flag', () => {
+      const stateWithManualFlag = {
+        ...initialState,
+        isDestTokenManuallySet: true,
+      };
+
+      const action = setDestToken(mockDestToken);
+      const state = reducer(stateWithManualFlag, action);
+
+      expect(state.isDestTokenManuallySet).toBe(true);
+    });
+  });
+
+  describe('setIsDestTokenManuallySet', () => {
+    it('sets the flag to true', () => {
+      const action = setIsDestTokenManuallySet(true);
+      const state = reducer(initialState, action);
+
+      expect(state.isDestTokenManuallySet).toBe(true);
+    });
+
+    it('sets the flag to false', () => {
+      const stateWithManualFlag = {
+        ...initialState,
+        isDestTokenManuallySet: true,
+      };
+
+      const action = setIsDestTokenManuallySet(false);
+      const state = reducer(stateWithManualFlag, action);
+
+      expect(state.isDestTokenManuallySet).toBe(false);
+    });
+  });
+
+  describe('selectIsDestTokenManuallySet', () => {
+    it('returns false from initial state', () => {
+      const mockState = {
+        bridge: initialState,
+      } as RootState;
+
+      const result = selectIsDestTokenManuallySet(mockState);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true when flag is set', () => {
+      const mockState = {
+        bridge: {
+          ...initialState,
+          isDestTokenManuallySet: true,
+        },
+      } as RootState;
+
+      const result = selectIsDestTokenManuallySet(mockState);
+
+      expect(result).toBe(true);
     });
   });
 

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -59,6 +59,12 @@ export interface BridgeState {
   isSelectingRecipient: boolean;
   isGasIncludedSTXSendBundleSupported: boolean;
   isGasIncluded7702Supported: boolean;
+  /**
+   * Tracks whether the user has manually selected a destination token.
+   * When true, changing the source token to a different network won't auto-update the dest token.
+   * When false, changing source network will update dest to the default for that network.
+   */
+  isDestTokenManuallySet: boolean;
 }
 
 export const initialState: BridgeState = {
@@ -76,6 +82,7 @@ export const initialState: BridgeState = {
   isSelectingRecipient: false,
   isGasIncludedSTXSendBundleSupported: false,
   isGasIncluded7702Supported: false,
+  isDestTokenManuallySet: false,
 };
 
 const name = 'bridge';
@@ -132,6 +139,13 @@ const slice = createSlice({
       state.destToken = action.payload;
       // Update selectedDestChainId to match the destination token's chain ID
       state.selectedDestChainId = action.payload.chainId;
+    },
+    /**
+     * Sets whether the destination token was manually selected by the user.
+     * When true, auto-updates to dest token are prevented when source chain changes.
+     */
+    setIsDestTokenManuallySet: (state, action: PayloadAction<boolean>) => {
+      state.isDestTokenManuallySet = action.payload;
     },
     setDestAddress: (state, action: PayloadAction<string | undefined>) => {
       state.destAddress = action.payload;
@@ -565,6 +579,11 @@ export const selectIsSelectingRecipient = createSelector(
   (bridgeState) => bridgeState.isSelectingRecipient,
 );
 
+export const selectIsDestTokenManuallySet = createSelector(
+  selectBridgeState,
+  (bridgeState) => bridgeState.isDestTokenManuallySet,
+);
+
 export const selectIsGaslessSwapEnabled = createSelector(
   selectIsSwap,
   selectBridgeFeatureFlags,
@@ -625,6 +644,7 @@ export const {
   resetBridgeState,
   setSourceToken,
   setDestToken,
+  setIsDestTokenManuallySet,
   setSelectedSourceChainIds,
   setSelectedDestChainId,
   setSlippage,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR introduce a change to the behavior of destination asset picker to match that of extension. We are introducing a mechanism to automatically change the destination asset  to match the source chain when users land on swaps. This behavior is canceled when users flip swap assets or manually select a destination asset. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Automatically change the destination asset to match source asset chain when users land on swaps.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3565

## **Manual testing steps**

Reopen app after manual dest selection: Kill app after manually selecting dest token → reopen → navigate to swaps → change source network → dest token auto-updates

Manual dest selection within session: Manually select dest token → change source network → dest token does NOT auto-update

Flip tokens: Tap flip button → change source network → dest token does NOT auto-update (flip counts as manual)
Navigate away and return: Manually set dest → go to dashboard → return to swaps → change source network → dest token auto-updates

Fresh swaps navigation: Open swaps fresh → select single source network → dest token auto-updates to match
Open from token details: Previously set dest manually → open swaps from token details → dest auto-update is enabled again

Background app (no kill): Manually select dest → background app → return to swaps → dest token remains manually 
selected. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/b060c665-4747-4b18-9b77-095c3d6f8918


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automatically updates the destination token when the source network/token changes, unless the user manually selected or flipped tokens, powered by a new hook and Redux flag.
> 
> - **State/Redux**
>   - Add `bridge.isDestTokenManuallySet` to `initialState`, reducers, actions (`setIsDestTokenManuallySet`), and selector `selectIsDestTokenManuallySet`.
>   - Ensure `setDestToken` updates `selectedDestChainId` without altering the manual flag.
> - **Hooks**
>   - New `useAutoUpdateDestToken` hook to set `destToken` based on source changes (default dest, native fallback, BTC→ETH special-case) when `isDestTokenManuallySet` is false.
>   - Update `useSwapBridgeNavigation` to reset `isDestTokenManuallySet` to `false` on entry and preseed `destToken` (default or native fallback).
>   - Update `useSwitchTokens` to set `isDestTokenManuallySet` to `true` on flip.
> - **UI**
>   - `BridgeSourceNetworkSelector`/`BridgeSourceTokenSelector`: when a single source chain/token is chosen, set source and call `autoUpdateDestToken`; also handle EVM/non‑EVM switching.
>   - `BridgeDestTokenSelector`: on selection, set `destToken` and mark `isDestTokenManuallySet=true`.
> - **Tests**
>   - Add/expand tests for auto-update logic, manual override, navigation reset, network switching, and selectors across affected components/hooks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d030b52876f65b35e8b07d2a20955c8320c6ae3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->