### PR TITLE
test: fixes multi-srp test with tapAtIndex in framework fixed

### DIFF
--- a/e2e/framework/Gestures.ts
+++ b/e2e/framework/Gestures.ts
@@ -160,12 +160,28 @@ export default class Gestures {
     index: number,
     options: TapOptions = {},
   ): Promise<void> {
-    const { timeout = BASE_DEFAULTS.timeout, elemDescription } = options;
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      elemDescription,
+      delay = 0,
+    } = options;
+
+    // Add delay before tapping if provided
+    if (delay > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+
+    // Use a shorter inner timeout to allow for retries within the overall timeout
+    // If inner timeout equals outer timeout, no retries can happen
+    const innerTimeout = Math.min(3000, timeout / 3);
+
     return Utilities.executeWithRetry(
       async () => {
         const el = (await elem) as Detox.IndexableNativeElement;
         const itemElementAtIndex = el.atIndex(index);
-        await waitFor(itemElementAtIndex).toBeVisible().withTimeout(timeout);
+        await waitFor(itemElementAtIndex)
+          .toBeVisible()
+          .withTimeout(innerTimeout);
         await itemElementAtIndex.tap();
         const successMessage = elemDescription
           ? `✅ Successfully tapped element at index: ${index} ${elemDescription}`
@@ -175,6 +191,7 @@ export default class Gestures {
       {
         timeout,
         description: `tapAtIndex(${index})`,
+        elemDescription,
       },
     );
   }

--- a/e2e/pages/wallet/AccountListBottomSheet.ts
+++ b/e2e/pages/wallet/AccountListBottomSheet.ts
@@ -217,6 +217,18 @@ class AccountListBottomSheet {
   }
 
   /**
+   * Get the ellipsis menu button for a specific account by index
+   * @param accountIndex - The index of the account (0-based)
+   * @returns The ellipsis menu element at the specified index
+   */
+  async getEllipsisMenuButtonAtIndex(
+    accountIndex: number,
+  ): Promise<Detox.IndexableNativeElement> {
+    const el = (await this.ellipsisMenuButton) as Detox.IndexableNativeElement;
+    return el.atIndex(accountIndex) as Detox.IndexableNativeElement;
+  }
+
+  /**
    * Tap the ellipsis menu button for a specific account in V2 multichain accounts
    * @param accountIndex - The index of the account to tap (0-based)
    */

--- a/e2e/specs/identity/account-syncing/multi-srp.spec.ts
+++ b/e2e/specs/identity/account-syncing/multi-srp.spec.ts
@@ -121,11 +121,12 @@ describe(SmokeIdentity('Account syncing - Mutiple SRPs'), () => {
 
         await waitUntilSyncedAccountsNumberEquals(4);
 
-        // Wait for account to be visible before interacting
+        // Wait for the 4th account's ellipsis button to be visible before tapping
         await Assertions.expectElementToBeVisible(
-          AccountListBottomSheet.getAccountElementByAccountNameV2('Account 1'),
+          await AccountListBottomSheet.getEllipsisMenuButtonAtIndex(3),
           {
-            description: 'fourth account should be visible after creation',
+            description:
+              'ellipsis button for 2nd account on SRP 2 should be visible',
             timeout: 10000,
           },
         );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
#### Context for the framework changes
The inner timeout of `tapAtIndex` was defaulting to the base timeout which is the same as the outer timeout used by `executeWithRetry`. This means that the "retry" part never actually occurs for situations where elements are stale as the inner timeout fills in the total timeout of the outer function. With these changes, we use a smaller inner timeout forcing an extra lookup.

#### Context for the test changes
The previous implementation was asserting for `getAccountElementByAccountNameV2('Account 1')` but `Account 1` is already present in SRP 1 and the previous step adds an account to SRP 2 to then edit details. The new implementation waits for the Account 2 of SRP2 to be displayed via the ellipses which is the element we'll then tap to edit details.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances tapAtIndex with optional delay and shorter inner timeout, adds an ellipsis-button accessor, and updates the multi-SRP test to wait for/tap the ellipsis by index before renaming.
> 
> - **E2E Framework (`e2e/framework/Gestures.ts`)**:
>   - Improves `tapAtIndex`:
>     - Adds `delay` option and pre-tap wait.
>     - Uses shorter inner visibility timeout (`min(3000, timeout/3)`) for retries.
>     - Passes `elemDescription` to retry metadata.
> - **Wallet Page Object (`e2e/pages/wallet/AccountListBottomSheet.ts`)**:
>   - Adds `getEllipsisMenuButtonAtIndex(accountIndex)` to fetch `AccountCellIds.MENU` at a given index.
> - **Tests (`e2e/specs/identity/account-syncing/multi-srp.spec.ts`)**:
>   - Updates flow to wait for the 4th account’s ellipsis button via `getEllipsisMenuButtonAtIndex(3)` before tapping and renaming.
>   - Clarifies descriptions/comments around visibility waits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 113a90a187875d57168473b40dea89588ad4ac23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->