### PR TITLE
fix: stop re-rendering wallet whenever we navigate from trending to home screen

### DIFF
--- a/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
@@ -222,10 +222,7 @@ describe('TabBar', () => {
     );
 
     fireEvent.press(getByTestId(`tab-bar-item-${TabBarIconKey.Trending}`));
-    expect(navigation.reset).toHaveBeenCalledWith({
-      index: 0,
-      routes: [{ name: Routes.TRENDING_VIEW }],
-    });
+    expect(navigation.navigate).toHaveBeenCalledWith(Routes.TRENDING_VIEW);
   });
 
   it('does not navigate to trending when trending feature flag is disabled', () => {

--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -95,10 +95,7 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
             break;
           case Routes.TRENDING_VIEW:
             if (isAssetsTrendingTokensEnabled) {
-              navigation.reset({
-                index: 0,
-                routes: [{ name: Routes.TRENDING_VIEW }],
-              });
+              navigation.navigate(Routes.TRENDING_VIEW);
             }
             break;
         }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
After profiling the app I encountered quite a big performance and UX issue when switching between home screen and trending screen:
- As you can see whenever we navigate to any screen and go back to the main screen, the state and UI is kept and not re-rendered
- But when we navigate to trending and going back to the main screen the whole UI is re-rendered

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: avoid re-rendering home when navigating back from trending

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2153

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/e2eac97d-da55-454d-a283-bf445a837cd1


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/5175b72c-6c1e-4da1-be96-634443a88bd9


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change trending tab to call `navigation.navigate` to `Routes.TRENDING_VIEW` (when enabled) instead of `navigation.reset`, with tests updated accordingly.
> 
> - **Navigation**
>   - `TabBar`: For `Routes.TRENDING_VIEW`, replace `navigation.reset(...)` with `navigation.navigate(Routes.TRENDING_VIEW)` when the `assetsTrendingTokens` feature flag is enabled.
> - **Tests**
>   - Update `app/component-library/components/Navigation/TabBar/TabBar.test.tsx` to expect `navigation.navigate(Routes.TRENDING_VIEW)` and not `reset`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5140c8c2c43638d2433c2f5b6f452dc8926bf02f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->