### PR TITLE
fix: Updated BottomSheetHeader to not have a vertical padding

### DIFF
--- a/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.stories.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 // Internal dependencies.
 import { default as BottomSheetHeader } from './BottomSheetHeader';
 import { BottomSheetHeaderVariant } from './BottomSheetHeader.types';
-import Text, { TextVariant } from '../../Texts/Text';
+
 const BottomSheetHeaderMeta = {
   title: 'Component Library / BottomSheets / BottomSheetHeader',
   component: BottomSheetHeader,
@@ -29,12 +29,33 @@ export const Variant = {
   render: function Render() {
     return (
       <>
+        <BottomSheetHeader variant={BottomSheetHeaderVariant.Compact}>
+          BottomSheetHeader Variant: Compact with a long title
+        </BottomSheetHeader>
         <BottomSheetHeader
+          variant={BottomSheetHeaderVariant.Compact}
+          onBack={() => {
+            console.log('Back button clicked');
+          }}
           onClose={() => {
             console.log('Close button clicked');
           }}
         >
-          <Text variant={TextVariant.HeadingMD}>Modify</Text>
+          BottomSheetHeader Variant: Compact with accessories
+        </BottomSheetHeader>
+        <BottomSheetHeader variant={BottomSheetHeaderVariant.Display}>
+          BottomSheetHeader Variant: Display with a long title
+        </BottomSheetHeader>
+        <BottomSheetHeader
+          variant={BottomSheetHeaderVariant.Display}
+          onBack={() => {
+            console.log('Back button clicked');
+          }}
+          onClose={() => {
+            console.log('Close button clicked');
+          }}
+        >
+          BottomSheetHeader Variant: Display with accessories
         </BottomSheetHeader>
       </>
     );

--- a/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.stories.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 // Internal dependencies.
 import { default as BottomSheetHeader } from './BottomSheetHeader';
 import { BottomSheetHeaderVariant } from './BottomSheetHeader.types';
-
+import Text, { TextVariant } from '../../Texts/Text';
 const BottomSheetHeaderMeta = {
   title: 'Component Library / BottomSheets / BottomSheetHeader',
   component: BottomSheetHeader,
@@ -29,33 +29,12 @@ export const Variant = {
   render: function Render() {
     return (
       <>
-        <BottomSheetHeader variant={BottomSheetHeaderVariant.Compact}>
-          BottomSheetHeader Variant: Compact with a long title
-        </BottomSheetHeader>
         <BottomSheetHeader
-          variant={BottomSheetHeaderVariant.Compact}
-          onBack={() => {
-            console.log('Back button clicked');
-          }}
           onClose={() => {
             console.log('Close button clicked');
           }}
         >
-          BottomSheetHeader Variant: Compact with accessories
-        </BottomSheetHeader>
-        <BottomSheetHeader variant={BottomSheetHeaderVariant.Display}>
-          BottomSheetHeader Variant: Display with a long title
-        </BottomSheetHeader>
-        <BottomSheetHeader
-          variant={BottomSheetHeaderVariant.Display}
-          onBack={() => {
-            console.log('Back button clicked');
-          }}
-          onClose={() => {
-            console.log('Close button clicked');
-          }}
-        >
-          BottomSheetHeader Variant: Display with accessories
+          <Text variant={TextVariant.HeadingMD}>Modify</Text>
         </BottomSheetHeader>
       </>
     );

--- a/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.styles.ts
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.styles.ts
@@ -24,7 +24,7 @@ const styleSheet = (params: {
   return StyleSheet.create({
     base: Object.assign(
       {
-        padding: 16,
+        paddingHorizontal: 16,
       } as ViewStyle,
       style,
     ) as ViewStyle,

--- a/app/component-library/components/BottomSheets/BottomSheetHeader/__snapshots__/BottomSheetHeader.test.tsx.snap
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/__snapshots__/BottomSheetHeader.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`BottomSheetHeader renders snapshot correctly with Compact variant 1`] =
       },
       false,
       {
-        "padding": 16,
+        "paddingHorizontal": 16,
       },
     ]
   }
@@ -68,7 +68,7 @@ exports[`BottomSheetHeader renders snapshot correctly with Display variant 1`] =
       },
       false,
       {
-        "padding": 16,
+        "paddingHorizontal": 16,
       },
     ]
   }
@@ -123,7 +123,7 @@ exports[`BottomSheetHeader should render snapshot correctly 1`] = `
       },
       false,
       {
-        "padding": 16,
+        "paddingHorizontal": 16,
       },
     ]
   }

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -947,7 +947,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                               },
                               false,
                               {
-                                "padding": 16,
+                                "paddingHorizontal": 16,
                               },
                             ]
                           }
@@ -1680,7 +1680,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                               },
                               false,
                               {
-                                "padding": 16,
+                                "paddingHorizontal": 16,
                               },
                             ]
                           }

--- a/app/components/UI/Bridge/components/BridgeDestNetworkSelector/__snapshots__/BridgeDestNetworkSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestNetworkSelector/__snapshots__/BridgeDestNetworkSelector.test.tsx.snap
@@ -441,7 +441,7 @@ exports[`BridgeDestNetworkSelector renders with initial state and displays netwo
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
@@ -441,7 +441,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/__snapshots__/BridgeSourceNetworkSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/__snapshots__/BridgeSourceNetworkSelector.test.tsx.snap
@@ -441,7 +441,7 @@ exports[`BridgeSourceNetworkSelector renders with initial state and displays net
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
@@ -441,7 +441,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
               },
               false,
               {
-                "padding": 16,
+                "paddingHorizontal": 16,
               },
             ]
           }

--- a/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`SlippageModal renders all UI elements with the proper slippage options 
               },
               false,
               {
-                "padding": 16,
+                "paddingHorizontal": 16,
               },
             ]
           }

--- a/app/components/UI/Card/components/AddFundsBottomSheet/__snapshots__/AddFundsBottomSheet.test.tsx.snap
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/__snapshots__/AddFundsBottomSheet.test.tsx.snap
@@ -441,7 +441,7 @@ exports[`AddFundsBottomSheet renders with both options enabled and matches snaps
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -1249,7 +1249,7 @@ exports[`AddFundsBottomSheet renders with no options when both are disabled and 
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -1841,7 +1841,7 @@ exports[`AddFundsBottomSheet renders with only deposit option when swaps are not
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -2541,7 +2541,7 @@ exports[`AddFundsBottomSheet renders with only swap option when deposit is disab
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`LendingLearnMoreModal render lending history apy chart 1`] = `
               },
               false,
               {
-                "padding": 16,
+                "paddingHorizontal": 16,
               },
             ]
           }

--- a/app/components/UI/Earn/components/EarnTokenList/__snapshots__/EarnTokenList.test.tsx.snap
+++ b/app/components/UI/Earn/components/EarnTokenList/__snapshots__/EarnTokenList.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`EarnTokenList render matches snapshot 1`] = `
               },
               false,
               {
-                "padding": 16,
+                "paddingHorizontal": 16,
               },
             ]
           }

--- a/app/components/UI/Earn/components/MaxInputModal/__snapshots__/MaxInputModal.test.tsx.snap
+++ b/app/components/UI/Earn/components/MaxInputModal/__snapshots__/MaxInputModal.test.tsx.snap
@@ -447,7 +447,7 @@ exports[`MaxInputModal render matches snapshot 1`] = `
                                   },
                                   false,
                                   {
-                                    "padding": 16,
+                                    "paddingHorizontal": 16,
                                   },
                                 ]
                               }

--- a/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/__snapshots__/LendingMaxWithdrawalModal.test.tsx.snap
+++ b/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/__snapshots__/LendingMaxWithdrawalModal.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`LendingMaxWithdrawalModal should render correctly 1`] = `
         },
         false,
         {
-          "padding": 16,
+          "paddingHorizontal": 16,
         },
       ]
     }

--- a/app/components/UI/NetworkModal/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/NetworkModal/__snapshots__/index.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`NetworkDetails renders correctly 1`] = `
                     },
                     false,
                     {
-                      "padding": 16,
+                      "paddingHorizontal": 16,
                     },
                   ]
                 }

--- a/app/components/UI/NetworkVerificationInfo/__snapshots__/NetworkVerificationInfo.test.tsx.snap
+++ b/app/components/UI/NetworkVerificationInfo/__snapshots__/NetworkVerificationInfo.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`NetworkVerificationInfo renders correctly 1`] = `
         },
         false,
         {
-          "padding": 16,
+          "paddingHorizontal": 16,
         },
       ]
     }
@@ -554,7 +554,7 @@ exports[`NetworkVerificationInfo renders updated details when isNetworkRpcUpdate
         },
         false,
         {
-          "padding": 16,
+          "paddingHorizontal": 16,
         },
       ]
     }

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/__snapshots__/PerpsBottomSheetTooltip.test.tsx.snap
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/__snapshots__/PerpsBottomSheetTooltip.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`PerpsBottomSheetTooltip renders correctly when visible 1`] = `
               },
               false,
               {
-                "padding": 16,
+                "paddingHorizontal": 16,
               },
             ]
           }

--- a/app/components/UI/Ramp/Aggregator/Views/Checkout/__snapshots__/Checkout.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Checkout/__snapshots__/Checkout.test.tsx.snap
@@ -441,7 +441,7 @@ exports[`Checkout displays WebView when url is present and no errors 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                   "paddingVertical": 0,
                                 },
                               ]
@@ -982,7 +982,7 @@ exports[`Checkout displays and tracks error if no url or errors 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                   "paddingVertical": 0,
                                 },
                               ]
@@ -1676,7 +1676,7 @@ exports[`Checkout displays sdkError when present 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                   "paddingVertical": 0,
                                 },
                               ]
@@ -2414,7 +2414,7 @@ exports[`Checkout displays sell WebView when url is present and no errors 1`] = 
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                   "paddingVertical": 0,
                                 },
                               ]
@@ -2955,7 +2955,7 @@ exports[`Checkout handles get order error gracefully 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                   "paddingVertical": 0,
                                 },
                               ]
@@ -3693,7 +3693,7 @@ exports[`Checkout handles undefined order gracefully 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                   "paddingVertical": 0,
                                 },
                               ]
@@ -4431,7 +4431,7 @@ exports[`Checkout ignores irrelevant error on http error in WebView for callback
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                   "paddingVertical": 0,
                                 },
                               ]
@@ -4972,7 +4972,7 @@ exports[`Checkout sets and displays error on http error in WebView 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                   "paddingVertical": 0,
                                 },
                               ]
@@ -5710,7 +5710,7 @@ exports[`Checkout sets and displays error on http error in WebView for callback 
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                   "paddingVertical": 0,
                                 },
                               ]
@@ -6448,7 +6448,7 @@ exports[`Checkout sets error when handling url navigation state change and selec
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                   "paddingVertical": 0,
                                 },
                               ]

--- a/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/__snapshots__/SettingsModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/__snapshots__/SettingsModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`SettingsModal renders snapshot correctly 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -1166,7 +1166,7 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -3449,7 +3449,7 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -5336,7 +5336,7 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`FiatSelectorModal renders the modal with currency list 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -1376,7 +1376,7 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -2312,7 +2312,7 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -3248,7 +3248,7 @@ exports[`FiatSelectorModal search displays max 20 results 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Aggregator/components/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`PaymentMethodSelectorModal renders correctly 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -1581,7 +1581,7 @@ exports[`PaymentMethodSelectorModal renders for sell flow 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -2722,7 +2722,7 @@ exports[`PaymentMethodSelectorModal renders without disclaimer when selected pay
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`RegionSelectorModal clears search when clear button is pressed 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -1300,7 +1300,7 @@ exports[`RegionSelectorModal clears search when clear button is pressed 2`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -2498,7 +2498,7 @@ exports[`RegionSelectorModal filters regions based on search input 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -3358,7 +3358,7 @@ exports[`RegionSelectorModal handles empty regions list gracefully 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -4086,7 +4086,7 @@ exports[`RegionSelectorModal handles undefined regions gracefully 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -4814,7 +4814,7 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -5664,7 +5664,7 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -6862,7 +6862,7 @@ exports[`RegionSelectorModal renders the modal with region list 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -8060,7 +8060,7 @@ exports[`RegionSelectorModal renders the modal with selected region in list 1`] 
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -9274,7 +9274,7 @@ exports[`RegionSelectorModal renders the modal with selected state in list 1`] =
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -10488,7 +10488,7 @@ exports[`RegionSelectorModal shows empty state when search returns no results 1`
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`TokenSelectModal renders the modal with token list 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Aggregator/components/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
@@ -420,7 +420,7 @@ exports[`UnsupportedRegionModal renders correctly for buy flow 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -1016,7 +1016,7 @@ exports[`UnsupportedRegionModal renders correctly for sell flow 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/__snapshots__/ConfigurationModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/__snapshots__/ConfigurationModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`ConfigurationModal render matches snapshot 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/ErrorDetailsModal/__snapshots__/ErrorDetailsModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/ErrorDetailsModal/__snapshots__/ErrorDetailsModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`ErrorDetailsModal renders correctly and matches snapshot 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`PaymentMethodSelectorModal Component renders correctly and matches snap
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`RegionSelectorModal Component handles empty regions array from navigati
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -1152,7 +1152,7 @@ exports[`RegionSelectorModal Component receives and uses regions from navigation
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -2060,7 +2060,7 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -3200,7 +3200,7 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -3953,7 +3953,7 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -4794,7 +4794,7 @@ exports[`RegionSelectorModal Component render matches snapshot with allRegionsSe
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -5934,7 +5934,7 @@ exports[`RegionSelectorModal Component render matches snapshot with custom selec
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -7074,7 +7074,7 @@ exports[`RegionSelectorModal Component sorts recommended regions to the top when
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/SsnInfoModal/__snapshots__/SsnInfoModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/SsnInfoModal/__snapshots__/SsnInfoModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`SsnInfoModal Component renders correctly and matches snapshot 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -1241,7 +1241,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -1986,7 +1986,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -2787,7 +2787,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -3588,7 +3588,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -4652,7 +4652,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`TokenSelectorModal Component displays empty state when no tokens match 
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -1394,7 +1394,7 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -2548,7 +2548,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
@@ -420,7 +420,7 @@ exports[`UnsupportedRegionModal handles missing region gracefully 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }
@@ -1090,7 +1090,7 @@ exports[`UnsupportedRegionModal render match snapshot 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/__snapshots__/UnsupportedStateModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/__snapshots__/UnsupportedStateModal.test.tsx.snap
@@ -420,7 +420,7 @@ exports[`UnsupportedStateModal render match snapshot 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/WebviewModal/__snapshots__/WebviewModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/WebviewModal/__snapshots__/WebviewModal.test.tsx.snap
@@ -441,7 +441,7 @@ exports[`WebviewModal Component renders correctly and matches snapshot 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                   "paddingVertical": 0,
                                 },
                               ]
@@ -1002,7 +1002,7 @@ exports[`WebviewModal Component should display error view when webview HTTP erro
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                   "paddingVertical": 0,
                                 },
                               ]

--- a/app/components/UI/Ramp/components/EligibilityFailedModal/__snapshots__/EligibilityFailedModal.test.tsx.snap
+++ b/app/components/UI/Ramp/components/EligibilityFailedModal/__snapshots__/EligibilityFailedModal.test.tsx.snap
@@ -323,7 +323,7 @@ exports[`EligibilityFailedModal renders modal with title and description 1`] = `
                           },
                           false,
                           {
-                            "padding": 16,
+                            "paddingHorizontal": 16,
                           },
                         ]
                       }

--- a/app/components/UI/Ramp/components/RampUnsupportedModal/__snapshots__/RampUnsupportedModal.test.tsx.snap
+++ b/app/components/UI/Ramp/components/RampUnsupportedModal/__snapshots__/RampUnsupportedModal.test.tsx.snap
@@ -323,7 +323,7 @@ exports[`RampUnsupportedModal renders modal with title and description 1`] = `
                           },
                           false,
                           {
-                            "padding": 16,
+                            "paddingHorizontal": 16,
                           },
                         ]
                       }

--- a/app/components/UI/Ramp/components/UnsupportedTokenModal/__snapshots__/UnsupportedTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/components/UnsupportedTokenModal/__snapshots__/UnsupportedTokenModal.test.tsx.snap
@@ -323,7 +323,7 @@ exports[`UnsupportedTokenModal renders the modal with correct title and descript
                           },
                           false,
                           {
-                            "padding": 16,
+                            "paddingHorizontal": 16,
                           },
                         ]
                       }

--- a/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
@@ -147,7 +147,7 @@ exports[`GasImpactModal render matches snapshot 1`] = `
                 },
                 false,
                 {
-                  "padding": 16,
+                  "paddingHorizontal": 16,
                 },
               ]
             }

--- a/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`PoolStakingLearnMoreModal render matches snapshot 1`] = `
                   },
                   false,
                   {
-                    "padding": 16,
+                    "paddingHorizontal": 16,
                   },
                 ]
               }

--- a/app/components/Views/AccountPermissions/AccountPermissionsConfirmRevokeAll/__snapshots__/AccountPermissionsConfirmRevokeAll.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/AccountPermissionsConfirmRevokeAll/__snapshots__/AccountPermissionsConfirmRevokeAll.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`AccountPermissionsConfirmRevokeAll renders correctly 1`] = `
               },
               false,
               {
-                "padding": 16,
+                "paddingHorizontal": 16,
               },
             ]
           }

--- a/app/components/Views/AccountPermissions/ConnectionDetails/__snapshots__/ConnectionDetails.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/ConnectionDetails/__snapshots__/ConnectionDetails.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`ConnectionDetails renders correctly 1`] = `
         },
         false,
         {
-          "padding": 16,
+          "paddingHorizontal": 16,
         },
       ]
     }

--- a/app/components/Views/AccountPermissions/PermittedNetworksInfoSheet/__snapshots__/PermittedNetworksInfoSheet.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/PermittedNetworksInfoSheet/__snapshots__/PermittedNetworksInfoSheet.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`PermittedNetworksInfoSheet should render correctly 1`] = `
         },
         false,
         {
-          "padding": 16,
+          "paddingHorizontal": 16,
         },
       ]
     }

--- a/app/components/Views/AddressSelector/__snapshots__/AddressSelector.test.tsx.snap
+++ b/app/components/Views/AddressSelector/__snapshots__/AddressSelector.test.tsx.snap
@@ -441,7 +441,7 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                                 },
                                 false,
                                 {
-                                  "padding": 16,
+                                  "paddingHorizontal": 16,
                                 },
                               ]
                             }

--- a/app/components/Views/NetworkSelector/RpcSelectionModal/__snapshots__/RpcSelectionModal.test.tsx.snap
+++ b/app/components/Views/NetworkSelector/RpcSelectionModal/__snapshots__/RpcSelectionModal.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`RpcSelectionModal should render correctly when visible 1`] = `
             },
             false,
             {
-              "padding": 16,
+              "paddingHorizontal": 16,
             },
           ]
         }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updates the `BottomSheetHeader` to not have 16px vertical padding along with a 48px height constraint. 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-645

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="1290" height="141" alt="Simulator Screenshot - iPhone 15 Pro Max - 2025-12-15 at 16 13 33" src="https://github.com/user-attachments/assets/31c54778-859e-4d0a-aa9d-41ccf00d64ff" />

<!-- [screenshots/recordings] -->

### **After**
<img width="1284" height="139" alt="Simulator Screenshot - iPhone 15 Pro Max - 2025-12-15 at 16 13 39" src="https://github.com/user-attachments/assets/a0e127f5-ae61-4bae-bc16-b752c5596348" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `padding: 16` with `paddingHorizontal: 16` for `BottomSheetHeader`, removing vertical padding and updating snapshots accordingly.
> 
> - **Component Library**
>   - `BottomSheetHeader.styles.ts`: replace `padding: 16` with `paddingHorizontal: 16` to remove vertical padding.
> - **Tests/Snapshots**
>   - Update snapshots across multiple bottom sheet consumers to reflect `paddingHorizontal: 16` (some retaining explicit `paddingVertical: 0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14045f5025bf9ddcd66ae4064293db337b36258e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->