### PR TITLE
test: initial metamask pay e2e tests

### DIFF
--- a/app/components/Views/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.tsx
@@ -5,6 +5,7 @@ import { useTransactionDetails } from '../../../hooks/activity/useTransactionDet
 import { strings } from '../../../../../../../locales/i18n';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { BigNumber } from 'bignumber.js';
+import { TransactionDetailsSelectorIDs } from '../../../../../../../e2e/selectors/Transactions/TransactionDetailsModal.selectors';
 
 export function TransactionDetailsBridgeFeeRow() {
   const formatFiat = useFiatFormatter({ currency: 'usd' });
@@ -25,7 +26,9 @@ export function TransactionDetailsBridgeFeeRow() {
     <TransactionDetailsRow
       label={strings('transaction_details.label.bridge_fee')}
     >
-      <Text>{bridgeFeeFiatFormatted}</Text>
+      <Text testID={TransactionDetailsSelectorIDs.TRANSACTION_FEE}>
+        {bridgeFeeFiatFormatted}
+      </Text>
     </TransactionDetailsRow>
   );
 }

--- a/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
@@ -8,6 +8,7 @@ import { hasTransactionType } from '../../../utils/transaction';
 import { useFeeCalculations } from '../../../hooks/gas/useFeeCalculations';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { BigNumber } from 'bignumber.js';
+import { TransactionDetailsSelectorIDs } from '../../../../../../../e2e/selectors/Transactions/TransactionDetailsModal.selectors';
 
 const FALLBACK_TYPES = [
   TransactionType.predictClaim,
@@ -40,7 +41,9 @@ export function TransactionDetailsNetworkFeeRow() {
     <TransactionDetailsRow
       label={strings('transaction_details.label.network_fee')}
     >
-      <Text>{networkFeeFormatted}</Text>
+      <Text testID={TransactionDetailsSelectorIDs.NETWORK_FEE}>
+        {networkFeeFormatted}
+      </Text>
     </TransactionDetailsRow>
   );
 }

--- a/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
@@ -7,6 +7,7 @@ import { TokenIcon, TokenIconVariant } from '../../token-icon';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { strings } from '../../../../../../../locales/i18n';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
+import { TransactionDetailsSelectorIDs } from '../../../../../../../e2e/selectors/Transactions/TransactionDetailsModal.selectors';
 
 export function TransactionDetailsPaidWithRow() {
   const { transactionMeta } = useTransactionDetails();
@@ -32,7 +33,9 @@ export function TransactionDetailsPaidWithRow() {
           address={tokenAddress}
           variant={TokenIconVariant.Row}
         />
-        <Text>{token.symbol}</Text>
+        <Text testID={TransactionDetailsSelectorIDs.PAID_WITH_SYMBOL}>
+          {token.symbol}
+        </Text>
       </Box>
     </TransactionDetailsRow>
   );

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
@@ -3,6 +3,7 @@ import { strings } from '../../../../../../../locales/i18n';
 import { TransactionDetailsRow } from '../transaction-details-row/transaction-details-row';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { TransactionDetailsStatus } from '../transaction-details-status';
+import { TransactionDetailsSelectorIDs } from '../../../../../../../e2e/selectors/Transactions/TransactionDetailsModal.selectors';
 
 export function TransactionDetailsStatusRow() {
   const { transactionMeta } = useTransactionDetails();
@@ -12,7 +13,10 @@ export function TransactionDetailsStatusRow() {
       <TransactionDetailsRow label={strings('transactions.status')}>
         <></>
       </TransactionDetailsRow>
-      <TransactionDetailsStatus transactionMeta={transactionMeta} />
+      <TransactionDetailsStatus
+        transactionMeta={transactionMeta}
+        testId={TransactionDetailsSelectorIDs.STATUS}
+      />
     </>
   );
 }

--- a/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.tsx
@@ -32,11 +32,13 @@ import { ARBITRUM_USDC } from '../../../constants/perps';
 export function TransactionDetailsStatus({
   gap,
   isBridgeReceive,
+  testId,
   text,
   transactionMeta,
 }: {
   gap?: number;
   isBridgeReceive?: boolean;
+  testId?: string;
   text?: string;
   transactionMeta: TransactionMeta;
 }) {
@@ -75,7 +77,11 @@ export function TransactionDetailsStatus({
         alignItems={AlignItems.center}
       >
         <StatusIcon status={status} transactionMeta={transactionMeta} />
-        <Text color={textColour} variant={TextVariant.BodyMDMedium}>
+        <Text
+          color={textColour}
+          variant={TextVariant.BodyMDMedium}
+          testID={testId}
+        >
           {statusText}
         </Text>
       </Box>

--- a/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
@@ -8,6 +8,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { hasTransactionType } from '../../../utils/transaction';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { BigNumber } from 'bignumber.js';
+import { TransactionDetailsSelectorIDs } from '../../../../../../../e2e/selectors/Transactions/TransactionDetailsModal.selectors';
 
 const FALLBACK_TYPES = [TransactionType.predictWithdraw];
 
@@ -39,7 +40,7 @@ export function TransactionDetailsTotalRow() {
 
   return (
     <TransactionDetailsRow label={label}>
-      <Text>{totalFormatted}</Text>
+      <Text testID={TransactionDetailsSelectorIDs.TOTAL}>{totalFormatted}</Text>
     </TransactionDetailsRow>
   );
 }

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -52,6 +52,7 @@ import Button, {
 import { useAlerts } from '../../../context/alert-system-context';
 import { useTransactionConfirm } from '../../../hooks/transactions/useTransactionConfirm';
 import EngineService from '../../../../../../core/EngineService';
+import { ConfirmationFooterSelectorIDs } from '../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 
 export interface CustomAmountInfoProps {
   children?: ReactNode;
@@ -262,6 +263,7 @@ function ConfirmButton({
       width={ButtonWidthTypes.Full}
       disabled={disabled}
       onPress={onConfirm}
+      testID={ConfirmationFooterSelectorIDs.CONFIRM_BUTTON}
     />
   );
 }

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -25,6 +25,7 @@ import AlertRow from '../../UI/info-row/alert-row';
 import { RowAlertKey } from '../../UI/info-row/alert-row/constants';
 import { useAlerts } from '../../../context/alert-system-context';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
+import { ConfirmationRowComponentIDs } from '../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 
 export function BridgeFeeRow() {
   const transactionMetadata = useTransactionMetadataOrThrow();
@@ -78,6 +79,7 @@ export function BridgeFeeRow() {
         <Text
           variant={TextVariant.BodyMD}
           color={hasAlert ? TextColor.Error : TextColor.Alternative}
+          testID={ConfirmationRowComponentIDs.TRANSACTION_FEE}
         >
           {feeTotalUsd}
         </Text>

--- a/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
@@ -15,6 +15,7 @@ import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTr
 import { InfoRowSkeleton, InfoRowVariant } from '../../UI/info-row/info-row';
 import { TransactionType } from '@metamask/transaction-controller';
 import { hasTransactionType } from '../../../utils/transaction';
+import { ConfirmationRowComponentIDs } from '../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 
 const SAME_CHAIN_DURATION_SECONDS = '< 10';
 
@@ -48,7 +49,11 @@ export function BridgeTimeRow() {
       label={strings('confirm.label.bridge_estimated_time')}
       rowVariant={InfoRowVariant.Small}
     >
-      <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+      <Text
+        variant={TextVariant.BodyMD}
+        color={TextColor.Alternative}
+        testID={ConfirmationRowComponentIDs.BRIDGE_TIME}
+      >
         {formattedSeconds}
       </Text>
     </InfoRow>

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -27,6 +27,10 @@ import Icon, {
   IconSize,
 } from '../../../../../../component-library/components/Icons/Icon';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
+import {
+  ConfirmationRowComponentIDs,
+  TransactionPayComponentIDs,
+} from '../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 
 export function PayWithRow() {
   const navigation = useNavigation();
@@ -56,7 +60,11 @@ export function PayWithRow() {
   }
 
   return (
-    <TouchableOpacity onPress={handleClick} disabled={!canEdit}>
+    <TouchableOpacity
+      onPress={handleClick}
+      disabled={!canEdit}
+      testID={ConfirmationRowComponentIDs.PAY_WITH}
+    >
       <Box
         flexDirection={FlexDirection.Row}
         alignItems={AlignItems.center}
@@ -65,10 +73,18 @@ export function PayWithRow() {
         style={styles.container}
       >
         <TokenIcon address={payToken.address} chainId={payToken.chainId} />
-        <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+        <Text
+          variant={TextVariant.BodyMDMedium}
+          color={TextColor.Default}
+          testID={TransactionPayComponentIDs.PAY_WITH_SYMBOL}
+        >
           {`${strings('confirm.label.pay_with')} ${payToken.symbol}`}
         </Text>
-        <Text variant={TextVariant.BodyMDMedium} color={TextColor.Alternative}>
+        <Text
+          variant={TextVariant.BodyMDMedium}
+          color={TextColor.Alternative}
+          testID={TransactionPayComponentIDs.PAY_WITH_BALANCE}
+        >
           {balanceUsdFormatted}
         </Text>
         {canEdit && from && (

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../hooks/pay/useTransactionPayData';
 import { InfoRowSkeleton, InfoRowVariant } from '../../UI/info-row/info-row';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
+import { ConfirmationRowComponentIDs } from '../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 
 export function TotalRow() {
   const formatFiat = useFiatFormatter({ currency: 'usd' });
@@ -35,7 +36,11 @@ export function TotalRow() {
         label={strings('confirm.label.total')}
         rowVariant={InfoRowVariant.Small}
       >
-        <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+        <Text
+          variant={TextVariant.BodyMD}
+          color={TextColor.Alternative}
+          testID={ConfirmationRowComponentIDs.TOTAL}
+        >
           {totalUsd}
         </Text>
       </InfoRow>

--- a/e2e/api-mocking/mock-responses/defaults/price-apis.ts
+++ b/e2e/api-mocking/mock-responses/defaults/price-apis.ts
@@ -68,6 +68,16 @@ export const PRICE_API_MOCKS: MockEventsObject = {
           usd: 1.0,
           eth: 0.000233,
         },
+        'eip155:137/erc20:0x2791bca1f2de4661ed88a30c99a7a9449aa84174': {
+          usd: 1.0,
+          eth: 0.000344,
+          price: 1.0,
+        },
+        'eip155:137/slip44:966': {
+          usd: 1.0,
+          price: 1.0,
+          eth: 0.000344,
+        },
       },
     },
     {

--- a/e2e/api-mocking/mock-responses/defaults/price-apis.ts
+++ b/e2e/api-mocking/mock-responses/defaults/price-apis.ts
@@ -24,6 +24,12 @@ export const PRICE_API_MOCKS: MockEventsObject = {
           value: 0.000233,
           currencyType: 'crypto',
         },
+        matic: {
+          name: 'Matic',
+          ticker: 'matic',
+          value: 0.000344,
+          currencyType: 'crypto',
+        },
         btc: {
           name: 'Bitcoin',
           ticker: 'btc',

--- a/e2e/api-mocking/mock-responses/polymarket/polymarket-mocks.ts
+++ b/e2e/api-mocking/mock-responses/polymarket/polymarket-mocks.ts
@@ -814,6 +814,12 @@ export const POLYMARKET_USDC_BALANCE_MOCKS = async (
         // This is critical for TransactionController to mark transactions as confirmed
         // TransactionController polls for receipts to determine transaction status
         result = MOCK_RPC_RESPONSES.TRANSACTION_RECEIPT_RESULT;
+      } else if (body?.method === 'eth_getBlockByNumber') {
+        // Return block details to enable EIP-1559 transactions
+        result = {
+          baseFeePerGas: '0x123',
+          number: currentBlockNumber,
+        };
       }
       // Note: We don't mock eth_gasPrice for Polygon - the app should use the gas API
       // (already mocked in DEFAULT_GAS_API_MOCKS) which provides EIP-1559 fields.

--- a/e2e/api-mocking/mock-responses/polymarket/polymarket-mocks.ts
+++ b/e2e/api-mocking/mock-responses/polymarket/polymarket-mocks.ts
@@ -747,6 +747,9 @@ export const POLYMARKET_USDC_BALANCE_MOCKS = async (
             // This indicates full allowance is granted
             result =
               '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+          } else if (callData?.toLowerCase()?.startsWith('0x6352211e')) {
+            // ownerOf(uint256) selector - return owner of the token
+            result = '0x';
           } else {
             // Other USDC contract calls - return current global balance as fallback
             result = currentUSDCBalance;

--- a/e2e/api-mocking/mock-responses/transaction-pay.ts
+++ b/e2e/api-mocking/mock-responses/transaction-pay.ts
@@ -1,0 +1,354 @@
+import { Mockttp } from 'mockttp';
+
+export const RELAY_QUOTE_MOCK = {
+  steps: [
+    {
+      id: 'deposit',
+      action: 'Confirm transaction in your wallet',
+      description:
+        'Depositing funds to the relayer to execute the swap for USDC.e',
+      kind: 'transaction',
+      items: [
+        {
+          status: 'incomplete',
+          data: {
+            from: '0xb0da5965d43369968574d399dbe6374683773a65',
+            to: '0x00000000aa467eba42a3d604b3d74d63b2b6c6cb',
+            data: '0x470b5f3b22544142d6b2116ec296913046fe06578b495e602ac2fe0c87b843de',
+            value: '429579670170726',
+            chainId: 59144,
+            gas: '43626',
+            maxFeePerGas: '67699627',
+            maxPriorityFeePerGas: '67699618',
+          },
+          check: {
+            endpoint:
+              '/intents/status?requestId=0x470b5f3b22544142d6b2116ec296913046fe06578b495e602ac2fe0c87b843de',
+            method: 'GET',
+          },
+        },
+      ],
+      requestId:
+        '0x470b5f3b22544142d6b2116ec296913046fe06578b495e602ac2fe0c87b843de',
+      depositAddress: '',
+    },
+  ],
+  fees: {
+    gas: {
+      currency: {
+        chainId: 59144,
+        address: '0x0000000000000000000000000000000000000000',
+        symbol: 'ETH',
+        name: 'Ether',
+        decimals: 18,
+        metadata: {
+          logoURI: 'https://assets.relay.link/icons/1/light.png',
+          verified: true,
+        },
+      },
+      amount: '2271931782493',
+      amountFormatted: '0.000002271931782493',
+      amountUsd: '0.006691',
+      minimumAmount: '2271931782493',
+    },
+    relayer: {
+      currency: {
+        chainId: 59144,
+        address: '0x0000000000000000000000000000000000000000',
+        symbol: 'ETH',
+        name: 'Ether',
+        decimals: 18,
+        metadata: {
+          logoURI: 'https://assets.relay.link/icons/1/light.png',
+          verified: true,
+        },
+      },
+      amount: '11066796286303',
+      amountFormatted: '0.000011066796286303',
+      amountUsd: '0.032592',
+      minimumAmount: '11066796286303',
+    },
+    relayerGas: {
+      currency: {
+        chainId: 59144,
+        address: '0x0000000000000000000000000000000000000000',
+        symbol: 'ETH',
+        name: 'Ether',
+        decimals: 18,
+        metadata: {
+          logoURI: 'https://assets.relay.link/icons/1/light.png',
+          verified: true,
+        },
+      },
+      amount: '2062086926533',
+      amountFormatted: '0.000002062086926533',
+      amountUsd: '0.006073',
+      minimumAmount: '2062086926533',
+    },
+    relayerService: {
+      currency: {
+        chainId: 59144,
+        address: '0x0000000000000000000000000000000000000000',
+        symbol: 'ETH',
+        name: 'Ether',
+        decimals: 18,
+        metadata: {
+          logoURI: 'https://assets.relay.link/icons/1/light.png',
+          verified: true,
+        },
+      },
+      amount: '9004709359770',
+      amountFormatted: '0.00000900470935977',
+      amountUsd: '0.026519',
+      minimumAmount: '9004709359770',
+    },
+    app: {
+      currency: {
+        chainId: 59144,
+        address: '0x0000000000000000000000000000000000000000',
+        symbol: 'ETH',
+        name: 'Ether',
+        decimals: 18,
+        metadata: {
+          logoURI: 'https://assets.relay.link/icons/1/light.png',
+          verified: true,
+        },
+      },
+      amount: '0',
+      amountFormatted: '0.0',
+      amountUsd: '0',
+      minimumAmount: '0',
+    },
+    subsidized: {
+      currency: {
+        chainId: 59144,
+        address: '0x0000000000000000000000000000000000000000',
+        symbol: 'ETH',
+        name: 'Ether',
+        decimals: 18,
+        metadata: {
+          logoURI: 'https://assets.relay.link/icons/1/light.png',
+          verified: true,
+        },
+      },
+      amount: '0',
+      amountFormatted: '0.0',
+      amountUsd: '0',
+      minimumAmount: '0',
+    },
+  },
+  details: {
+    operation: 'swap',
+    sender: '0xb0da5965d43369968574d399dbe6374683773a65',
+    recipient: '0x8f781b47e4a377dba9547cdcd00df98c7064a5b2',
+    currencyIn: {
+      currency: {
+        chainId: 59144,
+        address: '0x0000000000000000000000000000000000000000',
+        symbol: 'ETH',
+        name: 'Ether',
+        decimals: 18,
+        metadata: {
+          logoURI: 'https://assets.relay.link/icons/1/light.png',
+          verified: true,
+        },
+      },
+      amount: '429579670170726',
+      amountFormatted: '0.000429579670170726',
+      amountUsd: '1.265112',
+      minimumAmount: '429579670170726',
+    },
+    currencyOut: {
+      currency: {
+        chainId: 137,
+        address: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+        symbol: 'USDC.e',
+        name: 'USDCoin (bridged)',
+        decimals: 6,
+        metadata: {
+          logoURI: 'https://ethereum-optimism.github.io/data/USDC/logo.png',
+          verified: true,
+        },
+      },
+      amount: '1230000',
+      amountFormatted: '1.23',
+      amountUsd: '1.229758',
+      minimumAmount: '1223660',
+    },
+    refundCurrency: {
+      currency: {
+        chainId: 59144,
+        address: '0x0000000000000000000000000000000000000000',
+        symbol: 'ETH',
+        name: 'Ether',
+        decimals: 18,
+        metadata: {
+          logoURI: 'https://assets.relay.link/icons/1/light.png',
+          verified: true,
+        },
+      },
+      amount: '429579670170726',
+      amountFormatted: '0.000429579670170726',
+      amountUsd: '1.265112',
+      minimumAmount: '429579670170726',
+    },
+    totalImpact: {
+      usd: '-0.035354',
+      percent: '-2.79',
+    },
+    swapImpact: {
+      usd: '-0.003009',
+      percent: '-0.24',
+    },
+    expandedPriceImpact: {
+      swap: {
+        usd: '-0.003623',
+      },
+      execution: {
+        usd: '-0.026073',
+      },
+      relay: {
+        usd: '-0.005905',
+      },
+      app: {
+        usd: '0',
+      },
+    },
+    rate: '2862.6890083305493',
+    slippageTolerance: {
+      origin: {
+        usd: '0.000000',
+        value: '0',
+        percent: '0.00',
+      },
+      destination: {
+        usd: '0.006272',
+        value: '6340',
+        percent: '0.51',
+      },
+    },
+    timeEstimate: 4,
+    userBalance: '0',
+    isFixedRate: false,
+    route: {
+      origin: {
+        inputCurrency: {
+          currency: {
+            chainId: 59144,
+            address: '0x0000000000000000000000000000000000000000',
+            symbol: 'ETH',
+            name: 'Ether',
+            decimals: 18,
+            metadata: {
+              logoURI: 'https://assets.relay.link/icons/1/light.png',
+              verified: true,
+            },
+          },
+          amount: '429579670170726',
+          amountFormatted: '0.000429579670170726',
+          amountUsd: '1.265112',
+          minimumAmount: '429579670170726',
+        },
+        outputCurrency: {
+          currency: {
+            chainId: 59144,
+            address: '0x0000000000000000000000000000000000000000',
+            symbol: 'ETH',
+            name: 'Ether',
+            decimals: 18,
+            metadata: {
+              logoURI: 'https://assets.relay.link/icons/1/light.png',
+              verified: true,
+            },
+          },
+          amount: '429579670170726',
+          amountFormatted: '0.000429579670170726',
+          amountUsd: '1.265112',
+          minimumAmount: '429579670170726',
+        },
+        router: 'relay',
+      },
+      destination: {
+        inputCurrency: {
+          currency: {
+            chainId: 137,
+            address: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+            symbol: 'USDC',
+            name: 'USD Coin',
+            decimals: 6,
+            metadata: {
+              logoURI: 'https://ethereum-optimism.github.io/data/USDC/logo.png',
+              verified: true,
+            },
+          },
+          amount: '1229919',
+          amountFormatted: '1.229919',
+          amountUsd: '1.229677',
+          minimumAmount: '1229919',
+        },
+        outputCurrency: {
+          currency: {
+            chainId: 137,
+            address: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+            symbol: 'USDC.e',
+            name: 'USDCoin (bridged)',
+            decimals: 6,
+            metadata: {
+              logoURI: 'https://ethereum-optimism.github.io/data/USDC/logo.png',
+              verified: true,
+            },
+          },
+          amount: '1230000',
+          amountFormatted: '1.23',
+          amountUsd: '1.229758',
+          minimumAmount: '1223660',
+        },
+        router: '0x',
+      },
+    },
+  },
+};
+
+export const RELAY_STATUS_MOCK = {
+  status: 'success',
+  txHashes: [
+    '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  ],
+};
+
+export async function mockRelayQuote(mockServer: Mockttp) {
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const url = new URL(request.url).searchParams.get('url');
+      return Boolean(url?.includes('api.relay.link/quote'));
+    })
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: RELAY_QUOTE_MOCK,
+    }));
+}
+
+export async function mockRelayStatus(mockServer: Mockttp) {
+  const rule = await mockServer.forGet('/proxy').matching((request) => {
+    const url = new URL(request.url).searchParams.get('url');
+    return Boolean(url?.includes('api.relay.link/intents/status'));
+  });
+
+  await rule.thenCallback(() => ({
+    statusCode: 200,
+    json: { ...RELAY_STATUS_MOCK, status: 'pending' },
+  }));
+
+  await rule.thenCallback(() => ({
+    statusCode: 200,
+    json: { ...RELAY_STATUS_MOCK, status: 'pending' },
+  }));
+
+  await rule.thenCallback(() => ({
+    statusCode: 200,
+    json: RELAY_STATUS_MOCK,
+  }));
+
+  return rule;
+}

--- a/e2e/api-mocking/mock-responses/transaction-pay.ts
+++ b/e2e/api-mocking/mock-responses/transaction-pay.ts
@@ -331,25 +331,14 @@ export async function mockRelayQuote(mockServer: Mockttp) {
 }
 
 export async function mockRelayStatus(mockServer: Mockttp) {
-  const rule = await mockServer.forGet('/proxy').matching((request) => {
-    const url = new URL(request.url).searchParams.get('url');
-    return Boolean(url?.includes('api.relay.link/intents/status'));
-  });
-
-  await rule.thenCallback(() => ({
-    statusCode: 200,
-    json: { ...RELAY_STATUS_MOCK, status: 'pending' },
-  }));
-
-  await rule.thenCallback(() => ({
-    statusCode: 200,
-    json: { ...RELAY_STATUS_MOCK, status: 'pending' },
-  }));
-
-  await rule.thenCallback(() => ({
-    statusCode: 200,
-    json: RELAY_STATUS_MOCK,
-  }));
-
-  return rule;
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const url = new URL(request.url).searchParams.get('url');
+      return Boolean(url?.includes('api.relay.link/intents/status'));
+    })
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: RELAY_STATUS_MOCK,
+    }));
 }

--- a/e2e/api-mocking/mock-responses/transaction-pay.ts
+++ b/e2e/api-mocking/mock-responses/transaction-pay.ts
@@ -1,4 +1,5 @@
 import { Mockttp } from 'mockttp';
+import { DEFAULT_FIXTURE_ACCOUNT } from '../../framework/fixtures/FixtureBuilder';
 
 export const RELAY_QUOTE_MOCK = {
   steps: [
@@ -12,7 +13,7 @@ export const RELAY_QUOTE_MOCK = {
         {
           status: 'incomplete',
           data: {
-            from: '0xb0da5965d43369968574d399dbe6374683773a65',
+            from: DEFAULT_FIXTURE_ACCOUNT,
             to: '0x00000000aa467eba42a3d604b3d74d63b2b6c6cb',
             data: '0x470b5f3b22544142d6b2116ec296913046fe06578b495e602ac2fe0c87b843de',
             value: '429579670170726',
@@ -139,7 +140,7 @@ export const RELAY_QUOTE_MOCK = {
   },
   details: {
     operation: 'swap',
-    sender: '0xb0da5965d43369968574d399dbe6374683773a65',
+    sender: DEFAULT_FIXTURE_ACCOUNT,
     recipient: '0x8f781b47e4a377dba9547cdcd00df98c7064a5b2',
     currencyIn: {
       currency: {
@@ -318,7 +319,7 @@ export const RELAY_STATUS_MOCK = {
 
 export async function mockRelayQuote(mockServer: Mockttp) {
   await mockServer
-    .forGet('/proxy')
+    .forPost('/proxy')
     .matching((request) => {
       const url = new URL(request.url).searchParams.get('url');
       return Boolean(url?.includes('api.relay.link/quote'));

--- a/e2e/framework/fixtures/FixtureBuilder.ts
+++ b/e2e/framework/fixtures/FixtureBuilder.ts
@@ -2264,6 +2264,21 @@ class FixtureBuilder {
     });
   }
 
+  withTokenRates(chainId: string, tokenAddress: string, price: number) {
+    merge(this.fixture.state.engine.backgroundState.TokenRatesController, {
+      marketData: {
+        [chainId]: {
+          [tokenAddress]: {
+            tokenAddress,
+            price,
+          },
+        },
+      },
+    });
+
+    return this;
+  }
+
   /**
    * Build and return the fixture object.
    * @returns {Object} - The built fixture object.

--- a/e2e/pages/Confirmation/TransactionPayConfirmation.ts
+++ b/e2e/pages/Confirmation/TransactionPayConfirmation.ts
@@ -1,0 +1,98 @@
+import {
+  ConfirmationRowComponentIDs,
+  TransactionPayComponentIDs,
+} from '../../selectors/Confirmation/ConfirmationView.selectors';
+import Matchers from '../../framework/Matchers';
+import { Assertions, Gestures } from '../../framework';
+
+class TransactionPayConfirmation {
+  get bridgeTime(): DetoxElement {
+    return Matchers.getElementByID(ConfirmationRowComponentIDs.BRIDGE_TIME);
+  }
+
+  get payWithRow(): DetoxElement {
+    return Matchers.getElementByID(ConfirmationRowComponentIDs.PAY_WITH);
+  }
+
+  get payWithSymbol(): DetoxElement {
+    return Matchers.getElementByID(TransactionPayComponentIDs.PAY_WITH_SYMBOL);
+  }
+
+  get payWithFiat(): DetoxElement {
+    return Matchers.getElementByID(TransactionPayComponentIDs.PAY_WITH_FIAT);
+  }
+
+  get payWithBalance(): DetoxElement {
+    return Matchers.getElementByID(TransactionPayComponentIDs.PAY_WITH_BALANCE);
+  }
+
+  get keyboardContinueButton(): DetoxElement {
+    return Matchers.getElementByID(
+      TransactionPayComponentIDs.KEYBOARD_CONTINUE_BUTTON,
+    );
+  }
+
+  get total(): DetoxElement {
+    return Matchers.getElementByID(ConfirmationRowComponentIDs.TOTAL);
+  }
+
+  get transactionFee(): DetoxElement {
+    return Matchers.getElementByID(ConfirmationRowComponentIDs.TRANSACTION_FEE);
+  }
+
+  availableToken(address: string, chainId: string): DetoxElement {
+    return Matchers.getElementByID(`available-token-${address}-${chainId}`);
+  }
+
+  async tapPayWithRow(): Promise<void> {
+    await Gestures.waitAndTap(this.payWithRow, {
+      elemDescription: 'Pay With Row',
+    });
+  }
+
+  async tapPayWithToken(tokenSymbol: string): Promise<void> {
+    await Gestures.waitAndTap(Matchers.getElementByText(tokenSymbol), {
+      elemDescription: `Pay With Token ${tokenSymbol}`,
+    });
+  }
+
+  async tapKeyboardContinueButton(): Promise<void> {
+    await Gestures.waitAndTap(this.keyboardContinueButton, {
+      elemDescription: 'Keyboard Continue Button',
+    });
+  }
+
+  async tapKeyboardAmount(amount: string): Promise<void> {
+    for (const char of amount) {
+      await Gestures.waitAndTap(Matchers.getElementByText(char), {
+        elemDescription: `Keyboard Key ${char}`,
+      });
+    }
+  }
+
+  async verifyPayWithSymbol(symbol: string): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.payWithSymbol, {
+      description: `Token symbol ${symbol} should be selected in pay with row`,
+    });
+  }
+
+  async verifyTransactionFee(fee: string): Promise<void> {
+    await Assertions.expectElementToHaveText(this.transactionFee, fee, {
+      description: 'Transaction fee should be correct',
+    });
+  }
+
+  async verifyBridgeTime(time: string): Promise<void> {
+    await Assertions.expectElementToHaveText(this.bridgeTime, time, {
+      description: 'Bridge time should be correct',
+    });
+  }
+
+  async verifyTotal(total: string): Promise<void> {
+    await Assertions.expectElementToHaveText(this.total, total, {
+      description: 'Total should be correct',
+    });
+  }
+}
+
+export default new TransactionPayConfirmation();

--- a/e2e/pages/Confirmation/TransactionPayConfirmation.ts
+++ b/e2e/pages/Confirmation/TransactionPayConfirmation.ts
@@ -40,10 +40,6 @@ class TransactionPayConfirmation {
     return Matchers.getElementByID(ConfirmationRowComponentIDs.TRANSACTION_FEE);
   }
 
-  availableToken(address: string, chainId: string): DetoxElement {
-    return Matchers.getElementByID(`available-token-${address}-${chainId}`);
-  }
-
   async tapPayWithRow(): Promise<void> {
     await Gestures.waitAndTap(this.payWithRow, {
       elemDescription: 'Pay With Row',
@@ -70,27 +66,27 @@ class TransactionPayConfirmation {
     }
   }
 
-  async verifyPayWithSymbol(symbol: string): Promise<void> {
-    await Assertions.expectElementToBeVisible(this.payWithSymbol, {
-      description: `Token symbol ${symbol} should be selected in pay with row`,
-    });
-  }
-
-  async verifyTransactionFee(fee: string): Promise<void> {
-    await Assertions.expectElementToHaveText(this.transactionFee, fee, {
-      description: 'Transaction fee should be correct',
-    });
-  }
-
   async verifyBridgeTime(time: string): Promise<void> {
     await Assertions.expectElementToHaveText(this.bridgeTime, time, {
       description: 'Bridge time should be correct',
     });
   }
 
+  async verifyPayWithSymbol(symbol: string): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.payWithSymbol, {
+      description: `Token symbol ${symbol} should be selected in pay with row`,
+    });
+  }
+
   async verifyTotal(total: string): Promise<void> {
     await Assertions.expectElementToHaveText(this.total, total, {
       description: 'Total should be correct',
+    });
+  }
+
+  async verifyTransactionFee(fee: string): Promise<void> {
+    await Assertions.expectElementToHaveText(this.transactionFee, fee, {
+      description: 'Transaction fee should be correct',
     });
   }
 }

--- a/e2e/pages/Confirmation/TransactionPayConfirmation.ts
+++ b/e2e/pages/Confirmation/TransactionPayConfirmation.ts
@@ -72,12 +72,6 @@ class TransactionPayConfirmation {
     });
   }
 
-  async verifyPayWithSymbol(symbol: string): Promise<void> {
-    await Assertions.expectElementToBeVisible(this.payWithSymbol, {
-      description: `Token symbol ${symbol} should be selected in pay with row`,
-    });
-  }
-
   async verifyTotal(total: string): Promise<void> {
     await Assertions.expectElementToHaveText(this.total, total, {
       description: 'Total should be correct',

--- a/e2e/pages/Transactions/ActivitiesView.ts
+++ b/e2e/pages/Transactions/ActivitiesView.ts
@@ -52,6 +52,12 @@ class ActivitiesView {
     return Matchers.getElementByText(ActivitiesViewSelectorsText.APPROVE);
   }
 
+  get predictDeposit(): DetoxElement {
+    return Matchers.getElementByText(
+      ActivitiesViewSelectorsText.PREDICT_DEPOSIT,
+    );
+  }
+
   transactionStatus(row: number): DetoxElement {
     return Matchers.getElementByID(`transaction-status-${row}`);
   }
@@ -111,18 +117,22 @@ class ActivitiesView {
     const el = this.swapActivityTitle(sourceToken, destinationToken);
     await Gestures.waitAndTap(el);
   }
+
   async tapConfirmedTransaction(): Promise<void> {
     await Gestures.waitAndTap(this.confirmedLabel);
   }
+
   async swipeDown(): Promise<void> {
     await Gestures.swipe(this.container, 'down', {
       speed: 'slow',
       percentage: 0.5,
     });
   }
+
   async tapOnTransactionItem(row: number): Promise<void> {
     await Gestures.waitAndTap(this.transactionItem(row));
   }
+
   async tapOnPredictionsTab(): Promise<void> {
     // Swipe left on the tabs bar to reveal the Predictions tab (it may be off-screen)
     await Gestures.swipe(this.tabsBar, 'left', {
@@ -134,6 +144,7 @@ class ActivitiesView {
       elemDescription: 'Predictions Tab in Activity View',
     });
   }
+
   async tapPredictPosition(positionName: string): Promise<void> {
     const el = Matchers.getElementByText(positionName);
     await Gestures.waitAndTap(el, {

--- a/e2e/pages/Transactions/TransactionDetailsModal.ts
+++ b/e2e/pages/Transactions/TransactionDetailsModal.ts
@@ -1,19 +1,44 @@
 import {
   TransactionDetailsModalSelectorsText,
   TransactionDetailsModalSelectorsIDs,
+  TransactionDetailsSelectorIDs,
 } from '../../selectors/Transactions/TransactionDetailsModal.selectors';
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
-import { logger } from '../../framework';
+import { Assertions, logger } from '../../framework';
 
 class TransactionDetailsModal {
+  get closeIcon(): DetoxElement {
+    return Matchers.getElementByID(
+      TransactionDetailsModalSelectorsIDs.CLOSE_ICON,
+    );
+  }
+
+  get networkFee(): DetoxElement {
+    return Matchers.getElementByID(TransactionDetailsSelectorIDs.NETWORK_FEE);
+  }
+
+  get paidWithSymbol(): DetoxElement {
+    return Matchers.getElementByID(
+      TransactionDetailsSelectorIDs.PAID_WITH_SYMBOL,
+    );
+  }
+
+  get status(): DetoxElement {
+    return Matchers.getElementByID(TransactionDetailsSelectorIDs.STATUS);
+  }
+
   get title(): DetoxElement {
     return Matchers.getElementByID(TransactionDetailsModalSelectorsIDs.TITLE);
   }
 
-  get closeIcon(): DetoxElement {
+  get total(): DetoxElement {
+    return Matchers.getElementByID(TransactionDetailsSelectorIDs.TOTAL);
+  }
+
+  get transactionFee(): DetoxElement {
     return Matchers.getElementByID(
-      TransactionDetailsModalSelectorsIDs.CLOSE_ICON,
+      TransactionDetailsSelectorIDs.TRANSACTION_FEE,
     );
   }
 
@@ -33,6 +58,36 @@ class TransactionDetailsModal {
         'TransactionDetailsModal: tapOnCloseIcon - failed, skipping tap.',
       );
     }
+  }
+
+  async verifyNetworkFee(fee: string): Promise<void> {
+    await Assertions.expectElementToHaveText(this.networkFee, fee, {
+      description: 'Network fee should be correct',
+    });
+  }
+
+  async verifyPaidWithSymbol(symbol: string): Promise<void> {
+    await Assertions.expectElementToHaveText(this.paidWithSymbol, symbol, {
+      description: 'Paid with symbol should be correct',
+    });
+  }
+
+  async verifyStatus(status: string): Promise<void> {
+    await Assertions.expectElementToHaveText(this.status, status, {
+      description: 'Status should be correct',
+    });
+  }
+
+  async verifyTotal(total: string): Promise<void> {
+    await Assertions.expectElementToHaveText(this.total, total, {
+      description: 'Total should be correct',
+    });
+  }
+
+  async verifyTransactionFee(fee: string): Promise<void> {
+    await Assertions.expectElementToHaveText(this.transactionFee, fee, {
+      description: 'Transaction fee should be correct',
+    });
   }
 }
 

--- a/e2e/selectors/Confirmation/ConfirmationView.selectors.ts
+++ b/e2e/selectors/Confirmation/ConfirmationView.selectors.ts
@@ -31,17 +31,21 @@ export const ConfirmationRowComponentIDs = {
   ACCOUNT_NETWORK: 'account-network',
   ADVANCED_DETAILS: 'advanced-details',
   APPROVE_ROW: 'approve-row',
+  BRIDGE_TIME: 'bridge-time',
   FROM_TO: 'from-to',
   GAS_FEES_DETAILS: 'gas-fees-details',
+  GAS_FEE_TOKEN_PILL: 'selected-gas-fee-token',
   MESSAGE: 'message',
   NETWORK: 'network',
   ORIGIN_INFO: 'origin-info',
+  PAID_BY_METAMASK: 'paid-by-metamask',
+  PAY_WITH: 'pay-with',
   SIMULATION_DETAILS: 'simulation-details',
   SIWE_SIGNING_ACCOUNT_INFO: 'siwe-signing-account-info',
   STAKING_DETAILS: 'staking-details',
   TOKEN_HERO: 'token-hero',
-  PAID_BY_METAMASK: 'paid-by-metamask',
-  GAS_FEE_TOKEN_PILL: 'selected-gas-fee-token',
+  TOTAL: 'total',
+  TRANSACTION_FEE: 'transaction-fee',
 } as const;
 
 export const ConfirmationFooterSelectorIDs = {
@@ -87,3 +91,11 @@ export const GasFeeTokenModalSelectorsText = {
   GAS_FEE_TOKEN_SYMBOL: 'gas-fee-token-list-item-symbol',
   GAS_FEE_TOKEN_AMOUNT_FIAT: 'gas-fee-token-list-item-amount-fiat',
 } as const;
+
+export const TransactionPayComponentIDs = {
+  CLOSE_MODAL_BUTTON: 'bridge-token-selector-close-button',
+  KEYBOARD_CONTINUE_BUTTON: 'deposit-keyboard-done-button',
+  PAY_WITH_BALANCE: 'pay-with-balance',
+  PAY_WITH_FIAT: 'pay-with-fiat',
+  PAY_WITH_SYMBOL: 'pay-with-symbol',
+};

--- a/e2e/selectors/Transactions/ActivitiesView.selectors.ts
+++ b/e2e/selectors/Transactions/ActivitiesView.selectors.ts
@@ -26,6 +26,7 @@ export const ActivitiesViewSelectorsText = {
   STAKE_DEPOSIT: enContent.transactions.tx_review_staking_deposit,
   UNSTAKE: enContent.transactions.tx_review_staking_unstake,
   STAKING_CLAIM: enContent.transactions.tx_review_staking_claim,
+  PREDICT_DEPOSIT: enContent.transactions.tx_review_predict_deposit,
 };
 
 export const sentMessageTokenIDs = {

--- a/e2e/selectors/Transactions/TransactionDetailsModal.selectors.js
+++ b/e2e/selectors/Transactions/TransactionDetailsModal.selectors.js
@@ -9,3 +9,11 @@ export const TransactionDetailsModalSelectorsIDs = {
   TITLE: 'details-modal-title',
   CLOSE_ICON: 'details-modal-close-icon',
 };
+
+export const TransactionDetailsSelectorIDs = {
+  NETWORK_FEE: 'transaction-details-network-fee',
+  PAID_WITH_SYMBOL: 'transaction-details-paid-with-symbol',
+  STATUS: 'transaction-details-status',
+  TOTAL: 'transaction-details-total',
+  TRANSACTION_FEE: 'transaction-details-bridge-fee',
+};

--- a/e2e/specs/confirmations/transaction-pay.spec.ts
+++ b/e2e/specs/confirmations/transaction-pay.spec.ts
@@ -24,32 +24,22 @@ import WalletActionsBottomSheet from '../../pages/wallet/WalletActionsBottomShee
 import ActivitiesView from '../../pages/Transactions/ActivitiesView';
 import PredictMarketList from '../../pages/Predict/PredictMarketList';
 
-const testSpecificMock = async (mockServer: Mockttp) => {
-  await setupRemoteFeatureFlagsMock(mockServer, {
-    ...remoteFeatureFlagPredictEnabled(true),
-    ...remoteFeatureEip7702[1],
-  });
-
-  await POLYMARKET_COMPLETE_MOCKS(mockServer);
-  await mockRelayQuote(mockServer);
-  await mockRelayStatus(mockServer);
-};
-
 describe(SmokeConfirmationsRedesigned('Transaction Pay'), () => {
-  it('depoits to predict balance', async () => {
+  it('deposits to predict balance', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder()
           .withPolygon()
-          .withTokenRates(
+          .withTokens(
+            [
+              {
+                address: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+                decimals: 6,
+                name: 'USD Coin (PoS)',
+                symbol: 'USDC.e',
+              },
+            ],
             CHAIN_IDS.POLYGON,
-            '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-            2.0,
-          )
-          .withTokenRates(
-            CHAIN_IDS.LINEA_MAINNET,
-            '0x0000000000000000000000000000000000000000',
-            2.0,
           )
           .build(),
         restartDevice: true,
@@ -67,6 +57,7 @@ describe(SmokeConfirmationsRedesigned('Transaction Pay'), () => {
         await TransactionPayConfirmation.tapPayWithToken('LineaETH');
         await TransactionPayConfirmation.tapKeyboardAmount('1.23');
         await TransactionPayConfirmation.tapKeyboardContinueButton();
+
         await TransactionPayConfirmation.verifyTransactionFee('$0.05');
         await TransactionPayConfirmation.verifyBridgeTime('< 1 min');
         await TransactionPayConfirmation.verifyTotal('$1.28');
@@ -84,3 +75,14 @@ describe(SmokeConfirmationsRedesigned('Transaction Pay'), () => {
     );
   });
 });
+
+async function testSpecificMock(mockServer: Mockttp) {
+  await setupRemoteFeatureFlagsMock(mockServer, {
+    ...remoteFeatureFlagPredictEnabled(true),
+    ...remoteFeatureEip7702[1],
+  });
+
+  await POLYMARKET_COMPLETE_MOCKS(mockServer);
+  await mockRelayQuote(mockServer);
+  await mockRelayStatus(mockServer);
+}

--- a/e2e/specs/confirmations/transaction-pay.spec.ts
+++ b/e2e/specs/confirmations/transaction-pay.spec.ts
@@ -64,7 +64,9 @@ describe(SmokeConfirmationsRedesigned('Transaction Pay'), () => {
 
         await PredictMarketList.tapBackButton();
         await TabBarComponent.tapActivity();
-        await Gestures.waitAndTap(ActivitiesView.predictDeposit);
+        await Gestures.waitAndTap(ActivitiesView.predictDeposit, {
+          elemDescription: 'Predict Deposit transaction item',
+        });
         await TransactionDetailsModal.verifyNetworkFee('$4.13');
         await TransactionDetailsModal.verifyPaidWithSymbol('LineaETH');
         await TransactionDetailsModal.verifyTotal('$5.40');

--- a/e2e/specs/confirmations/transaction-pay.spec.ts
+++ b/e2e/specs/confirmations/transaction-pay.spec.ts
@@ -1,0 +1,64 @@
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { SmokePredictions } from '../../tags';
+import { loginToApp } from '../../viewHelper';
+import TabBarComponent from '../../pages/wallet/TabBarComponent';
+import WalletActionsBottomSheet from '../../pages/wallet/WalletActionsBottomSheet';
+import {
+  remoteFeatureEip7702,
+  remoteFeatureFlagPredictEnabled,
+} from '../../api-mocking/mock-responses/feature-flags-mocks';
+import { Mockttp } from 'mockttp';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
+import { POLYMARKET_COMPLETE_MOCKS } from '../../api-mocking/mock-responses/polymarket/polymarket-mocks';
+import PredictAddFunds from '../../pages/Predict/PredictAddFunds';
+import {
+  mockRelayQuote,
+  mockRelayStatus,
+} from '../../api-mocking/mock-responses/transaction-pay';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import TestHelpers from '../../helpers';
+
+const PredictionMarketFeature = async (mockServer: Mockttp) => {
+  await setupRemoteFeatureFlagsMock(mockServer, {
+    ...remoteFeatureFlagPredictEnabled(true),
+    ...remoteFeatureEip7702[1],
+  });
+
+  await POLYMARKET_COMPLETE_MOCKS(mockServer);
+  await mockRelayQuote(mockServer);
+  await mockRelayStatus(mockServer);
+};
+
+describe(SmokePredictions('Transaction Pay'), () => {
+  it('depoits USDC.e to Predict account', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder()
+          .withPolygon()
+          .withTokenRates(
+            CHAIN_IDS.POLYGON,
+            '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+            2.0,
+          )
+          .withTokenRates(
+            CHAIN_IDS.LINEA_MAINNET,
+            '0x0000000000000000000000000000000000000000',
+            2.0,
+          )
+          .build(),
+        restartDevice: true,
+        testSpecificMock: PredictionMarketFeature,
+      },
+      async () => {
+        await loginToApp();
+
+        await TabBarComponent.tapActions();
+        await WalletActionsBottomSheet.tapPredictButton();
+        await device.disableSynchronization();
+        await PredictAddFunds.tapAddFunds();
+        await TestHelpers.delay(10000);
+      },
+    );
+  });
+});

--- a/e2e/specs/confirmations/transaction-pay.spec.ts
+++ b/e2e/specs/confirmations/transaction-pay.spec.ts
@@ -57,18 +57,17 @@ describe(SmokeConfirmationsRedesigned('Transaction Pay'), () => {
         await TransactionPayConfirmation.tapPayWithToken('LineaETH');
         await TransactionPayConfirmation.tapKeyboardAmount('1.23');
         await TransactionPayConfirmation.tapKeyboardContinueButton();
-
-        await TransactionPayConfirmation.verifyTransactionFee('$0.05');
+        await TransactionPayConfirmation.verifyTransactionFee('$4.17');
         await TransactionPayConfirmation.verifyBridgeTime('< 1 min');
-        await TransactionPayConfirmation.verifyTotal('$1.28');
+        await TransactionPayConfirmation.verifyTotal('$5.40');
         await FooterActions.tapConfirmButton();
 
         await PredictMarketList.tapBackButton();
         await TabBarComponent.tapActivity();
         await Gestures.waitAndTap(ActivitiesView.predictDeposit);
-        await TransactionDetailsModal.verifyNetworkFee('$0.01');
+        await TransactionDetailsModal.verifyNetworkFee('$4.13');
         await TransactionDetailsModal.verifyPaidWithSymbol('LineaETH');
-        await TransactionDetailsModal.verifyTotal('$1.28');
+        await TransactionDetailsModal.verifyTotal('$5.40');
         await TransactionDetailsModal.verifyTransactionFee('$0.04');
         await TransactionDetailsModal.verifyStatus('Confirmed');
       },

--- a/e2e/specs/confirmations/transaction-pay.spec.ts
+++ b/e2e/specs/confirmations/transaction-pay.spec.ts
@@ -1,6 +1,6 @@
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
-import { SmokePredictions } from '../../tags';
+import { SmokeConfirmationsRedesigned } from '../../tags';
 import { loginToApp } from '../../viewHelper';
 import {
   remoteFeatureEip7702,
@@ -24,7 +24,7 @@ import WalletActionsBottomSheet from '../../pages/wallet/WalletActionsBottomShee
 import ActivitiesView from '../../pages/Transactions/ActivitiesView';
 import PredictMarketList from '../../pages/Predict/PredictMarketList';
 
-const PredictionMarketFeature = async (mockServer: Mockttp) => {
+const testSpecificMock = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(mockServer, {
     ...remoteFeatureFlagPredictEnabled(true),
     ...remoteFeatureEip7702[1],
@@ -35,7 +35,7 @@ const PredictionMarketFeature = async (mockServer: Mockttp) => {
   await mockRelayStatus(mockServer);
 };
 
-describe(SmokePredictions('Transaction Pay'), () => {
+describe(SmokeConfirmationsRedesigned('Transaction Pay'), () => {
   it('depoits to predict balance', async () => {
     await withFixtures(
       {
@@ -53,7 +53,7 @@ describe(SmokePredictions('Transaction Pay'), () => {
           )
           .build(),
         restartDevice: true,
-        testSpecificMock: PredictionMarketFeature,
+        testSpecificMock,
       },
       async () => {
         await loginToApp();


### PR DESCRIPTION
## **Description**

Add initial E2E test for MetaMask pay to deposit to Predict balance via Relay.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #22899 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an E2E test for MetaMask Pay predict deposit via Relay, plus supporting mocks, selectors, fixture utilities, and UI testIDs.
> 
> - **E2E Tests**:
>   - Add `transaction-pay.spec.ts` to validate Predict deposit via Relay (sets amount, verifies bridge time/fees/total, confirms, checks activity/details).
>   - New page objects for confirmation and transaction details; extend activities view interactions.
> - **Mocks & Fixtures**:
>   - Add Relay mocks (`transaction-pay.ts`) for quote/status; extend Polymarket RPC mocks (ownerOf selector, getBlockByNumber) and price API mocks (Polygon/MATIC/USDC.e entries).
>   - FixtureBuilder: add `withTokenRates` helper; configure Polygon network/token as needed for tests.
> - **Selectors & Test IDs**:
>   - Introduce/expand test selector IDs for confirmation rows and transaction details modal.
>   - Add `testID` props to UI rows: `bridge-fee`, `network-fee`, `total`, `paid-with`, `status`, `bridge-time`, `pay-with` (including symbol/balance), and confirm button.
> - **UI Components**:
>   - Wire test IDs into transaction details and confirmation rows to enable reliable assertions without altering business logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8adb1600b0c5e5c718fb33b0c8a278407f1acf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->