### PR TITLE
fix(perps): apply dynamic border radius to order details based on visible items

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -999,7 +999,16 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
         {!isInputFocused && (
           <View style={styles.detailsWrapper}>
             {/* Leverage */}
-            <View style={[styles.detailItem, styles.detailItemOnly]}>
+            <View
+              style={[
+                styles.detailItem,
+                // If there are items below (limit price or TP/SL), only round top corners
+                // Otherwise, round all corners
+                orderForm.type === 'limit' || !hideTPSL
+                  ? styles.detailItemFirst
+                  : styles.detailItemOnly,
+              ]}
+            >
               <TouchableOpacity onPress={() => setIsLeverageVisible(true)}>
                 <ListItem style={styles.detailItemWrapper}>
                   <ListItemColumn widthType={WidthType.Fill}>
@@ -1037,7 +1046,13 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
 
             {/* Limit price - only show for limit orders */}
             {orderForm.type === 'limit' && (
-              <View style={styles.detailItem}>
+              <View
+                style={[
+                  styles.detailItem,
+                  // If TP/SL is hidden, this is the last item so round bottom corners
+                  hideTPSL && styles.detailItemLast,
+                ]}
+              >
                 <TouchableOpacity onPress={() => setIsLimitPriceVisible(true)}>
                   <ListItem style={styles.detailItemWrapper}>
                     <ListItemColumn widthType={WidthType.Fill}>


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the border radius styling in the Perps Order View to dynamically adjust based on which items are visible in the order details section.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed rounded corners in Perps order screen when there are more than 2 rows displayed

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2191

## **Manual testing steps**

```gherkin
Feature: Perps Order View border radius

  Scenario: User views market order with TP/SL visible
    Given user is on the Perps Order View for a market order
    And TP/SL section is visible

    When user views the order details section
    Then Leverage row should have only top corners rounded
    And TP/SL row should have only bottom corners rounded

  Scenario: User views market order with TP/SL hidden
    Given user is on the Perps Order View for a market order
    And TP/SL section is hidden

    When user views the order details section
    Then Leverage row should have all corners rounded
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
See screenshots here https://consensyssoftware.atlassian.net/browse/TAT-2191

### **After**

<!-- [screenshots/recordings] -->
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-18 at 16 08 03" src="https://github.com/user-attachments/assets/ee0b72c7-c5f9-438b-af3e-f79f60cd2f3c" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `PerpsOrderView` to conditionally apply top/bottom/all corner rounding to order detail rows depending on limit price and TP/SL visibility.
> 
> - **UI (Perps Order View)**
>   - Update `app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx` to conditionally style order detail rows:
>     - Leverage row now uses `styles.detailItemFirst` when `orderForm.type === 'limit'` or `!hideTPSL`, else `styles.detailItemOnly`.
>     - Limit price row applies `styles.detailItemLast` when `hideTPSL` is true.
>   - Ensures correct rounded corners when limit price and/or TP/SL rows are shown/hidden.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02612d26145559e53511c82c26b4bcd060984b5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->