### PR TITLE
feat: update transition of DeFiProtocolPositionDetails screen

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -1257,6 +1257,19 @@ const MainNavigator = () => {
         component={DeFiProtocolPositionDetails}
         options={{
           headerShown: true,
+          animationEnabled: true,
+          cardStyleInterpolator: ({ current, layouts }) => ({
+            cardStyle: {
+              transform: [
+                {
+                  translateX: current.progress.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [layouts.screen.width, 0],
+                  }),
+                },
+              ],
+            },
+          }),
         }}
       />
       {

--- a/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
+++ b/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
@@ -265,6 +265,8 @@ exports[`MainNavigator matches rendered snapshot 1`] = `
     name="DeFiProtocolPositionDetails"
     options={
       {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
         "headerShown": true,
       }
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The DeFi detail page (DeFiProtocolPositionDetails) was transitioning into the viewport like a bottom sheet (sliding up from bottom) due to the parent Stack.Navigator using mode={'modal'}.
This PR changes the transition to slide in from right to left (standard push navigation) by adding a custom cardStyleInterpolator with horizontal translation, matching the pattern used by other screens like TrendingTokensFullView, ExploreSearchScreen, and PerpsScreenStack.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Changed DeFi protocol detail page to slide in from right instead of from bottom

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-263

## **Manual testing steps**

```gherkin
Feature: DeFi Protocol Position Details Navigation

  Scenario: user opens DeFi protocol position details
    Given user is on the Wallet view with DeFi positions visible

    When user taps on a DeFi protocol position
    Then the DeFi Protocol Position Details screen slides in from right to left
    And user can swipe from left edge to go back (gesture navigation)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/f1437617-fac2-4fbb-aa97-6c9a18a03272

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/2521f279-8fd3-4bd1-a49a-c3270e511a70


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `DeFiProtocolPositionDetails` to a right-to-left slide transition via custom `cardStyleInterpolator`, updating snapshots accordingly.
> 
> - **Navigation**
>   - `app/components/Nav/Main/MainNavigator.js`
>     - `DeFiProtocolPositionDetails`: enable `animationEnabled` and add horizontal `cardStyleInterpolator` (slides in from right), with `headerShown: true`.
> - **Tests**
>   - `app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap`: update snapshot to include new screen options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a7a46fadde7427bd545bc114c37aa966127589c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->