### PR TITLE
test: Re-enabled perps tests

### DIFF
--- a/.github/workflows/run-e2e-smoke-tests-android.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android.yml
@@ -29,20 +29,20 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
     secrets: inherit
 
-  # perps-android-smoke:
-  #   strategy:
-  #     matrix:
-  #       split: [1]
-  #     fail-fast: false
-  #   uses: ./.github/workflows/run-e2e-workflow.yml
-  #   with:
-  #     test-suite-name: perps-android-smoke-${{ matrix.split }}
-  #     platform: android
-  #     test_suite_tag: 'SmokePerps'
-  #     split_number: ${{ matrix.split }}
-  #     total_splits: 1
-  #     changed_files: ${{ inputs.changed_files }}
-  #   secrets: inherit
+  perps-android-smoke:
+    strategy:
+      matrix:
+        split: [1]
+      fail-fast: false
+    uses: ./.github/workflows/run-e2e-workflow.yml
+    with:
+      test-suite-name: perps-android-smoke-${{ matrix.split }}
+      platform: android
+      test_suite_tag: 'SmokePerps'
+      split_number: ${{ matrix.split }}
+      total_splits: 1
+      changed_files: ${{ inputs.changed_files }}
+    secrets: inherit
 
   wallet-platform-android-smoke:
     strategy:

--- a/e2e/api-mocking/mock-e2e-allowlist.ts
+++ b/e2e/api-mocking/mock-e2e-allowlist.ts
@@ -17,6 +17,7 @@ export const ALLOWLISTED_HOSTS = [
   'gamma-api.polymarket.com',
   'clob.polymarket.com',
   '*.polymarket.com',
+  'api.hyperliquid.xyz', // HyperLiquid SDK makes direct requests during initialization (controller mocking handles business logic)
 ];
 
 export const ALLOWLISTED_URLS = [

--- a/e2e/api-mocking/mock-e2e-allowlist.ts
+++ b/e2e/api-mocking/mock-e2e-allowlist.ts
@@ -17,7 +17,6 @@ export const ALLOWLISTED_HOSTS = [
   'gamma-api.polymarket.com',
   'clob.polymarket.com',
   '*.polymarket.com',
-  'api.hyperliquid.xyz', // HyperLiquid SDK makes direct requests during initialization (controller mocking handles business logic)
 ];
 
 export const ALLOWLISTED_URLS = [

--- a/e2e/api-mocking/mock-responses/perps-arbitrum-mocks.ts
+++ b/e2e/api-mocking/mock-responses/perps-arbitrum-mocks.ts
@@ -353,7 +353,7 @@ export const PERPS_ARBITRUM_MOCKS: TestSpecificMock = async (
           },
         }),
         headers: {
-          'Content-Type': 'image/svg+xml',
+          'Content-Type': 'application/json',
           'Cache-Control': 'public, max-age=3600',
         },
       };

--- a/e2e/api-mocking/mock-responses/perps-arbitrum-mocks.ts
+++ b/e2e/api-mocking/mock-responses/perps-arbitrum-mocks.ts
@@ -200,6 +200,30 @@ export const PERPS_ARBITRUM_MOCKS: TestSpecificMock = async (
       };
     });
 
+  // Mock Rewards API for perps fee discount through the mobile proxy
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const urlParam = new URL(request.url).searchParams.get('url') || '';
+      return (
+        urlParam.includes('rewards') && urlParam.includes('perps-fee-discount')
+      );
+    })
+    .asPriority(1000)
+    .thenCallback(() => {
+      console.log(
+        '[Perps E2E Mock] Intercepted Rewards perps-fee-discount request',
+      );
+      return {
+        statusCode: 200,
+        body: JSON.stringify({
+          discountPercentage: 0,
+          eligible: false,
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      };
+    });
+
   // Mock HyperLiquid coin image requests through the mobile proxy
   await mockServer
     .forGet('/proxy')

--- a/e2e/api-mocking/mock-responses/perps-arbitrum-mocks.ts
+++ b/e2e/api-mocking/mock-responses/perps-arbitrum-mocks.ts
@@ -274,4 +274,130 @@ export const PERPS_ARBITRUM_MOCKS: TestSpecificMock = async (
         headers: { 'Content-Type': 'application/json' },
       };
     });
+
+  // Mock HyperLiquid coin image requests through the mobile proxy
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const urlParam = new URL(request.url).searchParams.get('url') || '';
+      return urlParam.includes('price.api.cx.metamask.io/v2/chains/0xa4b1');
+    })
+    .asPriority(1000)
+    .thenCallback(() => {
+      console.log('[Perps E2E Mock] Intercepted Price API request');
+      return {
+        statusCode: 200,
+        body: JSON.stringify({
+          '0x0000000000000000000000000000000000000000': {
+            id: 'ethereum',
+            price: 0.999972651206969,
+            marketCap: 120787455.213762,
+            allTimeHigh: 1.65971963862127,
+            allTimeLow: 0.000145292455476714,
+            totalVolume: 9428228.34684131,
+            high1d: 1.06408228150965,
+            low1d: 0.998174024572987,
+            circulatingSupply: 120695108.243547,
+            dilutedMarketCap: 120787455.213762,
+            marketCapPercentChange1d: -3.65305,
+            priceChange1d: -113.150069710762,
+            pricePercentChange1h: -1.10669232294285,
+            pricePercentChange1d: -3.65812325301973,
+            pricePercentChange7d: -4.13635493022624,
+            pricePercentChange14d: 8.3078065082939,
+            pricePercentChange30d: -6.40996979150269,
+            pricePercentChange200d: 12.4178771617204,
+            pricePercentChange1y: -23.4708803114256,
+          },
+          '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8': {
+            id: 'usd-coin-ethereum-bridged',
+            price: 0.000335227092460614,
+            marketCap: 21157.8427362164,
+            allTimeHigh: 0.00040938889803337,
+            allTimeLow: 0.000301975989258871,
+            totalVolume: 18020.9748003926,
+            high1d: 0.000338249187883309,
+            low1d: 0.000327180587226235,
+            circulatingSupply: 63135587.501145,
+            dilutedMarketCap: 21157.8427362164,
+            marketCapPercentChange1d: -0.07227,
+            priceChange1d: -0.000314609931530985,
+            pricePercentChange1h: 0.315821469792684,
+            pricePercentChange1d: -0.0314827666724661,
+            pricePercentChange7d: -0.118860132989052,
+            pricePercentChange14d: 0.458309784944713,
+            pricePercentChange30d: -0.329602840383663,
+            pricePercentChange200d: 0.0819372345276349,
+            pricePercentChange1y: -0.155248818485504,
+          },
+          '0xaf88d065e77c8cc2239327c5edb3a432268e5831': {
+            id: 'usd-coin',
+            price: 0.000335558630355087,
+            marketCap: 26323870.6148644,
+            allTimeHigh: 0.000392610664507413,
+            allTimeLow: 0.000294507326387126,
+            totalVolume: 3835411.26953233,
+            high1d: 0.000335564670519156,
+            low1d: 0.000335358633811457,
+            circulatingSupply: 78452801620.0186,
+            dilutedMarketCap: 26327173.2440294,
+            marketCapPercentChange1d: 0.03968,
+            priceChange1d: 0.00004574,
+            pricePercentChange1h: 0.0119513851718319,
+            pricePercentChange1d: 0.00457461979403909,
+            pricePercentChange7d: 0.0172715843309844,
+            pricePercentChange14d: 0.0182646657767789,
+            pricePercentChange30d: 0.0172178802381209,
+            pricePercentChange200d: 0.0204803951277851,
+            pricePercentChange1y: 0.0285034972599191,
+          },
+        }),
+        headers: {
+          'Content-Type': 'image/svg+xml',
+          'Cache-Control': 'public, max-age=3600',
+        },
+      };
+    });
+
+  // Mock HyperLiquid coin image requests through the mobile proxy
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const urlParam = new URL(request.url).searchParams.get('url') || '';
+      return urlParam.includes('price.api.cx.metamask.io/v2/chains/0x89');
+    })
+    .asPriority(1000)
+    .thenCallback(() => {
+      console.log('[Perps E2E Mock] Intercepted Price API request');
+      return {
+        statusCode: 200,
+        body: JSON.stringify({
+          0x0000000000000000000000000000000000001010: {
+            id: 'polygon-ecosystem-token',
+            price: 0.113006,
+            marketCap: 1192507260,
+            allTimeHigh: 1.29,
+            allTimeLow: 0.113362,
+            totalVolume: 75356551,
+            high1d: 0.121302,
+            low1d: 0.112985,
+            circulatingSupply: 10556415953.6597,
+            dilutedMarketCap: 1192507260,
+            marketCapPercentChange1d: -4.20683,
+            priceChange1d: -0.00501858069982855,
+            pricePercentChange1h: -1.35595913652185,
+            pricePercentChange1d: -4.25215808442668,
+            pricePercentChange7d: -8.79747323054775,
+            pricePercentChange14d: -5.38334147678743,
+            pricePercentChange30d: -27.5942103216344,
+            pricePercentChange200d: -50.7418828223079,
+            pricePercentChange1y: -81.5387418720344,
+          },
+        }),
+        headers: {
+          'Content-Type': 'image/svg+xml',
+          'Cache-Control': 'public, max-age=3600',
+        },
+      };
+    });
 };

--- a/e2e/api-mocking/mock-responses/perps-arbitrum-mocks.ts
+++ b/e2e/api-mocking/mock-responses/perps-arbitrum-mocks.ts
@@ -372,7 +372,7 @@ export const PERPS_ARBITRUM_MOCKS: TestSpecificMock = async (
       return {
         statusCode: 200,
         body: JSON.stringify({
-          0x0000000000000000000000000000000000001010: {
+          '0x0000000000000000000000000000000000001010': {
             id: 'polygon-ecosystem-token',
             price: 0.113006,
             marketCap: 1192507260,
@@ -395,7 +395,7 @@ export const PERPS_ARBITRUM_MOCKS: TestSpecificMock = async (
           },
         }),
         headers: {
-          'Content-Type': 'image/svg+xml',
+          'Content-Type': 'application/json',
           'Cache-Control': 'public, max-age=3600',
         },
       };

--- a/e2e/api-mocking/mock-responses/perps-arbitrum-mocks.ts
+++ b/e2e/api-mocking/mock-responses/perps-arbitrum-mocks.ts
@@ -183,6 +183,23 @@ export const PERPS_ARBITRUM_MOCKS: TestSpecificMock = async (
       }
     });
 
+  // Mock HyperLiquid Exchange API GET requests through the mobile proxy
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const urlParam = new URL(request.url).searchParams.get('url') || '';
+      return urlParam.includes('api.hyperliquid.xyz/exchange');
+    })
+    .asPriority(1000)
+    .thenCallback(() => {
+      console.log('[Perps E2E Mock] Intercepted HyperLiquid Exchange GET');
+      return {
+        statusCode: 200,
+        body: JSON.stringify({ status: 'ok' }),
+        headers: { 'Content-Type': 'application/json' },
+      };
+    });
+
   // Mock HyperLiquid coin image requests through the mobile proxy
   await mockServer
     .forGet('/proxy')

--- a/e2e/controller-mocking/mock-config/perps-controller-mixin.ts
+++ b/e2e/controller-mocking/mock-config/perps-controller-mixin.ts
@@ -450,6 +450,34 @@ export function createE2EMockStreamManager(): unknown {
         return () => undefined;
       },
     },
+    oiCaps: {
+      subscribe: (params: { callback: (data: string[]) => void }) => {
+        // Return empty array - no markets at OI cap in E2E tests by default
+        setTimeout(() => params.callback([]), 0);
+        return () => undefined;
+      },
+    },
+    topOfBook: {
+      subscribeToSymbol: (params: {
+        symbol: string;
+        callback: (
+          data:
+            | { bestBid?: string; bestAsk?: string; spread?: string }
+            | undefined,
+        ) => void;
+      }) => {
+        // Return undefined - no top of book data in E2E tests by default
+        setTimeout(() => params.callback(undefined), 0);
+        return () => undefined;
+      },
+    },
+    candles: {
+      subscribe: (params: { callback: (data: unknown[]) => void }) => {
+        // Return empty array - no candle data in E2E tests by default
+        setTimeout(() => params.callback([]), 0);
+        return () => undefined;
+      },
+    },
   };
 }
 

--- a/e2e/pages/Perps/PerpsDepositView.ts
+++ b/e2e/pages/Perps/PerpsDepositView.ts
@@ -13,9 +13,9 @@ class PerpsDepositView {
     return Matchers.getElementByText('Continue');
   }
 
-  // Confirm button on review screen
-  get confirmButtonByText(): DetoxElement {
-    return Matchers.getElementByText('Confirm');
+  // Add funds button on review screen
+  get addFundsByText(): DetoxElement {
+    return Matchers.getElementByText('Add funds', 1);
   }
 
   // Pay with row (open selector)
@@ -75,9 +75,9 @@ class PerpsDepositView {
     });
   }
 
-  async tapConfirm(): Promise<void> {
-    await Gestures.waitAndTap(this.confirmButtonByText, {
-      elemDescription: 'Confirm deposit',
+  async tapAddFunds(): Promise<void> {
+    await Gestures.waitAndTap(this.addFundsByText, {
+      elemDescription: 'Add funds',
     });
   }
 }

--- a/e2e/pages/Perps/PerpsHomeView.ts
+++ b/e2e/pages/Perps/PerpsHomeView.ts
@@ -1,0 +1,28 @@
+import { PerpsHomeViewSelectorsIDs } from '../../selectors/Perps/Perps.selectors';
+import Gestures from '../../framework/Gestures';
+import Matchers from '../../framework/Matchers';
+import enContent from '../../../locales/languages/en.json';
+
+class PerpsHomeView {
+  get exploreCrypto(): DetoxElement {
+    return Matchers.getElementByText(enContent.perps.home.crypto);
+  }
+
+  get backHome(): DetoxElement {
+    return Matchers.getElementByID(PerpsHomeViewSelectorsIDs.BACK_HOME_BUTTON);
+  }
+
+  async tapExploreCrypto(): Promise<void> {
+    await Gestures.waitAndTap(this.exploreCrypto, {
+      elemDescription: 'Perps Explore Crypto Button',
+    });
+  }
+
+  async tapBackHomeButton(): Promise<void> {
+    await Gestures.waitAndTap(this.backHome, {
+      elemDescription: 'Perps Back Home Button',
+    });
+  }
+}
+
+export default new PerpsHomeView();

--- a/e2e/pages/Perps/PerpsMarketDetailsView.ts
+++ b/e2e/pages/Perps/PerpsMarketDetailsView.ts
@@ -2,7 +2,6 @@ import {
   PerpsMarketDetailsViewSelectorsIDs,
   PerpsMarketHeaderSelectorsIDs,
   PerpsCandlestickChartSelectorsIDs,
-  PerpsMarketTabsSelectorsIDs,
   PerpsOpenOrderCardSelectorsIDs,
 } from '../../selectors/Perps/Perps.selectors';
 import Gestures from '../../framework/Gestures';
@@ -210,12 +209,6 @@ class PerpsMarketDetailsView {
 
   // Verify that Orders tab has at least one open order card
   async expectOpenOrderVisible() {
-    const ordersTab = Matchers.getElementByID(
-      PerpsMarketTabsSelectorsIDs.ORDERS_TAB,
-    );
-    await Gestures.waitAndTap(ordersTab, {
-      elemDescription: 'Open Orders tab',
-    });
     const openOrderCard = Matchers.getElementByID(
       PerpsOpenOrderCardSelectorsIDs.CARD,
     ) as DetoxElement;

--- a/e2e/pages/Perps/PerpsOrderView.ts
+++ b/e2e/pages/Perps/PerpsOrderView.ts
@@ -3,6 +3,7 @@ import Matchers from '../../framework/Matchers';
 import Assertions from '../../framework/Assertions';
 import Utilities from '../../framework/Utilities';
 import {
+  PerpsOrderHeaderSelectorsIDs,
   PerpsOrderViewSelectorsIDs,
   PerpsAmountDisplaySelectorsIDs,
 } from '../../selectors/Perps/Perps.selectors';
@@ -18,6 +19,12 @@ class PerpsOrderView {
   get takeProfitButton() {
     return Matchers.getElementByID(
       PerpsOrderViewSelectorsIDs.TAKE_PROFIT_BUTTON,
+    );
+  }
+
+  get turnNotificationsOnButton() {
+    return Matchers.getElementByID(
+      PerpsOrderViewSelectorsIDs.TURN_ON_NOTIFICATION_BUTTON,
     );
   }
 
@@ -42,6 +49,12 @@ class PerpsOrderView {
 
   async tapTakeProfitButton() {
     await Gestures.waitAndTap(this.takeProfitButton);
+  }
+
+  async tapTurnOnNotificationsButton() {
+    await Gestures.waitAndTap(this.turnNotificationsOnButton, {
+      elemDescription: 'Turn on Notifications Button',
+    });
   }
 
   async selectLeverage(leverageX: number) {
@@ -136,21 +149,17 @@ class PerpsOrderView {
     return Matchers.getElementByText('Market');
   }
 
+  private get orderTypeSelector(): DetoxElement {
+    return Matchers.getElementByID(
+      PerpsOrderHeaderSelectorsIDs.ORDER_TYPE_BUTTON,
+    );
+  }
   private get orderTypeLimit(): DetoxElement {
     return Matchers.getElementByText('Limit');
   }
 
   async openOrderTypeSelector(): Promise<void> {
-    // Tap whichever order type label is currently visible (no try/catch)
-    const marketVisible = await Utilities.isElementVisible(
-      this.orderTypeMarket,
-      300,
-    );
-    const target = marketVisible ? this.orderTypeMarket : this.orderTypeLimit;
-    const desc = marketVisible
-      ? 'Open order type selector (Market)'
-      : 'Open order type selector (Limit)';
-    await Gestures.waitAndTap(target, { elemDescription: desc });
+    await Gestures.waitAndTap(this.orderTypeSelector);
   }
 
   async selectLimitOrderType() {

--- a/e2e/pages/Perps/PerpsOrderView.ts
+++ b/e2e/pages/Perps/PerpsOrderView.ts
@@ -168,12 +168,10 @@ class PerpsOrderView {
     });
   }
 
-  async setLimitPricePresetLong(percentage: number) {
-    // For long orders, presets are negative values: -1, -2, -5, -10
-    const label = `${percentage > 0 ? '+' : ''}${percentage}%`;
-    const preset = Matchers.getElementByText(label) as DetoxElement;
-    await Gestures.waitAndTap(preset, {
-      elemDescription: `Select limit price preset ${label}`,
+  async setLimitPricePresetLong(preset: string) {
+    const presetButton = Matchers.getElementByText(preset) as DetoxElement;
+    await Gestures.waitAndTap(presetButton, {
+      elemDescription: `Select limit price preset ${preset}`,
     });
   }
 

--- a/e2e/pages/Perps/PerpsTabView.ts
+++ b/e2e/pages/Perps/PerpsTabView.ts
@@ -20,7 +20,13 @@ class PerpsTabView {
   }
 
   get onboardingButton(): DetoxElement {
-    return Matchers.getElementByID(PerpsTabViewSelectorsIDs.ONBOARDING_BUTTON);
+    return Matchers.getElementByText('Start trading');
+  }
+
+  get startNewTradeButton(): DetoxElement {
+    return Matchers.getElementByID(
+      PerpsTabViewSelectorsIDs.START_NEW_TRADE_CTA,
+    );
   }
 
   get balanceValue(): DetoxElement {
@@ -68,6 +74,12 @@ class PerpsTabView {
   async tapOnboardingButton(): Promise<void> {
     await Gestures.waitAndTap(this.onboardingButton, {
       elemDescription: 'Perps Onboarding Button',
+    });
+  }
+
+  async tapStartNewTradeButton(): Promise<void> {
+    await Gestures.waitAndTap(this.startNewTradeButton, {
+      elemDescription: 'Perps Start New Trade Button',
     });
   }
 

--- a/e2e/pages/Perps/PerpsView.ts
+++ b/e2e/pages/Perps/PerpsView.ts
@@ -66,11 +66,6 @@ class PerpsView {
       PerpsMarketListViewSelectorsIDs.BACK_HEADER_BUTTON,
     );
   }
-  get backButtonMarketList() {
-    return Matchers.getElementByID(
-      PerpsMarketListViewSelectorsIDs.BACK_HEADER_BUTTON,
-    );
-  }
 
   get orderSuccessToastDismissButton() {
     return Matchers.getElementByID(
@@ -116,8 +111,8 @@ class PerpsView {
 
   getStopLossPercentageButton(percentage: number) {
     // Support legacy tests passing index (1..4) by mapping to actual ROE% (loss magnitudes)
-    // SL quick buttons: [5, 10, 25, 50]
-    const mapped = [0, 5, 10, 25, 50][percentage] || percentage;
+    // SL quick buttons: [-5, -10, -25, -50]
+    const mapped = [0, -5, -10, -25, -50][percentage] || percentage;
     return Matchers.getElementByID(
       getPerpsTPSLViewSelector.stopLossPercentageButton(mapped),
     );
@@ -283,12 +278,6 @@ class PerpsView {
   async tapBackButtonPositionSheet() {
     await Gestures.waitAndTap(this.backButtonPositionSheet, {
       elemDescription: 'Back button position sheet',
-    });
-  }
-
-  async tapBackButtonMarketList() {
-    await Gestures.waitAndTap(this.backButtonMarketList, {
-      elemDescription: 'Back button market list',
     });
   }
 }

--- a/e2e/pages/Perps/PerpsView.ts
+++ b/e2e/pages/Perps/PerpsView.ts
@@ -266,7 +266,6 @@ class PerpsView {
       elemDescription: 'Close position bottom sheet button',
       checkStability: true,
       timeout: 10000,
-      waitForElementToDisappear: true,
     });
   }
 

--- a/e2e/selectors/Perps/Perps.selectors.ts
+++ b/e2e/selectors/Perps/Perps.selectors.ts
@@ -215,6 +215,7 @@ export const PerpsHomeViewSelectorsIDs = {
   SUPPORT_BUTTON: 'perps-home-support-button',
   LEARN_MORE_BUTTON: 'perps-home-learn-more-button',
   BACK_BUTTON: 'back-button',
+  BACK_HOME_BUTTON: 'perps-home-back-button',
   SEARCH_TOGGLE: 'perps-home-search-toggle',
   SEARCH_INPUT: 'perps-home-search',
   SCROLL_CONTENT: 'scroll-content',
@@ -492,6 +493,8 @@ export const PerpsGTMModalSelectorsIDs = {
 export const PerpsOrderViewSelectorsIDs = {
   BOTTOM_SHEET_TOOLTIP: 'perps-order-view-bottom-sheet-tooltip',
   NOTIFICATION_TOOLTIP: 'perps-order-view-notification-tooltip',
+  TURN_ON_NOTIFICATION_BUTTON:
+    'perps-order-view-notification-tooltip-turn-on-button',
   LEVERAGE_INFO_ICON: 'perps-order-view-leverage-info-icon',
   LIMIT_PRICE_INFO_ICON: 'perps-order-view-limit-price-info-icon',
   MARGIN_INFO_ICON: 'perps-order-view-margin-info-icon',
@@ -510,7 +513,7 @@ export const PerpsOrderViewSelectorsIDs = {
 // ========================================
 
 export const PerpsOpenOrderCardSelectorsIDs = {
-  CARD: 'perps-open-order-card',
+  CARD: 'compact-order-mock_order_1',
   CANCEL_BUTTON: 'perps-open-order-card-cancel-button',
   EDIT_BUTTON: 'perps-open-order-card-edit-button',
 };
@@ -610,7 +613,7 @@ export const getPerpsHeroCardViewSelector = {
 
 export const PerpsGeneralSelectorsIDs = {
   // TPSL bottom sheet primary action button ("Set" / "Updating")
-  BOTTOM_SHEET_FOOTER_BUTTON: 'bottomsheetfooter-button',
+  BOTTOM_SHEET_FOOTER_BUTTON: 'perps-tpsl-bottomsheet',
   // Order success toast dismiss button on PerpsOrderView
   ORDER_SUCCESS_TOAST_DISMISS_BUTTON:
     'perps-order-success-toast-dismiss-button',

--- a/e2e/specs/perps/perps-add-funds.spec.ts
+++ b/e2e/specs/perps/perps-add-funds.spec.ts
@@ -14,7 +14,6 @@ import PerpsE2EModifiers from './helpers/perps-modifiers';
 import ToastModal from '../../pages/wallet/ToastModal';
 import Utilities from '../../framework/Utilities';
 import { createLogger, LogLevel } from '../../framework/logger';
-import PerpsDepositProcessingView from '../../pages/Perps/PerpsDepositProcessingView';
 
 const logger = createLogger({
   name: 'PerpsAddFundsSpec',
@@ -26,7 +25,7 @@ describe(SmokePerps('Perps - Add funds (has funds, not first time)'), () => {
     jest.setTimeout(150000);
   });
 
-  it.skip('deposits $80 from Add funds and verifies updated balance', async () => {
+  it('deposits $80 from Add funds and verifies updated balance', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder()
@@ -116,10 +115,11 @@ describe(SmokePerps('Perps - Add funds (has funds, not first time)'), () => {
 
         // Continue and Confirm
         await PerpsDepositView.tapContinue();
-        await PerpsDepositView.tapConfirm();
+        // Verify review screen shows quote
+        await Assertions.expectTextDisplayed('Transaction fee');
+        await Assertions.expectTextDisplayed('MetaMask fee');
+        await PerpsDepositView.tapAddFunds();
 
-        await PerpsDepositProcessingView.expectProcessingVisible();
-        // Apply deposit mock and verify balance update
         await PerpsE2EModifiers.applyDepositUSDServer(commandQueueServer, '80');
         logger.info('🔥 E2E Mock: Deposit applied');
         await Utilities.executeWithRetry(

--- a/e2e/specs/perps/perps-add-funds.spec.ts
+++ b/e2e/specs/perps/perps-add-funds.spec.ts
@@ -117,7 +117,6 @@ describe(SmokePerps('Perps - Add funds (has funds, not first time)'), () => {
         await PerpsDepositView.tapContinue();
         // Verify review screen shows quote
         await Assertions.expectTextDisplayed('Transaction fee');
-        await Assertions.expectTextDisplayed('MetaMask fee');
         await PerpsDepositView.tapAddFunds();
 
         await PerpsE2EModifiers.applyDepositUSDServer(commandQueueServer, '80');

--- a/e2e/specs/perps/perps-limit-long-fill.spec.ts
+++ b/e2e/specs/perps/perps-limit-long-fill.spec.ts
@@ -47,8 +47,7 @@ describe(RegressionTrade('Perps - ETH limit long fill'), () => {
         await PerpsOrderView.selectLimitOrderType();
 
         // When Limit is selected without price, the limit price bottom sheet opens automatically.
-        // Press preset -10% for long (config LONG_PRESETS: [-1,-2,-5,-10])
-        await PerpsOrderView.setLimitPricePresetLong(-10);
+        await PerpsOrderView.setLimitPricePresetLong('Mid');
 
         // Confirm limit price (Set button)
         await PerpsOrderView.confirmLimitPrice();

--- a/e2e/specs/perps/perps-limit-long-fill.spec.ts
+++ b/e2e/specs/perps/perps-limit-long-fill.spec.ts
@@ -15,7 +15,7 @@ import PerpsE2EModifiers from './helpers/perps-modifiers';
 import { TestSuiteParams } from '../../framework/types';
 
 describe(RegressionTrade('Perps - ETH limit long fill'), () => {
-  it('creates ETH limit long at -10%, shows open order, then fills after -15%', async () => {
+  it('creates ETH limit long at Mid, shows open order, then fills after -15%', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder()

--- a/e2e/specs/perps/perps-limit-long-fill.spec.ts
+++ b/e2e/specs/perps/perps-limit-long-fill.spec.ts
@@ -9,22 +9,24 @@ import WalletActionsBottomSheet from '../../pages/wallet/WalletActionsBottomShee
 import PerpsMarketListView from '../../pages/Perps/PerpsMarketListView';
 import PerpsMarketDetailsView from '../../pages/Perps/PerpsMarketDetailsView';
 import PerpsOrderView from '../../pages/Perps/PerpsOrderView';
+import PerpsHomeView from '../../pages/Perps/PerpsHomeView';
 import PerpsView from '../../pages/Perps/PerpsView';
 import PerpsE2EModifiers from './helpers/perps-modifiers';
+import { TestSuiteParams } from '../../framework/types';
 
 describe(RegressionTrade('Perps - ETH limit long fill'), () => {
-  it.skip('creates ETH limit long at -10%, shows open order, then fills after -15%', async () => {
+  it('creates ETH limit long at -10%, shows open order, then fills after -15%', async () => {
     await withFixtures(
       {
-        fixture: new FixtureBuilder()
-          .withPerpsProfile('no-positions')
-          .withPerpsFirstTimeUser(false)
-          .withPopularNetworks()
-          .build(),
+        fixture: new FixtureBuilder().build(),
         restartDevice: true,
         testSpecificMock: PERPS_ARBITRUM_MOCKS,
+        useCommandQueueServer: true,
       },
-      async () => {
+      async ({ commandQueueServer }: TestSuiteParams) => {
+        if (!commandQueueServer) {
+          throw new Error('Command queue server not found');
+        }
         await loginToApp();
         await PerpsHelpers.navigateToPerpsTab();
 
@@ -51,19 +53,26 @@ describe(RegressionTrade('Perps - ETH limit long fill'), () => {
         // Place order
         await PerpsView.tapPlaceOrderButton();
 
+        // Tap Turn on notifications on the Order placed modal
+        await PerpsOrderView.tapTurnOnNotificationsButton();
+
         // The view returns to Market Details. Change to Orders tab and verify open order card
         await PerpsMarketDetailsView.expectOpenOrderVisible();
 
         // Navigate back to main Perps screen to follow the same navigation pattern as other specs
         await PerpsView.tapBackButtonPositionSheet();
-        await PerpsView.tapBackButtonMarketList();
+        await PerpsHomeView.tapBackHomeButton();
 
         // Verify on the Perps tab main screen that the order is visible without entering the market
         await PerpsView.expectOpenOrdersOnTab();
 
         // Push the price -15% to ensure the order is executed
         // Default ETH price in mock is 2500.00, -15% => 2125.00
-        await PerpsE2EModifiers.updateMarketPrice('ETH', '2125.00');
+        await PerpsE2EModifiers.updateMarketPriceServer(
+          commandQueueServer,
+          'ETH',
+          '2125.00',
+        );
 
         // Navigate to ETH again to verify order is gone and position is present
         await TabBarComponent.tapActions();

--- a/e2e/specs/perps/perps-limit-long-fill.spec.ts
+++ b/e2e/specs/perps/perps-limit-long-fill.spec.ts
@@ -18,7 +18,11 @@ describe(RegressionTrade('Perps - ETH limit long fill'), () => {
   it('creates ETH limit long at -10%, shows open order, then fills after -15%', async () => {
     await withFixtures(
       {
-        fixture: new FixtureBuilder().build(),
+        fixture: new FixtureBuilder()
+          .withPerpsProfile('no-positions')
+          .withPerpsFirstTimeUser(false)
+          .withPopularNetworks()
+          .build(),
         restartDevice: true,
         testSpecificMock: PERPS_ARBITRUM_MOCKS,
         useCommandQueueServer: true,

--- a/e2e/specs/perps/perps-limit-long-fill.spec.ts
+++ b/e2e/specs/perps/perps-limit-long-fill.spec.ts
@@ -60,7 +60,9 @@ describe(RegressionTrade('Perps - ETH limit long fill'), () => {
         await PerpsView.tapPlaceOrderButton();
 
         // Tap Turn on notifications on the Order placed modal
-        await PerpsOrderView.tapTurnOnNotificationsButton();
+        if (device.getPlatform() === 'ios') {
+          await PerpsOrderView.tapTurnOnNotificationsButton();
+        }
 
         // The view returns to Market Details. Change to Orders tab and verify open order card
         await PerpsMarketDetailsView.expectOpenOrderVisible();

--- a/e2e/specs/perps/perps-limit-long-fill.spec.ts
+++ b/e2e/specs/perps/perps-limit-long-fill.spec.ts
@@ -28,14 +28,17 @@ describe(RegressionTrade('Perps - ETH limit long fill'), () => {
           throw new Error('Command queue server not found');
         }
         await loginToApp();
+
+        // This is needed due to disable animations
+        await device.disableSynchronization();
+
         await PerpsHelpers.navigateToPerpsTab();
 
         // Navigate to Perps from Actions
         await TabBarComponent.tapActions();
         await WalletActionsBottomSheet.tapPerpsButton();
 
-        // Open ETH market and select Long
-        await device.disableSynchronization();
+        // Select ETH market and tap Long
         await PerpsMarketListView.selectMarket('ETH');
         await PerpsMarketDetailsView.tapLongButton();
 

--- a/e2e/specs/perps/perps-no-funds-tutorial.spec.ts
+++ b/e2e/specs/perps/perps-no-funds-tutorial.spec.ts
@@ -19,7 +19,6 @@ describe(
       await withFixtures(
         {
           fixture: new FixtureBuilder()
-            .withPerpsProfile('no-funds')
             .withPerpsProfile('no-positions')
             .withPerpsFirstTimeUser(true)
             .build(),

--- a/e2e/specs/perps/perps-no-funds-tutorial.spec.ts
+++ b/e2e/specs/perps/perps-no-funds-tutorial.spec.ts
@@ -19,6 +19,7 @@ describe(
       await withFixtures(
         {
           fixture: new FixtureBuilder()
+            .withPerpsProfile('no-funds')
             .withPerpsProfile('no-positions')
             .withPerpsFirstTimeUser(true)
             .build(),

--- a/e2e/specs/perps/perps-no-funds-tutorial.spec.ts
+++ b/e2e/specs/perps/perps-no-funds-tutorial.spec.ts
@@ -15,7 +15,7 @@ describe(
       jest.setTimeout(150000);
     });
 
-    it('should show Start Trading on Perps tab and then tutorial screens', async () => {
+    it('displays Start Trading on Perps tab and tutorial screens', async () => {
       await withFixtures(
         {
           fixture: new FixtureBuilder()

--- a/e2e/specs/perps/perps-no-funds-tutorial.spec.ts
+++ b/e2e/specs/perps/perps-no-funds-tutorial.spec.ts
@@ -6,7 +6,6 @@ import WalletView from '../../pages/wallet/WalletView';
 import PerpsTabView from '../../pages/Perps/PerpsTabView';
 import Assertions from '../../framework/Assertions';
 import PerpsOnboarding from '../../pages/Perps/PerpsOnboarding';
-import PerpsMarketListView from '../../pages/Perps/PerpsMarketListView';
 import { PERPS_ARBITRUM_MOCKS } from '../../api-mocking/mock-responses/perps-arbitrum-mocks';
 
 describe(
@@ -16,11 +15,11 @@ describe(
       jest.setTimeout(150000);
     });
 
-    it.skip('should show Start Trading on Perps tab and then tutorial screens', async () => {
+    it('should show Start Trading on Perps tab and then tutorial screens', async () => {
       await withFixtures(
         {
           fixture: new FixtureBuilder()
-            .withPerpsProfile('no-funds')
+            .withPerpsProfile('no-positions')
             .withPerpsFirstTimeUser(true)
             .build(),
           restartDevice: true,
@@ -30,10 +29,13 @@ describe(
         async () => {
           await loginToApp();
 
+          // This is needed due to disable animations
+          await device.disableSynchronization();
+
           // Go to Perps tab from Wallet
           await WalletView.tapOnPerpsTab();
 
-          // Start Trading should be present for first-time/no-funds
+          // Start Trading should be present for first-time/no-positions
           await PerpsTabView.tapOnboardingButton();
 
           await PerpsOnboarding.tapContinueButton();
@@ -42,14 +44,14 @@ describe(
           await PerpsOnboarding.tapContinueButton();
           await PerpsOnboarding.tapContinueButton();
 
-          await PerpsOnboarding.tapSkipButton();
+          await PerpsOnboarding.tapContinueButton();
 
           // After skipping tutorial, user should land on markets screen
           await Assertions.expectElementToBeVisible(
-            PerpsMarketListView.listHeader as DetoxElement,
+            PerpsTabView.marketAddFundsButton as DetoxElement,
             {
               description:
-                'Perps market list header visible after skipping tutorial',
+                'Perps market add funds button visible after skipping tutorial',
             },
           );
         },

--- a/e2e/specs/perps/perps-position-liquidation.spec.ts
+++ b/e2e/specs/perps/perps-position-liquidation.spec.ts
@@ -23,7 +23,7 @@ const logger = createLogger({
 });
 
 describe(RegressionTrade('Perps Position'), () => {
-  it('should open a long position with custom profit and close it', async () => {
+  it('opens a long position with custom profit and closes it', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder()

--- a/e2e/specs/perps/perps-position-liquidation.spec.ts
+++ b/e2e/specs/perps/perps-position-liquidation.spec.ts
@@ -8,12 +8,14 @@ import WalletActionsBottomSheet from '../../pages/wallet/WalletActionsBottomShee
 import PerpsMarketListView from '../../pages/Perps/PerpsMarketListView';
 import { PERPS_ARBITRUM_MOCKS } from '../../api-mocking/mock-responses/perps-arbitrum-mocks';
 import PerpsMarketDetailsView from '../../pages/Perps/PerpsMarketDetailsView';
+import PerpsHomeView from '../../pages/Perps/PerpsHomeView';
 import PerpsView from '../../pages/Perps/PerpsView';
 import { createLogger, LogLevel } from '../../framework/logger';
 import PerpsE2EModifiers from './helpers/perps-modifiers';
 import Assertions from '../../framework/Assertions';
 import Matchers from '../../framework/Matchers';
 import { PerpsPositionsViewSelectorsIDs } from '../../selectors/Perps/Perps.selectors';
+import { TestSuiteParams } from '../../framework/types';
 
 const logger = createLogger({
   name: 'PerpsPositionSpec',
@@ -21,16 +23,21 @@ const logger = createLogger({
 });
 
 describe(RegressionTrade('Perps Position'), () => {
-  it.skip('should open a long position with custom profit and close it', async () => {
+  it('should open a long position with custom profit and close it', async () => {
     await withFixtures(
       {
-        fixture: new FixtureBuilder().build(),
+        fixture: new FixtureBuilder()
+          .withPerpsProfile('position-testing')
+          .build(),
         restartDevice: true,
         testSpecificMock: PERPS_ARBITRUM_MOCKS,
+        useCommandQueueServer: true,
       },
-      async () => {
+      async ({ commandQueueServer }: TestSuiteParams) => {
+        if (!commandQueueServer) {
+          throw new Error('Command queue server not found');
+        }
         logger.info('💰 Using E2E mock balance - no wallet import needed');
-        logger.info('🎯 Mock account: $10,000 total, $8,000 available');
         await loginToApp();
 
         // Navigate to Perps tab using manual sync management
@@ -42,7 +49,9 @@ describe(RegressionTrade('Perps Position'), () => {
         await WalletActionsBottomSheet.tapPerpsButton();
 
         await device.disableSynchronization();
-        await PerpsMarketListView.tapFirstMarketRowItem();
+
+        await PerpsMarketListView.selectMarket('ETH');
+
         await PerpsMarketDetailsView.tapLongButton();
 
         await PerpsView.tapPlaceOrderButton();
@@ -51,27 +60,41 @@ describe(RegressionTrade('Perps Position'), () => {
         logger.info('💎 E2E Mock: Position created with mock data');
 
         await PerpsView.tapBackButtonPositionSheet();
-        await PerpsView.tapBackButtonMarketList();
+        await PerpsHomeView.tapBackHomeButton();
 
         // add price change and liquidation -> not yet liquidated
-        await PerpsE2EModifiers.updateMarketPrice('BTC', '80000.00');
-        await PerpsE2EModifiers.triggerLiquidation('BTC');
+        await PerpsE2EModifiers.updateMarketPriceServer(
+          commandQueueServer,
+          'BTC',
+          '30000.00',
+        );
+        await PerpsE2EModifiers.triggerLiquidationServer(
+          commandQueueServer,
+          'BTC',
+        );
         logger.info('🔥 E2E Mock: Liquidation triggered. Not yet liquidated');
 
         // Assertion 1: still have 2 positions (the default and the recently opened)
         await PerpsView.ensurePerpsTabPositionVisible('BTC', 5, 'long', 0);
-        await PerpsView.ensurePerpsTabPositionVisible('BTC', 3, 'long', 1);
+        await PerpsView.ensurePerpsTabPositionVisible('ETH', 3, 'long', 1);
 
         // add price change and force liquidation - BTC below 30k triggers default BTC liquidation
-        await PerpsE2EModifiers.updateMarketPrice('BTC', '30000.00');
-        await PerpsE2EModifiers.triggerLiquidation('BTC');
+        await PerpsE2EModifiers.updateMarketPriceServer(
+          commandQueueServer,
+          'BTC',
+          '30000.00',
+        );
+        await PerpsE2EModifiers.triggerLiquidationServer(
+          commandQueueServer,
+          'BTC',
+        );
         logger.info('🔥 E2E Mock: Liquidation triggered. Liquidated');
 
         // Assertion 2: only BTC 3x is visible
         // 1) The expected (first item) exists and is visible
         await Assertions.expectElementToBeVisible(
-          PerpsView.getPositionItem('BTC', 3, 'long', 0),
-          { description: 'BTC 3x long en índice 0' },
+          PerpsView.getPositionItem('ETH', 3, 'long', 0),
+          { description: 'ETH 3x long en índice 0' },
         );
 
         // 2) There is no second item of position (verification by index with base ID)

--- a/e2e/specs/perps/perps-position-liquidation.spec.ts
+++ b/e2e/specs/perps/perps-position-liquidation.spec.ts
@@ -38,7 +38,10 @@ describe(RegressionTrade('Perps Position'), () => {
           throw new Error('Command queue server not found');
         }
         logger.info('💰 Using E2E mock balance - no wallet import needed');
+        logger.info('🎯 Mock account: $10,000 total, $8,000 available');
         await loginToApp();
+
+        await device.disableSynchronization();
 
         // Navigate to Perps tab using manual sync management
         await PerpsHelpers.navigateToPerpsTab();
@@ -47,8 +50,6 @@ describe(RegressionTrade('Perps Position'), () => {
         await TabBarComponent.tapActions();
 
         await WalletActionsBottomSheet.tapPerpsButton();
-
-        await device.disableSynchronization();
 
         await PerpsMarketListView.selectMarket('ETH');
 
@@ -66,7 +67,7 @@ describe(RegressionTrade('Perps Position'), () => {
         await PerpsE2EModifiers.updateMarketPriceServer(
           commandQueueServer,
           'BTC',
-          '30000.00',
+          '80000.00',
         );
         await PerpsE2EModifiers.triggerLiquidationServer(
           commandQueueServer,

--- a/e2e/specs/perps/perps-position.spec.ts
+++ b/e2e/specs/perps/perps-position.spec.ts
@@ -20,7 +20,7 @@ const logger = createLogger({
 });
 
 describe(RegressionTrade('Perps Position'), () => {
-  it('should open a long position with custom profit and close it', async () => {
+  it('opens a long position with custom profit and closes it', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder().build(),

--- a/e2e/specs/perps/perps-position.spec.ts
+++ b/e2e/specs/perps/perps-position.spec.ts
@@ -20,7 +20,7 @@ const logger = createLogger({
 });
 
 describe(RegressionTrade('Perps Position'), () => {
-  it.skip('should open a long position with custom profit and close it', async () => {
+  it('should open a long position with custom profit and close it', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder().build(),
@@ -38,9 +38,11 @@ describe(RegressionTrade('Perps Position'), () => {
         // Navigate to actions
         await TabBarComponent.tapActions();
 
+        // This is needed due to disable animations on the next modal
+        await device.disableSynchronization();
         await WalletActionsBottomSheet.tapPerpsButton();
 
-        await PerpsMarketListView.tapFirstMarketRowItem();
+        await PerpsMarketListView.selectMarket('ETH');
         await PerpsMarketDetailsView.tapLongButton();
         await PerpsOrderView.tapTakeProfitButton();
         await PerpsView.tapTakeProfitPercentageButton(1);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR re-enables the Perps Smoke and Regression tests that were disabled earlier

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables and updates Perps E2E tests with new page objects/selectors and richer mocks, and adds a Perps Android smoke job to CI.
> 
> - **E2E Tests**:
>   - Unskips/updates Perps specs (`perps-add-funds`, `perps-limit-long-fill`, `perps-no-funds-tutorial`, `perps-position*`) to new flows (e.g., review screen “Add funds”, Mid price preset, iOS notifications, back-to-home navigation) and command-queue server.
>   - Adds `e2e/pages/Perps/PerpsHomeView.ts`; updates `PerpsDepositView`, `PerpsOrderView` (order type button, notifications), `PerpsTabView` (Start trading CTA), `PerpsMarketDetailsView` (order card check), `PerpsView` (SL presets, nav tweaks).
>   - Selector changes: adds `PerpsOrderViewSelectorsIDs.TURN_ON_NOTIFICATION_BUTTON`, `PerpsHomeViewSelectorsIDs.BACK_HOME_BUTTON`; updates `PerpsOpenOrderCardSelectorsIDs.CARD` and `PerpsGeneralSelectorsIDs.BOTTOM_SHEET_FOOTER_BUTTON`.
> - **Mocks**:
>   - Expands `perps-arbitrum-mocks.ts` to mock HyperLiquid exchange, rewards fee discount, price APIs, token/accounts APIs, and Tx Sentinel.
>   - Extends controller/stream mocks with `oiCaps`, `topOfBook`, and `candles` subscriptions.
> - **CI**:
>   - Adds `perps-android-smoke` job to `.github/workflows/run-e2e-smoke-tests-android.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ce31eb5abf14a1a7c81f3830e035f39b604435e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->