### PR TITLE
chore: INFRA-3188: automate release branch sync

### DIFF
--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -1,0 +1,45 @@
+name: Release Branch Sync
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - stable
+
+jobs:
+  validate-branch:
+    name: Validate release branch format
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    outputs:
+      is-valid: ${{ steps.check.outputs.is-valid }}
+    steps:
+      - name: Check branch name format
+        id: check
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ "$BRANCH" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Branch '$BRANCH' matches release/X.Y.Z format"
+            echo "is-valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Branch '$BRANCH' does not match release/X.Y.Z format. Skipping."
+            echo "is-valid=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  sync-release-branches:
+    name: Sync open release branches with stable
+    needs: validate-branch
+    if: needs.validate-branch.outputs.is-valid == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync release branches with stable
+        uses: metamask/github-tools/.github/actions/release-branch-sync@INFRA-3188-AutomateReleaseBranchSync
+        with:
+          merged-release-branch: ${{ github.event.pull_request.head.ref }}
+          repo-type: 'mobile'
+          github-token: ${{ secrets.STABLE_SYNC_TOKEN }}

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync release branches with stable
-        uses: metamask/github-tools/.github/actions/release-branch-sync@INFRA-3188-AutomateReleaseBranchSync
+        uses: metamask/github-tools/.github/actions/release-branch-sync@v1.2.0
         with:
           merged-release-branch: ${{ github.event.pull_request.head.ref }}
           github-token: ${{ secrets.STABLE_SYNC_TOKEN }}

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -41,5 +41,4 @@ jobs:
         uses: metamask/github-tools/.github/actions/release-branch-sync@INFRA-3188-AutomateReleaseBranchSync
         with:
           merged-release-branch: ${{ github.event.pull_request.head.ref }}
-          repo-type: 'mobile'
           github-token: ${{ secrets.STABLE_SYNC_TOKEN }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Ticket: https://consensyssoftware.atlassian.net/browse/INFRA-3188
Test stable sync branch: https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/20148777729/job/57923961348, https://github.com/consensys-test/metamask-mobile-test-workflow/pull/174

> Adds a composite GitHub Action and script to auto-open PRs syncing `stable` into active `release/*` branches after a release is merged.
> 
> - **CI/GitHub Actions**
>   - **New composite action** `/.github/actions/release-branch-sync/action.yml`:
>     - Inputs: `merged-release-branch`, `github-token`, optional `github-tools-repository` and `github-tools-ref`.
>     - Checks out repo and tools, configures git, runs sync script.
>   - **New script** `/.github/scripts/release-branch-sync.sh`:
>     - Detects active release branches via open PR titles matching `release: X.Y.Z`.
>     - Creates `stable-sync-release-X.Y.Z` branches from `origin/stable`, pushes, and opens PRs into corresponding `release/X.Y.Z` branches.
>     - Skips invalid/older-than-merged branches, the just-merged branch, non-existent branches, already up-to-date branches, or if a sync PR already exists.
>     - Emits a summary of created/skipped/failed operations.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: None

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions workflow to validate merged release branch names and sync `stable` into open `release/*` branches.
> 
> - **CI/GitHub Actions**:
>   - **New workflow** `/.github/workflows/release-branch-sync.yml` triggered on closed PRs to `stable`.
>     - **`validate-branch` job**: Ensures merged head branch matches `release/X.Y.Z`.
>     - **`sync-release-branches` job**: If valid, runs `metamask/github-tools/.github/actions/release-branch-sync@v1.2.0` to sync `stable` into open `release/*` branches using `STABLE_SYNC_TOKEN`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5492723662c87dba90fe1593e669b214603eaca7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->