### PR TITLE
fix(perps): button flashing color on load

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -243,6 +243,9 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     useState(false);
   const [ohlcData, setOhlcData] = useState<OhlcData | null>(null);
 
+  // Track when position data has settled to avoid button flash (TAT-2236)
+  const [hasPositionSettled, setHasPositionSettled] = useState(false);
+
   const { account } = usePerpsLiveAccount();
 
   // Get real-time open orders via WebSocket
@@ -379,6 +382,19 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       asset: market?.symbol || '',
       loadOnMount: true,
     });
+
+  // Wait one frame after loading to avoid button flash (TAT-2236)
+  // This handles the gap between isLoadingPosition=false and existingPosition being populated
+  useEffect(() => {
+    if (isLoadingPosition) {
+      setHasPositionSettled(false);
+    } else {
+      const frame = requestAnimationFrame(() => {
+        setHasPositionSettled(true);
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+  }, [isLoadingPosition]);
 
   // Fetch order fills to get position opened timestamp
   const { orderFills } = usePerpsOrderFills({
@@ -861,8 +877,8 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
 
   // Determine if any action buttons will be visible
   const hasLongShortButtons = useMemo(
-    () => !isLoadingPosition && !hasZeroBalance,
-    [isLoadingPosition, hasZeroBalance],
+    () => !isLoadingPosition && !hasZeroBalance && hasPositionSettled,
+    [isLoadingPosition, hasZeroBalance, hasPositionSettled],
   );
 
   const hasAddFundsButton = useMemo(


### PR DESCRIPTION
## **Description**

Fixes button color flash when opening a market with an existing position. Users were briefly seeing Long/Short buttons before Modify/Close buttons appeared due to a one-render-cycle gap between position loading completing and position data being populated.

**Root cause:** In `usePerpsLivePositions`, `isInitialLoading` becomes `false` one frame before the positions array is fully populated, causing `!existingPosition` to briefly evaluate as `true`.

**Solution:** Added a `hasPositionSettled` state that waits one frame (via `requestAnimationFrame`) after loading completes before allowing buttons to render. This ensures position data is fully available before deciding which buttons to show.

## **Changelog**

CHANGELOG entry: Fixed button color flash when opening a market with an existing position

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2236

## **Manual testing steps**

```gherkin
Feature: Market Details Button Display

  Scenario: User opens market with existing position
    Given user has an open position in BTC-PERP
    When user navigates to BTC-PERP market details
    Then Modify and Close buttons should appear without any flash of Long/Short buttons

  Scenario: User opens market without position
    Given user has no position in ETH-PERP
    When user navigates to ETH-PERP market details
    Then Long and Short buttons should appear normally

  Scenario: User with zero balance opens market
    Given user has zero balance in their perps account
    When user navigates to any market details
    Then Add Funds button should appear correctly
```

## **Screenshots/Recordings**

### **Before**

<!-- Long/Short buttons briefly flash before Modify/Close appear -->

### **After**

<!-- Modify/Close buttons appear directly without any flash -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Waits one frame after position loading settles before rendering action buttons to avoid Long/Short flashing when a position exists.
> 
> - **Perps UI** (`PerpsMarketDetailsView.tsx`):
>   - Add `hasPositionSettled` state and `useEffect` using `requestAnimationFrame` to mark position data as settled after `isLoadingPosition` becomes false.
>   - Gate action buttons with `hasPositionSettled` by updating `hasLongShortButtons` to `!isLoadingPosition && !hasZeroBalance && hasPositionSettled`.
>   - Result: eliminates brief flash of `Long`/`Short` buttons before `Modify`/`Close` when an existing position is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ecad541724f75b6b141ba1f97ac7c6718bc7464. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->