### PR TITLE
fix: enhance insufficient balance alert logic for gas fee tokens

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -174,6 +174,44 @@ describe('useInsufficientBalanceAlert', () => {
     expect(result.current).toEqual([]);
   });
 
+  it('return alert when balance is insufficient and has GasFeeTokens but not selected gas fee token', () => {
+    useIsGaslessSupportedMock.mockReturnValueOnce({
+      isSmartTransaction: true,
+      isSupported: true,
+      pending: false,
+    });
+    mockSelectUseTransactionSimulations.mockReturnValueOnce(true);
+    const txWithGasFeeTokens = {
+      ...mockTransaction,
+      gasFeeTokens: [
+        {
+          tokenAddress: '0xabc' as Hex,
+          symbol: 'GFT',
+          decimals: 18,
+        },
+      ],
+    } as unknown as TransactionMeta;
+    mockUseTransactionMetadataRequest.mockReturnValue(txWithGasFeeTokens);
+
+    const { result } = renderHook(() => useInsufficientBalanceAlert());
+
+    expect(result.current).toEqual([
+      {
+        action: {
+          label: `Buy ${mockNativeCurrency}`,
+          callback: expect.any(Function),
+        },
+        isBlocking: true,
+        field: RowAlertKey.EstimatedFee,
+        key: AlertKeys.InsufficientBalance,
+        message: `Insufficient ${mockNativeCurrency} balance`,
+        title: 'Insufficient Balance',
+        severity: Severity.Danger,
+        skipConfirmation: true,
+      },
+    ]);
+  });
+
   it('return alert when balance is insufficient (with maxFeePerGas)', () => {
     // Transaction needs: value (5) + (maxFeePerGas (3) * gas (2)) = 11 wei
     // Balance is only 8 wei, so should show alert

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -71,18 +71,22 @@ export const useInsufficientBalanceAlert = ({
     // Check if user has selected a gas fee token (or we're ignoring that check)
     const hasNoGasFeeTokenSelected = ignoreGasFeeToken || !selectedGasFeeToken;
 
-    // Show alert when gasless check is done and either:
-    // - Gasless is NOT supported (user needs native currency for gas)
-    // - Gasless IS supported but gasFeeTokens is empty (no alternative tokens available)
+    // Gasless check is complete AND one of:
+    //  - Gasless is NOT supported (native currency needed for gas)
+    //  - Gasless IS supported but no alternative gas fee tokens are available
+    //  - Gas fee tokens are available but none is selected
     const shouldCheckGaslessConditions =
-      isGaslessCheckComplete && (!isGaslessSupported || isGasFeeTokensEmpty);
+      isGaslessCheckComplete &&
+      (!isGaslessSupported ||
+        isGasFeeTokensEmpty ||
+        (!isGasFeeTokensEmpty && !selectedGasFeeToken));
 
     const showAlert =
       hasInsufficientBalance &&
       isSimulationComplete &&
       hasNoGasFeeTokenSelected &&
-      !hasTransactionType(transactionMetadata, IGNORE_TYPES) &&
       shouldCheckGaslessConditions &&
+      !hasTransactionType(transactionMetadata, IGNORE_TYPES) &&
       !isSponsoredTransaction;
 
     if (!showAlert) {

--- a/app/components/Views/confirmations/hooks/useAutomaticGasFeeTokenSelect.ts
+++ b/app/components/Views/confirmations/hooks/useAutomaticGasFeeTokenSelect.ts
@@ -7,8 +7,7 @@ import { useTransactionMetadataRequest } from './transactions/useTransactionMeta
 import { useHasInsufficientBalance } from './useHasInsufficientBalance';
 
 export function useAutomaticGasFeeTokenSelect() {
-  const { isSupported: isGaslessSupported, isSmartTransaction } =
-    useIsGaslessSupported();
+  const { isSmartTransaction } = useIsGaslessSupported();
   const { hasInsufficientBalance } = useHasInsufficientBalance();
   const transactionMeta =
     (useTransactionMetadataRequest() as TransactionMeta) ??
@@ -36,7 +35,6 @@ export function useAutomaticGasFeeTokenSelect() {
 
   const shouldSelect =
     !checked &&
-    isGaslessSupported &&
     hasInsufficientBalance &&
     !selectedGasFeeToken &&
     Boolean(firstGasFeeTokenAddress);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This Pr fixed an scenario where gasless checks are completed, user has gas fee tokens to pay for the transaction, is automatically selected the other tokens available but user uses the modal to select the native token, which should be flagged by the alert and block user to submit the transaction.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where switching back to the native token after automatic gas fee token selection did not trigger the insufficient balance alert. 

## **Related issues**

Fixes: https://github.com/MetaMask/mobile-planning/issues/2383

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

[fixed_alert.webm](https://github.com/user-attachments/assets/77eca79c-e00c-4b06-becc-2011f932dfc2)

[alert_without_gasfeetokens.webm](https://github.com/user-attachments/assets/45d70640-a103-4be5-a0f4-eef93d427dba)


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates alert logic to trigger when gas fee tokens are available but not selected and refines automatic gas fee token selection; adds a targeted test.
> 
> - **Alerts**
>   - `useInsufficientBalanceAlert`: Refines `shouldCheckGaslessConditions` to also trigger when gas fee tokens exist but no token is selected; keeps alert gated by simulation completion and unsponsored status; minor condition reordering for clarity.
> - **Auto-selection**
>   - `useAutomaticGasFeeTokenSelect`: Removes dependency on `isSupported` for auto-selection; now auto-selects the first non-native gas fee token when balance is insufficient and no token is selected (still considers `isSmartTransaction`).
> - **Tests**
>   - `useInsufficientBalanceAlert.test`: Adds test covering the case where gas fee tokens are available but none is selected, asserting the insufficient balance alert is shown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c4937501f491a7b3b80aac0f7da11abc16c18bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->