### PR TITLE
chore: update network fee tooltip for gas fees sponsored case

### DIFF
--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -195,6 +195,7 @@ const QuoteDetailsCard: React.FC = () => {
                   nativeToken: nativeTokenName,
                 }),
                 size: TooltipSizes.Sm,
+                iconName: IconName.Info,
               },
             }}
             value={{

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -40,6 +40,7 @@ import styleSheet from './gas-fee-details-row.styles';
 import { IconColor } from '../../../../../../../component-library/components/Icons/Icon/Icon.types';
 import { selectNetworkConfigurationByChainId } from '../../../../../../../selectors/networkController';
 import type { RootState } from '../../../../../../../reducers';
+import useNetworkInfo from '../../../../hooks/useNetworkInfo';
 
 const PaidByMetaMask = () => (
   <Text variant={TextVariant.BodyMD} testID="paid-by-metamask">
@@ -263,12 +264,19 @@ const GasFeesDetailsRow = ({
   );
   const { nativeCurrency } = networkConfiguration ?? {};
 
+  const { networkNativeCurrency } = useNetworkInfo(
+    transactionMetadata?.chainId,
+  );
+
+  // Fallback chain: networkConfiguration.nativeCurrency -> networkNativeCurrency -> empty string
+  const nativeTokenSymbol = nativeCurrency ?? networkNativeCurrency ?? '';
+
   const showGasFeeTokenInfo =
     gasFeeToken?.metaMaskFee && gasFeeToken?.metaMaskFee !== '0x0';
 
   const confirmGasFeeTokenTooltip = isGasFeeSponsored
     ? strings('bridge.network_fee_info_content_sponsored', {
-        nativeToken: nativeCurrency,
+        nativeToken: nativeTokenSymbol,
       })
     : showGasFeeTokenInfo
       ? strings('transactions.confirm_gas_fee_token_tooltip', {

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -4,6 +4,7 @@ import {
 } from '@metamask/transaction-controller';
 import React, { useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { ConfirmationRowComponentIDs } from '../../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 import { strings } from '../../../../../../../../locales/i18n';
 import Icon, {
@@ -37,6 +38,8 @@ import InfoSection from '../../../UI/info-row/info-section';
 import { Skeleton } from '../../../../../../../component-library/components/Skeleton';
 import styleSheet from './gas-fee-details-row.styles';
 import { IconColor } from '../../../../../../../component-library/components/Icons/Icon/Icon.types';
+import { selectNetworkConfigurationByChainId } from '../../../../../../../selectors/networkController';
+import type { RootState } from '../../../../../../../reducers';
 
 const PaidByMetaMask = () => (
   <Text variant={TextVariant.BodyMD} testID="paid-by-metamask">
@@ -255,14 +258,23 @@ const GasFeesDetailsRow = ({
     });
   };
 
+  const networkConfiguration = useSelector((state: RootState) =>
+    selectNetworkConfigurationByChainId(state, transactionMetadata?.chainId),
+  );
+  const { nativeCurrency } = networkConfiguration ?? {};
+
   const showGasFeeTokenInfo =
     gasFeeToken?.metaMaskFee && gasFeeToken?.metaMaskFee !== '0x0';
 
-  const confirmGasFeeTokenTooltip = showGasFeeTokenInfo
-    ? strings('transactions.confirm_gas_fee_token_tooltip', {
-        metamaskFeeFiat,
+  const confirmGasFeeTokenTooltip = isGasFeeSponsored
+    ? strings('bridge.network_fee_info_content_sponsored', {
+        nativeToken: nativeCurrency,
       })
-    : strings('transactions.network_fee_tooltip');
+    : showGasFeeTokenInfo
+      ? strings('transactions.confirm_gas_fee_token_tooltip', {
+          metamaskFeeFiat,
+        })
+      : strings('transactions.network_fee_tooltip');
 
   const Container = noSection ? View : InfoSection;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Enhances the gas fee sponsorship user experience by updating the tooltip logo and content next to "network fee" to align with the other tooltip logo in the swap quote card.

### Problem
There was a different tooltip logo for gas fees sponsored swaps in the swap quote card.
The send transaction modal is missing the gas fees sponsored content network fee tooltip.

### Solution
Implement a UI-level workaround that updates the tooltip logo next to "network fee" in the swap quote card.
Add the the gas fees sponsored content network fee tooltip for send transaction.

## **Changelog**

CHANGELOG entry: updated network fee tooltip for gas fees sponsored case

## **Related issues**

Fixes: null

## **Manual testing steps**

1. Go to the swap page.
2. Request a same chain swap quote on a chain eligible of gas fees sponsored.
3. The quote response for network fees should display the correct tooltip logo.
4. The send transaction network fee tooltip should display the specific text for gas fees sponsored case.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="300" height="600" alt="Mobile before" src="https://github.com/user-attachments/assets/fbb9cdef-f522-4a97-8cbb-b82ef65074d1" />



### **After**

<!-- [screenshots/recordings] -->
<img width="300" height="600" alt="Mobile after" src="https://github.com/user-attachments/assets/7396b2e2-4934-435c-838c-33ae7f2a200f" />

<img width="300" height="600" alt="Monad send mob" src="https://github.com/user-attachments/assets/8b531a43-eec9-4074-843a-543ab2646d59" />



## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes the “network fee” tooltip for sponsored gas cases.
> 
> - Bridge `QuoteDetailsCard`: sets tooltip `iconName` to `Info` for `network_fee` when gas fees are sponsored.
> - Confirmations `gas-fee-details-row`: updates tooltip content to `bridge.network_fee_info_content_sponsored`, injecting the native token symbol (resolved via `selectNetworkConfigurationByChainId` with `useNetworkInfo` fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49bf386c402599569d4af822254907fe35cd3c5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->