### PR TITLE
chore: extract revealprivatecredential

### DIFF
--- a/app/components/Views/ResetPassword/index.test.tsx
+++ b/app/components/Views/ResetPassword/index.test.tsx
@@ -69,7 +69,6 @@ jest.mock('../../../core/Authentication', () => ({
     currentAuthType: 'passcode',
     availableBiometryType: null,
   }),
-  getPassword: jest.fn().mockResolvedValue(null),
   resetPassword: jest.fn().mockResolvedValue(undefined),
   storePassword: jest.fn().mockResolvedValue(undefined),
   storePasswordWithFallback: jest.fn().mockResolvedValue(undefined),

--- a/app/components/Views/ResetPassword/index.test.tsx
+++ b/app/components/Views/ResetPassword/index.test.tsx
@@ -69,6 +69,7 @@ jest.mock('../../../core/Authentication', () => ({
     currentAuthType: 'passcode',
     availableBiometryType: null,
   }),
+  getPassword: jest.fn().mockResolvedValue(null),
   resetPassword: jest.fn().mockResolvedValue(undefined),
   storePassword: jest.fn().mockResolvedValue(undefined),
   storePasswordWithFallback: jest.fn().mockResolvedValue(undefined),

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -9,7 +9,6 @@ import {
   View,
 } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
-import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import QRCode from 'react-native-qrcode-svg';
 import { RouteProp, ParamListBase } from '@react-navigation/native';
@@ -18,7 +17,6 @@ import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const CustomTabView = ScrollView as any;
 import { store } from '../../../store';
-import StorageWrapper from '../../../store/storage-wrapper';
 import ActionView from '../../UI/ActionView';
 import ButtonReveal from '../../UI/ButtonReveal';
 import Button, {
@@ -41,12 +39,9 @@ import {
 } from '../../../constants/urls';
 import ClipboardManager from '../../../core/ClipboardManager';
 import { useTheme } from '../../../util/theme';
-import Engine from '../../../core/Engine';
-import { BIOMETRY_CHOICE } from '../../../constants/storage';
 import { MetaMetricsEvents } from '../../../core/Analytics';
-import { uint8ArrayToMnemonic } from '../../../util/mnemonic';
 import { passwordRequirementsMet } from '../../../util/password';
-import { Authentication } from '../../../core/';
+import useAuthentication from '../../../core/Authentication/hooks/useAuthentication';
 
 import { isTest } from '../../../util/test/utils';
 import Device from '../../../util/device';
@@ -122,16 +117,13 @@ const RevealPrivateCredential = ({
   const [clipboardEnabled, setClipboardEnabled] = useState<boolean>(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
   const passwordInputRef = useRef<TextInput>(null);
+  const { reauthenticate, revealSRP, revealPrivateKey } = useAuthentication();
 
   const keyringId = route?.params?.keyringId;
 
   const checkSummedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
   );
-
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const passwordSet = useSelector((state: any) => state.user.passwordSet);
 
   const dispatch = useDispatch();
 
@@ -164,13 +156,11 @@ const RevealPrivateCredential = ({
     );
   };
 
-  const tryUnlockWithPassword = useCallback(
-    async (pswd: string, privCredentialName?: string) => {
-      // TODO: Replace "any" with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { KeyringController } = Engine.context as any;
+  const revealCredential = useCallback(
+    async (pswd?: string) => {
+      setIsModalVisible(false);
+      const privCredentialName = credentialName || route?.params.credentialName;
       const isPrivateKeyReveal = privCredentialName === PRIVATE_KEY;
-
       // This will trigger after the user hold-pressed the button, we want to trace the actual
       // keyring operation of extracting the credential
       const traceName = isPrivateKeyReveal
@@ -183,17 +173,24 @@ const RevealPrivateCredential = ({
       });
 
       try {
+        let passwordToUse = pswd;
+
+        if (!passwordToUse) {
+          const { password: verifiedPassword } = await reauthenticate();
+
+          if (!verifiedPassword) {
+            // Let user stay in the “enter password” flow; nothing to catch.
+            return;
+          }
+          passwordToUse = verifiedPassword;
+        }
         let privateCredential;
         if (!isPrivateKeyReveal) {
-          const uint8ArraySeed = await KeyringController.exportSeedPhrase(
-            pswd,
-            keyringId,
-          );
-          privateCredential = uint8ArrayToMnemonic(uint8ArraySeed, wordlist);
+          privateCredential = await revealSRP(passwordToUse, keyringId);
         } else {
-          privateCredential = await KeyringController.exportAccount(
-            pswd,
-            selectedAddress,
+          privateCredential = await revealPrivateKey(
+            passwordToUse,
+            selectedAddress as string,
           );
         }
 
@@ -223,7 +220,15 @@ const RevealPrivateCredential = ({
         setWarningIncorrectPassword(msg);
       }
     },
-    [selectedAddress, keyringId],
+    [
+      selectedAddress,
+      keyringId,
+      credentialName,
+      route?.params.credentialName,
+      reauthenticate,
+      revealSRP,
+      revealPrivateKey,
+    ],
   );
 
   useEffect(() => {
@@ -235,23 +240,7 @@ const RevealPrivateCredential = ({
       );
     }
 
-    const unlockWithBiometrics = async () => {
-      // Try to use biometrics to unlock
-      const { availableBiometryType } = await Authentication.getType();
-      if (!passwordSet) {
-        tryUnlockWithPassword('');
-      } else if (availableBiometryType) {
-        const biometryChoice = await StorageWrapper.getItem(BIOMETRY_CHOICE);
-        if (biometryChoice !== '' && biometryChoice === availableBiometryType) {
-          const credentials = await Authentication.getPassword();
-          if (credentials) {
-            tryUnlockWithPassword(credentials.password);
-          }
-        }
-      }
-    };
-
-    unlockWithBiometrics();
+    revealCredential();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -286,11 +275,8 @@ const RevealPrivateCredential = ({
   };
 
   const tryUnlock = async () => {
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { KeyringController } = Engine.context as any;
     try {
-      await KeyringController.verifyPassword(password);
+      await reauthenticate(password);
     } catch {
       const msg = strings('reveal_credential.warning_incorrect_password');
       setWarningIncorrectPassword(msg);
@@ -358,17 +344,6 @@ const RevealPrivateCredential = ({
       }),
     );
   };
-
-  const revealCredential = useCallback(() => {
-    const credential = credentialName || route?.params.credentialName;
-    tryUnlockWithPassword(password, credential);
-    setIsModalVisible(false);
-  }, [
-    credentialName,
-    password,
-    route?.params.credentialName,
-    tryUnlockWithPassword,
-  ]);
 
   const renderTabBar = () => <TabBar />;
 
@@ -572,7 +547,7 @@ const RevealPrivateCredential = ({
               })}
               variant={ButtonVariants.Primary}
               size={ButtonSize.Lg}
-              onPress={revealCredential}
+              onPress={() => revealCredential(password)}
               style={styles.revealButton}
               testID={RevealSeedViewSelectorsIDs.REVEAL_CREDENTIAL_BUTTON_ID}
             />
@@ -583,7 +558,7 @@ const RevealPrivateCredential = ({
                   ? strings('reveal_credential.private_key_text')
                   : strings('reveal_credential.srp_abbreviation_text'),
               })}
-              onLongPress={revealCredential}
+              onLongPress={() => revealCredential(password)}
             />
           )}
         </>

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -233,6 +233,10 @@ const RevealPrivateCredential = ({
     ],
   );
 
+  const revealCredentialWithPassword = () => {
+    revealCredential(password);
+  };
+
   useEffect(() => {
     updateNavBar();
     // Track SRP Reveal screen rendered
@@ -549,7 +553,7 @@ const RevealPrivateCredential = ({
               })}
               variant={ButtonVariants.Primary}
               size={ButtonSize.Lg}
-              onPress={() => revealCredential(password)}
+              onPress={revealCredentialWithPassword}
               style={styles.revealButton}
               testID={RevealSeedViewSelectorsIDs.REVEAL_CREDENTIAL_BUTTON_ID}
             />
@@ -560,7 +564,7 @@ const RevealPrivateCredential = ({
                   ? strings('reveal_credential.private_key_text')
                   : strings('reveal_credential.srp_abbreviation_text'),
               })}
-              onLongPress={() => revealCredential(password)}
+              onLongPress={revealCredentialWithPassword}
             />
           )}
         </>

--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -53,6 +53,7 @@ import Logger from '../../util/Logger';
 import Routes from '../../constants/navigation/Routes';
 import { strings } from '../../../locales/i18n';
 import { IconName } from '../../component-library/components/Icons/Icon';
+import { ReauthenticateErrorType } from './types';
 
 export type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
@@ -3718,7 +3719,7 @@ describe('Authentication', () => {
       expect(result.password).toBe('test-password');
     });
 
-    it('returns undefined password and skips verification when no biometric credentials are available', async () => {
+    it('throws PASSWORD_REQUIRED error when no biometric credentials are available', async () => {
       const verifyPasswordSpy = Engine.context.KeyringController.verifyPassword;
       const getItemSpy = jest
         .spyOn(StorageWrapper, 'getItem')
@@ -3727,12 +3728,13 @@ describe('Authentication', () => {
         .spyOn(Authentication, 'getPassword')
         .mockResolvedValueOnce(null);
 
-      const result = await Authentication.reauthenticate();
+      await expect(Authentication.reauthenticate()).rejects.toThrow(
+        ReauthenticateErrorType.BIOMETRIC_NOT_ENABLED,
+      );
 
       expect(getItemSpy).toHaveBeenCalledWith(BIOMETRY_CHOICE);
       expect(getPasswordSpy).not.toHaveBeenCalled();
       expect(verifyPasswordSpy).not.toHaveBeenCalled();
-      expect(result.password).toBeUndefined();
     });
 
     it('uses stored biometric password when no password is provided', async () => {

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -80,6 +80,7 @@ import MetaMetrics from '../Analytics/MetaMetrics';
 import { resetProviderToken as depositResetProviderToken } from '../../components/UI/Ramp/Deposit/utils/ProviderTokenVault';
 import { strings } from '../../../locales/i18n';
 import { IconName } from '../../component-library/components/Icons/Icon';
+import { ReauthenticateErrorType } from './types';
 
 /**
  * Holds auth data used to determine auth configuration
@@ -1425,12 +1426,10 @@ class AuthenticationService {
    *
    * @param password - Optional password to verify. When omitted, the method
    * attempts to use the stored biometric/remember-me password instead.
-   * @returns The verified password string, or `undefined` if verification fails before
-   * a password can be determined.
+   * @returns The verified password string. Throws an error if verification fails
+   * before a password can be determined.
    */
-  reauthenticate = async (
-    password?: string,
-  ): Promise<{ password: string | undefined }> => {
+  reauthenticate = async (password?: string): Promise<{ password: string }> => {
     let passwordToVerify = password || '';
     const { KeyringController } = Engine.context;
 
@@ -1445,9 +1444,12 @@ class AuthenticationService {
       }
 
       // If there is no biometric choice configured or no stored credentials,
-      // return gracefully instead of attempting to verify an empty password.
+      // throw a specific error instead of attempting to verify an empty password.
       if (!passwordToVerify) {
-        return { password: undefined };
+        const biometricNotEnabledErrorMessage = 'Biometric is not enabled';
+        throw new Error(
+          `${ReauthenticateErrorType.BIOMETRIC_NOT_ENABLED}: ${biometricNotEnabledErrorMessage}`,
+        );
       }
     }
 

--- a/app/core/Authentication/hooks/useAuthentication.ts
+++ b/app/core/Authentication/hooks/useAuthentication.ts
@@ -4,7 +4,7 @@ import { Authentication } from '../Authentication';
  * Hook that interfaces with the Authentication service.
  */
 export default () => ({
-    reauthenticate: Authentication.reauthenticate,
-    revealSRP: Authentication.revealSRP,
-    revealPrivateKey: Authentication.revealPrivateKey,
-  });
+  reauthenticate: Authentication.reauthenticate,
+  revealSRP: Authentication.revealSRP,
+  revealPrivateKey: Authentication.revealPrivateKey,
+});

--- a/app/core/Authentication/hooks/useAuthentication.ts
+++ b/app/core/Authentication/hooks/useAuthentication.ts
@@ -1,0 +1,10 @@
+import { Authentication } from '../Authentication';
+
+/**
+ * Hook that interfaces with the Authentication service.
+ */
+export default () => ({
+    reauthenticate: Authentication.reauthenticate,
+    revealSRP: Authentication.revealSRP,
+    revealPrivateKey: Authentication.revealPrivateKey,
+  });

--- a/app/core/Authentication/types.ts
+++ b/app/core/Authentication/types.ts
@@ -1,0 +1,3 @@
+export enum ReauthenticateErrorType {
+  BIOMETRIC_NOT_ENABLED = 'BIOMETRIC_NOT_ENABLED',
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Extract authentication logic in RevealPrivateCredential 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves SRP/private key reveal and reauth logic from `RevealPrivateCredential` into `Authentication` with a new hook, biometric-aware reauth, and tests.
> 
> - **Core Authentication**:
>   - Add `reauthenticate(password?)` with biometric/remember-me support and `ReauthenticateErrorType.BIOMETRIC_NOT_ENABLED`.
>   - Introduce `revealSRP(password, keyringId?)` and `revealPrivateKey(password, address)` helpers.
>   - New hook `core/Authentication/hooks/useAuthentication` exposing these APIs.
>   - Tests covering `reauthenticate`, `revealSRP`, and `revealPrivateKey`.
> - **UI (`RevealPrivateCredential`)**:
>   - Replace direct engine/mnemonic calls with `useAuthentication` (`reauthenticate`, `revealSRP`, `revealPrivateKey`).
>   - Authenticate first, then trace and reveal; auto-trigger reveal on mount.
>   - Handle `BIOMETRIC_NOT_ENABLED` without surfacing an error; update button handlers.
>   - Remove legacy biometric unlock path and related imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6608cf3e6131d4593607e0eb39f30aa871c1e98b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->