### PR TITLE
test: adds an explicitly delay option to the ellipsis tap

### DIFF
--- a/e2e/pages/wallet/AccountListBottomSheet.ts
+++ b/e2e/pages/wallet/AccountListBottomSheet.ts
@@ -134,7 +134,10 @@ class AccountListBottomSheet {
     });
   }
 
-  async tapAddAccountButtonV2(options?: { srpIndex?: number }): Promise<void> {
+  async tapAddAccountButtonV2(options?: {
+    srpIndex?: number;
+    shouldWait?: boolean;
+  }): Promise<void> {
     const button = Matchers.getElementByID(
       AccountListBottomSheetSelectorsIDs.CREATE_ACCOUNT,
       options?.srpIndex ?? 0,
@@ -142,6 +145,7 @@ class AccountListBottomSheet {
 
     await Gestures.waitAndTap(button, {
       elemDescription: 'Add Account button in V2 multichain accounts',
+      delay: options?.shouldWait ? 1500 : 0,
     });
   }
 

--- a/e2e/pages/wallet/AccountListBottomSheet.ts
+++ b/e2e/pages/wallet/AccountListBottomSheet.ts
@@ -232,9 +232,13 @@ class AccountListBottomSheet {
    * Tap the ellipsis menu button for a specific account in V2 multichain accounts
    * @param accountIndex - The index of the account to tap (0-based)
    */
-  async tapAccountEllipsisButtonV2(accountIndex: number): Promise<void> {
+  async tapAccountEllipsisButtonV2(
+    accountIndex: number,
+    { shouldWait = false }: { shouldWait: boolean } = { shouldWait: false },
+  ): Promise<void> {
     await Gestures.tapAtIndex(this.ellipsisMenuButton, accountIndex, {
       elemDescription: `V2 ellipsis menu button for account at index ${accountIndex}`,
+      delay: shouldWait ? 1500 : 0,
     });
   }
 

--- a/e2e/specs/identity/account-syncing/multi-srp.spec.ts
+++ b/e2e/specs/identity/account-syncing/multi-srp.spec.ts
@@ -131,7 +131,10 @@ describe(SmokeIdentity('Account syncing - Mutiple SRPs'), () => {
           },
         );
 
-        await AccountListBottomSheet.tapAccountEllipsisButtonV2(3);
+        // We need to explicitly wait here to avoid having the "Account" added toast appear on top of the EllipsisButton
+        await AccountListBottomSheet.tapAccountEllipsisButtonV2(3, {
+          shouldWait: true,
+        });
         await AccountDetails.tapEditAccountName();
         await EditAccountName.updateAccountName(SRP_2_SECOND_ACCOUNT);
         await EditAccountName.tapSave();

--- a/e2e/specs/identity/account-syncing/multi-srp.spec.ts
+++ b/e2e/specs/identity/account-syncing/multi-srp.spec.ts
@@ -117,6 +117,7 @@ describe(SmokeIdentity('Account syncing - Mutiple SRPs'), () => {
         // Create second account for SRP 2
         await AccountListBottomSheet.tapAddAccountButtonV2({
           srpIndex: 1,
+          shouldWait: true,
         });
 
         await waitUntilSyncedAccountsNumberEquals(4);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional delay to `tapAddAccountButtonV2` and `tapAccountEllipsisButtonV2`, and updates the multi-SRP e2e test to use it and wait for visibility to reduce flakiness.
> 
> - **E2E Page Objects (`e2e/pages/wallet/AccountListBottomSheet.ts`)**:
>   - `tapAddAccountButtonV2` now accepts `shouldWait` and applies a conditional `delay`.
>   - `tapAccountEllipsisButtonV2` now accepts `{ shouldWait }` with a conditional `delay`.
> - **E2E Test (`e2e/specs/identity/account-syncing/multi-srp.spec.ts`)**:
>   - Uses `shouldWait: true` when adding an account for SRP 2 and tapping the ellipsis on the 4th account.
>   - Adds explicit visibility assertion for the 4th account’s ellipsis button before tapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9776e25eabcbaa14ae78ad4039950506b46ffd1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->