### PR TITLE
chore: INFRA-3187: Added workflow to auto-merge old release branches into ne…

### DIFF
--- a/.github/workflows/merge-previous-release-branches.yml
+++ b/.github/workflows/merge-previous-release-branches.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge previous releases
-        uses: metamask/github-tools/.github/actions/merge-previous-releases@INFRA-3187-AutomateMergingReleaseBranches
+        uses: metamask/github-tools/.github/actions/merge-previous-releases@v1.2.0
         with:
           new-release-branch: ${{ github.event.ref }}
           github-token: ${{ secrets.METAMASK_MOBILE_BRANCH_SYNC_TOKEN }}

--- a/.github/workflows/merge-previous-release-branches.yml
+++ b/.github/workflows/merge-previous-release-branches.yml
@@ -25,10 +25,10 @@ jobs:
         run: |
           if [[ "$BRANCH" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Branch '$BRANCH' matches release/X.Y.Z format"
-            echo "is-valid=true" >> $GITHUB_OUTPUT
+            echo "is-valid=true" >> "$GITHUB_OUTPUT"
           else
             echo "Branch '$BRANCH' does not match release/X.Y.Z format. Skipping."
-            echo "is-valid=false" >> $GITHUB_OUTPUT
+            echo "is-valid=false" >> "$GITHUB_OUTPUT"
           fi
 
   merge-previous-releases:

--- a/.github/workflows/merge-previous-release-branches.yml
+++ b/.github/workflows/merge-previous-release-branches.yml
@@ -1,0 +1,41 @@
+name: Merge Previous Release Branches
+
+permissions:
+  pull-requests: write
+  contents: write
+  issues: write
+
+on:
+  create:
+    # Trigger when a branch is created, filter for release/* happens in the job
+
+jobs:
+  validate-branch:
+    name: Validate release branch format
+    runs-on: ubuntu-latest
+    # Only run for branch creation (not tags)
+    if: github.event.ref_type == 'branch'
+    outputs:
+      is-valid: ${{ steps.check.outputs.is-valid }}
+    steps:
+      - name: Check branch name format
+        id: check
+        run: |
+          BRANCH="${{ github.event.ref }}"
+          if [[ "$BRANCH" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Branch '$BRANCH' matches release/X.Y.Z format"
+            echo "is-valid=true" >> $GITHUB_OUTPUT
+          else
+            echo "Branch '$BRANCH' does not match release/X.Y.Z format. Skipping."
+            echo "is-valid=false" >> $GITHUB_OUTPUT
+          fi
+
+  merge-previous-releases:
+    name: Merge previous release branches
+    needs: validate-branch
+    if: needs.validate-branch.outputs.is-valid == 'true'
+    uses: metamask/github-tools/.github/workflows/merge-previous-releases.yml@INFRA-3187-AutomateMergingReleaseBranches
+    secrets:
+      github-token: ${{ secrets.METAMASK_MOBILE_BRANCH_SYNC_TOKEN }}
+    with:
+      new-release-branch: ${{ github.event.ref }}

--- a/.github/workflows/merge-previous-release-branches.yml
+++ b/.github/workflows/merge-previous-release-branches.yml
@@ -35,8 +35,10 @@ jobs:
     name: Merge previous release branches
     needs: validate-branch
     if: needs.validate-branch.outputs.is-valid == 'true'
-    uses: metamask/github-tools/.github/workflows/merge-previous-releases.yml@INFRA-3187-AutomateMergingReleaseBranches
-    secrets:
-      github-token: ${{ secrets.METAMASK_MOBILE_BRANCH_SYNC_TOKEN }}
-    with:
-      new-release-branch: ${{ github.event.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge previous releases
+        uses: metamask/github-tools/.github/actions/merge-previous-releases@INFRA-3187-AutomateMergingReleaseBranches
+        with:
+          new-release-branch: ${{ github.event.ref }}
+          github-token: ${{ secrets.METAMASK_MOBILE_BRANCH_SYNC_TOKEN }}

--- a/.github/workflows/merge-previous-release-branches.yml
+++ b/.github/workflows/merge-previous-release-branches.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - name: Check branch name format
         id: check
+        env:
+          BRANCH: ${{ github.event.ref }}
         run: |
-          BRANCH="${{ github.event.ref }}"
           if [[ "$BRANCH" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Branch '$BRANCH' matches release/X.Y.Z format"
             echo "is-valid=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
…w one

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a workflow and script to automatically merge all older release/X.Y.Z branches into a newly created release branch, favoring the destination on conflicts.

**CI/CD:**
New workflow /.github/workflows/merge-previous-releases.yml:
Triggers via workflow_call or workflow_dispatch with new-release-branch input.
Checks out repo and metamask/github-tools, configures git user, and runs merge script.
New script /.github/scripts/merge-previous-releases.sh:
Parses release/X.Y.Z branches, filters/sorts older versions, and merges them into NEW_RELEASE_BRANCH.
Uses -X ours to resolve conflicts favoring destination; skips already merged branches; pushes only if merges occurred.
Logs actions and summarizes merged vs skipped branches.

Testing:
https://github.com/consensys-test/metamask-mobile-test-workflow/pull/59
1. Multiple branches, one already merged: https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/20072233678
2. Multiple branches, neither merged: https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/20073029520
3. Multiple branches, with merge conflicts: https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/20073136324

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: None

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions workflow that, upon creating a `release/X.Y.Z` branch, validates the branch name and merges previous release branches into it using `metamask/github-tools`.
> 
> - **CI/CD — GitHub Actions**
>   - **New workflow** `/.github/workflows/merge-previous-release-branches.yml`:
>     - Triggers on branch creation; validates `release/X.Y.Z` format.
>     - If valid, runs job to merge previous release branches into `${{ github.event.ref }}` using `metamask/github-tools/.github/actions/merge-previous-releases@v1.2.0` with `METAMASK_MOBILE_BRANCH_SYNC_TOKEN`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb5031e6994423fc3adff2555586e5c5dd542b02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->