### PR TITLE
ci: Revert "chore(infra): optimize Android E2E build for lg runner (16 vCPUs, 48GB)"

### DIFF
--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -9,6 +9,9 @@ on:
       apk-uploaded:
         description: 'Whether the APK was successfully uploaded'
         value: ${{ jobs.build-android-apks.outputs.apk-uploaded }}
+      aab-uploaded:
+        description: 'Whether the AAB was successfully uploaded'
+        value: ${{ jobs.build-android-apks.outputs.aab-uploaded }}
     inputs:
       build_type:
         description: 'The type of build to perform'
@@ -29,15 +32,17 @@ on:
 jobs:
   build-android-apks:
     name: Build Android E2E APKs
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg # lg runner: 16 vCPUs, 48GB RAM
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-xl # Bumped from lg to xl to prevent Daemon disappearance issue (Daemon OOM issue in CI)
     timeout-minutes: 40
     env:
       GRADLE_USER_HOME: /home/admin/_work/.gradle
       CACHE_GENERATION: v1 # Increment this to bust the cache (v1, v2, v3, etc.)
     outputs:
       apk-uploaded: ${{ steps.upload-apk.outcome == 'success' }}
+      aab-uploaded: ${{ steps.upload-aab.outcome == 'success' }}
       apk-target-path: ${{ steps.determine-target-paths.outputs.apk-target-path }}
       test-apk-target-path: ${{ steps.determine-target-paths.outputs.test-apk-target-path }}
+      aab-target-path: ${{ steps.determine-target-paths.outputs.aab-target-path }}
       artifact_name: ${{ steps.determine-target-paths.outputs.artifact_name }}
 
     steps:
@@ -83,12 +88,14 @@ jobs:
             {
               echo "apk-target-path=android/app/build/outputs/apk/flask/release"
               echo "test-apk-target-path=android/app/build/outputs/apk/androidTest/flask/release"
+              echo "aab-target-path=android/app/build/outputs/bundle/flaskRelease"
               echo "artifact_name=app-flask-release"
             } >> "$GITHUB_OUTPUT"
           elif [[ "${{ inputs.build_type }}" == "main" ]]; then
             {
               echo "apk-target-path=android/app/build/outputs/apk/prod/release"
               echo "test-apk-target-path=android/app/build/outputs/apk/androidTest/prod/release"
+              echo "aab-target-path=android/app/build/outputs/bundle/prodRelease"
               echo "artifact_name=app-prod-release"
             } >> "$GITHUB_OUTPUT"
           else
@@ -103,6 +110,7 @@ jobs:
           path: |
             ${{ steps.determine-target-paths.outputs.apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.apk
             ${{ steps.determine-target-paths.outputs.test-apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}-androidTest.apk
+            ${{ steps.determine-target-paths.outputs.aab-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.aab
           # Include Gradle properties in key to force rebuild when properties change
           # Keep the `hashFiles` call for Gradle config in-sync with these steps:
           # - "Cache Gradle dependencies"
@@ -233,6 +241,7 @@ jobs:
           path: |
             ${{ steps.determine-target-paths.outputs.apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.apk
             ${{ steps.determine-target-paths.outputs.test-apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}-androidTest.apk
+            ${{ steps.determine-target-paths.outputs.aab-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.aab
           # Keep the `hashFiles` call for Gradle config in-sync with these steps:
           # - "Check and restore cached APKs if Fingerprint is found"
           # - "Cache Gradle dependencies"
@@ -255,3 +264,13 @@ jobs:
           path: ${{ steps.determine-target-paths.outputs.test-apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}-androidTest.apk
           retention-days: 7
           if-no-files-found: error
+
+      - name: Upload Android AAB
+        id: upload-aab
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.aab
+          path: ${{ steps.determine-target-paths.outputs.aab-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.aab
+          retention-days: 7
+          if-no-files-found: warn
+        continue-on-error: true

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -56,6 +56,7 @@ jobs:
     outputs:
       apk-target-path: ${{ steps.determine-target-paths.outputs.apk-target-path }}
       test-apk-target-path: ${{ steps.determine-target-paths.outputs.test-apk-target-path }}
+      aab-target-path: ${{ steps.determine-target-paths.outputs.aab-target-path }}
 
     env:
       PREBUILT_IOS_APP_PATH: artifacts/MetaMask.app
@@ -130,12 +131,14 @@ jobs:
             {
               echo "apk-target-path=android/app/build/outputs/apk/flask/release"
               echo "test-apk-target-path=android/app/build/outputs/apk/androidTest/flask/release"
+              echo "aab-target-path=android/app/build/outputs/bundle/flaskRelease"
               echo "artifact_name=app-flask-release"
             } >> "$GITHUB_OUTPUT"
           elif [[ "${{ inputs.build_type }}" == "main" ]]; then
             {
               echo "apk-target-path=android/app/build/outputs/apk/prod/release"
               echo "test-apk-target-path=android/app/build/outputs/apk/androidTest/prod/release"
+              echo "aab-target-path=android/app/build/outputs/bundle/prodRelease"
               echo "artifact_name=app-prod-release"
             } >> "$GITHUB_OUTPUT"
           else
@@ -149,6 +152,7 @@ jobs:
           echo "🏗 Setting up Android artifacts from build job..."
           mkdir -p ${{ steps.determine-target-paths.outputs.apk-target-path }}
           mkdir -p ${{ steps.determine-target-paths.outputs.test-apk-target-path }}
+          mkdir -p ${{ steps.determine-target-paths.outputs.aab-target-path }}
 
       - name: Download Android build artifacts
         if: ${{ inputs.platform == 'android' }}

--- a/android/gradle.properties.github
+++ b/android/gradle.properties.github
@@ -1,16 +1,16 @@
 # GitHub Actions-specific Gradle settings
 # Optimized for E2E builds on GitHub Actions runners
 
-# JVM configuration - tuned for 48GB runner to avoid OOM while maintaining performance
-# Heap: 12GB to leave room for Node.js/Metro and native memory
-# ExitOnOutOfMemoryError: fail-fast on OOM for CI
-org.gradle.jvmargs=-Xmx12g -Xms4g -XX:MaxMetaspaceSize=1g -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=500 -XX:+ExitOnOutOfMemoryError -Dfile.encoding=UTF-8
+# JVM configuration - balanced settings to avoid OOM while maintaining performance
+# Using 16GB heap to leave room for parallel workers and native memory
+org.gradle.jvmargs=-Xmx16g -XX:MaxMetaspaceSize=1g -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:+UseStringDeduplication -XX:+OptimizeStringConcat
 
 # Enable performance optimizations but limit parallelism to prevent OOM
 org.gradle.parallel=true
+org.gradle.configureondemand=true
 org.gradle.caching=true
-org.gradle.daemon=false
-org.gradle.workers.max=2
+org.gradle.daemon=true
+org.gradle.workers.max=6
 org.gradle.vfs.watch=false
 
 # CI-specific optimizations - enabled for GitHub Actions
@@ -54,4 +54,4 @@ hermesEnabled=true
 android.disableResourceValidation=true
 
 # Use legacy packaging to compress native libraries in the resulting APK.
-expo.useLegacyPackaging=false
+expo.useLegacyPackaging=false 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -547,8 +547,6 @@ generateAndroidBinary() {
 	local reactNativeArchitecturesArg=""
 	# Define Test build type arg
 	local testBuildTypeArg=""
-	# Define Gradle debug flags
-	local gradleDebugFlags=""
 
 	# Check if configuration is valid
 	if [ "$configuration" != "Debug" ] && [ "$configuration" != "Release" ] ; then
@@ -574,19 +572,14 @@ generateAndroidBinary() {
 		if [ "$METAMASK_ENVIRONMENT" = "e2e" ] ; then
 			# Only build for x86_64 for E2E builds
 			reactNativeArchitecturesArg="-PreactNativeArchitectures=x86_64"
-			# Enable Gradle debugging flags for E2E builds to investigate Daemon disappearance issues
-			gradleDebugFlags="--stacktrace --info"
-			echo "📊 E2E build: Enabling Gradle debugging flags (--stacktrace --info)"
 		fi
 	fi
 
 	# Generate Android APKs
 	echo "Generating Android binary for ($flavor) flavor with ($configuration) configuration"
-	./gradlew $assembleApkTask $assembleTestApkTask $testBuildTypeArg $reactNativeArchitecturesArg $gradleDebugFlags
+	./gradlew $assembleApkTask $assembleTestApkTask $testBuildTypeArg $reactNativeArchitecturesArg
 
-	# Skip AAB bundle for E2E environments - AAB cannot be installed on emulators
-	# and is only needed for Play Store distribution
-	if [ "$configuration" = "Release" ] && [ "$METAMASK_ENVIRONMENT" != "e2e" ] ; then		
+	if [ "$configuration" = "Release" ] ; then		
 		# Generate AAB bundle (not needed for E2E)
 		bundleConfiguration="bundle${flavor}Release"
 		echo "Generating AAB bundle for ($flavor) flavor with ($configuration) configuration"


### PR DESCRIPTION
Reverts MetaMask/metamask-mobile#23869, which was found to be causing build failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generates and uploads Android AABs in E2E builds, bumps the build runner to XL, and adjusts Gradle settings while cleaning up build flags.
> 
> - **CI/Workflows**
>   - **`build-android-e2e.yml`**:
>     - Add AAB support: new outputs (`aab-uploaded`), paths (`aab-target-path`), cache entries, and artifact upload step.
>     - Bump runner to `24.04-xl`.
>     - Extend outputs to include AAB paths and upload outcome.
>   - **`run-e2e-workflow.yml`**:
>     - Propagate `aab-target-path` and create target dir for Android artifacts.
> - **Build Script** (`scripts/build.sh`):
>   - Always generate AAB on Release builds (including E2E); remove Gradle debug flags.
> - **Gradle Config** (`android/gradle.properties.github`):
>   - Increase heap to 16g, enable daemon, `configureondemand`, and set `workers.max=6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd23401333b0cd842ac756e4734cc9aef06816dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->