### PR TITLE
chore: Remove unused PerpsController state

### DIFF
--- a/app/components/UI/Perps/__mocks__/serviceMocks.ts
+++ b/app/components/UI/Perps/__mocks__/serviceMocks.ts
@@ -32,12 +32,10 @@ export const createMockPerpsControllerState = (
 ): PerpsControllerState => ({
   activeProvider: 'hyperliquid',
   isTestnet: false,
-  connectionStatus: 'connected',
   initializationState: 'initialized' as InitializationState,
   initializationError: null,
   initializationAttempts: 0,
   accountState: null,
-  positions: [],
   perpsBalances: {},
   depositInProgress: false,
   lastDepositTransactionId: null,

--- a/app/components/UI/Perps/controllers/PerpsController.test.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.test.ts
@@ -483,9 +483,7 @@ describe('PerpsController', () => {
     it('initializes with default state', () => {
       // Constructor no longer auto-starts initialization (moved to Engine.ts)
       expect(controller.state.activeProvider).toBe('hyperliquid');
-      expect(controller.state.positions).toEqual([]);
       expect(controller.state.accountState).toBeNull();
-      expect(controller.state.connectionStatus).toBe('disconnected');
       expect(controller.state.initializationState).toBe('uninitialized'); // Waits for explicit initialization
       expect(controller.state.initializationError).toBeNull();
       expect(controller.state.initializationAttempts).toBe(0); // Not started yet
@@ -1480,18 +1478,6 @@ describe('PerpsController', () => {
       await controller.disconnect();
 
       expect(mockProvider.disconnect).toHaveBeenCalled();
-      expect(controller.state.connectionStatus).toBe('disconnected');
-    });
-
-    it('handles connection status from state', () => {
-      // Test that we can access connection status from controller state
-      expect(controller.state.connectionStatus).toBe('disconnected');
-
-      // Test that the state is accessible and has the expected default value
-      expect(typeof controller.state.connectionStatus).toBe('string');
-      expect(['connected', 'disconnected', 'connecting']).toContain(
-        controller.state.connectionStatus,
-      );
     });
   });
 

--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -129,7 +129,6 @@ export type PerpsControllerState = {
   // Active provider
   activeProvider: string;
   isTestnet: boolean; // Dev toggle for testnet
-  connectionStatus: 'disconnected' | 'connecting' | 'connected';
 
   // Initialization state machine
   initializationState: InitializationState;
@@ -138,9 +137,6 @@ export type PerpsControllerState = {
 
   // Account data (persisted) - using HyperLiquid property names
   accountState: AccountState | null;
-
-  // Current positions
-  positions: Position[];
 
   // Perps balances per provider for portfolio display (historical data)
   perpsBalances: {
@@ -279,12 +275,10 @@ export type PerpsControllerState = {
 export const getDefaultPerpsControllerState = (): PerpsControllerState => ({
   activeProvider: 'hyperliquid',
   isTestnet: false, // Default to mainnet
-  connectionStatus: 'disconnected',
   initializationState: InitializationState.UNINITIALIZED,
   initializationError: null,
   initializationAttempts: 0,
   accountState: null,
-  positions: [],
   perpsBalances: {},
   depositInProgress: false,
   lastDepositResult: null,
@@ -331,12 +325,6 @@ const metadata: StateMetadata<PerpsControllerState> = {
     includeInDebugSnapshot: false,
     usedInUi: true,
   },
-  positions: {
-    includeInStateLogs: true,
-    persist: false,
-    includeInDebugSnapshot: false,
-    usedInUi: true,
-  },
   perpsBalances: {
     includeInStateLogs: true,
     persist: true,
@@ -352,12 +340,6 @@ const metadata: StateMetadata<PerpsControllerState> = {
   activeProvider: {
     includeInStateLogs: true,
     persist: true,
-    includeInDebugSnapshot: false,
-    usedInUi: true,
-  },
-  connectionStatus: {
-    includeInStateLogs: true,
-    persist: false,
     includeInDebugSnapshot: false,
     usedInUi: true,
   },
@@ -1900,7 +1882,6 @@ export class PerpsController extends BaseController<
 
       this.update((state) => {
         state.isTestnet = !state.isTestnet;
-        state.connectionStatus = 'disconnected';
       });
 
       const newNetwork = this.state.isTestnet ? 'testnet' : 'mainnet';
@@ -1951,7 +1932,6 @@ export class PerpsController extends BaseController<
 
     this.update((state) => {
       state.activeProvider = providerId;
-      state.connectionStatus = 'disconnected';
     });
 
     return { success: true, providerId };

--- a/app/components/UI/Perps/hooks/usePerpsSelector.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsSelector.test.ts
@@ -59,7 +59,7 @@ describe('usePerpsSelector', () => {
     expect(result.current).toBe(false);
   });
 
-  it('should work with different selector functions', () => {
+  it('works with different selector functions', () => {
     // Arrange
     const mockState: PerpsControllerState = {
       isFirstTimeUser: {
@@ -67,8 +67,8 @@ describe('usePerpsSelector', () => {
         mainnet: true,
       },
       isEligible: true,
-      connectionStatus: 'connected',
-      positions: [{ coin: 'ETH' }],
+      isTestnet: false,
+      activeProvider: 'hyperliquid',
     } as PerpsControllerState;
 
     mockUseSelector.mockImplementation((selectorFn) =>
@@ -82,11 +82,10 @@ describe('usePerpsSelector', () => {
       state?.isFirstTimeUser.mainnet ?? false;
     const isEligibleSelector = (state: PerpsControllerState | undefined) =>
       state?.isEligible ?? false;
-    const connectionStatusSelector = (
-      state: PerpsControllerState | undefined,
-    ) => state?.connectionStatus ?? 'disconnected';
-    const positionsCountSelector = (state: PerpsControllerState | undefined) =>
-      state?.positions?.length ?? 0;
+    const isTestnetSelector = (state: PerpsControllerState | undefined) =>
+      state?.isTestnet ?? false;
+    const activeProviderSelector = (state: PerpsControllerState | undefined) =>
+      state?.activeProvider ?? 'hyperliquid';
 
     // Act & Assert
     const { result: isFirstTimeUserResult } = renderHook(() =>
@@ -99,24 +98,24 @@ describe('usePerpsSelector', () => {
     );
     expect(isEligibleResult.current).toBe(true);
 
-    const { result: connectionStatusResult } = renderHook(() =>
-      usePerpsSelector(connectionStatusSelector),
+    const { result: isTestnetResult } = renderHook(() =>
+      usePerpsSelector(isTestnetSelector),
     );
-    expect(connectionStatusResult.current).toBe('connected');
+    expect(isTestnetResult.current).toBe(false);
 
-    const { result: positionsCountResult } = renderHook(() =>
-      usePerpsSelector(positionsCountSelector),
+    const { result: activeProviderResult } = renderHook(() =>
+      usePerpsSelector(activeProviderSelector),
     );
-    expect(positionsCountResult.current).toBe(1);
+    expect(activeProviderResult.current).toBe('hyperliquid');
   });
 
-  it('should return computed values from selector functions', () => {
+  it('returns computed values from selector functions', () => {
     // Arrange
     const mockState: PerpsControllerState = {
-      positions: [
-        { coin: 'ETH', size: '1.5' },
-        { coin: 'BTC', size: '0.1' },
-      ],
+      watchlistMarkets: {
+        testnet: ['ETH', 'BTC'],
+        mainnet: ['SOL', 'DOGE'],
+      },
     } as PerpsControllerState;
 
     mockUseSelector.mockImplementation((selectorFn) =>
@@ -125,16 +124,17 @@ describe('usePerpsSelector', () => {
       }),
     );
 
-    const positionCoinsSelector = (state: PerpsControllerState | undefined) =>
-      state?.positions?.map((p) => p.coin) ?? [];
+    const mainnetWatchlistSelector = (
+      state: PerpsControllerState | undefined,
+    ) => state?.watchlistMarkets?.mainnet ?? [];
 
     // Act
     const { result } = renderHook(() =>
-      usePerpsSelector(positionCoinsSelector),
+      usePerpsSelector(mainnetWatchlistSelector),
     );
 
     // Assert
-    expect(result.current).toEqual(['ETH', 'BTC']);
+    expect(result.current).toEqual(['SOL', 'DOGE']);
   });
 
   it('should handle complex nested state selection', () => {

--- a/app/core/Engine/controllers/perps-controller/index.test.ts
+++ b/app/core/Engine/controllers/perps-controller/index.test.ts
@@ -80,31 +80,6 @@ describe('perps controller init', () => {
     const initialPerpsControllerState: PerpsControllerState = {
       activeProvider: 'hyperliquid',
       isTestnet: true,
-      connectionStatus: 'connected',
-      positions: [
-        {
-          coin: 'ETH',
-          size: '2.5',
-          entryPrice: '3200.00',
-          positionValue: '8000.00',
-          unrealizedPnl: '320.00',
-          marginUsed: '1600.00',
-          leverage: {
-            type: 'cross',
-            value: 5,
-          },
-          liquidationPrice: '2400.00',
-          maxLeverage: 100,
-          returnOnEquity: '20.0',
-          cumulativeFunding: {
-            allTime: '-12.50',
-            sinceOpen: '-8.20',
-            sinceChange: '-3.10',
-          },
-          takeProfitCount: 0,
-          stopLossCount: 0,
-        },
-      ],
       accountState: null,
       perpsBalances: {},
       depositInProgress: false,

--- a/app/util/logs/__snapshots__/index.test.ts.snap
+++ b/app/util/logs/__snapshots__/index.test.ts.snap
@@ -482,7 +482,6 @@ exports[`logs :: generateStateLogs Sanitized SeedlessOnboardingController State 
       "PerpsController": {
         "accountState": null,
         "activeProvider": "hyperliquid",
-        "connectionStatus": "disconnected",
         "depositInProgress": false,
         "depositRequests": [],
         "hasPlacedFirstOrder": {
@@ -506,7 +505,6 @@ exports[`logs :: generateStateLogs Sanitized SeedlessOnboardingController State 
         "lastWithdrawResult": null,
         "marketFilterPreferences": {},
         "perpsBalances": {},
-        "positions": [],
         "tradeConfigurations": {},
         "watchlistMarkets": [],
         "withdrawInProgress": false,
@@ -1260,7 +1258,6 @@ exports[`logs :: generateStateLogs generates a valid json export 1`] = `
       "PerpsController": {
         "accountState": null,
         "activeProvider": "hyperliquid",
-        "connectionStatus": "disconnected",
         "depositInProgress": false,
         "depositRequests": [],
         "hasPlacedFirstOrder": {
@@ -1284,7 +1281,6 @@ exports[`logs :: generateStateLogs generates a valid json export 1`] = `
         "lastWithdrawResult": null,
         "marketFilterPreferences": {},
         "perpsBalances": {},
-        "positions": [],
         "tradeConfigurations": {},
         "watchlistMarkets": [],
         "withdrawInProgress": false,

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -473,8 +473,6 @@
     "initializationState": "uninitialized",
     "initializationError": null,
     "initializationAttempts": 0,
-    "connectionStatus": "disconnected",
-    "positions": [],
     "accountState": null,
     "depositInProgress": false,
     "depositRequests": [],

--- a/e2e/controller-mocking/mock-config/perps-controller-mixin.ts
+++ b/e2e/controller-mocking/mock-config/perps-controller-mixin.ts
@@ -46,12 +46,10 @@ export class E2EControllerOverrides {
 
     // Update Redux state to reflect the new position/balance
     const mockAccount = this.mockService.getMockAccountState();
-    const mockPositions = this.mockService.getMockPositions();
 
     (this.controller as ControllerWithUpdate).update(
       (state: PerpsControllerState) => {
         state.accountState = mockAccount;
-        state.positions = mockPositions;
         state.lastUpdateTimestamp = Date.now();
         state.lastError = null;
       },
@@ -120,7 +118,6 @@ export class E2EControllerOverrides {
     // Update Redux state
     (this.controller as ControllerWithUpdate).update(
       (state: PerpsControllerState) => {
-        state.positions = mockPositions;
         state.lastUpdateTimestamp = Date.now();
         state.lastError = null;
       },
@@ -141,12 +138,10 @@ export class E2EControllerOverrides {
 
     // Update Redux state to reflect the position closure
     const mockAccount = this.mockService.getMockAccountState();
-    const mockPositions = this.mockService.getMockPositions();
 
     (this.controller as ControllerWithUpdate).update(
       (state: PerpsControllerState) => {
         state.accountState = mockAccount;
-        state.positions = mockPositions;
         state.lastUpdateTimestamp = Date.now();
         state.lastError = null;
       },
@@ -169,11 +164,9 @@ export class E2EControllerOverrides {
     params: UpdatePositionTPSLParams,
   ): Promise<OrderResult> {
     const result = this.mockService.mockUpdatePositionTPSL(params);
-    // Refresh Redux positions after TP/SL changes
-    const mockPositions = this.mockService.getMockPositions();
+    // Refresh Redux timestamp after TP/SL changes
     (this.controller as ControllerWithUpdate).update(
       (state: PerpsControllerState) => {
-        state.positions = mockPositions;
         state.lastUpdateTimestamp = Date.now();
         state.lastError = null;
       },
@@ -350,10 +343,8 @@ export function applyE2EPerpsControllerMocks(controller: unknown): void {
 
   (controller as ControllerWithUpdate).update((state: PerpsControllerState) => {
     state.accountState = mockAccount;
-    state.positions = mockPositions;
     state.lastUpdateTimestamp = Date.now();
     state.lastError = null;
-    state.connectionStatus = 'connected';
     state.isEligible = true;
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Removes unused state code in PerpsController

## **Changelog**

CHANGELOG entry: Removes dead state code from PerpsController

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2215

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies `PerpsController` state by removing unused `positions` and `connectionStatus`, aligning implementation and tests with actual data flow (positions come via provider callbacks; connection status not tracked in state).
> 
> - Drops `positions` and `connectionStatus` from `PerpsControllerState`, default state, and state `metadata`
> - Updates tests to stop asserting/using these fields; adjusts connection tests to only verify provider `disconnect()`
> - Refactors `usePerpsSelector` tests to select `isTestnet`, `activeProvider`, and `watchlistMarkets` instead of removed fields
> - Cleans up mocks, snapshots, and initial-state fixtures to remove the fields
> - E2E perps-controller mixin no longer writes `positions`/`connectionStatus` into state
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0613f25b5501ca1a401585687f289c768f081039. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->