### PR TITLE
test: disable GTM modals for perf builds

### DIFF
--- a/app/constants/storage.ts
+++ b/app/constants/storage.ts
@@ -73,10 +73,10 @@ export const PERPS_GTM_MODAL_SHOWN = `${prefix}perpsGTMModalShown`;
 
 export const PREDICT_GTM_MODAL_SHOWN = `${prefix}predictGTMModalShown`;
 
+export const REWARDS_GTM_MODAL_SHOWN = `${prefix}rewardsGTMModalShown`;
+
 export const RESUBSCRIBE_NOTIFICATIONS_EXPIRY = `${prefix}RESUBSCRIBE_NOTIFICATIONS_EXPIRY`;
 
 export const HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS = `${prefix}HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS`;
 
 export const OPTIN_META_METRICS_UI_SEEN = `${prefix}OptinMetaMetricsUISeen`;
-
-export const REWARDS_GTM_MODAL_SHOWN = `${prefix}rewardsGTMModalShown`;

--- a/app/util/generateSkipOnboardingState.ts
+++ b/app/util/generateSkipOnboardingState.ts
@@ -1,7 +1,12 @@
 import StorageWrapper from '../store/storage-wrapper';
-import { seedphraseBackedUp } from '../actions/user';
 import {
+  seedphraseBackedUp,
+  setMultichainAccountsIntroModalSeen,
+} from '../actions/user';
+import {
+  HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS,
   OPTIN_META_METRICS_UI_SEEN,
+  PREDICT_GTM_MODAL_SHOWN,
   TRUE,
   USE_TERMS,
 } from '../constants/storage';
@@ -96,6 +101,8 @@ async function applyVaultInitialization() {
     store.dispatch(seedphraseBackedUp());
     // removes the necessity of the user to see the privacy policy modal
     store.dispatch(storePrivacyPolicyClickedOrClosed());
+    // removes the necessity of the user to see the multichain accounts intro modal
+    store.dispatch(setMultichainAccountsIntroModalSeen(true));
     // Set auto-lock time for the default
     // Note: This line is tested via component tests (setLockTime action creator + store.dispatch)
     // Full integration testing requires PREDEFINED_PASSWORD env var set before module load
@@ -106,6 +113,12 @@ async function applyVaultInitialization() {
 
     // removes the necessity of the user to see the opt-in metrics modal
     await StorageWrapper.setItem(OPTIN_META_METRICS_UI_SEEN, TRUE);
+
+    // removes the necessity of the user to see the predictions GTM modal
+    await StorageWrapper.setItem(PREDICT_GTM_MODAL_SHOWN, TRUE);
+
+    // prevents the enable notifications modal from showing
+    await StorageWrapper.setItem(HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS, TRUE);
   }
 
   return null;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

> Pre-sets flags during automated vault initialization to bypass multichain intro, predictions GTM, and notifications prompts.
> 
> - **Onboarding initialization (`app/util/generateSkipOnboardingState.ts`)**:
>   - Dispatches `setMultichainAccountsIntroModalSeen(true)` to bypass the multichain accounts intro.
>   - Pre-sets storage flags to bypass modals:
>     - `PREDICT_GTM_MODAL_SHOWN` → `TRUE` (skip predictions GTM modal)
>     - `HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS` → `TRUE` (suppress enable notifications prompt)
> 


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/a31dd429-b8b9-43da-843a-bd14c46b38fe




### **After**

https://github.com/user-attachments/assets/03c0c605-bcfd-4046-9319-9a6405304af9



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pre-sets onboarding flags to skip the multichain intro, predictions GTM, and notifications prompts during automated vault initialization.
> 
> - **Onboarding initialization (`app/util/generateSkipOnboardingState.ts`)**:
>   - Dispatches `setMultichainAccountsIntroModalSeen(true)` to skip the multichain intro.
>   - Sets storage flags to bypass modals:
>     - `PREDICT_GTM_MODAL_SHOWN` → `TRUE` (skip predictions GTM modal)
>     - `HAS_USER_TURNED_OFF_ONCE_NOTIFICATIONS` → `TRUE` (suppress enable notifications prompt)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85b74a4669e0a48939b08e5d755212c0b324dfbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->