### PR TITLE
fix: chain id in batch alerts 

### DIFF
--- a/app/lib/ppom/ppom-util.test.ts
+++ b/app/lib/ppom/ppom-util.test.ts
@@ -27,6 +27,7 @@ import Logger from '../../util/Logger';
 
 const CHAIN_ID_REQUEST_MOCK = '0x1' as Hex;
 const CHAIN_ID_TRANSACTION_MOCK = '0x2' as Hex;
+const CHAIN_ID_NETWORK_CLIENT_MOCK = '0x3' as Hex;
 const CHAIN_ID_GLOBAL_MOCK = '0x3' as Hex;
 const NETWORK_CLIENT_ID_REQUEST_MOCK = 'testNetwork1';
 const NETWORK_CLIENT_ID_TRANSACTION_MOCK = 'testNetwork2';
@@ -191,7 +192,7 @@ describe('PPOM Utils', () => {
           chainId: {
             [NETWORK_CLIENT_ID_GLOBAL_MOCK]: CHAIN_ID_GLOBAL_MOCK,
             [NETWORK_CLIENT_ID_REQUEST_MOCK]: CHAIN_ID_REQUEST_MOCK,
-            [NETWORK_CLIENT_ID_TRANSACTION_MOCK]: CHAIN_ID_TRANSACTION_MOCK,
+            [NETWORK_CLIENT_ID_TRANSACTION_MOCK]: CHAIN_ID_NETWORK_CLIENT_MOCK,
           }[networkClientId] as Hex,
           ticker: 'ETH',
           type: NetworkClientType.Custom,
@@ -402,6 +403,7 @@ describe('PPOM Utils', () => {
       await PPOMUtil.validateRequest(mockRequest, {
         transactionMeta: {
           id: TRANSACTION_ID_MOCK,
+          chainId: CHAIN_ID_TRANSACTION_MOCK,
           networkClientId: NETWORK_CLIENT_ID_TRANSACTION_MOCK,
         } as TransactionMeta,
       });
@@ -413,15 +415,17 @@ describe('PPOM Utils', () => {
       );
     });
 
-    it('uses chain ID from request if provided', async () => {
-      await PPOMUtil.validateRequest({
-        ...mockRequest,
-        method: METHOD_SIGN_TYPED_DATA_V3,
+    it('uses chain ID from request network client ID', async () => {
+      await PPOMUtil.validateRequest(mockRequest, {
+        transactionMeta: {
+          id: TRANSACTION_ID_MOCK,
+          networkClientId: NETWORK_CLIENT_ID_TRANSACTION_MOCK,
+        } as TransactionMeta,
       });
 
       expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledTimes(1);
       expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledWith(
-        CHAIN_ID_REQUEST_MOCK,
+        CHAIN_ID_NETWORK_CLIENT_MOCK,
         expect.any(Object),
       );
     });
@@ -457,7 +461,7 @@ describe('PPOM Utils', () => {
 
       expect(spy).toHaveBeenCalledTimes(2);
       expect(spy).toHaveBeenCalledWith(TRANSACTION_ID_MOCK, {
-        chainId: CHAIN_ID_TRANSACTION_MOCK,
+        chainId: CHAIN_ID_NETWORK_CLIENT_MOCK,
         req: mockRequest,
         result_type: ResultType.Failed,
         reason: Reason.failed,


### PR DESCRIPTION
## **Description**

Use chain ID from transaction if available when building alert requests, rather than always relying on network client ID.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prioritizes accurate chain selection for security alert validation.
> 
> - In `ppom-util.validateRequest`, compute `chainId` from `transactionMeta.chainId` first; otherwise use `NetworkController.getNetworkClientById(networkClientId).configuration.chainId` resolved from `transactionMeta.networkClientId`, request `networkClientId`, then global selection
> - Handle possibly undefined `transactionMeta` by safely extracting `id`, `networkClientId`, and `chainId`
> - Update tests to assert precedence: transaction `chainId` > request network client `chainId` > global; adjust mocks and expectations; rename test to clarify behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a3201a598e2267d7177cf369b941b517ee30ad0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->