### PR TITLE
feat(ramp): add paste button for OTP verification code input

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/OtpCode/OtpCode.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/OtpCode/OtpCode.test.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
 import OtpCode from './OtpCode';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { NativeTransakAccessToken } from '@consensys/native-ramps-sdk';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import { renderScreen } from '../../../../../../util/test/renderWithProvider';
 import { trace } from '../../../../../../util/trace';
+
+jest.mock('@react-native-clipboard/clipboard', () => ({
+  getString: jest.fn(),
+}));
+
+const mockGetString = Clipboard.getString as jest.Mock;
 
 const mockEmail = 'test@email.com';
 
@@ -116,6 +123,7 @@ describe('OtpCode Screen', () => {
     mockVerifyUserOtp.mockResolvedValue('Success');
     mockSendUserOtp.mockResolvedValue('Success');
     mockTrackEvent.mockClear();
+    mockGetString.mockResolvedValue('');
   });
 
   it('render matches snapshot', () => {
@@ -304,6 +312,105 @@ describe('OtpCode Screen', () => {
         expect(mockVerifyUserOtp).toHaveBeenCalled();
         expect(mockSetAuthToken).toHaveBeenCalledWith(mockTokenResponse);
         expect(mockNavigate).toHaveBeenCalledWith(Routes.DEPOSIT.ROOT);
+      });
+    });
+  });
+
+  describe('paste functionality', () => {
+    it('renders paste button', () => {
+      const { getByTestId } = render(OtpCode);
+
+      const pasteButton = getByTestId('otp-code-paste-button');
+
+      expect(pasteButton).toBeOnTheScreen();
+    });
+
+    it('reads from clipboard when paste button is pressed', async () => {
+      mockGetString.mockResolvedValue('123456');
+      const { getByTestId } = render(OtpCode);
+      const pasteButton = getByTestId('otp-code-paste-button');
+
+      await act(async () => {
+        fireEvent.press(pasteButton);
+      });
+
+      expect(mockGetString).toHaveBeenCalled();
+    });
+
+    it('extracts only numeric characters from clipboard content', async () => {
+      mockGetString.mockResolvedValue('abc123def456');
+      const { getByTestId } = render(OtpCode);
+      const pasteButton = getByTestId('otp-code-paste-button');
+
+      await act(async () => {
+        fireEvent.press(pasteButton);
+      });
+
+      const codeInput = getByTestId('otp-code-input');
+      expect(codeInput.props.value).toBe('123456');
+    });
+
+    it('limits pasted content to 6 digits', async () => {
+      mockGetString.mockResolvedValue('123456789');
+      const { getByTestId } = render(OtpCode);
+      const pasteButton = getByTestId('otp-code-paste-button');
+
+      await act(async () => {
+        fireEvent.press(pasteButton);
+      });
+
+      const codeInput = getByTestId('otp-code-input');
+      expect(codeInput.props.value).toBe('123456');
+    });
+
+    it('does not update value when clipboard content has no numeric characters', async () => {
+      mockGetString.mockResolvedValue('abcdef');
+      const { getByTestId } = render(OtpCode);
+      const pasteButton = getByTestId('otp-code-paste-button');
+
+      await act(async () => {
+        fireEvent.press(pasteButton);
+      });
+
+      const codeInput = getByTestId('otp-code-input');
+      expect(codeInput.props.value).toBe('');
+    });
+
+    it('overwrites existing input when paste button is pressed', async () => {
+      mockGetString.mockResolvedValue('654321');
+      const { getByTestId } = render(OtpCode);
+      const codeInput = getByTestId('otp-code-input');
+
+      act(() => {
+        fireEvent.changeText(codeInput, '123');
+      });
+
+      const pasteButton = getByTestId('otp-code-paste-button');
+      await act(async () => {
+        fireEvent.press(pasteButton);
+      });
+
+      expect(codeInput.props.value).toBe('654321');
+    });
+
+    it('triggers auto-submit when pasting 6 digits', async () => {
+      const mockTokenResponse: NativeTransakAccessToken = {
+        accessToken: 'mock-access-token-paste',
+        ttl: 1000,
+        created: new Date('2024-01-01'),
+      };
+      mockVerifyUserOtp.mockResolvedValue(mockTokenResponse);
+      mockSetAuthToken.mockResolvedValue(undefined);
+      mockGetString.mockResolvedValue('123456');
+      const { getByTestId } = render(OtpCode);
+      const pasteButton = getByTestId('otp-code-paste-button');
+
+      await act(async () => {
+        fireEvent.press(pasteButton);
+      });
+
+      await waitFor(() => {
+        expect(mockVerifyUserOtp).toHaveBeenCalled();
       });
     });
   });

--- a/app/components/UI/Ramp/Deposit/Views/OtpCode/OtpCode.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/OtpCode/OtpCode.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback, useState, useEffect, useRef, FC } from 'react';
 import { TextInput, View, TouchableOpacity, Linking } from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
 import Text, {
   TextVariant,
+  TextColor,
 } from '../../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../../component-library/hooks';
 import styleSheet from './OtpCode.styles';
@@ -35,6 +37,7 @@ import Logger from '../../../../../../util/Logger';
 import useAnalytics from '../../../hooks/useAnalytics';
 import { createBuildQuoteNavDetails } from '../../../Deposit/Views/BuildQuote/BuildQuote';
 import { trace, TraceName } from '../../../../../../util/trace';
+import { Box, BoxAlignItems } from '@metamask/design-system-react-native';
 
 export interface OtpCodeParams {
   email: string;
@@ -244,6 +247,15 @@ const OtpCode = () => {
     setLatestValueSubmitted(null);
   }, []);
 
+  const handlePaste = useCallback(async () => {
+    const text = await Clipboard.getString();
+    // Extract only numeric characters and limit to CELL_COUNT digits
+    const numericText = text.replace(/\D/g, '').slice(0, CELL_COUNT);
+    if (numericText.length > 0) {
+      handleValueChange(numericText);
+    }
+  }, [handleValueChange]);
+
   useEffect(() => {
     if (value.length === CELL_COUNT && latestValueSubmitted !== value) {
       setLatestValueSubmitted(value);
@@ -267,6 +279,18 @@ const OtpCode = () => {
           <Text style={styles.description}>
             {strings('deposit.otp_code.description', { email })}
           </Text>
+
+          <Box alignItems={BoxAlignItems.End}>
+            <Text
+              variant={TextVariant.BodyMD}
+              color={TextColor.Primary}
+              onPress={handlePaste}
+              testID="otp-code-paste-button"
+            >
+              {strings('deposit.otp_code.paste')}
+            </Text>
+          </Box>
+
           <CodeField
             testID="otp-code-input"
             ref={inputRef as React.RefObject<TextInput>}

--- a/app/components/UI/Ramp/Deposit/Views/OtpCode/__snapshots__/OtpCode.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/OtpCode/__snapshots__/OtpCode.test.tsx.snap
@@ -488,6 +488,34 @@ exports[`OtpCode Screen calls resendOtp when resend link is clicked and properly
                               style={
                                 [
                                   {
+                                    "alignItems": "flex-end",
+                                    "display": "flex",
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                onPress={[Function]}
+                                style={
+                                  {
+                                    "color": "#4459ff",
+                                    "fontFamily": "Geist-Regular",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
+                                }
+                                testID="otp-code-paste-button"
+                              >
+                                Paste
+                              </Text>
+                            </View>
+                            <View
+                              style={
+                                [
+                                  {
                                     "flexDirection": "row",
                                     "justifyContent": "space-between",
                                   },
@@ -1326,6 +1354,34 @@ exports[`OtpCode Screen render matches snapshot 1`] = `
                             >
                               Enter the code we sent to test@email.com. If you don't see it, check your spam folder.
                             </Text>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "alignItems": "flex-end",
+                                    "display": "flex",
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                onPress={[Function]}
+                                style={
+                                  {
+                                    "color": "#4459ff",
+                                    "fontFamily": "Geist-Regular",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
+                                }
+                                testID="otp-code-paste-button"
+                              >
+                                Paste
+                              </Text>
+                            </View>
                             <View
                               style={
                                 [
@@ -2192,6 +2248,34 @@ exports[`OtpCode Screen renders cooldown timer snapshot after resending OTP 1`] 
                               style={
                                 [
                                   {
+                                    "alignItems": "flex-end",
+                                    "display": "flex",
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                onPress={[Function]}
+                                style={
+                                  {
+                                    "color": "#4459ff",
+                                    "fontFamily": "Geist-Regular",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
+                                }
+                                testID="otp-code-paste-button"
+                              >
+                                Paste
+                              </Text>
+                            </View>
+                            <View
+                              style={
+                                [
+                                  {
                                     "flexDirection": "row",
                                     "justifyContent": "space-between",
                                   },
@@ -3030,6 +3114,34 @@ exports[`OtpCode Screen renders error snapshot when API call fails 1`] = `
                             >
                               Enter the code we sent to test@email.com. If you don't see it, check your spam folder.
                             </Text>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "alignItems": "flex-end",
+                                    "display": "flex",
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                onPress={[Function]}
+                                style={
+                                  {
+                                    "color": "#4459ff",
+                                    "fontFamily": "Geist-Regular",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
+                                }
+                                testID="otp-code-paste-button"
+                              >
+                                Paste
+                              </Text>
+                            </View>
                             <View
                               style={
                                 [
@@ -3917,6 +4029,34 @@ exports[`OtpCode Screen renders resend error snapshot when resend fails 1`] = `
                             >
                               Enter the code we sent to test@email.com. If you don't see it, check your spam folder.
                             </Text>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "alignItems": "flex-end",
+                                    "display": "flex",
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                onPress={[Function]}
+                                style={
+                                  {
+                                    "color": "#4459ff",
+                                    "fontFamily": "Geist-Regular",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
+                                }
+                                testID="otp-code-paste-button"
+                              >
+                                Paste
+                              </Text>
+                            </View>
                             <View
                               style={
                                 [

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -785,7 +785,8 @@
       "resend_code_button": "Resend it",
       "resend_cooldown": "Resend code in {{seconds}} seconds",
       "contact_support": "Contact support",
-      "error": "An error occurred while verifying the code"
+      "error": "An error occurred while verifying the code",
+      "paste": "Paste"
     },
     "verify_identity": {
       "title": "Verify your identity",


### PR DESCRIPTION
## **Description**

Users on iOS devices are unable to paste the email verification code by long pressing into the input field. The paste menu does not appear, possibly due to the input being already focused when the screen opens.

This PR adds a "Paste" pressable text button above the OTP code input field, similar to the SRP (Secret Recovery Phrase) input implementation. When pressed, it reads from the clipboard, extracts only numeric characters, limits to 6 digits, and populates the input field (overriding any existing content). If all 6 digits are pasted, auto-submit is triggered.

## **Changelog**

CHANGELOG entry: Added paste button for email verification code input on Deposit flow

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-2892

## **Manual testing steps**

```gherkin
Feature: Paste OTP verification code

  Scenario: user pastes verification code from clipboard
    Given user is on the OTP verification screen in Deposit flow
    And user has copied a 6-digit code to clipboard

    When user taps the "Paste" button
    Then the code input is populated with the numeric characters from clipboard
    And the code is auto-submitted if 6 digits are pasted

  Scenario: user pastes code with non-numeric characters
    Given user is on the OTP verification screen
    And user has copied text with mixed characters (e.g. "abc123def456") to clipboard

    When user taps the "Paste" button
    Then only numeric characters are extracted and populated (e.g. "123456")

  Scenario: user pastes code longer than 6 digits
    Given user is on the OTP verification screen
    And user has copied a code longer than 6 digits to clipboard

    When user taps the "Paste" button
    Then only the first 6 digits are populated
```

## **Screenshots/Recordings**

### **Before**

<img width="299" alt="image" src="https://github.com/user-attachments/assets/ea96bfcd-7828-41ff-9fca-b86715b32524" />


### **After**

<img width="299" alt="paste" src="https://github.com/user-attachments/assets/3afb422c-82aa-4648-b51f-385b7fa1ea3c" />

https://github.com/user-attachments/assets/c93e17ec-1a6c-435c-81fa-2cab4d8dee78



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Paste action to the Deposit OTP screen that reads numeric digits from clipboard (max 6) and auto-submits when complete, with tests and i18n updates.
> 
> - **Deposit OTP UI (`OtpCode.tsx`)**:
>   - Add clipboard-based Paste action (`otp-code-paste-button`) using `@react-native-clipboard/clipboard`.
>   - Extract only numeric chars and cap to `CELL_COUNT` (6); updates input and triggers auto-submit on 6 digits.
>   - Minor UI addition using `Box` and `TextColor`; focus logic unchanged.
> - **Tests (`OtpCode.test.tsx`)**:
>   - Mock clipboard and add test suite covering paste button presence, clipboard read, numeric extraction, length cap, no-op on non-numeric, overwrite behavior, and auto-submit on 6 digits.
> - **Snapshots**:
>   - Updated to include the new Paste button in the screen.
> - **Localization (`locales/languages/en.json`)**:
>   - Add `deposit.otp_code.paste` string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bd5f36d3f2390b94b9bffda630a355f597b702a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->