### PR TITLE
fix: Fix send flow to not filter assets on back and forth navigation

### DIFF
--- a/app/components/Views/confirmations/components/send/recipient/recipient.test.tsx
+++ b/app/components/Views/confirmations/components/send/recipient/recipient.test.tsx
@@ -167,6 +167,14 @@ const mockUseRecipientSelectionMetrics = jest.mocked(
 const mockUseSendActions = jest.mocked(useSendActions);
 const mockUseSendType = jest.mocked(useSendType);
 
+function createMockUseSendType(
+  returnValues: Partial<ReturnType<typeof useSendType>>,
+) {
+  mockUseSendType.mockReturnValue(
+    returnValues as ReturnType<typeof useSendType>,
+  );
+}
+
 describe('Recipient', () => {
   const mockUpdateTo = jest.fn();
   const mockHandleSubmitPress = jest.fn();
@@ -212,14 +220,8 @@ describe('Recipient', () => {
     });
 
     mockDoENSLookup.mockReturnValue(Promise.resolve(''));
-    mockUseSendType.mockReturnValue({
+    createMockUseSendType({
       isEvmSendType: true,
-      isEvmNativeSendType: false,
-      isNonEvmSendType: false,
-      isNonEvmNativeSendType: false,
-      isSolanaSendType: false,
-      isBitcoinSendType: false,
-      isTronSendType: false,
     });
   });
 

--- a/app/components/Views/confirmations/hooks/send/useAccounts.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccounts.test.ts
@@ -61,6 +61,14 @@ const mockUseSendContext = useSendContext as jest.MockedFunction<
   typeof useSendContext
 >;
 
+function createMockUseSendType(
+  returnValues: Partial<ReturnType<typeof useSendType>>,
+) {
+  mockUseSendType.mockReturnValue(
+    returnValues as ReturnType<typeof useSendType>,
+  );
+}
+
 describe('useAccounts', () => {
   const mockEvmAccount = {
     id: 'evm-account-1',
@@ -166,14 +174,9 @@ describe('useAccounts', () => {
       return [];
     });
 
-    mockUseSendType.mockReturnValue({
+    createMockUseSendType({
       isEvmSendType: true,
-      isSolanaSendType: false,
-      isEvmNativeSendType: false,
-      isNonEvmSendType: false,
-      isNonEvmNativeSendType: false,
-      isBitcoinSendType: false,
-      isTronSendType: false,
+      isPredefinedEvm: true,
     });
 
     mockUseSendContext.mockReturnValue({
@@ -200,6 +203,10 @@ describe('useAccounts', () => {
         isNonEvmNativeSendType: false,
         isBitcoinSendType: false,
         isTronSendType: false,
+        isPredefinedEvm: true,
+        isPredefinedSolana: false,
+        isPredefinedBitcoin: false,
+        isPredefinedTron: false,
       });
       mockIsEvmAccountType.mockImplementation(
         (accountType) => accountType === 'eip155:eoa',
@@ -254,14 +261,9 @@ describe('useAccounts', () => {
 
   describe('when isSolanaSendType is true', () => {
     beforeEach(() => {
-      mockUseSendType.mockReturnValue({
-        isEvmSendType: false,
+      createMockUseSendType({
         isSolanaSendType: true,
-        isEvmNativeSendType: false,
-        isNonEvmSendType: false,
-        isNonEvmNativeSendType: false,
-        isBitcoinSendType: false,
-        isTronSendType: false,
+        isPredefinedSolana: true,
       });
       mockIsEvmAccountType.mockReturnValue(false);
       mockIsSolanaAccount.mockImplementation(
@@ -298,14 +300,9 @@ describe('useAccounts', () => {
 
   describe('when isBitcoinSendType is true', () => {
     beforeEach(() => {
-      mockUseSendType.mockReturnValue({
-        isEvmSendType: false,
-        isSolanaSendType: false,
-        isEvmNativeSendType: false,
-        isNonEvmSendType: false,
-        isNonEvmNativeSendType: false,
+      createMockUseSendType({
         isBitcoinSendType: true,
-        isTronSendType: false,
+        isPredefinedBitcoin: true,
       });
       mockIsEvmAccountType.mockReturnValue(false);
       mockIsSolanaAccount.mockReturnValue(false);
@@ -359,14 +356,9 @@ describe('useAccounts', () => {
 
   describe('when isTronSendType is true', () => {
     beforeEach(() => {
-      mockUseSendType.mockReturnValue({
-        isEvmSendType: false,
-        isSolanaSendType: false,
-        isEvmNativeSendType: false,
-        isNonEvmSendType: false,
-        isNonEvmNativeSendType: false,
-        isBitcoinSendType: false,
+      createMockUseSendType({
         isTronSendType: true,
+        isPredefinedTron: true,
       });
       mockIsEvmAccountType.mockReturnValue(false);
       mockIsSolanaAccount.mockReturnValue(false);
@@ -421,15 +413,7 @@ describe('useAccounts', () => {
 
   describe('when neither EVM nor Solana send type is active', () => {
     beforeEach(() => {
-      mockUseSendType.mockReturnValue({
-        isEvmSendType: false,
-        isSolanaSendType: false,
-        isEvmNativeSendType: false,
-        isNonEvmSendType: false,
-        isNonEvmNativeSendType: false,
-        isBitcoinSendType: false,
-        isTronSendType: false,
-      });
+      createMockUseSendType({});
     });
 
     it('returns empty array', () => {
@@ -472,14 +456,9 @@ describe('useAccounts', () => {
   });
 
   it('handles wallet with no compatible accounts', () => {
-    mockUseSendType.mockReturnValue({
+    createMockUseSendType({
       isEvmSendType: true,
-      isSolanaSendType: false,
-      isEvmNativeSendType: false,
-      isNonEvmSendType: false,
-      isNonEvmNativeSendType: false,
-      isBitcoinSendType: false,
-      isTronSendType: false,
+      isPredefinedEvm: true,
     });
     mockIsEvmAccountType.mockReturnValue(false);
 
@@ -568,14 +547,9 @@ describe('useAccounts', () => {
     };
 
     beforeEach(() => {
-      mockUseSendType.mockReturnValue({
+      createMockUseSendType({
         isEvmSendType: true,
-        isSolanaSendType: false,
-        isEvmNativeSendType: false,
-        isNonEvmSendType: false,
-        isNonEvmNativeSendType: false,
-        isBitcoinSendType: false,
-        isTronSendType: false,
+        isPredefinedEvm: true,
       });
       mockIsEvmAccountType.mockImplementation(
         (accountType) => accountType === 'eip155:eoa',
@@ -623,14 +597,9 @@ describe('useAccounts', () => {
   });
 
   it('calls isEvmAccountType for each account when isEvmSendType is true', () => {
-    mockUseSendType.mockReturnValue({
+    createMockUseSendType({
       isEvmSendType: true,
-      isSolanaSendType: false,
-      isEvmNativeSendType: false,
-      isNonEvmSendType: false,
-      isNonEvmNativeSendType: false,
-      isBitcoinSendType: false,
-      isTronSendType: false,
+      isPredefinedEvm: true,
     });
 
     renderHook(() => useAccounts());
@@ -640,14 +609,9 @@ describe('useAccounts', () => {
   });
 
   it('calls isSolanaAccount for each account when isSolanaSendType is true', () => {
-    mockUseSendType.mockReturnValue({
-      isEvmSendType: false,
+    createMockUseSendType({
       isSolanaSendType: true,
-      isEvmNativeSendType: false,
-      isNonEvmSendType: false,
-      isNonEvmNativeSendType: false,
-      isBitcoinSendType: false,
-      isTronSendType: false,
+      isPredefinedSolana: true,
     });
 
     renderHook(() => useAccounts());

--- a/app/components/Views/confirmations/hooks/send/useContacts.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useContacts.test.ts
@@ -20,6 +20,14 @@ import { selectAddressBook } from '../../../../../selectors/addressBookControlle
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockUseSendType = useSendType as jest.MockedFunction<typeof useSendType>;
 
+function createMockUseSendType(
+  returnValues: Partial<ReturnType<typeof useSendType>>,
+) {
+  mockUseSendType.mockReturnValue(
+    returnValues as ReturnType<typeof useSendType>,
+  );
+}
+
 describe('useContacts', () => {
   const mockEvmContact1 = {
     name: 'John Doe',
@@ -81,14 +89,8 @@ describe('useContacts', () => {
       return {};
     });
 
-    mockUseSendType.mockReturnValue({
+    createMockUseSendType({
       isEvmSendType: true,
-      isSolanaSendType: false,
-      isEvmNativeSendType: false,
-      isNonEvmSendType: false,
-      isNonEvmNativeSendType: false,
-      isBitcoinSendType: false,
-      isTronSendType: false,
     });
   });
 
@@ -102,6 +104,10 @@ describe('useContacts', () => {
         isNonEvmNativeSendType: false,
         isBitcoinSendType: false,
         isTronSendType: false,
+        isPredefinedEvm: true,
+        isPredefinedSolana: false,
+        isPredefinedBitcoin: false,
+        isPredefinedTron: false,
       });
     });
 
@@ -150,15 +156,7 @@ describe('useContacts', () => {
 
   describe('when neither EVM nor Solana send type is active', () => {
     beforeEach(() => {
-      mockUseSendType.mockReturnValue({
-        isEvmSendType: false,
-        isSolanaSendType: false,
-        isEvmNativeSendType: false,
-        isNonEvmSendType: false,
-        isNonEvmNativeSendType: false,
-        isBitcoinSendType: false,
-        isTronSendType: false,
-      });
+      createMockUseSendType({});
     });
 
     it('returns all contacts without filtering', () => {
@@ -202,14 +200,9 @@ describe('useContacts', () => {
   });
 
   it('returns empty array when isNonEvmSendType is true', () => {
-    mockUseSendType.mockReturnValue({
+    createMockUseSendType({
       isEvmSendType: true,
-      isSolanaSendType: false,
-      isEvmNativeSendType: false,
       isNonEvmSendType: true,
-      isNonEvmNativeSendType: false,
-      isBitcoinSendType: false,
-      isTronSendType: false,
     });
     const { result } = renderHook(() => useContacts());
     expect(result.current).toEqual([]);
@@ -289,14 +282,9 @@ describe('useContacts', () => {
     });
 
     it('filters addresses correctly for EVM when addresses have different lengths', () => {
-      mockUseSendType.mockReturnValue({
+      createMockUseSendType({
         isEvmSendType: true,
-        isSolanaSendType: false,
-        isEvmNativeSendType: false,
-        isNonEvmSendType: false,
-        isNonEvmNativeSendType: false,
-        isBitcoinSendType: false,
-        isTronSendType: false,
+        isPredefinedEvm: true,
       });
 
       const { result } = renderHook(() => useContacts());

--- a/app/components/Views/confirmations/hooks/send/useSendTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendTokens.test.ts
@@ -104,8 +104,20 @@ describe('useSendTokens', () => {
       isSolanaSendType: undefined,
       isBitcoinSendType: undefined,
       isTronSendType: undefined,
+      isPredefinedEvm: false,
+      isPredefinedSolana: false,
+      isPredefinedBitcoin: false,
+      isPredefinedTron: false,
     });
   });
+
+  function createMockUseSendType(
+    returnValues: Partial<ReturnType<typeof useSendType>>,
+  ) {
+    mockUseSendType.mockReturnValue(
+      returnValues as ReturnType<typeof useSendType>,
+    );
+  }
 
   it('returns all tokens when no send type is set', () => {
     mockUseAccountTokens.mockReturnValue([
@@ -123,15 +135,12 @@ describe('useSendTokens', () => {
     expect(result.current).toHaveLength(4);
   });
 
-  it('filters to EVM tokens when isEvmSendType is true', () => {
-    mockUseSendType.mockReturnValue({
-      isEvmSendType: true,
-      isEvmNativeSendType: undefined,
-      isNonEvmSendType: undefined,
-      isNonEvmNativeSendType: undefined,
-      isSolanaSendType: undefined,
-      isBitcoinSendType: undefined,
-      isTronSendType: undefined,
+  it('filters to EVM tokens when isPredefinedEvm is true', () => {
+    createMockUseSendType({
+      isPredefinedEvm: true,
+      isPredefinedSolana: false,
+      isPredefinedTron: false,
+      isPredefinedBitcoin: false,
     });
     mockUseAccountTokens.mockReturnValue([
       mockEvmToken,
@@ -149,15 +158,12 @@ describe('useSendTokens', () => {
     expect(result.current[0]).toEqual(mockEvmToken);
   });
 
-  it('filters to Solana tokens when isSolanaSendType is true', () => {
-    mockUseSendType.mockReturnValue({
-      isEvmSendType: undefined,
-      isEvmNativeSendType: undefined,
-      isNonEvmSendType: true,
-      isNonEvmNativeSendType: undefined,
-      isSolanaSendType: true,
-      isBitcoinSendType: undefined,
-      isTronSendType: undefined,
+  it('filters to Solana tokens when isPredefinedSolana is true', () => {
+    createMockUseSendType({
+      isPredefinedEvm: false,
+      isPredefinedSolana: true,
+      isPredefinedTron: false,
+      isPredefinedBitcoin: false,
     });
     mockUseAccountTokens.mockReturnValue([
       mockEvmToken,
@@ -175,15 +181,12 @@ describe('useSendTokens', () => {
     expect(result.current[0]).toEqual(mockSolanaToken);
   });
 
-  it('filters to Tron tokens when isTronSendType is true', () => {
-    mockUseSendType.mockReturnValue({
-      isEvmSendType: undefined,
-      isEvmNativeSendType: undefined,
-      isNonEvmSendType: true,
-      isNonEvmNativeSendType: undefined,
-      isSolanaSendType: undefined,
-      isBitcoinSendType: undefined,
-      isTronSendType: true,
+  it('filters to Tron tokens when isPredefinedTron is true', () => {
+    createMockUseSendType({
+      isPredefinedEvm: false,
+      isPredefinedSolana: false,
+      isPredefinedTron: true,
+      isPredefinedBitcoin: false,
     });
     mockUseAccountTokens.mockReturnValue([
       mockEvmToken,
@@ -201,15 +204,12 @@ describe('useSendTokens', () => {
     expect(result.current[0]).toEqual(mockTronToken);
   });
 
-  it('filters to Bitcoin tokens when isBitcoinSendType is true', () => {
-    mockUseSendType.mockReturnValue({
-      isEvmSendType: undefined,
-      isEvmNativeSendType: undefined,
-      isNonEvmSendType: true,
-      isNonEvmNativeSendType: undefined,
-      isSolanaSendType: undefined,
-      isBitcoinSendType: true,
-      isTronSendType: undefined,
+  it('filters to Bitcoin tokens when isPredefinedBitcoin is true', () => {
+    createMockUseSendType({
+      isPredefinedEvm: false,
+      isPredefinedSolana: false,
+      isPredefinedTron: false,
+      isPredefinedBitcoin: true,
     });
     mockUseAccountTokens.mockReturnValue([
       mockEvmToken,
@@ -238,14 +238,11 @@ describe('useSendTokens', () => {
   });
 
   it('prioritizes first matching account type when multiple are true', () => {
-    mockUseSendType.mockReturnValue({
-      isEvmSendType: true,
-      isEvmNativeSendType: undefined,
-      isNonEvmSendType: true,
-      isNonEvmNativeSendType: undefined,
-      isSolanaSendType: true,
-      isBitcoinSendType: undefined,
-      isTronSendType: undefined,
+    createMockUseSendType({
+      isPredefinedEvm: true,
+      isPredefinedSolana: true,
+      isPredefinedTron: false,
+      isPredefinedBitcoin: false,
     });
     mockUseAccountTokens.mockReturnValue([
       mockEvmToken,

--- a/app/components/Views/confirmations/hooks/send/useSendTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendTokens.ts
@@ -8,16 +8,20 @@ export function useSendTokens({
 }: {
   includeNoBalance?: boolean;
 } = {}): AssetType[] {
-  const { isEvmSendType, isSolanaSendType, isTronSendType, isBitcoinSendType } =
-    useSendType();
+  const {
+    isPredefinedTron,
+    isPredefinedBitcoin,
+    isPredefinedSolana,
+    isPredefinedEvm,
+  } = useSendType();
   const allTokens = useAccountTokens({ includeNoBalance });
 
   return useMemo(() => {
     const accountTypeMap: Record<string, boolean> = {
-      eip155: !!isEvmSendType,
-      solana: !!isSolanaSendType,
-      tron: !!isTronSendType,
-      bip122: !!isBitcoinSendType,
+      eip155: !!isPredefinedEvm,
+      solana: !!isPredefinedSolana,
+      tron: !!isPredefinedTron,
+      bip122: !!isPredefinedBitcoin,
     };
 
     const matchedAccountType = Object.entries(accountTypeMap).find(
@@ -33,9 +37,9 @@ export function useSendTokens({
     );
   }, [
     allTokens,
-    isEvmSendType,
-    isSolanaSendType,
-    isTronSendType,
-    isBitcoinSendType,
+    isPredefinedEvm,
+    isPredefinedSolana,
+    isPredefinedTron,
+    isPredefinedBitcoin,
   ]);
 }

--- a/app/components/Views/confirmations/hooks/send/useSendType.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.test.ts
@@ -52,10 +52,12 @@ describe('useSendType', () => {
         isNonEvmNativeSendType: undefined,
         isNonEvmSendType: undefined,
         isSolanaSendType: undefined,
-        isPredefinedEvm: undefined,
-        isPredefinedSolana: undefined,
-        isPredefinedBitcoin: undefined,
-        isPredefinedTron: undefined,
+        isBitcoinSendType: undefined,
+        isTronSendType: undefined,
+        isPredefinedEvm: false,
+        isPredefinedSolana: false,
+        isPredefinedBitcoin: false,
+        isPredefinedTron: false,
       });
     });
   });

--- a/app/components/Views/confirmations/hooks/send/useSendType.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.test.ts
@@ -52,6 +52,10 @@ describe('useSendType', () => {
         isNonEvmNativeSendType: undefined,
         isNonEvmSendType: undefined,
         isSolanaSendType: undefined,
+        isPredefinedEvm: undefined,
+        isPredefinedSolana: undefined,
+        isPredefinedBitcoin: undefined,
+        isPredefinedTron: undefined,
       });
     });
   });

--- a/app/components/Views/confirmations/hooks/send/useSendType.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.ts
@@ -81,27 +81,35 @@ export const useSendType = () => {
   return useMemo(
     () => ({
       isEvmSendType,
+      isPredefinedEvm,
       isEvmNativeSendType: isEvmSendType && assetIsNative,
       isNonEvmNativeSendType: isNonEvmSendType && assetIsNative,
       isNonEvmSendType,
       isSolanaSendType,
+      isPredefinedSolana,
       /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
       isBitcoinSendType,
+      isPredefinedBitcoin,
       /// END:ONLY_INCLUDE_IF
       /// BEGIN:ONLY_INCLUDE_IF(tron)
       isTronSendType,
+      isPredefinedTron,
       /// END:ONLY_INCLUDE_IF
     }),
     [
       isEvmSendType,
+      isPredefinedEvm,
       isNonEvmSendType,
       assetIsNative,
       isSolanaSendType,
+      isPredefinedSolana,
       /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
       isBitcoinSendType,
+      isPredefinedBitcoin,
       /// END:ONLY_INCLUDE_IF
       /// BEGIN:ONLY_INCLUDE_IF(tron)
       isTronSendType,
+      isPredefinedTron,
       /// END:ONLY_INCLUDE_IF
     ],
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to prevent send asset page to not filter assets when user picks nonEVM and then goes back to asset page. (or vice versa)

Asset page now only filter if there is predefined network is marked.

This issue introduced in 7.61 hence we don't need any changelog if we decide to CP. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/23859

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/b40544af-3f63-45ed-b192-c8421d4f6b28



### **After**


https://github.com/user-attachments/assets/dcf9b56a-f970-4722-81ca-de2dd2957dec



## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> useSendTokens now filters tokens only when a predefined chain type is set via new isPredefined* flags from useSendType; tests updated accordingly.
> 
> - **Hooks**:
>   - **useSendType**: Exposes new booleans `isPredefinedEvm`, `isPredefinedSolana`, `isPredefinedBitcoin`, `isPredefinedTron` derived from `predefinedRecipient.chainType`; returns them alongside existing send-type flags.
>   - **useSendTokens**: Uses `isPredefined*` flags to determine filtering (`eip155`, `solana`, `tron`, `bip122`); defaults to returning all tokens when no predefined type is set; memo deps updated.
> - **Tests**:
>   - Updated `useSendTokens.test`, `useSendType.test`, `useAccounts.test`, `useContacts.test`, and `recipient.test` to reflect `isPredefined*` behavior and expectations.
>   - Added `createMockUseSendType` helpers in tests to simplify mocking return values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9127b8d964b252d15dbcdf8da0ab36676a77afe4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->