### PR TITLE
chore: extract reauthentication

### DIFF
--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -422,7 +422,10 @@ class ResetPassword extends PureComponent {
         biometryType: authData.availableBiometryType,
         biometryChoice: biometryChoiceState,
       });
-      await Authentication.reauthenticate();
+      const biometricPassword = await Authentication.getBiometricPassword();
+      if (biometricPassword) {
+        this.tryUnlockWithPassword(biometricPassword);
+      }
     }
 
     this.setState(state);

--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -20,7 +20,6 @@ import StorageWrapper from '../../../store/storage-wrapper';
 import { connect } from 'react-redux';
 import { passwordSet, seedphraseNotBackedUp } from '../../../actions/user';
 import { setLockTime } from '../../../actions/settings';
-import Engine from '../../../core/Engine';
 import Device from '../../../util/device';
 import { fontStyles, baseStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
@@ -44,7 +43,6 @@ import {
   updateAuthTypeStorageFlags,
 } from '../../../util/authentication';
 import { Authentication } from '../../../core';
-import { reauthenticate } from '../../../core/Authentication/hooks/useAuthentication';
 import AUTHENTICATION_TYPE from '../../../constants/userProperties';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import { LoginOptionsSwitch } from '../../UI/LoginOptionsSwitch';
@@ -408,6 +406,7 @@ class ResetPassword extends PureComponent {
     );
     const passcodePreviouslyDisabled =
       await StorageWrapper.getItem(PASSCODE_DISABLED);
+
     if (authData.currentAuthType === AUTHENTICATION_TYPE.PASSCODE)
       this.setState({
         biometryType: passcodeType(authData.currentAuthType),
@@ -423,7 +422,7 @@ class ResetPassword extends PureComponent {
         biometryType: authData.availableBiometryType,
         biometryChoice: biometryChoiceState,
       });
-      await reauthenticate();
+      await Authentication.reauthenticate();
     }
 
     this.setState(state);
@@ -643,7 +642,7 @@ class ResetPassword extends PureComponent {
   tryUnlockWithPassword = async (password) => {
     this.setState({ ready: false });
     try {
-      await reauthenticate(password);
+      await Authentication.reauthenticate(password);
       this.setState({
         password: null,
         originalPassword: password,

--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -640,11 +640,6 @@ class ResetPassword extends PureComponent {
     );
   };
 
-  tryExportSeedPhrase = async (password) => {
-    const { KeyringController } = Engine.context;
-    await KeyringController.exportSeedPhrase(password);
-  };
-
   tryUnlockWithPassword = async (password) => {
     this.setState({ ready: false });
     try {

--- a/app/components/Views/ResetPassword/index.test.tsx
+++ b/app/components/Views/ResetPassword/index.test.tsx
@@ -89,6 +89,7 @@ jest.mock('../../../core/Authentication', () => ({
   authData: {
     currentAuthType: 'passcode',
   },
+  getBiometricPassword: jest.fn().mockResolvedValue(null),
   reauthenticate: (password?: string) => mockReauthenticate(password),
 }));
 

--- a/app/components/Views/ResetPassword/index.test.tsx
+++ b/app/components/Views/ResetPassword/index.test.tsx
@@ -35,6 +35,7 @@ const mockTrackOnboarding = trackOnboarding as jest.MockedFunction<
 >;
 
 const mockExportSeedPhrase = jest.fn();
+const mockReauthenticate = jest.fn();
 
 jest.mock('../../../core/Engine', () => ({
   context: {
@@ -88,6 +89,7 @@ jest.mock('../../../core/Authentication', () => ({
   authData: {
     currentAuthType: 'passcode',
   },
+  reauthenticate: (password?: string) => mockReauthenticate(password),
 }));
 
 jest.mock('../../../core/NavigationService', () => ({

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -76,6 +76,7 @@ import Text, {
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
 import TabBar from '../../../component-library/components-temp/TabBar/TabBar';
+import useAuthentication from '../../../core/Authentication/hooks/useAuthentication';
 
 export const PRIVATE_KEY = 'private_key';
 
@@ -137,6 +138,7 @@ const RevealPrivateCredential = ({
 
   const theme = useTheme();
   const { trackEvent, createEventBuilder } = useMetrics();
+  const { reauthenticate } = useAuthentication();
   const { colors, themeAppearance } = theme;
   const styles = createStyles(theme);
 
@@ -286,11 +288,8 @@ const RevealPrivateCredential = ({
   };
 
   const tryUnlock = async () => {
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { KeyringController } = Engine.context as any;
     try {
-      await KeyringController.verifyPassword(password);
+      await reauthenticate(password);
     } catch {
       const msg = strings('reveal_credential.warning_incorrect_password');
       setWarningIncorrectPassword(msg);

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -1373,37 +1373,22 @@ class AuthenticationService {
   }
 
   /**
-   * Verifies that the provided password can decrypt the main vault.
-   *
-   * It does this by trying to export the seed phrase with the given password.
-   * If the password is wrong, this method will throw an error.
-   *
-   * @param password - The password entered by the user.
-   * @param keyringId - Optional keyring id. When not provided, the primary keyring is used.
-   */
-  verifyPassword = async (
-    password: string,
-    keyringId?: string,
-  ): Promise<Uint8Array> => {
-    const { KeyringController } = Engine.context;
-    return await KeyringController.exportSeedPhrase(password, keyringId);
-  };
-
-  /**
    * Reauthenticates the user by verifying the password or using biometrics.
    *
    * @param password - The password entered by the user.
    */
   reauthenticate = async (password?: string): Promise<void> => {
     const biometryChoice = await StorageWrapper.getItem(BIOMETRY_CHOICE);
+    const { KeyringController } = Engine.context;
+    let passwordToVerify = password || '';
+
     if (biometryChoice) {
       const credentials = await this.getPassword();
       if (credentials) {
-        await this.verifyPassword(credentials.password);
+        passwordToVerify = credentials.password;
       }
-    } else if (password) {
-      await this.verifyPassword(password);
     }
+    return await KeyringController.verifyPassword(passwordToVerify);
   };
 }
 

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -7,6 +7,7 @@ import {
   PASSCODE_DISABLED,
   SEED_PHRASE_HINTS,
   OPTIN_META_METRICS_UI_SEEN,
+  BIOMETRY_CHOICE,
 } from '../../constants/storage';
 import {
   authSuccess,
@@ -1370,6 +1371,40 @@ class AuthenticationService {
       Logger.log(error, errorMsg);
     }
   }
+
+  /**
+   * Verifies that the provided password can decrypt the main vault.
+   *
+   * It does this by trying to export the seed phrase with the given password.
+   * If the password is wrong, this method will throw an error.
+   *
+   * @param password - The password entered by the user.
+   * @param keyringId - Optional keyring id. When not provided, the primary keyring is used.
+   */
+  verifyPassword = async (
+    password: string,
+    keyringId?: string,
+  ): Promise<Uint8Array> => {
+    const { KeyringController } = Engine.context;
+    return await KeyringController.exportSeedPhrase(password, keyringId);
+  };
+
+  /**
+   * Reauthenticates the user by verifying the password or using biometrics.
+   *
+   * @param password - The password entered by the user.
+   */
+  reauthenticate = async (password?: string): Promise<void> => {
+    const biometryChoice = await StorageWrapper.getItem(BIOMETRY_CHOICE);
+    if (biometryChoice) {
+      const credentials = await this.getPassword();
+      if (credentials) {
+        await this.verifyPassword(credentials.password);
+      }
+    } else if (password) {
+      await this.verifyPassword(password);
+    }
+  };
 }
 
 export const Authentication = new AuthenticationService();

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -1373,22 +1373,40 @@ class AuthenticationService {
   }
 
   /**
-   * Reauthenticates the user by verifying the password or using biometrics.
+   * Returns the password stored for biometric authentication, if any.
    *
-   * @param password - The password entered by the user.
+   * @returns The stored biometric password, or null when biometric auth
+   * is disabled or no password is stored.
    */
-  reauthenticate = async (password?: string): Promise<void> => {
+  getBiometricPassword = async (): Promise<string | null> => {
     const biometryChoice = await StorageWrapper.getItem(BIOMETRY_CHOICE);
-    const { KeyringController } = Engine.context;
-    let passwordToVerify = password || '';
 
-    if (biometryChoice) {
-      const credentials = await this.getPassword();
-      if (credentials) {
-        passwordToVerify = credentials.password;
+    if (!biometryChoice) {
+      return null;
+    }
+
+    const credentials = await this.getPassword();
+
+    if (credentials && typeof credentials !== 'boolean') {
+      const { password } = credentials;
+
+      if (password) {
+        return password;
       }
     }
-    return await KeyringController.verifyPassword(passwordToVerify);
+
+    return null;
+  };
+
+  /**
+   * Reauthenticates the user by verifying the provided password.
+   *
+   * @param password - The password to verify.
+   */
+  reauthenticate = async (password: string): Promise<void> => {
+    const { KeyringController } = Engine.context;
+
+    return await KeyringController.verifyPassword(password || '');
   };
 }
 

--- a/app/core/Authentication/hooks/useAuthentication.ts
+++ b/app/core/Authentication/hooks/useAuthentication.ts
@@ -1,0 +1,8 @@
+import { Authentication } from '../Authentication';
+
+/**
+ * Hook that interfaces with the Authentication service.
+ */
+export default () => ({
+    reauthenticate: Authentication.reauthenticate,
+  });

--- a/app/core/Authentication/hooks/useAuthentication.ts
+++ b/app/core/Authentication/hooks/useAuthentication.ts
@@ -4,5 +4,5 @@ import { Authentication } from '../Authentication';
  * Hook that interfaces with the Authentication service.
  */
 export default () => ({
-    reauthenticate: Authentication.reauthenticate,
-  });
+  reauthenticate: Authentication.reauthenticate,
+});

--- a/app/core/Authentication/hooks/useAuthentication.ts
+++ b/app/core/Authentication/hooks/useAuthentication.ts
@@ -5,4 +5,5 @@ import { Authentication } from '../Authentication';
  */
 export default () => ({
   reauthenticate: Authentication.reauthenticate,
+  getBiometricPassword: Authentication.getBiometricPassword,
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Add reauthentication to Authentication Service and refactor both resetpassord and revealprivatecredential. 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds reauthentication and biometric password helpers to Authentication and refactors ResetPassword and RevealPrivateCredential to use them.
> 
> - **Core Authentication**:
>   - Add `Authentication.reauthenticate(password)` to verify credentials via `KeyringController.verifyPassword`.
>   - Add `Authentication.getBiometricPassword()` to fetch stored biometric password.
>   - New hook `core/Authentication/hooks/useAuthentication` exposing these APIs.
>   - Unit tests added for both methods.
> - **ResetPassword (`app/components/Views/ResetPassword`)**:
>   - Replace Engine/seed-phrase export check with `Authentication.reauthenticate` for current-password validation.
>   - Auto-attempt unlock using `Authentication.getBiometricPassword()` when available.
>   - Remove legacy biometric unlock path and `Engine` dependency.
>   - Tests updated to mock `reauthenticate`/`getBiometricPassword` and flows.
> - **RevealPrivateCredential**:
>   - Use `useAuthentication().reauthenticate` for password verification before revealing credentials.
>   - Remove direct `Engine` password verification from component/tests; keep export calls for reveal.
>   - Tests updated to drive reauth success/failure and snapshots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb199e2d99e81c4153a5b0c94106da35872a7690. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->