### PR TITLE
fix(card): cp-7.61.0 change not enabled token on delegation screen not working

### DIFF
--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.test.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.test.tsx
@@ -139,6 +139,7 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'card.card_spending_limit.cancel': 'Cancel',
       'card.card_spending_limit.update_success': 'Spending limit updated',
       'card.card_spending_limit.update_error': 'Failed to update limit',
+      'card.card_spending_limit.select_token': 'Select token',
     };
     return strings[key] || key;
   },

--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
@@ -196,9 +196,11 @@ const SpendingLimit = ({
       if (params?.returnedSelectedToken) {
         setSelectedToken(params.returnedSelectedToken);
 
-        // Clear the returned token from params to avoid re-applying it
+        // Clear both the returned token and the original selectedToken from params
+        // to prevent the useEffect from overriding our selection
         navigation.setParams({
           returnedSelectedToken: undefined,
+          selectedToken: undefined,
         } as Record<string, unknown>);
       }
     }, [route?.params, navigation]),
@@ -398,6 +400,9 @@ const SpendingLimit = ({
         .build(),
     );
 
+    const { selectedToken: _excludedSelectedToken, ...restParams } =
+      route?.params ?? {};
+
     navigation.navigate(
       ...createAssetSelectionModalNavigationDetails({
         tokensWithAllowances: allTokens ?? [],
@@ -406,7 +411,7 @@ const SpendingLimit = ({
         selectionOnly: true,
         hideSolanaAssets: true,
         callerRoute: Routes.CARD.SPENDING_LIMIT,
-        callerParams: route?.params as Record<string, unknown>,
+        callerParams: restParams as Record<string, unknown>,
       }),
     );
   }, [
@@ -424,7 +429,7 @@ const SpendingLimit = ({
       return (
         <View style={styles.selectedTokenContainer}>
           <Text variant={TextVariant.BodyMD} style={styles.placeholderText}>
-            Select token
+            {strings('card.card_spending_limit.select_token')}
           </Text>
           <Icon name={IconName.ArrowDown} size={IconSize.Sm} />
         </View>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6709,7 +6709,8 @@
       "dismiss": "Dismiss",
       "update_success": "Spending limit updated successfully",
       "update_error": "Failed to update spending limit",
-      "solana_not_supported": "Enable Solana tokens on card.metamask.io"
+      "solana_not_supported": "Enable Solana tokens on card.metamask.io",
+      "select_token": "Select token"
     },
     "change_asset": {
       "title": "Change token and network",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On the Card Home screen, once the user is logged in, selecting Change Asset and choosing an asset that isn’t enabled should redirect them to the SpendingLimit or Delegation screen so they can delegate that asset. There was a bug where, inside the asset selector, changing the currently selected token caused it to briefly update and then revert back to the previous one. This PR fixes that issue and ensures the selected asset updates correctly.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where changing the selected asset on the Card Home screen caused the token to revert instead of updating properly

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/b0a8d01e-271d-4dbf-8620-f15b9de6b51d

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/7caaa035-6b08-457a-a5fb-2cf9a3110393

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents the selected token in `SpendingLimit` from being overwritten when returning from asset selection; adds "Select token" i18n and updates tests accordingly.
> 
> - **Card Spending Limit (logic/UI)**:
>   - Preserve user-selected token on return from asset selector by clearing `route.params.returnedSelectedToken` and `route.params.selectedToken` in `useFocusEffect`.
>   - Exclude `selectedToken` from `callerParams` when navigating to asset selection to avoid re-applying old selection.
>   - Localize placeholder with `strings('card.card_spending_limit.select_token')`.
> - **i18n**:
>   - Add `card.card_spending_limit.select_token` to `locales/languages/en.json`.
> - **Tests**:
>   - Update `SpendingLimit.test.tsx` to mock the new i18n key and assert navigation excludes `selectedToken`; expect localized "Select token" placeholder.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e9b673f41959fbe7cc8820105bb057e07997d58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->