### PR TITLE
Fix notification cta link

### DIFF
--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
@@ -15,6 +15,7 @@ import handleUniversalLink from '../handleUniversalLink';
 import handleDeepLinkModalDisplay from '../handleDeepLinkModalDisplay';
 import { DeepLinkModalLinkType } from '../../../../../components/UI/DeepLinkModal';
 import handleMetaMaskDeeplink from '../handleMetaMaskDeeplink';
+import { handlePerpsUrl } from '../handlePerpsUrl';
 // eslint-disable-next-line import/no-namespace
 import * as signatureUtils from '../../../utils/verifySignature';
 
@@ -504,6 +505,30 @@ describe('handleUniversalLink', () => {
       });
 
       expect(handled).toHaveBeenCalled();
+    });
+
+    it('calls _handlePerps when action is PERPS_ASSET and transforms URL to include screen=asset', async () => {
+      const perpsAssetUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.PERPS_ASSET}?symbol=ETH`;
+      const perpsAssetUrlObj = {
+        ...urlObj,
+        hostname: AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+        href: perpsAssetUrl,
+        pathname: `/${ACTIONS.PERPS_ASSET}`,
+      };
+
+      await handleUniversalLink({
+        instance,
+        handled,
+        urlObj: perpsAssetUrlObj,
+        browserCallBack: mockBrowserCallBack,
+        url: perpsAssetUrl,
+        source: 'test-source',
+      });
+
+      expect(handled).toHaveBeenCalled();
+      expect(handlePerpsUrl).toHaveBeenCalledWith({
+        perpsPath: '?screen=asset&symbol=ETH',
+      });
     });
   });
 

--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -311,9 +311,16 @@ async function handleUniversalLink({
     });
   } else if (
     action === SUPPORTED_ACTIONS.PERPS ||
-    action === SUPPORTED_ACTIONS.PERPS_MARKETS
+    action === SUPPORTED_ACTIONS.PERPS_MARKETS ||
+    action === SUPPORTED_ACTIONS.PERPS_ASSET
   ) {
-    const perpsPath = urlObj.href.replace(BASE_URL_ACTION, '');
+    let perpsPath = urlObj.href.replace(BASE_URL_ACTION, '');
+
+    // For perps-asset links (e.g. ?symbol=ETH), transform to screen=asset format
+    if (action === SUPPORTED_ACTIONS.PERPS_ASSET && perpsPath.includes('symbol=')) {
+      perpsPath = perpsPath.replace('?', '?screen=asset&');
+    }
+
     handlePerpsUrl({
       perpsPath,
     });


### PR DESCRIPTION
Add `PERPS_ASSET` action handling to `handleUniversalLink` and transform its URL to correctly open perps asset pages.

The `PERPS_ASSET` action was defined and whitelisted but not routed to `handlePerpsUrl`, causing "View in MetaMask" CTA buttons for perps-asset links (e.g., `perps-asset?symbol=ETH`) to fail. The URL also needed transformation to match `handlePerpsUrl`'s expected `screen=asset&symbol=X` format.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a6396f9-b4cb-4a9e-a856-d199e674fdf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a6396f9-b4cb-4a9e-a856-d199e674fdf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

