### PR TITLE
fix(EngineService): persist controller state changes during Engine.init

### DIFF
--- a/app/core/EngineService/EngineService.test.ts
+++ b/app/core/EngineService/EngineService.test.ts
@@ -800,10 +800,8 @@ describe('EngineService', () => {
     });
 
     it('logs persistence errors without crashing (graceful degradation)', async () => {
-      // Arrange
-      const persistError = new Error('Persistence failed');
-      mockPersistController.mockRejectedValue(persistError);
-
+      // Arrange - Start engine first, then set up failure mock
+      // This prevents unhandled rejections from state change detection during init
       await engineService.start();
 
       const mockSubscribe = Engine.controllerMessenger
@@ -822,6 +820,10 @@ describe('EngineService', () => {
       ]?.[1] as (controllerState: unknown) => Promise<void>;
 
       expect(subscriptionCallback).toBeDefined();
+
+      // Now set up the mock to reject for the subscription callback test
+      const persistError = new Error('Persistence failed');
+      mockPersistController.mockRejectedValue(persistError);
 
       const controllerState = { field1: 'value1' };
 
@@ -881,7 +883,12 @@ describe('EngineService', () => {
     });
 
     it('handles missing controllerMessenger without errors', async () => {
-      // Arrange
+      // Arrange - Save original controllerMessenger descriptor
+      const originalDescriptor = Object.getOwnPropertyDescriptor(
+        Engine,
+        'controllerMessenger',
+      );
+
       Object.defineProperty(Engine, 'controllerMessenger', {
         value: null,
         writable: true,
@@ -894,6 +901,249 @@ describe('EngineService', () => {
       // Should not log success message
       expect(Logger.log).not.toHaveBeenCalledWith(
         'Individual controller persistence subscriptions set up successfully',
+      );
+
+      // Cleanup - Restore original controllerMessenger
+      if (originalDescriptor) {
+        Object.defineProperty(
+          Engine,
+          'controllerMessenger',
+          originalDescriptor,
+        );
+      }
+    });
+
+    it('persists state that changed during Engine.init()', async () => {
+      // Arrange - Mock controller with state that differs from initial state
+      const initialControllerState = { field1: 'oldValue' };
+      const currentControllerState = { field1: 'newValue', field2: 'value2' };
+
+      // Override context with state included (the inner beforeEach only sets metadata)
+      Object.defineProperty(Engine, 'context', {
+        value: {
+          KeyringController: {
+            subscribe: jest.fn(),
+            state: currentControllerState,
+            metadata: {
+              field1: { persist: true, anonymous: false },
+              field2: { persist: true, anonymous: false },
+            },
+          },
+          PreferencesController: {
+            subscribe: jest.fn(),
+            state: { pref1: 'unchanged' },
+            metadata: {
+              pref1: { persist: true, anonymous: false },
+            },
+          },
+          NetworkController: {
+            subscribe: jest.fn(),
+            state: { network: 'mainnet' },
+            metadata: {
+              network: { persist: true, anonymous: false },
+            },
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // Mock getPersistentState to return filtered state based on actual state
+      mockGetPersistentState.mockImplementation(
+        (state) => state as unknown as ReturnType<typeof getPersistentState>,
+      );
+
+      // Mock ControllerStorage to return initial state
+      (ControllerStorage.getAllPersistedState as jest.Mock).mockResolvedValue({
+        backgroundState: {
+          KeyringController: initialControllerState,
+          PreferencesController: { pref1: 'unchanged' },
+          NetworkController: { network: 'mainnet' },
+        },
+      });
+
+      // Act
+      await engineService.start();
+
+      // Assert - KeyringController state changed, should be queued for persist
+      expect(Logger.log).toHaveBeenCalledWith(
+        'EngineService: KeyringController state changed during init, queued for persist',
+      );
+      expect(mockPersistController).toHaveBeenCalledWith(
+        currentControllerState,
+        'KeyringController',
+      );
+    });
+
+    it('does not persist state that has not changed during Engine.init()', async () => {
+      // Arrange - Mock controller with state that matches initial state (same reference)
+      const sharedState = { field1: 'value1' };
+
+      Object.defineProperty(Engine, 'context', {
+        value: {
+          KeyringController: {
+            subscribe: jest.fn(),
+            state: sharedState,
+            metadata: {
+              field1: { persist: true, anonymous: false },
+            },
+          },
+          PreferencesController: {
+            subscribe: jest.fn(),
+            state: sharedState,
+            metadata: {
+              field1: { persist: true, anonymous: false },
+            },
+          },
+          NetworkController: {
+            subscribe: jest.fn(),
+            state: sharedState,
+            metadata: {
+              field1: { persist: true, anonymous: false },
+            },
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // Mock getPersistentState to return the same reference
+      mockGetPersistentState.mockReturnValue(sharedState);
+
+      // Mock ControllerStorage to return initial state with same references
+      (ControllerStorage.getAllPersistedState as jest.Mock).mockResolvedValue({
+        backgroundState: {
+          KeyringController: sharedState,
+          PreferencesController: sharedState,
+          NetworkController: sharedState,
+        },
+      });
+
+      // Reset mock to track only init-triggered persistence
+      mockPersistController.mockClear();
+
+      // Act
+      await engineService.start();
+
+      // Assert - No state changed during init, should NOT call persist
+      expect(Logger.log).not.toHaveBeenCalledWith(
+        expect.stringContaining('state changed during init'),
+      );
+      // mockPersistController should not have been called for init persistence
+      // (it may be called for subscription setup)
+      const initPersistCalls = mockPersistController.mock.calls.filter(
+        (call) =>
+          call[1] === 'KeyringController' ||
+          call[1] === 'PreferencesController' ||
+          call[1] === 'NetworkController',
+      );
+      expect(initPersistCalls).toHaveLength(0);
+    });
+
+    it('persists state for new install when no initial state exists', async () => {
+      // Arrange - New install: no initial state
+      const currentControllerState = { field1: 'newValue' };
+
+      Object.defineProperty(Engine, 'context', {
+        value: {
+          KeyringController: {
+            subscribe: jest.fn(),
+            state: currentControllerState,
+            metadata: {
+              field1: { persist: true, anonymous: false },
+            },
+          },
+          PreferencesController: {
+            subscribe: jest.fn(),
+            state: { pref1: 'default' },
+            metadata: {
+              pref1: { persist: true, anonymous: false },
+            },
+          },
+          NetworkController: {
+            subscribe: jest.fn(),
+            state: { network: 'mainnet' },
+            metadata: {
+              network: { persist: true, anonymous: false },
+            },
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      mockGetPersistentState.mockImplementation(
+        (state) => state as unknown as ReturnType<typeof getPersistentState>,
+      );
+
+      // Mock ControllerStorage to return empty state (new install)
+      (ControllerStorage.getAllPersistedState as jest.Mock).mockResolvedValue({
+        backgroundState: {},
+      });
+
+      // Reset mock
+      mockPersistController.mockClear();
+
+      // Act
+      await engineService.start();
+
+      // Assert - New install should persist all controllers with state
+      expect(Logger.log).toHaveBeenCalledWith(
+        'EngineService: KeyringController state changed during init, queued for persist',
+      );
+      expect(mockPersistController).toHaveBeenCalledWith(
+        currentControllerState,
+        'KeyringController',
+      );
+    });
+
+    it('does not persist empty state for controllers without state to save', async () => {
+      // Arrange - Controller with empty filtered state
+      Object.defineProperty(Engine, 'context', {
+        value: {
+          KeyringController: {
+            subscribe: jest.fn(),
+            state: { someData: 'value' },
+            metadata: {
+              someData: { persist: true, anonymous: false },
+            },
+          },
+          PreferencesController: {
+            subscribe: jest.fn(),
+            state: { pref: 'value' },
+            metadata: {
+              pref: { persist: true, anonymous: false },
+            },
+          },
+          NetworkController: {
+            subscribe: jest.fn(),
+            state: { network: 'mainnet' },
+            metadata: {
+              network: { persist: true, anonymous: false },
+            },
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // Mock getPersistentState to return empty object (simulates all state being filtered out)
+      mockGetPersistentState.mockReturnValue({});
+
+      // Mock ControllerStorage to return empty state (new install)
+      (ControllerStorage.getAllPersistedState as jest.Mock).mockResolvedValue({
+        backgroundState: {},
+      });
+
+      // Reset mock
+      mockPersistController.mockClear();
+
+      // Act
+      await engineService.start();
+
+      // Assert - Empty filtered state should NOT be persisted
+      expect(Logger.log).not.toHaveBeenCalledWith(
+        expect.stringContaining('state changed during init'),
       );
     });
   });

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -256,14 +256,24 @@ export class EngineService {
               // Check if any property at the first level has changed
               // Only persist if there's state to persist AND either:
               // 1. No initial state existed but now there is state (new install/new controller)
-              // 2. Initial state existed and has changed
-              const hasStateToSave = Object.keys(filteredState).length > 0;
+              // 2. Initial state existed and has changed (added, modified, or removed properties)
+              const filteredStateKeys = Object.keys(filteredState);
+              const initialStateKeys = initialControllerState
+                ? Object.keys(initialControllerState)
+                : [];
+              const hasStateToSave = filteredStateKeys.length > 0;
+
+              // Check for changes: different key count, or any value differs
+              const hasKeyCountChanged =
+                filteredStateKeys.length !== initialStateKeys.length;
+              const hasValueChanged = filteredStateKeys.some(
+                (key) =>
+                  !initialControllerState ||
+                  filteredState[key] !== initialControllerState[key],
+              );
+
               const hasChanged =
-                hasStateToSave &&
-                (!initialControllerState ||
-                  Object.keys(filteredState).some(
-                    (key) => filteredState[key] !== initialControllerState[key],
-                  ));
+                hasStateToSave && (hasKeyCountChanged || hasValueChanged);
 
               if (hasChanged) {
                 // Reuse the same debounced function for consistency

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -220,11 +220,6 @@ export class EngineService {
         BACKGROUND_STATE_CHANGE_EVENT_NAMES.forEach((eventName) => {
           const controllerName = eventName.split(':')[0];
 
-          // Skip CronjobController as it's handled separately
-          if (eventName === 'CronjobController:stateChange') {
-            return;
-          }
-
           // Check if controller has any persistent state before setting up persistence
           const controllerMetadata =
             // @ts-expect-error - Engine context has stateless controllers, so metadata may not be available
@@ -267,11 +262,7 @@ export class EngineService {
                 hasStateToSave &&
                 (!initialControllerState ||
                   Object.keys(filteredState).some(
-                    (key) =>
-                      filteredState[key] !==
-                      initialControllerState[
-                        key as keyof typeof initialControllerState
-                      ],
+                    (key) => filteredState[key] !== initialControllerState[key],
                   ));
 
               if (hasChanged) {

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -50,7 +50,16 @@ export class EngineService {
     }),
   );
 
-  private initializeControllers = (engine: TypedEngine) => {
+  /**
+   * Initializes controller subscriptions for Redux updates and filesystem persistence.
+   *
+   * @param engine - The initialized Engine instance
+   * @param initialState - Optional initial state loaded from persistence. If provided, controllers whose state changed during Engine.init() will be persisted.
+   */
+  private initializeControllers = (
+    engine: TypedEngine,
+    initialState?: Record<string, unknown>,
+  ) => {
     // coordination mechanism to prevent race conditions between engine initialization and UI rendering
     if (!engine.context) {
       Logger.error(
@@ -107,7 +116,8 @@ export class EngineService {
     // CRITICAL: Set up filesystem persistence for all controllers
     // This is called automatically after Redux subscriptions to ensure
     // both Redux and filesystem are kept in sync when controller state changes
-    this.setupEnginePersistence();
+    // Pass initialState to detect and persist any state changes that occurred during Engine.init()
+    this.setupEnginePersistence(initialState);
   };
 
   /**
@@ -157,7 +167,11 @@ export class EngineService {
       const metaMetricsId = await MetaMetrics.getInstance().getMetaMetricsId();
       Engine.init(state, null, metaMetricsId);
       // `Engine.init()` call mutates `typeof UntypedEngine` to `TypedEngine`
-      this.initializeControllers(Engine as unknown as TypedEngine);
+      // Pass state to detect controllers that changed during init
+      this.initializeControllers(
+        Engine as unknown as TypedEngine,
+        state as Record<string, unknown>,
+      );
     } catch (error) {
       trackVaultCorruption((error as Error).message, {
         error_type: 'engine_initialization_failure',
@@ -197,12 +211,19 @@ export class EngineService {
    *
    * The persistence is debounced in createPersistController to prevent excessive disk writes during rapid state changes.
    * Controllers with no persistent state are skipped to avoid storing empty objects.
+   *
+   * @param initialState - Optional initial state to compare against. If provided, controllers whose state changed during Engine.init() will be persisted immediately. This catches state changes that occur before subscriptions are set up.
    */
-  private setupEnginePersistence = () => {
+  private setupEnginePersistence = (initialState?: Record<string, unknown>) => {
     try {
       if (UntypedEngine.controllerMessenger) {
         BACKGROUND_STATE_CHANGE_EVENT_NAMES.forEach((eventName) => {
           const controllerName = eventName.split(':')[0];
+
+          // Skip CronjobController as it's handled separately
+          if (eventName === 'CronjobController:stateChange') {
+            return;
+          }
 
           // Check if controller has any persistent state before setting up persistence
           const controllerMetadata =
@@ -215,8 +236,55 @@ export class EngineService {
             return;
           }
 
+          // Create debounced persist function (reused for both initial and ongoing persistence)
           const persistController = createPersistController(200);
 
+          // Check if state changed during Engine.init()
+          // Compare 1 level deep - check if any property of the filtered state differs
+          // from the initial state. Controllers preserve referential equality for unchanged properties.
+          // If initialControllerState is undefined (new install or new controller), always persist.
+          // @ts-expect-error - Engine context has stateless controllers
+          const currentState = UntypedEngine.context[controllerName]?.state;
+          const initialControllerState = initialState?.[controllerName] as
+            | Record<string, unknown>
+            | undefined;
+          const filteredState = getPersistentState(
+            currentState,
+            controllerMetadata,
+          );
+
+          // Check if any property at the first level has changed
+          // Only persist if there's state to persist AND either:
+          // 1. No initial state existed but now there is state (new install/new controller)
+          // 2. Initial state existed and has changed
+          const hasStateToSave = Object.keys(filteredState).length > 0;
+          const hasChanged =
+            hasStateToSave &&
+            (!initialControllerState ||
+              Object.keys(filteredState).some(
+                (key) =>
+                  filteredState[key] !==
+                  initialControllerState[
+                    key as keyof typeof initialControllerState
+                  ],
+              ));
+
+          if (hasChanged) {
+            try {
+              // Reuse the same debounced function for consistency
+              persistController(filteredState, controllerName);
+              Logger.log(
+                `${LOG_TAG}: ${controllerName} state changed during init, queued for persist`,
+              );
+            } catch (error) {
+              Logger.error(
+                error as Error,
+                `Failed to persist ${controllerName} state that changed during init`,
+              );
+            }
+          }
+
+          // Set up subscription for future state changes
           UntypedEngine.controllerMessenger.subscribe(
             eventName,
             async (controllerState: StateConstraint) => {
@@ -290,7 +358,8 @@ export class EngineService {
       const metaMetricsId = await MetaMetrics.getInstance().getMetaMetricsId();
       const instance = Engine.init(state, newKeyringState, metaMetricsId);
       if (instance) {
-        this.initializeControllers(instance);
+        // Pass state to detect controllers that changed during init
+        this.initializeControllers(instance, state as Record<string, unknown>);
         // this is a hack to give the engine time to reinitialize
         await new Promise((resolve) => setTimeout(resolve, 2000));
         return {


### PR DESCRIPTION
## **Description**

Controllers can modify state during `Engine.init()` (e.g., `SnapController` granting permissions to `PermissionController` when handling preinstalled snaps). These state changes were not being persisted because persistence subscriptions are set up **after** controller construction completes, missing any events emitted during initialization.

CHANGELOG entry: null

### The Problem

1. `EngineService.start()` calls `Engine.init()`
2. During `Engine.init()`, controllers are constructed via `initModularizedControllers()`
3. `SnapController` constructor calls `#handlePreinstalledSnaps()` → `#updatePermissions()` → `PermissionController:grantPermissions`
4. `PermissionController` updates its state (e.g., adds snap permissions)
5. `PermissionController` emits `stateChange` event, but no subscriptions exist yet
6. After `Engine.init()` returns, persistence subscriptions are set up - **too late to capture the changes**

### The Solution

This fix passes the initial state (loaded from persistence before init) to `setupEnginePersistence()` and compares controller state after init using **1-level deep referential equality**.

Controllers preserve referential equality for unchanged properties (via Immer). If a property reference at the first level differs from the initial state, the state changed during init and needs to be persisted.

### Key Changes

- Add `initialState` parameter to `initializeControllers()` and `setupEnginePersistence()`
- Compare `filteredState` properties against `initialState` at 1-level deep
- Handle new installs/controllers where `initialState` is undefined
- Only persist if there's actual state to save (non-empty `filteredState`)
- Reuse the same debounced `persistController` function for consistency

## **Changelog**

CHANGELOG entry: Fixed an issue where controller state changes during engine initialization were not being persisted

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Persist controller state changes during Engine.init()

  Scenario: Preinstalled snap permissions are persisted on fresh install
    Given the app is freshly installed with no persisted state
    
    When the app starts and Engine.init() completes
    Then PermissionController state should contain preinstalled snap permissions
    And the PermissionController state should be persisted to storage
    
    When the app is killed and restarted
    Then the preinstalled snap permissions should still be present

  Scenario: Controller state changes during init are detected and persisted
    Given the app has persisted state from a previous session
    
    When the app starts and a controller's state changes during Engine.init()
    Then the changed controller state should be persisted
    And a log message should indicate the controller state was queued for persist
```

## **Screenshots/Recordings**

### **Before**

N/A - This is a persistence/data fix, not a UI change.

### **After**

N/A - This is a persistence/data fix, not a UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects and persists controller state changes occurring during Engine.init by comparing post-init filtered state to initial state, and adds comprehensive tests.
> 
> - **EngineService**
>   - Pass `initialState` into `initializeControllers` and `setupEnginePersistence` to detect changes made during `Engine.init()`.
>   - In `setupEnginePersistence`, compute filtered state via `getPersistentState` and compare 1-level deep against `initialState`; if changed and non-empty, persist immediately using debounced `persistController` and log.
>   - Maintain subscriptions for future state changes; add error handling/logging and skip controllers without persistent state.
>   - Update `start()` and `initializeVaultFromBackup()` to pass loaded state when initializing controllers.
> - **Tests**
>   - Add/expand tests covering: init-time persistence detection, unchanged state, new installs, property removals, empty filtered state, missing `controllerMessenger`, and graceful error handling.
>   - Ensure cleanup/restoration of mocked properties and avoid unhandled rejections in persistence tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0cf0da45093344a804a86e716fee93dac4bfac5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->