### PR TITLE
chore: Remove redesigned_confirmation from ui_customization property

### DIFF
--- a/app/components/Views/confirmations/hooks/signatures/useSignatureMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/signatures/useSignatureMetrics.test.ts
@@ -49,7 +49,7 @@ const SignatureMetrics = {
   security_alert_response: 'Malicious',
   security_alert_source: 'api',
   signature_type: 'eth_signTypedData',
-  ui_customizations: ['redesigned_confirmation', 'flagged_as_malicious'],
+  ui_customizations: ['flagged_as_malicious'],
   version: 'V4',
 };
 
@@ -74,7 +74,7 @@ const SignatureMetricsLoading = {
   security_alert_response: 'loading',
   security_alert_source: 'api',
   signature_type: 'eth_signTypedData',
-  ui_customizations: ['redesigned_confirmation', 'security_alert_loading'],
+  ui_customizations: ['security_alert_loading'],
   version: 'V4',
   ppom_eth_call_count: 5,
   ppom_eth_getCode_count: 3,
@@ -89,7 +89,6 @@ const SignatureMetricsUndefined = {
   eip712_primary_type: 'Permit',
   request_source: 'In-App-Browser',
   signature_type: 'eth_signTypedData',
-  ui_customizations: ['redesigned_confirmation'],
   version: 'V4',
 };
 

--- a/app/components/Views/confirmations/hooks/signatures/useSignatureMetrics.ts
+++ b/app/components/Views/confirmations/hooks/signatures/useSignatureMetrics.ts
@@ -43,16 +43,17 @@ const getAnalyticsParams = (
       ? getBlockaidMetricsParams(securityAlertResponse)
       : {};
 
+  const allCustomizations = ui_customizations as string[];
+
   return {
     account_type: getAddressAccountType(from as string),
     dapp_host_name: getHostFromUrl(meta.url as string) ?? 'N/A',
     signature_type: type,
     version: version || 'N/A',
     chain_id: chainId ? getDecimalChainId(chainId) : '',
-    ui_customizations: [
-      'redesigned_confirmation',
-      ...(ui_customizations as string[]),
-    ],
+    ...(allCustomizations.length > 0 && {
+      ui_customizations: allCustomizations,
+    }),
     ...(primaryType ? { eip712_primary_type: primaryType } : {}),
     ...(meta.analytics as Record<string, string>),
     ...getSignatureDecodingEventProps(

--- a/app/components/Views/confirmations/hooks/useTrackERC20WithoutDecimalInformation.ts
+++ b/app/components/Views/confirmations/hooks/useTrackERC20WithoutDecimalInformation.ts
@@ -43,7 +43,6 @@ const useTrackERC20WithoutDecimalInformation = (
             asset_type: TokenStandard.ERC20,
             chain_id: chainId,
             location: metricLocation,
-            ui_customizations: ['redesigned_confirmation'],
           })
           .build(),
       );


### PR DESCRIPTION
## **Description**
We no longer need to track if a confirmations is redesign so we can delete this code. Similar thing was done in the extension: https://github.com/MetaMask/metamask-extension/pull/38706

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6075

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes 'redesigned_confirmation' from metrics and conditionally includes only Blockaid-provided `ui_customizations`; updates related tests and ERC20 tracking event.
> 
> - **Metrics (signatures)**
>   - `useSignatureMetrics`: stop appending `redesigned_confirmation`; only set `ui_customizations` when non-empty and pass through Blockaid values unchanged.
>   - Refactors analytics params construction accordingly.
> - **Tests**
>   - Update `useSignatureMetrics.test.ts` expectations to remove `redesigned_confirmation` and reflect conditional `ui_customizations`.
> - **ERC20 Tracking**
>   - `useTrackERC20WithoutDecimalInformation`: remove `ui_customizations` from `INCOMPLETE_ASSET_DISPLAYED` event properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93c9ece33e8380c34034978b0116b39cbda90a72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->