### PR TITLE
fix: use conditional ramp_type based on Unified V1 flag for analytics

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -104,6 +104,7 @@ import { createStakedTrxAsset } from './utils/createStakedTrxAsset';
 ///: END:ONLY_INCLUDE_IF
 import { getDetectedGeolocation } from '../../../reducers/fiatOrders';
 import { useRampsButtonClickData } from '../Ramp/hooks/useRampsButtonClickData';
+import useRampsUnifiedV1Enabled from '../Ramp/hooks/useRampsUnifiedV1Enabled';
 
 interface AssetOverviewProps {
   asset: TokenI;
@@ -188,6 +189,7 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
   const currentAddress = asset.address as Hex;
   const { goToBuy } = useRampNavigation();
   const rampsButtonClickData = useRampsButtonClickData();
+  const rampUnifiedV1Enabled = useRampsUnifiedV1Enabled();
   const { data: prices = [], isLoading } = useTokenHistoricalPrices({
     asset,
     address: currentAddress,
@@ -362,7 +364,7 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
           text: 'Buy',
           location: 'TokenDetails',
           chain_id_destination: getDecimalChainId(chainId),
-          ramp_type: 'BUY',
+          ramp_type: rampUnifiedV1Enabled ? 'UNIFIED_BUY' : 'BUY',
           region: rampGeodetectedRegion,
           ramp_routing: rampsButtonClickData.ramp_routing,
           is_authenticated: rampsButtonClickData.is_authenticated,

--- a/app/components/UI/BalanceEmptyState/BalanceEmptyState.test.tsx
+++ b/app/components/UI/BalanceEmptyState/BalanceEmptyState.test.tsx
@@ -24,6 +24,12 @@ jest.mock('../Ramp/hooks/useRampsButtonClickData', () => ({
   useRampsButtonClickData: jest.fn(() => mockButtonClickData),
 }));
 
+const mockUseRampsUnifiedV1Enabled = jest.fn();
+jest.mock('../Ramp/hooks/useRampsUnifiedV1Enabled', () => ({
+  __esModule: true,
+  default: () => mockUseRampsUnifiedV1Enabled(),
+}));
+
 const mockTrackEvent = jest.fn();
 const mockCreateEventBuilder = jest.fn();
 const mockEventBuilder = {
@@ -50,6 +56,7 @@ describe('BalanceEmptyState', () => {
       trackEvent: mockTrackEvent,
       createEventBuilder: mockCreateEventBuilder,
     });
+    mockUseRampsUnifiedV1Enabled.mockReturnValue(false);
   });
 
   const renderComponent = (props: Partial<BalanceEmptyStateProps> = {}) =>
@@ -87,7 +94,8 @@ describe('BalanceEmptyState', () => {
     expect(mockGoToBuy).toHaveBeenCalled();
   });
 
-  it('tracks RAMPS_BUTTON_CLICKED event when action button is pressed', () => {
+  it('tracks RAMPS_BUTTON_CLICKED event with ramp_type BUY when unified V1 is disabled', () => {
+    mockUseRampsUnifiedV1Enabled.mockReturnValue(false);
     const { getByTestId } = renderComponent();
     const actionButton = getByTestId('balance-empty-state-action-button');
 
@@ -100,6 +108,29 @@ describe('BalanceEmptyState', () => {
         location: 'BalanceEmptyState',
         chain_id_destination: 1,
         ramp_type: 'BUY',
+        ramp_routing: undefined,
+        is_authenticated: false,
+        preferred_provider: undefined,
+        order_count: 0,
+      }),
+    );
+    expect(mockTrackEvent).toHaveBeenCalled();
+  });
+
+  it('tracks RAMPS_BUTTON_CLICKED event with ramp_type UNIFIED_BUY when unified V1 is enabled', () => {
+    mockUseRampsUnifiedV1Enabled.mockReturnValue(true);
+    const { getByTestId } = renderComponent();
+    const actionButton = getByTestId('balance-empty-state-action-button');
+
+    fireEvent.press(actionButton);
+
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith('ramps_button_clicked');
+    expect(mockEventBuilder.addProperties).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Add funds',
+        location: 'BalanceEmptyState',
+        chain_id_destination: 1,
+        ramp_type: 'UNIFIED_BUY',
         ramp_routing: undefined,
         is_authenticated: false,
         preferred_provider: undefined,

--- a/app/components/UI/BalanceEmptyState/BalanceEmptyState.tsx
+++ b/app/components/UI/BalanceEmptyState/BalanceEmptyState.tsx
@@ -25,6 +25,7 @@ import { BalanceEmptyStateProps } from './BalanceEmptyState.types';
 import bankTransferImage from '../../../images/bank-transfer.png';
 import { getDetectedGeolocation } from '../../../reducers/fiatOrders';
 import { useRampsButtonClickData } from '../Ramp/hooks/useRampsButtonClickData';
+import useRampsUnifiedV1Enabled from '../Ramp/hooks/useRampsUnifiedV1Enabled';
 
 /**
  * BalanceEmptyState smart component displays an empty state for wallet balance
@@ -40,6 +41,7 @@ const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = ({
   const rampGeodetectedRegion = useSelector(getDetectedGeolocation);
   const { goToBuy } = useRampNavigation();
   const buttonClickData = useRampsButtonClickData();
+  const rampUnifiedV1Enabled = useRampsUnifiedV1Enabled();
 
   const handleAction = () => {
     goToBuy();
@@ -50,7 +52,7 @@ const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = ({
           text: 'Add funds',
           location: 'BalanceEmptyState',
           chain_id_destination: getDecimalChainId(chainId),
-          ramp_type: 'BUY',
+          ramp_type: rampUnifiedV1Enabled ? 'UNIFIED_BUY' : 'BUY',
           region: rampGeodetectedRegion,
           ramp_routing: buttonClickData.ramp_routing,
           is_authenticated: buttonClickData.is_authenticated,


### PR DESCRIPTION
## **Description**

The `ramp_type` analytics property was hardcoded to `BUY` in `BalanceEmptyState` and `AssetOverview` components, but when Unified Ramp V1 is enabled, it should be `UNIFIED_BUY` to correctly segment analytics data for the Unified Buy funnel.

This PR adds the `useRampsUnifiedV1Enabled` hook to both components and conditionally sets `ramp_type` based on the flag:
- When Unified V1 is **enabled** → `ramp_type: "UNIFIED_BUY"`
- When Unified V1 is **disabled** → `ramp_type: "BUY"`

This is consistent with the existing implementation in `FundActionMenu.tsx`.

## **Changelog**

CHANGELOG entry: Fixed analytics `ramp_type` to correctly report `UNIFIED_BUY` when Unified Ramp V1 is enabled

## **Related issues**

Fixes: #24219

## **Manual testing steps**

```gherkin
Feature: Ramps Button Analytics

  Scenario: user taps Add Funds from BalanceEmptyState with Unified V1 enabled
    Given Ramps Unified V1 feature flag is enabled
    And user has zero balance (BalanceEmptyState is visible)

    When user taps "Add funds" button
    Then RAMPS_BUTTON_CLICKED event is tracked with ramp_type: "UNIFIED_BUY"

  Scenario: user taps Buy from TokenDetails with Unified V1 disabled
    Given Ramps Unified V1 feature flag is disabled
    And user is viewing token details (AssetOverview)

    When user taps "Buy" button
    Then RAMPS_BUTTON_CLICKED event is tracked with ramp_type: "BUY"
```

## **Screenshots/Recordings**

N/A - No UI changes, analytics fix only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns buy-flow analytics with Unified Ramp V1.
> 
> - In `AssetOverview.tsx` and `BalanceEmptyState.tsx`, add `useRampsUnifiedV1Enabled` and set `ramp_type` to `UNIFIED_BUY` when enabled, otherwise `BUY`, for `RAMPS_BUTTON_CLICKED`
> - Update tests (`AssetOverview.test.tsx`, `BalanceEmptyState.test.tsx`) to mock the flag and assert `ramp_type` for both enabled/disabled scenarios
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d0409a7e3c964be952ddc96727ad1e6fce19f92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->