### PR TITLE
refactor: update token detail options bottom sheet

### DIFF
--- a/app/components/Views/AssetOptions/AssetOptions.styles.ts
+++ b/app/components/Views/AssetOptions/AssetOptions.styles.ts
@@ -1,44 +1,13 @@
-import type { Theme } from '@metamask/design-tokens';
-import { StyleSheet, TextStyle } from 'react-native';
-import {
-  getFontFamily,
-  TextVariant,
-} from '../../../component-library/components/Texts/Text';
+import { StyleSheet } from 'react-native';
 
-const styleSheet = (params: { theme: Theme }) => {
-  const { theme } = params;
-  const { colors, typography } = theme;
-  return StyleSheet.create({
-    screen: { justifyContent: 'flex-end' },
-    sheet: {
-      backgroundColor: colors.background.default,
-      borderTopLeftRadius: 20,
-      borderTopRightRadius: 20,
-    },
-    notch: {
-      width: 48,
-      height: 5,
-      borderRadius: 4,
-      backgroundColor: colors.border.default,
-      marginTop: 12,
-      alignSelf: 'center',
-      marginBottom: 16,
-    },
+const styleSheet = () =>
+  StyleSheet.create({
     optionButton: {
       alignItems: 'center',
       flexDirection: 'row',
-      padding: 16,
+      padding: 12,
+      gap: 16,
     },
-    icon: {
-      marginRight: 16,
-      color: colors.text.default,
-    },
-    optionLabel: {
-      ...typography.sBodyLGMedium,
-      fontFamily: getFontFamily(TextVariant.BodyLGMedium),
-      color: colors.text.default,
-    } as TextStyle,
   });
-};
 
 export default styleSheet;

--- a/app/components/Views/AssetOptions/AssetOptions.test.tsx
+++ b/app/components/Views/AssetOptions/AssetOptions.test.tsx
@@ -41,6 +41,7 @@ jest.mock('react-redux', () => ({
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: jest.fn(() => ({ bottom: 10 })),
+  useSafeAreaFrame: jest.fn(() => ({ width: 390, height: 844 })),
 }));
 
 // Mock InteractionManager.runAfterInteractions to execute callbacks immediately

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2355,6 +2355,7 @@
     "lists": "Token Lists",
     "hide_cta": "Hide token",
     "options": {
+      "title": "Token options",
       "view_on_portfolio": "View on Portfolio",
       "view_on_block": "View on block explorer",
       "token_details": "Token details",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Updated to use the BottomSheet component, and removed unused styles

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: refactor: update token detail options bottom sheet

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2131

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="280" height="602" alt="tradedetail-viewactionmenu-bs" src="https://github.com/user-attachments/assets/ee9755ac-846b-4d5f-a555-42780e9b158c" />


### **After**

<!-- [screenshots/recordings] -->

<img width="961" height="1028" alt="Screenshot 2025-12-16 at 12 32 19" src="https://github.com/user-attachments/assets/bb748db7-397f-43d5-9cb3-0ec446b35e8c" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the AssetOptions modal with the new BottomSheet and design-system Text/Icon, simplifying styles and adding an i18n header title.
> 
> - **UI**:
>   - Replace `ReusableModal` with `BottomSheet`/`BottomSheetHeader` in `AssetOptions.tsx`; switch `dismissModal` calls to `onCloseBottomSheet`.
>   - Use `@metamask/design-system-react-native` `Text`/`Icon`; streamline option row rendering and layout.
>   - Simplify styles in `AssetOptions.styles.ts` (remove theme deps; set `padding: 12`, `gap: 16`).
> - **Tests**:
>   - Update mocks (e.g., add `useSafeAreaFrame`) to support new bottom sheet rendering.
> - **i18n**:
>   - Add `asset_details.options.title` (“Token options”) for the bottom sheet header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5817061f358f46b53f3fb850e098ba198428697. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->