### PR TITLE
test: update element retrieval methods in PredictDetailsScreen

### DIFF
--- a/wdio/screen-objects/PredictDetailsScreen.js
+++ b/wdio/screen-objects/PredictDetailsScreen.js
@@ -38,7 +38,7 @@ class PredictDetailsScreen {
     if (!this._device) {
       return Selectors.getXpathElementByText(PredictMarketDetailsSelectorsText.ABOUT_TAB_TEXT);
     } else {
-      return AppwrightSelectors.getElementByID(this._device, PredictMarketDetailsSelectorsIDs.ABOUT_TAB_LABEL);
+      return AppwrightSelectors.getElementByText(this._device, PredictMarketDetailsSelectorsText.ABOUT_TAB_TEXT);
     }
   }
 
@@ -54,7 +54,7 @@ class PredictDetailsScreen {
     if (!this._device) {
       return Selectors.getXpathElementByText(PredictMarketDetailsSelectorsText.OUTCOMES_TAB_TEXT);
     } else {
-      return AppwrightSelectors.getElementByID(this._device, PredictMarketDetailsSelectorsIDs.OUTCOMES_TAB_LABEL);
+      return AppwrightSelectors.getElementByText(this._device, PredictMarketDetailsSelectorsText.OUTCOMES_TAB_TEXT);
     }
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Updated the methods for retrieving elements in the PredictDetailsScreen class to use text-based selectors instead of ID-based selectors. This change enhances the flexibility and maintainability of the code by aligning with the updated selector strategy.

- Replaced getElementByID calls with getElementByText for ABOUT_TAB and OUTCOMES_TAB.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict Market Details Performance
  As a user
  I want to view prediction market details quickly
  So that I can make informed predictions efficiently

  Background:
    Given the user has the MetaMask app installed
    And the user has an existing wallet with valid credentials
    And the network conditions are set to 4G LTE

  @performance @predict @market-details
  Scenario: View prediction market details and navigate between tabs
    Given the user is logged into the MetaMask app
    When the user taps the action button on the wallet tab bar
    And the user taps the Predict button in the action modal
    Then the Predict Market List screen is displayed

    When the user taps on the first trending market card
    Then the Market Details screen is displayed

    When the user taps the About tab
    Then the About tab content is loaded
    And the Volume information is visible

    When the user taps the Outcomes tab
    Then the Outcomes tab content is displayed
    And the outcome options are visible

  @performance @predict @deposit
  Scenario: Complete a deposit flow in Predict
    Given the user is logged into the MetaMask app
    And the user has navigated to the Predict Market List
    When the user taps the Add Funds button
    Then the Deposit screen is displayed with the amount input

    When the user taps Pay With to change payment method
    Then the Select Payment Method modal appears

    When the user searches for "USDC" token
    And the user selects the Ethereum network filter
    And the user selects USDC as the payment token
    And the user enters "1" as the deposit amount
    And the user taps Continue
    Then the Confirmation screen is displayed
    And the deposit amount shows "$1"
    And the fee information is visible
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Appwright device-path selectors for About and Outcomes tabs to text-based retrieval instead of ID-based.
> 
> - **E2E selectors (PredictDetailsScreen)**:
>   - Replace Appwright ID-based lookups with `getElementByText` for `aboutTab` and `outcomesTab`.
>   - Non-Appwright path and other getters unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d9383235b8db61cf2eae00473d9352273f5f6f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->