### PR TITLE
test: Fix flaky GasFeeToken e2e test via 7702

### DIFF
--- a/e2e/pages/Browser/Confirmations/RowComponents.ts
+++ b/e2e/pages/Browser/Confirmations/RowComponents.ts
@@ -80,6 +80,17 @@ class RowComponents {
       GasFeeTokenSelectorIDs.SELECTED_GAS_FEE_TOKEN_ARROW,
     );
   }
+
+  async getNetworkFeeGasFeeTokenSymbolText(): Promise<string> {
+    const symbolElement =
+      (await this.NetworkFeeGasFeeTokenSymbol) as IndexableNativeElement;
+    const symbolElementAttributes = await symbolElement.getAttributes();
+    return (
+      (symbolElementAttributes as { text?: string; label?: string })?.text ??
+      (symbolElementAttributes as { text?: string; label?: string })?.label ??
+      ''
+    );
+  }
 }
 
 export default new RowComponents();

--- a/e2e/pages/Browser/Confirmations/RowComponents.ts
+++ b/e2e/pages/Browser/Confirmations/RowComponents.ts
@@ -82,8 +82,8 @@ class RowComponents {
   }
 
   async getNetworkFeeGasFeeTokenSymbolText(): Promise<string> {
-    const symbolElement =
-      (await this.NetworkFeeGasFeeTokenSymbol) as IndexableNativeElement;
+    const symbolElement = (await this
+      .NetworkFeeGasFeeTokenSymbol) as IndexableNativeElement;
     const symbolElementAttributes = await symbolElement.getAttributes();
     return (
       (symbolElementAttributes as { text?: string; label?: string })?.text ??

--- a/e2e/pages/Confirmation/GasFeeTokenModal.ts
+++ b/e2e/pages/Confirmation/GasFeeTokenModal.ts
@@ -37,6 +37,11 @@ class GasFeeTokenModal {
     const amountFiatElement = await Matchers.getElementByID(
       `${GasFeeTokenModalSelectorsText.GAS_FEE_TOKEN_AMOUNT_FIAT}-${symbol}`,
     );
+
+    await Assertions.expectElementToBeVisible(amountFiatElement, {
+      description: `Amount fiat for ${symbol} is visible`,
+    });
+
     const amountFiatElementAttributes = await amountFiatElement.getAttributes();
     const amountFiatElementLabel = this.elementSafe(
       amountFiatElementAttributes,

--- a/e2e/specs/confirmations-redesigned/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/e2e/specs/confirmations-redesigned/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -269,9 +269,6 @@ describe(
           await SendView.inputRecipientAddress(RECIPIENT_ADDRESS_MOCK);
           await SendView.pressReviewButton();
 
-          // const gasFeeTokenSelected = await getGasFeeTokenSelected();
-          // await Assertions.checkIfTextMatches(gasFeeTokenSelected, 'ETH');
-
           await Assertions.expectElementToBeVisible(
             RowComponents.NetworkFeeGasFeeTokenArrow,
             { description: 'Gas Fee Token Arrow' },

--- a/e2e/specs/confirmations-redesigned/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/e2e/specs/confirmations-redesigned/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -139,8 +139,7 @@ const SIMULATION_GAS_STATION_MOCK = {
   },
 };
 
-// Skipping this spec as it is currently causing app crashes on CI
-describe.skip(
+describe(
   SmokeConfirmationsRedesigned('Send native asset Gas Station using EIP-7702'),
   () => {
     beforeAll(async () => {
@@ -270,12 +269,20 @@ describe.skip(
           await SendView.inputRecipientAddress(RECIPIENT_ADDRESS_MOCK);
           await SendView.pressReviewButton();
 
+          // const gasFeeTokenSelected = await getGasFeeTokenSelected();
+          // await Assertions.checkIfTextMatches(gasFeeTokenSelected, 'ETH');
+
           await Assertions.expectElementToBeVisible(
             RowComponents.NetworkFeeGasFeeTokenArrow,
             { description: 'Gas Fee Token Arrow' },
           );
 
           await TransactionConfirmView.tapGasFeeTokenPill();
+
+          await Assertions.expectElementToBeVisible(
+            Matchers.getElementByText('Select a token'),
+            { description: 'Modal is visible' },
+          );
 
           await GasFeeTokenModal.checkAmountFiat('DAI', daiValues.fiatAmount);
           await GasFeeTokenModal.checkAmountToken('DAI', daiValues.tokenAmount);
@@ -294,16 +301,8 @@ describe.skip(
             { description: 'Selected Gas Fee Token is USDC' },
           );
 
-          const symbolElement =
-            (await RowComponents.NetworkFeeGasFeeTokenSymbol) as IndexableNativeElement;
-
-          const symbolElementAttributes = await symbolElement.getAttributes();
           const symbolElementLabel =
-            (symbolElementAttributes as { text?: string; label?: string })
-              ?.text ??
-            (symbolElementAttributes as { text?: string; label?: string })
-              ?.label ??
-            '';
+            await RowComponents.getNetworkFeeGasFeeTokenSymbolText();
 
           await Assertions.checkIfTextMatches(symbolElementLabel, 'USDC');
           await Assertions.expectTextDisplayed(usdcValues.fiatAmount);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This Pr aims to fix the flakiness for  `e2e/specs/confirmations-redesigned/transactions/gas-fee-tokens-eip-7702.spec.ts`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/24139

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves stability of the EIP-7702 gas fee token e2e and re-enables the test.
> 
> - Unskips `gas-fee-tokens-eip-7702.spec.ts`; adds assertion that `Select a token` modal is visible before validations
> - Replaces inline attribute access with `RowComponents.getNetworkFeeGasFeeTokenSymbolText()` to read the selected token symbol
> - Adds `getNetworkFeeGasFeeTokenSymbolText()` to `RowComponents.ts`
> - Adds a visibility check in `GasFeeTokenModal.checkAmountFiat()` before reading attributes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c40a243d27e633e2358def6af2e232387372ef92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->