### PR TITLE
chore: add maxFontSizeMultiplier to HeaderBase

### DIFF
--- a/app/component-library/components/BottomSheets/BottomSheetHeader/__snapshots__/BottomSheetHeader.test.tsx.snap
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/__snapshots__/BottomSheetHeader.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`BottomSheetHeader renders snapshot correctly with Compact variant 1`] =
     style={
       [
         {
-          "alignItems": "center",
           "display": "flex",
           "flexBasis": "0%",
           "flexGrow": 1,
@@ -34,6 +33,7 @@ exports[`BottomSheetHeader renders snapshot correctly with Compact variant 1`] =
   >
     <Text
       accessibilityRole="text"
+      maxFontSizeMultiplier={1.75}
       style={
         [
           {
@@ -78,7 +78,6 @@ exports[`BottomSheetHeader renders snapshot correctly with Display variant 1`] =
     style={
       [
         {
-          "alignItems": "flex-start",
           "display": "flex",
           "flexBasis": "0%",
           "flexGrow": 1,
@@ -90,6 +89,7 @@ exports[`BottomSheetHeader renders snapshot correctly with Display variant 1`] =
   >
     <Text
       accessibilityRole="text"
+      maxFontSizeMultiplier={1.75}
       style={
         [
           {
@@ -133,7 +133,6 @@ exports[`BottomSheetHeader should render snapshot correctly 1`] = `
     style={
       [
         {
-          "alignItems": "center",
           "display": "flex",
           "flexBasis": "0%",
           "flexGrow": 1,
@@ -145,6 +144,7 @@ exports[`BottomSheetHeader should render snapshot correctly 1`] = `
   >
     <Text
       accessibilityRole="text"
+      maxFontSizeMultiplier={1.75}
       style={
         [
           {

--- a/app/component-library/components/HeaderBase/HeaderBase.tsx
+++ b/app/component-library/components/HeaderBase/HeaderBase.tsx
@@ -125,11 +125,6 @@ const HeaderBase: React.FC<HeaderBaseProps> = ({
     ? `${baseStyles} ${twClassName}`
     : baseStyles;
 
-  // Title classes based on variant
-  const titleWrapperClass = isLeftAligned
-    ? 'flex-1 items-start'
-    : 'flex-1 items-center';
-
   return (
     <View
       style={[
@@ -157,12 +152,13 @@ const HeaderBase: React.FC<HeaderBaseProps> = ({
       )}
 
       {/* Title */}
-      <Box twClassName={titleWrapperClass}>
+      <Box twClassName={'flex-1'}>
         {typeof children === 'string' ? (
           <Text
             variant={textVariant}
             testID={HEADERBASE_TITLE_TEST_ID}
             style={isLeftAligned ? undefined : tw.style('text-center')}
+            maxFontSizeMultiplier={1.75}
           >
             {children}
           </Text>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -995,7 +995,6 @@ exports[`SnapUIForm will render with fields 1`] = `
                             style={
                               [
                                 {
-                                  "alignItems": "center",
                                   "display": "flex",
                                   "flexBasis": "0%",
                                   "flexGrow": 1,
@@ -1007,6 +1006,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                           >
                             <Text
                               accessibilityRole="text"
+                              maxFontSizeMultiplier={1.75}
                               style={
                                 [
                                   {
@@ -1728,7 +1728,6 @@ exports[`SnapUIForm will render with fields 1`] = `
                             style={
                               [
                                 {
-                                  "alignItems": "center",
                                   "display": "flex",
                                   "flexBasis": "0%",
                                   "flexGrow": 1,
@@ -1740,6 +1739,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                           >
                             <Text
                               accessibilityRole="text"
+                              maxFontSizeMultiplier={1.75}
                               style={
                                 [
                                   {

--- a/app/components/UI/Bridge/components/BridgeDestNetworkSelector/__snapshots__/BridgeDestNetworkSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestNetworkSelector/__snapshots__/BridgeDestNetworkSelector.test.tsx.snap
@@ -456,7 +456,6 @@ exports[`BridgeDestNetworkSelector renders with initial state and displays netwo
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -468,6 +467,7 @@ exports[`BridgeDestNetworkSelector renders with initial state and displays netwo
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
@@ -456,7 +456,6 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -468,6 +467,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/__snapshots__/BridgeSourceNetworkSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/__snapshots__/BridgeSourceNetworkSelector.test.tsx.snap
@@ -456,7 +456,6 @@ exports[`BridgeSourceNetworkSelector renders with initial state and displays net
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -468,6 +467,7 @@ exports[`BridgeSourceNetworkSelector renders with initial state and displays net
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
@@ -456,7 +456,6 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -468,6 +467,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
@@ -155,7 +155,6 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -167,6 +166,7 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
           >
             <Text
               accessibilityRole="text"
+              maxFontSizeMultiplier={1.75}
               style={
                 [
                   {

--- a/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
@@ -155,7 +155,6 @@ exports[`SlippageModal renders all UI elements with the proper slippage options 
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -167,6 +166,7 @@ exports[`SlippageModal renders all UI elements with the proper slippage options 
           >
             <Text
               accessibilityRole="text"
+              maxFontSizeMultiplier={1.75}
               style={
                 [
                   {

--- a/app/components/UI/Card/components/AddFundsBottomSheet/__snapshots__/AddFundsBottomSheet.test.tsx.snap
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/__snapshots__/AddFundsBottomSheet.test.tsx.snap
@@ -456,7 +456,6 @@ exports[`AddFundsBottomSheet renders with both options enabled and matches snaps
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1264,7 +1263,6 @@ exports[`AddFundsBottomSheet renders with no options when both are disabled and 
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1856,7 +1854,6 @@ exports[`AddFundsBottomSheet renders with only deposit option when swaps are not
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -2556,7 +2553,6 @@ exports[`AddFundsBottomSheet renders with only swap option when deposit is disab
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
@@ -135,7 +135,6 @@ exports[`LendingLearnMoreModal render lending history apy chart 1`] = `
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,

--- a/app/components/UI/Earn/components/EarnTokenList/__snapshots__/EarnTokenList.test.tsx.snap
+++ b/app/components/UI/Earn/components/EarnTokenList/__snapshots__/EarnTokenList.test.tsx.snap
@@ -150,7 +150,6 @@ exports[`EarnTokenList render matches snapshot 1`] = `
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,

--- a/app/components/UI/Earn/components/MaxInputModal/__snapshots__/MaxInputModal.test.tsx.snap
+++ b/app/components/UI/Earn/components/MaxInputModal/__snapshots__/MaxInputModal.test.tsx.snap
@@ -462,7 +462,6 @@ exports[`MaxInputModal render matches snapshot 1`] = `
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
                                       "display": "flex",
                                       "flexBasis": "0%",
                                       "flexGrow": 1,

--- a/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/__snapshots__/LendingMaxWithdrawalModal.test.tsx.snap
+++ b/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/__snapshots__/LendingMaxWithdrawalModal.test.tsx.snap
@@ -28,7 +28,6 @@ exports[`LendingMaxWithdrawalModal should render correctly 1`] = `
       style={
         [
           {
-            "alignItems": "center",
             "display": "flex",
             "flexBasis": "0%",
             "flexGrow": 1,

--- a/app/components/UI/NetworkModal/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/NetworkModal/__snapshots__/index.test.tsx.snap
@@ -167,7 +167,6 @@ exports[`NetworkDetails renders correctly 1`] = `
                   style={
                     [
                       {
-                        "alignItems": "center",
                         "display": "flex",
                         "flexBasis": "0%",
                         "flexGrow": 1,

--- a/app/components/UI/NetworkVerificationInfo/__snapshots__/NetworkVerificationInfo.test.tsx.snap
+++ b/app/components/UI/NetworkVerificationInfo/__snapshots__/NetworkVerificationInfo.test.tsx.snap
@@ -25,7 +25,6 @@ exports[`NetworkVerificationInfo renders correctly 1`] = `
       style={
         [
           {
-            "alignItems": "center",
             "display": "flex",
             "flexBasis": "0%",
             "flexGrow": 1,
@@ -564,7 +563,6 @@ exports[`NetworkVerificationInfo renders updated details when isNetworkRpcUpdate
       style={
         [
           {
-            "alignItems": "center",
             "display": "flex",
             "flexBasis": "0%",
             "flexGrow": 1,

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/__snapshots__/PerpsBottomSheetTooltip.test.tsx.snap
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/__snapshots__/PerpsBottomSheetTooltip.test.tsx.snap
@@ -151,7 +151,6 @@ exports[`PerpsBottomSheetTooltip renders correctly when visible 1`] = `
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,

--- a/app/components/UI/Ramp/Aggregator/Views/Checkout/__snapshots__/Checkout.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Checkout/__snapshots__/Checkout.test.tsx.snap
@@ -457,7 +457,6 @@ exports[`Checkout displays WebView when url is present and no errors 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -998,7 +997,6 @@ exports[`Checkout displays and tracks error if no url or errors 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1692,7 +1690,6 @@ exports[`Checkout displays sdkError when present 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -2430,7 +2427,6 @@ exports[`Checkout displays sell WebView when url is present and no errors 1`] = 
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -2971,7 +2967,6 @@ exports[`Checkout handles get order error gracefully 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -3709,7 +3704,6 @@ exports[`Checkout handles undefined order gracefully 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -4447,7 +4441,6 @@ exports[`Checkout ignores irrelevant error on http error in WebView for callback
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -4988,7 +4981,6 @@ exports[`Checkout sets and displays error on http error in WebView 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -5726,7 +5718,6 @@ exports[`Checkout sets and displays error on http error in WebView for callback 
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -6464,7 +6455,6 @@ exports[`Checkout sets error when handling url navigation state change and selec
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/__snapshots__/SettingsModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/__snapshots__/SettingsModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`SettingsModal renders snapshot correctly 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -467,6 +466,7 @@ exports[`SettingsModal renders snapshot correctly 1`] = `
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -1181,7 +1181,6 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1193,6 +1192,7 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {
@@ -3464,7 +3464,6 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -3476,6 +3475,7 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {
@@ -5351,7 +5351,6 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -5363,6 +5362,7 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`FiatSelectorModal renders the modal with currency list 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1391,7 +1390,6 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -2327,7 +2325,6 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -3263,7 +3260,6 @@ exports[`FiatSelectorModal search displays max 20 results 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Aggregator/components/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`PaymentMethodSelectorModal renders correctly 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1596,7 +1595,6 @@ exports[`PaymentMethodSelectorModal renders for sell flow 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -2737,7 +2735,6 @@ exports[`PaymentMethodSelectorModal renders without disclaimer when selected pay
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`RegionSelectorModal clears search when clear button is pressed 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1315,7 +1314,6 @@ exports[`RegionSelectorModal clears search when clear button is pressed 2`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -2513,7 +2511,6 @@ exports[`RegionSelectorModal filters regions based on search input 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -3373,7 +3370,6 @@ exports[`RegionSelectorModal handles empty regions list gracefully 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -4101,7 +4097,6 @@ exports[`RegionSelectorModal handles undefined regions gracefully 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -4863,7 +4858,6 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -5679,7 +5673,6 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -6877,7 +6870,6 @@ exports[`RegionSelectorModal renders the modal with region list 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -8075,7 +8067,6 @@ exports[`RegionSelectorModal renders the modal with selected region in list 1`] 
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -9289,7 +9280,6 @@ exports[`RegionSelectorModal renders the modal with selected state in list 1`] =
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -10503,7 +10493,6 @@ exports[`RegionSelectorModal shows empty state when search returns no results 1`
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`TokenSelectModal renders the modal with token list 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Aggregator/components/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
@@ -430,7 +430,6 @@ exports[`UnsupportedRegionModal renders correctly for buy flow 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1026,7 +1025,6 @@ exports[`UnsupportedRegionModal renders correctly for sell flow 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/__snapshots__/ConfigurationModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/__snapshots__/ConfigurationModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`ConfigurationModal render matches snapshot 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -467,6 +466,7 @@ exports[`ConfigurationModal render matches snapshot 1`] = `
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Deposit/Views/Modals/ErrorDetailsModal/__snapshots__/ErrorDetailsModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/ErrorDetailsModal/__snapshots__/ErrorDetailsModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`ErrorDetailsModal renders correctly and matches snapshot 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`PaymentMethodSelectorModal Component renders correctly and matches snap
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -467,6 +466,7 @@ exports[`PaymentMethodSelectorModal Component renders correctly and matches snap
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`RegionSelectorModal Component handles empty regions array from navigati
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -467,6 +466,7 @@ exports[`RegionSelectorModal Component handles empty regions array from navigati
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {
@@ -1167,7 +1167,6 @@ exports[`RegionSelectorModal Component receives and uses regions from navigation
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1179,6 +1178,7 @@ exports[`RegionSelectorModal Component receives and uses regions from navigation
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {
@@ -2075,7 +2075,6 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -2087,6 +2086,7 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {
@@ -3215,7 +3215,6 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -3227,6 +3226,7 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {
@@ -3968,7 +3968,6 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -3980,6 +3979,7 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {
@@ -4809,7 +4809,6 @@ exports[`RegionSelectorModal Component render matches snapshot with allRegionsSe
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -4821,6 +4820,7 @@ exports[`RegionSelectorModal Component render matches snapshot with allRegionsSe
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {
@@ -5949,7 +5949,6 @@ exports[`RegionSelectorModal Component render matches snapshot with custom selec
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -5961,6 +5960,7 @@ exports[`RegionSelectorModal Component render matches snapshot with custom selec
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {
@@ -7089,7 +7089,6 @@ exports[`RegionSelectorModal Component sorts recommended regions to the top when
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -7101,6 +7100,7 @@ exports[`RegionSelectorModal Component sorts recommended regions to the top when
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Deposit/Views/Modals/SsnInfoModal/__snapshots__/SsnInfoModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/SsnInfoModal/__snapshots__/SsnInfoModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`SsnInfoModal Component renders correctly and matches snapshot 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1256,7 +1255,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -2001,7 +1999,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -2802,7 +2799,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -3603,7 +3599,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -4667,7 +4662,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`TokenSelectorModal Component displays empty state when no tokens match 
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1409,7 +1408,6 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -2563,7 +2561,6 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
@@ -435,7 +435,6 @@ exports[`UnsupportedRegionModal handles missing region gracefully 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1105,7 +1104,6 @@ exports[`UnsupportedRegionModal render match snapshot 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/__snapshots__/UnsupportedStateModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/__snapshots__/UnsupportedStateModal.test.tsx.snap
@@ -435,7 +435,6 @@ exports[`UnsupportedStateModal render match snapshot 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/Deposit/Views/Modals/WebviewModal/__snapshots__/WebviewModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/WebviewModal/__snapshots__/WebviewModal.test.tsx.snap
@@ -457,7 +457,6 @@ exports[`WebviewModal Component renders correctly and matches snapshot 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -1018,7 +1017,6 @@ exports[`WebviewModal Component should display error view when webview HTTP erro
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,

--- a/app/components/UI/Ramp/components/EligibilityFailedModal/__snapshots__/EligibilityFailedModal.test.tsx.snap
+++ b/app/components/UI/Ramp/components/EligibilityFailedModal/__snapshots__/EligibilityFailedModal.test.tsx.snap
@@ -338,7 +338,6 @@ exports[`EligibilityFailedModal renders modal with title and description 1`] = `
                         style={
                           [
                             {
-                              "alignItems": "center",
                               "display": "flex",
                               "flexBasis": "0%",
                               "flexGrow": 1,

--- a/app/components/UI/Ramp/components/RampUnsupportedModal/__snapshots__/RampUnsupportedModal.test.tsx.snap
+++ b/app/components/UI/Ramp/components/RampUnsupportedModal/__snapshots__/RampUnsupportedModal.test.tsx.snap
@@ -338,7 +338,6 @@ exports[`RampUnsupportedModal renders modal with title and description 1`] = `
                         style={
                           [
                             {
-                              "alignItems": "center",
                               "display": "flex",
                               "flexBasis": "0%",
                               "flexGrow": 1,

--- a/app/components/UI/Ramp/components/UnsupportedTokenModal/__snapshots__/UnsupportedTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/components/UnsupportedTokenModal/__snapshots__/UnsupportedTokenModal.test.tsx.snap
@@ -338,7 +338,6 @@ exports[`UnsupportedTokenModal renders the modal with correct title and descript
                         style={
                           [
                             {
-                              "alignItems": "center",
                               "display": "flex",
                               "flexBasis": "0%",
                               "flexGrow": 1,
@@ -350,6 +349,7 @@ exports[`UnsupportedTokenModal renders the modal with correct title and descript
                       >
                         <Text
                           accessibilityRole="text"
+                          maxFontSizeMultiplier={1.75}
                           style={
                             [
                               {

--- a/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
@@ -162,7 +162,6 @@ exports[`GasImpactModal render matches snapshot 1`] = `
               style={
                 [
                   {
-                    "alignItems": "center",
                     "display": "flex",
                     "flexBasis": "0%",
                     "flexGrow": 1,

--- a/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
@@ -139,7 +139,6 @@ exports[`PoolStakingLearnMoreModal render matches snapshot 1`] = `
                 style={
                   [
                     {
-                      "alignItems": "center",
                       "display": "flex",
                       "flexBasis": "0%",
                       "flexGrow": 1,

--- a/app/components/UI/UpdateNeeded/__snapshots__/UpdateNeeded.test.tsx.snap
+++ b/app/components/UI/UpdateNeeded/__snapshots__/UpdateNeeded.test.tsx.snap
@@ -419,7 +419,6 @@ exports[`UpdateNeeded should render snapshot correctly 1`] = `
                             style={
                               [
                                 {
-                                  "alignItems": "center",
                                   "display": "flex",
                                   "flexBasis": "0%",
                                   "flexGrow": 1,

--- a/app/components/Views/AccountPermissions/AccountPermissionsConfirmRevokeAll/__snapshots__/AccountPermissionsConfirmRevokeAll.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/AccountPermissionsConfirmRevokeAll/__snapshots__/AccountPermissionsConfirmRevokeAll.test.tsx.snap
@@ -147,7 +147,6 @@ exports[`AccountPermissionsConfirmRevokeAll renders correctly 1`] = `
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -159,6 +158,7 @@ exports[`AccountPermissionsConfirmRevokeAll renders correctly 1`] = `
           >
             <Text
               accessibilityRole="text"
+              maxFontSizeMultiplier={1.75}
               style={
                 [
                   {

--- a/app/components/Views/AccountPermissions/ConnectionDetails/__snapshots__/ConnectionDetails.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/ConnectionDetails/__snapshots__/ConnectionDetails.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`ConnectionDetails renders correctly 1`] = `
       style={
         [
           {
-            "alignItems": "center",
             "display": "flex",
             "flexBasis": "0%",
             "flexGrow": 1,
@@ -42,6 +41,7 @@ exports[`ConnectionDetails renders correctly 1`] = `
     >
       <Text
         accessibilityRole="text"
+        maxFontSizeMultiplier={1.75}
         style={
           [
             {

--- a/app/components/Views/AccountPermissions/PermittedNetworksInfoSheet/__snapshots__/PermittedNetworksInfoSheet.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/PermittedNetworksInfoSheet/__snapshots__/PermittedNetworksInfoSheet.test.tsx.snap
@@ -31,7 +31,6 @@ exports[`PermittedNetworksInfoSheet should render correctly 1`] = `
       style={
         [
           {
-            "alignItems": "center",
             "display": "flex",
             "flexBasis": "0%",
             "flexGrow": 1,
@@ -43,6 +42,7 @@ exports[`PermittedNetworksInfoSheet should render correctly 1`] = `
     >
       <Text
         accessibilityRole="text"
+        maxFontSizeMultiplier={1.75}
         style={
           [
             {

--- a/app/components/Views/ActivityView/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ActivityView/__snapshots__/index.test.tsx.snap
@@ -351,7 +351,6 @@ exports[`ActivityView matches snapshot 1`] = `
                           style={
                             [
                               {
-                                "alignItems": "flex-start",
                                 "display": "flex",
                                 "flexBasis": "0%",
                                 "flexGrow": 1,
@@ -363,6 +362,7 @@ exports[`ActivityView matches snapshot 1`] = `
                         >
                           <Text
                             accessibilityRole="text"
+                            maxFontSizeMultiplier={1.75}
                             style={
                               [
                                 {

--- a/app/components/Views/AddressSelector/__snapshots__/AddressSelector.test.tsx.snap
+++ b/app/components/Views/AddressSelector/__snapshots__/AddressSelector.test.tsx.snap
@@ -456,7 +456,6 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
                                     "display": "flex",
                                     "flexBasis": "0%",
                                     "flexGrow": 1,
@@ -468,6 +467,7 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                             >
                               <Text
                                 accessibilityRole="text"
+                                maxFontSizeMultiplier={1.75}
                                 style={
                                   [
                                     {

--- a/app/components/Views/Asset/__snapshots__/index.test.js.snap
+++ b/app/components/Views/Asset/__snapshots__/index.test.js.snap
@@ -396,7 +396,6 @@ exports[`Asset Multichain Functionality renders empty state when no multichain t
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -2081,7 +2080,6 @@ exports[`Asset Multichain Functionality returns empty list for unknown SPL token
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -3807,7 +3805,6 @@ exports[`Asset Multichain Functionality should exclude mixed token/SOL transacti
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -5492,7 +5489,6 @@ exports[`Asset Multichain Functionality should exclude transactions with empty a
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -7177,7 +7173,6 @@ exports[`Asset Multichain Functionality should filter SPL token transactions cor
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -8903,7 +8898,6 @@ exports[`Asset Multichain Functionality should filter native SOL transactions co
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -10588,7 +10582,6 @@ exports[`Asset Multichain Functionality should render EVM assets with Transactio
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -11116,7 +11109,6 @@ exports[`Asset Multichain Functionality should render non-EVM assets with Multic
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -12801,7 +12793,6 @@ exports[`Asset Multichain Functionality should sort filtered transactions by tim
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -14486,7 +14477,6 @@ exports[`Asset Multichain Functionality should use EVM transactions for EVM acco
             style={
               [
                 {
-                  "alignItems": "center",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,

--- a/app/components/Views/NetworkSelector/RpcSelectionModal/__snapshots__/RpcSelectionModal.test.tsx.snap
+++ b/app/components/Views/NetworkSelector/RpcSelectionModal/__snapshots__/RpcSelectionModal.test.tsx.snap
@@ -139,7 +139,6 @@ exports[`RpcSelectionModal should render correctly when visible 1`] = `
           style={
             [
               {
-                "alignItems": "center",
                 "display": "flex",
                 "flexBasis": "0%",
                 "flexGrow": 1,

--- a/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
@@ -58,7 +58,6 @@ exports[`Wallet Conditional Rendering should render banner when basic functional
             style={
               [
                 {
-                  "alignItems": "flex-start",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -1236,7 +1235,6 @@ exports[`Wallet Conditional Rendering should render loader when no selected acco
             style={
               [
                 {
-                  "alignItems": "flex-start",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -2414,7 +2412,6 @@ exports[`Wallet should render correctly 1`] = `
             style={
               [
                 {
-                  "alignItems": "flex-start",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -3592,7 +3589,6 @@ exports[`Wallet should render correctly when Solana support is enabled 1`] = `
             style={
               [
                 {
-                  "alignItems": "flex-start",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,
@@ -4770,7 +4766,6 @@ exports[`Wallet should render correctly when there are no detected tokens 1`] = 
             style={
               [
                 {
-                  "alignItems": "flex-start",
                   "display": "flex",
                   "flexBasis": "0%",
                   "flexGrow": 1,


### PR DESCRIPTION
## **Description**

This PR adds `maxFontSizeMultiplier={1.75}` to the HeaderBase component's title Text element. This prevents the header title from becoming excessively large when users have increased their device's accessibility font size settings, which could otherwise cause layout issues or text overflow in the header.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: HeaderBase title font scaling

  Scenario: user increases device font size
    Given the app is open with a screen using HeaderBase
    And the device accessibility font size is set to maximum

    When user views the header
    Then the header title should be larger than default
    And the header title should not exceed 1.75x the base font size
    And the header layout should remain intact without overflow
```

## **Screenshots/Recordings**

### **Before**

### **After**
https://github.com/user-attachments/assets/66c20cf9-5988-4937-bc10-7c8214e3f20f

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caps header title text scaling at 1.75x and standardizes title container alignment, updating affected snapshots.
> 
> - **Component Library**
>   - **`HeaderBase`**: Add `maxFontSizeMultiplier={1.75}` to title `Text`; replace variant-based title wrapper with `twClassName="flex-1"` (removes `items-start/center` alignment logic).
> - **Tests/Snapshots**
>   - Update snapshots across headers and modals (e.g., `BottomSheetHeader`, Ramp, Bridge, Earn, Stake, Network screens) to reflect capped text scaling and removal of `alignItems` on title wrapper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fff6e379c178ea6d0ee16c9d964a46c47c116532. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->