### PR TITLE
fix: rounds down the min received amount in swaps

### DIFF
--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { TouchableOpacity, Platform, UIManager } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import I18n, { strings } from '../../../../../../locales/i18n';
+import { strings } from '../../../../../../locales/i18n';
 import Text, {
   TextColor,
   TextVariant,
@@ -30,7 +30,7 @@ import {
   selectSourceToken,
 } from '../../../../../core/redux/slices/bridge';
 import { getNativeSourceToken } from '../../utils/tokenUtils';
-import { getIntlNumberFormatter } from '../../../../../util/intl';
+import { formatMinimumReceived } from '../../utils/currencyUtils';
 import { useRewards } from '../../hooks/useRewards';
 import RewardsAnimations, {
   RewardAnimationState,
@@ -54,11 +54,6 @@ const QuoteDetailsCard: React.FC = () => {
   const theme = useTheme();
   const navigation = useNavigation();
   const styles = createStyles(theme);
-
-  const locale = I18n.locale;
-  const intlNumberFormatter = getIntlNumberFormatter(locale, {
-    maximumSignificantDigits: 8,
-  });
 
   const {
     formattedQuoteData,
@@ -142,8 +137,8 @@ const QuoteDetailsCard: React.FC = () => {
   const gasIncluded7702 = !!activeQuote?.quote.gasIncluded7702;
   const isGasless = gasIncluded7702 || gasIncluded;
 
-  const formattedMinToTokenAmount = intlNumberFormatter.format(
-    parseFloat(activeQuote?.minToTokenAmount?.amount || '0'),
+  const formattedMinToTokenAmount = formatMinimumReceived(
+    activeQuote?.minToTokenAmount?.amount || '0',
   );
 
   return (

--- a/app/components/UI/Bridge/utils/currencyUtils.test.ts
+++ b/app/components/UI/Bridge/utils/currencyUtils.test.ts
@@ -1,6 +1,6 @@
 import I18n from '../../../../../locales/i18n';
 import { getIntlNumberFormatter } from '../../../../util/intl';
-import { formatCurrency } from './currencyUtils';
+import { formatCurrency, formatMinimumReceived } from './currencyUtils';
 
 jest.mock('../../../../../locales/i18n', () => ({
   locale: 'en-US',
@@ -398,5 +398,57 @@ describe('formatCurrency', () => {
       // Reset locale
       (I18n as { locale: string }).locale = 'en-US';
     });
+  });
+});
+
+describe('formatMinimumReceived', () => {
+  const mockFormat = jest.fn();
+  const mockGetIntlNumberFormatter =
+    getIntlNumberFormatter as jest.MockedFunction<typeof getIntlNumberFormatter>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetIntlNumberFormatter.mockReturnValue({
+      format: mockFormat,
+    } as unknown as Intl.NumberFormat);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('floors values down instead of rounding up', () => {
+    mockFormat.mockImplementation((val) => String(val));
+
+    formatMinimumReceived(0.012579999);
+
+    expect(mockFormat).toHaveBeenCalledWith(0.01257999);
+  });
+
+  it('parses string amounts', () => {
+    mockFormat.mockImplementation((val) => String(val));
+
+    formatMinimumReceived('1.2345');
+
+    expect(mockFormat).toHaveBeenCalledWith(1.2345);
+  });
+
+  it('returns "0" for invalid input', () => {
+    const result = formatMinimumReceived('not-a-number');
+
+    expect(result).toBe('0');
+  });
+
+  it('uses locale from I18n', () => {
+    mockFormat.mockImplementation((val) => String(val));
+    (I18n as { locale: string }).locale = 'de-DE';
+
+    formatMinimumReceived(1.234);
+
+    expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith('de-DE', {
+      maximumSignificantDigits: 8,
+    });
+
+    (I18n as { locale: string }).locale = 'en-US';
   });
 });

--- a/app/components/UI/Bridge/utils/currencyUtils.test.ts
+++ b/app/components/UI/Bridge/utils/currencyUtils.test.ts
@@ -404,7 +404,9 @@ describe('formatCurrency', () => {
 describe('formatMinimumReceived', () => {
   const mockFormat = jest.fn();
   const mockGetIntlNumberFormatter =
-    getIntlNumberFormatter as jest.MockedFunction<typeof getIntlNumberFormatter>;
+    getIntlNumberFormatter as jest.MockedFunction<
+      typeof getIntlNumberFormatter
+    >;
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/app/components/UI/Bridge/utils/currencyUtils.ts
+++ b/app/components/UI/Bridge/utils/currencyUtils.ts
@@ -2,6 +2,22 @@ import I18n from '../../../../../locales/i18n';
 import { getIntlNumberFormatter } from '../../../../util/intl';
 
 /**
+ * Formats a minimum received amount, always rounding down to ensure users
+ * never see a minimum higher than they might actually receive.
+ */
+export function formatMinimumReceived(amount: number | string): string {
+  const numAmount = typeof amount === 'string' ? parseFloat(amount) : amount;
+  if (isNaN(numAmount)) return '0';
+
+  // Floor to 8 decimal places before formatting
+  const flooredAmount = Math.floor(numAmount * 1e8) / 1e8;
+
+  return getIntlNumberFormatter(I18n.locale, {
+    maximumSignificantDigits: 8,
+  }).format(flooredAmount);
+}
+
+/**
  * Formats currency amounts using the device's locale
  * @param amount - The amount to format (number or string)
  * @param currency - The currency code (e.g., 'USD', 'EUR')


### PR DESCRIPTION
## **Description**

The "Minimum Received" amount in the bridge feature was rounding up when displaying values with decimal precision, which could show users a minimum amount higher than they might actually receive (e.g., 0.01257 displayed as 0.013).

This change ensures the minimum received amount always rounds down by flooring the value before formatting, so users never see a minimum that exceeds what they'll actually receive.

## **Changelog**

CHANGELOG entry: improved the minimum received bridge label by rounding down

## **Related issues**

Fixes: [add your ticket link here]

## **Manual testing steps**

Feature: Bridge Minimum Received Display

  Scenario: user views minimum received amount in bridge quote

    Given user is on the bridge screen with a valid quote
    And the estimated destination amount has decimal precision (e.g., 0.01257)

    When user views the quote details

    Then the "Minimum received" amount should be rounded down
    And the displayed minimum should never exceed the estimated amount

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a formatter that floors minimum received to 8 decimals and uses it in QuoteDetailsCard, with unit tests.
> 
> - **Bridge Utils**:
>   - Add `formatMinimumReceived` in `utils/currencyUtils` to floor values to 8 decimals and format via locale.
>   - Add tests in `utils/currencyUtils.test.ts` covering flooring behavior, string parsing, invalid input, and locale usage.
> - **UI**:
>   - Update `components/QuoteDetailsCard/QuoteDetailsCard.tsx` to use `formatMinimumReceived` for displaying `minimum_received`, replacing direct intl formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7abb276748a8dba075b2e06ed395c1a58d51e62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->