### PR TITLE
chore: Abstract password outdated check logic to Authentication Service

### DIFF
--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -88,8 +88,6 @@ import { useIdentityEffects } from '../../../util/identity/hooks/useIdentityEffe
 import ProtectWalletMandatoryModal from '../../Views/ProtectWalletMandatoryModal/ProtectWalletMandatoryModal';
 import { selectIsSeedlessPasswordOutdated } from '../../../selectors/seedlessOnboardingController';
 import { Authentication } from '../../../core';
-import { IconName } from '../../../component-library/components/Icons/Icon';
-import Routes from '../../../constants/navigation/Routes';
 import { useCompletedOnboardingEffect } from '../../../util/onboarding/hooks/useCompletedOnboardingEffect';
 import {
   useNetworksByNamespace,
@@ -128,40 +126,10 @@ const Main = (props) => {
   );
 
   useEffect(() => {
-    const checkIsSeedlessPasswordOutdated = async () => {
-      if (isSeedlessPasswordOutdated) {
-        // Check for latest seedless password outdated state
-        // isSeedlessPasswordOutdated is true when navigate to wallet main screen after login with password sync
-        const isOutdated =
-          await Authentication.checkIsSeedlessPasswordOutdated(false);
-        if (!isOutdated) {
-          return;
-        }
-
-        // show seedless password outdated modal and force user to lock app
-        props.navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-          screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-          params: {
-            title: strings('login.seedless_password_outdated_modal_title'),
-            description: strings(
-              'login.seedless_password_outdated_modal_content',
-            ),
-            primaryButtonLabel: strings(
-              'login.seedless_password_outdated_modal_confirm',
-            ),
-            type: 'error',
-            icon: IconName.Danger,
-            isInteractable: false,
-            onPrimaryButtonPress: async () => {
-              await Authentication.lockApp({ locked: true });
-            },
-            closeOnPrimaryButtonPress: true,
-          },
-        });
-      }
-    };
-    checkIsSeedlessPasswordOutdated();
-  }, [isSeedlessPasswordOutdated, props.navigation]);
+    Authentication.checkAndShowSeedlessPasswordOutdatedModal(
+      isSeedlessPasswordOutdated,
+    );
+  }, [isSeedlessPasswordOutdated]);
 
   const { connectionChangeHandler } = useConnectionHandler(props.navigation);
 

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -77,6 +77,8 @@ import { EntropySourceId } from '@metamask/keyring-api';
 import { trackVaultCorruption } from '../../util/analytics/vaultCorruptionTracking';
 import MetaMetrics from '../Analytics/MetaMetrics';
 import { resetProviderToken as depositResetProviderToken } from '../../components/UI/Ramp/Deposit/utils/ProviderTokenVault';
+import { strings } from '../../../locales/i18n';
+import { IconName } from '../../component-library/components/Icons/Icon';
 
 /**
  * Holds auth data used to determine auth configuration
@@ -1283,6 +1285,47 @@ class AuthenticationService {
       Logger.error(error as Error, 'Error in checkIsSeedlessPasswordOutdated');
       return false;
     }
+  };
+
+  /**
+   * Checks if the seedless password is outdated and shows a modal if it is.
+   * This method verifies the outdated state and navigates to show the password outdated modal.
+   *
+   * @param {boolean} isSeedlessPasswordOutdated - whether the seedless password is marked as outdated in state
+   * @returns {Promise<void>}
+   */
+  checkAndShowSeedlessPasswordOutdatedModal = async (
+    isSeedlessPasswordOutdated: boolean,
+  ): Promise<void> => {
+    if (!isSeedlessPasswordOutdated) {
+      return;
+    }
+
+    // Check for latest seedless password outdated state
+    // isSeedlessPasswordOutdated is true when navigate to wallet main screen after login with password sync
+    const isOutdated = await this.checkIsSeedlessPasswordOutdated(false);
+    if (!isOutdated) {
+      return;
+    }
+
+    // show seedless password outdated modal and force user to lock app
+    NavigationService.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
+      params: {
+        title: strings('login.seedless_password_outdated_modal_title'),
+        description: strings('login.seedless_password_outdated_modal_content'),
+        primaryButtonLabel: strings(
+          'login.seedless_password_outdated_modal_confirm',
+        ),
+        type: 'error',
+        icon: IconName.Danger,
+        isInteractable: false,
+        onPrimaryButtonPress: async () => {
+          await this.lockApp({ locked: true });
+        },
+        closeOnPrimaryButtonPress: true,
+      },
+    });
   };
 
   /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR refactors the seedless password outdated modal logic by moving it from the Main component to the Authentication service. The Authentication service is now the single source of truth for all authentication-related operations, including checking and displaying the seedless password outdated modal.

**Reason for change:**
1. The seedless password outdated check and modal display logic was previously embedded in the Main component, which violates separation of concerns
2. Authentication-related logic should be centralized in the Authentication service for better maintainability and testability
3. This change improves code organization and makes the logic reusable across the application

**Improvement/solution:**
1. Created a new method `checkAndShowSeedlessPasswordOutdatedModal` in the Authentication service that encapsulates the entire flow
2. The method accepts `isSeedlessPasswordOutdated` as a parameter, making it flexible and testable
3. Simplified the Main component by removing inline logic and replacing it with a single method call
4. Added comprehensive test coverage for the new method with 4 test cases covering all scenarios

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

Feature: Seedless password outdated modal

  Scenario: user navigates to main screen with outdated password
    Given user has seedless onboarding enabled
    And user's seedless password is outdated
    And user successfully logs in

    When user navigates to the main wallet screen
    Then the seedless password outdated modal is displayed
    And when user taps the confirm button, the app locks

  Scenario: user navigates to main screen with up-to-date password
    Given user has seedless onboarding enabled
    And user's seedless password is up-to-date
    And user successfully logs in

    When user navigates to the main wallet screen
    Then no modal is displayed
    And user can use the app normally## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves seedless password outdated check/modal from Main to Authentication service with a new helper and adds focused tests.
> 
> - **Authentication service (`app/core/Authentication/Authentication.ts`)**:
>   - Add `checkAndShowSeedlessPasswordOutdatedModal(isSeedlessPasswordOutdated)` to verify outdated state via `checkIsSeedlessPasswordOutdated(false)` and navigate to `Routes.SHEET.SUCCESS_ERROR_SHEET` with non-interactable error modal and lock-on-confirm.
>   - Wire i18n strings and `IconName.Danger` for the modal.
> - **Main navigator (`app/components/Nav/Main/index.js`)**:
>   - Replace inline modal logic with `Authentication.checkAndShowSeedlessPasswordOutdatedModal(isSeedlessPasswordOutdated)` in `useEffect`.
> - **Tests (`app/core/Authentication/Authentication.test.ts`)**:
>   - Add suite for `checkAndShowSeedlessPasswordOutdatedModal` covering: early return when flag false, early return when recheck false, modal navigation when outdated, and lock on primary action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59ec0531aa38cd6c518f43316ae5fec1373f7588. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->