### PR TITLE
fix: update execution of `getInternalAccountByAddress`

### DIFF
--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -133,8 +133,14 @@ const RevealPrivateCredential = ({
   const selectedAddress =
     route?.params?.selectedAccount?.address || checkSummedAddress;
 
-  // Address will always be defined because checkSummedAddress is the selectedAccount's address
-  const account = getInternalAccountByAddress(selectedAddress as string);
+  const [account, setAccount] = useState<InternalAccount | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    const acc = getInternalAccountByAddress(selectedAddress as string);
+    setAccount(acc);
+  }, [selectedAddress]);
 
   const isPrivateKey = credentialSlug === PRIVATE_KEY;
 

--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -339,6 +339,12 @@ export function isEthAddress(address: string): boolean {
 export function getInternalAccountByAddress(
   address: string,
 ): InternalAccount | undefined {
+  // This guard clause is added in case we try to access the engine
+  // before it's available. Otherwise, this method will throw.
+  if (!Engine) {
+    return undefined;
+  }
+
   const { accounts } = Engine.context.AccountsController.state.internalAccounts;
   return Object.values(accounts).find((a: InternalAccount) =>
     areAddressesEqual(a.address, address),

--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -341,7 +341,7 @@ export function getInternalAccountByAddress(
 ): InternalAccount | undefined {
   // This guard clause is added in case we try to access the engine
   // before it's available. Otherwise, this method will throw.
-  if (!Engine.context) {
+  if (!Engine) {
     return undefined;
   }
 

--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -341,7 +341,7 @@ export function getInternalAccountByAddress(
 ): InternalAccount | undefined {
   // This guard clause is added in case we try to access the engine
   // before it's available. Otherwise, this method will throw.
-  if (!Engine) {
+  if (!Engine.context) {
     return undefined;
   }
 

--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -339,12 +339,6 @@ export function isEthAddress(address: string): boolean {
 export function getInternalAccountByAddress(
   address: string,
 ): InternalAccount | undefined {
-  // This guard clause is added in case we try to access the engine
-  // before it's available. Otherwise, this method will throw.
-  if (!Engine) {
-    return undefined;
-  }
-
   const { accounts } = Engine.context.AccountsController.state.internalAccounts;
   return Object.values(accounts).find((a: InternalAccount) =>
     areAddressesEqual(a.address, address),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

During the execution of `getInternalAccountByAddress` it can happen that the `Engine` is not yet available to be used, this PR update how the method is used by waiting for the component to be rendered

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: http://github.com/MetaMask/metamask-mobile/issues/22969

## **Manual testing steps**

Not applicable

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use state with useEffect to fetch `account` from `getInternalAccountByAddress` based on `selectedAddress`, allowing for `undefined` until available.
> 
> - **RevealPrivateCredential (`app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx`)**:
>   - Replace immediate `getInternalAccountByAddress(selectedAddress)` call with `useState` + `useEffect` to set `account` when `selectedAddress` changes.
>   - Gate rendering so `AccountInfo` shows only when `account` exists; tolerate `account` being `undefined`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b15a430fc0f028ad0a06fb00b10a867d36617d75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->