### PR TITLE
feat: add feature-flags to user traits

### DIFF
--- a/app/contexts/FeatureFlagOverrideContext.test.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.test.tsx
@@ -875,6 +875,87 @@ describe('FeatureFlagOverrideContext', () => {
     });
   });
 
+  describe('Remote Feature Flag Change Tracking', () => {
+    it('adds all feature flags to user traits in bulk when received', async () => {
+      const mockFlags = {
+        booleanFlag: true,
+        stringFlag: 'variant_a',
+        numberFlag: 42,
+      };
+      mockUseSelector.mockReturnValue(mockFlags);
+
+      renderHook(() => useFeatureFlagOverride(), {
+        wrapper: createWrapper,
+      });
+
+      await waitFor(() => {
+        expect(mockAddTraitsToUser).toHaveBeenCalledWith({
+          booleanFlag: true,
+          stringFlag: 'variant_a',
+          numberFlag: 42,
+        });
+      });
+    });
+
+    it('adds all feature flags to user traits in bulk when flags change', async () => {
+      const initialFlags = { flag1: true, flag2: 'variant_a' };
+      mockUseSelector.mockReturnValue(initialFlags);
+
+      const { rerender } = renderHook(() => useFeatureFlagOverride(), {
+        wrapper: createWrapper,
+      });
+
+      mockAddTraitsToUser.mockClear();
+
+      const updatedFlags = { flag1: false, flag2: 'variant_b', newFlag: 100 };
+      mockUseSelector.mockReturnValue(updatedFlags);
+
+      rerender(null);
+
+      await waitFor(() => {
+        expect(mockAddTraitsToUser).toHaveBeenCalledWith({
+          flag1: false,
+          flag2: 'variant_b',
+          newFlag: 100,
+        });
+      });
+    });
+
+    it('does not call addTraitsToUser when no feature flags exist', async () => {
+      mockUseSelector.mockReturnValue({});
+
+      renderHook(() => useFeatureFlagOverride(), {
+        wrapper: createWrapper,
+      });
+
+      await waitFor(
+        () => {
+          expect(mockAddTraitsToUser).not.toHaveBeenCalled();
+        },
+        { timeout: 200 },
+      );
+    });
+
+    it('sends user traits in a single bulk call, not per-flag', async () => {
+      const mockFlags = { flag1: true, flag2: 'variant', flag3: 123 };
+      mockUseSelector.mockReturnValue(mockFlags);
+
+      renderHook(() => useFeatureFlagOverride(), {
+        wrapper: createWrapper,
+      });
+
+      await waitFor(() => {
+        // Should be called exactly once with all flags
+        expect(mockAddTraitsToUser).toHaveBeenCalledTimes(1);
+        expect(mockAddTraitsToUser).toHaveBeenCalledWith({
+          flag1: true,
+          flag2: 'variant',
+          flag3: 123,
+        });
+      });
+    });
+  });
+
   describe('Snapshot Functionality', () => {
     it('takes snapshot when getFeatureFlag is called for boolean flag', async () => {
       const mockFlags = { testBooleanFlag: true };

--- a/app/contexts/FeatureFlagOverrideContext.test.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.test.tsx
@@ -1013,6 +1013,9 @@ describe('FeatureFlagOverrideContext', () => {
         wrapper: createWrapper,
       });
 
+      // Clear the initial bulk call from useEffect
+      mockAddTraitsToUser.mockClear();
+
       await act(async () => {
         result.current.getFeatureFlag('flag1');
       });
@@ -1046,7 +1049,7 @@ describe('FeatureFlagOverrideContext', () => {
       expect(mockAddTraitsToUser).toHaveBeenCalledTimes(3);
     });
 
-    it('does not take snapshot for non-boolean flags', async () => {
+    it('does not take additional snapshot for non-boolean flags via getFeatureFlag', async () => {
       const mockFlags = {
         stringFlag: 'test value',
         numberFlag: 42,
@@ -1060,11 +1063,15 @@ describe('FeatureFlagOverrideContext', () => {
         wrapper: createWrapper,
       });
 
+      // Clear the initial bulk call from useEffect
+      mockAddTraitsToUser.mockClear();
+
       await act(async () => {
         result.current.getFeatureFlag('stringFlag');
         result.current.getFeatureFlag('numberFlag');
       });
 
+      // getFeatureFlag should not add additional traits for non-boolean flags
       await waitFor(
         () => {
           expect(mockAddTraitsToUser).not.toHaveBeenCalled();
@@ -1141,8 +1148,8 @@ describe('FeatureFlagOverrideContext', () => {
       });
     });
 
-    it('does not call addTraitsToUser when no snapshots are taken', () => {
-      const mockFlags = { stringFlag: 'test' };
+    it('calls addTraitsToUser in bulk on mount with all feature flags', () => {
+      const mockFlags = { stringFlag: 'test', boolFlag: true };
       mockUseSelector.mockReturnValue(mockFlags);
       mockGetFeatureFlagType.mockReturnValue('string');
 
@@ -1150,7 +1157,11 @@ describe('FeatureFlagOverrideContext', () => {
         wrapper: createWrapper,
       });
 
-      expect(mockAddTraitsToUser).not.toHaveBeenCalled();
+      // useEffect sends all flags in bulk on mount
+      expect(mockAddTraitsToUser).toHaveBeenCalledWith({
+        stringFlag: 'test',
+        boolFlag: true,
+      });
     });
   });
 });

--- a/app/contexts/FeatureFlagOverrideContext.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   ReactNode,
   useMemo,
+  useEffect,
 } from 'react';
 import { useSelector } from 'react-redux';
 import { selectRemoteFeatureFlags } from '../selectors/featureFlagController';
@@ -61,6 +62,13 @@ export const FeatureFlagOverrideProvider: React.FC<
   );
   const toastContext = useContext(ToastContext);
   const toastRef = toastContext?.toastRef;
+
+  // Track remote feature flags and add all flags to user traits in bulk
+  useEffect(() => {
+    if (Object.keys(rawFeatureFlags).length > 0) {
+      addTraitsToUser(rawFeatureFlags);
+    }
+  }, [rawFeatureFlags, addTraitsToUser]);
 
   // Local state for overrides
   const [overrides, setOverrides] = useState<FeatureFlagOverrides>({});


### PR DESCRIPTION
## **Description**

This PR adds tracking for remote feature flags to user traits for analytics purposes.

**What is the reason for the change?**
We need to capture feature flag values as user traits in our analytics system to better understand user segmentation and feature adoption.

**What is the improvement/solution?**
Added a `useEffect` in `FeatureFlagOverrideContext` that sends all remote feature flags to user traits in a single bulk call via `addTraitsToUser` whenever the flags are received or updated from the `RemoteFeatureFlagController`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

Feature: Feature Flag User Traits Tracking

  Scenario: Feature flags are added to user traits when received from remote controller
    Given the app is launched with MetaMetrics enabled
    
    When remote feature flags are fetched from the server
    Then all feature flag values are sent to Segment as user traits in a single bulk call

  Scenario: Feature flags are updated in user traits when they change
    Given the app has already received feature flags
    
    When the remote feature flags are updated with new values
    Then the updated feature flag values are sent to Segment as user traits## **Screenshots/Recordings**

<!-- Not applicable - analytics/internal change with no UI impact -->

### **Before**

N/A - Feature flags were not being tracked as user traits when received from remote controller.

### **After**

Feature flags from the remote controller are now automatically sent to user traits via `addTraitsToUser` in bulk whenever they are received or updated.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bulk-send remote feature flags to analytics user traits on receipt/updates and add tests validating single-call, bulk behavior.
> 
> - **Feature Flags/Analytics**:
>   - Add `useEffect` in `app/contexts/FeatureFlagOverrideContext.tsx` to call `addTraitsToUser(rawFeatureFlags)` whenever remote flags are received or updated (bulk, single call).
> - **Tests** (`app/contexts/FeatureFlagOverrideContext.test.tsx`):
>   - Add “Remote Feature Flag Change Tracking” tests to verify bulk add on initial load, on updates, no call when empty, and single-call (not per-flag).
>   - Adjust snapshot tests to account for initial bulk call (clearing mocks) and add a test asserting bulk call on mount; minor test description tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ebbba8653dfb68cffb7f5f6cff98655fb3f1152. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->