### PR TITLE
chore: update cta to respect buy regions and route correctly per chain

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -111,7 +111,7 @@ export MM_MUSD_CONVERSION_FLOW_ENABLED="false"
 # IMPORTANT: Must use SINGLE QUOTES to preserve JSON format
 # Example: MM_MUSD_CONVERTIBLE_TOKENS_ALLOWLIST='{"0x1":["USDC","USDT"],"0xa4b1":["USDC","DAI"]}'
 export MM_MUSD_CONVERTIBLE_TOKENS_ALLOWLIST=''
-
+export MM_MUSD_CTA_ENABLED="false"
 # Activates remote feature flag override mode.
 # Remote feature flag values won't be updated,
 # and selectors should return their fallback values

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.styles.ts
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.styles.ts
@@ -11,10 +11,14 @@ const styleSheet = () =>
     assetInfo: {
       flexDirection: 'row',
       gap: 20,
+      alignItems: 'center',
     },
     button: {
       alignSelf: 'center',
       height: 32,
+    },
+    badge: {
+      alignSelf: 'center',
     },
   });
 

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.test.tsx
@@ -33,6 +33,7 @@ import { EARN_TEST_IDS } from '../../../constants/testIds';
 import initialRootState from '../../../../../../util/test/initial-root-state';
 import Logger from '../../../../../../util/Logger';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { BADGE_WRAPPER_BADGE_TEST_ID } from '../../../../../../component-library/components/Badges/BadgeWrapper/BadgeWrapper.constants';
 
 const mockToken = {
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
@@ -473,7 +474,7 @@ describe('MusdConversionAssetListCta', () => {
         getByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA),
       ).toBeOnTheScreen();
       // Badge wrapper is not rendered when showNetworkIcon is false
-      expect(queryByTestId('badge-wrapper')).toBeNull();
+      expect(queryByTestId(BADGE_WRAPPER_BADGE_TEST_ID)).toBeNull();
     });
 
     it('renders with network badge when showNetworkIcon is true and mainnet selected', () => {

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.test.tsx
@@ -4,6 +4,7 @@ import { Hex } from '@metamask/utils';
 
 jest.mock('../../../hooks/useMusdConversionTokens');
 jest.mock('../../../hooks/useMusdConversion');
+jest.mock('../../../hooks/useMusdCtaVisibility');
 jest.mock('../../../../Ramp/hooks/useRampNavigation');
 jest.mock('../../../../../../util/Logger');
 
@@ -22,6 +23,7 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import MusdConversionAssetListCta from '.';
 import { useMusdConversionTokens } from '../../../hooks/useMusdConversionTokens';
 import { useMusdConversion } from '../../../hooks/useMusdConversion';
+import { useMusdCtaVisibility } from '../../../hooks/useMusdCtaVisibility';
 import { useRampNavigation } from '../../../../Ramp/hooks/useRampNavigation';
 import {
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
@@ -30,6 +32,7 @@ import {
 import { EARN_TEST_IDS } from '../../../constants/testIds';
 import initialRootState from '../../../../../../util/test/initial-root-state';
 import Logger from '../../../../../../util/Logger';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
 
 const mockToken = {
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
@@ -67,6 +70,15 @@ describe('MusdConversionAssetListCta', () => {
       initiateConversion: mockInitiateConversion,
       error: null,
       hasSeenConversionEducationScreen: true,
+    });
+
+    // Default mock for visibility - show CTA without network icon
+    (
+      useMusdCtaVisibility as jest.MockedFunction<typeof useMusdCtaVisibility>
+    ).mockReturnValue({
+      shouldShowCta: true,
+      showNetworkIcon: false,
+      selectedChainId: null,
     });
   });
 
@@ -371,6 +383,154 @@ describe('MusdConversionAssetListCta', () => {
           '[mUSD Conversion] Failed to initiate conversion from CTA',
         );
       });
+    });
+  });
+
+  describe('visibility behavior', () => {
+    beforeEach(() => {
+      (
+        useMusdConversionTokens as jest.MockedFunction<
+          typeof useMusdConversionTokens
+        >
+      ).mockReturnValue({
+        tokens: [],
+        tokenFilter: jest.fn(),
+        isConversionToken: jest.fn(),
+        isMusdSupportedOnChain: jest.fn().mockReturnValue(true),
+        getMusdOutputChainId: jest.fn((chainId) => (chainId ?? '0x1') as Hex),
+      });
+    });
+
+    it('renders null when shouldShowCta is false', () => {
+      (
+        useMusdCtaVisibility as jest.MockedFunction<typeof useMusdCtaVisibility>
+      ).mockReturnValue({
+        shouldShowCta: false,
+        showNetworkIcon: false,
+        selectedChainId: null,
+      });
+
+      const { queryByTestId } = renderWithProvider(
+        <MusdConversionAssetListCta />,
+        { state: initialRootState },
+      );
+
+      expect(
+        queryByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA),
+      ).toBeNull();
+    });
+
+    it('renders component when shouldShowCta is true', () => {
+      (
+        useMusdCtaVisibility as jest.MockedFunction<typeof useMusdCtaVisibility>
+      ).mockReturnValue({
+        shouldShowCta: true,
+        showNetworkIcon: false,
+        selectedChainId: null,
+      });
+
+      const { getByTestId } = renderWithProvider(
+        <MusdConversionAssetListCta />,
+        { state: initialRootState },
+      );
+
+      expect(
+        getByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  describe('network badge', () => {
+    beforeEach(() => {
+      (
+        useMusdConversionTokens as jest.MockedFunction<
+          typeof useMusdConversionTokens
+        >
+      ).mockReturnValue({
+        tokens: [],
+        tokenFilter: jest.fn(),
+        isConversionToken: jest.fn(),
+        isMusdSupportedOnChain: jest.fn().mockReturnValue(true),
+        getMusdOutputChainId: jest.fn((chainId) => (chainId ?? '0x1') as Hex),
+      });
+    });
+
+    it('renders without network badge when showNetworkIcon is false', () => {
+      (
+        useMusdCtaVisibility as jest.MockedFunction<typeof useMusdCtaVisibility>
+      ).mockReturnValue({
+        shouldShowCta: true,
+        showNetworkIcon: false,
+        selectedChainId: null,
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <MusdConversionAssetListCta />,
+        { state: initialRootState },
+      );
+
+      expect(
+        getByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA),
+      ).toBeOnTheScreen();
+      // Badge wrapper is not rendered when showNetworkIcon is false
+      expect(queryByTestId('badge-wrapper')).toBeNull();
+    });
+
+    it('renders with network badge when showNetworkIcon is true and mainnet selected', () => {
+      (
+        useMusdCtaVisibility as jest.MockedFunction<typeof useMusdCtaVisibility>
+      ).mockReturnValue({
+        shouldShowCta: true,
+        showNetworkIcon: true,
+        selectedChainId: CHAIN_IDS.MAINNET,
+      });
+
+      const { getByTestId } = renderWithProvider(
+        <MusdConversionAssetListCta />,
+        { state: initialRootState },
+      );
+
+      expect(
+        getByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders with network badge when showNetworkIcon is true and Linea selected', () => {
+      (
+        useMusdCtaVisibility as jest.MockedFunction<typeof useMusdCtaVisibility>
+      ).mockReturnValue({
+        shouldShowCta: true,
+        showNetworkIcon: true,
+        selectedChainId: CHAIN_IDS.LINEA_MAINNET,
+      });
+
+      const { getByTestId } = renderWithProvider(
+        <MusdConversionAssetListCta />,
+        { state: initialRootState },
+      );
+
+      expect(
+        getByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders with network badge when showNetworkIcon is true and BSC selected', () => {
+      (
+        useMusdCtaVisibility as jest.MockedFunction<typeof useMusdCtaVisibility>
+      ).mockReturnValue({
+        shouldShowCta: true,
+        showNetworkIcon: true,
+        selectedChainId: CHAIN_IDS.BSC,
+      });
+
+      const { getByTestId } = renderWithProvider(
+        <MusdConversionAssetListCta />,
+        { state: initialRootState },
+      );
+
+      expect(
+        getByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA),
+      ).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
@@ -24,9 +24,17 @@ import Logger from '../../../../../../util/Logger';
 import { useStyles } from '../../../../../hooks/useStyles';
 import { useMusdConversionTokens } from '../../../hooks/useMusdConversionTokens';
 import { useMusdConversion } from '../../../hooks/useMusdConversion';
+import { useMusdCtaVisibility } from '../../../hooks/useMusdCtaVisibility';
 import AvatarToken from '../../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
 import { AvatarSize } from '../../../../../../component-library/components/Avatars/Avatar';
 import { toChecksumAddress } from '../../../../../../util/address';
+import Badge, {
+  BadgeVariant,
+} from '../../../../../../component-library/components/Badges/Badge';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../../../component-library/components/Badges/BadgeWrapper';
+import { getNetworkImageSource } from '../../../../../../util/networks';
 
 const MusdConversionAssetListCta = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -36,6 +44,9 @@ const MusdConversionAssetListCta = () => {
   const { tokens, getMusdOutputChainId } = useMusdConversionTokens();
 
   const { initiateConversion } = useMusdConversion();
+
+  const { shouldShowCta, showNetworkIcon, selectedChainId } =
+    useMusdCtaVisibility();
 
   const canConvert = useMemo(
     () => Boolean(tokens.length > 0 && tokens?.[0]?.chainId !== undefined),
@@ -54,7 +65,10 @@ const MusdConversionAssetListCta = () => {
     // Redirect users to deposit flow if they don't have any stablecoins to convert.
     if (!canConvert) {
       const rampIntent: RampIntent = {
-        assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[MUSD_CONVERSION_DEFAULT_CHAIN_ID],
+        assetId:
+          MUSD_TOKEN_ASSET_ID_BY_CHAIN[
+            selectedChainId || MUSD_CONVERSION_DEFAULT_CHAIN_ID
+          ],
       };
       goToBuy(rampIntent);
       return;
@@ -84,17 +98,43 @@ const MusdConversionAssetListCta = () => {
     }
   };
 
+  // Don't render if visibility conditions are not met
+  if (!shouldShowCta) {
+    return null;
+  }
+
+  const renderTokenAvatar = () => (
+    <AvatarToken
+      name={MUSD_TOKEN.symbol}
+      imageSource={MUSD_TOKEN.imageSource}
+      size={AvatarSize.Lg}
+    />
+  );
+
   return (
     <View
       style={styles.container}
       testID={EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA}
     >
       <View style={styles.assetInfo}>
-        <AvatarToken
-          name={MUSD_TOKEN.symbol}
-          imageSource={MUSD_TOKEN.imageSource}
-          size={AvatarSize.Lg}
-        />
+        {showNetworkIcon && selectedChainId ? (
+          <BadgeWrapper
+            style={styles.badge}
+            badgePosition={BadgePosition.BottomRight}
+            badgeElement={
+              <Badge
+                variant={BadgeVariant.Network}
+                imageSource={getNetworkImageSource({
+                  chainId: selectedChainId,
+                })}
+              />
+            }
+          >
+            {renderTokenAvatar()}
+          </BadgeWrapper>
+        ) : (
+          renderTokenAvatar()
+        )}
         <View>
           <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
             MetaMask USD

--- a/app/components/UI/Earn/constants/musd.ts
+++ b/app/components/UI/Earn/constants/musd.ts
@@ -22,6 +22,16 @@ export const MUSD_TOKEN_ADDRESS_BY_CHAIN: Record<Hex, Hex> = {
   [CHAIN_IDS.BSC]: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
 };
 
+/**
+ * Chains where mUSD CTA should show (buy routes available).
+ * BSC is excluded as buy routes are not yet available.
+ */
+export const MUSD_BUYABLE_CHAIN_IDS: Hex[] = [
+  CHAIN_IDS.MAINNET,
+  CHAIN_IDS.LINEA_MAINNET,
+  // CHAIN_IDS.BSC, // TODO: Uncomment once buy routes are available
+];
+
 export const MUSD_TOKEN_ASSET_ID_BY_CHAIN: Record<Hex, string> = {
   [CHAIN_IDS.MAINNET]:
     'eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',

--- a/app/components/UI/Earn/hooks/useHasMusdBalance.test.ts
+++ b/app/components/UI/Earn/hooks/useHasMusdBalance.test.ts
@@ -1,0 +1,230 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useSelector } from 'react-redux';
+import { Hex } from '@metamask/utils';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { useHasMusdBalance } from './useHasMusdBalance';
+import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../constants/musd';
+
+jest.mock('react-redux');
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+describe('useHasMusdBalance', () => {
+  const MUSD_ADDRESS = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('hook structure', () => {
+    it('returns object with hasMusdBalance and balancesByChain properties', () => {
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current).toHaveProperty('hasMusdBalance');
+      expect(result.current).toHaveProperty('balancesByChain');
+    });
+
+    it('returns hasMusdBalance as boolean', () => {
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(typeof result.current.hasMusdBalance).toBe('boolean');
+    });
+
+    it('returns balancesByChain as object', () => {
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(typeof result.current.balancesByChain).toBe('object');
+    });
+  });
+
+  describe('balance detection', () => {
+    it('returns hasMusdBalance false when no balances exist', () => {
+      mockUseSelector.mockReturnValue({});
+
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current.hasMusdBalance).toBe(false);
+      expect(result.current.balancesByChain).toEqual({});
+    });
+
+    it('returns hasMusdBalance false when MUSD balance is 0x0', () => {
+      mockUseSelector.mockReturnValue({
+        [CHAIN_IDS.MAINNET]: {
+          [MUSD_ADDRESS]: '0x0',
+        },
+      });
+
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current.hasMusdBalance).toBe(false);
+      expect(result.current.balancesByChain).toEqual({});
+    });
+
+    it('returns hasMusdBalance true when MUSD balance exists on mainnet', () => {
+      const balance = '0x1234';
+      mockUseSelector.mockReturnValue({
+        [CHAIN_IDS.MAINNET]: {
+          [MUSD_ADDRESS]: balance,
+        },
+      });
+
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current.hasMusdBalance).toBe(true);
+      expect(result.current.balancesByChain).toEqual({
+        [CHAIN_IDS.MAINNET]: balance,
+      });
+    });
+
+    it('returns hasMusdBalance true when MUSD balance exists on Linea', () => {
+      const lineaMusdAddress =
+        MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.LINEA_MAINNET];
+      const balance = '0x5678';
+      mockUseSelector.mockReturnValue({
+        [CHAIN_IDS.LINEA_MAINNET]: {
+          [lineaMusdAddress]: balance,
+        },
+      });
+
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current.hasMusdBalance).toBe(true);
+      expect(result.current.balancesByChain).toEqual({
+        [CHAIN_IDS.LINEA_MAINNET]: balance,
+      });
+    });
+
+    it('returns hasMusdBalance true when MUSD balance exists on BSC', () => {
+      const bscMusdAddress = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.BSC];
+      const balance = '0x9abc';
+      mockUseSelector.mockReturnValue({
+        [CHAIN_IDS.BSC]: {
+          [bscMusdAddress]: balance,
+        },
+      });
+
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current.hasMusdBalance).toBe(true);
+      expect(result.current.balancesByChain).toEqual({
+        [CHAIN_IDS.BSC]: balance,
+      });
+    });
+
+    it('returns balances from multiple chains', () => {
+      const mainnetBalance = '0x1111';
+      const lineaBalance = '0x2222';
+      mockUseSelector.mockReturnValue({
+        [CHAIN_IDS.MAINNET]: {
+          [MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET]]: mainnetBalance,
+        },
+        [CHAIN_IDS.LINEA_MAINNET]: {
+          [MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.LINEA_MAINNET]]: lineaBalance,
+        },
+      });
+
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current.hasMusdBalance).toBe(true);
+      expect(result.current.balancesByChain).toEqual({
+        [CHAIN_IDS.MAINNET]: mainnetBalance,
+        [CHAIN_IDS.LINEA_MAINNET]: lineaBalance,
+      });
+    });
+  });
+
+  describe('address case handling', () => {
+    it('handles lowercase token address in balances', () => {
+      const balance = '0x1234';
+      mockUseSelector.mockReturnValue({
+        [CHAIN_IDS.MAINNET]: {
+          [MUSD_ADDRESS.toLowerCase()]: balance,
+        },
+      });
+
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current.hasMusdBalance).toBe(true);
+    });
+
+    it('handles checksummed token address in balances', () => {
+      const balance = '0x1234';
+      // MUSD_ADDRESS is already lowercase in the constant
+      mockUseSelector.mockReturnValue({
+        [CHAIN_IDS.MAINNET]: {
+          [MUSD_ADDRESS]: balance,
+        },
+      });
+
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current.hasMusdBalance).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('ignores non-MUSD tokens on supported chains', () => {
+      const otherTokenAddress =
+        '0x1234567890abcdef1234567890abcdef12345678' as Hex;
+      mockUseSelector.mockReturnValue({
+        [CHAIN_IDS.MAINNET]: {
+          [otherTokenAddress]: '0x9999',
+        },
+      });
+
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current.hasMusdBalance).toBe(false);
+      expect(result.current.balancesByChain).toEqual({});
+    });
+
+    it('ignores MUSD-like tokens on unsupported chains', () => {
+      const polygonChainId = '0x89' as Hex;
+      mockUseSelector.mockReturnValue({
+        [polygonChainId]: {
+          [MUSD_ADDRESS]: '0x1234',
+        },
+      });
+
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current.hasMusdBalance).toBe(false);
+      expect(result.current.balancesByChain).toEqual({});
+    });
+
+    it('handles mixed zero and non-zero balances correctly', () => {
+      const balance = '0x1234';
+      mockUseSelector.mockReturnValue({
+        [CHAIN_IDS.MAINNET]: {
+          [MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET]]: '0x0',
+        },
+        [CHAIN_IDS.LINEA_MAINNET]: {
+          [MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.LINEA_MAINNET]]: balance,
+        },
+      });
+
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current.hasMusdBalance).toBe(true);
+      expect(result.current.balancesByChain).toEqual({
+        [CHAIN_IDS.LINEA_MAINNET]: balance,
+      });
+    });
+
+    it('handles undefined chain balances gracefully', () => {
+      mockUseSelector.mockReturnValue({
+        [CHAIN_IDS.MAINNET]: undefined,
+      });
+
+      const { result } = renderHook(() => useHasMusdBalance());
+
+      expect(result.current.hasMusdBalance).toBe(false);
+      expect(result.current.balancesByChain).toEqual({});
+    });
+  });
+});

--- a/app/components/UI/Earn/hooks/useHasMusdBalance.ts
+++ b/app/components/UI/Earn/hooks/useHasMusdBalance.ts
@@ -1,0 +1,47 @@
+import { useSelector } from 'react-redux';
+import { useMemo } from 'react';
+import { Hex } from '@metamask/utils';
+import { selectContractBalancesPerChainId } from '../../../../selectors/tokenBalancesController';
+import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../constants/musd';
+import { toChecksumAddress } from '../../../../util/address';
+
+/**
+ * Hook to check if the user has any MUSD token balance across supported chains.
+ * @returns Object containing hasMusdBalance boolean and balancesByChain for detailed balance info
+ */
+export const useHasMusdBalance = () => {
+  const balancesPerChainId = useSelector(selectContractBalancesPerChainId);
+  const { hasMusdBalance, balancesByChain } = useMemo(() => {
+    const result: Record<Hex, string> = {};
+    let hasBalance = false;
+
+    for (const [chainId, tokenAddress] of Object.entries(
+      MUSD_TOKEN_ADDRESS_BY_CHAIN,
+    )) {
+      const chainBalances = balancesPerChainId[chainId as Hex];
+
+      if (!chainBalances) continue;
+
+      // MUSD token addresses are lowercase in the constant, but balances might be checksummed
+      const normalizedTokenAddress = toChecksumAddress(tokenAddress as Hex);
+      const balance =
+        chainBalances[normalizedTokenAddress] ||
+        chainBalances[tokenAddress as Hex];
+
+      if (balance && balance !== '0x0') {
+        result[chainId as Hex] = balance;
+        hasBalance = true;
+      }
+    }
+
+    return {
+      hasMusdBalance: hasBalance,
+      balancesByChain: result,
+    };
+  }, [balancesPerChainId]);
+
+  return {
+    hasMusdBalance,
+    balancesByChain,
+  };
+};

--- a/app/components/UI/Earn/hooks/useMusdCtaVisibility.test.ts
+++ b/app/components/UI/Earn/hooks/useMusdCtaVisibility.test.ts
@@ -1,0 +1,515 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { Hex } from '@metamask/utils';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { useMusdCtaVisibility } from './useMusdCtaVisibility';
+import { useHasMusdBalance } from './useHasMusdBalance';
+import { useCurrentNetworkInfo } from '../../../hooks/useCurrentNetworkInfo';
+import { useNetworksByCustomNamespace } from '../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
+import { useRampTokens, RampsToken } from '../../Ramp/hooks/useRampTokens';
+import { MUSD_TOKEN_ASSET_ID_BY_CHAIN } from '../constants/musd';
+
+jest.mock('./useHasMusdBalance');
+jest.mock('../../../hooks/useCurrentNetworkInfo');
+jest.mock('../../../hooks/useNetworksByNamespace/useNetworksByNamespace');
+jest.mock('../../Ramp/hooks/useRampTokens');
+
+const mockUseHasMusdBalance = useHasMusdBalance as jest.MockedFunction<
+  typeof useHasMusdBalance
+>;
+const mockUseCurrentNetworkInfo = useCurrentNetworkInfo as jest.MockedFunction<
+  typeof useCurrentNetworkInfo
+>;
+const mockUseNetworksByCustomNamespace =
+  useNetworksByCustomNamespace as jest.MockedFunction<
+    typeof useNetworksByCustomNamespace
+  >;
+const mockUseRampTokens = useRampTokens as jest.MockedFunction<
+  typeof useRampTokens
+>;
+
+describe('useMusdCtaVisibility', () => {
+  const defaultNetworkInfo = {
+    enabledNetworks: [],
+    getNetworkInfo: jest.fn(),
+    getNetworkInfoByChainId: jest.fn(),
+    isDisabled: false,
+    hasEnabledNetworks: false,
+  };
+
+  const defaultNetworksByNamespace = {
+    networks: [],
+    selectedNetworks: [],
+    areAllNetworksSelected: false,
+    areAnyNetworksSelected: false,
+    networkCount: 0,
+    selectedCount: 0,
+    totalEnabledNetworksCount: 0,
+  };
+
+  const createMusdRampToken = (
+    chainId: Hex,
+    tokenSupported = true,
+  ): RampsToken => {
+    const assetId = MUSD_TOKEN_ASSET_ID_BY_CHAIN[chainId].toLowerCase();
+    // Extract CAIP-2 chainId from CAIP-19 assetId (e.g., 'eip155:1' from 'eip155:1/erc20:0x...')
+    const caipChainId = assetId.split('/')[0] as `${string}:${string}`;
+    return {
+      assetId: assetId as `${string}:${string}/${string}:${string}`,
+      symbol: 'MUSD',
+      chainId: caipChainId,
+      tokenSupported,
+      name: 'MetaMask USD',
+      iconUrl: '',
+      decimals: 6,
+    };
+  };
+
+  const defaultRampTokens = {
+    topTokens: null,
+    allTokens: [
+      createMusdRampToken(CHAIN_IDS.MAINNET),
+      createMusdRampToken(CHAIN_IDS.LINEA_MAINNET),
+    ],
+    isLoading: false,
+    error: null,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseHasMusdBalance.mockReturnValue({
+      hasMusdBalance: false,
+      balancesByChain: {},
+    });
+    mockUseCurrentNetworkInfo.mockReturnValue(defaultNetworkInfo);
+    mockUseNetworksByCustomNamespace.mockReturnValue(
+      defaultNetworksByNamespace,
+    );
+    mockUseRampTokens.mockReturnValue(defaultRampTokens);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('hook structure', () => {
+    it('returns object with shouldShowCta, showNetworkIcon, and selectedChainId properties', () => {
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: true,
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current).toHaveProperty('shouldShowCta');
+      expect(result.current).toHaveProperty('showNetworkIcon');
+      expect(result.current).toHaveProperty('selectedChainId');
+    });
+  });
+
+  describe('all networks selected (popular networks)', () => {
+    beforeEach(() => {
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: true,
+      });
+      mockUseCurrentNetworkInfo.mockReturnValue({
+        ...defaultNetworkInfo,
+        enabledNetworks: [
+          { chainId: CHAIN_IDS.MAINNET, enabled: true },
+          { chainId: CHAIN_IDS.LINEA_MAINNET, enabled: true },
+          { chainId: CHAIN_IDS.BSC, enabled: true },
+        ],
+      });
+    });
+
+    it('returns shouldShowCta true when user has no MUSD balance and MUSD is buyable', () => {
+      mockUseHasMusdBalance.mockReturnValue({
+        hasMusdBalance: false,
+        balancesByChain: {},
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.shouldShowCta).toBe(true);
+      expect(result.current.showNetworkIcon).toBe(false);
+      expect(result.current.selectedChainId).toBeNull();
+    });
+
+    it('returns shouldShowCta false when user has MUSD balance', () => {
+      mockUseHasMusdBalance.mockReturnValue({
+        hasMusdBalance: true,
+        balancesByChain: { [CHAIN_IDS.MAINNET]: '0x1234' },
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.shouldShowCta).toBe(false);
+      expect(result.current.showNetworkIcon).toBe(false);
+      expect(result.current.selectedChainId).toBeNull();
+    });
+
+    it('returns shouldShowCta false when MUSD is not buyable on any chain', () => {
+      mockUseRampTokens.mockReturnValue({
+        ...defaultRampTokens,
+        allTokens: [],
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.shouldShowCta).toBe(false);
+    });
+
+    it('returns showNetworkIcon false for all networks', () => {
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.showNetworkIcon).toBe(false);
+    });
+  });
+
+  describe('single supported network selected', () => {
+    describe('mainnet selected', () => {
+      beforeEach(() => {
+        mockUseNetworksByCustomNamespace.mockReturnValue({
+          ...defaultNetworksByNamespace,
+          areAllNetworksSelected: false,
+        });
+        mockUseCurrentNetworkInfo.mockReturnValue({
+          ...defaultNetworkInfo,
+          enabledNetworks: [{ chainId: CHAIN_IDS.MAINNET, enabled: true }],
+        });
+      });
+
+      it('returns shouldShowCta true when user has no MUSD on mainnet', () => {
+        mockUseHasMusdBalance.mockReturnValue({
+          hasMusdBalance: false,
+          balancesByChain: {},
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowCta).toBe(true);
+        expect(result.current.showNetworkIcon).toBe(true);
+        expect(result.current.selectedChainId).toBe(CHAIN_IDS.MAINNET);
+      });
+
+      it('returns shouldShowCta false when user has MUSD on mainnet', () => {
+        mockUseHasMusdBalance.mockReturnValue({
+          hasMusdBalance: true,
+          balancesByChain: { [CHAIN_IDS.MAINNET]: '0x1234' },
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowCta).toBe(false);
+      });
+
+      it('returns shouldShowCta true when user has MUSD on different chain but not mainnet', () => {
+        mockUseHasMusdBalance.mockReturnValue({
+          hasMusdBalance: true,
+          balancesByChain: { [CHAIN_IDS.LINEA_MAINNET]: '0x1234' },
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowCta).toBe(true);
+        expect(result.current.showNetworkIcon).toBe(true);
+      });
+
+      it('returns shouldShowCta false when MUSD not buyable in region for mainnet', () => {
+        mockUseRampTokens.mockReturnValue({
+          ...defaultRampTokens,
+          allTokens: [
+            createMusdRampToken(CHAIN_IDS.MAINNET, false), // tokenSupported = false
+            createMusdRampToken(CHAIN_IDS.LINEA_MAINNET),
+          ],
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowCta).toBe(false);
+        expect(result.current.showNetworkIcon).toBe(false);
+        expect(result.current.selectedChainId).toBeNull();
+      });
+
+      it('returns shouldShowCta false when MUSD not buyable anywhere', () => {
+        mockUseRampTokens.mockReturnValue({
+          ...defaultRampTokens,
+          allTokens: [
+            createMusdRampToken(CHAIN_IDS.MAINNET, false),
+            createMusdRampToken(CHAIN_IDS.LINEA_MAINNET, false),
+          ],
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowCta).toBe(false);
+      });
+    });
+
+    describe('linea selected', () => {
+      beforeEach(() => {
+        mockUseNetworksByCustomNamespace.mockReturnValue({
+          ...defaultNetworksByNamespace,
+          areAllNetworksSelected: false,
+        });
+        mockUseCurrentNetworkInfo.mockReturnValue({
+          ...defaultNetworkInfo,
+          enabledNetworks: [
+            { chainId: CHAIN_IDS.LINEA_MAINNET, enabled: true },
+          ],
+        });
+      });
+
+      it('returns shouldShowCta true with network icon when no MUSD on Linea', () => {
+        mockUseHasMusdBalance.mockReturnValue({
+          hasMusdBalance: false,
+          balancesByChain: {},
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowCta).toBe(true);
+        expect(result.current.showNetworkIcon).toBe(true);
+        expect(result.current.selectedChainId).toBe(CHAIN_IDS.LINEA_MAINNET);
+      });
+
+      it('returns shouldShowCta false when MUSD not buyable in region for Linea', () => {
+        mockUseRampTokens.mockReturnValue({
+          ...defaultRampTokens,
+          allTokens: [
+            createMusdRampToken(CHAIN_IDS.MAINNET),
+            createMusdRampToken(CHAIN_IDS.LINEA_MAINNET, false), // tokenSupported = false
+          ],
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowCta).toBe(false);
+        expect(result.current.showNetworkIcon).toBe(false);
+        expect(result.current.selectedChainId).toBeNull();
+      });
+    });
+
+    describe('BSC selected', () => {
+      beforeEach(() => {
+        mockUseNetworksByCustomNamespace.mockReturnValue({
+          ...defaultNetworksByNamespace,
+          areAllNetworksSelected: false,
+        });
+        mockUseCurrentNetworkInfo.mockReturnValue({
+          ...defaultNetworkInfo,
+          enabledNetworks: [{ chainId: CHAIN_IDS.BSC, enabled: true }],
+        });
+      });
+
+      it('returns shouldShowCta false when BSC selected', () => {
+        mockUseHasMusdBalance.mockReturnValue({
+          hasMusdBalance: false,
+          balancesByChain: {},
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowCta).toBe(false);
+        expect(result.current.showNetworkIcon).toBe(false);
+        expect(result.current.selectedChainId).toBeNull();
+      });
+
+      it('returns shouldShowCta false when user has MUSD balance', () => {
+        mockUseHasMusdBalance.mockReturnValue({
+          hasMusdBalance: true,
+          balancesByChain: { [CHAIN_IDS.MAINNET]: '0x1234' },
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowCta).toBe(false);
+      });
+    });
+  });
+
+  describe('unsupported network selected', () => {
+    it('returns shouldShowCta false for Polygon', () => {
+      const polygonChainId = '0x89' as Hex;
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: false,
+      });
+      mockUseCurrentNetworkInfo.mockReturnValue({
+        ...defaultNetworkInfo,
+        enabledNetworks: [{ chainId: polygonChainId, enabled: true }],
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.shouldShowCta).toBe(false);
+      expect(result.current.showNetworkIcon).toBe(false);
+      expect(result.current.selectedChainId).toBeNull();
+    });
+
+    it('returns shouldShowCta false for Arbitrum', () => {
+      const arbitrumChainId = '0xa4b1' as Hex;
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: false,
+      });
+      mockUseCurrentNetworkInfo.mockReturnValue({
+        ...defaultNetworkInfo,
+        enabledNetworks: [{ chainId: arbitrumChainId, enabled: true }],
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.shouldShowCta).toBe(false);
+      expect(result.current.showNetworkIcon).toBe(false);
+    });
+
+    it('returns shouldShowCta false for Optimism', () => {
+      const optimismChainId = '0xa' as Hex;
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: false,
+      });
+      mockUseCurrentNetworkInfo.mockReturnValue({
+        ...defaultNetworkInfo,
+        enabledNetworks: [{ chainId: optimismChainId, enabled: true }],
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.shouldShowCta).toBe(false);
+      expect(result.current.showNetworkIcon).toBe(false);
+    });
+
+    it('returns shouldShowCta false for unsupported network when user has MUSD balance', () => {
+      const polygonChainId = '0x89' as Hex;
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: false,
+      });
+      mockUseCurrentNetworkInfo.mockReturnValue({
+        ...defaultNetworkInfo,
+        enabledNetworks: [{ chainId: polygonChainId, enabled: true }],
+      });
+      mockUseHasMusdBalance.mockReturnValue({
+        hasMusdBalance: true,
+        balancesByChain: { [CHAIN_IDS.MAINNET]: '0x1234' },
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.shouldShowCta).toBe(false);
+    });
+  });
+
+  describe('multiple networks selected (not all)', () => {
+    it('returns shouldShowCta true without network icon when multiple networks selected and no MUSD balance', () => {
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: false,
+      });
+      mockUseCurrentNetworkInfo.mockReturnValue({
+        ...defaultNetworkInfo,
+        enabledNetworks: [
+          { chainId: CHAIN_IDS.MAINNET, enabled: true },
+          { chainId: CHAIN_IDS.LINEA_MAINNET, enabled: true },
+        ],
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.shouldShowCta).toBe(true);
+      expect(result.current.showNetworkIcon).toBe(false);
+      expect(result.current.selectedChainId).toBeNull();
+    });
+
+    it('returns shouldShowCta false when multiple networks selected and user has MUSD balance', () => {
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: false,
+      });
+      mockUseCurrentNetworkInfo.mockReturnValue({
+        ...defaultNetworkInfo,
+        enabledNetworks: [
+          { chainId: CHAIN_IDS.MAINNET, enabled: true },
+          { chainId: CHAIN_IDS.LINEA_MAINNET, enabled: true },
+        ],
+      });
+      mockUseHasMusdBalance.mockReturnValue({
+        hasMusdBalance: true,
+        balancesByChain: { [CHAIN_IDS.MAINNET]: '0x1234' },
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.shouldShowCta).toBe(false);
+    });
+  });
+
+  describe('geo restriction scenarios', () => {
+    it('returns shouldShowCta false when allTokens is null (loading)', () => {
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: true,
+      });
+      mockUseRampTokens.mockReturnValue({
+        ...defaultRampTokens,
+        allTokens: null,
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.shouldShowCta).toBe(false);
+    });
+
+    it('returns shouldShowCta true when MUSD buyable on at least one chain in all networks view', () => {
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: true,
+      });
+      mockUseRampTokens.mockReturnValue({
+        ...defaultRampTokens,
+        allTokens: [
+          createMusdRampToken(CHAIN_IDS.MAINNET, false), // not buyable
+          createMusdRampToken(CHAIN_IDS.LINEA_MAINNET, true), // buyable
+        ],
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.shouldShowCta).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns shouldShowCta false with empty enabledNetworks', () => {
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: false,
+      });
+      mockUseCurrentNetworkInfo.mockReturnValue({
+        ...defaultNetworkInfo,
+        enabledNetworks: [],
+      });
+
+      const { result } = renderHook(() => useMusdCtaVisibility());
+
+      expect(result.current.shouldShowCta).toBe(false);
+      expect(result.current.showNetworkIcon).toBe(false);
+      expect(result.current.selectedChainId).toBeNull();
+    });
+
+    it('handles undefined values gracefully', () => {
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: false,
+      });
+      mockUseCurrentNetworkInfo.mockReturnValue({
+        ...defaultNetworkInfo,
+        enabledNetworks: [],
+      });
+
+      expect(() => renderHook(() => useMusdCtaVisibility())).not.toThrow();
+    });
+  });
+});

--- a/app/components/UI/Earn/hooks/useMusdCtaVisibility.ts
+++ b/app/components/UI/Earn/hooks/useMusdCtaVisibility.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
 import { useRampTokens } from '../../Ramp/hooks/useRampTokens';
 import { selectIsMusdCtaEnabledFlag } from '../selectors/featureFlags';
+import { toLowerCaseEquals } from '../../../../util/general';
 
 /**
  * Hook to determine visibility and network icon display for the MUSD CTA.
@@ -49,7 +50,7 @@ export const useMusdCtaVisibility = () => {
 
       const musdToken = allTokens.find(
         (token) =>
-          token.assetId === musdAssetId.toLowerCase() &&
+          toLowerCaseEquals(token.assetId, musdAssetId) &&
           token.tokenSupported === true,
       );
 

--- a/app/components/UI/Earn/hooks/useMusdCtaVisibility.ts
+++ b/app/components/UI/Earn/hooks/useMusdCtaVisibility.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { Hex, KnownCaipNamespace } from '@metamask/utils';
+import { useSelector } from 'react-redux';
 import {
   MUSD_BUYABLE_CHAIN_IDS,
   MUSD_TOKEN_ASSET_ID_BY_CHAIN,
@@ -11,6 +12,7 @@ import {
   useNetworksByCustomNamespace,
 } from '../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
 import { useRampTokens } from '../../Ramp/hooks/useRampTokens';
+import { selectIsMusdCtaEnabledFlag } from '../selectors/featureFlags';
 
 /**
  * Hook to determine visibility and network icon display for the MUSD CTA.
@@ -21,6 +23,7 @@ import { useRampTokens } from '../../Ramp/hooks/useRampTokens';
  * - selectedChainId: the selected chain ID for the network badge (null if all networks)
  */
 export const useMusdCtaVisibility = () => {
+  const isMusdCtaEnabled = useSelector(selectIsMusdCtaEnabledFlag);
   const { enabledNetworks } = useCurrentNetworkInfo();
   const { areAllNetworksSelected } = useNetworksByCustomNamespace({
     networkType: NetworkType.Popular,
@@ -63,6 +66,15 @@ export const useMusdCtaVisibility = () => {
   );
 
   const { shouldShowCta, showNetworkIcon, selectedChainId } = useMemo(() => {
+    // If the mUSD CTA feature flag is disabled, don't show the CTA
+    if (!isMusdCtaEnabled) {
+      return {
+        shouldShowCta: false,
+        showNetworkIcon: false,
+        selectedChainId: null,
+      };
+    }
+
     // Get selected chains from enabled networks
     const selectedChains = enabledNetworks
       .filter((network) => network.enabled)
@@ -115,6 +127,7 @@ export const useMusdCtaVisibility = () => {
       selectedChainId: chainId,
     };
   }, [
+    isMusdCtaEnabled,
     areAllNetworksSelected,
     enabledNetworks,
     hasMusdBalance,

--- a/app/components/UI/Earn/hooks/useMusdCtaVisibility.ts
+++ b/app/components/UI/Earn/hooks/useMusdCtaVisibility.ts
@@ -1,0 +1,131 @@
+import { useMemo } from 'react';
+import { Hex, KnownCaipNamespace } from '@metamask/utils';
+import {
+  MUSD_BUYABLE_CHAIN_IDS,
+  MUSD_TOKEN_ASSET_ID_BY_CHAIN,
+} from '../constants/musd';
+import { useHasMusdBalance } from './useHasMusdBalance';
+import { useCurrentNetworkInfo } from '../../../hooks/useCurrentNetworkInfo';
+import {
+  NetworkType,
+  useNetworksByCustomNamespace,
+} from '../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
+import { useRampTokens } from '../../Ramp/hooks/useRampTokens';
+
+/**
+ * Hook to determine visibility and network icon display for the MUSD CTA.
+ *
+ * @returns Object containing:
+ * - shouldShowCta: false if non-MUSD chain selected OR user has MUSD balance OR MUSD not buyable in region
+ * - showNetworkIcon: true only when a single MUSD-supported chain is selected
+ * - selectedChainId: the selected chain ID for the network badge (null if all networks)
+ */
+export const useMusdCtaVisibility = () => {
+  const { enabledNetworks } = useCurrentNetworkInfo();
+  const { areAllNetworksSelected } = useNetworksByCustomNamespace({
+    networkType: NetworkType.Popular,
+    namespace: KnownCaipNamespace.Eip155,
+  });
+  const { hasMusdBalance, balancesByChain } = useHasMusdBalance();
+  const { allTokens } = useRampTokens();
+
+  // Check if mUSD is buyable on a specific chain based on ramp availability
+  const isMusdBuyableOnChain = useMemo(() => {
+    if (!allTokens) {
+      return {};
+    }
+
+    const buyableByChain: Record<Hex, boolean> = {};
+
+    MUSD_BUYABLE_CHAIN_IDS.forEach((chainId) => {
+      const musdAssetId = MUSD_TOKEN_ASSET_ID_BY_CHAIN[chainId];
+      if (!musdAssetId) {
+        buyableByChain[chainId] = false;
+        return;
+      }
+
+      const musdToken = allTokens.find(
+        (token) =>
+          token.assetId === musdAssetId.toLowerCase() &&
+          token.tokenSupported === true,
+      );
+
+      buyableByChain[chainId] = Boolean(musdToken);
+    });
+
+    return buyableByChain;
+  }, [allTokens]);
+
+  // Check if mUSD is buyable on any chain (for "all networks" view)
+  const isMusdBuyableOnAnyChain = useMemo(
+    () => Object.values(isMusdBuyableOnChain).some(Boolean),
+    [isMusdBuyableOnChain],
+  );
+
+  const { shouldShowCta, showNetworkIcon, selectedChainId } = useMemo(() => {
+    // Get selected chains from enabled networks
+    const selectedChains = enabledNetworks
+      .filter((network) => network.enabled)
+      .map((network) => network.chainId as Hex);
+
+    // If all networks are selected (popular networks filter)
+    if (areAllNetworksSelected || selectedChains.length > 1) {
+      // Show CTA without network icon if:
+      // - User doesn't have MUSD on any chain
+      // - AND mUSD is buyable on at least one chain in user's region
+      return {
+        shouldShowCta: !hasMusdBalance && isMusdBuyableOnAnyChain,
+        showNetworkIcon: false,
+        selectedChainId: null,
+      };
+    }
+
+    // If exactly one chain is selected
+
+    const chainId = selectedChains[0];
+    const isBuyableChain = MUSD_BUYABLE_CHAIN_IDS.includes(chainId);
+
+    if (!isBuyableChain) {
+      // Chain doesn't have buy routes available (e.g., BSC) - hide CTA
+      return {
+        shouldShowCta: false,
+        showNetworkIcon: false,
+        selectedChainId: null,
+      };
+    }
+
+    // Check if mUSD is buyable on this chain in user's region
+    const isMusdBuyableInRegion = isMusdBuyableOnChain[chainId] ?? false;
+
+    if (!isMusdBuyableInRegion) {
+      // mUSD not buyable in user's region for this chain - hide CTA
+      return {
+        shouldShowCta: false,
+        showNetworkIcon: false,
+        selectedChainId: null,
+      };
+    }
+
+    // Supported chain selected - check if user has MUSD on this specific chain
+    const hasMusdOnSelectedChain = Boolean(balancesByChain[chainId]);
+
+    return {
+      shouldShowCta: !hasMusdOnSelectedChain,
+      showNetworkIcon: true,
+      selectedChainId: chainId,
+    };
+  }, [
+    areAllNetworksSelected,
+    enabledNetworks,
+    hasMusdBalance,
+    balancesByChain,
+    isMusdBuyableOnChain,
+    isMusdBuyableOnAnyChain,
+  ]);
+
+  return {
+    shouldShowCta,
+    showNetworkIcon,
+    selectedChainId,
+  };
+};

--- a/app/components/UI/Earn/selectors/featureFlags/index.ts
+++ b/app/components/UI/Earn/selectors/featureFlags/index.ts
@@ -70,6 +70,19 @@ export const selectIsMusdConversionFlowEnabledFlag = createSelector(
   },
 );
 
+export const selectIsMusdCtaEnabledFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    return true;
+    const localFlag = process.env.MM_MUSD_CTA_ENABLED === 'true';
+    const remoteFlag =
+      remoteFeatureFlags?.earnMusdCtaEnabled as unknown as VersionGatedFeatureFlag;
+
+    // Fallback to local flag if remote flag is not available
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
+  },
+);
+
 /**
  * Selects the allowed payment tokens for mUSD conversion from remote config or local fallback.
  * Returns a mapping of chain IDs to arrays of token addresses that users can pay with to convert to mUSD.

--- a/app/components/UI/Earn/selectors/featureFlags/index.ts
+++ b/app/components/UI/Earn/selectors/featureFlags/index.ts
@@ -73,7 +73,6 @@ export const selectIsMusdConversionFlowEnabledFlag = createSelector(
 export const selectIsMusdCtaEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {
-    return true;
     const localFlag = process.env.MM_MUSD_CTA_ENABLED === 'true';
     const remoteFlag =
       remoteFeatureFlags?.earnMusdCtaEnabled as unknown as VersionGatedFeatureFlag;


### PR DESCRIPTION
## **Description**

Fixed an issue where the MUSD CTA was incorrectly displaying when a single unsupported chain (like BSC) was selected in the network filter. 

The bug occurred because when a non-buyable chain was selected, the code was still showing the CTA if mUSD was buyable on *any* chain (e.g., Mainnet or Linea), rather than hiding it completely. This was confusing for users since they couldn't actually buy mUSD on the selected chain.

**Changes:**
- When a non-buyable chain is selected (BSC, Polygon, Arbitrum, etc.), the CTA now correctly hides
- When a buyable chain is selected but mUSD is not available in the user's region for that specific chain, the CTA now correctly hides

## **Changelog**

CHANGELOG entry: Fixed mUSD CTA incorrectly appearing on unsupported chains like BSC

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-124

## **Manual testing steps**

```gherkin
Feature: MUSD CTA visibility

  Scenario: user selects BSC network
    Given user is on the token list view
    And user does not have any MUSD balance
    And user does not have any token balance

    When user selects BSC as the only network filter
    Then the MUSD CTA should not be displayed

  Scenario: user selects Linea network
    Given user is on the token list view
    And user does not have any MUSD balance
    And user does not have any token balance
    And mUSD is buyable in user's region on Linea

    When user selects Linea as the only network filter
    Then the MUSD CTA should be displayed with network icon

  Scenario: user selects Mainnet network
    Given user is on the token list view
    And user does not have any MUSD balance
    And user does not have any token balance
    And mUSD is buyable in user's region on Mainnet

    When user selects Mainnet as the only network filter
    Then the MUSD CTA should be displayed with network icon

  Scenario: user selects all networks
    Given user is on the token list view
    And user does not have any MUSD balance
    And user does not have any token balance
    And mUSD is buyable in user's region

    When user has all networks selected
    Then the MUSD CTA should be displayed without network icon

  Scenario: user selects Linea network
    Given user is on the token list view
    And user does not have any MUSD balance
    And user does has token balance

    When user selects any network filter
    Then the MUSD CTA should be displayed with network icon
    Then the MUSD CTA should direct to BuyWithToken component on the chain of token being converted (soon to be constrained to that chain specifically in. separate pr)
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/45040e69-f737-4112-baad-36f0390c3453

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the mUSD CTA to show/hide and route per selected chain and regional availability, with a new feature flag, network badge, and supporting hooks/tests.
> 
> - **Earn UI – mUSD CTA**:
>   - Integrates `useMusdCtaVisibility` to conditionally render CTA; hides on non-buyable/unsupported chains and when mUSD isn’t buyable in-region.
>   - Shows network badge for single supported selections using `BadgeWrapper` and `getNetworkImageSource`; aligns avatar layout.
>   - Adjusts buy flow to use `selectedChainId` (fallback to `MUSD_CONVERSION_DEFAULT_CHAIN_ID`).
> - **Hooks/Logic**:
>   - Adds `useHasMusdBalance` to detect mUSD balances across chains.
>   - Adds `useMusdCtaVisibility` to compute `shouldShowCta`, `showNetworkIcon`, and `selectedChainId` based on feature flag, selected networks, ramp token availability, and balances.
>   - Introduces `MUSD_BUYABLE_CHAIN_IDS` (excludes BSC) and uses `MUSD_TOKEN_ASSET_ID_BY_CHAIN` for routing.
> - **Feature Flags/Config**:
>   - Adds env flag `MM_MUSD_CTA_ENABLED` and selector `selectIsMusdCtaEnabledFlag`.
> - **Tests**:
>   - Extensive new tests for `useHasMusdBalance`, `useMusdCtaVisibility`, and updated CTA tests for visibility, routing, and network badge behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd047458374616a8ee56d1aa200ab91f94d2b641. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->