### PR TITLE
fix: biometric-reset

### DIFF
--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -171,7 +171,6 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
 
   const updateBiometryChoice = useCallback(
     async (newBiometryChoice: boolean) => {
-      await updateAuthTypeStorageFlags(newBiometryChoice);
       setBiometryChoice(newBiometryChoice);
     },
     [setBiometryChoice],
@@ -402,6 +401,7 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
         },
         async () => {
           await Authentication.userEntryAuth(password, authType);
+          await updateAuthTypeStorageFlags(biometryChoice);
         },
       );
 

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -165,7 +165,7 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
   };
 
   const handleBackPress = () => {
-    Authentication.lockApp();
+    Authentication.lockApp({ reset: false });
     return false;
   };
 

--- a/app/components/Views/Login/index2.test.tsx
+++ b/app/components/Views/Login/index2.test.tsx
@@ -13,7 +13,6 @@ import { Authentication } from '../../../core';
 
 // Mock dependencies
 import AUTHENTICATION_TYPE from '../../../constants/userProperties';
-import { updateAuthTypeStorageFlags } from '../../../util/authentication';
 
 import Engine from '../../../core/Engine';
 import StorageWrapper from '../../../store/storage-wrapper';
@@ -356,8 +355,6 @@ describe('Login test suite 2', () => {
       await act(async () => {
         fireEvent(passwordInput, 'submitEditing');
       });
-
-      expect(updateAuthTypeStorageFlags).toHaveBeenCalledWith(false);
 
       mockRoute.mockClear();
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1) Back press handler in Login Screen are calling lockApp which reseted the biometric password causing biometric reseted in the scenario in the issue https://github.com/MetaMask/metamask-mobile/issues/23292

2) `Biometric choice disable` update upon switch toggle causing inaccurate biometric choice state.

This PR fix the back press issue and fix biometric choice to update after unlocked instead of biometric switch update 


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix biometric sudden reset issue

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/23292

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user back press at unlock screen
    Given user lock the wallet with biometric set

    When user trigger back press gesture
    Then app will send to background
    When user reopen the app
    Then user are prompt for biometric 
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids biometric reset on back press and moves biometry preference persistence to after successful login; updates tests accordingly.
> 
> - **Login flow (`app/components/Views/Login/index.tsx`)**:
>   - Back press now calls `Authentication.lockApp({ reset: false })` to avoid resetting biometrics.
>   - `updateBiometryChoice` only updates local state; storage flags are no longer set on toggle.
>   - Persist biometry preference by calling `updateAuthTypeStorageFlags(biometryChoice)` after `Authentication.userEntryAuth` succeeds.
> - **Tests (`app/components/Views/Login/index2.test.tsx`)**:
>   - Remove direct import and expectation of `updateAuthTypeStorageFlags` on submit; align tests with new persistence timing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83294ee4af3f7efd55a1f7db6d324f986783a12a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->