### PR TITLE
ci: run only low end device when perf e2e job runs on PRs

### DIFF
--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -15,6 +15,10 @@ on:
         required: false
         type: string
         description: 'BrowserStack Android Imported Wallet App URL (bs://...)'
+      branch_name:
+        required: false
+        type: string
+        description: 'Branch name to use for Bitrise builds (defaults to github.ref_name)'
     outputs:
       with-srp-browserstack-url:
         description: 'BrowserStack URL for with-SRP version'
@@ -88,11 +92,14 @@ jobs:
         id: trigger-build
         if: needs.check-builds-needed.outputs.builds-needed == 'true'
         run: |
+          # Use branch_name input if provided, otherwise fall back to github.ref_name
+          BRANCH_NAME="${{ inputs.branch_name || github.ref_name }}"
+
           echo "Triggering Android with-SRP build on Bitrise..."
           echo "Workflow: $METAMASK_WORKFLOW"
           echo "BITRISE_APP_ID: $BITRISE_APP_ID"
-          echo "Current branch: ${{ github.ref_name }}"
-          
+          echo "Branch: $BRANCH_NAME"
+
           # Validate required environment variables
           if [[ -z "$BITRISE_APP_ID" ]]; then
             echo "Error: BITRISE_APP_ID is not set"
@@ -106,7 +113,7 @@ jobs:
             echo "Error: BITRISE_API_TOKEN is not set"
             exit 1
           fi
-          
+
           # Set environment variables for with-SRP build
           ENV_VARS='[
             {
@@ -115,7 +122,7 @@ jobs:
               "is_expand": true
             },
             {
-              "mapped_to": "PREDEFINED_PASSWORD", 
+              "mapped_to": "PREDEFINED_PASSWORD",
               "value": "'"${{ secrets.E2E_PASSWORD }}"'",
               "is_expand": true
             },
@@ -126,14 +133,14 @@ jobs:
             }
           ]'
           CUSTOM_ID="MetaMask-Android-With-SRP-${{ github.run_id }}"
-          
+
           # Trigger Android workflow
           BUILD_RESPONSE=$(curl -s -X POST \
             "https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json" \
             -H "Content-Type: application/json" \
             -d '{
               "build_params": {
-                "branch": "${{ github.ref_name }}",
+                "branch": "'"$BRANCH_NAME"'",
                 "workflow_id": "${{ env.METAMASK_WORKFLOW }}",
                 "commit_message": "Triggered by Android Dual Versions workflow - Build with Predefined-SRP",
                 "environments": '"$ENV_VARS"',
@@ -224,11 +231,14 @@ jobs:
         id: trigger-build
         if: needs.check-builds-needed.outputs.builds-needed == 'true'
         run: |
+          # Use branch_name input if provided, otherwise fall back to github.ref_name
+          BRANCH_NAME="${{ inputs.branch_name || github.ref_name }}"
+
           echo "Triggering Android without-SRP build on Bitrise..."
           echo "Workflow: $METAMASK_WORKFLOW"
           echo "BITRISE_APP_ID: $BITRISE_APP_ID"
-          echo "Current branch: ${{ github.ref_name }}"
-          
+          echo "Branch: $BRANCH_NAME"
+
           # Validate required environment variables
           if [[ -z "$BITRISE_APP_ID" ]]; then
             echo "Error: BITRISE_APP_ID is not set"
@@ -242,24 +252,24 @@ jobs:
             echo "Error: BITRISE_API_TOKEN is not set"
             exit 1
           fi
-          
+
           # Set environment variables for without-SRP build
           ENV_VARS='[
             {
               "mapped_to": "DISABLE_NOTIFICATION_PROMPT",
-              "value": "true", 
+              "value": "true",
               "is_expand": true
             }
           ]'
           CUSTOM_ID="MetaMask-Android-Without-SRP-${{ github.run_id }}"
-          
+
           # Trigger Android workflow
           BUILD_RESPONSE=$(curl -s -X POST \
             "https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json" \
             -H "Content-Type: application/json" \
             -d '{
               "build_params": {
-                "branch": "${{ github.ref_name }}",
+                "branch": "'"$BRANCH_NAME"'",
                 "workflow_id": "${{ env.METAMASK_WORKFLOW }}",
                 "commit_message": "Triggered by Android Dual Versions workflow - Build without Predefined-SRP",
                 "environments": '"$ENV_VARS"',

--- a/.github/workflows/build-ios-upload-to-browserstack.yml
+++ b/.github/workflows/build-ios-upload-to-browserstack.yml
@@ -15,6 +15,10 @@ on:
         required: false
         type: string
         description: 'BrowserStack iOS Imported Wallet App URL (bs://...)'
+      branch_name:
+        required: false
+        type: string
+        description: 'Branch name to use for Bitrise builds (defaults to github.ref_name)'
     outputs:
       with-srp-ipa-uploaded:
         description: 'Whether the with-SRP IPA was successfully uploaded'
@@ -89,11 +93,14 @@ jobs:
         id: trigger-build
         if: needs.check-builds-needed.outputs.builds-needed == 'true'
         run: |
+          # Use branch_name input if provided, otherwise fall back to github.ref_name
+          BRANCH_NAME="${{ inputs.branch_name || github.ref_name }}"
+
           echo "Triggering iOS with-SRP build on Bitrise..."
           echo "Workflow: $METAMASK_WORKFLOW"
           echo "BITRISE_APP_ID: $BITRISE_APP_ID"
-          echo "Current branch: ${{ github.ref_name }}"
-          
+          echo "Branch: $BRANCH_NAME"
+
           # Validate required environment variables
           if [[ -z "$BITRISE_APP_ID" ]]; then
             echo "Error: BITRISE_APP_ID is not set"
@@ -107,7 +114,7 @@ jobs:
             echo "Error: BITRISE_API_TOKEN is not set"
             exit 1
           fi
-          
+
           # Set environment variables for with-SRP build
           ENV_VARS='[
             {
@@ -116,7 +123,7 @@ jobs:
               "is_expand": true
             },
             {
-              "mapped_to": "PREDEFINED_PASSWORD", 
+              "mapped_to": "PREDEFINED_PASSWORD",
               "value": "'"${{ secrets.E2E_PASSWORD }}"'",
               "is_expand": true
             },
@@ -127,14 +134,14 @@ jobs:
             }
           ]'
           CUSTOM_ID="MetaMask-iOS-With-SRP-${{ github.run_id }}"
-          
+
           # Trigger iOS workflow
           BUILD_RESPONSE=$(curl -s -X POST \
             "https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json" \
             -H "Content-Type: application/json" \
             -d '{
               "build_params": {
-                "branch": "${{ github.ref_name }}",
+                "branch": "'"$BRANCH_NAME"'",
                 "workflow_id": "${{ env.METAMASK_WORKFLOW }}",
                 "commit_message": "Triggered by iOS Dual Versions workflow - Build with Predefined-SRP",
                 "environments": '"$ENV_VARS"',
@@ -225,11 +232,14 @@ jobs:
         id: trigger-build
         if: needs.check-builds-needed.outputs.builds-needed == 'true'
         run: |
+          # Use branch_name input if provided, otherwise fall back to github.ref_name
+          BRANCH_NAME="${{ inputs.branch_name || github.ref_name }}"
+
           echo "Triggering iOS without-SRP build on Bitrise..."
           echo "Workflow: $METAMASK_WORKFLOW"
           echo "BITRISE_APP_ID: $BITRISE_APP_ID"
-          echo "Current branch: ${{ github.ref_name }}"
-          
+          echo "Branch: $BRANCH_NAME"
+
           # Validate required environment variables
           if [[ -z "$BITRISE_APP_ID" ]]; then
             echo "Error: BITRISE_APP_ID is not set"
@@ -243,24 +253,24 @@ jobs:
             echo "Error: BITRISE_API_TOKEN is not set"
             exit 1
           fi
-          
+
           # Set environment variables for without-SRP build
           ENV_VARS='[
             {
               "mapped_to": "DISABLE_NOTIFICATION_PROMPT",
-              "value": "true", 
+              "value": "true",
               "is_expand": true
             }
           ]'
           CUSTOM_ID="MetaMask-iOS-Without-SRP-${{ github.run_id }}"
-          
+
           # Trigger iOS workflow
           BUILD_RESPONSE=$(curl -s -X POST \
             "https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json" \
             -H "Content-Type: application/json" \
             -d '{
               "build_params": {
-                "branch": "${{ github.ref_name }}",
+                "branch": "'"$BRANCH_NAME"'",
                 "workflow_id": "${{ env.METAMASK_WORKFLOW }}",
                 "commit_message": "Triggered by iOS Dual Versions workflow - Build without Predefined-SRP",
                 "environments": '"$ENV_VARS"',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,12 +362,14 @@ jobs:
   run-performance-e2e-tests:
     name: 'Performance E2E Tests'
     # TODO: Change to main only after testing: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
     permissions:
       contents: read
       id-token: write
     needs: [needs_e2e_build]
     uses: ./.github/workflows/run-performance-e2e.yml
+    with:
+      branch_name: ${{ github.head_ref || github.ref_name }}
     secrets: inherit
 
   js-bundle-size-check:

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -343,12 +343,12 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Send Slack Notification
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
-        with:
-          webhook: ${{ secrets.PERFORMANCE_E2E_SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "${{ steps.summary.outputs.summary }}"
-            }
+      # - name: Send Slack Notification
+      #   uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+      #   with:
+      #     webhook: ${{ secrets.PERFORMANCE_E2E_SLACK_WEBHOOK_URL }}
+      #     webhook-type: incoming-webhook
+      #     payload: |
+      #       {
+      #         "text": "${{ steps.summary.outputs.summary }}"
+      #       }

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -5,6 +5,8 @@ name: Build Apps and Run Performance E2E Tests
 on:
   schedule:
     - cron: '0 */3 * * 1-6'
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       description:
@@ -77,33 +79,73 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Read device matrix
+      - name: Determine Matrix Mode
+        id: matrix-mode
+        run: |
+          EVENT_NAME="${{ github.event_name }}"
+          
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            MATRIX_MODE="full"
+            MODE_DESC="Full (all devices) - Scheduled run"
+          else
+            MATRIX_MODE="pr"
+            MODE_DESC="Single device - $EVENT_NAME event"
+          fi
+          
+          echo "matrix_mode=$MATRIX_MODE" >> "$GITHUB_OUTPUT"
+          echo "Event: $EVENT_NAME → Matrix mode: $MODE_DESC"
+
+      - name: Select Devices
         id: read-matrix
         run: |
-          echo "Reading device matrix from appwright/device-matrix.json"
-          # Extract Android devices
-          ANDROID_MATRIX=$(jq -r ".android_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson" appwright/device-matrix.json)
-          # Extract iOS devices
-          IOS_MATRIX=$(jq -r ".ios_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson" appwright/device-matrix.json)
-
+          MATRIX_MODE="${{ steps.matrix-mode.outputs.matrix_mode }}"
+          MATRIX_FILE="appwright/device-matrix.json"
+          
+          select_device() {
+            local platform=$1
+            local devices=$(jq ".${platform}_devices" "$MATRIX_FILE")
+            
+            local low=$(echo "$devices" | jq 'map(select(.category == "low")) | .[0] // empty')
+            local medium=$(echo "$devices" | jq 'map(select(.category == "medium")) | .[0] // empty')
+            local first=$(echo "$devices" | jq '.[0] // empty')
+            
+            if [ -n "$low" ] && [ "$low" != "null" ] && [ "$low" != "" ]; then
+              echo "$low"
+            elif [ -n "$medium" ] && [ "$medium" != "null" ] && [ "$medium" != "" ]; then
+              echo "$medium"
+            else
+              echo "$first"
+            fi
+          }
+          
+          if [ "$MATRIX_MODE" = "pr" ]; then
+            ANDROID_DEVICE=$(select_device "android")
+            IOS_DEVICE=$(select_device "ios")
+            
+            ANDROID_MATRIX=$(echo "$ANDROID_DEVICE" | jq -s '.')
+            IOS_MATRIX=$(echo "$IOS_DEVICE" | jq -s '.')
+            
+            echo "Selected Android: $(echo "$ANDROID_DEVICE" | jq -r '.name // "none"')"
+            echo "Selected iOS: $(echo "$IOS_DEVICE" | jq -r '.name // "none"')"
+          else
+            ANDROID_MATRIX=$(jq -r ".android_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson" "$MATRIX_FILE")
+            IOS_MATRIX=$(jq -r ".ios_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson" "$MATRIX_FILE")
+          fi
+          
+          ANDROID_COUNT=$(echo "$ANDROID_MATRIX" | jq 'length')
+          IOS_COUNT=$(echo "$IOS_MATRIX" | jq 'length')
+          
+          if [ "$ANDROID_COUNT" -eq 0 ] && [ "$IOS_COUNT" -eq 0 ]; then
+            echo "Error: No devices found"
+            exit 1
+          fi
+          
           {
             echo "android_matrix=$ANDROID_MATRIX"
             echo "ios_matrix=$IOS_MATRIX"
           } >> "$GITHUB_OUTPUT"
-
-          echo "Android matrix: $ANDROID_MATRIX"
-          echo "iOS matrix: $IOS_MATRIX"
-
-          # Validate that we have devices
-          ANDROID_COUNT=$(echo "$ANDROID_MATRIX" | jq 'length')
-          IOS_COUNT=$(echo "$IOS_MATRIX" | jq 'length')
-
-          echo "Found $ANDROID_COUNT Android devices and $IOS_COUNT iOS devices"
-
-          if [ "$ANDROID_COUNT" -eq 0 ] && [ "$IOS_COUNT" -eq 0 ]; then
-            echo "Error: No devices found in device-matrix.json"
-            exit 1
-          fi
+          
+          echo "Device matrix: $ANDROID_COUNT Android, $IOS_COUNT iOS"
 
   set-build-names:
     name: Set Unified BrowserStack Build Names

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -140,9 +140,14 @@ jobs:
             exit 1
           fi
           
+          # Write outputs using multiline format to handle JSON arrays properly
           {
-            echo "android_matrix=$ANDROID_MATRIX"
-            echo "ios_matrix=$IOS_MATRIX"
+            echo "android_matrix<<EOF"
+            echo "$ANDROID_MATRIX"
+            echo "EOF"
+            echo "ios_matrix<<EOF"
+            echo "$IOS_MATRIX"
+            echo "EOF"
           } >> "$GITHUB_OUTPUT"
           
           echo "Device matrix: $ANDROID_COUNT Android, $IOS_COUNT iOS"

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -61,6 +61,11 @@ on:
 permissions:
   contents: read
   id-token: write
+  actions: write
+
+concurrency:
+  group: performance-e2e-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 env:
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -120,27 +120,26 @@ jobs:
     steps:
       - name: Get correct branch name
         id: get-branch
+        env:
+          INPUT_BRANCH: ${{ inputs.branch_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           # Priority: explicit input > PR head_ref > ref_name
-          # When called from ci.yml on PRs, branch_name input will be provided
-          # When triggered directly, use head_ref for PRs or ref_name for others
-          INPUT_BRANCH="${{ inputs.branch_name }}"
-          EVENT_NAME="${{ github.event_name }}"
-          HEAD_REF="${{ github.head_ref }}"
-          
           if [ -n "$INPUT_BRANCH" ]; then
             BRANCH_NAME="$INPUT_BRANCH"
-            echo "Using explicit branch name from input: $BRANCH_NAME"
-          elif [ "$EVENT_NAME" = "pull_request" ] || [ -n "$HEAD_REF" ]; then
+            echo "Using explicit input: $BRANCH_NAME"
+          elif [ "$EVENT_NAME" = "pull_request" ] && [ -n "$HEAD_REF" ]; then
             BRANCH_NAME="$HEAD_REF"
-            echo "PR context detected - using source branch: $BRANCH_NAME"
+            echo "Using PR source branch: $BRANCH_NAME"
           else
-            BRANCH_NAME="${{ github.ref_name }}"
+            BRANCH_NAME="$REF_NAME"
             echo "Using ref_name: $BRANCH_NAME"
           fi
 
           echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
-          echo "Branch name for Bitrise: $BRANCH_NAME"
+          echo "Branch for Bitrise: $BRANCH_NAME"
 
   set-build-names:
     name: Set Unified BrowserStack Build Names
@@ -341,12 +340,12 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      # - name: Send Slack Notification
-      #   uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
-      #   with:
-      #     webhook: ${{ secrets.PERFORMANCE_E2E_SLACK_WEBHOOK_URL }}
-      #     webhook-type: incoming-webhook
-      #     payload: |
-      #       {
-      #         "text": "${{ steps.summary.outputs.summary }}"
-      #       }
+      - name: Send Slack Notification
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+        with:
+          webhook: ${{ secrets.PERFORMANCE_E2E_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ steps.summary.outputs.summary }}"
+            }

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -152,6 +152,28 @@ jobs:
           
           echo "Device matrix: $ANDROID_COUNT Android, $IOS_COUNT iOS"
 
+  determine-branch-name:
+    name: Determine Branch Name for Bitrise
+    runs-on: ubuntu-latest
+    outputs:
+      branch_name: ${{ steps.get-branch.outputs.branch_name }}
+    steps:
+      - name: Get correct branch name
+        id: get-branch
+        run: |
+          # For PRs, use the source branch (head_ref), not the merge ref
+          # For other events (schedule, workflow_dispatch), use ref_name
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BRANCH_NAME="${{ github.head_ref }}"
+            echo "PR detected - using source branch: $BRANCH_NAME"
+          else
+            BRANCH_NAME="${{ github.ref_name }}"
+            echo "Using ref_name: $BRANCH_NAME"
+          fi
+
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+          echo "Branch name for Bitrise: $BRANCH_NAME"
+
   set-build-names:
     name: Set Unified BrowserStack Build Names
     runs-on: ubuntu-latest
@@ -171,13 +193,19 @@ jobs:
   trigger-android-dual-versions:
     name: Trigger Android Dual Versions and Extract BrowserStack URLs
     uses: ./.github/workflows/build-android-upload-to-browserstack.yml
+    needs: [determine-branch-name]
     if: (!inputs.browserstack_app_url_android_onboarding && !inputs.browserstack_app_url_android_imported_wallet)
+    with:
+      branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
     secrets: inherit
 
   trigger-ios-dual-versions:
     name: Trigger iOS Dual Versions and Extract BrowserStack URLs
     uses: ./.github/workflows/build-ios-upload-to-browserstack.yml
+    needs: [determine-branch-name]
     if: (!inputs.browserstack_app_url_ios_onboarding && !inputs.browserstack_app_url_ios_imported_wallet)
+    with:
+      branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
     secrets: inherit
 
   # =============================================================================

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -53,6 +53,10 @@ on:
         description: 'BrowserStack iOS Imported Wallet App URL (bs://...)'
         required: false
         type: string
+      branch_name:
+        description: 'Branch name to use for build names (defaults to auto-detection)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -79,68 +83,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Determine Matrix Mode
-        id: matrix-mode
-        run: |
-          EVENT_NAME="${{ github.event_name }}"
-          
-          if [ "$EVENT_NAME" = "schedule" ]; then
-            MATRIX_MODE="full"
-            MODE_DESC="Full (all devices) - Scheduled run"
-          else
-            MATRIX_MODE="pr"
-            MODE_DESC="Single device - $EVENT_NAME event"
-          fi
-          
-          echo "matrix_mode=$MATRIX_MODE" >> "$GITHUB_OUTPUT"
-          echo "Event: $EVENT_NAME → Matrix mode: $MODE_DESC"
-
       - name: Select Devices
         id: read-matrix
         run: |
-          MATRIX_MODE="${{ steps.matrix-mode.outputs.matrix_mode }}"
-          MATRIX_FILE="appwright/device-matrix.json"
-          
-          select_device() {
-            local platform=$1
-            local devices=$(jq ".${platform}_devices" "$MATRIX_FILE")
-            
-            local low=$(echo "$devices" | jq 'map(select(.category == "low")) | .[0] // empty')
-            local medium=$(echo "$devices" | jq 'map(select(.category == "medium")) | .[0] // empty')
-            local first=$(echo "$devices" | jq '.[0] // empty')
-            
-            if [ -n "$low" ] && [ "$low" != "null" ] && [ "$low" != "" ]; then
-              echo "$low"
-            elif [ -n "$medium" ] && [ "$medium" != "null" ] && [ "$medium" != "" ]; then
-              echo "$medium"
-            else
-              echo "$first"
-            fi
-          }
-          
-          if [ "$MATRIX_MODE" = "pr" ]; then
-            ANDROID_DEVICE=$(select_device "android")
-            IOS_DEVICE=$(select_device "ios")
-            
-            ANDROID_MATRIX=$(echo "$ANDROID_DEVICE" | jq -s '.')
-            IOS_MATRIX=$(echo "$IOS_DEVICE" | jq -s '.')
-            
-            echo "Selected Android: $(echo "$ANDROID_DEVICE" | jq -r '.name // "none"')"
-            echo "Selected iOS: $(echo "$IOS_DEVICE" | jq -r '.name // "none"')"
+          FILE="appwright/device-matrix.json"
+
+          # PR: Use first low/medium device (fallback to first)
+          # Other: Use all devices
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            FILTER='[first(.[] | select(.category == "low" or .category == "medium")) // .[0]]'
+            echo "PR mode: 1 device per platform"
           else
-            ANDROID_MATRIX=$(jq -r ".android_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson" "$MATRIX_FILE")
-            IOS_MATRIX=$(jq -r ".ios_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson" "$MATRIX_FILE")
+            FILTER='.'
+            echo "Full mode: All devices"
           fi
-          
-          ANDROID_COUNT=$(echo "$ANDROID_MATRIX" | jq 'length')
-          IOS_COUNT=$(echo "$IOS_MATRIX" | jq 'length')
-          
-          if [ "$ANDROID_COUNT" -eq 0 ] && [ "$IOS_COUNT" -eq 0 ]; then
-            echo "Error: No devices found"
-            exit 1
-          fi
-          
-          # Write outputs using multiline format to handle JSON arrays properly
+
+          ANDROID_MATRIX=$(jq ".android_devices | $FILTER" "$FILE")
+          IOS_MATRIX=$(jq ".ios_devices | $FILTER" "$FILE")
+
           {
             echo "android_matrix<<EOF"
             echo "$ANDROID_MATRIX"
@@ -149,8 +109,8 @@ jobs:
             echo "$IOS_MATRIX"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
-          
-          echo "Device matrix: $ANDROID_COUNT Android, $IOS_COUNT iOS"
+
+          echo "Selected: $(echo "$ANDROID_MATRIX" | jq length) Android, $(echo "$IOS_MATRIX" | jq length) iOS"
 
   determine-branch-name:
     name: Determine Branch Name for Bitrise
@@ -161,11 +121,19 @@ jobs:
       - name: Get correct branch name
         id: get-branch
         run: |
-          # For PRs, use the source branch (head_ref), not the merge ref
-          # For other events (schedule, workflow_dispatch), use ref_name
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BRANCH_NAME="${{ github.head_ref }}"
-            echo "PR detected - using source branch: $BRANCH_NAME"
+          # Priority: explicit input > PR head_ref > ref_name
+          # When called from ci.yml on PRs, branch_name input will be provided
+          # When triggered directly, use head_ref for PRs or ref_name for others
+          INPUT_BRANCH="${{ inputs.branch_name }}"
+          EVENT_NAME="${{ github.event_name }}"
+          HEAD_REF="${{ github.head_ref }}"
+          
+          if [ -n "$INPUT_BRANCH" ]; then
+            BRANCH_NAME="$INPUT_BRANCH"
+            echo "Using explicit branch name from input: $BRANCH_NAME"
+          elif [ "$EVENT_NAME" = "pull_request" ] || [ -n "$HEAD_REF" ]; then
+            BRANCH_NAME="$HEAD_REF"
+            echo "PR context detected - using source branch: $BRANCH_NAME"
           else
             BRANCH_NAME="${{ github.ref_name }}"
             echo "Using ref_name: $BRANCH_NAME"
@@ -177,6 +145,7 @@ jobs:
   set-build-names:
     name: Set Unified BrowserStack Build Names
     runs-on: ubuntu-latest
+    needs: [determine-branch-name]
     outputs:
       android_build_name: ${{ steps.set-builds.outputs.android_build_name }}
       ios_build_name: ${{ steps.set-builds.outputs.ios_build_name }}
@@ -184,11 +153,12 @@ jobs:
       - name: Set unified build names
         id: set-builds
         run: |
-          echo "android_build_name=Android-Performance-${{ github.ref_name }}-Branch" >> "$GITHUB_OUTPUT"
-          echo "ios_build_name=iOS-Performance-${{ github.ref_name }}-Branch" >> "$GITHUB_OUTPUT"
+          BRANCH_NAME="${{ needs.determine-branch-name.outputs.branch_name }}"
+          echo "android_build_name=Android-Performance-$BRANCH_NAME-Branch" >> "$GITHUB_OUTPUT"
+          echo "ios_build_name=iOS-Performance-$BRANCH_NAME-Branch" >> "$GITHUB_OUTPUT"
           echo "Set unified build names:"
-          echo "  Android: Android-Performance-${{ github.ref_name }}-Branch"
-          echo "  iOS: iOS-Performance-${{ github.ref_name }}-Branch"
+          echo "  Android: Android-Performance-$BRANCH_NAME-Branch"
+          echo "  iOS: iOS-Performance-$BRANCH_NAME-Branch"
 
   trigger-android-dual-versions:
     name: Trigger Android Dual Versions and Extract BrowserStack URLs

--- a/appwright/appwright.config.ts
+++ b/appwright/appwright.config.ts
@@ -47,13 +47,7 @@ export default defineConfig({
     },
     {
       name: 'browserstack-android',
-      testMatch: [
-        '**/tests/performance/login/eth-swap-flow.spec.js',
-        '**/tests/performance/login/cross-chain-swap-flow.spec.js',
-        '**/tests/performance/login/import-multiple-srps.spec.js',
-        '**/tests/performance/login/perps-add-funds.spec.js',
-        '**/tests/performance/login/predict/predict-market-details.spec.js',
-      ],
+      testMatch: '**/tests/performance/login/**/*.spec.js',
       use: {
         platform: Platform.ANDROID,
         device: {
@@ -67,13 +61,7 @@ export default defineConfig({
     },
     {
       name: 'browserstack-ios',
-      testMatch: [
-        '**/tests/performance/login/eth-swap-flow.spec.js',
-        '**/tests/performance/login/cross-chain-swap-flow.spec.js',
-        '**/tests/performance/login/import-multiple-srps.spec.js',
-        '**/tests/performance/login/perps-add-funds.spec.js',
-        '**/tests/performance/login/predict/predict-market-details.spec.js',
-      ],
+      testMatch: '**/tests/performance/login/**/*.spec.js',
       use: {
         platform: Platform.IOS,
         device: {

--- a/appwright/appwright.config.ts
+++ b/appwright/appwright.config.ts
@@ -47,7 +47,13 @@ export default defineConfig({
     },
     {
       name: 'browserstack-android',
-      testMatch: '**/tests/performance/login/**/*.spec.js',
+      testMatch: [
+        '**/tests/performance/login/eth-swap-flow.spec.js',
+        '**/tests/performance/login/cross-chain-swap-flow.spec.js',
+        '**/tests/performance/login/import-multiple-srps.spec.js',
+        '**/tests/performance/login/perps-add-funds.spec.js',
+        '**/tests/performance/login/predict/predict-market-details.spec.js',
+      ],
       use: {
         platform: Platform.ANDROID,
         device: {
@@ -61,7 +67,13 @@ export default defineConfig({
     },
     {
       name: 'browserstack-ios',
-      testMatch: '**/tests/performance/login/**/*.spec.js',
+      testMatch: [
+        '**/tests/performance/login/eth-swap-flow.spec.js',
+        '**/tests/performance/login/cross-chain-swap-flow.spec.js',
+        '**/tests/performance/login/import-multiple-srps.spec.js',
+        '**/tests/performance/login/perps-add-funds.spec.js',
+        '**/tests/performance/login/predict/predict-market-details.spec.js',
+      ],
       use: {
         platform: Platform.IOS,
         device: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Run Performance E2E on PRs with a single low/medium device and plumb an optional branch_name through CI to Bitrise-triggered Android/iOS builds and build naming.

> Performance E2E workflow (.github/workflows/run-performance-e2e.yml):
> Add PR trigger, concurrency control, and actions: write permission.
> Select only the first low/medium device per platform on PRs; use full matrix otherwise.
> Compute branch_name (input > PR head_ref > ref_name) and use it for unified BrowserStack build names.
> Pass branch_name to Android/iOS dual-version build workflows.
> Android/iOS build upload workflows (build-android-upload-to-browserstack.yml, build-ios-upload-to-browserstack.yml):
> Add optional branch_name input and use it for Bitrise branch when triggering builds; update logs accordingly.
> CI (.github/workflows/ci.yml):
> Enable Performance E2E on push and PR; forward branch_name (github.head_ref || github.ref_name) to the performance workflow.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Run Performance E2E on PRs with a single low/medium device and plumb an optional branch_name through CI to Bitrise-triggered Android/iOS builds and build naming.
> 
> - **Performance E2E workflow (`.github/workflows/run-performance-e2e.yml`)**:
>   - Add PR trigger, concurrency control, and `actions: write` permission.
>   - Select only the first low/medium device per platform on PRs; use full matrix otherwise.
>   - Compute `branch_name` (input > PR head_ref > ref_name) and use it for unified BrowserStack build names.
>   - Pass `branch_name` to Android/iOS dual-version build workflows.
> - **Android/iOS build upload workflows** (`build-android-upload-to-browserstack.yml`, `build-ios-upload-to-browserstack.yml`):
>   - Add optional `branch_name` input and use it for Bitrise `branch` when triggering builds; update logs accordingly.
> - **CI (`.github/workflows/ci.yml`)**:
>   - Enable Performance E2E on push and PR; forward `branch_name` (`github.head_ref || github.ref_name`) to the performance workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d50f7741b94428c490f00488ed404cfabe0245da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->