### PR TITLE
chore: created getBiometricPasswordIfAllowed in Authentication service

### DIFF
--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -20,7 +20,6 @@ import StorageWrapper from '../../../store/storage-wrapper';
 import { connect } from 'react-redux';
 import { passwordSet, seedphraseNotBackedUp } from '../../../actions/user';
 import { setLockTime } from '../../../actions/settings';
-import Engine from '../../../core/Engine';
 import Device from '../../../util/device';
 import { fontStyles, baseStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
@@ -32,7 +31,6 @@ import {
   TRUE,
   BIOMETRY_CHOICE_DISABLED,
   PASSCODE_DISABLED,
-  BIOMETRY_CHOICE,
 } from '../../../constants/storage';
 import {
   getPasswordStrengthWord,
@@ -639,16 +637,11 @@ class ResetPassword extends PureComponent {
     );
   };
 
-  tryExportSeedPhrase = async (password) => {
-    const { KeyringController } = Engine.context;
-    await KeyringController.exportSeedPhrase(password);
-  };
-
   tryUnlockWithPassword = async (password) => {
     this.setState({ ready: false });
     try {
       // Just try
-      await this.tryExportSeedPhrase(password);
+      await Authentication.verifySrpExportPassword(password);
       this.setState({
         password: null,
         originalPassword: password,

--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -399,13 +399,9 @@ class ResetPassword extends PureComponent {
   };
 
   unlockWithBiometrics = async () => {
-    // Try to use biometrics to unlock
-    const biometryChoice = await StorageWrapper.getItem(BIOMETRY_CHOICE);
-    if (biometryChoice) {
-      const credentials = await Authentication.getPassword();
-      if (credentials) {
-        this.tryUnlockWithPassword(credentials.password);
-      }
+    const password = await Authentication.getBiometricPasswordIfAllowed();
+    if (password) {
+      this.tryUnlockWithPassword(password);
     }
   };
 

--- a/app/components/Views/ResetPassword/index.test.tsx
+++ b/app/components/Views/ResetPassword/index.test.tsx
@@ -64,6 +64,9 @@ jest.mock('../../../core/Authentication', () => ({
   }),
   getPassword: jest.fn().mockResolvedValue(null),
   getBiometricPasswordIfAllowed: jest.fn().mockResolvedValue(null),
+  verifySrpExportPassword: jest
+    .fn()
+    .mockResolvedValue(new Uint8Array([1, 2, 3])),
   resetPassword: jest.fn().mockResolvedValue(undefined),
   storePassword: jest.fn().mockResolvedValue(undefined),
   newWalletAndKeychain: jest

--- a/app/components/Views/ResetPassword/index.test.tsx
+++ b/app/components/Views/ResetPassword/index.test.tsx
@@ -16,7 +16,7 @@ import NavigationService from '../../../core/NavigationService';
 import AUTHENTICATION_TYPE from '../../../constants/userProperties';
 import { Authentication } from '../../../core';
 import StorageWrapper from '../../../store/storage-wrapper';
-import { BIOMETRY_TYPE, STORAGE_TYPE } from 'react-native-keychain';
+import { BIOMETRY_TYPE } from 'react-native-keychain';
 import Device from '../../../util/device';
 import ReduxService from '../../../core/redux/ReduxService';
 import { ReduxStore } from '../../../core/redux/types';
@@ -63,6 +63,7 @@ jest.mock('../../../core/Authentication', () => ({
     availableBiometryType: null,
   }),
   getPassword: jest.fn().mockResolvedValue(null),
+  getBiometricPasswordIfAllowed: jest.fn().mockResolvedValue(null),
   resetPassword: jest.fn().mockResolvedValue(undefined),
   storePassword: jest.fn().mockResolvedValue(undefined),
   newWalletAndKeychain: jest
@@ -602,14 +603,12 @@ describe('ResetPassword', () => {
       availableBiometryType: BIOMETRY_TYPE.FACE_ID,
     });
 
-    // Mock Authentication.getPassword to return credentials
-    const mockGetPassword = jest.spyOn(Authentication, 'getPassword');
-    mockGetPassword.mockResolvedValueOnce({
-      username: 'testUser',
-      password: 'testPassword123',
-      service: 'testService',
-      storage: STORAGE_TYPE.AES_GCM,
-    });
+    // Mock Authentication.getBiometricPasswordIfAllowed to return a password
+    const mockGetBiometricPasswordIfAllowed = jest.spyOn(
+      Authentication,
+      'getBiometricPasswordIfAllowed',
+    );
+    mockGetBiometricPasswordIfAllowed.mockResolvedValueOnce('testPassword123');
 
     // Mock StorageWrapper.getItem to return biometry choice
     const mockStorageWrapper = jest.mocked(StorageWrapper);
@@ -642,6 +641,9 @@ describe('ResetPassword', () => {
     expect(mockStorageWrapper.getItem).toHaveBeenCalledWith(
       '@MetaMask:passcodeDisabled',
     );
+
+    // Verify that biometric password lookup was attempted
+    expect(mockGetBiometricPasswordIfAllowed).toHaveBeenCalled();
 
     // Component should render without errors
     expect(component).toBeTruthy();

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.test.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.test.tsx
@@ -96,6 +96,9 @@ jest.mock('../../../core/Authentication', () => ({
   getType: jest.fn().mockResolvedValue({ availableBiometryType: null }),
   getPassword: jest.fn().mockResolvedValue(null),
   getBiometricPasswordIfAllowed: jest.fn().mockResolvedValue(null),
+  verifySrpExportPassword: jest
+    .fn()
+    .mockResolvedValue(new Uint8Array([1, 2, 3])),
 }));
 
 // Mock StorageWrapper - necessary for testing without real storage operations

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -164,9 +164,6 @@ const RevealPrivateCredential = ({
 
   const tryUnlockWithPassword = useCallback(
     async (pswd: string, privCredentialName?: string) => {
-      // TODO: Replace "any" with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { KeyringController } = Engine.context as any;
       const isPrivateKeyReveal = privCredentialName === PRIVATE_KEY;
 
       // This will trigger after the user hold-pressed the button, we want to trace the actual
@@ -183,12 +180,15 @@ const RevealPrivateCredential = ({
       try {
         let privateCredential;
         if (!isPrivateKeyReveal) {
-          const uint8ArraySeed = await KeyringController.exportSeedPhrase(
+          const uint8ArraySeed = await Authentication.verifySrpExportPassword(
             pswd,
             keyringId,
           );
           privateCredential = uint8ArrayToMnemonic(uint8ArraySeed, wordlist);
         } else {
+          // TODO: Replace "any" with type
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const { KeyringController } = Engine.context as any;
           privateCredential = await KeyringController.exportAccount(
             pswd,
             selectedAddress,

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -18,7 +18,6 @@ import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const CustomTabView = ScrollView as any;
 import { store } from '../../../store';
-import StorageWrapper from '../../../store/storage-wrapper';
 import ActionView from '../../UI/ActionView';
 import ButtonReveal from '../../UI/ButtonReveal';
 import Button, {
@@ -42,7 +41,6 @@ import {
 import ClipboardManager from '../../../core/ClipboardManager';
 import { useTheme } from '../../../util/theme';
 import Engine from '../../../core/Engine';
-import { BIOMETRY_CHOICE } from '../../../constants/storage';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { uint8ArrayToMnemonic } from '../../../util/mnemonic';
 import { passwordRequirementsMet } from '../../../util/password';
@@ -241,12 +239,9 @@ const RevealPrivateCredential = ({
       if (!passwordSet) {
         tryUnlockWithPassword('');
       } else if (availableBiometryType) {
-        const biometryChoice = await StorageWrapper.getItem(BIOMETRY_CHOICE);
-        if (biometryChoice !== '' && biometryChoice === availableBiometryType) {
-          const credentials = await Authentication.getPassword();
-          if (credentials) {
-            tryUnlockWithPassword(credentials.password);
-          }
+        const password = await Authentication.getBiometricPasswordIfAllowed();
+        if (password) {
+          tryUnlockWithPassword(password);
         }
       }
     };

--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -4,6 +4,7 @@ import {
   TRUE,
   PASSCODE_DISABLED,
   SOLANA_DISCOVERY_PENDING,
+  BIOMETRY_CHOICE,
 } from '../../constants/storage';
 import { Authentication } from './Authentication';
 import AUTHENTICATION_TYPE from '../../constants/userProperties';
@@ -3164,6 +3165,44 @@ describe('Authentication', () => {
           shouldSelectAccount: false,
         },
       );
+    });
+  });
+
+  describe('getBiometricPasswordIfAllowed', () => {
+    beforeEach(() => {
+      (SecureKeychain.getGenericPassword as jest.Mock).mockReset();
+    });
+
+    it('returns null when biometry choice is not enabled', async () => {
+      const result = await Authentication.getBiometricPasswordIfAllowed();
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when biometry choice is enabled but no credentials are stored', async () => {
+      await StorageWrapper.setItem(BIOMETRY_CHOICE, TRUE);
+
+      (SecureKeychain.getGenericPassword as jest.Mock).mockResolvedValue(null);
+
+      const result = await Authentication.getBiometricPasswordIfAllowed();
+
+      expect(SecureKeychain.getGenericPassword).toHaveBeenCalledTimes(1);
+      expect(result).toBeNull();
+    });
+
+    it('returns stored password when biometry choice is enabled and credentials exist', async () => {
+      await StorageWrapper.setItem(BIOMETRY_CHOICE, TRUE);
+
+      const mockPassword = 'test-password';
+      (SecureKeychain.getGenericPassword as jest.Mock).mockResolvedValue({
+        username: 'test-user',
+        password: mockPassword,
+      });
+
+      const result = await Authentication.getBiometricPasswordIfAllowed();
+
+      expect(SecureKeychain.getGenericPassword).toHaveBeenCalledTimes(1);
+      expect(result).toBe(mockPassword);
     });
   });
 });

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -1311,6 +1311,21 @@ class AuthenticationService {
     }
     return credentials?.password ?? null;
   };
+
+  /**
+   * Verifies a password by attempting to export the SRP for a given keyring.
+   * Returns the SRP bytes on success and throws on failure.
+   *
+   * @param password - Password provided by the user.
+   * @param keyringId - Optional keyring id. When not provided, the primary keyring is used.
+   */
+  verifySrpExportPassword = async (
+    password: string,
+    keyringId?: string,
+  ): Promise<Uint8Array> => {
+    const { KeyringController } = Engine.context;
+    return await KeyringController.exportSeedPhrase(password, keyringId);
+  };
 }
 
 export const Authentication = new AuthenticationService();

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -6,6 +6,7 @@ import {
   TRUE,
   PASSCODE_DISABLED,
   SEED_PHRASE_HINTS,
+  BIOMETRY_CHOICE,
 } from '../../constants/storage';
 import {
   authSuccess,
@@ -1293,6 +1294,22 @@ class AuthenticationService {
     await SeedlessOnboardingController.storeKeyringEncryptionKey(
       keyringEncryptionKey,
     );
+  };
+
+  /**
+   * Returns the stored password if biometric login is enabled, otherwise null.
+   */
+  getBiometricPasswordIfAllowed = async (): Promise<string | null> => {
+    const biometryChoice = await StorageWrapper.getItem(BIOMETRY_CHOICE);
+    if (!biometryChoice) {
+      return null;
+    }
+
+    const credentials = await this.getPassword();
+    if (!credentials) {
+      return null;
+    }
+    return credentials?.password ?? null;
   };
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Created getBiometricPasswordIfAllowed & verifySrpExportPassword functions in Authentication service

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes: this is part of https://github.com/MetaMask/MetaMask-planning/issues/6008

## **Manual testing steps**
No functional changes 
```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds helpers to fetch biometric-stored password and verify SRP export, and refactors ResetPassword and RevealPrivateCredential to use them with updated tests.
> 
> - **Core/Auth**:
>   - Add `Authentication.getBiometricPasswordIfAllowed` (checks `BIOMETRY_CHOICE` and returns stored keychain password).
>   - Add `Authentication.verifySrpExportPassword` (wraps `KeyringController.exportSeedPhrase`).
>   - Unit tests for both methods.
> - **Views**:
>   - `Views/ResetPassword`:
>     - Use `getBiometricPasswordIfAllowed` for biometric unlock.
>     - Use `verifySrpExportPassword` to validate current password before reset.
>     - Remove direct `Engine` usage and `BIOMETRY_CHOICE` checks.
>   - `Views/RevealPrivateCredential`:
>     - Use `verifySrpExportPassword` for SRP reveal and keep `exportAccount` for private key.
>     - Use `getBiometricPasswordIfAllowed` for biometric unlock.
>     - Remove `StorageWrapper`/`BIOMETRY_CHOICE` dependency for biometric flow.
> - **Tests**:
>   - Update mocks and expectations to new `Authentication` methods in `ResetPassword` and `RevealPrivateCredential` tests.
>   - Remove unused imports (e.g., `STORAGE_TYPE`) and adjust biometric flow assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec3a92b0614db5c4fd539e3f5f2b3b02ac8e62fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->