### PR TITLE
fix: disable automatic gas fee updates

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
@@ -50,7 +50,8 @@ import { trace } from '../../../../util/trace';
 import { Delegation7702PublishHook } from '../../../../util/transactions/hooks/delegation-7702-publish';
 import { isSendBundleSupported } from '../../../../util/transactions/sentinel-api';
 import { NetworkClientId } from '@metamask/network-controller';
-import { toHex } from '@metamask/controller-utils';
+import { ORIGIN_METAMASK, toHex } from '@metamask/controller-utils';
+import { hasTransactionType } from '../../../../components/Views/confirmations/utils/transaction';
 
 export const TransactionControllerInit: ControllerInitFunction<
   TransactionController,
@@ -78,8 +79,7 @@ export const TransactionControllerInit: ControllerInitFunction<
   try {
     const transactionController: TransactionController =
       new TransactionController({
-        isAutomaticGasFeeUpdateEnabled: ({ type }) =>
-          REDESIGNED_TRANSACTION_TYPES.includes(type as TransactionType),
+        isAutomaticGasFeeUpdateEnabled,
         disableHistory: true,
         disableSendFlowHistory: true,
         disableSwaps: true,
@@ -357,6 +357,23 @@ function beforeSign(
 ) {
   const predictController = request.getController('PredictController');
   return predictController.beforeSign(hookRequest);
+}
+
+function isAutomaticGasFeeUpdateEnabled(transaction: TransactionMeta) {
+  if (hasTransactionType(transaction, [TransactionType.relayDeposit])) {
+    return false;
+  }
+
+  if (
+    transaction.origin === ORIGIN_METAMASK &&
+    transaction.type === TransactionType.tokenMethodApprove
+  ) {
+    return false;
+  }
+
+  return REDESIGNED_TRANSACTION_TYPES.includes(
+    transaction.type as TransactionType,
+  );
 }
 
 function addTransactionControllerListeners(


### PR DESCRIPTION
## **Description**

Disable automatic gas fee updates for source transactions generated by Perps and Predict deposits.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines automatic gas fee update logic, disabling it for transactions with nested relayDeposit and MetaMask-origin token approvals, and updates tests accordingly.
> 
> - **Transaction Controller**:
>   - **Automatic Gas Fee Updates**:
>     - Implement `isAutomaticGasFeeUpdateEnabled(transaction)` and wire into `TransactionController` options.
>     - Disable when transaction has nested `relayDeposit`.
>     - Disable for `tokenMethodApprove` when `origin === ORIGIN_METAMASK`.
>     - Maintain behavior: enabled for `REDESIGNED_TRANSACTION_TYPES`, disabled for non-redesigned types.
>   - Add `hasTransactionType` and `ORIGIN_METAMASK` usage.
> - **Tests**:
>   - Expand `isAutomaticGasFeeUpdateEnabled` test coverage for redesigned/non-redesigned, nested `relayDeposit`, and MetaMask vs external origins.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f664ff642dd5742d66620c7fa0a29021dfceef16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->