### PR TITLE
fix(perps): strip trailing zeros from chart y-axis price labels

### DIFF
--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.html
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.html
@@ -254,7 +254,9 @@ PERFORMANCE OPTIMIZATIONS:
 
                             // Format with final decimal precision using cached formatter
                             const formatter = window.getCachedFormatter(finalDecimals);
-                            return formatter.format(formattedValue);
+                            const formatted = formatter.format(formattedValue);
+                            // Strip trailing zeros to match header formatting
+                            return formatted.replace(/(\.[0-9]*?)0+$/, '$1').replace(/\.$/, '');
                         },
                         timeFormatter: (time) => {
                             // Format time in user's local timezone for crosshair labels

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
@@ -554,7 +554,9 @@ export const createTradingViewChartTemplate = (
 
                             // Format with final decimal precision using cached formatter
                             const formatter = window.getCachedFormatter(finalDecimals);
-                            return formatter.format(formattedValue);
+                            const formatted = formatter.format(formattedValue);
+                            // Strip trailing zeros to match header formatting
+                            return formatted.replace(/(\\.[0-9]*?)0+$/, '$1').replace(/\\.$/, '');
                         },
                         timeFormatter: (time) => {
                             // Format time in user's local timezone for crosshair labels


### PR DESCRIPTION
## **Description**

The TradingView chart y-axis was displaying more decimal places than needed for price labels, while the header displayed prices correctly with trailing zeros stripped.


## **Changelog**

CHANGELOG entry: Fixed inconsistent price formatting on TradingView chart y-axis that showed unnecessary trailing zeros


## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2208

## **Manual testing steps**

```gherkin
Feature: Perps TradingView Chart Price Formatting

  Scenario: user views chart for a low-priced asset
    Given user is on the Perps market details screen for a low-priced asset (e.g., a token priced at $0.01234)

    When user views the TradingView chart
    Then the y-axis price labels should not display unnecessary trailing zeros
    And the y-axis price format should match the header price format

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See here https://consensyssoftware.atlassian.net/browse/TAT-2208
<!-- [screenshots/recordings] -->

### **After**
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-19 at 12 52 50" src="https://github.com/user-attachments/assets/435719f0-9eae-414a-b076-36d1f32c9b22" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Y-axis price labels now strip trailing zeros to match header formatting in the TradingView chart.
> 
> - **Chart Price Formatting**
>   - Update `localization.priceFormatter` in `app/components/UI/Perps/components/TradingViewChart/TradingViewChart.html` and `TradingViewChartTemplate.tsx` to strip trailing zeros after Intl formatting, aligning Y-axis labels with header formatting.
>   - Preserves dynamic decimal precision logic; only post-format cleanup added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45bef0cb83359428e78ec7d39c0eec6ae0046963. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->