### PR TITLE
feat: Enhance Toast component styles and layout

### DIFF
--- a/app/component-library/components/Toast/Toast.styles.ts
+++ b/app/component-library/components/Toast/Toast.styles.ts
@@ -26,6 +26,7 @@ const styleSheet = (params: { theme: Theme }) => {
       borderRadius: 12,
       padding,
       flexDirection: 'row',
+      alignItems: 'center',
     },
     avatar: {
       marginRight: 16,

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -48,7 +48,7 @@ import ButtonIcon from '../Buttons/ButtonIcon';
 
 const visibilityDuration = 2750;
 const animationDuration = 250;
-const bottomPadding = 16;
+const bottomPadding = 36;
 const screenHeight = Dimensions.get('window').height;
 
 const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Improves Toast component styling and positioning:

1. **Vertical centering:** Added alignItems: 'center' to the toast base styles to vertically center the icon/avatar with the text content
2. **Elevated position:** Increased bottomPadding from 16px to 36px to raise the toast higher above the tab bar for better visibility

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
3. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved Toast component visual alignment and positioning

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-261
https://consensyssoftware.atlassian.net/browse/MDP-387

## **Manual testing steps**

```gherkin
Feature: Toast component styling improvements

  Scenario: Toast appears at elevated position
    Given the app is running
    When any toast notification is triggered
    Then the toast renders 20px higher than before (36px padding vs 16px) with the icon vertically centered with the text
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="406" height="463" alt="Screenshot 2025-12-11 at 16 16 26" src="https://github.com/user-attachments/assets/a73efca1-2a0e-4471-befa-01d624aae2df" />

<!-- [screenshots/recordings] -->

### **After**
<img width="391" height="453" alt="Screenshot 2025-12-11 at 16 08 08" src="https://github.com/user-attachments/assets/a126742c-0c31-429d-b2cf-467da0526a07" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Vertically centers Toast content and raises its position by increasing bottom padding to 36.
> 
> - **Toast**:
>   - **Styles**: Add `alignItems: 'center'` to `Toast.styles.ts` base container for vertical alignment of avatar/icon with text.
>   - **Layout**: Increase `bottomPadding` from `16` to `36` in `Toast.tsx` to position the toast higher above the tab bar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eea5f9740aa32d136c5fd45d92c8b973c1b182c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->