### PR TITLE
ci: Use shallow Git checkout for E2E

### DIFF
--- a/.github/workflows/run-e2e-api-specs.yml
+++ b/.github/workflows/run-e2e-api-specs.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref }}
           clean: true
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -99,7 +99,6 @@ jobs:
         with:
           ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.head.sha || github.sha }}
           clean: true
-          fetch-depth: 0
 
       - name: Install Android System Images
         if: ${{ inputs.platform == 'android' }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Reduce CI time by using a shallow Git checkout in the E2E flow, this saves us ~40s in each E2E shard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch E2E workflows to shallow checkout by removing `fetch-depth: 0` from `actions/checkout` steps.
> 
> - **CI/GitHub Actions**:
>   - Use shallow checkout in E2E workflows by removing full-depth fetch from `actions/checkout` in:
>     - `/.github/workflows/run-e2e-api-specs.yml`
>     - `/.github/workflows/run-e2e-workflow.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1167f4ba974e029178daeebcec925064ab915fe1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->