### PR TITLE
fix: added padding to price chart in asset details

### DIFF
--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
@@ -12,8 +12,7 @@ const styleSheet = (params: { theme: Theme }) => {
   const { typography } = theme;
   return StyleSheet.create({
     chart: {
-      paddingRight: 0,
-      paddingLeft: 0,
+      paddingHorizontal: 16,
       height: CHART_HEIGHT - 10, // hack to remove internal padding that is not configurable
       paddingTop: 0,
       marginVertical: 10,

--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
@@ -6,13 +6,14 @@ import {
 } from '../../../../component-library/components/Texts/Text';
 
 export const CHART_HEIGHT = Dimensions.get('screen').height * 0.44;
+export const CHART_HORIZONTAL_PADDING = 16;
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
   const { typography } = theme;
   return StyleSheet.create({
     chart: {
-      paddingHorizontal: 16,
+      paddingHorizontal: CHART_HORIZONTAL_PADDING,
       height: CHART_HEIGHT - 10, // hack to remove internal padding that is not configurable
       paddingTop: 0,
       marginVertical: 10,
@@ -23,7 +24,7 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     chartLoading: {
       width: Dimensions.get('screen').width,
-      paddingHorizontal: 16,
+      paddingHorizontal: CHART_HORIZONTAL_PADDING,
       paddingTop: 10,
     },
     noDataOverlay: {

--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.tsx
@@ -31,7 +31,10 @@ import Text, {
   TextVariant,
 } from '../../../../component-library/components/Texts/Text';
 import Title from '../../../Base/Title';
-import styleSheet, { CHART_HEIGHT } from './PriceChart.styles';
+import styleSheet, {
+  CHART_HEIGHT,
+  CHART_HORIZONTAL_PADDING,
+} from './PriceChart.styles';
 import { placeholderData } from './utils';
 import PriceChartContext from './PriceChart.context';
 
@@ -134,7 +137,9 @@ const PriceChart = ({
       onActiveIndexChange(-1);
       return;
     }
-    const chartWidth = Dimensions.get('window').width;
+    // Account for horizontal padding when calculating chart width
+    const chartWidth =
+      Dimensions.get('window').width - CHART_HORIZONTAL_PADDING * 2;
     const xDistance = chartWidth / priceList.length;
     if (x <= 0) {
       x = 0;

--- a/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
+++ b/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
@@ -140,8 +140,7 @@ exports[`AssetOverview should render native balances when non evm network is sel
         {
           "height": 576.96,
           "marginVertical": 10,
-          "paddingLeft": 0,
-          "paddingRight": 0,
+          "paddingHorizontal": 16,
           "paddingTop": 0,
           "width": 750,
         }


### PR DESCRIPTION
## **Description**

added padding to price chart in asset details

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-229

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

| before | after |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/9c705265-b59f-4c64-b885-8f89d94815ba) | ![after](https://github.com/user-attachments/assets/570f8804-cc48-47b7-b227-b3b01dbf0374) |

https://github.com/user-attachments/assets/e82ba486-c8e9-4ac2-a0e8-91fb79b08193

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds 16px horizontal padding to the Asset Overview price chart and updates touch/index calculations to use the padded width; updates snapshot.
> 
> - **UI — Asset Overview Price Chart**
>   - Add `CHART_HORIZONTAL_PADDING` (16) and apply `paddingHorizontal` in `PriceChart.styles.tsx` for `chart` and `chartLoading`.
>   - Update touch/index calculation in `PriceChart.tsx` to use `Dimensions.get('window').width - CHART_HORIZONTAL_PADDING * 2`.
>   - Adjust imports to include `CHART_HORIZONTAL_PADDING`.
> - **Tests**
>   - Update snapshot to reflect new `paddingHorizontal: 16` on the chart container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 108d82754dcd92a1191be96dc9b89cf61df46b9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->