### PR TITLE
chore: move network icon to the left in network filter in send flow

### DIFF
--- a/app/components/Views/confirmations/components/network-filter/network-filter.tsx
+++ b/app/components/Views/confirmations/components/network-filter/network-filter.tsx
@@ -50,11 +50,8 @@ const NetworkFilterTab: React.FC<NetworkFilterTabProps> = ({
       }
       hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
     >
-      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-        {label}
-      </Text>
       {showIcon && imageSource && (
-        <Box twClassName="ml-2">
+        <Box twClassName="mr-2">
           <Avatar
             variant={AvatarVariant.Network}
             size={AvatarSize.Xs}
@@ -63,6 +60,10 @@ const NetworkFilterTab: React.FC<NetworkFilterTabProps> = ({
           />
         </Box>
       )}
+
+      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+        {label}
+      </Text>
     </Pressable>
   );
 };


### PR DESCRIPTION
## **Description**

Move network icon to the left in network filter in send flow

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-303

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

| before | after |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/f4269ea0-26ab-4b14-b823-a54718ea04c2) | ![after](https://github.com/user-attachments/assets/f4ec2d2c-0e63-4285-9d24-20599b568136) |

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders `NetworkFilterTab` to place the network avatar before the label, updating spacing to `mr-2`.
> 
> - **UI/Layout**
>   - In `app/components/Views/confirmations/components/network-filter/network-filter.tsx`:
>     - `NetworkFilterTab`: Moves the network `Avatar` before the text label and updates spacing from `ml-2` to `mr-2` to align the icon on the left of the label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03e8a7dbcc71900b53ae8f8040869e3a7b086fa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->