### PR TITLE
feat: Update StakeScreens with custom navigation options

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -1108,7 +1108,26 @@ const MainNavigator = () => {
         component={BridgeModalStack}
         options={clearStackNavigatorOptions}
       />
-      <Stack.Screen name="StakeScreens" component={StakeScreenStack} />
+      <Stack.Screen
+        name="StakeScreens"
+        component={StakeScreenStack}
+        options={{
+          headerShown: false,
+          animationEnabled: true,
+          cardStyleInterpolator: ({ current, layouts }) => ({
+            cardStyle: {
+              transform: [
+                {
+                  translateX: current.progress.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [layouts.screen.width, 0],
+                  }),
+                },
+              ],
+            },
+          }),
+        }}
+      />
       <Stack.Screen name={Routes.EARN.ROOT} component={EarnScreenStack} />
       <Stack.Screen
         name={Routes.EARN.MODALS.ROOT}

--- a/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
+++ b/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
@@ -184,6 +184,13 @@ exports[`MainNavigator matches rendered snapshot 1`] = `
   <Screen
     component={[Function]}
     name="StakeScreens"
+    options={
+      {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
+        "headerShown": false,
+      }
+    }
   />
   <Screen
     component={[Function]}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When selecting "Deposit" from the Trade Menu, the Deposit page was sliding in from the bottom (default modal behavior). Per design requirements, it should slide in from the right, consistent with other navigation flows.
Applied the same cardStyleInterpolator pattern already used by:

- Settings (Routes.SETTINGS_VIEW)
- TrendingTokensFullView
- ExploreSearchScreen
- SitesFullView
- Perps

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated Deposit page transition to slide in from the right instead of bottom

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-235

## **Manual testing steps**

```gherkin
Feature: Deposit page navigation transition

  Scenario: user opens Deposit page from Trade Menu
    Given the user is on the Wallet home screen
    And the user has Deposit enabled

    When user taps on the Trade/Fund action button
    And user selects "Deposit" from the menu
    Then the Deposit page slides in from the right side of the screen
    And user can swipe from left edge to go back
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/fba1e102-92cc-4cf5-8bb5-d94bedbb48a4


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/d18e1e5b-5b89-451d-87d5-b18446180cc9


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures `StakeScreens` to hide the header and use a right-to-left slide transition; updates snapshot accordingly.
> 
> - **Navigation**:
>   - **`MainNavigator.js`**: Add custom options to `Stack.Screen` for `StakeScreens`:
>     - `headerShown: false`
>     - Enable right-to-left slide via `animationEnabled: true` and custom `cardStyleInterpolator`.
> - **Tests**:
>   - Update snapshot `MainNavigator.test.tsx.snap` to reflect new `StakeScreens` options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f185550c377ae047af18ad088d2bc35c00ff99d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->