### PR TITLE
refactor: Move set existing user from login to vault recovery method

### DIFF
--- a/app/components/Views/Login/index.test.tsx
+++ b/app/components/Views/Login/index.test.tsx
@@ -32,7 +32,6 @@ import {
   TRUE,
 } from '../../../constants/storage';
 import { useMetrics } from '../../hooks/useMetrics';
-import { setExistingUser } from '../../../actions/user';
 
 const mockNavigate = jest.fn();
 const mockReplace = jest.fn();
@@ -123,13 +122,6 @@ jest.mock('../../../actions/security', () => ({
   ActionType: {
     SET_ALLOW_LOGIN_WITH_REMEMBER_ME: 'SET_ALLOW_LOGIN_WITH_REMEMBER_ME',
   },
-}));
-
-jest.mock('../../../actions/user', () => ({
-  setExistingUser: jest.fn((value) => ({
-    type: 'SET_EXISTING_USER',
-    existingUser: value,
-  })),
 }));
 
 jest.mock('../../../store/storage-wrapper', () => ({
@@ -790,102 +782,6 @@ describe('Login', () => {
 
       // Assert
       expect(passwordInput).toBeOnTheScreen();
-    });
-  });
-
-  describe('Vault Recovery', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-
-    it('dispatches setExistingUser after successful login from vault recovery', async () => {
-      // Arrange
-      mockRoute.mockReturnValue({
-        params: {
-          locked: false,
-          oauthLoginSuccess: false,
-          isVaultRecovery: true,
-        },
-      });
-
-      (StorageWrapper.getItem as jest.Mock).mockImplementation((key) => {
-        if (key === OPTIN_META_METRICS_UI_SEEN) return Promise.resolve('true');
-        return Promise.resolve(null);
-      });
-
-      (Authentication.userEntryAuth as jest.Mock).mockResolvedValueOnce(
-        undefined,
-      );
-      (
-        Authentication.componentAuthenticationType as jest.Mock
-      ).mockResolvedValueOnce({
-        currentAuthType: 'password',
-      });
-
-      const { getByTestId } = renderWithProvider(<Login />);
-      const passwordInput = getByTestId(LoginViewSelectors.PASSWORD_INPUT);
-      const loginButton = getByTestId(LoginViewSelectors.LOGIN_BUTTON_ID);
-
-      // Act
-      await act(async () => {
-        fireEvent.changeText(passwordInput, 'validPassword123');
-      });
-
-      await act(async () => {
-        fireEvent.press(loginButton);
-      });
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      // Assert
-      expect(setExistingUser).toHaveBeenCalledWith(true);
-    });
-
-    it('does not dispatch setExistingUser when not from vault recovery', async () => {
-      // Arrange
-      mockRoute.mockReturnValue({
-        params: {
-          locked: false,
-          oauthLoginSuccess: false,
-          isVaultRecovery: false,
-        },
-      });
-
-      (StorageWrapper.getItem as jest.Mock).mockImplementation((key) => {
-        if (key === OPTIN_META_METRICS_UI_SEEN) return Promise.resolve('true');
-        return Promise.resolve(null);
-      });
-
-      (Authentication.userEntryAuth as jest.Mock).mockResolvedValueOnce(
-        undefined,
-      );
-      (
-        Authentication.componentAuthenticationType as jest.Mock
-      ).mockResolvedValueOnce({
-        currentAuthType: 'password',
-      });
-
-      const { getByTestId } = renderWithProvider(<Login />);
-      const passwordInput = getByTestId(LoginViewSelectors.PASSWORD_INPUT);
-      const loginButton = getByTestId(LoginViewSelectors.LOGIN_BUTTON_ID);
-
-      // Act
-      await act(async () => {
-        fireEvent.changeText(passwordInput, 'validPassword123');
-      });
-
-      await act(async () => {
-        fireEvent.press(loginButton);
-      });
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      // Assert
-      expect(setExistingUser).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -29,8 +29,7 @@ import {
   saveOnboardingEvent as saveEvent,
 } from '../../../actions/onboarding';
 import { setAllowLoginWithRememberMe as setAllowLoginWithRememberMeUtil } from '../../../actions/security';
-import { setExistingUser } from '../../../actions/user';
-import { connect, useDispatch, useSelector } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import { Dispatch } from 'redux';
 import {
   passcodeType,
@@ -111,7 +110,6 @@ const EmptyRecordConstant = {};
 
 interface LoginRouteParams {
   locked: boolean;
-  isVaultRecovery?: boolean;
 }
 
 interface LoginProps {
@@ -142,15 +140,12 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
 
   const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
   const route = useRoute<RouteProp<{ params: LoginRouteParams }, 'params'>>();
-  const dispatch = useDispatch();
   const {
     styles,
     theme: { colors, themeAppearance },
   } = useStyles(stylesheet, EmptyRecordConstant);
   const setAllowLoginWithRememberMe = (enabled: boolean) =>
     setAllowLoginWithRememberMeUtil(enabled);
-  // coming from vault recovery flow flag
-  const isComingFromVaultRecovery = route?.params?.isVaultRecovery ?? false;
 
   const isSeedlessPasswordOutdated = useSelector(
     selectIsSeedlessPasswordOutdated,
@@ -407,13 +402,6 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
         },
       );
 
-      // CRITICAL: Set existingUser = true after successful vault unlock from recovery
-      // This prevents the vault recovery screen from appearing again on app restart
-      // Only set after successful unlock to ensure vault is unlocked and credentials are stored
-      if (isComingFromVaultRecovery) {
-        dispatch(setExistingUser(true));
-      }
-
       await checkMetricsUISeen();
 
       setLoading(false);
@@ -428,8 +416,6 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
     loading,
     handleLoginError,
     checkMetricsUISeen,
-    dispatch,
-    isComingFromVaultRecovery,
   ]);
 
   const handleLogin = async () => {

--- a/app/components/Views/RestoreWallet/WalletRestored.test.tsx
+++ b/app/components/Views/RestoreWallet/WalletRestored.test.tsx
@@ -122,7 +122,6 @@ describe('WalletRestored', () => {
     await waitFor(() => {
       expect(mockNavigation.replace).toHaveBeenCalledWith(
         Routes.ONBOARDING.LOGIN,
-        { isVaultRecovery: true },
       );
     });
   });
@@ -223,7 +222,6 @@ describe('WalletRestored', () => {
     await waitFor(() => {
       expect(mockNavigation.replace).toHaveBeenCalledWith(
         Routes.ONBOARDING.LOGIN,
-        { isVaultRecovery: true },
       );
     });
   });

--- a/app/components/Views/RestoreWallet/WalletRestored.tsx
+++ b/app/components/Views/RestoreWallet/WalletRestored.tsx
@@ -59,9 +59,7 @@ const WalletRestored = () => {
       Logger.error(error as Error, 'Failed to clear migration error flag');
     }
 
-    navigation.replace(Routes.ONBOARDING.LOGIN, {
-      isVaultRecovery: true,
-    });
+    navigation.replace(Routes.ONBOARDING.LOGIN);
   }, [navigation]);
 
   const onPressBackupSRP = useCallback(async (): Promise<void> => {

--- a/app/core/EngineService/EngineService.test.ts
+++ b/app/core/EngineService/EngineService.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../store/persistConfig';
 import { BACKGROUND_STATE_CHANGE_EVENT_NAMES } from '../Engine/constants';
 import { getPersistentState } from '../../store/getPersistentState/getPersistentState';
+import { setExistingUser } from '../../actions/user';
 
 // Mock NavigationService
 jest.mock('../NavigationService', () => ({
@@ -278,6 +279,23 @@ describe('EngineService', () => {
       {
         hasState: false, // Correctly detects no persisted state now that the bug is fixed
       },
+    );
+
+    // Restore fake timers for other tests
+    jest.useFakeTimers();
+  });
+
+  it('sets existingUser flag after successful vault recovery', async () => {
+    // Arrange
+    jest.useRealTimers();
+
+    // Act
+    await engineService.start();
+    await engineService.initializeVaultFromBackup();
+
+    // Assert
+    expect(ReduxService.store.dispatch).toHaveBeenCalledWith(
+      setExistingUser(true),
     );
 
     // Restore fake timers for other tests

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -29,6 +29,7 @@ import { trackVaultCorruption } from '../../util/analytics/vaultCorruptionTracki
 import { INIT_BG_STATE_KEY, LOG_TAG, UPDATE_BG_STATE_KEY } from './constants';
 import { StateConstraint } from '@metamask/base-controller';
 import { hasPersistedState } from './utils/persistence-utils';
+import { setExistingUser } from '../../actions/user';
 
 export class EngineService {
   private engineInitialized = false;
@@ -367,6 +368,10 @@ export class EngineService {
       if (instance) {
         // Pass state to detect controllers that changed during init
         this.initializeControllers(instance, state as Record<string, unknown>);
+        // CRITICAL: Set existingUser = true after successful vault unlock from recovery
+        // This prevents the vault recovery screen from appearing again on app restart
+        // Only set after successful unlock to ensure vault is unlocked and credentials are stored
+        ReduxService.store.dispatch(setExistingUser(true));
         // this is a hack to give the engine time to reinitialize
         await new Promise((resolve) => setTimeout(resolve, 2000));
         return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This change moves setting existing user from the `Login` component to the `initializeVaultFromBackup` method in `EngineService`. It used to live in the `Login` component since we needed to ensure that existing user was set to true so that users would not re-encounter the vault recovery flow when backgrounding/re-opening post vault recovery. However, it does not need to belong in the component if vault recovery relies on `initializeVaultFromBackup`, which is where we've moved the set existing user call. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: Part of https://consensyssoftware.atlassian.net/browse/MCWP-240

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

Existing user is set to true on vault recovery
https://github.com/user-attachments/assets/a1cb3040-4545-44f3-8472-74b280644e41


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts responsibility for marking returning users to the engine layer during vault recovery.
> 
> - Sets `existingUser` via Redux in `EngineService.initializeVaultFromBackup` after successful re-init; adds test asserting dispatch of `setExistingUser(true)`
> - Removes `setExistingUser` usage and `isVaultRecovery` logic from `Login` (no `useDispatch`; route params/type cleaned up)
> - Updates `WalletRestored` to navigate to `Routes.ONBOARDING.LOGIN` without `{ isVaultRecovery }`; adjusts related tests
> - Cleans up `Login` tests by removing mocks and cases tied to vault recovery flag
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97b1a1ab20c11d294713ae03bab93d7f68afd3a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->