### PR TITLE
chore: Update `@metamask/eslint-config-typescript`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,15 +34,11 @@ module.exports = {
         'react/no-unused-prop-types': 'off',
         'react/prop-types': 'off',
         'react/self-closing-comp': 'off',
-        // This change is included in `@metamask/eslint-config-typescript@10.0.0
-        '@typescript-eslint/no-unused-vars': [
+        // Temporarily overriding this rule to postpone this breaking change: https://github.com/MetaMask/eslint-config/pull/216
+        // TODO: Remove this override and align on prefering type over interface.
+        '@typescript-eslint/consistent-type-definitions': [
           'error',
-          {
-            vars: 'all',
-            args: 'all',
-            argsIgnorePattern: '[_]+',
-            ignoreRestSiblings: true, // this line is what has changed
-          },
+          'interface',
         ],
         '@typescript-eslint/no-explicit-any': 'error',
         // Under discussion

--- a/package.json
+++ b/package.json
@@ -500,7 +500,7 @@
     "@metamask/auto-changelog": "^5.3.0",
     "@metamask/browser-passworder": "^5.0.0",
     "@metamask/build-utils": "^3.0.0",
-    "@metamask/eslint-config-typescript": "^9.0.0",
+    "@metamask/eslint-config-typescript": "^10.0.0",
     "@metamask/eslint-plugin-design-tokens": "^1.0.0",
     "@metamask/foundryup": "1.0.0",
     "@metamask/mobile-provider": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7754,16 +7754,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eslint-config-typescript@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "@metamask/eslint-config-typescript@npm:9.0.1"
+"@metamask/eslint-config-typescript@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@metamask/eslint-config-typescript@npm:10.0.0"
   peerDependencies:
-    "@metamask/eslint-config": ^9.0.0
-    "@typescript-eslint/eslint-plugin": ^4.20.0
-    "@typescript-eslint/parser": ^4.20.0
-    eslint: ^7.23.0
+    "@metamask/eslint-config": ^10.0.0
+    "@typescript-eslint/eslint-plugin": ^5.33.0
+    "@typescript-eslint/parser": ^5.33.0
+    eslint: ^8.21.0
     typescript: ^4.0.7
-  checksum: 10/df6c630e285b1a125caffce1988c23b3ba0f76507c337a849fb30fb5f9b9df4bb563419f9bb2ec7e39072601b7e95a4d5be52ddff1643bde65206f33d73440d3
+  checksum: 10/08c052d3fe034c9712a69fda395975438ea18c10ee73bb573a6758e068d7020e62d9a7347eb2d67e5e7a38275fcd96b8f33e975d4f37363a8631c253d30f7dd9
   languageName: node
   linkType: hard
 
@@ -34317,7 +34317,7 @@ __metadata:
     "@metamask/eip1193-permission-middleware": "npm:^1.0.2"
     "@metamask/ens-resolver-snap": "npm:^1.0.0"
     "@metamask/error-reporting-service": "npm:^3.0.0"
-    "@metamask/eslint-config-typescript": "npm:^9.0.0"
+    "@metamask/eslint-config-typescript": "npm:^10.0.0"
     "@metamask/eslint-plugin-design-tokens": "npm:^1.0.0"
     "@metamask/eth-hd-keyring": "npm:^13.0.0"
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"


### PR DESCRIPTION
## **Description**

This package had a peer dependency on ESLint v7, but we're using v8. This update eliminates that peer dependency warning, and moves us closer to updating to ESLint v9.


## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades the ESLint TypeScript config to v10 and adds a temporary `consistent-type-definitions` override enforcing `interface` in `.eslintrc.js`.
> 
> - **Tooling / ESLint**:
>   - Upgrade `@metamask/eslint-config-typescript` to `^10.0.0` in `package.json` (lockfile updated accordingly).
>   - Update `.eslintrc.js` overrides for `*.{ts,tsx}`:
>     - Add temporary `@typescript-eslint/consistent-type-definitions: ['error', 'interface']` rule to defer a breaking change.
>     - Remove previous custom settings for `@typescript-eslint/no-unused-vars`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75899b36075fb1fa6a9d044875ae5610687f885f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->