### PR TITLE
fix: remove background from more button in multichain account selector

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.styles.ts
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.styles.ts
@@ -68,10 +68,6 @@ const styleSheet = (params: { theme: Theme; vars: unknown }) => {
       verticalAlign: 'middle',
     },
     menuButton: {
-      backgroundColor: colors.background.muted,
-      borderRadius: 8,
-      height: 28,
-      width: 28,
       display: 'flex',
       flexDirection: 'row',
       justifyContent: 'center',

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
@@ -262,13 +262,9 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                         style={
                           {
                             "alignItems": "center",
-                            "backgroundColor": "#3c4d9d0f",
-                            "borderRadius": 8,
                             "display": "flex",
                             "flexDirection": "row",
-                            "height": 28,
                             "justifyContent": "center",
-                            "width": 28,
                           }
                         }
                         testID="multichain-account-cell-menu"
@@ -471,13 +467,9 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                         style={
                           {
                             "alignItems": "center",
-                            "backgroundColor": "#3c4d9d0f",
-                            "borderRadius": 8,
                             "display": "flex",
                             "flexDirection": "row",
-                            "height": 28,
                             "justifyContent": "center",
-                            "width": 28,
                           }
                         }
                         testID="multichain-account-cell-menu"


### PR DESCRIPTION
## **Description**

remove background from more button in multichain account selector

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-277

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

| before | after |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/ac3d8983-b0e4-4310-90c9-7ac210a563b1) | ![after](https://github.com/user-attachments/assets/55113c0c-92c8-4432-9405-3f4d3161e832) |

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes background, border radius, and fixed dimensions from the multichain account cell "more" menu button, updating snapshots accordingly.
> 
> - **UI (Multichain Accounts)**
>   - `AccountCell.styles.ts`: Remove `menuButton` `backgroundColor`, `borderRadius`, `height`, and `width` to make the "more" button icon-only.
> - **Tests**
>   - Update snapshots in `MultichainAccountsConnectedList.test.tsx.snap` to reflect the menu button style change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b2e2cc42f92b658a61535947a73e9f329be4eb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->