### PR TITLE
fix(perps): minor UI updates for close positions and market balance views

### DIFF
--- a/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.styles.ts
@@ -32,6 +32,10 @@ export const createStyles = (_theme: Theme) =>
       zIndex: 0, // Ensure footer stays behind modal overlays
       elevation: 0, // Android equivalent
     },
+    footerButtonSecondary: {
+      flex: 1,
+      borderWidth: 0,
+    },
     labelWithTooltip: {
       flexDirection: 'row',
       alignItems: 'center',

--- a/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.tsx
@@ -227,6 +227,7 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
         onPress: handleKeepButtonPress,
         variant: ButtonVariants.Secondary,
         size: ButtonSize.Lg,
+        style: styles.footerButtonSecondary,
         disabled: isClosing,
       },
       {
@@ -240,7 +241,12 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
         danger: true,
       },
     ],
-    [handleKeepButtonPress, handleCloseAll, isClosing],
+    [
+      handleKeepButtonPress,
+      handleCloseAll,
+      isClosing,
+      styles.footerButtonSecondary,
+    ],
   );
 
   // Show loading state while fetching positions

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
@@ -242,7 +242,7 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
     <>
       <Box
         testID={PerpsMarketBalanceActionsSelectorsIDs.CONTAINER}
-        twClassName={isBalanceEmpty ? 'mx-4 mt-4 mb-4 rounded-xl' : ''}
+        twClassName={isBalanceEmpty ? 'mx-4 mt-4 mb-4 rounded-xl' : 'mb-4'}
         style={isBalanceEmpty ? tw.style('bg-background-section') : undefined}
       >
         <PerpsProgressBar


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR addresses minor UI polish issues in the Perps feature:

1. **Close All Positions View**: Removed the border from the secondary "Keep" button in the footer and ensured both buttons have equal flex width for better visual consistency.

2. **Market Balance Actions**: Added bottom margin (`mb-4`) to the container when the balance is not empty, improving spacing consistency in the layout.

## **Changelog**



CHANGELOG entry: Fixed UI styling inconsistencies in Perps close positions and market balance views

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2233

## **Manual testing steps**

```gherkin
Feature: Perps Close All Positions UI

  Scenario: User views the close all positions sheet
    Given user has open perps positions
    
    When user opens the "Close All Positions" bottom sheet
    Then the "Keep" and "Close All" buttons should have equal width and wrap the text the same way
Feature: Perps Market Balance Actions UI

  Scenario: User views market balance with non-empty balance
    Given user has a non-empty perps market balance
    
    When user views the market balance actions section
    Then there should be appropriate bottom margin spacing below the component
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See here https://consensyssoftware.atlassian.net/browse/TAT-2233

### **After**

<!-- [screenshots/recordings] -->
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-05 at 11 30 38" src="https://github.com/user-attachments/assets/0cf8ea41-9723-48df-81e6-bb9ce0817c62" />

<img width="1206" height="2622" alt="simulator_screenshot_75B46A50-1FC8-4693-82D7-3064FC34FF76" src="https://github.com/user-attachments/assets/3942ba1b-39d8-460b-acca-091b36e08869" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor UI polish for Perps screens.
> 
> - **Close All Positions:** Adds `footerButtonSecondary` style (`flex: 1`, `borderWidth: 0`) and applies it to the secondary "Keep positions" button for equal width with the primary button and no border.
> - **Market Balance Actions:** Sets `twClassName` to include `mb-4` when balance is not empty to ensure consistent bottom spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c5ab6406e4144baef602dbe80457e8c3bae698d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->