### PR TITLE
chore(predict): add disclaimer to market about tab

### DIFF
--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -1023,6 +1023,10 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
       <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
         {market?.description}
       </Text>
+      <Box twClassName="w-full border-t border-muted" />
+      <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
+        {strings('predict.market_details.disclaimer')}
+      </Text>
     </Box>
   );
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1979,7 +1979,8 @@
       "outcome_at_price": "{{outcome}} at {{price}}¢",
       "fee_exemption": "We don't charge any fees on this market.",
       "ended": "Ended",
-      "resolved_early": "Resolved early"
+      "resolved_early": "Resolved early",
+      "disclaimer": "This information may be incomplete. All market rules, resolution criteria, and final outcomes are governed solely by Polymarket. Trades should be made based on the full rules available on Polymarket."
     },
     "tab": {
       "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",


### PR DESCRIPTION
## **Description**

This PR adds a disclaimer to the "About" tab on the Predict market details page.

**Reason for change:**
Users need to be informed that the market information displayed may be incomplete and that all market rules, resolution criteria, and final outcomes are governed by Polymarket.

**Solution:**
Added a disclaimer text section below the market description in the About tab, separated by a horizontal divider. The disclaimer directs users to Polymarket for the full rules before making trades.

## **Changelog**

CHANGELOG entry: Added disclaimer to Predict market details About tab informing users to check Polymarket for full market rules

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-386

## **Manual testing steps**

```gherkin
Feature: Predict Market Details Disclaimer

  Scenario: user views market About tab
    Given user has Predict enabled
    And user is on a Predict market details screen

    When user scrolls to the About section
    Then user sees the market description
    And user sees a disclaimer below the description stating market info may be incomplete and rules are governed by Polymarket
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="1179" height="2556" alt="simulator_screenshot_1BDF6804-092E-4394-9D94-E3071EBD51EB" src="https://github.com/user-attachments/assets/e9645ba5-0589-4459-a35a-399b74ec0c3c" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a short legal disclaimer to the Predict market details About section.
> 
> - Updates `PredictMarketDetails.tsx` to render a divider and `Text` with `strings('predict.market_details.disclaimer')` beneath the market description
> - Adds `predict.market_details.disclaimer` to `locales/languages/en.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14b3b27d08ec6052e726e1d253b984dea99ba0eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->