### PR TITLE
test: exposes delay in tapAtIndex

### DIFF
--- a/e2e/framework/Gestures.ts
+++ b/e2e/framework/Gestures.ts
@@ -160,7 +160,15 @@ export default class Gestures {
     index: number,
     options: TapOptions = {},
   ): Promise<void> {
-    const { timeout = BASE_DEFAULTS.timeout, elemDescription } = options;
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      elemDescription,
+      delay = 0,
+    } = options;
+
+    // Add delay before tapping if provided
+    await new Promise((resolve) => setTimeout(resolve, delay));
+
     return Utilities.executeWithRetry(
       async () => {
         const el = (await elem) as Detox.IndexableNativeElement;

--- a/e2e/pages/wallet/AccountListBottomSheet.ts
+++ b/e2e/pages/wallet/AccountListBottomSheet.ts
@@ -220,9 +220,13 @@ class AccountListBottomSheet {
    * Tap the ellipsis menu button for a specific account in V2 multichain accounts
    * @param accountIndex - The index of the account to tap (0-based)
    */
-  async tapAccountEllipsisButtonV2(accountIndex: number): Promise<void> {
+  async tapAccountEllipsisButtonV2(
+    accountIndex: number,
+    options?: { delay?: number },
+  ): Promise<void> {
     await Gestures.tapAtIndex(this.ellipsisMenuButton, accountIndex, {
       elemDescription: `V2 ellipsis menu button for account at index ${accountIndex}`,
+      delay: options?.delay ?? 0,
     });
   }
 

--- a/e2e/specs/identity/account-syncing/multi-srp.spec.ts
+++ b/e2e/specs/identity/account-syncing/multi-srp.spec.ts
@@ -130,7 +130,9 @@ describe(SmokeIdentity('Account syncing - Mutiple SRPs'), () => {
           },
         );
 
-        await AccountListBottomSheet.tapAccountEllipsisButtonV2(3);
+        await AccountListBottomSheet.tapAccountEllipsisButtonV2(3, {
+          delay: 1500,
+        });
         await AccountDetails.tapEditAccountName();
         await EditAccountName.updateAccountName(SRP_2_SECOND_ACCOUNT);
         await EditAccountName.tapSave();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional pre-tap delay to `Gestures.tapAtIndex`, plumbs it through `AccountListBottomSheet.tapAccountEllipsisButtonV2`, and updates the multi-SRP e2e test to use it.
> 
> - **E2E Framework**
>   - `Gestures.tapAtIndex`: Add `delay` option (defaults to `0`) and wait before tapping.
> - **Page Object**
>   - `AccountListBottomSheet.tapAccountEllipsisButtonV2`: Accepts `{ delay? }` and forwards `delay` to `tapAtIndex`.
> - **Tests**
>   - `e2e/specs/identity/account-syncing/multi-srp.spec.ts`: Uses `tapAccountEllipsisButtonV2(3, { delay: 1500 })` when opening the ellipsis menu.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba1b775a6b244de5b696625b9d18529dd63cc88e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->