### PR TITLE
fix: Remove emojis from gas modals

### DIFF
--- a/app/components/Views/confirmations/components/gas/gas-option/gas-option.styles.ts
+++ b/app/components/Views/confirmations/components/gas/gas-option/gas-option.styles.ts
@@ -35,11 +35,7 @@ const styleSheet = (params: { theme: Theme }) => {
     leftSection: {
       flexDirection: 'row',
       alignItems: 'center',
-    },
-    emoji: {
-      fontSize: 24,
-      marginRight: 12,
-      marginLeft: 6,
+      marginLeft: 8,
     },
     optionTextContainer: {
       justifyContent: 'center',

--- a/app/components/Views/confirmations/components/gas/gas-option/gas-option.test.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-option/gas-option.test.tsx
@@ -4,7 +4,6 @@ import { noop } from 'lodash';
 import { GasOption } from './gas-option';
 
 const mockGasOption = {
-  emoji: '🚀',
   estimatedTime: '',
   isSelected: false,
   key: 'fast',
@@ -21,7 +20,6 @@ describe('GasOption', () => {
     );
 
     expect(getByTestId('gas-option-fast')).toBeOnTheScreen();
-    expect(getByText('🚀')).toBeOnTheScreen();
     expect(getByText('Test gas option')).toBeOnTheScreen();
     expect(getByText('< 0.0001')).toBeOnTheScreen();
     expect(getByText('0.05')).toBeOnTheScreen();

--- a/app/components/Views/confirmations/components/gas/gas-option/gas-option.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-option/gas-option.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, TouchableOpacity, Text as RNText } from 'react-native';
+import { View, TouchableOpacity } from 'react-native';
 
 import { useStyles } from '../../../../../../component-library/hooks';
 import Text, {
@@ -9,16 +9,8 @@ import { type GasOption as GasOptionType } from '../../../types/gas';
 import styleSheet from './gas-option.styles';
 
 export const GasOption = ({ option }: { option: GasOptionType }) => {
-  const {
-    onSelect,
-    name,
-    estimatedTime,
-    valueInFiat,
-    value,
-    emoji,
-    isSelected,
-    key,
-  } = option;
+  const { onSelect, name, estimatedTime, valueInFiat, value, isSelected, key } =
+    option;
 
   const { styles } = useStyles(styleSheet, {});
 
@@ -33,7 +25,6 @@ export const GasOption = ({ option }: { option: GasOptionType }) => {
         onPress={() => onSelect()}
       >
         <View style={styles.leftSection}>
-          <RNText style={styles.emoji}>{emoji}</RNText>
           <View style={styles.optionTextContainer}>
             <Text variant={TextVariant.BodyMDMedium} style={styles.optionName}>
               {name}

--- a/app/components/Views/confirmations/components/gas/gas-speed/gas-speed.test.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-speed/gas-speed.test.tsx
@@ -30,33 +30,10 @@ describe('GasSpeed', () => {
     jest.clearAllMocks();
   });
 
-  it('renders null when transaction metadata has no userFeeLevel', () => {
-    const stateWithoutUserFeeLevel = merge({}, transferTransactionStateMock, {
-      engine: {
-        backgroundState: {
-          TransactionController: {
-            transactions: [
-              {
-                id: '56f60ff0-2bef-11f0-80ce-2f66f7fbd577',
-                userFeeLevel: undefined,
-              },
-            ],
-          },
-        },
-      },
-    });
-
-    const { queryByText } = renderWithProvider(<GasSpeed />, {
-      state: stateWithoutUserFeeLevel,
-    });
-
-    expect(queryByText(/🐢|🦊|🦍|🌐|⚙️/)).toBeNull();
-  });
-
   it.each([
-    [GasFeeEstimateLevel.Low, 'Low', /🐢.*Low.*~ 30 sec/],
-    [GasFeeEstimateLevel.Medium, 'Medium', /🦊.*Market.*~ 20 sec/],
-    [GasFeeEstimateLevel.High, 'High', /🦍.*Aggressive.*~ 10 sec/],
+    [GasFeeEstimateLevel.Low, 'Low', /.*Low.*~ 30 sec/],
+    [GasFeeEstimateLevel.Medium, 'Medium', /.*Market.*~ 20 sec/],
+    [GasFeeEstimateLevel.High, 'High', /.*Aggressive.*~ 10 sec/],
   ])(
     'renders correct content for %s gas fee estimate level',
     (userFeeLevel, _levelName, expectedPattern) => {
@@ -104,7 +81,7 @@ describe('GasSpeed', () => {
       state: stateWithDappSuggested,
     });
 
-    expect(getByText('🌐 Site suggested')).toBeTruthy();
+    expect(getByText('Site suggested')).toBeTruthy();
   });
 
   it('renders correct content for CUSTOM user fee level', () => {
@@ -126,7 +103,7 @@ describe('GasSpeed', () => {
       state: stateWithCustom,
     });
 
-    expect(getByText('⚙️ Advanced')).toBeTruthy();
+    expect(getByText('Advanced')).toBeTruthy();
   });
 
   it('does not show estimated time for gas price estimate when Medium level is selected', () => {
@@ -151,7 +128,7 @@ describe('GasSpeed', () => {
       state: stateWithGasPriceEstimate,
     });
 
-    expect(getByText('🦊 Market')).toBeTruthy();
+    expect(getByText('Market')).toBeTruthy();
     expect(queryByText(/sec/)).toBeNull();
   });
 
@@ -177,7 +154,7 @@ describe('GasSpeed', () => {
       state: stateWithFeeMarketEstimate,
     });
 
-    expect(getByText(/🦍.*Aggressive.*~ 10 sec/)).toBeTruthy();
+    expect(getByText(/.*Aggressive.*~ 10 sec/)).toBeTruthy();
   });
 
   it('handles unknown user fee level by defaulting to advanced', () => {
@@ -199,7 +176,7 @@ describe('GasSpeed', () => {
       state: stateWithUnknownFeeLevel,
     });
 
-    expect(getByText('⚙️ Advanced')).toBeTruthy();
+    expect(getByText('Advanced')).toBeTruthy();
   });
 
   it('calls useGasFeeEstimates with correct networkClientId', () => {

--- a/app/components/Views/confirmations/components/gas/gas-speed/gas-speed.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-speed/gas-speed.tsx
@@ -9,25 +9,8 @@ import {
 import Text from '../../../../../../component-library/components/Texts/Text/Text';
 import { strings } from '../../../../../../../locales/i18n';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { GasOptionIcon } from '../../../constants/gas';
 import { useGasFeeEstimates } from '../../../hooks/gas/useGasFeeEstimates';
 import { toHumanSeconds } from '../../../utils/time';
-
-const getEmoji = (userFeeLevel: UserFeeLevel | GasFeeEstimateLevel) => {
-  switch (userFeeLevel) {
-    case GasFeeEstimateLevel.Low:
-      return GasOptionIcon.LOW;
-    case GasFeeEstimateLevel.Medium:
-      return GasOptionIcon.MEDIUM;
-    case GasFeeEstimateLevel.High:
-      return GasOptionIcon.HIGH;
-    case UserFeeLevel.DAPP_SUGGESTED:
-      return GasOptionIcon.SITE_SUGGESTED;
-    case UserFeeLevel.CUSTOM:
-    default:
-      return GasOptionIcon.ADVANCED;
-  }
-};
 
 const getText = (userFeeLevel: UserFeeLevel | GasFeeEstimateLevel) => {
   switch (userFeeLevel) {
@@ -86,7 +69,6 @@ export const GasSpeed = () => {
     transactionMeta.gasFeeEstimates?.type === GasFeeEstimateType.GasPrice &&
     userFeeLevel === GasFeeEstimateLevel.Medium;
 
-  const emoji = getEmoji(userFeeLevel);
   const text = getText(userFeeLevel);
   const estimatedTime = getEstimatedTime(
     userFeeLevel,
@@ -94,6 +76,5 @@ export const GasSpeed = () => {
     isGasPriceEstimateSelected,
   );
 
-  // Intentionally no space between text and estimated time
-  return <Text>{`${emoji} ${text}${estimatedTime}`}</Text>;
+  return <Text>{`${text}${estimatedTime}`}</Text>;
 };

--- a/app/components/Views/confirmations/components/modals/estimates-modal/estimates-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/estimates-modal/estimates-modal.test.tsx
@@ -10,7 +10,6 @@ jest.mock('../../../hooks/gas/useGasOptions', () => ({
     return {
       options: [
         {
-          emoji: '🚀',
           estimatedTime: '',
           isSelected: false,
           key: 'fast',
@@ -44,9 +43,7 @@ describe('EstimatesModal', () => {
     // Header
     expect(getByText('Edit network fee')).toBeOnTheScreen();
 
-    // Gas option expected to be rendered
     expect(getByTestId('gas-option-fast')).toBeOnTheScreen();
-    expect(getByText('🚀')).toBeOnTheScreen();
     expect(getByText('Test gas option')).toBeOnTheScreen();
     expect(getByText('< 0.0001')).toBeOnTheScreen();
     expect(getByText('0.05')).toBeOnTheScreen();

--- a/app/components/Views/confirmations/constants/gas.ts
+++ b/app/components/Views/confirmations/constants/gas.ts
@@ -4,13 +4,4 @@ export enum GasModalType {
   ADVANCED_GAS_PRICE = 'advancedGasPriceModal',
 }
 
-export enum GasOptionIcon {
-  ADVANCED = '⚙️',
-  GAS_PRICE = '⛓️',
-  HIGH = '🦍',
-  LOW = '🐢',
-  MEDIUM = '🦊',
-  SITE_SUGGESTED = '🌐',
-}
-
 export const EMPTY_VALUE_STRING = '--';

--- a/app/components/Views/confirmations/hooks/gas/useAdvancedGasFeeOption.ts
+++ b/app/components/Views/confirmations/hooks/gas/useAdvancedGasFeeOption.ts
@@ -9,11 +9,7 @@ import {
 import { strings } from '../../../../../../locales/i18n';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useFeeCalculations } from './useFeeCalculations';
-import {
-  EMPTY_VALUE_STRING,
-  GasModalType,
-  GasOptionIcon,
-} from '../../constants/gas';
+import { EMPTY_VALUE_STRING, GasModalType } from '../../constants/gas';
 import { type GasOption } from '../../types/gas';
 
 const HEX_ZERO = '0x0';
@@ -118,7 +114,6 @@ export const useAdvancedGasFeeOption = ({
   const memoizedGasOption = useMemo(
     () => [
       {
-        emoji: GasOptionIcon.ADVANCED,
         estimatedTime: '',
         isSelected: isAdvancedGasFeeSelected,
         key: 'advanced',

--- a/app/components/Views/confirmations/hooks/gas/useDappSuggestedGasFeeOption.ts
+++ b/app/components/Views/confirmations/hooks/gas/useDappSuggestedGasFeeOption.ts
@@ -7,7 +7,7 @@ import {
 import { strings } from '../../../../../../locales/i18n';
 import { updateTransactionGasFees } from '../../../../../util/transaction-controller';
 import { type GasOption } from '../../types/gas';
-import { EMPTY_VALUE_STRING, GasOptionIcon } from '../../constants/gas';
+import { EMPTY_VALUE_STRING } from '../../constants/gas';
 import { MMM_ORIGIN } from '../../constants/confirmations';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useFeeCalculations } from './useFeeCalculations';
@@ -71,7 +71,6 @@ export const useDappSuggestedGasFeeOption = ({
       });
 
     options.push({
-      emoji: GasOptionIcon.SITE_SUGGESTED,
       estimatedTime: undefined,
       isSelected: isDappSuggestedGasFeeSelected,
       key: 'site_suggested',

--- a/app/components/Views/confirmations/hooks/gas/useGasOptions.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useGasOptions.test.ts
@@ -23,7 +23,6 @@ describe('useGasOptions', () => {
   );
 
   const mockAdvancedOption: GasOption = {
-    emoji: '⚙️',
     estimatedTime: '',
     isSelected: false,
     key: 'advanced',
@@ -34,7 +33,6 @@ describe('useGasOptions', () => {
   };
 
   const mockLowLevelOption: GasOption = {
-    emoji: '🐢',
     estimatedTime: '~1 min',
     isSelected: false,
     key: 'low',
@@ -45,7 +43,6 @@ describe('useGasOptions', () => {
   };
 
   const mockMediumLevelOption: GasOption = {
-    emoji: '🦊',
     estimatedTime: '~30 sec',
     isSelected: true,
     key: 'medium',
@@ -56,7 +53,6 @@ describe('useGasOptions', () => {
   };
 
   const mockGasPriceOption: GasOption = {
-    emoji: '⛽️',
     estimatedTime: '',
     isSelected: false,
     key: 'gasPrice',
@@ -67,7 +63,6 @@ describe('useGasOptions', () => {
   };
 
   const mockDappSuggestedOption: GasOption = {
-    emoji: '🌐',
     estimatedTime: '',
     isSelected: false,
     key: 'site_suggested',

--- a/app/components/Views/confirmations/hooks/gas/useGasPriceEstimateOption.ts
+++ b/app/components/Views/confirmations/hooks/gas/useGasPriceEstimateOption.ts
@@ -12,7 +12,7 @@ import { useTransactionMetadataRequest } from '../transactions/useTransactionMet
 import { useGasFeeEstimates } from './useGasFeeEstimates';
 import { useFeeCalculations } from './useFeeCalculations';
 import { type GasOption } from '../../types/gas';
-import { EMPTY_VALUE_STRING, GasOptionIcon } from '../../constants/gas';
+import { EMPTY_VALUE_STRING } from '../../constants/gas';
 
 const HEX_ZERO = '0x0';
 
@@ -109,7 +109,6 @@ export const useGasPriceEstimateOption = ({
 
     return [
       {
-        emoji: GasOptionIcon.GAS_PRICE,
         estimatedTime: undefined,
         isSelected: isGasPriceEstimateSelected,
         key: 'gasPrice',

--- a/app/components/Views/confirmations/types/gas.ts
+++ b/app/components/Views/confirmations/types/gas.ts
@@ -1,5 +1,4 @@
 export interface GasOption {
-  emoji: string;
   estimatedTime?: string;
   isSelected: boolean;
   key: string;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to drop emoji usage on gas modals and speed row.

It also adds filtering of `high` option in fee levels if they are same with `medium`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Remove emojis from gas options

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6446

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="542" height="1078" alt="Screenshot 2025-12-11 at 00 50 28" src="https://github.com/user-attachments/assets/260a534e-78b5-4897-b581-7077320497a8" />

### **After**

<img width="586" height="1122" alt="Screenshot 2025-12-11 at 00 50 13" src="https://github.com/user-attachments/assets/62f3ed56-419c-4a0b-ad43-d419fa963ed3" />

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes emojis from gas options/speed and skips the High option when its fees match Medium for fee market estimates.
> 
> - **UI (gas options/speed)**
>   - Remove emojis from `GasOption` and `GasSpeed` displays; adjust styles (`leftSection` spacing) and keep selection indicator/value display.
> - **Types/Constants**
>   - Drop `GasOptionIcon` enum and `GasOption.emoji` field.
> - **Logic**
>   - In `useGasFeeEstimateLevelOptions`, omit `High` when its `maxFeePerGas` and `maxPriorityFeePerGas` equal `Medium` (FeeMarket).
> - **Tests**
>   - Update tests to remove emoji assertions; add test ensuring `High` is excluded when equal to `Medium`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feaba63192801d1ca1a46d3a812813f26ac6f8f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->