### PR TITLE
style: update notification badge component

### DIFF
--- a/app/components/UI/Notification/List/styles.ts
+++ b/app/components/UI/Notification/List/styles.ts
@@ -58,13 +58,6 @@ export const createStyles = ({ colors }: Theme) =>
       height: 32,
     },
     containerFill: { flex: 1 },
-    badgeWrapper: {
-      alignItems: 'center',
-      justifyContent: 'center',
-      alignSelf: 'flex-start',
-      position: 'absolute',
-      top: '10%',
-    },
     circleLogo: {
       width: 32,
       height: 32,

--- a/app/components/UI/Notification/NotificationMenuItem/Icon.test.tsx
+++ b/app/components/UI/Notification/NotificationMenuItem/Icon.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { ReactTestInstance } from 'react-test-renderer';
+import { IconName } from '@metamask/design-system-react-native';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import NotificationIcon, { TEST_IDS } from './Icon';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
 import SVG_ETH_LOGO_PATH from '../../../../component-library/components/Icons/Icon/assets/ethereum.svg';
 import { BADGE_WRAPPER_BADGE_TEST_ID } from '../../../../component-library/components/Badges/BadgeWrapper/BadgeWrapper.constants';
 

--- a/app/components/UI/Notification/NotificationMenuItem/Icon.tsx
+++ b/app/components/UI/Notification/NotificationMenuItem/Icon.tsx
@@ -1,6 +1,11 @@
 import { View } from 'react-native';
 import { Image } from 'expo-image';
-import { BadgeIcon, IconSize } from '@metamask/design-system-react-native';
+import {
+  BadgeIcon,
+  IconSize,
+  BadgeStatus,
+  BadgeStatusStatus,
+} from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { NotificationMenuItem } from '../../../../util/notifications/notification-states/types/NotificationMenuItem';
 import React, {
@@ -65,31 +70,31 @@ function NotificationIcon(props: NotificationIconProps) {
               iconProps={{ size: IconSize.Lg }}
             />
           }
-          style={styles.badgeWrapper}
         >
           {children}
         </BadgeWrapper>
       ) : (
         <>{children}</>
       ),
-    [props.badgeIcon, styles.badgeWrapper],
+    [props.badgeIcon],
+  );
+
+  const statusStyle = useMemo(
+    () => (props.isRead ? tw`self-center opacity-0` : tw`self-center`),
+    [props.isRead, tw],
   );
 
   return (
-    <React.Fragment>
-      <View style={styles.itemLogoSize} testID={TEST_IDS.CONTAINER}>
-        <MaybeBadgeContainer>
-          <MenuIcon {...props} />
-        </MaybeBadgeContainer>
-        <View
-          style={
-            !props.isRead
-              ? tw`absolute -left-2 top-1/2 size-1 rounded-full bg-info-default`
-              : undefined
-          }
-        />
+    <View>
+      <View style={tw`flex-row gap-1`}>
+        <BadgeStatus status={BadgeStatusStatus.New} style={statusStyle} />
+        <View style={styles.itemLogoSize} testID={TEST_IDS.CONTAINER}>
+          <MaybeBadgeContainer>
+            <MenuIcon {...props} />
+          </MaybeBadgeContainer>
+        </View>
       </View>
-    </React.Fragment>
+    </View>
   );
 }
 

--- a/app/components/UI/Notification/NotificationMenuItem/Icon.tsx
+++ b/app/components/UI/Notification/NotificationMenuItem/Icon.tsx
@@ -1,5 +1,6 @@
 import { View } from 'react-native';
 import { Image } from 'expo-image';
+import { BadgeIcon, IconSize } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { NotificationMenuItem } from '../../../../util/notifications/notification-states/types/NotificationMenuItem';
 import React, {
@@ -10,9 +11,6 @@ import React, {
 } from 'react';
 import useStyles from '../List/useStyles';
 import BadgeWrapper from '../../../../component-library/components/Badges/BadgeWrapper';
-import Badge, {
-  BadgeVariant,
-} from '../../../../component-library/components/Badges/Badge';
 import { BOTTOM_BADGEWRAPPER_BADGEPOSITION } from '../../../../component-library/components/Badges/BadgeWrapper/BadgeWrapper.constants';
 import METAMASK_FOX from '../../../../images/branding/fox.png';
 
@@ -62,9 +60,9 @@ function NotificationIcon(props: NotificationIconProps) {
         <BadgeWrapper
           badgePosition={BOTTOM_BADGEWRAPPER_BADGEPOSITION}
           badgeElement={
-            <Badge
-              variant={BadgeVariant.NotificationsKinds}
+            <BadgeIcon
               iconName={props.badgeIcon}
+              iconProps={{ size: IconSize.Lg }}
             />
           }
           style={styles.badgeWrapper}
@@ -86,7 +84,7 @@ function NotificationIcon(props: NotificationIconProps) {
         <View
           style={
             !props.isRead
-              ? tw`absolute -left-1 top-1/2 size-1 rounded-full bg-info-default`
+              ? tw`absolute -left-2 top-1/2 size-1 rounded-full bg-info-default`
               : undefined
           }
         />

--- a/app/util/notifications/methods/common.ts
+++ b/app/util/notifications/methods/common.ts
@@ -1,9 +1,9 @@
 import dayjs, { Dayjs } from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-
 import localeData from 'dayjs/plugin/localeData';
 import { Web3Provider } from '@ethersproject/providers';
 import { toHex } from '@metamask/controller-utils';
+import { IconName } from '@metamask/design-system-react-native';
 import BigNumber from 'bignumber.js';
 import {
   OnChainRawNotification,
@@ -18,7 +18,6 @@ import {
   SUPPORTED_NOTIFICATION_BLOCK_EXPLORERS,
 } from '@metamask/notification-services-controller/notification-services/ui';
 import Engine from '../../../core/Engine';
-import { IconName } from '../../../component-library/components/Icons/Icon';
 import { hexWEIToDecETH, hexWEIToDecGWEI } from '../../conversions';
 import { calcTokenAmount } from '../../transactions';
 import images from '../../../images/image-icons';
@@ -262,7 +261,7 @@ export const getNetworkFees = async (notification: OnChainRawNotification) => {
   }
 };
 
-export const getNotificationBadge = (trigger_type: string) => {
+export const getNotificationBadge = (trigger_type: string): IconName => {
   switch (trigger_type) {
     case TRIGGER_TYPES.ERC20_SENT:
     case TRIGGER_TYPES.ERC721_SENT:

--- a/app/util/notifications/notification-states/types/NotificationMenuItem.ts
+++ b/app/util/notifications/notification-states/types/NotificationMenuItem.ts
@@ -1,4 +1,4 @@
-import { IconName } from '../../../../component-library/components/Icons/Icon';
+import { IconName } from '@metamask/design-system-react-native';
 import { ImageSourcePropType } from 'react-native';
 
 export interface NotificationMenuItem {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Update notification badges to use `BadgeIcon` from the design system to improve visibility of icons.

The previous `Badge` component with `BadgeVariant.NotificationsKinds` rendered icons at `IconSize.Xss`, making them difficult to see. Switching to `BadgeIcon` with `IconSize.Lg` addresses this by providing a larger, more readable icon.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: style: update notification item badge style

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-371 https://consensyssoftware.atlassian.net/browse/ASSETS-2122

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="436" height="893" alt="Screenshot 2025-12-12 at 14 03 20" src="https://github.com/user-attachments/assets/613350a6-0f86-488f-bdd6-d0381c1824b0" />


### **After**

<img width="437" height="906" alt="Screenshot 2025-12-12 at 11 35 52" src="https://github.com/user-attachments/assets/d813daa9-b1bb-41f5-9641-ebabc3a4cbe9" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<a href="https://cursor.com/background-agent?bcId=bc-1e901d8a-a6db-48c0-9c90-3a80aa114e18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e901d8a-a6db-48c0-9c90-3a80aa114e18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces notification item badge with design-system BadgeIcon (larger size) and adds a design-system unread status indicator, updating related imports/types and removing an unused style.
> 
> - **UI**:
>   - `NotificationMenuItem/Icon.tsx`: Replace `Badge` with `BadgeIcon` (`IconSize.Lg`); add `BadgeStatus` ("New") shown when unread; tweak layout (`flex-row gap-1`) and remove reliance on `styles.badgeWrapper`.
>   - `Notification/List/styles.ts`: Remove unused `badgeWrapper` style.
> - **Types/Utils**:
>   - Use `IconName` from `@metamask/design-system-react-native` across files; annotate `getNotificationBadge` to return `IconName`.
> - **Tests**:
>   - Update `Icon.test.tsx` to import `IconName` from design system.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 681890e0820201dc2f0bc1ad65620353d1de1f29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->