### PR TITLE
fix: sentence case violations 5001-6000 of locales file

### DIFF
--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/__snapshots__/EarnLendingDepositConfirmationView.test.tsx.snap
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/__snapshots__/EarnLendingDepositConfirmationView.test.tsx.snap
@@ -1563,7 +1563,7 @@ exports[`EarnLendingDepositConfirmationView matches snapshot 1`] = `
           }
           testID="earn-lending-confirmation-footer-risk-disclosure-button"
         >
-          Risk Disclosure
+          Risk disclosure
         </Text>
         <Text
           accessibilityRole="text"

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ConfirmationFooter/__snapshots__/ConfirmationFooter.test.tsx.snap
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ConfirmationFooter/__snapshots__/ConfirmationFooter.test.tsx.snap
@@ -422,7 +422,7 @@ exports[`ConfirmationFooter renders correctly 1`] = `
         }
         testID="earn-lending-confirmation-footer-risk-disclosure-button"
       >
-        Risk Disclosure
+        Risk disclosure
       </Text>
       <Text
         accessibilityRole="text"

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/__snapshots__/EarnLendingWithdrawalConfirmationView.test.tsx.snap
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/__snapshots__/EarnLendingWithdrawalConfirmationView.test.tsx.snap
@@ -1066,7 +1066,7 @@ exports[`EarnLendingWithdrawalConfirmationView matches snapshot 1`] = `
           }
           testID="earn-lending-confirmation-footer-risk-disclosure-button"
         >
-          Risk Disclosure
+          Risk disclosure
         </Text>
         <Text
           accessibilityRole="text"

--- a/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/__snapshots__/LendingMaxWithdrawalModal.test.tsx.snap
+++ b/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/__snapshots__/LendingMaxWithdrawalModal.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`LendingMaxWithdrawalModal should render correctly 1`] = `
           }
         }
       >
-        • Pool Liquidity:
+        • Pool liquidity:
       </Text>
        
       Not enough funds available in the lending pool right now.
@@ -168,7 +168,7 @@ exports[`LendingMaxWithdrawalModal should render correctly 1`] = `
           }
         }
       >
-        • Existing Borrow Positions:
+        • Existing borrow positions:
       </Text>
        
       Withdrawing could put your existing loan positions at risk of liquidation.

--- a/app/components/UI/EditGasFee1559/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/EditGasFee1559/__snapshots__/index.test.tsx.snap
@@ -518,7 +518,7 @@ exports[`EditGasFee1559 should render correctly 1`] = `
                       infoModal={true}
                       noMargin={true}
                     >
-                      Use Low to wait for a cheaper price. Time estimates are much less accurate as prices are somewhat unpredictable.
+                      Use low to wait for a cheaper price. Time estimates are much less accurate as prices are somewhat unpredictable.
                     </Text>
                     <Text
                       bold={true}
@@ -538,7 +538,7 @@ exports[`EditGasFee1559 should render correctly 1`] = `
                       infoModal={true}
                       noMargin={true}
                     >
-                      Use Market for fast processing at current market price.
+                      Use market for fast processing at current market price.
                     </Text>
                     <Text
                       bold={true}

--- a/app/components/UI/SimulationDetails/FiatDisplay/FiatDisplay.test.tsx
+++ b/app/components/UI/SimulationDetails/FiatDisplay/FiatDisplay.test.tsx
@@ -45,7 +45,7 @@ const mockStateWithHideFiatOnTestnets = merge({}, mockStateWithTestnet, {
 describe('FiatDisplay', () => {
   describe('IndividualFiatDisplay', () => {
     it.each([
-      [FIAT_UNAVAILABLE, 'Not Available'],
+      [FIAT_UNAVAILABLE, 'Not available'],
       [new BigNumber(100), '$100'],
       [new BigNumber(-100), '$100'],
       [new BigNumber(-100.5), '$100.50'],
@@ -69,8 +69,8 @@ describe('FiatDisplay', () => {
 
   describe('TotalFiatDisplay', () => {
     it.each([
-      [[FIAT_UNAVAILABLE, FIAT_UNAVAILABLE], 'Not Available'],
-      [[], 'Not Available'],
+      [[FIAT_UNAVAILABLE, FIAT_UNAVAILABLE], 'Not available'],
+      [[], 'Not available'],
       [
         [
           new BigNumber(100),

--- a/app/components/Views/confirmations/components/footer/footer.test.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.test.tsx
@@ -181,7 +181,7 @@ describe('Footer', () => {
       state: stakingDepositConfirmationState,
     });
 
-    fireEvent.press(getByText('Risk Disclosure'));
+    fireEvent.press(getByText('Risk disclosure'));
     expect(Linking.openURL).toHaveBeenCalledWith(
       AppConstants.URLS.STAKING_RISK_DISCLOSURE,
     );

--- a/app/components/Views/confirmations/components/info/contract-interaction/contract-interaction.test.tsx
+++ b/app/components/Views/confirmations/components/info/contract-interaction/contract-interaction.test.tsx
@@ -191,6 +191,6 @@ describe('ContractInteraction', () => {
       state: getAppStateForConfirmation(upgradeAccountConfirmation),
     });
     expect(getByText('Now')).toBeDefined();
-    expect(getByText('Switching To')).toBeDefined();
+    expect(getByText('Switching to')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/info/switch-account-type/switch-account-type.test.tsx
+++ b/app/components/Views/confirmations/components/info/switch-account-type/switch-account-type.test.tsx
@@ -63,7 +63,7 @@ describe('SwitchAccountType - Info Component', () => {
     });
     expect(getByText('Now')).toBeDefined();
     expect(getByText('Standard Account')).toBeDefined();
-    expect(getByText('Switching To')).toBeDefined();
+    expect(getByText('Switching to')).toBeDefined();
     expect(getByText('Smart Account')).toBeDefined();
   });
 
@@ -73,7 +73,7 @@ describe('SwitchAccountType - Info Component', () => {
     });
     expect(getByText('Now')).toBeDefined();
     expect(getByText('Smart Account')).toBeDefined();
-    expect(getByText('Switching To')).toBeDefined();
+    expect(getByText('Switching to')).toBeDefined();
     expect(getByText('Standard Account')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/rows/switch-account-type-info-row/switch-account-type-info-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/switch-account-type-info-row/switch-account-type-info-row.test.tsx
@@ -56,7 +56,7 @@ describe('SwitchAccountTypeInfoRow', () => {
     });
     expect(getByText('Now')).toBeDefined();
     expect(getByText('Standard Account')).toBeDefined();
-    expect(getByText('Switching To')).toBeDefined();
+    expect(getByText('Switching to')).toBeDefined();
     expect(getByText('Smart Account')).toBeDefined();
   });
 
@@ -66,7 +66,7 @@ describe('SwitchAccountTypeInfoRow', () => {
     });
     expect(getByText('Now')).toBeDefined();
     expect(getByText('Standard Account')).toBeDefined();
-    expect(getByText('Switching To')).toBeDefined();
+    expect(getByText('Switching to')).toBeDefined();
     expect(getByText('Smart Account')).toBeDefined();
   });
 
@@ -76,7 +76,7 @@ describe('SwitchAccountTypeInfoRow', () => {
     });
     expect(getByText('Now')).toBeDefined();
     expect(getByText('Smart Account')).toBeDefined();
-    expect(getByText('Switching To')).toBeDefined();
+    expect(getByText('Switching to')).toBeDefined();
     expect(getByText('Standard Account')).toBeDefined();
   });
 });

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5057,7 +5057,7 @@
       "approve": "Approve {{sourceToken}} for swaps: Up to {{upTo}}"
     },
     "notification_label": {
-      "swap_pending": "Pending Swap ({{sourceToken}} to {{destinationToken}})",
+      "swap_pending": "Pending swap ({{sourceToken}} to {{destinationToken}})",
       "swap_confirmed": "Swap complete ({{sourceToken}} to {{destinationToken}})",
       "approve_pending": "Approving {{sourceToken}} for swaps",
       "approve_confirmed": "{{sourceToken}} approved for swaps"
@@ -5132,7 +5132,7 @@
       "descriptions": {
         "description_1": "Network dropdown moved to your assets",
         "description_2": "Swap and Bridge in one simple flow",
-        "description_3": "Streamlined Send experience",
+        "description_3": "Streamlined send experience",
         "description_4": "A fresh account view"
       },
       "more_information": "Now you can focus on your tokens and activity, not the networks behind them.",
@@ -5155,7 +5155,7 @@
     "request_update_network_url": "{{dapp_origin}} is requesting to update your default network URL. You can edit defaults and network information any time.",
     "available": "is now available in the network selector.",
     "cancel": "Cancel",
-    "switch": "Switch Network"
+    "switch": "Switch network"
   },
   "add_custom_network": {
     "title": "Allow this site to add a network?",
@@ -5204,21 +5204,21 @@
       "aggressive_label": "Aggressive",
       "aggressive_text": "High probability, even in volatile markets. Use Aggressive to cover surges in network traffic due to things like popular NFT drops.",
       "market_label": "Market",
-      "market_text": "Use Market for fast processing at current market price.",
+      "market_text": "Use market for fast processing at current market price.",
       "low_label": "Low",
-      "low_text": "Use Low to wait for a cheaper price. Time estimates are much less accurate as prices are somewhat unpredictable.",
+      "low_text": "Use low to wait for a cheaper price. Time estimates are much less accurate as prices are somewhat unpredictable.",
       "link": "Learn more about customizing gas."
     },
     "save": "Save",
     "submit": "Submit",
-    "max_priority_fee_low": "Max Priority Fee is low for current network conditions",
-    "max_priority_fee_high": "Max Priority Fee is higher than necessary",
-    "max_priority_fee_speed_up_low": "Max Priority Fee must be at least {{speed_up_floor_value}} GWEI (10% higher than initial transaction)",
-    "max_priority_fee_cancel_low": "Max Priority Fee must be at least {{cancel_value}} GWEI (50% higher than initial transaction)",
-    "max_fee_low": "Max Fee is low for current network conditions",
-    "max_fee_high": "Max Fee is higher than necessary",
-    "max_fee_speed_up_low": "Max Fee must be at least {{speed_up_floor_value}} GWEI (10% higher than initial transaction)",
-    "max_fee_cancel_low": "Max Fee must be at least {{cancel_value}} GWEI (50% higher than initial transaction)",
+    "max_priority_fee_low": "Max priority fee is low for current network conditions",
+    "max_priority_fee_high": "Max priority fee is higher than necessary",
+    "max_priority_fee_speed_up_low": "Max priority fee must be at least {{speed_up_floor_value}} GWEI (10% higher than initial transaction)",
+    "max_priority_fee_cancel_low": "Max priority fee must be at least {{cancel_value}} GWEI (50% higher than initial transaction)",
+    "max_fee_low": "Max fee is low for current network conditions",
+    "max_fee_high": "Max fee is higher than necessary",
+    "max_fee_speed_up_low": "Max fee must be at least {{speed_up_floor_value}} GWEI (10% higher than initial transaction)",
+    "max_fee_cancel_low": "Max fee must be at least {{cancel_value}} GWEI (50% higher than initial transaction)",
     "learn_more_gas_limit": "Gas limit is the maximum units of gas you are willing to use. Units of gas are a multiplier to “Max priority fee” and “Max fee”. ",
     "learn_more_max_priority_fee": "Max priority fee (aka “miner tip”) goes directly to miners and incentivizes them to prioritize your transaction. You’ll most often pay your max setting. ",
     "learn_more_max_fee": "The max fee is the most you’ll pay (base fee + priority fee). ",
@@ -5609,7 +5609,7 @@
     "approval": "Approval",
     "confirm": "Confirm",
     "cancel": "Cancel",
-    "transaction_submitted": "Transaction Submitted",
+    "transaction_submitted": "Transaction submitted",
     "every_minute": "Every minute",
     "immediate": "Immediate",
     "apr": "APR",
@@ -5627,20 +5627,20 @@
       "withdrawal_time": "The time it takes to withdraw your token from the protocol and get it back in your wallet",
       "receive": "This token is used to track your assets and rewards. Do not transfer or trade them, or you won’t be able to withdraw your assets.",
       "health_factor": {
-        "your_health_factor_measures_liquidation_risk": "Your Health Factor measures liquidation risk",
+        "your_health_factor_measures_liquidation_risk": "Your health factor measures liquidation risk",
         "above_two_dot_zero": "Above 2.0",
         "safe_position": "Safe position",
         "between_one_dot_five_and_2_dot_zero": "Between 1.5-2.0",
-        "medium_liquidation_risk": "Medium Liquidation risk",
+        "medium_liquidation_risk": "Medium liquidation risk",
         "below_one_dot_five": "Below 1.5",
         "higher_liquidation_risk": "Higher liquidation risk"
       },
       "lending_risk_aware_withdrawal_tooltip": {
         "why_cant_i_withdraw_full_balance": "Why can't I withdraw my full balance?",
         "your_withdrawal_amount_may_be_limited_by": "Your withdrawal amount may be limited by",
-        "pool_liquidity": "Pool Liquidity",
+        "pool_liquidity": "Pool liquidity",
         "not_enough_funds_available_in_the_lending_pool_right_now": "Not enough funds available in the lending pool right now.",
-        "existing_borrow_positions": "Existing Borrow Positions",
+        "existing_borrow_positions": "Existing borrow positions",
         "withdrawing_could_put_your_existing_loans_at_risk_of_liquidation": "Withdrawing could put your existing loan positions at risk of liquidation."
       }
     },
@@ -5652,7 +5652,7 @@
     "network": "Network",
     "health_factor": "Health factor",
     "liquidation_risk": "Liquidation risk",
-    "insufficient_pool_liquidity": "Insufficient Pool Liquidity",
+    "insufficient_pool_liquidity": "Insufficient pool liquidity",
     "available_to_withdraw": "available to withdraw",
     "unknown": "unknown",
     "how_it_works": "How it works",
@@ -5671,7 +5671,7 @@
       "lending": "Position history",
       "staking": "Payout history"
     },
-    "allowance_reset": "Allowance Reset",
+    "allowance_reset": "Allowance reset",
     "tron": {
       "fee": "Fee"
     },
@@ -5852,11 +5852,11 @@
     "one_year_average": "1 year average"
   },
   "default_settings": {
-    "title": "Your Wallet is ready",
+    "title": "Your wallet is ready",
     "description": "MetaMask uses default settings to best balance safety and ease of use. Change these settings to further increase your privacy.",
     "learn_more_about_privacy": "Learn more about privacy best practices.",
     "privacy_policy": "Privacy policy",
-    "default_settings": "Default Settings",
+    "default_settings": "Default settings",
     "done": "Done",
     "basic_functionality": "Basic functionality",
     "manage_networks": "Choose your network",
@@ -5892,7 +5892,7 @@
   },
   "simulation_details": {
     "failed": "There was an error loading your estimation.",
-    "fiat_not_available": "Not Available",
+    "fiat_not_available": "Not available",
     "incoming_heading": "You receive",
     "no_balance_changes": "No changes",
     "outgoing_heading": "You send",
@@ -5942,7 +5942,7 @@
       "part1": "By continuing, you agree to our ",
       "terms_of_use": "Terms of Use",
       "part2": " and ",
-      "risk_disclosure": "Risk Disclosure",
+      "risk_disclosure": "Risk disclosure",
       "part3": "."
     },
     "label": {
@@ -5957,7 +5957,7 @@
       "signing_in_with": "Signing in with",
       "spender": "Spender",
       "now": "Now",
-      "switching_to": "Switching To",
+      "switching_to": "Switching to",
       "bridge_estimated_time": "Est. time",
       "pay_with": "Pay with",
       "total": "Total",
@@ -5978,7 +5978,7 @@
       "switch_account_type": "Account update",
       "approve": "Approve request",
       "perps_deposit": "Add funds",
-      "predict_deposit": "Add Predict funds",
+      "predict_deposit": "Add predict funds",
       "predict_withdraw": "Withdraw"
     },
     "sub_title": {


### PR DESCRIPTION
## **Description**

This PR fixes sentence case violations in lines 5001-6000 of the `locales/languages/en.json` file as part of ongoing content papercut improvements. The changes convert Title Case strings to sentence case following standard capitalization conventions.

**What is the reason for the change?**
Content consistency and adherence to proper sentence case formatting across the app.

**What is the improvement/solution?**
Updated ~50 locale keys from Title Case to sentence case, and will update all affected test files to match the new casing.

## **Changelog**

CHANGELOG entry: Fixed sentence case violations in English locale strings lines 5001-6000

## **Related issues**

Fixes: Part of content papercut improvements batch 6
Follows: #23499 (lines 1-1000), #23516 (lines 1001-2000), #23957 (lines 2001-3000), #23994 (lines 3001-4000), #23996 (lines 4001-5000)
Related: #23272 (original comprehensive PR)

## **Manual testing steps**

```gherkin
Feature: Locale string display

  Scenario: user views UI elements with updated locale strings
    Given the app is running with the updated locale file

    When user views swap notifications
    Then "Pending swap" should display in sentence case

    When user views network switcher
    Then "Switch network" should display in sentence case

    When user views gas fee options
    Then "Use market" and "Use low" should display in sentence case
    And "Max priority fee" and "Max fee" messages should display in sentence case

    When user views transaction confirmations
    Then "Transaction submitted" should display in sentence case

    When user views lending/staking screens
    Then "Your health factor", "Pool liquidity", "Existing borrow positions" should display in sentence case
    And "Allowance reset", "Insufficient pool liquidity" should display in sentence case

    When user views wallet setup
    Then "Your wallet is ready" and "Default settings" should display in sentence case

    When user views simulation details
    Then "Not available" should display in sentence case

    When user views consent screens
    Then "Risk disclosure" and "Switching to" should display in sentence case
```

## **Screenshots/Recordings**

N/A - This is a content-only change with no visual differences beyond text casing. Snapshot updates in progress.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable (test updates in progress)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## **Technical Details**

### Changes Made:
- **Locale file**: Updated ~50 keys in `locales/languages/en.json` (lines 5001-6000)
- **Test files**: Test snapshot updates in progress
- **Snapshots**: Snapshot regeneration in progress

### Affected Areas:
- Swap notifications and confirmations
- Network switcher dialogs
- Gas fee estimation UI (Market, Low priority options)
- Transaction submission messages
- Lending/Staking screens (Health factor, Pool liquidity, Borrow positions)
- Wallet setup and default settings screens
- Simulation details
- Risk disclosure and consent screens
- Predict feature labels

### Validation:
- Changes are purely cosmetic (text casing only)
- No functional changes to app behavior
- Test updates will ensure all assertions match new casing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize sentence casing for English locale strings (~5001–6000) and update related tests/snapshots accordingly.
> 
> - **Locales (en.json)**:
>   - Standardize to sentence case across keys in the 5001–6000 range:
>     - Swaps: `notification_label.swap_pending` → "Pending swap".
>     - Gas fee UI: guidance text uses "Use low/market"; validation messages use "Max priority fee/Max fee" in sentence case.
>     - Confirm views: labels like `switching_to` → "Switching to"; titles like `predict_deposit` → "Add predict funds".
>     - Consent/links: "Risk disclosure" (sentence case).
>     - Earn/Lending: "Transaction submitted", "Pool liquidity", "Existing borrow positions", health factor copy in sentence case.
>     - Default settings: "Your wallet is ready", "Default settings".
>     - Simulation details: "Not available".
> - **Tests/Snapshots**:
>   - Update expectations/text in snapshots and unit tests to match new casing:
>     - Confirmation footers/links use "Risk disclosure".
>     - Gas fee modal info uses "Use low/market".
>     - Fiat display shows "Not available".
>     - Switch account type sections use "Switching to".
>     - Lending withdrawal modal bullets use "Pool liquidity" / "Existing borrow positions".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f97e9f8ce817c39ad874c9030a93c257bb5728eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->