### PR TITLE
chore: bump bridge-controller to v64.1

### DIFF
--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -286,7 +286,7 @@ export const TokenInputArea = forwardRef<
     nonEvmMultichainAssetRates = useSelector(selectMultichainAssetsRates);
     ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 
-    const currencyValue = getDisplayCurrencyValue({
+    const displayCurrencyValue = getDisplayCurrencyValue({
       token,
       amount,
       evmMultiChainMarketData,
@@ -396,8 +396,13 @@ export const TokenInputArea = forwardRef<
             ) : (
               <>
                 <Box style={styles.currencyContainer}>
-                  {token && amount && Number(amount) > 0 && currencyValue ? (
-                    <Text color={TextColor.Alternative}>{currencyValue}</Text>
+                  {token &&
+                  amount &&
+                  Number(amount) > 0 &&
+                  displayCurrencyValue ? (
+                    <Text color={TextColor.Alternative}>
+                      {displayCurrencyValue}
+                    </Text>
                   ) : null}
                 </Box>
                 <Box

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -286,7 +286,7 @@ export const TokenInputArea = forwardRef<
     nonEvmMultichainAssetRates = useSelector(selectMultichainAssetsRates);
     ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 
-    const displayCurrencyValue = getDisplayCurrencyValue({
+    const currencyValue = getDisplayCurrencyValue({
       token,
       amount,
       evmMultiChainMarketData,
@@ -396,13 +396,8 @@ export const TokenInputArea = forwardRef<
             ) : (
               <>
                 <Box style={styles.currencyContainer}>
-                  {token &&
-                  amount &&
-                  Number(amount) > 0 &&
-                  displayCurrencyValue ? (
-                    <Text color={TextColor.Alternative}>
-                      {displayCurrencyValue}
-                    </Text>
+                  {token && amount && Number(amount) > 0 && currencyValue ? (
+                    <Text color={TextColor.Alternative}>{currencyValue}</Text>
                   ) : null}
                 </Box>
                 <Box

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
@@ -6,7 +6,7 @@ import {
 import { useEffect, useMemo } from 'react';
 import Engine from '../../../../../core/Engine';
 import {
-  formatProviderLabel,
+  getQuotesReceivedProperties,
   QuoteWarning,
   UnifiedSwapBridgeEventName,
 } from '@metamask/bridge-controller';
@@ -59,22 +59,12 @@ export const useBridgeQuoteEvents = ({
     if (!isLoading && quotesRefreshCount > 0 && !quoteFetchError) {
       Engine.context.BridgeController.trackUnifiedSwapBridgeEvent(
         UnifiedSwapBridgeEventName.QuotesReceived,
-        {
-          can_submit: !isSubmitDisabled,
-          gas_included: Boolean(activeQuote?.quote?.gasIncluded),
-          gas_included_7702: Boolean(activeQuote?.quote?.gasIncluded7702),
-          quoted_time_minutes: activeQuote?.estimatedProcessingTimeInSeconds
-            ? activeQuote.estimatedProcessingTimeInSeconds / 60
-            : 0,
-          usd_quoted_gas: Number(activeQuote?.gasFee?.effective?.usd ?? 0),
-          usd_quoted_return: Number(activeQuote?.toTokenAmount?.usd ?? 0),
-          best_quote_provider: recommendedQuote
-            ? formatProviderLabel(recommendedQuote.quote)
-            : undefined,
-          provider: activeQuote ? formatProviderLabel(activeQuote.quote) : '_',
+        getQuotesReceivedProperties(
+          activeQuote,
           warnings,
-          price_impact: Number(activeQuote?.quote.priceData?.priceImpact ?? 0),
-        },
+          !isSubmitDisabled,
+          recommendedQuote,
+        ),
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
@@ -7,6 +7,7 @@ import { useEffect, useMemo } from 'react';
 import Engine from '../../../../../core/Engine';
 import {
   formatProviderLabel,
+  QuoteWarning,
   UnifiedSwapBridgeEventName,
 } from '@metamask/bridge-controller';
 
@@ -35,14 +36,14 @@ export const useBridgeQuoteEvents = ({
     useSelector(selectBridgeQuotes);
 
   const warnings = useMemo(() => {
-    const latestWarnings = [];
+    const latestWarnings: QuoteWarning[] = [];
 
     hasNoQuotesAvailable && latestWarnings.push('no_quotes');
     hasInsufficientGas &&
       latestWarnings.push('insufficient_gas_for_selected_quote');
     hasInsufficientBalance && latestWarnings.push('insufficient_balance');
     hasTxAlert && latestWarnings.push('tx_alert');
-    isPriceImpactWarningVisible && latestWarnings.push('price_impact_warning');
+    isPriceImpactWarningVisible && latestWarnings.push('price_impact');
 
     return latestWarnings;
   }, [

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
@@ -59,10 +59,10 @@ describe('useBridgeQuoteEvents', () => {
     [{ hasInsufficientGas: true }, ['insufficient_gas_for_selected_quote']],
     [{ hasInsufficientBalance: true }, ['insufficient_balance']],
     [{ hasTxAlert: true }, ['tx_alert']],
-    [{ isPriceImpactWarningVisible: true }, ['price_impact_warning']],
+    [{ isPriceImpactWarningVisible: true }, ['price_impact']],
     [
       { hasTxAlert: true, isPriceImpactWarningVisible: true },
-      ['tx_alert', 'price_impact_warning'],
+      ['tx_alert', 'price_impact'],
     ],
     [{}, []],
   ])(

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
@@ -48,7 +48,7 @@ export const useUnifiedSwapBridgeContext = () => {
 
   const usdAmountSource = usdConversionRate
     ? tokenFiatValue / usdConversionRate
-    : undefined;
+    : 0;
 
   return useMemo(
     () => ({

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
@@ -3,13 +3,53 @@ import { useSelector } from 'react-redux';
 import {
   selectDestToken,
   selectSourceToken,
+  selectSourceAmount,
 } from '../../../../../core/redux/slices/bridge';
 import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
+import { selectCurrencyRates } from '../../../../../selectors/currencyRateController';
+import { selectTokenMarketData } from '../../../../../selectors/tokenRatesController';
+import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
+///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+import { selectMultichainAssetsRates } from '../../../../../selectors/multichain';
+///: END:ONLY_INCLUDE_IF(keyring-snaps)
+import { calcTokenFiatValue } from '../../utils/exchange-rates';
 
 export const useUnifiedSwapBridgeContext = () => {
   const smartTransactionsEnabled = useSelector(selectShouldUseSmartTransaction);
   const fromToken = useSelector(selectSourceToken);
   const toToken = useSelector(selectDestToken);
+  const sourceAmount = useSelector(selectSourceAmount);
+
+  const evmMultiChainMarketData = useSelector(selectTokenMarketData);
+  const evmMultiChainCurrencyRates = useSelector(selectCurrencyRates);
+  const networkConfigurationsByChainId = useSelector(
+    selectNetworkConfigurations,
+  );
+
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  const nonEvmMultichainAssetRates = useSelector(selectMultichainAssetsRates);
+  ///: END:ONLY_INCLUDE_IF(keyring-snaps)
+
+  // TODO this is not actually the USD amount source yet, it's the amount source in the user's selected currency
+  const usdAmountSource = useMemo(
+    () =>
+      calcTokenFiatValue({
+        token: fromToken ?? undefined,
+        amount: sourceAmount,
+        evmMultiChainMarketData,
+        networkConfigurationsByChainId,
+        evmMultiChainCurrencyRates,
+        nonEvmMultichainAssetRates,
+      }),
+    [
+      fromToken,
+      sourceAmount,
+      evmMultiChainMarketData,
+      networkConfigurationsByChainId,
+      evmMultiChainCurrencyRates,
+      nonEvmMultichainAssetRates,
+    ],
+  );
 
   return useMemo(
     () => ({
@@ -18,7 +58,8 @@ export const useUnifiedSwapBridgeContext = () => {
       token_symbol_destination: toToken?.symbol ?? '',
       security_warnings: [], // TODO
       warnings: [], // TODO
+      usd_amount_source: usdAmountSource,
     }),
-    [smartTransactionsEnabled, fromToken, toToken],
+    [smartTransactionsEnabled, fromToken, toToken, usdAmountSource],
   );
 };

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
@@ -9,9 +9,7 @@ import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartT
 import { selectCurrencyRates } from '../../../../../selectors/currencyRateController';
 import { selectTokenMarketData } from '../../../../../selectors/tokenRatesController';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { selectMultichainAssetsRates } from '../../../../../selectors/multichain';
-///: END:ONLY_INCLUDE_IF(keyring-snaps)
 import { calcTokenFiatValue } from '../../utils/exchange-rates';
 
 export const useUnifiedSwapBridgeContext = () => {
@@ -25,10 +23,7 @@ export const useUnifiedSwapBridgeContext = () => {
   const networkConfigurationsByChainId = useSelector(
     selectNetworkConfigurations,
   );
-
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const nonEvmMultichainAssetRates = useSelector(selectMultichainAssetsRates);
-  ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 
   const usdConversionRate = evmMultiChainCurrencyRates?.usd?.conversionRate;
   const tokenFiatValue = useMemo(

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
@@ -30,8 +30,8 @@ export const useUnifiedSwapBridgeContext = () => {
   const nonEvmMultichainAssetRates = useSelector(selectMultichainAssetsRates);
   ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 
-  // TODO this is not actually the USD amount source yet, it's the amount source in the user's selected currency
-  const usdAmountSource = useMemo(
+  const usdConversionRate = evmMultiChainCurrencyRates?.usd?.conversionRate;
+  const tokenFiatValue = useMemo(
     () =>
       calcTokenFiatValue({
         token: fromToken ?? undefined,
@@ -50,6 +50,10 @@ export const useUnifiedSwapBridgeContext = () => {
       nonEvmMultichainAssetRates,
     ],
   );
+
+  const usdAmountSource = usdConversionRate
+    ? tokenFiatValue / usdConversionRate
+    : undefined;
 
   return useMemo(
     () => ({

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
@@ -179,7 +179,7 @@ describe('useUnifiedSwapBridgeContext', () => {
     expect(typeof result.current.usd_amount_source).toBe('number');
   });
 
-  it('returns undefined usd_amount_source when usd conversion rate is missing', () => {
+  it('returns 0 usd_amount_source when usd conversion rate is missing', () => {
     const mockToken = {
       symbol: 'ETH',
       address: '0x0000000000000000000000000000000000000000',
@@ -199,6 +199,6 @@ describe('useUnifiedSwapBridgeContext', () => {
       },
     );
 
-    expect(result.current.usd_amount_source).toBeUndefined();
+    expect(result.current.usd_amount_source).toBe(0);
   });
 });

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
@@ -93,7 +93,7 @@ describe('useUnifiedSwapBridgeContext', () => {
       token_symbol_destination: 'USDC',
       security_warnings: [],
       warnings: [],
-      usd_amount_source: undefined,
+      usd_amount_source: 0,
     });
   });
 
@@ -122,7 +122,7 @@ describe('useUnifiedSwapBridgeContext', () => {
       token_symbol_destination: '',
       security_warnings: [],
       warnings: [],
-      usd_amount_source: undefined,
+      usd_amount_source: 0,
     });
   });
 

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
@@ -158,6 +158,7 @@ describe('useUnifiedSwapBridgeContext', () => {
     mockSelectSourceAmount.mockReturnValue('1');
     mockSelectCurrencyRates.mockReturnValue({
       usd: { conversionRate: 1 },
+      ETH: { conversionRate: 1 },
     });
     mockSelectTokenMarketData.mockReturnValue({
       '0x1': {
@@ -176,7 +177,7 @@ describe('useUnifiedSwapBridgeContext', () => {
     );
 
     expect(result.current.usd_amount_source).toBeDefined();
-    expect(typeof result.current.usd_amount_source).toBe('number');
+    expect(result.current.usd_amount_source).toBe(2000);
   });
 
   it('returns 0 usd_amount_source when usd conversion rate is missing', () => {

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
@@ -12,6 +12,24 @@ jest.mock('../../../../../selectors/smartTransactionsController', () => ({
 jest.mock('../../../../../core/redux/slices/bridge', () => ({
   selectSourceToken: jest.fn(),
   selectDestToken: jest.fn(),
+  selectSourceAmount: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors/currencyRateController', () => ({
+  selectCurrencyRates: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors/tokenRatesController', () => ({
+  selectTokenMarketData: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors/networkController', () => ({
+  ...jest.requireActual('../../../../../selectors/networkController'),
+  selectNetworkConfigurations: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors/multichain', () => ({
+  selectMultichainAssetsRates: jest.fn(),
 }));
 
 describe('useUnifiedSwapBridgeContext', () => {
@@ -27,12 +45,37 @@ describe('useUnifiedSwapBridgeContext', () => {
     '../../../../../core/redux/slices/bridge',
   ).selectDestToken;
 
+  const mockSelectSourceAmount = jest.requireMock(
+    '../../../../../core/redux/slices/bridge',
+  ).selectSourceAmount;
+
+  const mockSelectCurrencyRates = jest.requireMock(
+    '../../../../../selectors/currencyRateController',
+  ).selectCurrencyRates;
+
+  const mockSelectTokenMarketData = jest.requireMock(
+    '../../../../../selectors/tokenRatesController',
+  ).selectTokenMarketData;
+
+  const mockSelectNetworkConfigurations = jest.requireMock(
+    '../../../../../selectors/networkController',
+  ).selectNetworkConfigurations;
+
+  const mockSelectMultichainAssetsRates = jest.requireMock(
+    '../../../../../selectors/multichain',
+  ).selectMultichainAssetsRates;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    // Set default mock values
+    mockSelectSourceAmount.mockReturnValue(undefined);
+    mockSelectCurrencyRates.mockReturnValue({});
+    mockSelectTokenMarketData.mockReturnValue({});
+    mockSelectNetworkConfigurations.mockReturnValue({});
+    mockSelectMultichainAssetsRates.mockReturnValue({});
   });
 
   it('returns correct context with smart transactions enabled and tokens', () => {
-    // Setup mocks
     mockSelectShouldUseSmartTransaction.mockReturnValue(true);
     mockSelectSourceToken.mockReturnValue({ symbol: 'ETH' });
     mockSelectDestToken.mockReturnValue({ symbol: 'USDC' });
@@ -50,11 +93,11 @@ describe('useUnifiedSwapBridgeContext', () => {
       token_symbol_destination: 'USDC',
       security_warnings: [],
       warnings: [],
+      usd_amount_source: undefined,
     });
   });
 
   it('returns empty token symbols when tokens are undefined', () => {
-    // Setup mocks
     mockSelectShouldUseSmartTransaction.mockReturnValue(false);
     mockSelectSourceToken.mockReturnValue(undefined);
     mockSelectDestToken.mockReturnValue(undefined);
@@ -79,11 +122,11 @@ describe('useUnifiedSwapBridgeContext', () => {
       token_symbol_destination: '',
       security_warnings: [],
       warnings: [],
+      usd_amount_source: undefined,
     });
   });
 
   it('memoizes the result when dependencies do not change', () => {
-    // Setup mocks
     mockSelectShouldUseSmartTransaction.mockReturnValue(true);
     mockSelectSourceToken.mockReturnValue({ symbol: 'ETH' });
     mockSelectDestToken.mockReturnValue({ symbol: 'USDC' });
@@ -100,5 +143,62 @@ describe('useUnifiedSwapBridgeContext', () => {
     const secondResult = result.current;
 
     expect(firstResult).toBe(secondResult);
+  });
+
+  it('calculates usd_amount_source when currency rates and token data are available', () => {
+    const mockToken = {
+      symbol: 'ETH',
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: '0x1',
+    };
+
+    mockSelectShouldUseSmartTransaction.mockReturnValue(true);
+    mockSelectSourceToken.mockReturnValue(mockToken);
+    mockSelectDestToken.mockReturnValue({ symbol: 'USDC' });
+    mockSelectSourceAmount.mockReturnValue('1');
+    mockSelectCurrencyRates.mockReturnValue({
+      usd: { conversionRate: 1 },
+    });
+    mockSelectTokenMarketData.mockReturnValue({
+      '0x1': {
+        '0x0000000000000000000000000000000000000000': { price: 2000 },
+      },
+    });
+    mockSelectNetworkConfigurations.mockReturnValue({
+      '0x1': { nativeCurrency: 'ETH' },
+    });
+
+    const { result } = renderHookWithProvider(
+      () => useUnifiedSwapBridgeContext(),
+      {
+        state: initialRootState,
+      },
+    );
+
+    expect(result.current.usd_amount_source).toBeDefined();
+    expect(typeof result.current.usd_amount_source).toBe('number');
+  });
+
+  it('returns undefined usd_amount_source when usd conversion rate is missing', () => {
+    const mockToken = {
+      symbol: 'ETH',
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: '0x1',
+    };
+
+    mockSelectShouldUseSmartTransaction.mockReturnValue(true);
+    mockSelectSourceToken.mockReturnValue(mockToken);
+    mockSelectDestToken.mockReturnValue({ symbol: 'USDC' });
+    mockSelectSourceAmount.mockReturnValue('1');
+    mockSelectCurrencyRates.mockReturnValue({});
+
+    const { result } = renderHookWithProvider(
+      () => useUnifiedSwapBridgeContext(),
+      {
+        state: initialRootState,
+      },
+    );
+
+    expect(result.current.usd_amount_source).toBeUndefined();
   });
 });

--- a/app/components/UI/Bridge/utils/exchange-rates.ts
+++ b/app/components/UI/Bridge/utils/exchange-rates.ts
@@ -23,7 +23,7 @@ import { safeToChecksumAddress } from '../../../../util/address';
 import { toAssetId } from '../hooks/useAssetMetadata/utils';
 import { formatCurrency } from './currencyUtils';
 
-interface GetDisplayCurrencyValueParams {
+export interface CalcTokenFiatValueParams {
   token: BridgeToken | undefined;
   amount: string | undefined;
   evmMultiChainMarketData:
@@ -33,8 +33,65 @@ interface GetDisplayCurrencyValueParams {
   evmMultiChainCurrencyRates:
     | Record<string, { conversionRate: number | null }>
     | undefined;
-  currentCurrency: string;
   nonEvmMultichainAssetRates: ReturnType<typeof selectMultichainAssetsRates>;
+}
+
+/**
+ * Calculates the fiat value of a token amount
+ * @returns The numeric fiat value (not formatted)
+ */
+export const calcTokenFiatValue = ({
+  token,
+  amount,
+  evmMultiChainMarketData,
+  networkConfigurationsByChainId,
+  evmMultiChainCurrencyRates,
+  nonEvmMultichainAssetRates,
+}: CalcTokenFiatValueParams): number => {
+  if (!token || !amount) {
+    return 0;
+  }
+
+  if (isNonEvmChainId(token.chainId)) {
+    const assetId = token.address as CaipAssetType;
+    // This rate is asset to fiat. Whatever the user selected display fiat currency is.
+    // We don't need to have an additional conversion from native token to fiat.
+    const rate = nonEvmMultichainAssetRates?.[assetId]?.rate;
+    if (rate) {
+      return Number(balanceToFiatNumber(amount, Number(rate), 1));
+    }
+    return token?.currencyExchangeRate && amount
+      ? Number(amount) * token?.currencyExchangeRate
+      : 0;
+  }
+
+  // EVM
+  const evmChainId = token.chainId as Hex;
+  const evmMultiChainExchangeRates = evmMultiChainMarketData?.[evmChainId];
+  const evmTokenMarketData = evmMultiChainExchangeRates?.[token.address as Hex];
+
+  const nativeCurrency =
+    networkConfigurationsByChainId[evmChainId]?.nativeCurrency;
+  const multiChainConversionRate =
+    evmMultiChainCurrencyRates?.[nativeCurrency]?.conversionRate;
+
+  if (multiChainConversionRate && evmTokenMarketData?.price) {
+    return Number(
+      balanceToFiatNumber(
+        amount,
+        multiChainConversionRate,
+        evmTokenMarketData.price,
+      ),
+    );
+  }
+
+  return token?.currencyExchangeRate && amount
+    ? Number(amount) * token?.currencyExchangeRate
+    : 0;
+};
+
+interface GetDisplayCurrencyValueParams extends CalcTokenFiatValueParams {
+  currentCurrency: string;
 }
 
 export const getDisplayCurrencyValue = ({
@@ -46,51 +103,17 @@ export const getDisplayCurrencyValue = ({
   currentCurrency,
   nonEvmMultichainAssetRates,
 }: GetDisplayCurrencyValueParams): string => {
+  const currencyValue = calcTokenFiatValue({
+    token,
+    amount,
+    evmMultiChainMarketData,
+    networkConfigurationsByChainId,
+    evmMultiChainCurrencyRates,
+    nonEvmMultichainAssetRates,
+  });
+
   if (!token || !amount) {
     return formatCurrency('0', currentCurrency);
-  }
-
-  let currencyValue = 0;
-
-  if (isNonEvmChainId(token.chainId)) {
-    const assetId = token.address as CaipAssetType;
-    // This rate is asset to fiat. Whatever the user selected display fiat currency is.
-    // We don't need to have an additional conversion from native token to fiat.
-    const rate = nonEvmMultichainAssetRates?.[assetId]?.rate;
-    if (rate) {
-      currencyValue = Number(balanceToFiatNumber(amount, Number(rate), 1));
-    } else {
-      currencyValue =
-        token?.currencyExchangeRate && amount
-          ? Number(amount) * token?.currencyExchangeRate
-          : 0;
-    }
-  } else {
-    // EVM
-    const evmChainId = token.chainId as Hex;
-    const evmMultiChainExchangeRates = evmMultiChainMarketData?.[evmChainId];
-    const evmTokenMarketData =
-      evmMultiChainExchangeRates?.[token.address as Hex];
-
-    const nativeCurrency =
-      networkConfigurationsByChainId[evmChainId]?.nativeCurrency;
-    const multiChainConversionRate =
-      evmMultiChainCurrencyRates?.[nativeCurrency]?.conversionRate;
-
-    if (multiChainConversionRate && evmTokenMarketData?.price) {
-      currencyValue = Number(
-        balanceToFiatNumber(
-          amount,
-          multiChainConversionRate,
-          evmTokenMarketData.price,
-        ),
-      );
-    } else {
-      currencyValue =
-        token?.currencyExchangeRate && amount
-          ? Number(amount) * token?.currencyExchangeRate
-          : 0;
-    }
   }
 
   const formattedCurrencyValue = formatCurrency(currencyValue, currentCurrency);

--- a/app/components/UI/Bridge/utils/exchange-rates.ts
+++ b/app/components/UI/Bridge/utils/exchange-rates.ts
@@ -37,7 +37,7 @@ export interface CalcTokenFiatValueParams {
 }
 
 /**
- * Calculates the fiat value of a token amount
+ * Calculates the fiat value of a token amount in the user's current currency
  * @returns The numeric fiat value (not formatted)
  */
 export const calcTokenFiatValue = ({
@@ -85,9 +85,12 @@ export const calcTokenFiatValue = ({
     );
   }
 
-  return token?.currencyExchangeRate && amount
-    ? Number(amount) * token?.currencyExchangeRate
-    : 0;
+  const currentCurrencyValue =
+    token?.currencyExchangeRate && amount
+      ? Number(amount) * token?.currencyExchangeRate
+      : 0;
+
+  return currentCurrencyValue;
 };
 
 interface GetDisplayCurrencyValueParams extends CalcTokenFiatValueParams {

--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -270,6 +270,7 @@ jest.mock('../../util/getHighestFiatToken', () => ({
 
 // Mock isSolanaChainId
 jest.mock('@metamask/bridge-controller', () => ({
+  ...jest.requireActual('@metamask/bridge-controller'),
   isSolanaChainId: jest.fn(),
 }));
 

--- a/app/core/Engine/messengers/bridge-status-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/bridge-status-controller-messenger/index.ts
@@ -30,7 +30,6 @@ export function getBridgeStatusControllerMessenger(
       'NetworkController:getNetworkClientById',
       'NetworkController:findNetworkClientIdByChainId',
       'NetworkController:getState',
-      'BridgeController:getBridgeERC20Allowance',
       'BridgeController:stopPollingForQuotes',
       'BridgeController:trackUnifiedSwapBridgeEvent',
       'GasFeeController:getState',

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "@metamask/assets-controllers": "^93.0.0",
     "@metamask/base-controller": "^9.0.0",
     "@metamask/bitcoin-wallet-snap": "^1.8.0",
-    "@metamask/bridge-controller": "patch:@metamask/bridge-controller@npm%3A61.0.0#~/.yarn/patches/@metamask-bridge-controller-npm-61.0.0-8c413c463f.patch",
+    "@metamask/bridge-controller": "^64.1.0",
     "@metamask/bridge-status-controller": "^61.0.0",
     "@metamask/chain-agnostic-permission": "^1.2.2",
     "@metamask/composable-controller": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "@metamask/base-controller": "^9.0.0",
     "@metamask/bitcoin-wallet-snap": "^1.8.0",
     "@metamask/bridge-controller": "^64.1.0",
-    "@metamask/bridge-status-controller": "^61.0.0",
+    "@metamask/bridge-status-controller": "^64.0.1",
     "@metamask/chain-agnostic-permission": "^1.2.2",
     "@metamask/composable-controller": "^12.0.0",
     "@metamask/controller-utils": "^11.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7297,29 +7297,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-status-controller@npm:^61.0.0":
-  version: 61.0.0
-  resolution: "@metamask/bridge-status-controller@npm:61.0.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.15.0"
-    "@metamask/polling-controller": "npm:^15.0.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.8.1"
-    bignumber.js: "npm:^9.1.2"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/accounts-controller": ^34.0.0
-    "@metamask/bridge-controller": ^61.0.0
-    "@metamask/gas-fee-controller": ^25.0.0
-    "@metamask/network-controller": ^25.0.0
-    "@metamask/snaps-controllers": ^14.0.0
-    "@metamask/transaction-controller": ^61.0.0
-  checksum: 10/5f84b9c46b57079a3d39dd570d5b9e1a0c475435e05c6ec183fd832e563ed362df927ce83c88f9026dbd3ccd279309686e900e15a2b5f17dcff2ebb39959b7b5
-  languageName: node
-  linkType: hard
-
-"@metamask/bridge-status-controller@npm:^64.1.0":
+"@metamask/bridge-status-controller@npm:^64.0.1, @metamask/bridge-status-controller@npm:^64.1.0":
   version: 64.1.0
   resolution: "@metamask/bridge-status-controller@npm:64.1.0"
   dependencies:
@@ -34158,7 +34136,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^1.8.0"
     "@metamask/bridge-controller": "npm:^64.1.0"
-    "@metamask/bridge-status-controller": "npm:^61.0.0"
+    "@metamask/bridge-status-controller": "npm:^64.0.1"
     "@metamask/browser-passworder": "npm:^5.0.0"
     "@metamask/build-utils": "npm:^3.0.0"
     "@metamask/chain-agnostic-permission": "npm:^1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7266,38 +7266,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:61.0.0":
-  version: 61.0.0
-  resolution: "@metamask/bridge-controller@npm:61.0.0"
-  dependencies:
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/constants": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.15.0"
-    "@metamask/gas-fee-controller": "npm:^25.0.0"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-network-controller": "npm:^2.0.0"
-    "@metamask/polling-controller": "npm:^15.0.0"
-    "@metamask/utils": "npm:^11.8.1"
-    bignumber.js: "npm:^9.1.2"
-    reselect: "npm:^5.1.1"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/accounts-controller": ^34.0.0
-    "@metamask/assets-controllers": ^89.0.0
-    "@metamask/network-controller": ^25.0.0
-    "@metamask/remote-feature-flag-controller": ^2.0.0
-    "@metamask/snaps-controllers": ^14.0.0
-    "@metamask/transaction-controller": ^61.0.0
-  checksum: 10/f1e8f4e6ec44130711a1ebf2bef082cd13b63b2e5043ca7b3a37eabce694913d2ca512f9178dc9e3925ec6eff28bdd75c7b52e78ba50f2c9b502f2a47a38f6bc
-  languageName: node
-  linkType: hard
-
 "@metamask/bridge-controller@npm:^64.1.0":
   version: 64.1.0
   resolution: "@metamask/bridge-controller@npm:64.1.0"
@@ -7326,38 +7294,6 @@ __metadata:
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
   checksum: 10/b5019e54b79e89da5271b43309074ce43dc831dc01a5acc028c3acc9a8655f842d6d0b74092a0ddab9e4db3c622dd31280af6cedc179fdc0af970b7373ba4474
-  languageName: node
-  linkType: hard
-
-"@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A61.0.0#~/.yarn/patches/@metamask-bridge-controller-npm-61.0.0-8c413c463f.patch":
-  version: 61.0.0
-  resolution: "@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A61.0.0#~/.yarn/patches/@metamask-bridge-controller-npm-61.0.0-8c413c463f.patch::version=61.0.0&hash=edc633"
-  dependencies:
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/constants": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.15.0"
-    "@metamask/gas-fee-controller": "npm:^25.0.0"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-network-controller": "npm:^2.0.0"
-    "@metamask/polling-controller": "npm:^15.0.0"
-    "@metamask/utils": "npm:^11.8.1"
-    bignumber.js: "npm:^9.1.2"
-    reselect: "npm:^5.1.1"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/accounts-controller": ^34.0.0
-    "@metamask/assets-controllers": ^89.0.0
-    "@metamask/network-controller": ^25.0.0
-    "@metamask/remote-feature-flag-controller": ^2.0.0
-    "@metamask/snaps-controllers": ^14.0.0
-    "@metamask/transaction-controller": ^61.0.0
-  checksum: 10/1beb273ef7bb5e419a82fd4a974569327d7dafd72142eb11de18ee2d7461bc53e38eddb35b56e0e882f3957952bc90af67122168c832760020ac0d09ef0fc896
   languageName: node
   linkType: hard
 
@@ -34221,7 +34157,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^5.3.0"
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^1.8.0"
-    "@metamask/bridge-controller": "patch:@metamask/bridge-controller@npm%3A61.0.0#~/.yarn/patches/@metamask-bridge-controller-npm-61.0.0-8c413c463f.patch"
+    "@metamask/bridge-controller": "npm:^64.1.0"
     "@metamask/bridge-status-controller": "npm:^61.0.0"
     "@metamask/browser-passworder": "npm:^5.0.0"
     "@metamask/build-utils": "npm:^3.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR bumps `@metamask/bridge-controller` to v64.1 and `@metamask/bridge-status-controller` to v64.0.1

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


<img width="1520" height="919" alt="Screenshot 2025-12-10 at 5 11 46 PM" src="https://github.com/user-attachments/assets/7b086e9d-fb48-4d83-8319-b482090931e4" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades bridge controllers and refactors bridge hooks/utils to use new quote properties and fiat calculations, adds `usd_amount_source`, updates tests, and removes an obsolete messenger action.
> 
> - **Dependencies**
>   - Upgrade `@metamask/bridge-controller` to `^64.1.0` and `@metamask/bridge-status-controller` to `^64.0.1`; remove patch; update `yarn.lock`.
> - **Bridge Quote Events**
>   - Replace manual event props with `getQuotesReceivedProperties` and adopt `QuoteWarning` typings; change warning key to `price_impact`.
> - **Unified Swap/Bridge Context**
>   - Add USD source amount via new exchange-rate utilities: compute `usd_amount_source` from `calcTokenFiatValue` and currency rates.
> - **Exchange Rates Utils**
>   - Extract `calcTokenFiatValue` (numeric) and rework `getDisplayCurrencyValue` to use it.
>   - Add `fetchTokenExchangeRates` for EVM (Codefi) and non-EVM (Price API) paths.
> - **Messaging**
>   - Remove delegated action `BridgeController:getBridgeERC20Allowance` from Bridge Status messenger.
> - **Tests**
>   - Update/expand tests for new warnings, event props, fiat calculations, fetching paths, and Solana handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 392679d409b3fedaa17a0a12b1b687405ff3c211. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->