### PR TITLE
fix: updated checkbox border to correct color

### DIFF
--- a/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/__snapshots__/ListItemMultiSelectWithMenuButton.test.tsx.snap
+++ b/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/__snapshots__/ListItemMultiSelectWithMenuButton.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`ListItemMultiSelectWithMenuButton should render correctly with default 
               {
                 "alignItems": "center",
                 "backgroundColor": "#ffffff",
-                "borderColor": "#121314",
+                "borderColor": "#b7bbc8",
                 "borderRadius": 4,
                 "borderWidth": 2,
                 "height": 20,

--- a/app/component-library/components/Cells/Cell/__snapshots__/Cell.test.tsx.snap
+++ b/app/component-library/components/Cells/Cell/__snapshots__/Cell.test.tsx.snap
@@ -312,7 +312,7 @@ exports[`Cell should render CellMultiSelect given the type MultiSelect 1`] = `
               {
                 "alignItems": "center",
                 "backgroundColor": "#ffffff",
-                "borderColor": "#121314",
+                "borderColor": "#b7bbc8",
                 "borderRadius": 4,
                 "borderWidth": 2,
                 "height": 20,
@@ -636,7 +636,7 @@ exports[`Cell should render CellMultiSelectWithMenu given the type MultiSelectWi
               {
                 "alignItems": "center",
                 "backgroundColor": "#ffffff",
-                "borderColor": "#121314",
+                "borderColor": "#b7bbc8",
                 "borderRadius": 4,
                 "borderWidth": 2,
                 "height": 20,

--- a/app/component-library/components/Cells/Cell/variants/CellMultiSelect/__snapshots__/CellMultiSelect.test.tsx.snap
+++ b/app/component-library/components/Cells/Cell/variants/CellMultiSelect/__snapshots__/CellMultiSelect.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`CellMultiSelect should render default settings correctly 1`] = `
               {
                 "alignItems": "center",
                 "backgroundColor": "#ffffff",
-                "borderColor": "#121314",
+                "borderColor": "#b7bbc8",
                 "borderRadius": 4,
                 "borderWidth": 2,
                 "height": 20,

--- a/app/component-library/components/Checkbox/Checkbox.styles.ts
+++ b/app/component-library/components/Checkbox/Checkbox.styles.ts
@@ -43,7 +43,7 @@ const styleSheet = (params: { theme: Theme; vars: CheckboxStyleSheetVars }) => {
       ? theme.colors.error.default
       : isChecked || isIndeterminate
         ? theme.colors.primary.default
-        : theme.colors.icon.default;
+        : theme.colors.border.default;
 
   return StyleSheet.create({
     base: Object.assign(

--- a/app/component-library/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/app/component-library/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Checkbox should render correctly 1`] = `
       {
         "alignItems": "center",
         "backgroundColor": "#ffffff",
-        "borderColor": "#121314",
+        "borderColor": "#b7bbc8",
         "borderRadius": 4,
         "borderWidth": 2,
         "height": 20,

--- a/app/components/UI/BasicFunctionality/BasicFunctionalityModal/__snapshots__/BasicFunctionalityModal.test.js.snap
+++ b/app/components/UI/BasicFunctionality/BasicFunctionalityModal/__snapshots__/BasicFunctionalityModal.test.js.snap
@@ -270,7 +270,7 @@ exports[`BasicFunctionalityModal should render correctly 1`] = `
                 {
                   "alignItems": "center",
                   "backgroundColor": "#ffffff",
-                  "borderColor": "#121314",
+                  "borderColor": "#b7bbc8",
                   "borderRadius": 4,
                   "borderWidth": 2,
                   "height": 20,

--- a/app/components/UI/NetworkSelectorList/__snapshots__/NetworkSelectorList.test.tsx.snap
+++ b/app/components/UI/NetworkSelectorList/__snapshots__/NetworkSelectorList.test.tsx.snap
@@ -113,7 +113,7 @@ exports[`NetworkSelectorList renders correctly with default props 1`] = `
                       {
                         "alignItems": "center",
                         "backgroundColor": "#ffffff",
-                        "borderColor": "#121314",
+                        "borderColor": "#b7bbc8",
                         "borderRadius": 4,
                         "borderWidth": 2,
                         "height": 20,

--- a/app/components/UI/OptinMetrics/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/OptinMetrics/__snapshots__/index.test.tsx.snap
@@ -472,7 +472,7 @@ exports[`OptinMetrics Snapshots android render matches snapshot 1`] = `
                                         {
                                           "alignItems": "center",
                                           "backgroundColor": "#ffffff",
-                                          "borderColor": "#121314",
+                                          "borderColor": "#b7bbc8",
                                           "borderRadius": 4,
                                           "borderWidth": 2,
                                           "height": 20,
@@ -1164,7 +1164,7 @@ exports[`OptinMetrics Snapshots android render matches snapshot with status bar 
                                         {
                                           "alignItems": "center",
                                           "backgroundColor": "#ffffff",
-                                          "borderColor": "#121314",
+                                          "borderColor": "#b7bbc8",
                                           "borderRadius": 4,
                                           "borderWidth": 2,
                                           "height": 20,
@@ -1968,7 +1968,7 @@ exports[`OptinMetrics Snapshots iOS renders correctly 1`] = `
                                         {
                                           "alignItems": "center",
                                           "backgroundColor": "#ffffff",
-                                          "borderColor": "#121314",
+                                          "borderColor": "#b7bbc8",
                                           "borderRadius": 4,
                                           "borderWidth": 2,
                                           "height": 20,

--- a/app/components/UI/Ramp/Deposit/components/NetworksFilterSelector/__snapshots__/NetworksFilterSelector.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/NetworksFilterSelector/__snapshots__/NetworksFilterSelector.test.tsx.snap
@@ -468,7 +468,7 @@ exports[`NetworksFilterSelector renders correctly when networkFilter is a subset
                       {
                         "alignItems": "center",
                         "backgroundColor": "#ffffff",
-                        "borderColor": "#121314",
+                        "borderColor": "#b7bbc8",
                         "borderRadius": 4,
                         "borderWidth": 2,
                         "height": 20,
@@ -743,7 +743,7 @@ exports[`NetworksFilterSelector renders correctly when networkFilter is null 1`]
                       {
                         "alignItems": "center",
                         "backgroundColor": "#ffffff",
-                        "borderColor": "#121314",
+                        "borderColor": "#b7bbc8",
                         "borderRadius": 4,
                         "borderWidth": 2,
                         "height": 20,
@@ -894,7 +894,7 @@ exports[`NetworksFilterSelector renders correctly when networkFilter is null 1`]
                       {
                         "alignItems": "center",
                         "backgroundColor": "#ffffff",
-                        "borderColor": "#121314",
+                        "borderColor": "#b7bbc8",
                         "borderRadius": 4,
                         "borderWidth": 2,
                         "height": 20,
@@ -1045,7 +1045,7 @@ exports[`NetworksFilterSelector renders correctly when networkFilter is null 1`]
                       {
                         "alignItems": "center",
                         "backgroundColor": "#ffffff",
-                        "borderColor": "#121314",
+                        "borderColor": "#b7bbc8",
                         "borderRadius": 4,
                         "borderWidth": 2,
                         "height": 20,

--- a/app/components/UI/SearchTokenAutocomplete/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/SearchTokenAutocomplete/__snapshots__/index.test.tsx.snap
@@ -566,7 +566,7 @@ exports[`SearchTokenAutocomplete renders correctly with selected chain 1`] = `
                                                 {
                                                   "alignItems": "center",
                                                   "backgroundColor": "#ffffff",
-                                                  "borderColor": "#121314",
+                                                  "borderColor": "#b7bbc8",
                                                   "borderRadius": 4,
                                                   "borderWidth": 2,
                                                   "height": 20,
@@ -808,7 +808,7 @@ exports[`SearchTokenAutocomplete renders correctly with selected chain 1`] = `
                                                 {
                                                   "alignItems": "center",
                                                   "backgroundColor": "#ffffff",
-                                                  "borderColor": "#121314",
+                                                  "borderColor": "#b7bbc8",
                                                   "borderRadius": 4,
                                                   "borderWidth": 2,
                                                   "height": 20,

--- a/app/components/UI/SkipAccountSecurityModal/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/SkipAccountSecurityModal/__snapshots__/index.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`SkipAccountSecurityModal with empty route params render matches snapsho
             {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderColor": "#121314",
+              "borderColor": "#b7bbc8",
               "borderRadius": 4,
               "borderWidth": 2,
               "height": 20,
@@ -285,7 +285,7 @@ exports[`SkipAccountSecurityModal with route params render matches snapshot 1`] 
             {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderColor": "#121314",
+              "borderColor": "#b7bbc8",
               "borderRadius": 4,
               "borderWidth": 2,
               "height": 20,

--- a/app/components/Views/AccountConnect/AccountConnectMultiSelector/__snapshots__/AccountConnectMultiSelector.test.tsx.snap
+++ b/app/components/Views/AccountConnect/AccountConnectMultiSelector/__snapshots__/AccountConnectMultiSelector.test.tsx.snap
@@ -542,7 +542,7 @@ exports[`AccountConnectMultiSelector renders correctly 1`] = `
                         {
                           "alignItems": "center",
                           "backgroundColor": "#ffffff",
-                          "borderColor": "#121314",
+                          "borderColor": "#b7bbc8",
                           "borderRadius": 4,
                           "borderWidth": 2,
                           "height": 20,

--- a/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
@@ -436,7 +436,7 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                   {
                     "alignItems": "center",
                     "backgroundColor": "#ffffff",
-                    "borderColor": "#121314",
+                    "borderColor": "#b7bbc8",
                     "borderRadius": 4,
                     "borderWidth": 2,
                     "height": 20,

--- a/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/__snapshots__/NetworkConnectMultiSelector.test.tsx.snap
+++ b/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/__snapshots__/NetworkConnectMultiSelector.test.tsx.snap
@@ -448,7 +448,7 @@ exports[`NetworkConnectMultiSelector renders correctly 1`] = `
                           {
                             "alignItems": "center",
                             "backgroundColor": "#ffffff",
-                            "borderColor": "#121314",
+                            "borderColor": "#b7bbc8",
                             "borderRadius": 4,
                             "borderWidth": 2,
                             "height": 20,


### PR DESCRIPTION
## **Description**

updated checkbox border to correct color

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-248

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

`~`

### **Before**

<img width="500" alt="Simulator Screenshot - iPhone 17 - 2025-12-10 at 10 44 33" src="https://github.com/user-attachments/assets/654932f7-f22d-4505-afaf-72b8328cf58d" />

### **After**

<img width="500" alt="Simulator Screenshot - iPhone 17 - 2025-12-10 at 10 28 21" src="https://github.com/user-attachments/assets/c9f193f6-f379-400c-8e36-550742491a9d" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets unchecked checkbox border to `theme.colors.border.default`, updating snapshots across affected components.
> 
> - **Component styles**:
>   - Update `borderColor` for unchecked `Checkbox` in `app/component-library/components/Checkbox/Checkbox.styles.ts` from `theme.colors.icon.default` to `theme.colors.border.default`.
> - **Tests/Snapshots**:
>   - Refresh snapshots to reflect `borderColor` change (`#121314` → `#b7bbc8`) across `Cells/Cell`, `CellMultiSelect`, `ListItemMultiSelectWithMenuButton`, `BasicFunctionalityModal`, `NetworkSelectorList`, `OptinMetrics`, `NetworksFilterSelector`, `SearchTokenAutocomplete`, `SkipAccountSecurityModal`, `AccountConnectMultiSelector`, `ChoosePassword`, and `NetworkConnectMultiSelector`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17d99c12b8ab5316dbb7b7d458792730d0a60b82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->