### PR TITLE
fix: cp-7.61.0 Perps eligibility refresh race condition causing users to be incorrectly geo-blocked

### DIFF
--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -2189,11 +2189,7 @@ export class PerpsController extends BaseController<
     const versionAtStart = this.blockedRegionListVersion;
 
     try {
-      console.log('PerpsController: Refreshing eligibility', {
-        version: versionAtStart,
-        source: this.blockedRegionList.source,
-      });
-
+      // TODO: It would be good to have this location before we call this async function to avoid the race condition
       const isEligible = await EligibilityService.checkEligibility(
         this.blockedRegionList.list,
       );
@@ -2202,18 +2198,8 @@ export class PerpsController extends BaseController<
       // This prevents stale fallback-based eligibility checks from overwriting
       // results from remote-based checks.
       if (this.blockedRegionListVersion !== versionAtStart) {
-        console.log('PerpsController: Skipping stale eligibility update', {
-          versionAtStart,
-          currentVersion: this.blockedRegionListVersion,
-          wouldHaveSet: isEligible,
-        });
         return;
       }
-
-      console.log('PerpsController: Updating eligibility', {
-        isEligible,
-        version: versionAtStart,
-      });
 
       this.update((state) => {
         state.isEligible = isEligible;

--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -2205,7 +2205,7 @@ export class PerpsController extends BaseController<
         state.isEligible = isEligible;
       });
     } catch (error) {
-      console.error(
+      Logger.error(
         ensureError(error),
         this.getErrorContext('refreshEligibility'),
       );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fix race condition causing users to be geo-blocked incorrectly.

The Bug: `refreshEligibility()` is called with fallback regions but isn't awaited — so the constructor continues, updates to remote config, and starts new eligibility checks. The fallback check finishes last and overwrites the correct remote result with false.

Workaround: a version counter ensures stale checks (started before the config changed) are discarded when they complete.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix perps refreshEligibility race condition causing users to be geo-blocked

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guards async eligibility updates with a versioned blocked-region list to avoid stale fallback results overwriting remote-config checks.
> 
> - **PerpsController (`app/components/UI/Perps/controllers/PerpsController.ts`)**
>   - Add `blockedRegionListVersion` to track changes to `blockedRegionList`.
>   - Increment version when setting blocked regions in `setBlockedRegionList` and in `refreshEligibilityOnFeatureFlagChange`.
>   - Update `refreshEligibility()` to:
>     - Capture version at start and skip state updates if version changed while awaiting.
>     - Only set default eligible on error if version is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fa308b498e659e5550e6dedb89fe71d2a11566f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->