### PR TITLE
chore: Flip order of onboarding buttons

### DIFF
--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
@@ -476,6 +476,14 @@ const PerpsTutorialCarousel: React.FC = () => {
       {/* Footer */}
       <View style={[styles.footer, { paddingBottom: safeAreaInsets.bottom }]}>
         <View style={styles.buttonRow}>
+          <Button
+            variant={ButtonVariants.Primary}
+            label={buttonLabel}
+            onPress={handleContinue}
+            size={ButtonSize.Lg}
+            testID={PerpsTutorialSelectorsIDs.CONTINUE_BUTTON}
+            style={styles.continueButton}
+          />
           {isLastScreen && (
             <Button
               variant={ButtonVariants.Secondary}
@@ -486,14 +494,6 @@ const PerpsTutorialCarousel: React.FC = () => {
               testID={PerpsTutorialSelectorsIDs.LEARN_MORE_BUTTON}
             />
           )}
-          <Button
-            variant={ButtonVariants.Primary}
-            label={buttonLabel}
-            onPress={handleContinue}
-            size={ButtonSize.Lg}
-            testID={PerpsTutorialSelectorsIDs.CONTINUE_BUTTON}
-            style={styles.continueButton}
-          />
           {!isLastScreen && (
             <View style={styles.skipButton}>
               <TouchableOpacity


### PR DESCRIPTION
## **Description**

Flips logical order of buttons on last screen of perps onboarding

## **Changelog**

CHANGELOG entry: Flip logical order of buttons on last screen of perps onboarding

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2130

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<img width="426" height="859" alt="Screenshot 2026-01-06 at 11 19 09 AM" src="https://github.com/user-attachments/assets/95e423e9-ce7e-434d-83f9-abdb3f706097" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders footer actions in `PerpsTutorialCarousel.tsx` to prioritize the primary call-to-action.
> 
> - Places `Continue` (Primary) before `Learn more` (Secondary) on the final screen; skip logic remains unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 714fb45eaa1038b82d9afb90f293f8f17714af98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->