### PR TITLE
chore: remove announcement setting icon

### DIFF
--- a/app/components/Views/Settings/NotificationsSettings/CustomNotificationsRow/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/NotificationsSettings/CustomNotificationsRow/__snapshots__/index.test.tsx.snap
@@ -37,7 +37,6 @@ exports[`CustomNotificationsRow should render correctly 1`] = `
       style={
         {
           "color": "#121314",
-          "flex": 1,
           "fontFamily": "Geist-Medium",
           "fontSize": 18,
           "letterSpacing": 0,
@@ -46,21 +45,6 @@ exports[`CustomNotificationsRow should render correctly 1`] = `
       }
     >
       Title
-    </Text>
-    <Text
-      accessibilityRole="text"
-      style={
-        {
-          "color": "#121314",
-          "flex": 1,
-          "fontFamily": "Geist-Medium",
-          "fontSize": 18,
-          "letterSpacing": 0,
-          "lineHeight": 24,
-        }
-      }
-    >
-      Description
     </Text>
   </View>
   <RCTSwitch

--- a/app/components/Views/Settings/NotificationsSettings/CustomNotificationsRow/index.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/CustomNotificationsRow/index.test.tsx
@@ -8,7 +8,6 @@ describe('CustomNotificationsRow', () => {
     const { toJSON } = render(
       <CustomNotificationsRow
         title={'Title'}
-        description={'Description'}
         icon={IconName.Sparkle}
         isEnabled={false}
         toggleCustomNotificationsEnabled={() => jest.fn()}

--- a/app/components/Views/Settings/NotificationsSettings/CustomNotificationsRow/index.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/CustomNotificationsRow/index.tsx
@@ -18,7 +18,6 @@ export const CUSTOM_NOTIFICATIONS_ROW_SWITCH_CONTAINER_TEST_ID = (
 
 interface CustomNotificationsRowProps {
   title: string;
-  description?: string;
   icon?: IconName;
   isEnabled: boolean;
   toggleCustomNotificationsEnabled: () => void;
@@ -27,7 +26,6 @@ interface CustomNotificationsRowProps {
 
 const CustomNotificationsRow = ({
   title,
-  description,
   icon,
   isEnabled,
   toggleCustomNotificationsEnabled,
@@ -51,14 +49,7 @@ const CustomNotificationsRow = ({
         />
       )}
       <View style={styles.titleContainer}>
-        <Text variant={TextVariant.BodyLGMedium} style={styles.title}>
-          {title}
-        </Text>
-        {description && (
-          <Text variant={TextVariant.BodyLGMedium} style={styles.title}>
-            {description}
-          </Text>
-        )}
+        <Text variant={TextVariant.BodyLGMedium}>{title}</Text>
       </View>
       <Switch
         value={isEnabled}

--- a/app/components/Views/Settings/NotificationsSettings/CustomNotificationsRow/index.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/CustomNotificationsRow/index.tsx
@@ -19,7 +19,7 @@ export const CUSTOM_NOTIFICATIONS_ROW_SWITCH_CONTAINER_TEST_ID = (
 interface CustomNotificationsRowProps {
   title: string;
   description?: string;
-  icon: IconName;
+  icon?: IconName;
   isEnabled: boolean;
   toggleCustomNotificationsEnabled: () => void;
   testID?: string;
@@ -42,12 +42,14 @@ const CustomNotificationsRow = ({
       style={styles.container}
       testID={CUSTOM_NOTIFICATIONS_ROW_SWITCH_CONTAINER_TEST_ID(testID)}
     >
-      <Icon
-        name={icon}
-        style={styles.icon}
-        color={IconColor.Default}
-        size={IconSize.Lg}
-      />
+      {icon && (
+        <Icon
+          name={icon}
+          style={styles.icon}
+          color={IconColor.Default}
+          size={IconSize.Lg}
+        />
+      )}
       <View style={styles.titleContainer}>
         <Text variant={TextVariant.BodyLGMedium} style={styles.title}>
           {title}

--- a/app/components/Views/Settings/NotificationsSettings/FeatureAnnouncementToggle.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/FeatureAnnouncementToggle.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react';
 import { useFeatureAnnouncementToggle } from '../../../../util/notifications/hooks/useSwitchNotifications';
 import CustomNotificationsRow from './CustomNotificationsRow';
 import { strings } from '../../../../../locales/i18n';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { NotificationSettingsViewSelectorsIDs } from '../../../../../e2e/selectors/Notifications/NotificationSettingsView.selectors';
 
 export function FeatureAnnouncementToggle() {
@@ -18,7 +17,6 @@ export function FeatureAnnouncementToggle() {
       title={strings(
         `app_settings.notifications_opts.products_announcements_title`,
       )}
-      icon={IconName.Sparkle}
       isEnabled={isEnabled}
       toggleCustomNotificationsEnabled={toggleCustomNotificationsEnabled}
       testID={NotificationSettingsViewSelectorsIDs.FEATURE_ANNOUNCEMENTS_TOGGLE}

--- a/app/components/Views/Settings/NotificationsSettings/NotificationOptionToggle/styles.ts
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationOptionToggle/styles.ts
@@ -11,9 +11,6 @@ export const createStyles = () =>
       alignItems: 'flex-start',
       flex: 1,
     },
-    title: {
-      flex: 1,
-    },
     switch: {
       alignSelf: 'flex-start',
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Remove the sparkle icon from the product announcements setting.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: style: remove announcement settings sparkle icon

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-372, https://consensyssoftware.atlassian.net/browse/ASSETS-2121

## **Manual testing steps**

1. View Notifications Settings
2. Inspect Feature Announcement Label

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="420" height="880" alt="Screenshot 2025-12-12 at 09 35 06" src="https://github.com/user-attachments/assets/e759bb67-b9ec-438b-aa22-bbf7f4ddcc54" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<a href="https://cursor.com/background-agent?bcId=bc-fe4cd523-44cf-4b37-ad51-47ed238dd763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe4cd523-44cf-4b37-ad51-47ed238dd763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the icon from the Feature Announcement toggle and makes `CustomNotificationsRow` simpler by making `icon` optional and removing `description`, with styles/tests updated.
> 
> - **Settings/Notifications**
>   - **FeatureAnnouncementToggle**: Stop passing `icon` prop to `CustomNotificationsRow`.
>   - **CustomNotificationsRow**:
>     - Make `icon` optional and render it conditionally.
>     - Remove `description` prop and its rendering.
>     - Simplify title text usage and remove extra title style.
>   - **Styles**: Remove unused `title` style in `NotificationOptionToggle/styles.ts`.
>   - **Tests**: Update test and snapshot to reflect removed `description` and optional `icon`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4c65f2c3bcca1c71030d6e5b722a5f309401617. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->