### PR TITLE
fix: Subscribe to current price changes to rerender

### DIFF
--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
@@ -771,5 +771,6 @@ export default memo(
     prevProps.leverage === nextProps.leverage &&
     prevProps.minLeverage === nextProps.minLeverage &&
     prevProps.maxLeverage === nextProps.maxLeverage &&
+    prevProps.currentPrice === nextProps.currentPrice &&
     prevProps.direction === nextProps.direction,
 );

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
@@ -353,7 +353,7 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
 
   const currentPrice = parseFloat(currentLivePrice[asset]?.price);
 
-  // // Dynamically calculate liquidation price based on tempLeverage
+  // Dynamically calculate liquidation price based on tempLeverage
   // Use limit price for limit orders, market price for market orders
   const entryPrice = useMemo(
     () =>
@@ -362,7 +362,6 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
         : currentPrice,
     [orderType, limitPrice, currentPrice],
   );
-  // const entryPrice = 0;
 
   // Always use tempLeverage for precise API calls (debounced)
   const { liquidationPrice: apiLiquidationPrice, isCalculating } =

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
@@ -63,6 +63,7 @@ import {
   PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
 import { createStyles } from './PerpsLeverageBottomSheet.styles';
+import { usePerpsLivePrices } from '../../hooks';
 
 interface PerpsLeverageBottomSheetProps {
   isVisible: boolean;
@@ -331,7 +332,6 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
   leverage: initialLeverage,
   minLeverage,
   maxLeverage,
-  currentPrice,
   direction,
   asset = '',
   limitPrice,
@@ -346,7 +346,14 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
   const [inputMethod, setInputMethod] = useState<'slider' | 'preset'>('slider');
   const [shouldShowSkeleton, setShouldShowSkeleton] = useState(false);
 
-  // Dynamically calculate liquidation price based on tempLeverage
+  const currentLivePrice = usePerpsLivePrices({
+    symbols: [asset],
+    throttleMs: 1000,
+  });
+
+  const currentPrice = parseFloat(currentLivePrice[asset]?.price);
+
+  // // Dynamically calculate liquidation price based on tempLeverage
   // Use limit price for limit orders, market price for market orders
   const entryPrice = useMemo(
     () =>
@@ -355,6 +362,7 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
         : currentPrice,
     [orderType, limitPrice, currentPrice],
   );
+  // const entryPrice = 0;
 
   // Always use tempLeverage for precise API calls (debounced)
   const { liquidationPrice: apiLiquidationPrice, isCalculating } =
@@ -771,6 +779,5 @@ export default memo(
     prevProps.leverage === nextProps.leverage &&
     prevProps.minLeverage === nextProps.minLeverage &&
     prevProps.maxLeverage === nextProps.maxLeverage &&
-    prevProps.currentPrice === nextProps.currentPrice &&
     prevProps.direction === nextProps.direction,
 );


### PR DESCRIPTION
## **Description**

under-memoization was causing data changes in live prices to not trigger re-renders in the leverage slider.

## **Changelog**

CHANGELOG entry: fix non-live current price in leverage slider

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2062

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/9fcc4de5-94fc-4b30-bc82-a3a9f299112c

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> PerpsLeverageBottomSheet now derives current price from usePerpsLivePrices (instead of prop) to re-render on live updates, with tests adjusted to mock and validate price states.
> 
> - **PerpsLeverageBottomSheet (`PerpsLeverageBottomSheet.tsx`)**:
>   - Replace `currentPrice` prop usage with live price from `usePerpsLivePrices({ symbols: [asset], throttleMs: 1000 })` and parse via `parseFloat`.
>   - Compute `entryPrice` from `limitPrice` for `limit` orders or from live `currentPrice` for `market` orders.
>   - Maintain liquidation calculations and skeleton logic; no UI changes beyond sourcing price.
> - **Tests (`PerpsLeverageBottomSheet.test.tsx`)**:
>   - Mock `usePerpsLivePrices` and default to `'BTC-USD': { price: '3000' }`.
>   - Update scenarios to handle zero and missing price via mocked hook; verify "Price information unavailable" and `0.0%` cases.
>   - Keep liquidation formatting and behavior assertions; remove reliance on `currentPrice` prop for rendering/logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 905a2f43b9822ef70ddcc0097940891035573cb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->