### PR TITLE
fix(perps): use consistent font size for TP/SL text in position card

### DIFF
--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -351,14 +351,14 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
               }
 
               return (
-                <Text variant={TextVariant.BodySM} color={TextColor.Default}>
+                <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
                   {parts.join(', ')}
                 </Text>
               );
             }
 
             return (
-              <Text variant={TextVariant.BodySM} color={TextColor.Default}>
+              <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
                 {strings('perps.auto_close.description')}
               </Text>
             );


### PR DESCRIPTION

## **Description**

The TP (Take Profit) and SL (Stop Loss) text displayed below the "Auto close" label in the Perps position card was using `TextVariant.BodySM`, which appeared visually smaller than other values on the same card.

This PR updates the text variant from `BodySM` to `BodyMD` to ensure consistent font sizing throughout the position card, matching the styling of other value fields like P&L, ROE, Size, and Margin.

## **Changelog**

CHANGELOG entry: Fixed inconsistent font size for TP/SL text in Perps position card


## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2176

## **Manual testing steps**

```gherkin
Feature: Perps Position Card TP/SL Display

  Scenario: User views position card with TP/SL configured
    Given user has an open Perps position with TP and SL set
    
    When user views the position card
    Then the TP/SL text below "Auto close" label should have the same font size as other values on the card (P&L, ROE, Size, Margin)

  Scenario: User views position card without TP/SL configured
    Given user has an open Perps position without TP/SL set
    
    When user views the position card
    Then the "Set take profit and stop loss" description text should have the same font size as other values on the card
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See here https://consensyssoftware.atlassian.net/browse/TAT-2176

### **After**

<img width="1206" height="2622" alt="simulator_screenshot_B0629DD2-5EBE-40DB-B6B2-D6FF0DEE4C6B" src="https://github.com/user-attachments/assets/4e6c3323-026b-4767-bcc2-0a8d64f40ffd" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures consistent typography in the Perps position card.
> 
> - Updates `Text` variant from `BodySM` to `BodyMD` for TP/SL values and the default description under `Auto close` in `PerpsPositionCard.tsx`
> - No behavioral or logic changes; UI-only styling adjustment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ab398e4d6454a6556f128a4a1e4fa56bbcf93b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->