### PR TITLE
fix: Lock `snaps-sdk` and `snaps-utils` for RC

### DIFF
--- a/e2e/specs/snaps/test-snap-background-events.spec.ts
+++ b/e2e/specs/snaps/test-snap-background-events.spec.ts
@@ -36,7 +36,7 @@ describe(FlaskBuildTests('Background Events Snap Tests'), () => {
         skipReactNativeReload: true,
       },
       async () => {
-        const futureDate = new Date(Date.now() + 5_000).toISOString();
+        const futureDate = new Date(Date.now() + 10_000).toISOString();
 
         await TestSnaps.fillMessage('backgroundEventDateInput', futureDate);
         await TestSnaps.tapButton('scheduleBackgroundEventWithDateButton');

--- a/e2e/specs/snaps/test-snap-background-events.spec.ts
+++ b/e2e/specs/snaps/test-snap-background-events.spec.ts
@@ -36,7 +36,7 @@ describe(FlaskBuildTests('Background Events Snap Tests'), () => {
         skipReactNativeReload: true,
       },
       async () => {
-        const futureDate = new Date(Date.now() + 10_000).toISOString();
+        const futureDate = new Date(Date.now() + 5_000).toISOString();
 
         await TestSnaps.fillMessage('backgroundEventDateInput', futureDate);
         await TestSnaps.tapButton('scheduleBackgroundEventWithDateButton');

--- a/package.json
+++ b/package.json
@@ -175,7 +175,8 @@
     "@expo/fingerprint": "^0.15.0",
     "appwright@^0.1.45": "patch:appwright@npm%3A0.1.45#./.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch",
     "@scure/bip32": "1.7.0",
-    "@metamask/snaps-sdk": "^10.0.0",
+    "@metamask/snaps-sdk": "10.1.0",
+    "@metamask/snaps-utils": "11.6.1",
     "react-native@0.76.9": "patch:react-native@npm%3A0.76.9#./.yarn/patches/react-native-npm-0.76.9-1c25352097.patch",
     "@metamask/transaction-controller@npm:^62.6.0": "patch:@metamask/transaction-controller@npm%3A62.6.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9698,18 +9698,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-registry@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@metamask/snaps-registry@npm:4.0.0"
-  dependencies:
-    "@metamask/superstruct": "npm:^3.2.1"
-    "@metamask/utils": "npm:^11.4.0"
-    "@noble/curves": "npm:^1.2.0"
-    "@noble/hashes": "npm:^1.3.2"
-  checksum: 10/62387701d0433402bbe93495f90e24f2df3bdff2b063402b029294fada62c9f389048a2c68a1e51b260cb10cec949dd0c80596bf6295abc4175f5039c486a108
-  languageName: node
-  linkType: hard
-
 "@metamask/snaps-rpc-methods@npm:^13.5.0":
   version: 13.5.3
   resolution: "@metamask/snaps-rpc-methods@npm:13.5.3"
@@ -9743,32 +9731,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "@metamask/snaps-sdk@npm:10.0.0"
+"@metamask/snaps-sdk@npm:10.1.0":
+  version: 10.1.0
+  resolution: "@metamask/snaps-sdk@npm:10.1.0"
   dependencies:
     "@metamask/key-tree": "npm:^10.1.1"
     "@metamask/providers": "npm:^22.1.1"
     "@metamask/rpc-errors": "npm:^7.0.3"
     "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/utils": "npm:^11.8.1"
-  checksum: 10/f753e92b2d4b06aae448beabc891de9be913c6c42ffbbd38039196982c19eafa3cb9fd158a7717f2d0692eeba2e4714a3620d3b19ce40550db75b1e8c5470da3
+  checksum: 10/72b24beda70e2848de308011475b94716109036dba8f8555cefffb0b757415457f5577795581d967279533874d1991a61bf81c8209049f83042c6d3615b52e76
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^11.0.0, @metamask/snaps-utils@npm:^11.5.0, @metamask/snaps-utils@npm:^11.6.0, @metamask/snaps-utils@npm:^11.6.1":
-  version: 11.6.3
-  resolution: "@metamask/snaps-utils@npm:11.6.3"
+"@metamask/snaps-utils@npm:11.6.1":
+  version: 11.6.1
+  resolution: "@metamask/snaps-utils@npm:11.6.1"
   dependencies:
     "@babel/core": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
     "@metamask/key-tree": "npm:^10.1.1"
     "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/permission-controller": "npm:^12.1.1"
+    "@metamask/permission-controller": "npm:^12.0.0"
     "@metamask/rpc-errors": "npm:^7.0.3"
     "@metamask/slip44": "npm:^4.3.0"
-    "@metamask/snaps-registry": "npm:^4.0.0"
-    "@metamask/snaps-sdk": "npm:^10.2.0"
+    "@metamask/snaps-registry": "npm:^3.2.3"
+    "@metamask/snaps-sdk": "npm:^10.0.0"
     "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/utils": "npm:^11.8.1"
     "@noble/hashes": "npm:^1.7.1"
@@ -9784,7 +9772,7 @@ __metadata:
     semver: "npm:^7.5.4"
     ses: "npm:^1.14.0"
     validate-npm-package-name: "npm:^5.0.0"
-  checksum: 10/6bd471fafacbebb287240a740c32bddcfabb4060df7c6980ee92ab3cd2ee6162825bc8119611c25126d8f891a107c822b2af69e97c0a8b055432df3b06a91378
+  checksum: 10/ad694a02aeea9ab8dc159a032681b5eb57b75debf636ac229669ece479fc38deda423b3e79a1ef2af30ef69be627ad5fcd7852a24448eeb58799f510d07b8216
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes two things: It restores the Snaps SDK version to the expected version for this RC. It also locks both snaps-sdk and snaps-utils temporarily to work around an issue where some exports were moved, but due to new features being introduced in the same version we don't wanna risk bringing that into the RC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins snaps package versions and updates yarn.lock to match for the RC.
> 
> - **Dependencies**:
>   - Lock `@metamask/snaps-sdk` to `10.1.0` and `@metamask/snaps-utils` to `11.6.1` in `package.json` resolutions.
>   - Update `yarn.lock` to reflect pinned versions, adjusting related entries (`snaps-sdk`, `snaps-utils`, and `snaps-registry`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 239ba4256f622fd780e8c1c184b59029be1e69c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->