### PR TITLE
chore: Improve readability of ESLint config (continued)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -229,7 +229,7 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'no-alert': 'error',
     'no-constant-condition': [
-      2,
+      'error',
       {
         checkLoops: false,
       },
@@ -253,14 +253,14 @@ module.exports = {
     'no-throw-literal': 'error',
     'no-unmodified-loop-condition': 'error',
     'no-unneeded-ternary': [
-      2,
+      'error',
       {
         defaultAssignment: false,
       },
     ],
     'no-unsafe-negation': 'error',
     'no-unused-expressions': 'off',
-    'no-use-before-define': [2, 'nofunc'],
+    'no-use-before-define': ['error', 'nofunc'],
     'no-useless-call': 'error',
     'no-useless-computed-key': 'error',
     'no-useless-concat': 'error',
@@ -290,7 +290,7 @@ module.exports = {
     'react/no-did-update-set-state': 'error',
     'react/no-find-dom-node': 'error',
     'react/no-multi-comp': [
-      2,
+      'error',
       {
         ignoreStateless: true,
       },


### PR DESCRIPTION
## **Description**

The previous PR to improve ESLint config readability missed a few cases where a number was used instead of a string for the rule severity. The last ones have been updated now.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

This is a continuation of #23821

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces remaining numeric ESLint severities with string "error" in .eslintrc.js.
> 
> - **ESLint config (`.eslintrc.js`)**:
>   - Standardizes severity to strings (`'error'`) for:
>     - `no-constant-condition`
>     - `no-unneeded-ternary`
>     - `no-use-before-define` (now `['error', 'nofunc']`)
>     - `react/no-multi-comp`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c4c8daf437cd7358be054d82d993dcd2170d1df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->