### PR TITLE
fix(predict): Guards against undefined tags being returned from search endpoint

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -2296,6 +2296,61 @@ describe('polymarket utils', () => {
       );
     });
 
+    it('returns empty array when search results omit markets', async () => {
+      const eventWithoutMarkets = {
+        ...mockEvent,
+        markets: undefined,
+      } as unknown as PolymarketApiEvent;
+
+      const mockResponse = {
+        events: [eventWithoutMarkets],
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const params: GetMarketsParams = {
+        providerId: 'polymarket',
+        q: 'nhl',
+        limit: 10,
+        offset: 0,
+      };
+
+      const result = await getParsedMarketsFromPolymarketApi(params);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty tags when search results omit tags', async () => {
+      const eventWithoutTags = {
+        ...mockEvent,
+        tags: undefined,
+      } as unknown as PolymarketApiEvent;
+
+      const mockResponse = {
+        events: [eventWithoutTags],
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const params: GetMarketsParams = {
+        providerId: 'polymarket',
+        q: 'nhl',
+        limit: 10,
+        offset: 0,
+      };
+
+      const result = await getParsedMarketsFromPolymarketApi(params);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].tags).toEqual([]);
+    });
+
     it('handle different categories', async () => {
       const mockResponse = {
         data: [mockEvent],

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -386,7 +386,9 @@ export const submitClobOrder = async ({
 };
 
 export const isSportEvent = (event: PolymarketApiEvent): boolean =>
-  event.tags.some((tag) => tag.slug === 'sports');
+  (Array.isArray(event.tags) ? event.tags : []).some(
+    (tag) => tag.slug === 'sports',
+  );
 
 export const isSpreadMarket = (market: PolymarketApiMarket): boolean =>
   market.sportsMarketType?.toLowerCase().includes('spread') ?? false;
@@ -562,7 +564,8 @@ export const sortMarkets = (
   event: PolymarketApiEvent,
   sortBy?: 'price' | 'ascending' | 'descending',
 ): PolymarketApiMarket[] => {
-  const { markets, sortBy: eventSortBy } = event;
+  const markets = Array.isArray(event.markets) ? event.markets : [];
+  const eventSortBy = event.sortBy;
 
   if (sortBy) {
     return sortMarketsByField(markets, sortBy);
@@ -605,28 +608,32 @@ export const parsePolymarketEvents = (
   sortMarketsBy?: 'price' | 'ascending' | 'descending',
 ): PredictMarket[] => {
   const parsedMarkets: PredictMarket[] = events.map(
-    (event: PolymarketApiEvent) => ({
-      id: event.id,
-      slug: event.slug,
-      providerId: 'polymarket',
-      title: event.title,
-      description: event.description,
-      image: event.icon,
-      status: event.closed
-        ? PredictMarketStatus.CLOSED
-        : PredictMarketStatus.OPEN,
-      recurrence: getRecurrence(event.series),
-      endDate: event.endDate,
-      category,
-      tags: event.tags.map((t) => t.label),
-      outcomes: sortMarkets(event, sortMarketsBy)
-        .filter((market: PolymarketApiMarket) => market.active !== false)
-        .map((market: PolymarketApiMarket) =>
-          parsePolymarketMarket(market, event),
-        ),
-      liquidity: event.liquidity,
-      volume: event.volume,
-    }),
+    (event: PolymarketApiEvent) => {
+      const tags = Array.isArray(event.tags) ? event.tags : [];
+
+      return {
+        id: event.id,
+        slug: event.slug,
+        providerId: 'polymarket',
+        title: event.title,
+        description: event.description,
+        image: event.icon,
+        status: event.closed
+          ? PredictMarketStatus.CLOSED
+          : PredictMarketStatus.OPEN,
+        recurrence: getRecurrence(event.series),
+        endDate: event.endDate,
+        category,
+        tags: tags.map((t) => t.label),
+        outcomes: sortMarkets(event, sortMarketsBy)
+          .filter((market: PolymarketApiMarket) => market?.active !== false)
+          .map((market: PolymarketApiMarket) =>
+            parsePolymarketMarket(market, event),
+          ),
+        liquidity: event.liquidity,
+        volume: event.volume,
+      };
+    },
   );
   return parsedMarkets;
 };
@@ -759,20 +766,17 @@ export const getParsedMarketsFromPolymarketApi = async (
   }
   const data = await response.json();
 
-  DevLogger.log('Polymarket response data:', data);
-
-  // Handle different response structures
-  const events = q ? data?.events : data?.data;
-
-  if (!events || !Array.isArray(events)) {
-    return [];
-  }
+  const events: PolymarketApiEvent[] = q ? data.events || [] : data.data || [];
 
   const parsedMarkets: PredictMarket[] = parsePolymarketEvents(
     events,
     category,
     'price',
   );
+
+  if (q) {
+    return parsedMarkets.filter((m) => m.outcomes.length > 0);
+  }
 
   return parsedMarkets;
 };

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -766,7 +766,10 @@ export const getParsedMarketsFromPolymarketApi = async (
   }
   const data = await response.json();
 
-  const events: PolymarketApiEvent[] = q ? data.events || [] : data.data || [];
+  const eventsData = q ? data?.events : data?.data;
+  const events: PolymarketApiEvent[] = Array.isArray(eventsData)
+    ? eventsData
+    : [];
 
   const parsedMarkets: PredictMarket[] = parsePolymarketEvents(
     events,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes an issue where certain search queries in Predict would return no results despite the API returning valid data.

**Reason for change:**
When users searched for terms like "nhl", the app would display no results even though the search API returned valid events. Some events had their tags field set to undefined instead of an empty array, causing array method calls to throw. These errors were caught and silently returned an empty array, resulting in "no results" displayed to users.

**Solution:**
Added defensive checks to safely handle undefined or non-array tags. This ensures malformed events don't crash parsing and valid markets are still displayed. Applied the same pattern to the markets field.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes issue where certain search queries in Predict would return no results

## **Related issues**

Fixes: [PRED-414](https://consensyssoftware.atlassian.net/browse/PRED-414)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/71fd088c-2c30-45a7-b8bb-a8cc6f728002" />

### **After**

<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/33fbf6e6-7c3b-4cb4-8dd4-0702160ac331" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves resilience of Polymarket market parsing and search results handling.
> 
> - Guard `isSportEvent` against non-array `tags`; treat missing tags as empty
> - In `sortMarkets`, treat non-array `markets` as empty and respect `event.sortBy`
> - In `parsePolymarketEvents`, default missing `tags` to `[]`, ignore inactive markets defensively, and continue parsing
> - In `getParsedMarketsFromPolymarketApi`, normalize response (`events`/`data`) to arrays and, for search (`q`), return only events with outcomes; remove extraneous logging
> - Tests: add cases for missing `markets` (returns `[]`) and missing `tags` (yields empty tags)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cbcfd66631d6ca55645351126f9a5a194aee02a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[PRED-414]: https://consensyssoftware.atlassian.net/browse/PRED-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ