### PR TITLE
feat(predict): configure fees via feature flag cp-7.61.0

### DIFF
--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -1,0 +1,12 @@
+import { PredictFeeCollection } from '../types/flags';
+
+export const DEFAULT_FEE_COLLECTION_FLAG = {
+  enabled: true,
+  collector:
+    process.env.METAMASK_ENVIRONMENT === 'dev'
+      ? '0xe6a2026d58eaff3c7ad7ba9386fb143388002382'
+      : '0x100c7b833bbd604a77890783439bbb9d65e31de7',
+  metamaskFee: 0.02, // 2%
+  providerFee: 0.02, // 2%
+  waiveList: [],
+} satisfies PredictFeeCollection;

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -79,6 +79,19 @@ jest.mock('../../../../core/Engine', () => ({
         },
       }),
     },
+    RemoteFeatureFlagController: {
+      state: {
+        remoteFeatureFlags: {
+          predictFeeCollection: {
+            enabled: true,
+            collector: '0x100c7b833bbd604a77890783439bbb9d65e31de7',
+            metamaskFee: 0.02,
+            providerFee: 0.02,
+            waiveList: [],
+          },
+        },
+      },
+    },
   },
 }));
 
@@ -3269,19 +3282,26 @@ describe('PredictController', () => {
         });
 
         expect(result).toEqual(mockOrderPreview);
-        expect(mockPolymarketProvider.previewOrder).toHaveBeenCalledWith({
-          providerId: 'polymarket',
-          marketId: 'market-1',
-          outcomeId: 'outcome-1',
-          outcomeTokenId: 'token-1',
-          side: Side.BUY,
-          size: 100,
-          signer: expect.objectContaining({
-            address: '0x1234567890123456789012345678901234567890',
-            signTypedMessage: expect.any(Function),
-            signPersonalMessage: expect.any(Function),
+        expect(mockPolymarketProvider.previewOrder).toHaveBeenCalledWith(
+          expect.objectContaining({
+            marketId: 'market-1',
+            outcomeId: 'outcome-1',
+            outcomeTokenId: 'token-1',
+            side: Side.BUY,
+            size: 100,
+            signer: expect.objectContaining({
+              address: '0x1234567890123456789012345678901234567890',
+              signTypedMessage: expect.any(Function),
+              signPersonalMessage: expect.any(Function),
+            }),
+            feeCollection: expect.objectContaining({
+              enabled: true,
+              collector: expect.any(String),
+              metamaskFee: expect.any(Number),
+              providerFee: expect.any(Number),
+            }),
           }),
-        });
+        );
       });
     });
 

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -80,6 +80,8 @@ import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../constants/errors';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { GEO_BLOCKED_COUNTRIES } from '../constants/geoblock';
 import { MATIC_CONTRACTS } from '../providers/polymarket/constants';
+import { DEFAULT_FEE_COLLECTION_FLAG } from '../constants/flags';
+import { PredictFeeCollection } from '../types/flags';
 
 /**
  * State shape for PredictController
@@ -1265,9 +1267,16 @@ export class PredictController extends BaseController<
         throw new Error('Provider not available');
       }
 
+      const { RemoteFeatureFlagController } = Engine.context;
+      const feeCollection =
+        (RemoteFeatureFlagController.state.remoteFeatureFlags
+          .predictFeeCollection as unknown as
+          | PredictFeeCollection
+          | undefined) ?? DEFAULT_FEE_COLLECTION_FLAG;
+
       const signer = this.getSigner();
 
-      return provider.previewOrder({ ...params, signer });
+      return provider.previewOrder({ ...params, signer, feeCollection });
     } catch (error) {
       // Log to Sentry with preview context (no sensitive amounts)
       Logger.error(

--- a/app/components/UI/Predict/hooks/usePredictOrderPreview.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderPreview.test.ts
@@ -3,6 +3,7 @@ import { usePredictOrderPreview } from './usePredictOrderPreview';
 import { usePredictTrading } from './usePredictTrading';
 import { OrderPreview, PreviewOrderParams } from '../providers/types';
 import { Side } from '../types';
+import { DEFAULT_FEE_COLLECTION_FLAG } from '../constants/flags';
 
 jest.mock('./usePredictTrading');
 
@@ -26,6 +27,7 @@ describe('usePredictOrderPreview', () => {
       providerFee: 1,
       totalFee: 2,
       totalFeePercentage: 4,
+      collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
     },
   };
 

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -38,6 +38,7 @@ import {
   Side,
 } from '../../types';
 import { PREDICT_ERROR_CODES } from '../../constants/errors';
+import { DEFAULT_FEE_COLLECTION_FLAG } from '../../constants/flags';
 import { OrderPreview, PlaceOrderParams } from '../types';
 import { PolymarketProvider } from './PolymarketProvider';
 import {
@@ -741,6 +742,7 @@ describe('PolymarketProvider', () => {
         providerFee: 0.02,
         totalFee: 0.04,
         totalFeePercentage: 0.04,
+        collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
       },
       ...overrides,
     };
@@ -1364,6 +1366,7 @@ describe('PolymarketProvider', () => {
           providerFee: 0.02,
           totalFee: 0.04,
           totalFeePercentage: 0.04,
+          collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
         },
       });
       const orderParams: PlaceOrderParams = {
@@ -1385,6 +1388,7 @@ describe('PolymarketProvider', () => {
           providerFee: 0.02,
           totalFee: 0.04,
           totalFeePercentage: 0.04,
+          collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
         },
       });
       const orderParams: PlaceOrderParams = {
@@ -1411,6 +1415,7 @@ describe('PolymarketProvider', () => {
           providerFee: 0.02,
           totalFee: 0.04,
           totalFeePercentage: 0.04,
+          collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
         },
       });
       const orderParams: PlaceOrderParams = {
@@ -1437,6 +1442,7 @@ describe('PolymarketProvider', () => {
           providerFee: 0.02,
           totalFee: 0.04,
           totalFeePercentage: 0.04,
+          collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
         },
       });
       const orderParams: PlaceOrderParams = {
@@ -1464,7 +1470,7 @@ describe('PolymarketProvider', () => {
       );
     });
 
-    it('uses FEE_COLLECTOR_ADDRESS as recipient', async () => {
+    it('uses collector from fees as recipient', async () => {
       const { provider, mockSigner } = setupPlaceOrderTest();
       const preview = createMockOrderPreview({
         side: Side.BUY,
@@ -1473,6 +1479,7 @@ describe('PolymarketProvider', () => {
           providerFee: 0.02,
           totalFee: 0.04,
           totalFeePercentage: 0.04,
+          collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
         },
       });
       const orderParams: PlaceOrderParams = {
@@ -1503,6 +1510,7 @@ describe('PolymarketProvider', () => {
           providerFee: 0,
           totalFee: 0,
           totalFeePercentage: 0,
+          collector: '0x0',
         },
       });
 
@@ -3459,6 +3467,8 @@ describe('PolymarketProvider', () => {
             metamaskFee: 0.5,
             providerFee: 0.5,
             totalFee: 1,
+            totalFeePercentage: 1,
+            collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
           },
         });
       };

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -1214,6 +1214,11 @@ describe('PolymarketProvider', () => {
   describe('previewOrder', () => {
     it('calls previewOrder utility function with correct parameters', async () => {
       const provider = createProvider();
+      const mockSigner = {
+        address: '0x1234567890123456789012345678901234567890',
+        signTypedMessage: jest.fn(),
+        signPersonalMessage: jest.fn(),
+      };
       const mockParams = {
         marketId: 'market-123',
         outcomeId: 'outcome-456',
@@ -1221,6 +1226,7 @@ describe('PolymarketProvider', () => {
         side: Side.BUY,
         amount: 100,
         size: 100,
+        signer: mockSigner,
       };
 
       await provider.previewOrder(mockParams);
@@ -3495,21 +3501,6 @@ describe('PolymarketProvider', () => {
         });
 
         expect(sellPreview.rateLimited).toBe(true);
-      });
-
-      it('does not set rateLimited when signer is not provided', async () => {
-        setupPreviewOrderMock();
-        const { provider } = setupPlaceOrderTest();
-
-        const preview = await provider.previewOrder({
-          marketId: 'market-1',
-          outcomeId: 'outcome-1',
-          outcomeTokenId: '0',
-          side: Side.BUY,
-          size: 10,
-        });
-
-        expect(preview.rateLimited).toBeUndefined();
       });
 
       it('does not set rateLimited when address has never placed an order', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -50,7 +50,6 @@ import {
   SignWithdrawResponse,
 } from '../types';
 import {
-  FEE_COLLECTOR_ADDRESS,
   MATIC_CONTRACTS,
   MIN_COLLATERAL_BALANCE_FOR_CLAIM,
   ORDER_RATE_LIMIT_MS,
@@ -96,6 +95,7 @@ import {
   roundOrderAmount,
   submitClobOrder,
 } from './utils';
+import { PredictFeeCollection } from '../../types/flags';
 
 export type SignTypedMessageFn = (
   params: TypedMessageParams,
@@ -868,7 +868,10 @@ export class PolymarketProvider implements PredictProvider {
   }
 
   public async previewOrder(
-    params: Omit<PreviewOrderParams, 'providerId'> & { signer?: Signer },
+    params: Omit<PreviewOrderParams, 'providerId'> & {
+      signer: Signer;
+      feeCollection?: PredictFeeCollection;
+    },
   ): Promise<OrderPreview> {
     const basePreview = await previewOrder(params);
 
@@ -1062,7 +1065,7 @@ export class PolymarketProvider implements PredictProvider {
           safeAddress,
           signer,
           amount: feeAmountInUsdc,
-          to: FEE_COLLECTOR_ADDRESS,
+          to: fees.collector,
         });
       }
 

--- a/app/components/UI/Predict/providers/polymarket/constants.ts
+++ b/app/components/UI/Predict/providers/polymarket/constants.ts
@@ -2,12 +2,6 @@ import { ContractConfig, RoundConfig, TickSize } from './types';
 
 export const POLYMARKET_PROVIDER_ID = 'polymarket';
 
-export const FEE_PERCENTAGE = 4; // 4%
-export const FEE_COLLECTOR_ADDRESS =
-  process.env.METAMASK_ENVIRONMENT === 'dev'
-    ? '0xe6a2026d58eaff3c7ad7ba9386fb143388002382'
-    : '0x100c7b833bbd604a77890783439bbb9d65e31de7';
-
 /**
  * Default slippage for market orders.
  */

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -29,7 +29,6 @@ import type {
 import {
   ClobAuthDomain,
   EIP712Domain,
-  FEE_PERCENTAGE,
   HASH_ZERO_BYTES32,
   MATIC_CONTRACTS,
   MSG_TO_SIGN,
@@ -57,6 +56,7 @@ import {
   OrderBook,
 } from './types';
 import { PREDICT_ERROR_CODES } from '../../constants/errors';
+import { PredictFeeCollection } from '../../types/flags';
 
 export const getPolymarketEndpoints = () => ({
   GAMMA_API_ENDPOINT: 'https://gamma-api.polymarket.com',
@@ -915,44 +915,57 @@ export function encodeClaim(
   });
 }
 
-async function waiveFees({ marketId }: { marketId: string }) {
+async function waiveFees({
+  marketId,
+  waiveList,
+}: {
+  marketId: string;
+  waiveList: string[];
+}) {
   const market = await getMarketDetailsFromGammaApi({ marketId });
   const { tags } = market;
-  return tags?.map((t) => t.slug).includes('middle-east') ?? false;
+  const slugs = tags.map((t) => t.slug);
+  return slugs.some((slug) => waiveList.includes(slug)) ?? false;
 }
 
 export async function calculateFees({
+  feeCollection,
   marketId,
   userBetAmount,
 }: {
+  feeCollection?: PredictFeeCollection;
   marketId: string;
   userBetAmount: number;
 }): Promise<PredictFees> {
-  if (await waiveFees({ marketId })) {
+  if (
+    !feeCollection ||
+    (await waiveFees({ marketId, waiveList: feeCollection.waiveList }))
+  ) {
     return {
       metamaskFee: 0,
       providerFee: 0,
       totalFee: 0,
       totalFeePercentage: 0,
+      collector: '0x0',
     };
   }
 
-  let totalFee = 0;
+  const totalFeePercentage =
+    (feeCollection.metamaskFee + feeCollection.providerFee) * 100;
 
-  totalFee = (userBetAmount * FEE_PERCENTAGE) / 100;
+  const metamaskFee = userBetAmount * feeCollection.metamaskFee;
+  const providerFee = userBetAmount * feeCollection.providerFee;
+  let totalFee = metamaskFee + providerFee;
 
   // Round to 4 decimals
   totalFee = Math.round(totalFee * 10000) / 10000;
-
-  // split total 50/50 between metamask and provider
-  const metamaskFee = totalFee / 2;
-  const providerFee = totalFee - metamaskFee;
 
   return {
     metamaskFee,
     providerFee,
     totalFee,
-    totalFeePercentage: FEE_PERCENTAGE,
+    totalFeePercentage,
+    collector: feeCollection.collector,
   };
 }
 
@@ -1300,9 +1313,12 @@ export const roundOrderAmount = ({
 };
 
 export const previewOrder = async (
-  params: Omit<PreviewOrderParams, 'providerId'>,
+  params: Omit<PreviewOrderParams, 'providerId'> & {
+    feeCollection?: PredictFeeCollection;
+  },
 ): Promise<OrderPreview> => {
-  const { marketId, outcomeId, outcomeTokenId, side, size } = params;
+  const { marketId, outcomeId, outcomeTokenId, side, size, feeCollection } =
+    params;
   const book = await getOrderBook({ tokenId: outcomeTokenId });
   if (!book) {
     throw new Error(PREDICT_ERROR_CODES.PREVIEW_NO_ORDER_BOOK);
@@ -1337,6 +1353,7 @@ export const previewOrder = async (
       minOrderSize: parseFloat(book.min_order_size),
       negRisk: book.neg_risk,
       fees: await calculateFees({
+        feeCollection,
         marketId,
         userBetAmount: size,
       }),

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -953,12 +953,15 @@ export async function calculateFees({
   const totalFeePercentage =
     (feeCollection.metamaskFee + feeCollection.providerFee) * 100;
 
-  const metamaskFee = userBetAmount * feeCollection.metamaskFee;
-  const providerFee = userBetAmount * feeCollection.providerFee;
-  let totalFee = metamaskFee + providerFee;
+  let metamaskFee = userBetAmount * feeCollection.metamaskFee;
+  let providerFee = userBetAmount * feeCollection.providerFee;
 
-  // Round to 4 decimals
-  totalFee = Math.round(totalFee * 10000) / 10000;
+  // Round to 3 decimals
+  metamaskFee = Math.round(metamaskFee * 1000) / 1000;
+  providerFee = Math.round(providerFee * 1000) / 1000;
+
+  // Rounded to 4 decimals
+  const totalFee = metamaskFee + providerFee;
 
   return {
     metamaskFee,

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -924,8 +924,8 @@ async function waiveFees({
 }) {
   const market = await getMarketDetailsFromGammaApi({ marketId });
   const { tags } = market;
-  const slugs = tags.map((t) => t.slug);
-  return slugs.some((slug) => waiveList.includes(slug)) ?? false;
+  const slugs = tags?.map((t) => t.slug);
+  return slugs?.some((slug) => waiveList.includes(slug)) ?? false;
 }
 
 export async function calculateFees({
@@ -938,7 +938,7 @@ export async function calculateFees({
   userBetAmount: number;
 }): Promise<PredictFees> {
   if (
-    !feeCollection ||
+    !feeCollection?.enabled ||
     (await waiveFees({ marketId, waiveList: feeCollection.waiveList }))
   ) {
     return {

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -13,6 +13,7 @@ import {
 } from '../types';
 import { Hex } from '@metamask/utils';
 import { TransactionType } from '@metamask/transaction-controller';
+import { PredictFeeCollection } from '../types/flags';
 
 export interface GetMarketsParams {
   providerId?: string;
@@ -73,6 +74,7 @@ export interface PredictFees {
   providerFee: number;
   totalFee: number;
   totalFeePercentage: number;
+  collector: Hex;
 }
 
 export interface GeoBlockResponse {
@@ -234,7 +236,10 @@ export interface PredictProvider {
 
   // Order management
   previewOrder(
-    params: Omit<PreviewOrderParams, 'providerId'> & { signer: Signer },
+    params: Omit<PreviewOrderParams, 'providerId'> & {
+      signer: Signer;
+      feeCollection?: PredictFeeCollection;
+    },
   ): Promise<OrderPreview>;
   placeOrder(
     params: Omit<PlaceOrderParams, 'providerId'> & { signer: Signer },

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -1,0 +1,9 @@
+import type { Hex } from '@metamask/utils';
+
+export interface PredictFeeCollection {
+  enabled: boolean;
+  collector: Hex;
+  metamaskFee: number;
+  providerFee: number;
+  waiveList: string[];
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Currently, fee collection settings are all hardcoded (amounts, collector address, waived categories).
However, this creates a security concern in a scenario where the collector account gets compromised.

This change enables the use of LD feature flag to configure the Predict fee collection.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/23856

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds remote-configurable Predict fee collection (percentages, collector, waivers) and wires it through order preview and Polymarket flows, replacing hardcoded fees.
> 
> - **Predict Fees (Feature Flag)**
>   - Add `PredictFeeCollection` type and `DEFAULT_FEE_COLLECTION_FLAG`.
>   - Load `remoteFeatureFlags.predictFeeCollection` in `PredictController.previewOrder` and pass `feeCollection` to providers.
> - **Polymarket Provider & Utils**
>   - Update `previewOrder` and fee logic to accept `feeCollection`; compute fees from `metamaskFee`/`providerFee`, respect `waiveList`, and include `collector`.
>   - Use `fees.collector` for Safe fee authorization in `placeOrder`; remove hardcoded `FEE_PERCENTAGE` and `FEE_COLLECTOR_ADDRESS`.
> - **Types**
>   - Extend `PredictFees` with `collector`; update provider interfaces to accept `feeCollection`.
> - **Tests**
>   - Adjust/add tests to validate flag-driven fee calculation, collector propagation, waived-fee cases, and controller/provider integrations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec2cc32546326f16bc677a88a8783266c2766d3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->