### PR TITLE
feat: remove the dot on the card icon

### DIFF
--- a/app/components/UI/Card/components/CardButton/CardButton.test.tsx
+++ b/app/components/UI/Card/components/CardButton/CardButton.test.tsx
@@ -4,6 +4,7 @@ import CardButton from './CardButton';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import { WalletViewSelectorsIDs } from '../../../../../../e2e/selectors/wallet/WalletView.selectors';
+
 jest.mock('../../../../hooks/useMetrics', () => {
   const actual = jest.requireActual('../../../../hooks/useMetrics');
   return {
@@ -19,14 +20,7 @@ jest.mock('../../../../hooks/useMetrics', () => {
   };
 });
 
-interface PartialCardState {
-  hasViewedCardButton?: boolean;
-}
-
-function renderWithProvider(
-  component: React.ComponentType,
-  stateOverride: PartialCardState = {},
-) {
+function renderWithProvider(component: React.ComponentType) {
   return renderScreen(
     component,
     { name: 'CardButton' },
@@ -39,7 +33,6 @@ function renderWithProvider(
           lastFetchedByAddress: {},
           hasViewedCardButton: false,
           isLoaded: false,
-          ...stateOverride,
         },
       },
     },
@@ -53,7 +46,7 @@ describe('CardButton Component', () => {
     jest.clearAllMocks();
   });
 
-  it('renders with badge (not yet viewed) and matches snapshot', () => {
+  it('renders and matches snapshot', () => {
     const { toJSON, getByTestId } = renderWithProvider(() => (
       <CardButton
         onPress={mockOnPress}
@@ -61,12 +54,12 @@ describe('CardButton Component', () => {
       />
     ));
 
-    expect(getByTestId(WalletViewSelectorsIDs.CARD_BUTTON_BADGE)).toBeTruthy();
+    expect(getByTestId(WalletViewSelectorsIDs.CARD_BUTTON)).toBeTruthy();
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('dispatches setHasViewedCardButton(true) and hides badge on first press', () => {
-    const { getByTestId, store, queryByTestId } = renderWithProvider(() => (
+  it('calls onPress when button is pressed', () => {
+    const { getByTestId } = renderWithProvider(() => (
       <CardButton
         onPress={mockOnPress}
         touchAreaSlop={{ top: 0, bottom: 0, left: 0, right: 0 }}
@@ -77,40 +70,5 @@ describe('CardButton Component', () => {
     fireEvent.press(button);
 
     expect(mockOnPress).toHaveBeenCalledTimes(1);
-    expect(store.getState().card.hasViewedCardButton).toBe(true);
-    expect(queryByTestId(WalletViewSelectorsIDs.CARD_BUTTON_BADGE)).toBeNull();
-  });
-
-  it('does not dispatch setHasViewedCardButton again if already viewed', () => {
-    const { getByTestId, store } = renderWithProvider(
-      () => (
-        <CardButton
-          onPress={mockOnPress}
-          touchAreaSlop={{ top: 0, bottom: 0, left: 0, right: 0 }}
-        />
-      ),
-      { hasViewedCardButton: true },
-    );
-
-    const button = getByTestId(WalletViewSelectorsIDs.CARD_BUTTON);
-    fireEvent.press(button);
-
-    expect(mockOnPress).toHaveBeenCalledTimes(1);
-    expect(store.getState().card.hasViewedCardButton).toBe(true);
-  });
-
-  it('renders without badge when already viewed', () => {
-    const { toJSON, queryByTestId } = renderWithProvider(
-      () => (
-        <CardButton
-          onPress={mockOnPress}
-          touchAreaSlop={{ top: 0, bottom: 0, left: 0, right: 0 }}
-        />
-      ),
-      { hasViewedCardButton: true },
-    );
-
-    expect(queryByTestId(WalletViewSelectorsIDs.CARD_BUTTON_BADGE)).toBeNull();
-    expect(toJSON()).toMatchSnapshot();
   });
 });

--- a/app/components/UI/Card/components/CardButton/CardButton.tsx
+++ b/app/components/UI/Card/components/CardButton/CardButton.tsx
@@ -1,9 +1,4 @@
 import {
-  BadgeStatus,
-  BadgeStatusStatus,
-  BadgeWrapper,
-  BadgeWrapperPosition,
-  BadgeWrapperPositionAnchorShape,
   ButtonIcon,
   ButtonIconSize,
   IconName,
@@ -13,11 +8,6 @@ import {
 import React, { useEffect } from 'react';
 import { WalletViewSelectorsIDs } from '../../../../../../e2e/selectors/wallet/WalletView.selectors';
 import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
-import { useDispatch, useSelector } from 'react-redux';
-import {
-  selectHasViewedCardButton,
-  setHasViewedCardButton,
-} from '../../../../../core/redux/slices/card';
 
 interface CardButtonProps {
   onPress: () => void;
@@ -30,8 +20,6 @@ interface CardButtonProps {
 }
 
 const CardButton: React.FC<CardButtonProps> = ({ onPress, touchAreaSlop }) => {
-  const dispatch = useDispatch();
-  const hasViewedCardButton = useSelector(selectHasViewedCardButton);
   const { trackEvent, createEventBuilder } = useMetrics();
 
   useEffect(() => {
@@ -40,35 +28,15 @@ const CardButton: React.FC<CardButtonProps> = ({ onPress, touchAreaSlop }) => {
     );
   }, [trackEvent, createEventBuilder]);
 
-  const onPressHandler = () => {
-    if (!hasViewedCardButton) {
-      dispatch(setHasViewedCardButton(true));
-    }
-    onPress();
-  };
-
   return (
-    <BadgeWrapper
-      position={BadgeWrapperPosition.TopRight}
-      positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
-      badge={
-        !hasViewedCardButton ? (
-          <BadgeStatus
-            testID={WalletViewSelectorsIDs.CARD_BUTTON_BADGE}
-            status={BadgeStatusStatus.New}
-          />
-        ) : null
-      }
-    >
-      <ButtonIcon
-        iconProps={{ color: MMDSIconColor.IconDefault }}
-        onPress={onPressHandler}
-        iconName={IconName.Card}
-        size={ButtonIconSize.Lg}
-        testID={WalletViewSelectorsIDs.CARD_BUTTON}
-        hitSlop={touchAreaSlop}
-      />
-    </BadgeWrapper>
+    <ButtonIcon
+      iconProps={{ color: MMDSIconColor.IconDefault }}
+      onPress={onPress}
+      iconName={IconName.Card}
+      size={ButtonIconSize.Lg}
+      testID={WalletViewSelectorsIDs.CARD_BUTTON}
+      hitSlop={touchAreaSlop}
+    />
   );
 };
 

--- a/app/components/UI/Card/components/CardButton/__snapshots__/CardButton.test.tsx.snap
+++ b/app/components/UI/Card/components/CardButton/__snapshots__/CardButton.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CardButton Component renders with badge (not yet viewed) and matches snapshot 1`] = `
+exports[`CardButton Component renders and matches snapshot 1`] = `
 <View
   style={
     {
@@ -316,589 +316,88 @@ exports[`CardButton Component renders with badge (not yet viewed) and matches sn
                       style={
                         [
                           {
-                            "alignSelf": "flex-start",
-                            "position": "relative",
+                            "transform": [
+                              {
+                                "scale": 1,
+                              },
+                            ],
                           },
-                          undefined,
+                          {
+                            "alignItems": "center",
+                            "justifyContent": "center",
+                          },
                         ]
                       }
                     >
                       <View
-                        onLayout={[Function]}
-                      >
-                        <View
-                          style={
-                            [
-                              {
-                                "transform": [
-                                  {
-                                    "scale": 1,
-                                  },
-                                ],
-                              },
-                              {
-                                "alignItems": "center",
-                                "justifyContent": "center",
-                              },
-                            ]
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": false,
+                            "expanded": undefined,
+                            "selected": undefined,
                           }
-                        >
-                          <View
-                            accessibilityState={
-                              {
-                                "busy": undefined,
-                                "checked": undefined,
-                                "disabled": false,
-                                "expanded": undefined,
-                                "selected": undefined,
-                              }
-                            }
-                            accessibilityValue={
-                              {
-                                "max": undefined,
-                                "min": undefined,
-                                "now": undefined,
-                                "text": undefined,
-                              }
-                            }
-                            accessible={true}
-                            collapsable={false}
-                            focusable={true}
-                            hitSlop={
-                              {
-                                "bottom": 0,
-                                "left": 0,
-                                "right": 0,
-                                "top": 0,
-                              }
-                            }
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onResponderGrant={[Function]}
-                            onResponderMove={[Function]}
-                            onResponderRelease={[Function]}
-                            onResponderTerminate={[Function]}
-                            onResponderTerminationRequest={[Function]}
-                            onStartShouldSetResponder={[Function]}
-                            style={
-                              [
-                                {
-                                  "alignItems": "center",
-                                  "backgroundColor": "transparent",
-                                  "borderRadius": 2,
-                                  "height": 40,
-                                  "justifyContent": "center",
-                                  "opacity": 1,
-                                  "width": 40,
-                                },
-                                undefined,
-                              ]
-                            }
-                            testID="card-button"
-                          >
-                            <SvgMock
-                              fill="currentColor"
-                              name="Card"
-                              style={
-                                [
-                                  {
-                                    "color": "#121314",
-                                    "height": 24,
-                                    "width": 24,
-                                  },
-                                  undefined,
-                                ]
-                              }
-                            />
-                          </View>
-                        </View>
-                      </View>
-                      <View
-                        onLayout={[Function]}
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        hitSlop={
+                          {
+                            "bottom": 0,
+                            "left": 0,
+                            "right": 0,
+                            "top": 0,
+                          }
+                        }
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
                         style={
                           [
                             {
-                              "position": "absolute",
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": 2,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "opacity": 1,
+                              "width": 40,
                             },
-                            {
-                              "right": 0,
-                              "top": 0,
-                            },
+                            undefined,
                           ]
                         }
+                        testID="card-button"
                       >
-                        <View
+                        <SvgMock
+                          fill="currentColor"
+                          name="Card"
                           style={
                             [
                               {
-                                "alignSelf": "flex-start",
-                                "borderColor": "#ffffff",
-                                "borderRadius": 9999,
-                                "borderWidth": 2,
+                                "color": "#121314",
+                                "height": 24,
+                                "width": 24,
                               },
                               undefined,
                             ]
                           }
-                          testID="card-button-badge"
-                        >
-                          <View
-                            style={
-                              [
-                                {
-                                  "backgroundColor": "#4459ff",
-                                  "borderColor": "#4459ff",
-                                  "borderRadius": 9999,
-                                  "borderWidth": 2,
-                                  "height": 8,
-                                  "width": 8,
-                                },
-                              ]
-                            }
-                          />
-                        </View>
+                        />
                       </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </RNSScreen>
-    </RNSScreenContainer>
-  </RNCSafeAreaProvider>
-</View>
-`;
-
-exports[`CardButton Component renders without badge when already viewed 1`] = `
-<View
-  style={
-    {
-      "flex": 1,
-    }
-  }
->
-  <RNCSafeAreaProvider
-    onInsetsChange={[Function]}
-    style={
-      [
-        {
-          "flex": 1,
-        },
-        undefined,
-      ]
-    }
-  >
-    <View
-      collapsable={false}
-      pointerEvents="box-none"
-      style={
-        {
-          "zIndex": 1,
-        }
-      }
-    >
-      <View
-        accessibilityElementsHidden={false}
-        importantForAccessibility="auto"
-        onLayout={[Function]}
-        pointerEvents="box-none"
-        style={null}
-      >
-        <View
-          collapsable={false}
-          pointerEvents="box-none"
-          style={
-            {
-              "bottom": 0,
-              "left": 0,
-              "opacity": 1,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-              "zIndex": 0,
-            }
-          }
-        >
-          <View
-            collapsable={false}
-            style={
-              {
-                "backgroundColor": "rgb(255, 255, 255)",
-                "borderBottomColor": "rgb(216, 216, 216)",
-                "flex": 1,
-                "shadowColor": "rgb(216, 216, 216)",
-                "shadowOffset": {
-                  "height": 0.5,
-                  "width": 0,
-                },
-                "shadowOpacity": 0.85,
-                "shadowRadius": 0,
-              }
-            }
-          />
-        </View>
-        <View
-          collapsable={false}
-          pointerEvents="box-none"
-          style={
-            {
-              "height": 64,
-              "maxHeight": undefined,
-              "minHeight": undefined,
-              "opacity": undefined,
-              "transform": undefined,
-            }
-          }
-        >
-          <View
-            pointerEvents="none"
-            style={
-              {
-                "height": 20,
-              }
-            }
-          />
-          <View
-            pointerEvents="box-none"
-            style={
-              {
-                "alignItems": "center",
-                "flex": 1,
-                "flexDirection": "row",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <View
-              collapsable={false}
-              pointerEvents="box-none"
-              style={
-                {
-                  "marginHorizontal": 16,
-                  "opacity": 1,
-                }
-              }
-            >
-              <Text
-                accessibilityRole="header"
-                aria-level="1"
-                collapsable={false}
-                numberOfLines={1}
-                onLayout={[Function]}
-                style={
-                  {
-                    "color": "rgb(28, 28, 30)",
-                    "fontSize": 17,
-                    "fontWeight": "600",
-                  }
-                }
-              >
-                CardButton
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <RNSScreenContainer
-      onLayout={[Function]}
-      style={
-        {
-          "flex": 1,
-        }
-      }
-    >
-      <RNSScreen
-        activityState={2}
-        collapsable={false}
-        gestureResponseDistance={
-          {
-            "bottom": -1,
-            "end": -1,
-            "start": -1,
-            "top": -1,
-          }
-        }
-        onGestureCancel={[Function]}
-        pointerEvents="box-none"
-        sheetAllowedDetents="large"
-        sheetCornerRadius={-1}
-        sheetExpandsWhenScrolledToEdge={true}
-        sheetGrabberVisible={false}
-        sheetLargestUndimmedDetent="all"
-        style={
-          {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-            "zIndex": undefined,
-          }
-        }
-      >
-        <View
-          collapsable={false}
-          style={
-            {
-              "opacity": 1,
-            }
-          }
-        />
-        <View
-          accessibilityElementsHidden={false}
-          closing={false}
-          gestureVelocityImpact={0.3}
-          importantForAccessibility="auto"
-          onClose={[Function]}
-          onGestureBegin={[Function]}
-          onGestureCanceled={[Function]}
-          onGestureEnd={[Function]}
-          onOpen={[Function]}
-          onTransition={[Function]}
-          pointerEvents="box-none"
-          style={
-            [
-              {
-                "overflow": undefined,
-              },
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-            ]
-          }
-          transitionSpec={
-            {
-              "close": {
-                "animation": "spring",
-                "config": {
-                  "damping": 500,
-                  "mass": 3,
-                  "overshootClamping": true,
-                  "restDisplacementThreshold": 10,
-                  "restSpeedThreshold": 10,
-                  "stiffness": 1000,
-                },
-              },
-              "open": {
-                "animation": "spring",
-                "config": {
-                  "damping": 500,
-                  "mass": 3,
-                  "overshootClamping": true,
-                  "restDisplacementThreshold": 10,
-                  "restSpeedThreshold": 10,
-                  "stiffness": 1000,
-                },
-              },
-            }
-          }
-        >
-          <View
-            collapsable={false}
-            needsOffscreenAlphaCompositing={false}
-            pointerEvents="box-none"
-            style={
-              {
-                "flex": 1,
-              }
-            }
-          >
-            <View
-              collapsable={false}
-              enabled={false}
-              handlerTag={-1}
-              handlerType="PanGestureHandler"
-              onGestureHandlerEvent={[Function]}
-              onGestureHandlerStateChange={[Function]}
-              style={
-                {
-                  "flex": 1,
-                  "transform": [
-                    {
-                      "translateX": 0,
-                    },
-                    {
-                      "translateX": 0,
-                    },
-                  ],
-                }
-              }
-            >
-              <View
-                collapsable={false}
-                pointerEvents="none"
-                style={
-                  {
-                    "backgroundColor": "rgb(242, 242, 242)",
-                    "bottom": 0,
-                    "left": 0,
-                    "position": "absolute",
-                    "shadowColor": "#000",
-                    "shadowOffset": {
-                      "height": 1,
-                      "width": -1,
-                    },
-                    "shadowOpacity": 0.3,
-                    "shadowRadius": 5,
-                    "top": 0,
-                    "width": 3,
-                  }
-                }
-              />
-              <View
-                style={
-                  [
-                    {
-                      "flex": 1,
-                      "overflow": "hidden",
-                    },
-                    [
-                      {
-                        "backgroundColor": "rgb(242, 242, 242)",
-                      },
-                      undefined,
-                    ],
-                  ]
-                }
-              >
-                <View
-                  style={
-                    {
-                      "flex": 1,
-                      "flexDirection": "column-reverse",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        [
-                          {
-                            "alignSelf": "flex-start",
-                            "position": "relative",
-                          },
-                          undefined,
-                        ]
-                      }
-                    >
-                      <View
-                        onLayout={[Function]}
-                      >
-                        <View
-                          style={
-                            [
-                              {
-                                "transform": [
-                                  {
-                                    "scale": 1,
-                                  },
-                                ],
-                              },
-                              {
-                                "alignItems": "center",
-                                "justifyContent": "center",
-                              },
-                            ]
-                          }
-                        >
-                          <View
-                            accessibilityState={
-                              {
-                                "busy": undefined,
-                                "checked": undefined,
-                                "disabled": false,
-                                "expanded": undefined,
-                                "selected": undefined,
-                              }
-                            }
-                            accessibilityValue={
-                              {
-                                "max": undefined,
-                                "min": undefined,
-                                "now": undefined,
-                                "text": undefined,
-                              }
-                            }
-                            accessible={true}
-                            collapsable={false}
-                            focusable={true}
-                            hitSlop={
-                              {
-                                "bottom": 0,
-                                "left": 0,
-                                "right": 0,
-                                "top": 0,
-                              }
-                            }
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onResponderGrant={[Function]}
-                            onResponderMove={[Function]}
-                            onResponderRelease={[Function]}
-                            onResponderTerminate={[Function]}
-                            onResponderTerminationRequest={[Function]}
-                            onStartShouldSetResponder={[Function]}
-                            style={
-                              [
-                                {
-                                  "alignItems": "center",
-                                  "backgroundColor": "transparent",
-                                  "borderRadius": 2,
-                                  "height": 40,
-                                  "justifyContent": "center",
-                                  "opacity": 1,
-                                  "width": 40,
-                                },
-                                undefined,
-                              ]
-                            }
-                            testID="card-button"
-                          >
-                            <SvgMock
-                              fill="currentColor"
-                              name="Card"
-                              style={
-                                [
-                                  {
-                                    "color": "#121314",
-                                    "height": 24,
-                                    "width": 24,
-                                  },
-                                  undefined,
-                                ]
-                              }
-                            />
-                          </View>
-                        </View>
-                      </View>
-                      <View
-                        onLayout={[Function]}
-                        style={
-                          [
-                            {
-                              "position": "absolute",
-                            },
-                            {
-                              "right": 0,
-                              "top": 0,
-                            },
-                          ]
-                        }
-                      />
                     </View>
                   </View>
                 </View>

--- a/e2e/pages/wallet/WalletView.ts
+++ b/e2e/pages/wallet/WalletView.ts
@@ -77,10 +77,6 @@ class WalletView {
     return Matchers.getElementByID(WalletViewSelectorsIDs.CARD_BUTTON);
   }
 
-  get navbarCardButtonBadge(): DetoxElement {
-    return Matchers.getElementByID(WalletViewSelectorsIDs.CARD_BUTTON_BADGE);
-  }
-
   get nftTab(): DetoxElement {
     return Matchers.getElementByText(WalletViewSelectorsText.NFTS_TAB);
   }

--- a/e2e/selectors/wallet/WalletView.selectors.ts
+++ b/e2e/selectors/wallet/WalletView.selectors.ts
@@ -10,7 +10,6 @@ export const WalletViewSelectorsIDs = {
   WALLET_TOKEN_DETECTION_LINK_BUTTON: 'wallet-token-detection-link-button',
   TOTAL_BALANCE_TEXT: 'total-balance-text',
   CARD_BUTTON: 'card-button',
-  CARD_BUTTON_BADGE: 'card-button-badge',
   STAKE_BUTTON: 'stake-button',
   EARN_EARNINGS_HISTORY_BUTTON: 'earn-earnings-history-button',
   UNSTAKE_BUTTON: 'unstake-button',

--- a/e2e/specs/card/card-button.spec.ts
+++ b/e2e/specs/card/card-button.spec.ts
@@ -51,12 +51,9 @@ describe.skip(SmokeCard('Card NavBar Button'), () => {
     jest.setTimeout(150000);
   });
 
-  it('should open Card Home when pressing card navbar button', async () => {
+  it('opens Card Home when pressing card navbar button', async () => {
     await setupCardTest(async () => {
       await Assertions.expectElementToBeVisible(WalletView.navbarCardButton);
-      await Assertions.expectElementToBeVisible(
-        WalletView.navbarCardButtonBadge,
-      );
       await WalletView.tapNavbarCardButton();
       await Assertions.expectElementToBeVisible(CardHomeView.cardViewTitle);
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The badge (dot) on the card icon button was displayed using a different color than the notification bell icon's badge, creating visual inconsistency. Per the issue requirements, this PR removes the badge from the card icon entirely to resolve the UX discrepancy.

**Changes:**

- Removed BadgeWrapper and BadgeStatus from CardButton component
- Removed hasViewedCardButton state dependency from the component (metrics tracking still works)
- Cleaned up related unit tests and snapshots
- Removed badge getter from e2e page object and e2e test assertions
- Removed unused CARD_BUTTON_BADGE selector

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removed the notification badge from the card icon button

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-203

## **Manual testing steps**

```gherkin
Feature: Card button without badge

  Scenario: user views wallet header
    Given user is on the wallet home screen

    When user looks at the card icon button in the navbar
    Then no badge/dot is displayed on the card icon
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="391" height="823" alt="Screenshot 2025-12-12 at 15 41 42" src="https://github.com/user-attachments/assets/badf48df-78dc-4d18-93a1-878273729438" />

<!-- [screenshots/recordings] -->

### **After**
<img width="391" height="833" alt="Screenshot 2025-12-12 at 16 21 33" src="https://github.com/user-attachments/assets/06628914-50de-490f-b0a5-4050c918cf46" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the badge from the navbar Card button and eliminates related state, selectors, and tests while keeping metrics tracking intact.
> 
> - **UI**
>   - `CardButton`: remove `BadgeWrapper`/`BadgeStatus` and Redux `hasViewedCardButton` logic; call `onPress` directly; continue tracking `CARD_BUTTON_VIEWED` on mount.
> - **Tests**
>   - Unit: simplify to render + `onPress` assertion; drop badge/state checks; update snapshot.
>   - E2E: remove badge assertions and getter; test taps `CARD_BUTTON` and verifies Card Home.
> - **Selectors**
>   - Remove `WalletViewSelectorsIDs.CARD_BUTTON_BADGE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46dbfffc8bbdd4b50a0b842f5be230ce8be7cc51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->