### PR TITLE
chore: fix Browser components memoization

### DIFF
--- a/app/components/UI/BrowserUrlBar/BrowserUrlBar.tsx
+++ b/app/components/UI/BrowserUrlBar/BrowserUrlBar.tsx
@@ -42,268 +42,273 @@ import ButtonIcon, {
 } from '../../../component-library/components/Buttons/ButtonIcon';
 import { hasProperty } from '@metamask/utils';
 
-const BrowserUrlBar = forwardRef<BrowserUrlBarRef, BrowserUrlBarProps>(
-  (
-    {
-      connectionType,
-      onSubmitEditing,
-      onCancel,
-      onFocus,
-      onBlur,
-      onChangeText,
-      connectedAccounts,
-      activeUrl,
-      setIsUrlBarFocused,
-      isUrlBarFocused,
-      showCloseButton,
-    },
-    ref,
-  ) => {
-    const inputValueRef = useRef<string>('');
-    const inputRef = useRef<TextInput>(null);
-    const shouldTriggerBlurCallbackRef = useRef(true);
-    const accountsLength = useSelector(selectAccountsLength);
-    const networkConfigurations = useSelector(selectNetworkConfigurations);
-    const { trackEvent, createEventBuilder } = useMetrics();
-    const navigation = useNavigation();
-    const selectedAddress = connectedAccounts?.[0];
-    const {
-      styles,
-      theme: { colors, themeAppearance },
-    } = useStyles(stylesheet, { isUrlBarFocused });
-    const isConnectionIconVisible =
-      connectionType !== ConnectionType.UNKNOWN && !isUrlBarFocused;
+const BrowserUrlBar = React.memo(
+  forwardRef<BrowserUrlBarRef, BrowserUrlBarProps>(
+    (
+      {
+        connectionType,
+        onSubmitEditing,
+        onCancel,
+        onFocus,
+        onBlur,
+        onChangeText,
+        connectedAccounts,
+        activeUrl,
+        setIsUrlBarFocused,
+        isUrlBarFocused,
+        showCloseButton,
+      },
+      ref,
+    ) => {
+      const inputValueRef = useRef<string>('');
+      const inputRef = useRef<TextInput>(null);
+      const shouldTriggerBlurCallbackRef = useRef(true);
+      const accountsLength = useSelector(selectAccountsLength);
+      const networkConfigurations = useSelector(selectNetworkConfigurations);
+      const { trackEvent, createEventBuilder } = useMetrics();
+      const navigation = useNavigation();
+      const selectedAddress = connectedAccounts?.[0];
+      const {
+        styles,
+        theme: { colors, themeAppearance },
+      } = useStyles(stylesheet, { isUrlBarFocused });
+      const isConnectionIconVisible =
+        connectionType !== ConnectionType.UNKNOWN && !isUrlBarFocused;
 
-    const unfocusInput = useCallback(() => {
-      setIsUrlBarFocused(false);
-      // Reset the input value
-      inputValueRef.current = '';
-    }, [setIsUrlBarFocused]);
+      const unfocusInput = useCallback(() => {
+        setIsUrlBarFocused(false);
+        // Reset the input value
+        inputValueRef.current = '';
+      }, [setIsUrlBarFocused]);
 
-    const onCancelInput = useCallback(() => {
-      shouldTriggerBlurCallbackRef.current = false;
-      inputRef?.current?.blur();
-      unfocusInput();
-      onCancel();
-    }, [unfocusInput, onCancel]);
+      const onCancelInput = useCallback(() => {
+        shouldTriggerBlurCallbackRef.current = false;
+        inputRef?.current?.blur();
+        unfocusInput();
+        onCancel();
+      }, [unfocusInput, onCancel]);
 
-    const handleAccountRightButtonPress = useCallback(() => {
-      const nonTestnetNetworks = Object.keys(networkConfigurations).length + 1;
-      const numberOfConnectedAccounts = connectedAccounts.length;
+      const handleAccountRightButtonPress = useCallback(() => {
+        const nonTestnetNetworks =
+          Object.keys(networkConfigurations).length + 1;
+        const numberOfConnectedAccounts = connectedAccounts.length;
 
-      // TODO: This is currently tracking two events, we should consolidate
-      trackEvent(
-        createEventBuilder(MetaMetricsEvents.OPEN_DAPP_PERMISSIONS)
-          .addProperties({
-            number_of_accounts: accountsLength,
-            number_of_accounts_connected: numberOfConnectedAccounts,
-            number_of_networks: nonTestnetNetworks,
-          })
-          .build(),
-      );
-      // Track Event: "Opened Acount Switcher"
-      trackEvent(
-        createEventBuilder(MetaMetricsEvents.BROWSER_OPEN_ACCOUNT_SWITCH)
-          .addProperties({
-            number_of_accounts: numberOfConnectedAccounts,
-          })
-          .build(),
-      );
+        // TODO: This is currently tracking two events, we should consolidate
+        trackEvent(
+          createEventBuilder(MetaMetricsEvents.OPEN_DAPP_PERMISSIONS)
+            .addProperties({
+              number_of_accounts: accountsLength,
+              number_of_accounts_connected: numberOfConnectedAccounts,
+              number_of_networks: nonTestnetNetworks,
+            })
+            .build(),
+        );
+        // Track Event: "Opened Acount Switcher"
+        trackEvent(
+          createEventBuilder(MetaMetricsEvents.BROWSER_OPEN_ACCOUNT_SWITCH)
+            .addProperties({
+              number_of_accounts: numberOfConnectedAccounts,
+            })
+            .build(),
+        );
 
-      navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-        screen: Routes.SHEET.ACCOUNT_PERMISSIONS,
-        params: {
-          hostInfo: {
-            metadata: {
-              origin: activeUrl && new URLParse(activeUrl).origin,
+        navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+          screen: Routes.SHEET.ACCOUNT_PERMISSIONS,
+          params: {
+            hostInfo: {
+              metadata: {
+                origin: activeUrl && new URLParse(activeUrl).origin,
+              },
             },
           },
-        },
-      });
-    }, [
-      networkConfigurations,
-      connectedAccounts,
-      trackEvent,
-      createEventBuilder,
-      accountsLength,
-      navigation,
-      activeUrl,
-    ]);
+        });
+      }, [
+        networkConfigurations,
+        connectedAccounts,
+        trackEvent,
+        createEventBuilder,
+        accountsLength,
+        navigation,
+        activeUrl,
+      ]);
 
-    const renderRightButton = useCallback(() => {
-      if (!isUrlBarFocused) {
-        return (
-          <AccountRightButton
-            selectedAddress={selectedAddress}
-            onPress={handleAccountRightButtonPress}
-          />
-        );
-      }
+      const renderRightButton = useCallback(() => {
+        if (!isUrlBarFocused) {
+          return (
+            <AccountRightButton
+              selectedAddress={selectedAddress}
+              onPress={handleAccountRightButtonPress}
+            />
+          );
+        }
 
-      if (showCloseButton) {
+        if (showCloseButton) {
+          return (
+            <ButtonIcon
+              iconName={IconName.Close}
+              onPress={onCancelInput}
+              iconColor={colors.icon.default}
+              size={ButtonIconSizes.Lg}
+              style={styles.closeButton}
+              testID={BrowserURLBarSelectorsIDs.CANCEL_BUTTON_ON_BROWSER_ID}
+            />
+          );
+        }
+
         return (
-          <ButtonIcon
-            iconName={IconName.Close}
-            onPress={onCancelInput}
-            iconColor={colors.icon.default}
-            size={ButtonIconSizes.Lg}
-            style={styles.closeButton}
+          <TouchableOpacity
+            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+            style={styles.cancelButton}
             testID={BrowserURLBarSelectorsIDs.CANCEL_BUTTON_ON_BROWSER_ID}
-          />
+            onPress={onCancelInput}
+          >
+            <Text style={styles.cancelButtonText}>
+              {strings('browser.cancel')}
+            </Text>
+          </TouchableOpacity>
         );
-      }
+      }, [
+        isUrlBarFocused,
+        showCloseButton,
+        selectedAddress,
+        handleAccountRightButtonPress,
+        onCancelInput,
+        colors.icon.default,
+        styles.closeButton,
+        styles.cancelButton,
+        styles.cancelButtonText,
+      ]);
+
+      useImperativeHandle(ref, () => ({
+        hide: () => onCancelInput(),
+        blur: () => inputRef?.current?.blur(),
+        focus: () => inputRef?.current?.focus(),
+        setNativeProps: (props: object) => {
+          const inputText = hasProperty(props, 'text') ? props.text : null;
+
+          if (typeof inputText === 'string') {
+            inputValueRef.current = inputText;
+          }
+          inputRef?.current?.setNativeProps(props);
+        },
+      }));
+
+      /**
+       * Gets browser url bar icon based on connection type
+       */
+      const connectionTypeIcon = useMemo(() => {
+        // Default to unsecure icon
+        let iconName = IconName.LockSlash;
+
+        switch (connectionType) {
+          case ConnectionType.SECURE:
+            iconName = IconName.Lock;
+            break;
+          case ConnectionType.UNSECURE:
+            iconName = IconName.LockSlash;
+            break;
+        }
+        return iconName;
+      }, [connectionType]);
+
+      const onBlurInput = () => {
+        if (!shouldTriggerBlurCallbackRef.current) {
+          shouldTriggerBlurCallbackRef.current = true;
+          return;
+        }
+        unfocusInput();
+        onBlur();
+      };
+
+      const onFocusInput = () => {
+        setIsUrlBarFocused(true);
+        onFocus();
+      };
+
+      const onChangeTextInput = (text: string) => {
+        inputRef?.current?.setNativeProps({ text });
+        onChangeText(text);
+      };
+
+      const onSubmitEditingInput = ({
+        nativeEvent: { text },
+      }: NativeSyntheticEvent<TextInputSubmitEditingEventData>) => {
+        const trimmedText = text.trim();
+        inputValueRef.current = trimmedText;
+        onSubmitEditing(trimmedText);
+      };
+
+      /**
+       * Clears the input value and calls the onChangeText callback
+       */
+      const onClearInput = () => {
+        const clearedText = '';
+        inputRef?.current?.clear();
+        inputValueRef.current = clearedText;
+        onChangeText(clearedText);
+      };
 
       return (
-        <TouchableOpacity
-          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
-          style={styles.cancelButton}
-          testID={BrowserURLBarSelectorsIDs.CANCEL_BUTTON_ON_BROWSER_ID}
-          onPress={onCancelInput}
-        >
-          <Text style={styles.cancelButtonText}>
-            {strings('browser.cancel')}
-          </Text>
-        </TouchableOpacity>
-      );
-    }, [
-      isUrlBarFocused,
-      showCloseButton,
-      selectedAddress,
-      handleAccountRightButtonPress,
-      onCancelInput,
-      colors.icon.default,
-      styles.closeButton,
-      styles.cancelButton,
-      styles.cancelButtonText,
-    ]);
-
-    useImperativeHandle(ref, () => ({
-      hide: () => onCancelInput(),
-      blur: () => inputRef?.current?.blur(),
-      focus: () => inputRef?.current?.focus(),
-      setNativeProps: (props: object) => {
-        const inputText = hasProperty(props, 'text') ? props.text : null;
-
-        if (typeof inputText === 'string') {
-          inputValueRef.current = inputText;
-        }
-        inputRef?.current?.setNativeProps(props);
-      },
-    }));
-
-    /**
-     * Gets browser url bar icon based on connection type
-     */
-    const connectionTypeIcon = useMemo(() => {
-      // Default to unsecure icon
-      let iconName = IconName.LockSlash;
-
-      switch (connectionType) {
-        case ConnectionType.SECURE:
-          iconName = IconName.Lock;
-          break;
-        case ConnectionType.UNSECURE:
-          iconName = IconName.LockSlash;
-          break;
-      }
-      return iconName;
-    }, [connectionType]);
-
-    const onBlurInput = () => {
-      if (!shouldTriggerBlurCallbackRef.current) {
-        shouldTriggerBlurCallbackRef.current = true;
-        return;
-      }
-      unfocusInput();
-      onBlur();
-    };
-
-    const onFocusInput = () => {
-      setIsUrlBarFocused(true);
-      onFocus();
-    };
-
-    const onChangeTextInput = (text: string) => {
-      inputRef?.current?.setNativeProps({ text });
-      onChangeText(text);
-    };
-
-    const onSubmitEditingInput = ({
-      nativeEvent: { text },
-    }: NativeSyntheticEvent<TextInputSubmitEditingEventData>) => {
-      const trimmedText = text.trim();
-      inputValueRef.current = trimmedText;
-      onSubmitEditing(trimmedText);
-    };
-
-    /**
-     * Clears the input value and calls the onChangeText callback
-     */
-    const onClearInput = () => {
-      const clearedText = '';
-      inputRef?.current?.clear();
-      inputValueRef.current = clearedText;
-      onChangeText(clearedText);
-    };
-
-    return (
-      <View style={styles.browserUrlBarWrapper}>
-        <View style={styles.main} testID={BrowserViewSelectorsIDs.URL_INPUT}>
-          {isConnectionIconVisible ? (
-            <Icon
-              color={colors.icon.alternative}
-              name={connectionTypeIcon}
-              size={IconSize.Sm}
-              style={styles.connectionIcon}
-            />
-          ) : null}
-          <View style={styles.textInputWrapper}>
-            <TextInput
-              testID={BrowserURLBarSelectorsIDs.URL_INPUT}
-              keyboardType={'web-search'}
-              autoCapitalize={'none'}
-              autoCorrect={false}
-              ref={inputRef}
-              numberOfLines={1}
-              placeholder={strings('autocomplete.placeholder')}
-              placeholderTextColor={colors.text.muted}
-              returnKeyType={'go'}
-              selectTextOnFocus
-              keyboardAppearance={themeAppearance}
-              style={[styles.textInput, !isUrlBarFocused && styles.hidden]}
-              onChangeText={onChangeTextInput}
-              onSubmitEditing={onSubmitEditingInput}
-              onBlur={onBlurInput}
-              onFocus={onFocusInput}
-            />
-            <TouchableWithoutFeedback
-              onPress={() => inputRef?.current?.focus()}
-            >
-              <Text
-                style={styles.urlBarText}
+        <View style={styles.browserUrlBarWrapper}>
+          <View style={styles.main} testID={BrowserViewSelectorsIDs.URL_INPUT}>
+            {isConnectionIconVisible ? (
+              <Icon
+                color={colors.icon.alternative}
+                name={connectionTypeIcon}
+                size={IconSize.Sm}
+                style={styles.connectionIcon}
+              />
+            ) : null}
+            <View style={styles.textInputWrapper}>
+              <TextInput
+                testID={BrowserURLBarSelectorsIDs.URL_INPUT}
+                keyboardType={'web-search'}
+                autoCapitalize={'none'}
+                autoCorrect={false}
+                ref={inputRef}
                 numberOfLines={1}
-                ellipsizeMode="head"
+                placeholder={strings('autocomplete.placeholder')}
+                placeholderTextColor={colors.text.muted}
+                returnKeyType={'go'}
+                selectTextOnFocus
+                keyboardAppearance={themeAppearance}
+                style={[styles.textInput, !isUrlBarFocused && styles.hidden]}
+                onChangeText={onChangeTextInput}
+                onSubmitEditing={onSubmitEditingInput}
+                onBlur={onBlurInput}
+                onFocus={onFocusInput}
+              />
+              <TouchableWithoutFeedback
+                onPress={() => inputRef?.current?.focus()}
               >
-                {inputValueRef.current || activeUrl}
-              </Text>
-            </TouchableWithoutFeedback>
+                <Text
+                  style={styles.urlBarText}
+                  numberOfLines={1}
+                  ellipsizeMode="head"
+                >
+                  {inputValueRef.current || activeUrl}
+                </Text>
+              </TouchableWithoutFeedback>
+            </View>
+            {isUrlBarFocused ? (
+              <ButtonIcon
+                iconName={IconName.CircleX}
+                onPress={onClearInput}
+                iconColor={colors.icon.alternative}
+                size={ButtonIconSizes.Md}
+                style={styles.clearButton}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                testID={BrowserURLBarSelectorsIDs.URL_CLEAR_ICON}
+              />
+            ) : null}
           </View>
-          {isUrlBarFocused ? (
-            <ButtonIcon
-              iconName={IconName.CircleX}
-              onPress={onClearInput}
-              iconColor={colors.icon.alternative}
-              size={ButtonIconSizes.Md}
-              style={styles.clearButton}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              testID={BrowserURLBarSelectorsIDs.URL_CLEAR_ICON}
-            />
-          ) : null}
+          <View style={styles.rightButton}>{renderRightButton()}</View>
         </View>
-        <View style={styles.rightButton}>{renderRightButton()}</View>
-      </View>
-    );
-  },
+      );
+    },
+  ),
 );
+
+BrowserUrlBar.displayName = 'BrowserUrlBar';
 
 export default BrowserUrlBar;

--- a/app/components/UI/UrlAutocomplete/index.tsx
+++ b/app/components/UI/UrlAutocomplete/index.tsx
@@ -67,282 +67,290 @@ interface ResultsWithCategory {
 /**
  * Autocomplete list that appears when the browser url bar is focused
  */
-const UrlAutocomplete = forwardRef<
-  UrlAutocompleteRef,
-  UrlAutocompleteComponentProps
->(({ onSelect, onDismiss }, ref) => {
-  const browserHistory = useSelector(selectBrowserHistoryWithType);
-  const bookmarks = useSelector(selectBrowserBookmarksWithType);
-  const initialFuseResults = useMemo(
-    () => [...browserHistory, ...bookmarks],
-    [browserHistory, bookmarks],
-  );
-  const [fuseResults, setFuseResults] =
-    useState<FuseSearchResult[]>(initialFuseResults);
-  const {
-    searchTokens,
-    results: tokenSearchResults,
-    reset: resetTokenSearch,
-    isLoading: isTokenSearchLoading,
-  } = useTokenSearchDiscovery();
-  const usdConversionRate = useSelector(selectUsdConversionRate);
-  const tokenResults: TokenSearchResult[] = useMemo(
-    () =>
-      tokenSearchResults
-        .map(
-          ({
-            tokenAddress,
-            usdPricePercentChange,
-            usdPrice,
-            chainId,
-            ...rest
-          }) => ({
-            ...rest,
-            category: UrlAutocompleteCategory.Tokens as const,
-            address: tokenAddress,
-            chainId: chainId as Hex,
-            price: usdConversionRate ? usdPrice / usdConversionRate : -1,
-            percentChange: usdPricePercentChange.oneDay,
-            decimals: 18,
-            isFromSearch: true as const,
-          }),
-        )
-        .slice(0, TOKEN_SEARCH_LIMIT),
-    [tokenSearchResults, usdConversionRate],
-  );
+const UrlAutocomplete = React.memo(
+  forwardRef<UrlAutocompleteRef, UrlAutocompleteComponentProps>(
+    ({ onSelect, onDismiss }, ref) => {
+      const browserHistory = useSelector(selectBrowserHistoryWithType);
+      const bookmarks = useSelector(selectBrowserBookmarksWithType);
+      const initialFuseResults = useMemo(
+        () => [...browserHistory, ...bookmarks],
+        [browserHistory, bookmarks],
+      );
+      const [fuseResults, setFuseResults] =
+        useState<FuseSearchResult[]>(initialFuseResults);
+      const {
+        searchTokens,
+        results: tokenSearchResults,
+        reset: resetTokenSearch,
+        isLoading: isTokenSearchLoading,
+      } = useTokenSearchDiscovery();
+      const usdConversionRate = useSelector(selectUsdConversionRate);
+      const tokenResults: TokenSearchResult[] = useMemo(
+        () =>
+          tokenSearchResults
+            .map(
+              ({
+                tokenAddress,
+                usdPricePercentChange,
+                usdPrice,
+                chainId,
+                ...rest
+              }) => ({
+                ...rest,
+                category: UrlAutocompleteCategory.Tokens as const,
+                address: tokenAddress,
+                chainId: chainId as Hex,
+                price: usdConversionRate ? usdPrice / usdConversionRate : -1,
+                percentChange: usdPricePercentChange.oneDay,
+                decimals: 18,
+                isFromSearch: true as const,
+              }),
+            )
+            .slice(0, TOKEN_SEARCH_LIMIT),
+        [tokenSearchResults, usdConversionRate],
+      );
 
-  const hasResults = fuseResults.length > 0 || tokenResults.length > 0;
+      const hasResults = fuseResults.length > 0 || tokenResults.length > 0;
 
-  const currentCurrency = useSelector(selectCurrentCurrency);
+      const currentCurrency = useSelector(selectCurrentCurrency);
 
-  useEffect(() => {
-    if (currentCurrency) {
-      Engine.context.CurrencyRateController.updateExchangeRate([
-        currentCurrency,
-      ]);
-    }
-  }, [currentCurrency]);
-
-  const resultsByCategory: ResultsWithCategory[] = useMemo(
-    () =>
-      ORDERED_CATEGORIES.flatMap((category) => {
-        if (category === UrlAutocompleteCategory.Tokens) {
-          if (tokenResults.length === 0 && !isTokenSearchLoading) {
-            return [];
-          }
-          return {
-            category,
-            data: tokenResults,
-          };
+      useEffect(() => {
+        if (currentCurrency) {
+          Engine.context.CurrencyRateController.updateExchangeRate([
+            currentCurrency,
+          ]);
         }
+      }, [currentCurrency]);
 
-        let data = fuseResults.filter(
-          (result, index, self) =>
-            result.category === category &&
-            index ===
-              self.findIndex(
-                (r) => r.url === result.url && r.category === result.category,
-              ),
-        );
-        if (data.length === 0) {
-          return [];
-        }
-        if (category === UrlAutocompleteCategory.Recents) {
-          data = data.slice(0, MAX_RECENTS);
-        }
-        return {
-          category,
-          data,
-        };
-      }),
-    [fuseResults, tokenResults, isTokenSearchLoading],
-  );
-
-  const fuseRef = useRef<Fuse<FuseSearchResult> | null>(null);
-  const resultsRef = useRef<View | null>(null);
-  const { styles } = useStyles(styleSheet, {});
-
-  /**
-   * Show the results view
-   */
-  const show = () => {
-    resultsRef.current?.setNativeProps({ style: { display: 'flex' } });
-  };
-
-  /**
-   * Reset the autocomplete results
-   */
-  const reset = useCallback(() => {
-    setFuseResults(initialFuseResults);
-    resetTokenSearch();
-  }, [initialFuseResults, resetTokenSearch]);
-
-  const latestSearchTerm = useRef<string | null>(null);
-  const search = useCallback(
-    (text: string) => {
-      latestSearchTerm.current = text;
-      if (!text) {
-        reset();
-        return;
-      }
-      const fuseSearchResult = fuseRef.current?.search(text);
-      if (Array.isArray(fuseSearchResult)) {
-        setFuseResults(fuseSearchResult);
-      } else {
-        setFuseResults([]);
-      }
-
-      searchTokens(text);
-    },
-    [searchTokens, reset],
-  );
-
-  /**
-   * Debounce the search function
-   */
-  const debouncedSearch = useMemo(() => debounce(search, 100), [search]);
-
-  /**
-   * Hide the results view
-   */
-  const hide = useCallback(() => {
-    // Cancel the search
-    debouncedSearch.cancel();
-    reset();
-    resultsRef.current?.setNativeProps({ style: { display: 'none' } });
-  }, [debouncedSearch, reset]);
-
-  const dismissAutocomplete = () => {
-    hide();
-    // Call the onDismiss callback
-    onDismiss();
-  };
-
-  useImperativeHandle(ref, () => ({
-    search: debouncedSearch,
-    hide,
-    show,
-  }));
-
-  useEffect(() => {
-    const allUrls: FuseSearchResult[] = [
-      ...dappsWithType,
-      ...browserHistory,
-      ...bookmarks,
-    ];
-
-    // Create the fuse search
-    fuseRef.current = new Fuse(allUrls, {
-      shouldSort: true,
-      threshold: 0.4,
-      location: 0,
-      distance: 100,
-      maxPatternLength: 32,
-      minMatchCharLength: 1,
-      keys: [
-        { name: 'name', weight: 0.5 },
-        { name: 'url', weight: 0.5 },
-      ],
-    });
-
-    if (latestSearchTerm.current !== null) {
-      search(latestSearchTerm.current);
-    }
-  }, [browserHistory, bookmarks, search]);
-
-  const { goToSwaps: goToSwapsHook, networkModal } = useSwapBridgeNavigation({
-    location: SwapBridgeNavigationLocation.TokenDetails,
-    sourcePage: 'MainView',
-  });
-
-  const goToSwaps = useCallback(
-    async (tokenResult: TokenSearchResult) => {
-      try {
-        const bridgeToken = {
-          address: tokenResult.address,
-          name: tokenResult.name,
-          symbol: tokenResult.symbol,
-          image: tokenResult.logoUrl,
-          decimals: tokenResult.decimals,
-          chainId: tokenResult.chainId,
-        } satisfies BridgeToken;
-
-        goToSwapsHook(bridgeToken);
-      } catch (error) {
-        return;
-      }
-    },
-    [goToSwapsHook],
-  );
-
-  const renderSectionHeader = useCallback(
-    ({ section: { category } }: { section: ResultsWithCategory }) => (
-      <View style={styles.categoryWrapper}>
-        <Text style={styles.category}>
-          {strings(`autocomplete.${category}`)}
-        </Text>
-        {category === UrlAutocompleteCategory.Tokens &&
-          isTokenSearchLoading && (
-            <ActivityIndicator testID="loading-indicator" size="small" />
-          )}
-      </View>
-    ),
-    [styles, isTokenSearchLoading],
-  );
-
-  const renderItem: SectionListRenderItem<AutocompleteSearchResult> =
-    useCallback(
-      ({ item }) => (
-        <Result
-          result={item}
-          onPress={() => {
-            if (item.category !== UrlAutocompleteCategory.Tokens) {
-              hide();
+      const resultsByCategory: ResultsWithCategory[] = useMemo(
+        () =>
+          ORDERED_CATEGORIES.flatMap((category) => {
+            if (category === UrlAutocompleteCategory.Tokens) {
+              if (tokenResults.length === 0 && !isTokenSearchLoading) {
+                return [];
+              }
+              return {
+                category,
+                data: tokenResults,
+              };
             }
-            onSelect(item);
-          }}
-          onSwapPress={goToSwaps}
-        />
-      ),
-      [hide, onSelect, goToSwaps],
-    );
 
-  if (!hasResults && !isTokenSearchLoading) {
-    return (
-      <View ref={resultsRef} style={styles.wrapper}>
-        <TouchableWithoutFeedback
-          style={styles.bg}
-          onPress={dismissAutocomplete}
-        >
-          <View style={styles.bg} />
-        </TouchableWithoutFeedback>
-      </View>
-    );
-  }
+            let data = fuseResults.filter(
+              (result, index, self) =>
+                result.category === category &&
+                index ===
+                  self.findIndex(
+                    (r) =>
+                      r.url === result.url && r.category === result.category,
+                  ),
+            );
+            if (data.length === 0) {
+              return [];
+            }
+            if (category === UrlAutocompleteCategory.Recents) {
+              data = data.slice(0, MAX_RECENTS);
+            }
+            return {
+              category,
+              data,
+            };
+          }),
+        [fuseResults, tokenResults, isTokenSearchLoading],
+      );
 
-  return (
-    <View ref={resultsRef} style={styles.wrapper}>
-      <KeyboardAvoidingView
-        style={styles.keyboardAvoidingView}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        keyboardVerticalOffset={100}
-      >
-        <SectionList<AutocompleteSearchResult, ResultsWithCategory>
-          contentContainerStyle={styles.contentContainer}
-          sections={resultsByCategory}
-          keyExtractor={(item) =>
-            item.category === UrlAutocompleteCategory.Tokens
-              ? `${item.category}-${item.chainId}-${item.address}`
-              : `${item.category}-${item.url}`
+      const fuseRef = useRef<Fuse<FuseSearchResult> | null>(null);
+      const resultsRef = useRef<View | null>(null);
+      const { styles } = useStyles(styleSheet, {});
+
+      /**
+       * Show the results view
+       */
+      const show = () => {
+        resultsRef.current?.setNativeProps({ style: { display: 'flex' } });
+      };
+
+      /**
+       * Reset the autocomplete results
+       */
+      const reset = useCallback(() => {
+        setFuseResults(initialFuseResults);
+        resetTokenSearch();
+      }, [initialFuseResults, resetTokenSearch]);
+
+      const latestSearchTerm = useRef<string | null>(null);
+      const search = useCallback(
+        (text: string) => {
+          latestSearchTerm.current = text;
+          if (!text) {
+            reset();
+            return;
           }
-          renderSectionHeader={renderSectionHeader}
-          renderItem={renderItem}
-          keyboardShouldPersistTaps="handled"
-        />
-      </KeyboardAvoidingView>
-      {networkModal}
-    </View>
-  );
-});
+          const fuseSearchResult = fuseRef.current?.search(text);
+          if (Array.isArray(fuseSearchResult)) {
+            setFuseResults(fuseSearchResult);
+          } else {
+            setFuseResults([]);
+          }
+
+          searchTokens(text);
+        },
+        [searchTokens, reset],
+      );
+
+      /**
+       * Debounce the search function
+       */
+      const debouncedSearch = useMemo(() => debounce(search, 100), [search]);
+
+      /**
+       * Hide the results view
+       */
+      const hide = useCallback(() => {
+        // Cancel the search
+        debouncedSearch.cancel();
+        reset();
+        resultsRef.current?.setNativeProps({ style: { display: 'none' } });
+      }, [debouncedSearch, reset]);
+
+      const dismissAutocomplete = useCallback(() => {
+        hide();
+        // Call the onDismiss callback
+        onDismiss();
+      }, [hide, onDismiss]);
+
+      useImperativeHandle(ref, () => ({
+        search: debouncedSearch,
+        hide,
+        show,
+      }));
+
+      useEffect(() => {
+        const allUrls: FuseSearchResult[] = [
+          ...dappsWithType,
+          ...browserHistory,
+          ...bookmarks,
+        ];
+
+        // Create the fuse search
+        fuseRef.current = new Fuse(allUrls, {
+          shouldSort: true,
+          threshold: 0.4,
+          location: 0,
+          distance: 100,
+          maxPatternLength: 32,
+          minMatchCharLength: 1,
+          keys: [
+            { name: 'name', weight: 0.5 },
+            { name: 'url', weight: 0.5 },
+          ],
+        });
+
+        if (latestSearchTerm.current !== null) {
+          search(latestSearchTerm.current);
+        }
+      }, [browserHistory, bookmarks, search]);
+
+      const { goToSwaps: goToSwapsHook, networkModal } =
+        useSwapBridgeNavigation({
+          location: SwapBridgeNavigationLocation.TokenDetails,
+          sourcePage: 'MainView',
+        });
+
+      const goToSwaps = useCallback(
+        async (tokenResult: TokenSearchResult) => {
+          try {
+            const bridgeToken = {
+              address: tokenResult.address,
+              name: tokenResult.name,
+              symbol: tokenResult.symbol,
+              image: tokenResult.logoUrl,
+              decimals: tokenResult.decimals,
+              chainId: tokenResult.chainId,
+            } satisfies BridgeToken;
+
+            goToSwapsHook(bridgeToken);
+          } catch (error) {
+            return;
+          }
+        },
+        [goToSwapsHook],
+      );
+
+      const renderSectionHeader = useCallback(
+        ({ section: { category } }: { section: ResultsWithCategory }) => (
+          <View style={styles.categoryWrapper}>
+            <Text style={styles.category}>
+              {strings(`autocomplete.${category}`)}
+            </Text>
+            {category === UrlAutocompleteCategory.Tokens &&
+              isTokenSearchLoading && (
+                <ActivityIndicator testID="loading-indicator" size="small" />
+              )}
+          </View>
+        ),
+        [styles, isTokenSearchLoading],
+      );
+
+      const renderItem: SectionListRenderItem<AutocompleteSearchResult> =
+        useCallback(
+          ({ item }) => (
+            <Result
+              result={item}
+              onPress={() => {
+                if (item.category !== UrlAutocompleteCategory.Tokens) {
+                  hide();
+                }
+                onSelect(item);
+              }}
+              onSwapPress={goToSwaps}
+            />
+          ),
+          [hide, onSelect, goToSwaps],
+        );
+
+      const keyExtractor = useCallback((item: AutocompleteSearchResult) => {
+        if (item.category === UrlAutocompleteCategory.Tokens) {
+          return `${item.category}-${item.chainId}-${item.address}`;
+        }
+        return `${item.category}-${item.url}`;
+      }, []);
+
+      if (!hasResults && !isTokenSearchLoading) {
+        return (
+          <View ref={resultsRef} style={styles.wrapper}>
+            <TouchableWithoutFeedback
+              style={styles.bg}
+              onPress={dismissAutocomplete}
+            >
+              <View style={styles.bg} />
+            </TouchableWithoutFeedback>
+          </View>
+        );
+      }
+
+      return (
+        <View ref={resultsRef} style={styles.wrapper}>
+          <KeyboardAvoidingView
+            style={styles.keyboardAvoidingView}
+            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+            keyboardVerticalOffset={100}
+          >
+            <SectionList<AutocompleteSearchResult, ResultsWithCategory>
+              contentContainerStyle={styles.contentContainer}
+              sections={resultsByCategory}
+              keyExtractor={keyExtractor}
+              renderSectionHeader={renderSectionHeader}
+              renderItem={renderItem}
+              keyboardShouldPersistTaps="handled"
+            />
+          </KeyboardAvoidingView>
+          {networkModal}
+        </View>
+      );
+    },
+  ),
+);
+
+UrlAutocomplete.displayName = 'UrlAutocomplete';
 
 export default UrlAutocomplete;

--- a/app/components/Views/Browser/MaxBrowserTabsModal.tsx
+++ b/app/components/Views/Browser/MaxBrowserTabsModal.tsx
@@ -22,7 +22,7 @@ const MaxBrowserTabsModal = () => {
   const {
     styles,
     theme: { colors },
-  } = useStyles(styleSheet, {});
+  } = useStyles(styleSheet);
   const modalRef = useRef<BottomSheetRef>(null);
 
   const dismissModal = (): void => {

--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -22,10 +22,6 @@ import {
   setActiveTab,
   updateTab,
 } from '../../../actions/browser';
-import {
-  selectBrowserTabs,
-  selectBrowserActiveTabId,
-} from '../../../reducers/browser/selectors';
 import { selectAvatarAccountType } from '../../../selectors/settings';
 import {
   ToastContext,
@@ -76,9 +72,9 @@ export const Browser = React.memo((props) => {
     closeTab: triggerCloseTab,
     setActiveTab,
     updateTab,
+    activeTab: activeTabId,
+    tabs,
   } = props;
-  const tabs = useSelector(selectBrowserTabs);
-  const activeTabId = useSelector(selectBrowserActiveTabId);
   const previousTabs = useRef(null);
   const { top: topInset } = useSafeAreaInsets();
   const { styles } = useStyles(styleSheet, { topInset });
@@ -488,7 +484,10 @@ export const Browser = React.memo((props) => {
 
 Browser.displayName = 'Browser';
 
-const mapStateToProps = () => ({});
+const mapStateToProps = (state) => ({
+  tabs: state.browser.tabs,
+  activeTab: state.browser.activeTab,
+});
 
 const mapDispatchToProps = (dispatch) => ({
   createNewTab: (url, linkType) => dispatch(createNewTab(url, linkType)),
@@ -524,6 +523,14 @@ Browser.propTypes = {
    */
   updateTab: PropTypes.func,
   /**
+   * Array of tabs
+   */
+  tabs: PropTypes.array,
+  /**
+   * ID of the active tab
+   */
+  activeTab: PropTypes.number,
+  /**
    * Object that represents the current route info like params passed to it
    */
   route: PropTypes.object,
@@ -531,7 +538,10 @@ Browser.propTypes = {
 
 export { default as createBrowserNavDetails } from './Browser.types';
 
-const ConnectedBrowser = connect(mapStateToProps, mapDispatchToProps)(Browser);
+export const ConnectedBrowser = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Browser);
 ConnectedBrowser.displayName = 'ConnectedBrowser';
 
 const MemoConnectedBrowser = ({ route, ...props }) => {

--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -5,10 +5,12 @@ import React, {
   useEffect,
   useRef,
   useState,
+  useMemo,
 } from 'react';
 import { View } from 'react-native';
 import { captureScreen } from 'react-native-view-shot';
 import { connect, useSelector } from 'react-redux';
+import { deepEqual } from 'fast-equals';
 import { parseCaipAccountId } from '@metamask/utils';
 import { strings } from '../../../../locales/i18n';
 import { selectPermissionControllerState } from '../../../selectors/snaps';
@@ -20,6 +22,10 @@ import {
   setActiveTab,
   updateTab,
 } from '../../../actions/browser';
+import {
+  selectBrowserTabs,
+  selectBrowserActiveTabId,
+} from '../../../reducers/browser/selectors';
 import { selectAvatarAccountType } from '../../../selectors/settings';
 import {
   ToastContext,
@@ -61,7 +67,7 @@ const MAX_BROWSER_TABS = 5;
  * Component that wraps all the browser
  * individual tabs and the tabs view
  */
-export const Browser = (props) => {
+export const Browser = React.memo((props) => {
   const {
     route,
     navigation,
@@ -70,9 +76,9 @@ export const Browser = (props) => {
     closeTab: triggerCloseTab,
     setActiveTab,
     updateTab,
-    activeTab: activeTabId,
-    tabs,
   } = props;
+  const tabs = useSelector(selectBrowserTabs);
+  const activeTabId = useSelector(selectBrowserActiveTabId);
   const previousTabs = useRef(null);
   const { top: topInset } = useSafeAreaInsets();
   const { styles } = useStyles(styleSheet, { topInset });
@@ -120,22 +126,34 @@ export const Browser = (props) => {
     [updateTab],
   );
 
-  const hideTabsAndUpdateUrl = (url) => {
-    setShouldShowTabs(false);
-    setCurrentUrl(url);
-  };
+  const hideTabsAndUpdateUrl = useCallback(
+    (url) => {
+      setShouldShowTabs(false);
+      setCurrentUrl(url);
+    },
+    [setShouldShowTabs, setCurrentUrl],
+  );
 
-  const switchToTab = (tab) => {
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.BROWSER_SWITCH_TAB).build(),
-    );
-    setActiveTab(tab.id);
-    hideTabsAndUpdateUrl(tab.url);
-    updateTabInfo(tab.id, {
-      url: tab.url,
-      isArchived: false,
-    });
-  };
+  const switchToTab = useCallback(
+    (tab) => {
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.BROWSER_SWITCH_TAB).build(),
+      );
+      setActiveTab(tab.id);
+      hideTabsAndUpdateUrl(tab.url);
+      updateTabInfo(tab.id, {
+        url: tab.url,
+        isArchived: false,
+      });
+    },
+    [
+      trackEvent,
+      createEventBuilder,
+      setActiveTab,
+      hideTabsAndUpdateUrl,
+      updateTabInfo,
+    ],
+  );
 
   const hasAccounts = useRef(Boolean(accounts.length));
 
@@ -327,55 +345,62 @@ export const Browser = (props) => {
     [updateTab],
   );
 
+  const activeTabUrl = useMemo(
+    () => tabs.find((tab) => tab.id === activeTabId)?.url,
+    [tabs, activeTabId],
+  );
+
   const showTabsView = useCallback(async () => {
     try {
-      const activeTab = tabs.find((tab) => tab.id === activeTabId);
-      await takeScreenshot(activeTab.url, activeTab.id);
+      await takeScreenshot(activeTabUrl, activeTabId);
     } catch (e) {
       Logger.error(e);
     }
 
     setShouldShowTabs(true);
-  }, [tabs, activeTabId, takeScreenshot]);
+  }, [activeTabUrl, activeTabId, takeScreenshot]);
 
-  const closeAllTabs = () => {
+  const closeAllTabs = useCallback(() => {
     if (tabs.length) {
       triggerCloseAllTabs();
       setCurrentUrl(null);
     }
-  };
+  }, [tabs, triggerCloseAllTabs, setCurrentUrl]);
 
-  const closeTab = (tab) => {
-    // If the tab was selected we have to select
-    // the next one, and if there's no next one,
-    // we select the previous one.
-    if (tab.id === activeTabId) {
-      if (tabs.length > 1) {
-        tabs.forEach((t, i) => {
-          if (t.id === tab.id) {
-            let newTab = tabs[i - 1];
-            if (tabs[i + 1]) {
-              newTab = tabs[i + 1];
+  const closeTab = useCallback(
+    (tab) => {
+      // If the tab was selected we have to select
+      // the next one, and if there's no next one,
+      // we select the previous one.
+      if (tab.id === activeTabId) {
+        if (tabs.length > 1) {
+          tabs.forEach((t, i) => {
+            if (t.id === tab.id) {
+              let newTab = tabs[i - 1];
+              if (tabs[i + 1]) {
+                newTab = tabs[i + 1];
+              }
+              setActiveTab(newTab.id);
+              setCurrentUrl(newTab.url);
             }
-            setActiveTab(newTab.id);
-            setCurrentUrl(newTab.url);
-          }
-        });
-      } else {
-        setCurrentUrl(null);
+          });
+        } else {
+          setCurrentUrl(null);
+        }
       }
-    }
 
-    triggerCloseTab(tab.id);
-  };
+      triggerCloseTab(tab.id);
+    },
+    [activeTabId, triggerCloseTab, tabs, setActiveTab],
+  );
 
-  const closeTabsView = () => {
+  const closeTabsView = useCallback(() => {
     if (tabs.length) {
       setShouldShowTabs(false);
     }
-  };
+  }, [tabs, setShouldShowTabs]);
 
-  const renderTabList = () => {
+  const renderTabList = useCallback(() => {
     if (shouldShowTabs) {
       return (
         <Tabs
@@ -390,7 +415,16 @@ export const Browser = (props) => {
       );
     }
     return null;
-  };
+  }, [
+    shouldShowTabs,
+    tabs,
+    activeTabId,
+    switchToTab,
+    newTab,
+    closeTab,
+    closeTabsView,
+    closeAllTabs,
+  ]);
 
   const renderBrowserTabWindows = useCallback(
     () =>
@@ -447,12 +481,11 @@ export const Browser = (props) => {
       {renderTabList()}
     </View>
   );
-};
-
-const mapStateToProps = (state) => ({
-  tabs: state.browser.tabs,
-  activeTab: state.browser.activeTab,
 });
+
+Browser.displayName = 'Browser';
+
+const mapStateToProps = () => ({});
 
 const mapDispatchToProps = (dispatch) => ({
   createNewTab: (url, linkType) => dispatch(createNewTab(url, linkType)),
@@ -488,14 +521,6 @@ Browser.propTypes = {
    */
   updateTab: PropTypes.func,
   /**
-   * Array of tabs
-   */
-  tabs: PropTypes.array,
-  /**
-   * ID of the active tab
-   */
-  activeTab: PropTypes.number,
-  /**
    * Object that represents the current route info like params passed to it
    */
   route: PropTypes.object,
@@ -503,4 +528,17 @@ Browser.propTypes = {
 
 export { default as createBrowserNavDetails } from './Browser.types';
 
-export default connect(mapStateToProps, mapDispatchToProps)(Browser);
+const ConnectedBrowser = connect(mapStateToProps, mapDispatchToProps)(Browser);
+ConnectedBrowser.displayName = 'ConnectedBrowser';
+
+const MemoConnectedBrowser = ({ route, ...props }) => {
+  // Little hack to prevent some extra re-renders because route is an object that could be re-created (but stays the same) which triggers a re-render
+  const previousRoute = useRef(route);
+  if (!deepEqual(previousRoute.current, route)) {
+    previousRoute.current = route;
+  }
+  return <ConnectedBrowser route={previousRoute.current} {...props} />;
+};
+MemoConnectedBrowser.propTypes = ConnectedBrowser.propTypes;
+
+export default MemoConnectedBrowser;

--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -352,6 +352,9 @@ export const Browser = React.memo((props) => {
 
   const showTabsView = useCallback(async () => {
     try {
+      if (!activeTabUrl) {
+        throw new Error('Active tab URL is not set');
+      }
       await takeScreenshot(activeTabUrl, activeTabId);
     } catch (e) {
       Logger.error(e);

--- a/app/components/Views/Browser/index.test.tsx
+++ b/app/components/Views/Browser/index.test.tsx
@@ -3,7 +3,7 @@
 // 2. if tabs.length <= 4, create a new tab
 
 import React from 'react';
-import { Browser } from './index';
+import { Browser as BrowserComponent } from './index';
 import Routes from '../../../constants/navigation/Routes';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../util/test/initial-root-state';
@@ -24,6 +24,10 @@ import {
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { ToastContext } from '../../../component-library/components/Toast/Toast.context';
 import { parseCaipAccountId } from '@metamask/utils';
+
+const Browser = BrowserComponent as React.ComponentType<
+  Record<string, unknown>
+>;
 
 jest.useFakeTimers();
 

--- a/app/components/Views/DiscoveryTab/DiscoveryTab.tsx
+++ b/app/components/Views/DiscoveryTab/DiscoveryTab.tsx
@@ -116,15 +116,18 @@ export const DiscoveryTab: React.FC<DiscoveryTabProps> = ({
   /**
    * Render the bottom (navigation/options) bar
    */
-  const renderBottomBar = () =>
-    isTabActive && !isUrlBarFocused ? (
-      <BrowserBottomBar
-        canGoBack={false}
-        canGoForward={false}
-        showTabs={showTabs}
-        showUrlModal={toggleUrlModal}
-      />
-    ) : null;
+  const renderBottomBar = useCallback(
+    () =>
+      isTabActive && !isUrlBarFocused ? (
+        <BrowserBottomBar
+          canGoBack={false}
+          canGoForward={false}
+          showTabs={showTabs}
+          showUrlModal={toggleUrlModal}
+        />
+      ) : null,
+    [isTabActive, isUrlBarFocused, showTabs, toggleUrlModal],
+  );
 
   /**
    * Main render

--- a/app/reducers/browser/selectors.ts
+++ b/app/reducers/browser/selectors.ts
@@ -9,8 +9,3 @@ export const selectBrowserHistory = (state: RootState) => state.browser.history;
  */
 export const selectSearchEngine = (state: RootState) =>
   state.settings.searchEngine;
-
-export const selectBrowserTabs = (state: RootState) => state.browser.tabs;
-
-export const selectBrowserActiveTabId = (state: RootState) =>
-  state.browser.activeTab;

--- a/app/reducers/browser/selectors.ts
+++ b/app/reducers/browser/selectors.ts
@@ -9,3 +9,8 @@ export const selectBrowserHistory = (state: RootState) => state.browser.history;
  */
 export const selectSearchEngine = (state: RootState) =>
   state.settings.searchEngine;
+
+export const selectBrowserTabs = (state: RootState) => state.browser.tabs;
+
+export const selectBrowserActiveTabId = (state: RootState) =>
+  state.browser.activeTab;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds bunch of useCallbacks, React.memo etc. all around for in-app browser components. This prevents some rerenders during tab switching and page loading which should bring some minor performance improvements on low end devices.

(diff looks quite big but it's because of indentation changes because of added useCallbacks etc.)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. In app browser works

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

8 re-renders when opening Browser tab

<img width="420" height="44" alt="Screenshot 2026-01-05 at 15 11 29" src="https://github.com/user-attachments/assets/361fe621-c266-458e-9c19-1df129303a40" />

### **After**
Just 4 re-renders when opening Browser tab

<img width="314" height="42" alt="Screenshot 2026-01-05 at 16 20 45" src="https://github.com/user-attachments/assets/2c30db59-3827-4e52-b60d-04852a252be7" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves in-app browser performance by broadly memoizing components and stabilizing handlers/props to reduce unnecessary re-renders.
> 
> - Wraps `Browser`, `BrowserUrlBar`, `UrlAutocomplete`, `BrowserTab`, and `DiscoveryTab` in `React.memo`; adds `displayName`s
> - Converts many event handlers/selectors to `useCallback`/`useMemo`; extracts stable `keyExtractor` and renderers in `UrlAutocomplete`
> - Refactors `Browser` logic: memoized helpers (`hideTabsAndUpdateUrl`, `switchToTab`, `closeTab`, etc.), `activeTabUrl` via `useMemo`, and safer `showTabsView`
> - Memoizes navigation/webview handlers in `BrowserTab` (e.g., `onShouldStartLoadWithRequest`, `onMessage`, progress bar, bottom bar); minor UI handling tweaks (cancel/clear buttons)
> - Fixes `useStyles` call in `MaxBrowserTabsModal`; adjusts `Browser` export with a memoized connected wrapper to avoid route-induced re-renders
> - Updates unit tests to use the memoized `Browser` export and validates tab limits/archiving/account toast behaviors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cfdb9d0e9bda4eb2705046a548c296c3faf0c78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->