### PR TITLE
fix(perps): buttons colors for abtest cp-7.61.0 (#23811)

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -1121,7 +1121,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
               <View style={styles.actionButtonWrapper}>
                 {buttonColorVariant === 'monochrome' ? (
                   <Button
-                    variant={ButtonVariants.Secondary}
+                    variant={ButtonVariants.Primary}
                     size={ButtonSize.Lg}
                     width={ButtonWidthTypes.Full}
                     label={strings('perps.market.long')}
@@ -1146,7 +1146,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
               <View style={styles.actionButtonWrapper}>
                 {buttonColorVariant === 'monochrome' ? (
                   <Button
-                    variant={ButtonVariants.Secondary}
+                    variant={ButtonVariants.Primary}
                     size={ButtonSize.Lg}
                     width={ButtonWidthTypes.Full}
                     label={strings('perps.market.short')}

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.styles.ts
@@ -63,7 +63,7 @@ const styleSheet = (params: { theme: Theme }) => {
       right: 0,
       paddingHorizontal: 16,
       paddingTop: 12,
-      paddingBottom: 24,
+      // paddingBottom is calculated dynamically in component with safe area insets
       backgroundColor: colors.background.default,
       borderTopWidth: 1,
       borderTopColor: colors.border.muted,

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -258,7 +258,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   const { isAtCap: isAtOICap } = usePerpsOICap(orderForm.asset);
 
   // A/B Testing: Button color test (TAT-1937)
-  const { variantName: buttonColorVariant } = usePerpsABTest({
+  const {
+    variantName: buttonColorVariant,
+    isEnabled: isButtonColorTestEnabled,
+  } = usePerpsABTest({
     test: BUTTON_COLOR_TEST,
     featureFlagSelector: selectPerpsButtonColorTestVariant,
   });
@@ -303,6 +306,9 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
         orderForm.direction === 'long'
           ? PerpsEventValues.DIRECTION.LONG
           : PerpsEventValues.DIRECTION.SHORT,
+      ...(isButtonColorTestEnabled && {
+        [PerpsEventProperties.AB_TEST_BUTTON_COLOR]: buttonColorVariant,
+      }),
     },
   });
 
@@ -706,6 +712,20 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
 
     orderStartTimeRef.current = Date.now();
 
+    // Track Place Order button press with A/B test context
+    if (isButtonColorTestEnabled) {
+      track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
+        [PerpsEventProperties.INTERACTION_TYPE]:
+          PerpsEventValues.INTERACTION_TYPE.TAP,
+        [PerpsEventProperties.ASSET]: orderForm.asset,
+        [PerpsEventProperties.DIRECTION]:
+          orderForm.direction === 'long'
+            ? PerpsEventValues.DIRECTION.LONG
+            : PerpsEventValues.DIRECTION.SHORT,
+        [PerpsEventProperties.AB_TEST_BUTTON_COLOR]: buttonColorVariant,
+      });
+    }
+
     try {
       // Validation errors are shown in the UI
       if (!orderValidation.isValid) {
@@ -867,6 +887,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     feeResults.metamaskFeeRate,
     feeResults.feeDiscountPercentage,
     feeResults.estimatedPoints,
+    isButtonColorTestEnabled,
+    buttonColorVariant,
   ]);
 
   // Memoize the tooltip handlers to prevent recreating them on every render
@@ -1303,7 +1325,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
 
           {buttonColorVariant === 'monochrome' ? (
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariants.Primary}
               size={ButtonSize.Lg}
               width={ButtonWidthTypes.Full}
               label={placeOrderLabel}

--- a/docs/perps/perps-metametrics-reference.md
+++ b/docs/perps/perps-metametrics-reference.md
@@ -100,7 +100,7 @@ MetaMetrics.getInstance().trackEvent(
 - `input_method` (optional): How value was entered: `'slider' | 'keyboard' | 'preset' | 'manual' | 'percentage_button'`
 - `candle_period` (optional): Selected candle period
 - `favorites_count` (optional): Total number of markets in watchlist after toggle (number, used with `favorite_toggled`)
-- `ab_test_button_color` (optional): Button color test variant (`'control' | 'monochrome'`), only included when test is enabled and user taps Long/Short button (for engagement tracking)
+- `ab_test_button_color` (optional): Button color test variant (`'control' | 'monochrome'`), only included when test is enabled and user taps Long/Short or Place Order button (for engagement tracking)
 - Future AB tests: `ab_test_{test_name}` (see [Multiple Concurrent Tests](#multiple-concurrent-tests))
 
 ### 3. PERPS_TRADE_TRANSACTION
@@ -287,7 +287,7 @@ usePerpsEventTracking({
    - Required to calculate engagement rate
 
 2. **PERPS_UI_INTERACTION** (engagement):
-   - Include `ab_test_button_color` when user taps Long/Short button
+   - Include `ab_test_button_color` when user taps Long/Short or Place Order button
    - Only sent when test is enabled
    - Measures which variant drives more button presses
 


### PR DESCRIPTION
Fixes TAT-2134: Incorrect color for Long/Short buttons in A/B test.

1. **Added A/B test support to PerpsOrderBookView**: The Long/Short buttons in `PerpsOrderBookView.tsx` were always rendering as monochrome, ignoring the A/B test configuration. Added the same `usePerpsABTest` hook and conditional rendering that exists in
`PerpsMarketDetailsView.tsx` and `PerpsOrderView.tsx`.

2. **Fixed dark/light mode theming for monochrome variant**: Changed monochrome buttons from `ButtonVariants.Secondary` to `ButtonVariants.Primary` across all three views. This provides proper theme-aware styling:
   - Dark mode: White/light buttons with dark text
   - Light mode: Dark buttons with light text

This matches the styling of the "Set leverage" button in `PerpsLeverageBottomSheet.tsx`.

CHANGELOG entry: null

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2134
-  https://github.com/MetaMask/metamask-mobile/issues/23804

```gherkin
Feature: A/B Test Button Colors Consistency

  Scenario: User sees consistent button colors across all Perps trading screens
    Given user has Perps feature enabled
    And A/B test is configured in LaunchDarkly

    When user navigates to PerpsMarketDetailsView
    Then Long/Short buttons match the assigned A/B test variant (colored or monochrome)

    When user navigates to PerpsOrderBookView
    Then Long/Short buttons match the same A/B test variant as PerpsMarketDetailsView

    When user navigates to PerpsOrderView
    Then Place Order button matches the same A/B test variant

  Scenario: Monochrome buttons have correct dark mode styling
    Given user has dark mode enabled
    And A/B test assigns "monochrome" variant

    When user views any Perps trading screen with Long/Short buttons
    Then buttons should have white/light background with dark text
    And buttons should be clearly visible against dark background
```

- Monochrome buttons showed dark background on dark mode (low contrast)
- PerpsOrderBookView always showed secondary buttons regardless of A/B test

- Monochrome buttons show white/light background on dark mode (proper contrast)
- All three views (PerpsMarketDetailsView, PerpsOrderView, PerpsOrderBookView) respect A/B test variant

https://github.com/user-attachments/assets/d17cfd45-2a03-479c-8cc2-d9022001fa53

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

The button color A/B test (TAT-1937) is connected to MetaMetrics via the `ab_test_button_color` property.

| Property | Values | Description |
|----------|--------|-------------|
| `ab_test_button_color` | `'control'` \| `'monochrome'` | Variant assigned by LaunchDarkly |

1. **`PERPS_SCREEN_VIEWED`** (baseline exposure)
- Sent when user views `PerpsMarketDetailsView` (asset details screen)
   - Includes `ab_test_button_color` when test is enabled
   - Used to count how many users were exposed to each variant

2. **`PERPS_UI_INTERACTION`** (engagement)
   - Sent when user taps Long/Short button
- Includes `ab_test_button_color` + `interaction_type: 'tap'` + `direction: 'long'|'short'`
   - Used to measure which variant drives more button presses

```
Engagement Rate = Count(PERPS_UI_INTERACTION where ab_test_button_color = 'X')
                  / Count(PERPS_SCREEN_VIEWED where ab_test_button_color = 'X')
```

Compare engagement rates between `control` (green/red buttons) and `monochrome` (white buttons) variants.

- Property constant: `PerpsEventProperties.AB_TEST_BUTTON_COLOR` in `app/components/UI/Perps/constants/eventNames.ts:111`
- Screen view tracking: `PerpsMarketDetailsView.tsx:454-467`
- LaunchDarkly flag: `perps-abtest-button-color` → Redux: `perpsAbtestButtonColor`

---

-
`app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx`
- Changed monochrome Long/Short buttons from `ButtonVariants.Secondary` to `ButtonVariants.Primary`
- `app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx` - Changed monochrome Place Order button from `ButtonVariants.Secondary` to `ButtonVariants.Primary`
-
`app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx`
- Added A/B test support and changed monochrome Long/Short buttons from `ButtonVariants.Secondary` to `ButtonVariants.Primary`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns monochrome button styling to Primary, adds button color A/B test and metrics to Order Book and Place Order, and makes Order Book footer respect safe area.
> 
> - **UI**:
>   - **Button color A/B test**: Add variant-based Long/Short buttons to `PerpsOrderBookView.tsx` (monochrome uses `Button` Primary; colored uses `ButtonSemantic`).
>   - **Monochrome styling fix**: Switch `ButtonVariants.Secondary` → `ButtonVariants.Primary` for Long/Short in `PerpsMarketDetailsView.tsx` and `PerpsOrderBookView.tsx`, and Place Order in `PerpsOrderView.tsx`.
>   - **Layout**: `PerpsOrderBookView` footer padding now computed with safe area insets.
> - **Analytics/Docs**:
>   - Track `ab_test_button_color` when tapping Long/Short (Order Book, Market Details) and Place Order; include on relevant screen views where enabled.
>   - Update `docs/perps/perps-metametrics-reference.md` to reflect engagement tracking for Long/Short and Place Order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea52a8286407d61abf02fb00a8c48ebaa64da849. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
