### PR TITLE
ci(android): add JVM flags and verbose logging for E2E builds

### DIFF
--- a/android/gradle.properties.github
+++ b/android/gradle.properties.github
@@ -1,9 +1,11 @@
 # GitHub Actions-specific Gradle settings
 # Optimized for E2E builds on GitHub Actions runners
 
-# JVM configuration - balanced settings to avoid OOM while maintaining performance
+# JVM configuration
 # Using 16GB heap to leave room for parallel workers and native memory
-org.gradle.jvmargs=-Xmx16g -XX:MaxMetaspaceSize=1g -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:+UseStringDeduplication -XX:+OptimizeStringConcat
+# ExitOnOutOfMemoryError: fail-fast on JVM heap exhaustion (does not catch OS OOM killer)
+# file.encoding=UTF-8: ensure consistent charset across different runner configurations
+org.gradle.jvmargs=-Xmx16g -XX:MaxMetaspaceSize=1g -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:+UseStringDeduplication -XX:+OptimizeStringConcat -XX:+ExitOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # Enable performance optimizations but limit parallelism to prevent OOM
 org.gradle.parallel=true
@@ -54,4 +56,4 @@ hermesEnabled=true
 android.disableResourceValidation=true
 
 # Use legacy packaging to compress native libraries in the resulting APK.
-expo.useLegacyPackaging=false 
+expo.useLegacyPackaging=false

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -547,6 +547,8 @@ generateAndroidBinary() {
 	local reactNativeArchitecturesArg=""
 	# Define Test build type arg
 	local testBuildTypeArg=""
+	# Define Gradle logging flags for E2E builds
+	local gradleLoggingFlags=""
 
 	# Check if configuration is valid
 	if [ "$configuration" != "Debug" ] && [ "$configuration" != "Release" ] ; then
@@ -572,12 +574,14 @@ generateAndroidBinary() {
 		if [ "$METAMASK_ENVIRONMENT" = "e2e" ] ; then
 			# Only build for x86_64 for E2E builds
 			reactNativeArchitecturesArg="-PreactNativeArchitectures=x86_64"
+			# Enable verbose logging for E2E builds to help diagnose build failures
+			gradleLoggingFlags="--stacktrace --info"
 		fi
 	fi
 
 	# Generate Android APKs
 	echo "Generating Android binary for ($flavor) flavor with ($configuration) configuration"
-	./gradlew $assembleApkTask $assembleTestApkTask $testBuildTypeArg $reactNativeArchitecturesArg
+	./gradlew $assembleApkTask $assembleTestApkTask $testBuildTypeArg $reactNativeArchitecturesArg $gradleLoggingFlags
 
 	# Skip AAB bundle for E2E environments - AAB cannot be installed on emulators
 	# and is only needed for Play Store distribution


### PR DESCRIPTION
## **Description**

This PR adds JVM and Gradle configuration improvements for Android E2E builds to help diagnose and mitigate build failures.

**Changes:**
1. **JVM Flags** (`gradle.properties.github`):
   - `ExitOnOutOfMemoryError`: Fail-fast on JVM heap exhaustion (note: does not catch OS OOM killer)
   - `file.encoding=UTF-8`: Ensure consistent charset across different runner configurations

2. **Gradle Logging** (`scripts/build.sh`):
   - Enable `--stacktrace --info` for E2E builds to provide actionable logs when builds fail

These are additive improvements only - no existing values were reduced.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3174](https://consensyssoftware.atlassian.net/browse/INFRA-3174)

## **Manual testing steps**

```gherkin
Feature: Android E2E Build Improvements

  Scenario: E2E build with verbose logging
    Given the PR is merged to main
    
    When an Android E2E build runs
    Then Gradle uses --stacktrace --info flags
    And build logs show detailed information for debugging
    
  Scenario: JVM exits on heap exhaustion
    Given the Gradle JVM encounters OutOfMemoryError
    
    When the error is thrown
    Then the JVM exits immediately (fail-fast)
    And the build fails with clear OOM indication
```

## **Screenshots/Recordings**

### **Before**

N/A - infrastructure/CI change

### **After**

Build results will be visible in PR checks after workflow runs.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[INFRA-3174]: https://consensyssoftware.atlassian.net/browse/INFRA-3174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ