### PR TITLE
feat: metamask pay max button

### DIFF
--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -34,6 +34,7 @@ import {
 import { calculateTotalGas, renderGwei } from './utils-gas';
 import { getTokenTransferData } from '../../Views/confirmations/utils/transaction-pay';
 import { hasTransactionType } from '../../Views/confirmations/utils/transaction';
+import { BigNumber } from 'bignumber.js';
 
 const POSITIVE_TRANSFER_TRANSACTION_TYPES = [
   TransactionType.perpsDeposit,
@@ -82,6 +83,12 @@ function getTokenTransfer(args) {
       decimals: tx.transferInformation.decimals,
       address: tx.transferInformation.contractAddress,
     };
+  }
+
+  const targetFiat = getMetamaskPayTargetFiat(tx, token?.decimals);
+
+  if (targetFiat && token) {
+    amount = targetFiat;
   }
 
   const isIncomplete = isTransactionIncomplete(status);
@@ -183,6 +190,21 @@ function getTokenTransfer(args) {
   };
 
   return [transactionElement, transactionDetails];
+}
+
+function getMetamaskPayTargetFiat(tx, decimals) {
+  const { metamaskPay } = tx ?? {};
+  const { targetFiat } = metamaskPay ?? {};
+
+  if (!targetFiat || targetFiat === '0') {
+    return undefined;
+  }
+
+  const targetFiatNoDecimals = new BigNumber(targetFiat)
+    .shiftedBy(decimals ?? 0)
+    .toFixed();
+
+  return new BN(targetFiatNoDecimals);
 }
 
 function getCollectibleTransfer(args) {

--- a/app/components/UI/TransactionElement/utils.test.js
+++ b/app/components/UI/TransactionElement/utils.test.js
@@ -452,6 +452,55 @@ describe('Transaction Element Utils', () => {
       });
     });
 
+    it('uses metamaskPay.targetFiat when available', async () => {
+      const args = {
+        tx: {
+          txParams: {
+            to: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+            from: '0x1440ec793ae50fa046b95bfeca5af475b6003f9e',
+            value: '52daf0',
+            data: '0xa9059cbb0000000000000000000000001234567890abcdef1234567890abcdef1234567800000000000000000000000000000000000000000000000000000000052daf0',
+            gas: '0x12345',
+            maxFeePerGas: '0x123456789',
+            maxPriorityFeePerGas: '0x123456789',
+            estimatedBaseFee: '0xABCDEF123',
+          },
+          hash: '0x942d7843454266b81bf631022aa5f3f944691731b62d67c4e80c4bb5740058bb',
+          type: TransactionType.perpsDeposit,
+          metamaskPay: {
+            targetFiat: '99.99',
+          },
+        },
+        currentCurrency: 'usd',
+        contractExchangeRates: {
+          '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359': {
+            price: 2.0,
+          },
+        },
+        conversionRate: 2.0,
+        totalGas: '0x64',
+        actionKey: 'key',
+        primaryCurrency: 'ETH',
+        selectedAddress: '0x1440ec793ae50fa046b95bfeca5af475b6003f9e',
+        ticker: 'POL',
+        txChainId: '0x89',
+        tokens: {
+          '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359': {
+            address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+            symbol: 'USDC',
+            decimals: 6,
+          },
+        },
+      };
+
+      const [transactionElement, transactionDetails] =
+        await decodeTransaction(args);
+
+      expect(transactionElement.value).toBe('99.99 USDC');
+      expect(transactionDetails.renderValue).toBe('99.99 USDC');
+      expect(transactionDetails.summaryAmount).toBe('99.99 USDC');
+    });
+
     it('sets SENT_COLLECTIBLE type when user is sender', async () => {
       const selectedAddress = '0x1440ec793ae50fa046b95bfeca5af475b6003f9e';
       const args = {

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -134,4 +134,19 @@ describe('TransactionDetailsHero', () => {
     const { queryByTestId } = render();
     expect(queryByTestId('transaction-details-hero')).toBeNull();
   });
+
+  it('renders targetFiat from metamaskPay when available', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        ...TRANSACTION_META_MOCK,
+        metamaskPay: {
+          targetFiat: '456.78',
+        },
+      } as unknown as TransactionMeta,
+    });
+
+    const { getByText } = render();
+
+    expect(getByText('$456.78')).toBeDefined();
+  });
 });

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -53,6 +53,7 @@ import { useAlerts } from '../../../context/alert-system-context';
 import { useTransactionConfirm } from '../../../hooks/transactions/useTransactionConfirm';
 import EngineService from '../../../../../../core/EngineService';
 import { ConfirmationFooterSelectorIDs } from '../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
+import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 
 export interface CustomAmountInfoProps {
   children?: ReactNode;
@@ -73,8 +74,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     currency,
     disablePay,
     hasMax,
-    preferredToken,
     overrideContent,
+    preferredToken,
   }) => {
     useClearConfirmationOnBackSwipe();
     useAutomaticTransactionPayToken({
@@ -83,6 +84,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     });
     useTransactionPayMetrics();
 
+    const { isNative: isNativePayToken } = useTransactionPayToken();
     const { styles } = useStyles(styleSheet, {});
     const [isKeyboardVisible, setIsKeyboardVisible] = useState(true);
     const availableTokens = useTransactionPayAvailableTokens();
@@ -161,7 +163,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               onDonePress={handleDone}
               onPercentagePress={updatePendingAmountPercentage}
               hasInput={hasInput}
-              hasMax={hasMax}
+              hasMax={hasMax && !isNativePayToken}
             />
           )}
           {!hasTokens && <BuySection />}

--- a/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
+++ b/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
@@ -73,6 +73,7 @@ export const MusdConversionInfo = () => {
     <CustomAmountInfo
       preferredToken={preferredPaymentToken}
       overrideContent={renderOverrideContent}
+      hasMax
     />
   );
 };

--- a/app/components/Views/confirmations/components/info/perps-deposit-info/perps-deposit-info.tsx
+++ b/app/components/Views/confirmations/components/info/perps-deposit-info/perps-deposit-info.tsx
@@ -17,5 +17,5 @@ export function PerpsDepositInfo() {
     tokenAddress: ARBITRUM_USDC.address,
   });
 
-  return <CustomAmountInfo currency={PERPS_CURRENCY} />;
+  return <CustomAmountInfo currency={PERPS_CURRENCY} hasMax />;
 }

--- a/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.test.tsx
+++ b/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.test.tsx
@@ -7,11 +7,16 @@ import { transactionApprovalControllerMock } from '../../__mocks__/controllers/a
 import { otherControllersMock } from '../../__mocks__/controllers/other-controllers-mock';
 import { useTokenFiatRates } from '../../hooks/tokens/useTokenFiatRates';
 import { useTransactionPayToken } from '../../hooks/pay/useTransactionPayToken';
+import {
+  useTransactionPayIsMaxAmount,
+  useIsTransactionPayLoading,
+} from '../../hooks/pay/useTransactionPayData';
 
 jest.mock('../../hooks/useTokenAmount');
 jest.mock('../../hooks/useTokenAsset');
 jest.mock('../../hooks/tokens/useTokenFiatRates');
 jest.mock('../../hooks/pay/useTransactionPayToken');
+jest.mock('../../hooks/pay/useTransactionPayData');
 
 const ASSET_AMOUNT_MOCK = '100';
 const ASSET_FIAT_RATE_MOCK = 10;
@@ -36,6 +41,12 @@ function render({ disabled = false } = {}) {
 describe('PayTokenAmount', () => {
   const useTokenFiatRatesMock = jest.mocked(useTokenFiatRates);
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+  const useTransactionPayIsMaxAmountMock = jest.mocked(
+    useTransactionPayIsMaxAmount,
+  );
+  const useIsTransactionPayLoadingMock = jest.mocked(
+    useIsTransactionPayLoading,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -52,6 +63,9 @@ describe('PayTokenAmount', () => {
         symbol: PAY_TOKEN_SYMBOL_MOCK,
       },
     } as unknown as ReturnType<typeof useTransactionPayToken>);
+
+    useTransactionPayIsMaxAmountMock.mockReturnValue(false);
+    useIsTransactionPayLoadingMock.mockReturnValue(false);
   });
 
   it('renders equivalent pay token value', () => {
@@ -75,5 +89,14 @@ describe('PayTokenAmount', () => {
   it('returns fixed value if disabled', () => {
     const { getByText } = render({ disabled: true });
     expect(getByText('0 ETH')).toBeDefined();
+  });
+
+  it('renders skeleton if isMaxAmount and quotes loading', () => {
+    useTransactionPayIsMaxAmountMock.mockReturnValue(true);
+    useIsTransactionPayLoadingMock.mockReturnValue(true);
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('pay-token-amount-skeleton')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.tsx
+++ b/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.tsx
@@ -13,6 +13,10 @@ import { Hex } from 'viem';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
 import { Skeleton } from '../../../../../component-library/components/Skeleton';
 import { getTokenAddress } from '../../utils/transaction-pay';
+import {
+  useIsTransactionPayLoading,
+  useTransactionPayIsMaxAmount,
+} from '../../hooks/pay/useTransactionPayData';
 
 export interface PayTokenAmountProps {
   amountHuman: string;
@@ -24,6 +28,8 @@ export function PayTokenAmount({ amountHuman, disabled }: PayTokenAmountProps) {
   const { chainId } = transaction ?? { chainId: '0x0' };
   const { payToken } = useTransactionPayToken();
   const targetTokenAddress = getTokenAddress(transaction);
+  const isMaxAmount = useTransactionPayIsMaxAmount();
+  const isQuotesLoading = useIsTransactionPayLoading();
 
   const fiatRequests = useMemo(
     () =>
@@ -71,7 +77,9 @@ export function PayTokenAmount({ amountHuman, disabled }: PayTokenAmountProps) {
     );
   }
 
-  if (!formattedAmount) return <PayTokenAmountSkeleton />;
+  if (!formattedAmount || (isMaxAmount && isQuotesLoading)) {
+    return <PayTokenAmountSkeleton />;
+  }
 
   return (
     <View testID="pay-token-amount">

--- a/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
+++ b/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
@@ -2,8 +2,25 @@ import React from 'react';
 import { CustomAmount } from './custom-amount';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
+import {
+  useIsTransactionPayLoading,
+  useTransactionPayIsMaxAmount,
+} from '../../../hooks/pay/useTransactionPayData';
+
+jest.mock('../../../hooks/pay/useTransactionPayData');
+
+const mockUseTransactionPayIsMaxAmount = jest.mocked(
+  useTransactionPayIsMaxAmount,
+);
+const mockUseIsTransactionPayLoading = jest.mocked(useIsTransactionPayLoading);
 
 describe('CustomAmount', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockUseTransactionPayIsMaxAmount.mockReturnValue(false);
+    mockUseIsTransactionPayLoading.mockReturnValue(false);
+  });
+
   it('renders amount', () => {
     const { getByText } = renderWithProvider(
       <CustomAmount amountFiat="123.45" />,
@@ -34,6 +51,39 @@ describe('CustomAmount', () => {
       <CustomAmount amountFiat="123.45" isLoading />,
     );
 
-    expect(getByTestId('custom-amount-skeleton')).toBeDefined();
+    expect(getByTestId('custom-amount-skeleton')).toBeOnTheScreen();
+  });
+
+  it('renders skeleton when max amount and quotes are loading', () => {
+    mockUseTransactionPayIsMaxAmount.mockReturnValue(true);
+    mockUseIsTransactionPayLoading.mockReturnValue(true);
+
+    const { getByTestId } = renderWithProvider(
+      <CustomAmount amountFiat="123.45" />,
+    );
+
+    expect(getByTestId('custom-amount-skeleton')).toBeOnTheScreen();
+  });
+
+  it('renders amount when max amount but quotes are not loading', () => {
+    mockUseTransactionPayIsMaxAmount.mockReturnValue(true);
+    mockUseIsTransactionPayLoading.mockReturnValue(false);
+
+    const { getByText } = renderWithProvider(
+      <CustomAmount amountFiat="123.45" />,
+    );
+
+    expect(getByText('123.45')).toBeOnTheScreen();
+  });
+
+  it('renders amount when quotes are loading but not max amount', () => {
+    mockUseTransactionPayIsMaxAmount.mockReturnValue(false);
+    mockUseIsTransactionPayLoading.mockReturnValue(true);
+
+    const { getByText } = renderWithProvider(
+      <CustomAmount amountFiat="123.45" />,
+    );
+
+    expect(getByText('123.45')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.tsx
+++ b/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.tsx
@@ -7,6 +7,10 @@ import { Skeleton } from '../../../../../../component-library/components/Skeleto
 import { useSelector } from 'react-redux';
 import { selectCurrentCurrency } from '../../../../../../selectors/currencyRateController';
 import Text from '../../../../../../component-library/components/Texts/Text';
+import {
+  useIsTransactionPayLoading,
+  useTransactionPayIsMaxAmount,
+} from '../../../hooks/pay/useTransactionPayData';
 
 export interface CustomAmountProps {
   amountFiat: string;
@@ -27,6 +31,8 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
     onPress,
   } = props;
 
+  const isMaxAmount = useTransactionPayIsMaxAmount();
+  const isQuotesLoading = useIsTransactionPayLoading();
   const selectedCurrency = useSelector(selectCurrentCurrency);
   const currency = currencyProp ?? selectedCurrency;
   const fiatSymbol = getCurrencySymbol(currency);
@@ -38,7 +44,9 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
     disabled,
   });
 
-  if (isLoading) {
+  const showLoader = isLoading || (isMaxAmount && isQuotesLoading);
+
+  if (showLoader) {
     return <CustomAmountSkeleton />;
   }
 

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayData.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayData.test.ts
@@ -13,6 +13,7 @@ import {
   useTransactionPayRequiredTokens,
   useTransactionPaySourceAmounts,
   useTransactionPayTotals,
+  useTransactionPayIsMaxAmount,
 } from './useTransactionPayData';
 import { cloneDeep, merge } from 'lodash';
 import {
@@ -53,6 +54,7 @@ const state = merge(
           transactionData: {
             [transactionIdMock]: {
               isLoading: true,
+              isMaxAmount: true,
               quotes: [QUOTE_MOCK],
               sourceAmounts: [SOURCE_AMOUNT_MOCK],
               tokens: [REQUIRED_TOKEN_MOCK],
@@ -148,5 +150,12 @@ describe('useTransactionPayData', () => {
     expect(
       renderHookWithProvider(useTransactionPayTotals, { state }).result.current,
     ).toStrictEqual(TOTALS_MOCK);
+  });
+
+  it('returns isMaxAmount', () => {
+    expect(
+      renderHookWithProvider(useTransactionPayIsMaxAmount, { state }).result
+        .current,
+    ).toBe(true);
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayData.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayData.ts
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../reducers';
 import {
   selectIsTransactionPayLoadingByTransactionId,
+  selectTransactionPayIsMaxAmountByTransactionId,
   selectTransactionPayQuotesByTransactionId,
   selectTransactionPaySourceAmountsByTransactionId,
   selectTransactionPayTokensByTransactionId,
@@ -36,6 +37,10 @@ export function useIsTransactionPayLoading() {
 
 export function useTransactionPayTotals() {
   return useTransactionPayData(selectTransactionPayTotalsByTransactionId);
+}
+
+export function useTransactionPayIsMaxAmount() {
+  return useTransactionPayData(selectTransactionPayIsMaxAmountByTransactionId);
 }
 
 function useTransactionPayData<T>(

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
@@ -116,7 +116,9 @@ describe('useTransactionPayToken', () => {
 
   it('returns undefined if no state', () => {
     const { result } = runHook();
+
     expect(result.current.payToken).toBeUndefined();
+    expect(result.current.isNative).toBeFalsy();
   });
 
   it('returns token matching state', () => {
@@ -125,6 +127,7 @@ describe('useTransactionPayToken', () => {
     });
 
     expect(result.current.payToken).toStrictEqual(PAY_TOKEN_MOCK);
+    expect(result.current.isNative).toBe(false);
   });
 
   it('sets token in state', async () => {
@@ -142,5 +145,16 @@ describe('useTransactionPayToken', () => {
       tokenAddress: PAY_TOKEN_MOCK.address,
       chainId: PAY_TOKEN_MOCK.chainId,
     });
+  });
+
+  it('returns isNative true when pay token is native address', () => {
+    const { result } = runHook({
+      payToken: {
+        ...PAY_TOKEN_MOCK,
+        address: '0x0000000000000000000000000000000000000000',
+      } as TransactionPaymentToken,
+    });
+
+    expect(result.current.isNative).toBe(true);
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -7,13 +7,22 @@ import { selectTransactionPaymentTokenByTransactionId } from '../../../../../sel
 import { Hex } from '@metamask/utils';
 import { noop } from 'lodash';
 import EngineService from '../../../../../core/EngineService';
+import { getNativeTokenAddress } from '../../utils/asset';
+import { TransactionPaymentToken } from '@metamask/transaction-pay-controller';
 
-export function useTransactionPayToken() {
+export function useTransactionPayToken(): {
+  isNative?: boolean;
+  payToken: TransactionPaymentToken | undefined;
+  setPayToken: (newPayToken: { address: Hex; chainId: Hex }) => void;
+} {
   const { id: transactionId } = useTransactionMetadataRequest() || { id: '' };
 
   const payToken = useSelector((state: RootState) =>
     selectTransactionPaymentTokenByTransactionId(state, transactionId),
   );
+
+  const isNative =
+    payToken && payToken?.address === getNativeTokenAddress(payToken?.chainId);
 
   const setPayToken = useCallback(
     (newPayToken: { address: Hex; chainId: Hex }) => {
@@ -44,6 +53,7 @@ export function useTransactionPayToken() {
   );
 
   return {
+    isNative,
     payToken,
     setPayToken,
   };

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -11,13 +11,14 @@ import { useUpdateTokenAmount } from './useUpdateTokenAmount';
 import { getTokenAddress } from '../../utils/transaction-pay';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { debounce } from 'lodash';
-import { useSelector } from 'react-redux';
-import { selectMetaMaskPayFlags } from '../../../../../selectors/featureFlagController/confirmations';
-import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { hasTransactionType } from '../../utils/transaction';
 import { usePredictBalance } from '../../../../UI/Predict/hooks/usePredictBalance';
-import { useTransactionPayRequiredTokens } from '../pay/useTransactionPayData';
+import {
+  useTransactionPayIsMaxAmount,
+  useTransactionPayTotals,
+} from '../pay/useTransactionPayData';
 import { useConfirmationMetricEvents } from '../metrics/useConfirmationMetricEvents';
+import Engine from '../../../../../core/Engine';
 
 export const MAX_LENGTH = 28;
 const DEBOUNCE_DELAY = 500;
@@ -26,11 +27,11 @@ export function useTransactionCustomAmount({
   currency,
 }: { currency?: string } = {}) {
   const { amount: defaultAmount } = useParams<{ amount?: string }>();
-  const [amountFiat, setAmountFiat] = useState(defaultAmount ?? '0');
+  const [amountFiatState, setAmountFiat] = useState(defaultAmount ?? '0');
   const [isInputChanged, setInputChanged] = useState(false);
   const [hasInput, setHasInput] = useState(false);
   const [amountHumanDebounced, setAmountHumanDebounced] = useState('0');
-  const maxPercentage = useMaxPercentage();
+  const totals = useTransactionPayTotals();
   const { setConfirmationMetric } = useConfirmationMetricEvents();
 
   const debounceSetAmountDelayed = useMemo(
@@ -42,14 +43,27 @@ export function useTransactionCustomAmount({
   );
 
   const transactionMeta = useTransactionMetadataRequest() as TransactionMeta;
-  const { chainId } = transactionMeta;
+  const { chainId, id: transactionId } = transactionMeta;
 
+  const isMaxAmount = useTransactionPayIsMaxAmount();
   const tokenAddress = getTokenAddress(transactionMeta);
   const tokenFiatRate = useTokenFiatRate(tokenAddress, chainId, currency) ?? 1;
   const balanceUsd = useTokenBalance(tokenFiatRate);
 
   const { updateTokenAmount: updateTokenAmountCallback } =
     useUpdateTokenAmount();
+
+  const amountFiat = useMemo(() => {
+    const targetAmountUsd = totals?.targetAmount.usd;
+
+    if (isMaxAmount && targetAmountUsd && targetAmountUsd !== '0') {
+      return new BigNumber(targetAmountUsd)
+        .decimalPlaces(2, BigNumber.ROUND_HALF_UP)
+        .toString(10);
+    }
+
+    return amountFiatState;
+  }, [amountFiatState, isMaxAmount, totals?.targetAmount.usd]);
 
   const amountHuman = useMemo(
     () =>
@@ -71,6 +85,15 @@ export function useTransactionCustomAmount({
     );
   }, [amountHumanDebounced]);
 
+  const setIsMax = useCallback(
+    (value: boolean) => {
+      const { TransactionPayController } = Engine.context;
+
+      TransactionPayController.setIsMaxAmount(transactionId, value);
+    },
+    [transactionId],
+  );
+
   const updatePendingAmount = useCallback(
     (value: string) => {
       let newAmount = value.replace(/^0+/, '') || '0';
@@ -83,14 +106,19 @@ export function useTransactionCustomAmount({
         return;
       }
 
+      if (isMaxAmount) {
+        setIsMax(false);
+      }
+
       setConfirmationMetric({
         properties: {
           mm_pay_amount_input_type: 'manual',
         },
       });
+
       setAmountFiat(newAmount);
     },
-    [setConfirmationMetric],
+    [isMaxAmount, setIsMax, setConfirmationMetric],
   );
 
   const updatePendingAmountPercentage = useCallback(
@@ -99,9 +127,7 @@ export function useTransactionCustomAmount({
         return;
       }
 
-      const finalPercentage = percentage === 100 ? maxPercentage : percentage;
-
-      const newAmount = new BigNumber(finalPercentage)
+      const newAmount = new BigNumber(percentage)
         .dividedBy(100)
         .multipliedBy(balanceUsd)
         .decimalPlaces(2, BigNumber.ROUND_DOWN)
@@ -112,9 +138,16 @@ export function useTransactionCustomAmount({
           mm_pay_amount_input_type: `${percentage}%`,
         },
       });
+
+      if (percentage === 100) {
+        setIsMax(true);
+      } else if (isMaxAmount) {
+        setIsMax(false);
+      }
+
       setAmountFiat(newAmount);
     },
-    [balanceUsd, maxPercentage, setConfirmationMetric],
+    [balanceUsd, isMaxAmount, setIsMax, setConfirmationMetric],
   );
 
   const updateTokenAmount = useCallback(() => {
@@ -131,48 +164,6 @@ export function useTransactionCustomAmount({
     updatePendingAmountPercentage,
     updateTokenAmount,
   };
-}
-
-function useMaxPercentage() {
-  const featureFlags = useSelector(selectMetaMaskPayFlags);
-  const { payToken } = useTransactionPayToken();
-  const { chainId } = useTransactionMetadataRequest() ?? { chainId: '0x0' };
-  const requiredTokens = useTransactionPayRequiredTokens();
-
-  return useMemo(() => {
-    // Assumes we're not targetting native tokens.
-    const payTokenIsRequiredToken =
-      payToken?.chainId === chainId &&
-      payToken?.address.toLowerCase() ===
-        requiredTokens[0]?.address?.toLowerCase();
-
-    if (!payToken || payTokenIsRequiredToken) {
-      return 100;
-    }
-
-    const requiredQuoteCount = requiredTokens.filter(
-      (token) =>
-        !token.skipIfBalance ||
-        new BigNumber(token.balanceRaw).lt(token.amountRaw),
-    ).length;
-
-    let bufferPercentage =
-      requiredQuoteCount > 0 ? featureFlags.bufferInitial : 0;
-
-    if (requiredQuoteCount > 1) {
-      bufferPercentage +=
-        featureFlags.bufferSubsequent * (requiredQuoteCount - 1);
-    }
-
-    if (
-      payToken?.address === getNativeTokenAddress(payToken?.chainId ?? '0x0')
-    ) {
-      // Cannot calculate gas cost yet so just add an additional buffer if pay token is native
-      bufferPercentage += featureFlags.bufferInitial;
-    }
-
-    return 100 - bufferPercentage * 100;
-  }, [chainId, featureFlags, payToken, requiredTokens]);
 }
 
 function useTokenBalance(tokenUsdRate: number) {

--- a/app/selectors/transactionPayController.ts
+++ b/app/selectors/transactionPayController.ts
@@ -43,6 +43,11 @@ export const selectTransactionPaySourceAmountsByTransactionId = createSelector(
   (transactionData) => transactionData?.sourceAmounts,
 );
 
+export const selectTransactionPayIsMaxAmountByTransactionId = createSelector(
+  selectTransactionDataByTransactionId,
+  (transactionData) => transactionData?.isMaxAmount ?? false,
+);
+
 export const selectTransactionPayTransactionData = createSelector(
   selectTransactionPayControllerState,
   (state) => state.transactionData,

--- a/package.json
+++ b/package.json
@@ -180,7 +180,8 @@
     "@metamask/transaction-controller@npm:^62.9.0": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch",
     "qs": "6.14.1",
     "@metamask/network-controller": "27.1.0",
-    "@metamask/bridge-controller": "64.3.0"
+    "@metamask/bridge-controller": "64.3.0",
+    "@metamask/bridge-status-controller": "64.0.1"
   },
   "dependencies": {
     "@config-plugins/detox": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,9 @@
     "@metamask/key-tree@npm:^10.1.1": "patch:@metamask/key-tree@npm%3A10.1.1#~/.yarn/patches/@metamask-key-tree-npm-10.1.1-0bfab435ac.patch",
     "@metamask/key-tree@npm:^10.0.2": "patch:@metamask/key-tree@npm%3A10.1.1#~/.yarn/patches/@metamask-key-tree-npm-10.1.1-0bfab435ac.patch",
     "@metamask/transaction-controller@npm:^62.9.0": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch",
-    "qs": "6.14.1"
+    "qs": "6.14.1",
+    "@metamask/network-controller": "27.1.0",
+    "@metamask/bridge-controller": "64.2.0"
   },
   "dependencies": {
     "@config-plugins/detox": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "@metamask/transaction-controller@npm:^62.9.0": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch",
     "qs": "6.14.1",
     "@metamask/network-controller": "27.1.0",
-    "@metamask/bridge-controller": "64.2.0"
+    "@metamask/bridge-controller": "64.3.0"
   },
   "dependencies": {
     "@config-plugins/detox": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "@ethereumjs/util@npm:^9.0.2": "patch:@ethereumjs/util@npm%3A9.1.0#~/.yarn/patches/@ethereumjs-util-npm-9.1.0-7e85509408.patch",
     "@metamask/key-tree@npm:^10.1.1": "patch:@metamask/key-tree@npm%3A10.1.1#~/.yarn/patches/@metamask-key-tree-npm-10.1.1-0bfab435ac.patch",
     "@metamask/key-tree@npm:^10.0.2": "patch:@metamask/key-tree@npm%3A10.1.1#~/.yarn/patches/@metamask-key-tree-npm-10.1.1-0bfab435ac.patch",
-    "@metamask/transaction-controller@npm:^62.7.0": "patch:@metamask/transaction-controller@npm%3A62.7.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch",
+    "@metamask/transaction-controller@npm:^62.9.0": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch",
     "qs": "6.14.1"
   },
   "dependencies": {
@@ -291,8 +291,8 @@
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/swaps-controller": "^15.0.0",
     "@metamask/token-search-discovery-controller": "^4.0.0",
-    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.7.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch",
-    "@metamask/transaction-pay-controller": "^10.5.0",
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch",
+    "@metamask/transaction-pay-controller": "^11.0.0",
     "@metamask/tron-wallet-snap": "^1.19.0",
     "@metamask/utils": "^11.8.1",
     "@ngraveio/bc-ur": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,6 @@
     "@metamask/key-tree@npm:^10.0.2": "patch:@metamask/key-tree@npm%3A10.1.1#~/.yarn/patches/@metamask-key-tree-npm-10.1.1-0bfab435ac.patch",
     "@metamask/transaction-controller@npm:^62.9.0": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch",
     "qs": "6.14.1",
-    "@metamask/network-controller": "27.1.0",
     "@metamask/bridge-controller": "64.3.0",
     "@metamask/bridge-status-controller": "64.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7100,18 +7100,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/approval-controller@npm:^7.1.3":
-  version: 7.2.1
-  resolution: "@metamask/approval-controller@npm:7.2.1"
-  dependencies:
-    "@metamask/base-controller": "npm:^8.4.2"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.8.1"
-    nanoid: "npm:^3.3.8"
-  checksum: 10/037be80727f2c6d15c335c4ecd0eb029cdcb088f65682a3e80a4aca5a0556844a8240dae9c4390530ddf6aaab30b09942a42969a3e832733cd116a7dd4430a36
-  languageName: node
-  linkType: hard
-
 "@metamask/approval-controller@npm:^8.0.0":
   version: 8.0.0
   resolution: "@metamask/approval-controller@npm:8.0.0"
@@ -7125,115 +7113,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^93.1.0":
-  version: 93.1.0
-  resolution: "@metamask/assets-controllers@npm:93.1.0"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/account-tree-controller": "npm:^4.0.0"
-    "@metamask/accounts-controller": "npm:^35.0.0"
-    "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/contract-metadata": "npm:^2.4.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
-    "@metamask/core-backend": "npm:^5.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/keyring-controller": "npm:^25.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-account-service": "npm:^4.0.0"
-    "@metamask/network-controller": "npm:^27.0.0"
-    "@metamask/permission-controller": "npm:^12.1.1"
-    "@metamask/phishing-controller": "npm:^16.1.0"
-    "@metamask/polling-controller": "npm:^16.0.0"
-    "@metamask/preferences-controller": "npm:^22.0.0"
-    "@metamask/profile-sync-controller": "npm:^27.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/snaps-controllers": "npm:^14.0.1"
-    "@metamask/snaps-sdk": "npm:^9.0.0"
-    "@metamask/snaps-utils": "npm:^11.0.0"
-    "@metamask/transaction-controller": "npm:^62.4.0"
-    "@metamask/utils": "npm:^11.8.1"
-    "@types/bn.js": "npm:^5.1.5"
-    "@types/uuid": "npm:^8.3.0"
-    async-mutex: "npm:^0.5.0"
-    bitcoin-address-validation: "npm:^2.2.3"
-    bn.js: "npm:^5.2.1"
-    immer: "npm:^9.0.6"
-    lodash: "npm:^4.17.21"
-    multiformats: "npm:^9.9.0"
-    reselect: "npm:^5.1.1"
-    single-call-balance-checker-abi: "npm:^1.0.0"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/providers": ^22.0.0
-    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/9511e927310959e84a6a046ffde6a7f553c9c64e122d7951010ed0cb7da4066d6f27b4ef874706ebce3c664de0662ccd792339bb66ac9359b5686ec53858e9ae
-  languageName: node
-  linkType: hard
-
-"@metamask/assets-controllers@npm:^94.1.0":
-  version: 94.1.0
-  resolution: "@metamask/assets-controllers@npm:94.1.0"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/account-tree-controller": "npm:^4.0.0"
-    "@metamask/accounts-controller": "npm:^35.0.0"
-    "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/contract-metadata": "npm:^2.4.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
-    "@metamask/core-backend": "npm:^5.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/keyring-controller": "npm:^25.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-account-service": "npm:^4.0.1"
-    "@metamask/network-controller": "npm:^27.0.0"
-    "@metamask/permission-controller": "npm:^12.1.1"
-    "@metamask/phishing-controller": "npm:^16.1.0"
-    "@metamask/polling-controller": "npm:^16.0.0"
-    "@metamask/preferences-controller": "npm:^22.0.0"
-    "@metamask/profile-sync-controller": "npm:^27.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/snaps-controllers": "npm:^14.0.1"
-    "@metamask/snaps-sdk": "npm:^9.0.0"
-    "@metamask/snaps-utils": "npm:^11.0.0"
-    "@metamask/transaction-controller": "npm:^62.6.0"
-    "@metamask/utils": "npm:^11.8.1"
-    "@types/bn.js": "npm:^5.1.5"
-    "@types/uuid": "npm:^8.3.0"
-    async-mutex: "npm:^0.5.0"
-    bitcoin-address-validation: "npm:^2.2.3"
-    bn.js: "npm:^5.2.1"
-    immer: "npm:^9.0.6"
-    lodash: "npm:^4.17.21"
-    multiformats: "npm:^9.9.0"
-    reselect: "npm:^5.1.1"
-    single-call-balance-checker-abi: "npm:^1.0.0"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/providers": ^22.0.0
-    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/80f0fb88d55fd747540f141154a59eb9b49df8546d81881bb7f9683d92b462b73ede18fced3f9c4a551da3037b8f27886f1ec297d55e9a4eeb2f1c18b8ea65e7
-  languageName: node
-  linkType: hard
-
-"@metamask/assets-controllers@npm:^95.1.0":
+"@metamask/assets-controllers@npm:^95.0.0, @metamask/assets-controllers@npm:^95.1.0":
   version: 95.1.0
   resolution: "@metamask/assets-controllers@npm:95.1.0"
   dependencies:
@@ -7338,17 +7218,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^8.0.1, @metamask/base-controller@npm:^8.1.0, @metamask/base-controller@npm:^8.4.2":
-  version: 8.4.2
-  resolution: "@metamask/base-controller@npm:8.4.2"
-  dependencies:
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/utils": "npm:^11.8.1"
-    immer: "npm:^9.0.6"
-  checksum: 10/e5c4d97a35952072dc8e93c90a334ea60a8d9faa7c15584b5ce8f60b151cf56a7dd5304cb8549b183cdd61d53421b45e3c4688170fcd0a3e2c6a184aeb942067
-  languageName: node
-  linkType: hard
-
 "@metamask/base-controller@npm:^9.0.0":
   version: 9.0.0
   resolution: "@metamask/base-controller@npm:9.0.0"
@@ -7367,9 +7236,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^64.1.0, @metamask/bridge-controller@npm:^64.2.0, @metamask/bridge-controller@npm:^64.3.0":
-  version: 64.3.0
-  resolution: "@metamask/bridge-controller@npm:64.3.0"
+"@metamask/bridge-controller@npm:^64.3.0, @metamask/bridge-controller@npm:^64.4.0":
+  version: 64.4.0
+  resolution: "@metamask/bridge-controller@npm:64.4.0"
   dependencies:
     "@ethersproject/address": "npm:^5.7.0"
     "@ethersproject/bignumber": "npm:^5.7.0"
@@ -7377,45 +7246,45 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/accounts-controller": "npm:^35.0.0"
-    "@metamask/assets-controllers": "npm:^94.1.0"
+    "@metamask/assets-controllers": "npm:^95.0.0"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.17.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
     "@metamask/gas-fee-controller": "npm:^26.0.0"
     "@metamask/keyring-api": "npm:^21.0.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/multichain-network-controller": "npm:^3.0.0"
-    "@metamask/network-controller": "npm:^27.1.0"
+    "@metamask/network-controller": "npm:^27.2.0"
     "@metamask/polling-controller": "npm:^16.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
     "@metamask/snaps-controllers": "npm:^17.2.0"
-    "@metamask/transaction-controller": "npm:^62.7.0"
+    "@metamask/transaction-controller": "npm:^62.8.0"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/c96b0cb96cbe3694bcd239594fa1d05b67001e556a97a344b368be5176da8f241cb2bc197b9fbd85086814e17f3a71d18a68885f665ad8f3f045744909e6384c
+  checksum: 10/60678f855590434a0f081a03dbd5cbac4a6fe62a9391619fd4db1b4659448986303b4f19acb9326555294fc4377171a3fe72241d843c298072b0b1db2da6bf2d
   languageName: node
   linkType: hard
 
-"@metamask/bridge-status-controller@npm:^64.0.1, @metamask/bridge-status-controller@npm:^64.1.0":
-  version: 64.2.0
-  resolution: "@metamask/bridge-status-controller@npm:64.2.0"
+"@metamask/bridge-status-controller@npm:^64.0.1, @metamask/bridge-status-controller@npm:^64.4.1":
+  version: 64.4.1
+  resolution: "@metamask/bridge-status-controller@npm:64.4.1"
   dependencies:
     "@metamask/accounts-controller": "npm:^35.0.0"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/bridge-controller": "npm:^64.2.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/bridge-controller": "npm:^64.4.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
     "@metamask/gas-fee-controller": "npm:^26.0.0"
-    "@metamask/network-controller": "npm:^27.0.0"
+    "@metamask/network-controller": "npm:^27.2.0"
     "@metamask/polling-controller": "npm:^16.0.0"
-    "@metamask/snaps-controllers": "npm:^14.0.1"
+    "@metamask/snaps-controllers": "npm:^17.2.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^62.7.0"
-    "@metamask/utils": "npm:^11.8.1"
+    "@metamask/transaction-controller": "npm:^62.8.0"
+    "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     uuid: "npm:^8.3.2"
-  checksum: 10/f707ea4ba3d52e2231025e24a8923121881fa303a4d1ab40ee5405fb62fa791bef0271ae4117afe60936dd4e8326815acd4b3806ea46869ba9dab91c43ce1d9d
+  checksum: 10/e6474f5e68eda62b67ab4e623b818f910f39b93e190e82e87cb37035e4bae40144eb51b8d0d123afec28897f32b1d60fb1cc73120debd6ea1154fac847c6d85a
   languageName: node
   linkType: hard
 
@@ -7479,7 +7348,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.11.0, @metamask/controller-utils@npm:^11.14.1, @metamask/controller-utils@npm:^11.15.0, @metamask/controller-utils@npm:^11.16.0, @metamask/controller-utils@npm:^11.17.0, @metamask/controller-utils@npm:^11.18.0, @metamask/controller-utils@npm:^11.3.0":
+"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.14.1, @metamask/controller-utils@npm:^11.15.0, @metamask/controller-utils@npm:^11.16.0, @metamask/controller-utils@npm:^11.17.0, @metamask/controller-utils@npm:^11.18.0, @metamask/controller-utils@npm:^11.3.0":
   version: 11.18.0
   resolution: "@metamask/controller-utils@npm:11.18.0"
   dependencies:
@@ -8301,36 +8170,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/multichain-account-service@npm:^4.0.0, @metamask/multichain-account-service@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@metamask/multichain-account-service@npm:4.0.1"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@metamask/accounts-controller": "npm:^35.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/error-reporting-service": "npm:^3.0.0"
-    "@metamask/eth-snap-keyring": "npm:^18.0.0"
-    "@metamask/key-tree": "npm:^10.1.1"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/keyring-controller": "npm:^25.0.0"
-    "@metamask/keyring-internal-api": "npm:^9.0.0"
-    "@metamask/keyring-snap-client": "npm:^8.0.0"
-    "@metamask/keyring-utils": "npm:^3.1.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/snaps-controllers": "npm:^14.0.1"
-    "@metamask/snaps-sdk": "npm:^9.0.0"
-    "@metamask/snaps-utils": "npm:^11.0.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.8.1"
-    async-mutex: "npm:^0.5.0"
-  peerDependencies:
-    "@metamask/account-api": ^0.12.0
-    "@metamask/providers": ^22.0.0
-    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/a664bed3b1f54c27c26f0eec2e07b666dbc09d80fb6cad6f081fecc40b6029971988cad0a9cc010ce97fea83b962d31809aae21e37792c19e94dce509eeb98e2
-  languageName: node
-  linkType: hard
-
 "@metamask/multichain-account-service@npm:^5.0.0":
   version: 5.0.0
   resolution: "@metamask/multichain-account-service@npm:5.0.0"
@@ -8588,25 +8427,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@npm:^11.0.6":
-  version: 11.1.1
-  resolution: "@metamask/permission-controller@npm:11.1.1"
-  dependencies:
-    "@metamask/base-controller": "npm:^8.4.2"
-    "@metamask/controller-utils": "npm:^11.14.1"
-    "@metamask/json-rpc-engine": "npm:^10.1.1"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.8.1"
-    "@types/deep-freeze-strict": "npm:^1.1.0"
-    deep-freeze-strict: "npm:^1.1.1"
-    immer: "npm:^9.0.6"
-    nanoid: "npm:^3.3.8"
-  peerDependencies:
-    "@metamask/approval-controller": ^7.0.0
-  checksum: 10/98d618ee3280603ac08f127c7a36c9c8d264f8d3a5656c3287866bbe56707625a43c491ad87bb50be00798861191f1ef0173ed9899b56c0db029437d9d3ad853
-  languageName: node
-  linkType: hard
-
 "@metamask/permission-controller@npm:^12.0.0, @metamask/permission-controller@npm:^12.1.0, @metamask/permission-controller@npm:^12.1.1, @metamask/permission-controller@npm:^12.2.0":
   version: 12.2.0
   resolution: "@metamask/permission-controller@npm:12.2.0"
@@ -8623,21 +8443,6 @@ __metadata:
     immer: "npm:^9.0.6"
     nanoid: "npm:^3.3.8"
   checksum: 10/d15ce9b69b3f8dbed2409d2e789e800d06798e42e55ac05095f19db0feda7492a64e221865ec6ee3d41b6c809ba5467f2bdab443c2d99133df88ac624ae264b8
-  languageName: node
-  linkType: hard
-
-"@metamask/phishing-controller@npm:^13.1.0":
-  version: 13.1.0
-  resolution: "@metamask/phishing-controller@npm:13.1.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^8.0.1"
-    "@metamask/controller-utils": "npm:^11.11.0"
-    "@noble/hashes": "npm:^1.4.0"
-    "@types/punycode": "npm:^2.1.0"
-    ethereum-cryptography: "npm:^2.1.2"
-    fastest-levenshtein: "npm:^1.0.16"
-    punycode: "npm:^2.1.1"
-  checksum: 10/c62f71291736dfd635cc69b2d422687d8d610591a5e1cd9a6b4806cdc19221a72fe7699c0cabe0a2a108b49c3cc4dcb88a5b283fba374fe13e54d5813fb77902
   languageName: node
   linkType: hard
 
@@ -8927,19 +8732,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/remote-feature-flag-controller@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "@metamask/remote-feature-flag-controller@npm:3.1.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/utils": "npm:^11.8.1"
-    uuid: "npm:^8.3.2"
-  checksum: 10/38963a2e0980db9bb02a845c84118f558a30426c93fa2f8b0b7870b9c0f9317b8867f363df76dd80cd3a3ed41324b58aa049ae9a705362b0f73e829010980e4c
-  languageName: node
-  linkType: hard
-
 "@metamask/remote-feature-flag-controller@npm:^4.0.0":
   version: 4.0.0
   resolution: "@metamask/remote-feature-flag-controller@npm:4.0.0"
@@ -9124,47 +8916,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^14.0.1":
-  version: 14.2.2
-  resolution: "@metamask/snaps-controllers@npm:14.2.2"
-  dependencies:
-    "@metamask/approval-controller": "npm:^7.1.3"
-    "@metamask/base-controller": "npm:^8.1.0"
-    "@metamask/json-rpc-engine": "npm:^10.0.2"
-    "@metamask/json-rpc-middleware-stream": "npm:^8.0.7"
-    "@metamask/key-tree": "npm:^10.1.1"
-    "@metamask/object-multiplex": "npm:^2.1.0"
-    "@metamask/permission-controller": "npm:^11.0.6"
-    "@metamask/phishing-controller": "npm:^13.1.0"
-    "@metamask/post-message-stream": "npm:^10.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.3"
-    "@metamask/snaps-registry": "npm:^3.2.3"
-    "@metamask/snaps-rpc-methods": "npm:^13.5.0"
-    "@metamask/snaps-sdk": "npm:^9.3.0"
-    "@metamask/snaps-utils": "npm:^11.5.0"
-    "@metamask/utils": "npm:^11.4.2"
-    "@xstate/fsm": "npm:^2.0.0"
-    async-mutex: "npm:^0.5.0"
-    concat-stream: "npm:^2.0.0"
-    cron-parser: "npm:^4.5.0"
-    fast-deep-equal: "npm:^3.1.3"
-    get-npm-tarball-url: "npm:^2.0.3"
-    immer: "npm:^9.0.21"
-    luxon: "npm:^3.5.0"
-    nanoid: "npm:^3.3.10"
-    readable-stream: "npm:^3.6.2"
-    readable-web-to-node-stream: "npm:^3.0.2"
-    semver: "npm:^7.5.4"
-    tar-stream: "npm:^3.1.7"
-  peerDependencies:
-    "@metamask/snaps-execution-environments": ^10.2.1
-  peerDependenciesMeta:
-    "@metamask/snaps-execution-environments":
-      optional: true
-  checksum: 10/8b9081d2954408b0f4465e9fee007aed1ad3af66624380b4a4a7a98ebf463cbbc4bb2b8d624d984afdaf7bee13c3668b44f0bfee7c27c9bd41c46242dc5e4647
-  languageName: node
-  linkType: hard
-
 "@metamask/snaps-controllers@npm:^17.2.0":
   version: 17.2.0
   resolution: "@metamask/snaps-controllers@npm:17.2.0"
@@ -9226,18 +8977,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-registry@npm:^3.2.3":
-  version: 3.3.0
-  resolution: "@metamask/snaps-registry@npm:3.3.0"
-  dependencies:
-    "@metamask/superstruct": "npm:^3.2.1"
-    "@metamask/utils": "npm:^11.4.0"
-    "@noble/curves": "npm:^1.2.0"
-    "@noble/hashes": "npm:^1.3.2"
-  checksum: 10/1a53ad150318cbaf703b639a3a831a6ac57f84b2266ac176e6b0d470df31ecf66f0f885256f17a7acae265ada085c904ba97f1e2cb5371e136bf90778ffaed0a
-  languageName: node
-  linkType: hard
-
 "@metamask/snaps-registry@npm:^4.0.0":
   version: 4.0.0
   resolution: "@metamask/snaps-registry@npm:4.0.0"
@@ -9247,22 +8986,6 @@ __metadata:
     "@noble/curves": "npm:^1.2.0"
     "@noble/hashes": "npm:^1.3.2"
   checksum: 10/62387701d0433402bbe93495f90e24f2df3bdff2b063402b029294fada62c9f389048a2c68a1e51b260cb10cec949dd0c80596bf6295abc4175f5039c486a108
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-rpc-methods@npm:^13.5.0":
-  version: 13.5.3
-  resolution: "@metamask/snaps-rpc-methods@npm:13.5.3"
-  dependencies:
-    "@metamask/key-tree": "npm:^10.1.1"
-    "@metamask/permission-controller": "npm:^11.0.6"
-    "@metamask/rpc-errors": "npm:^7.0.3"
-    "@metamask/snaps-sdk": "npm:^10.0.0"
-    "@metamask/snaps-utils": "npm:^11.6.0"
-    "@metamask/superstruct": "npm:^3.2.1"
-    "@metamask/utils": "npm:^11.8.1"
-    "@noble/hashes": "npm:^1.7.1"
-  checksum: 10/3474e7a7e3de18d8d6e2dd0b1adb43ba79d676bcbd5a9ecb41e85015524044a6371aa325872153835a19405cd5ce4e4656adbe28f339105b59d9e00085e48538
   languageName: node
   linkType: hard
 
@@ -9297,7 +9020,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^11.0.0, @metamask/snaps-utils@npm:^11.5.0, @metamask/snaps-utils@npm:^11.6.0, @metamask/snaps-utils@npm:^11.6.1, @metamask/snaps-utils@npm:^11.6.2, @metamask/snaps-utils@npm:^11.7.0":
+"@metamask/snaps-utils@npm:^11.0.0, @metamask/snaps-utils@npm:^11.6.1, @metamask/snaps-utils@npm:^11.6.2, @metamask/snaps-utils@npm:^11.7.0":
   version: 11.7.0
   resolution: "@metamask/snaps-utils@npm:11.7.0"
   dependencies:
@@ -9466,9 +9189,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:62.7.0":
-  version: 62.7.0
-  resolution: "@metamask/transaction-controller@npm:62.7.0"
+"@metamask/transaction-controller@npm:62.9.0, @metamask/transaction-controller@npm:^62.8.0":
+  version: 62.9.0
+  resolution: "@metamask/transaction-controller@npm:62.9.0"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -9480,16 +9203,16 @@ __metadata:
     "@metamask/accounts-controller": "npm:^35.0.0"
     "@metamask/approval-controller": "npm:^8.0.0"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/gas-fee-controller": "npm:^26.0.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^27.0.0"
+    "@metamask/network-controller": "npm:^27.2.0"
     "@metamask/nonce-tracker": "npm:^6.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^3.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.8.1"
+    "@metamask/utils": "npm:^11.9.0"
     async-mutex: "npm:^0.5.0"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
@@ -9500,7 +9223,7 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/f9b34194b4e9bf775f66256da6fe0908854346da348238d122856a3bae3621e6ccafab273ed6c4f2b175848a2d74f0257a9f98a6efc6ff14f19b8d37bc256737
+  checksum: 10/4657f097d3c10f4e4f97c32e84c07384f66c4e437de2b70c874df138bca4a193e1856fc2eb25a0c7005c8171f37616f986d28464d132ae4d39b7f0585b72f2d9
   languageName: node
   linkType: hard
 
@@ -9542,9 +9265,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^62.4.0, @metamask/transaction-controller@npm:^62.6.0, @metamask/transaction-controller@npm:^62.8.0":
-  version: 62.8.0
-  resolution: "@metamask/transaction-controller@npm:62.8.0"
+"@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch":
+  version: 62.9.0
+  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch::version=62.9.0&hash=1a3342"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -9576,71 +9299,33 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/698b52fc954fa23ff7e231bd8bd79d9b1c37a6d7e684fe3de0310755195e0df64c15dbc6ddd3d73713f0523f2241ea3a99cf616598ac79836a59bee6ae212ec6
+  checksum: 10/79154f9723065d4593521235e7cb8f19f4c31468228674d6b9c3f8af36d91316956970a457589f331d97beb64fb9c1a51ec5dd7ce726d1ef0888cd280fbf7fbf
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.7.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch":
-  version: 62.7.0
-  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.7.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch::version=62.7.0&hash=1a3342"
-  dependencies:
-    "@ethereumjs/common": "npm:^4.4.0"
-    "@ethereumjs/tx": "npm:^5.4.0"
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^35.0.0"
-    "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/gas-fee-controller": "npm:^26.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^27.0.0"
-    "@metamask/nonce-tracker": "npm:^6.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^3.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.8.1"
-    async-mutex: "npm:^0.5.0"
-    bignumber.js: "npm:^9.1.2"
-    bn.js: "npm:^5.2.1"
-    eth-method-registry: "npm:^4.0.0"
-    fast-json-patch: "npm:^3.1.1"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@babel/runtime": ^7.0.0
-    "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/07f3ac5bcb5b47c1b056ba6ad444c5dfd87cfb1246d3aeab02e41635a03f0860c73fa6f4726bf9c561c98d198372ca48e5fb44ead0cfea4f8493952b38a0f863
-  languageName: node
-  linkType: hard
-
-"@metamask/transaction-pay-controller@npm:^10.5.0":
-  version: 10.5.0
-  resolution: "@metamask/transaction-pay-controller@npm:10.5.0"
+"@metamask/transaction-pay-controller@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "@metamask/transaction-pay-controller@npm:11.0.0"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
-    "@metamask/assets-controllers": "npm:^93.1.0"
+    "@metamask/assets-controllers": "npm:^95.1.0"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/bridge-controller": "npm:^64.1.0"
-    "@metamask/bridge-status-controller": "npm:^64.1.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/bridge-controller": "npm:^64.4.0"
+    "@metamask/bridge-status-controller": "npm:^64.4.1"
+    "@metamask/controller-utils": "npm:^11.18.0"
     "@metamask/gas-fee-controller": "npm:^26.0.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^27.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^3.0.0"
-    "@metamask/transaction-controller": "npm:^62.6.0"
-    "@metamask/utils": "npm:^11.8.1"
+    "@metamask/network-controller": "npm:^27.2.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
+    "@metamask/transaction-controller": "npm:^62.9.0"
+    "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/909b54d41b9d94bca0ea59b9e68231adb7c4baab1de01d9c18d8fd91a55fa556b94f07b9ba618dd223b09c977a624cae794e8de5008bcf46365111326bfefeca
+  checksum: 10/a2a0f8108cd6da860901c460f1df905d1bd8c337231c5b956678ef73e67e2d0f7487f1c6ed3a598cf7eaf5a9c531fbc6ee8e49d25d7070c99875f8f5adbd5493
   languageName: node
   linkType: hard
 
@@ -9668,7 +9353,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.5.0, @metamask/utils@npm:^11.8.0, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
+"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.5.0, @metamask/utils@npm:^11.8.0, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
   version: 11.9.0
   resolution: "@metamask/utils@npm:11.9.0"
   dependencies:
@@ -34306,8 +33991,8 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/token-search-discovery-controller": "npm:^4.0.0"
-    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.7.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch"
-    "@metamask/transaction-pay-controller": "npm:^10.5.0"
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch"
+    "@metamask/transaction-pay-controller": "npm:^11.0.0"
     "@metamask/tron-wallet-snap": "npm:^1.19.0"
     "@metamask/utils": "npm:^11.8.1"
     "@ngraveio/bc-ur": "npm:^1.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7100,6 +7100,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/approval-controller@npm:^7.1.3":
+  version: 7.2.1
+  resolution: "@metamask/approval-controller@npm:7.2.1"
+  dependencies:
+    "@metamask/base-controller": "npm:^8.4.2"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.8.1"
+    nanoid: "npm:^3.3.8"
+  checksum: 10/037be80727f2c6d15c335c4ecd0eb029cdcb088f65682a3e80a4aca5a0556844a8240dae9c4390530ddf6aaab30b09942a42969a3e832733cd116a7dd4430a36
+  languageName: node
+  linkType: hard
+
 "@metamask/approval-controller@npm:^8.0.0":
   version: 8.0.0
   resolution: "@metamask/approval-controller@npm:8.0.0"
@@ -7113,7 +7125,61 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^95.0.0, @metamask/assets-controllers@npm:^95.1.0":
+"@metamask/assets-controllers@npm:^94.1.0":
+  version: 94.1.0
+  resolution: "@metamask/assets-controllers@npm:94.1.0"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/abi-utils": "npm:^2.0.3"
+    "@metamask/account-tree-controller": "npm:^4.0.0"
+    "@metamask/accounts-controller": "npm:^35.0.0"
+    "@metamask/approval-controller": "npm:^8.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/contract-metadata": "npm:^2.4.0"
+    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/core-backend": "npm:^5.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/keyring-api": "npm:^21.0.0"
+    "@metamask/keyring-controller": "npm:^25.0.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-account-service": "npm:^4.0.1"
+    "@metamask/network-controller": "npm:^27.0.0"
+    "@metamask/permission-controller": "npm:^12.1.1"
+    "@metamask/phishing-controller": "npm:^16.1.0"
+    "@metamask/polling-controller": "npm:^16.0.0"
+    "@metamask/preferences-controller": "npm:^22.0.0"
+    "@metamask/profile-sync-controller": "npm:^27.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/snaps-controllers": "npm:^14.0.1"
+    "@metamask/snaps-sdk": "npm:^9.0.0"
+    "@metamask/snaps-utils": "npm:^11.0.0"
+    "@metamask/transaction-controller": "npm:^62.6.0"
+    "@metamask/utils": "npm:^11.8.1"
+    "@types/bn.js": "npm:^5.1.5"
+    "@types/uuid": "npm:^8.3.0"
+    async-mutex: "npm:^0.5.0"
+    bitcoin-address-validation: "npm:^2.2.3"
+    bn.js: "npm:^5.2.1"
+    immer: "npm:^9.0.6"
+    lodash: "npm:^4.17.21"
+    multiformats: "npm:^9.9.0"
+    reselect: "npm:^5.1.1"
+    single-call-balance-checker-abi: "npm:^1.0.0"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/80f0fb88d55fd747540f141154a59eb9b49df8546d81881bb7f9683d92b462b73ede18fced3f9c4a551da3037b8f27886f1ec297d55e9a4eeb2f1c18b8ea65e7
+  languageName: node
+  linkType: hard
+
+"@metamask/assets-controllers@npm:^95.1.0":
   version: 95.1.0
   resolution: "@metamask/assets-controllers@npm:95.1.0"
   dependencies:
@@ -7218,6 +7284,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/base-controller@npm:^8.0.1, @metamask/base-controller@npm:^8.1.0, @metamask/base-controller@npm:^8.4.2":
+  version: 8.4.2
+  resolution: "@metamask/base-controller@npm:8.4.2"
+  dependencies:
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/utils": "npm:^11.8.1"
+    immer: "npm:^9.0.6"
+  checksum: 10/e5c4d97a35952072dc8e93c90a334ea60a8d9faa7c15584b5ce8f60b151cf56a7dd5304cb8549b183cdd61d53421b45e3c4688170fcd0a3e2c6a184aeb942067
+  languageName: node
+  linkType: hard
+
 "@metamask/base-controller@npm:^9.0.0":
   version: 9.0.0
   resolution: "@metamask/base-controller@npm:9.0.0"
@@ -7236,9 +7313,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^64.3.0, @metamask/bridge-controller@npm:^64.4.0":
-  version: 64.4.0
-  resolution: "@metamask/bridge-controller@npm:64.4.0"
+"@metamask/bridge-controller@npm:64.2.0":
+  version: 64.2.0
+  resolution: "@metamask/bridge-controller@npm:64.2.0"
   dependencies:
     "@ethersproject/address": "npm:^5.7.0"
     "@ethersproject/bignumber": "npm:^5.7.0"
@@ -7246,24 +7323,24 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/accounts-controller": "npm:^35.0.0"
-    "@metamask/assets-controllers": "npm:^95.0.0"
+    "@metamask/assets-controllers": "npm:^94.1.0"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/controller-utils": "npm:^11.16.0"
     "@metamask/gas-fee-controller": "npm:^26.0.0"
     "@metamask/keyring-api": "npm:^21.0.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/multichain-network-controller": "npm:^3.0.0"
-    "@metamask/network-controller": "npm:^27.2.0"
+    "@metamask/network-controller": "npm:^27.0.0"
     "@metamask/polling-controller": "npm:^16.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
-    "@metamask/snaps-controllers": "npm:^17.2.0"
-    "@metamask/transaction-controller": "npm:^62.8.0"
-    "@metamask/utils": "npm:^11.9.0"
+    "@metamask/remote-feature-flag-controller": "npm:^3.0.0"
+    "@metamask/snaps-controllers": "npm:^14.0.1"
+    "@metamask/transaction-controller": "npm:^62.7.0"
+    "@metamask/utils": "npm:^11.8.1"
     bignumber.js: "npm:^9.1.2"
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/60678f855590434a0f081a03dbd5cbac4a6fe62a9391619fd4db1b4659448986303b4f19acb9326555294fc4377171a3fe72241d843c298072b0b1db2da6bf2d
+  checksum: 10/3669dca650e7b0424a55c852f1cb4f1c73a4e3e5554b1b1311f5ec9aa3e13eb4d752a90851b7d40de876bfdcc42b325d355d07fbeb6cee471bd362c0044d762b
   languageName: node
   linkType: hard
 
@@ -7348,7 +7425,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.14.1, @metamask/controller-utils@npm:^11.15.0, @metamask/controller-utils@npm:^11.16.0, @metamask/controller-utils@npm:^11.17.0, @metamask/controller-utils@npm:^11.18.0, @metamask/controller-utils@npm:^11.3.0":
+"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.11.0, @metamask/controller-utils@npm:^11.14.1, @metamask/controller-utils@npm:^11.15.0, @metamask/controller-utils@npm:^11.16.0, @metamask/controller-utils@npm:^11.17.0, @metamask/controller-utils@npm:^11.18.0, @metamask/controller-utils@npm:^11.3.0":
   version: 11.18.0
   resolution: "@metamask/controller-utils@npm:11.18.0"
   dependencies:
@@ -8170,6 +8247,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/multichain-account-service@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@metamask/multichain-account-service@npm:4.0.1"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@metamask/accounts-controller": "npm:^35.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/error-reporting-service": "npm:^3.0.0"
+    "@metamask/eth-snap-keyring": "npm:^18.0.0"
+    "@metamask/key-tree": "npm:^10.1.1"
+    "@metamask/keyring-api": "npm:^21.0.0"
+    "@metamask/keyring-controller": "npm:^25.0.0"
+    "@metamask/keyring-internal-api": "npm:^9.0.0"
+    "@metamask/keyring-snap-client": "npm:^8.0.0"
+    "@metamask/keyring-utils": "npm:^3.1.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/snaps-controllers": "npm:^14.0.1"
+    "@metamask/snaps-sdk": "npm:^9.0.0"
+    "@metamask/snaps-utils": "npm:^11.0.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.8.1"
+    async-mutex: "npm:^0.5.0"
+  peerDependencies:
+    "@metamask/account-api": ^0.12.0
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/a664bed3b1f54c27c26f0eec2e07b666dbc09d80fb6cad6f081fecc40b6029971988cad0a9cc010ce97fea83b962d31809aae21e37792c19e94dce509eeb98e2
+  languageName: node
+  linkType: hard
+
 "@metamask/multichain-account-service@npm:^5.0.0":
   version: 5.0.0
   resolution: "@metamask/multichain-account-service@npm:5.0.0"
@@ -8300,12 +8407,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:^27.0.0, @metamask/network-controller@npm:^27.1.0, @metamask/network-controller@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "@metamask/network-controller@npm:27.2.0"
+"@metamask/network-controller@npm:27.1.0":
+  version: 27.1.0
+  resolution: "@metamask/network-controller@npm:27.1.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/controller-utils": "npm:^11.17.0"
+    "@metamask/error-reporting-service": "npm:^3.0.0"
     "@metamask/eth-block-tracker": "npm:^15.0.0"
     "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
     "@metamask/eth-json-rpc-middleware": "npm:^22.0.1"
@@ -8315,7 +8423,7 @@ __metadata:
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/swappable-obj-proxy": "npm:^2.3.0"
-    "@metamask/utils": "npm:^11.9.0"
+    "@metamask/utils": "npm:^11.8.1"
     async-mutex: "npm:^0.5.0"
     fast-deep-equal: "npm:^3.1.3"
     immer: "npm:^9.0.6"
@@ -8323,7 +8431,7 @@ __metadata:
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/52f9523b30d1136c3a8cd466bf81bbf0ca5e9399ecc8b256054a09597940b1bddecb2bc117ba8f1872ba0b0dc55537521d2cbf2fb1b4c1aa741322879b2f7ba8
+  checksum: 10/032e91853ebafc79edee2279427f0f5bd7e19fe036b021a6f5131f4c3c5e36975ae0b971cb53e8ea9300f262ca67a66ab2fca52209dba4b51ebdea9437231a36
   languageName: node
   linkType: hard
 
@@ -8427,6 +8535,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/permission-controller@npm:^11.0.6":
+  version: 11.1.1
+  resolution: "@metamask/permission-controller@npm:11.1.1"
+  dependencies:
+    "@metamask/base-controller": "npm:^8.4.2"
+    "@metamask/controller-utils": "npm:^11.14.1"
+    "@metamask/json-rpc-engine": "npm:^10.1.1"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.8.1"
+    "@types/deep-freeze-strict": "npm:^1.1.0"
+    deep-freeze-strict: "npm:^1.1.1"
+    immer: "npm:^9.0.6"
+    nanoid: "npm:^3.3.8"
+  peerDependencies:
+    "@metamask/approval-controller": ^7.0.0
+  checksum: 10/98d618ee3280603ac08f127c7a36c9c8d264f8d3a5656c3287866bbe56707625a43c491ad87bb50be00798861191f1ef0173ed9899b56c0db029437d9d3ad853
+  languageName: node
+  linkType: hard
+
 "@metamask/permission-controller@npm:^12.0.0, @metamask/permission-controller@npm:^12.1.0, @metamask/permission-controller@npm:^12.1.1, @metamask/permission-controller@npm:^12.2.0":
   version: 12.2.0
   resolution: "@metamask/permission-controller@npm:12.2.0"
@@ -8443,6 +8570,21 @@ __metadata:
     immer: "npm:^9.0.6"
     nanoid: "npm:^3.3.8"
   checksum: 10/d15ce9b69b3f8dbed2409d2e789e800d06798e42e55ac05095f19db0feda7492a64e221865ec6ee3d41b6c809ba5467f2bdab443c2d99133df88ac624ae264b8
+  languageName: node
+  linkType: hard
+
+"@metamask/phishing-controller@npm:^13.1.0":
+  version: 13.1.0
+  resolution: "@metamask/phishing-controller@npm:13.1.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^8.0.1"
+    "@metamask/controller-utils": "npm:^11.11.0"
+    "@noble/hashes": "npm:^1.4.0"
+    "@types/punycode": "npm:^2.1.0"
+    ethereum-cryptography: "npm:^2.1.2"
+    fastest-levenshtein: "npm:^1.0.16"
+    punycode: "npm:^2.1.1"
+  checksum: 10/c62f71291736dfd635cc69b2d422687d8d610591a5e1cd9a6b4806cdc19221a72fe7699c0cabe0a2a108b49c3cc4dcb88a5b283fba374fe13e54d5813fb77902
   languageName: node
   linkType: hard
 
@@ -8732,6 +8874,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/remote-feature-flag-controller@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "@metamask/remote-feature-flag-controller@npm:3.1.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/utils": "npm:^11.8.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/38963a2e0980db9bb02a845c84118f558a30426c93fa2f8b0b7870b9c0f9317b8867f363df76dd80cd3a3ed41324b58aa049ae9a705362b0f73e829010980e4c
+  languageName: node
+  linkType: hard
+
 "@metamask/remote-feature-flag-controller@npm:^4.0.0":
   version: 4.0.0
   resolution: "@metamask/remote-feature-flag-controller@npm:4.0.0"
@@ -8916,6 +9071,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/snaps-controllers@npm:^14.0.1":
+  version: 14.2.2
+  resolution: "@metamask/snaps-controllers@npm:14.2.2"
+  dependencies:
+    "@metamask/approval-controller": "npm:^7.1.3"
+    "@metamask/base-controller": "npm:^8.1.0"
+    "@metamask/json-rpc-engine": "npm:^10.0.2"
+    "@metamask/json-rpc-middleware-stream": "npm:^8.0.7"
+    "@metamask/key-tree": "npm:^10.1.1"
+    "@metamask/object-multiplex": "npm:^2.1.0"
+    "@metamask/permission-controller": "npm:^11.0.6"
+    "@metamask/phishing-controller": "npm:^13.1.0"
+    "@metamask/post-message-stream": "npm:^10.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.3"
+    "@metamask/snaps-registry": "npm:^3.2.3"
+    "@metamask/snaps-rpc-methods": "npm:^13.5.0"
+    "@metamask/snaps-sdk": "npm:^9.3.0"
+    "@metamask/snaps-utils": "npm:^11.5.0"
+    "@metamask/utils": "npm:^11.4.2"
+    "@xstate/fsm": "npm:^2.0.0"
+    async-mutex: "npm:^0.5.0"
+    concat-stream: "npm:^2.0.0"
+    cron-parser: "npm:^4.5.0"
+    fast-deep-equal: "npm:^3.1.3"
+    get-npm-tarball-url: "npm:^2.0.3"
+    immer: "npm:^9.0.21"
+    luxon: "npm:^3.5.0"
+    nanoid: "npm:^3.3.10"
+    readable-stream: "npm:^3.6.2"
+    readable-web-to-node-stream: "npm:^3.0.2"
+    semver: "npm:^7.5.4"
+    tar-stream: "npm:^3.1.7"
+  peerDependencies:
+    "@metamask/snaps-execution-environments": ^10.2.1
+  peerDependenciesMeta:
+    "@metamask/snaps-execution-environments":
+      optional: true
+  checksum: 10/8b9081d2954408b0f4465e9fee007aed1ad3af66624380b4a4a7a98ebf463cbbc4bb2b8d624d984afdaf7bee13c3668b44f0bfee7c27c9bd41c46242dc5e4647
+  languageName: node
+  linkType: hard
+
 "@metamask/snaps-controllers@npm:^17.2.0":
   version: 17.2.0
   resolution: "@metamask/snaps-controllers@npm:17.2.0"
@@ -8977,6 +9173,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/snaps-registry@npm:^3.2.3":
+  version: 3.3.0
+  resolution: "@metamask/snaps-registry@npm:3.3.0"
+  dependencies:
+    "@metamask/superstruct": "npm:^3.2.1"
+    "@metamask/utils": "npm:^11.4.0"
+    "@noble/curves": "npm:^1.2.0"
+    "@noble/hashes": "npm:^1.3.2"
+  checksum: 10/1a53ad150318cbaf703b639a3a831a6ac57f84b2266ac176e6b0d470df31ecf66f0f885256f17a7acae265ada085c904ba97f1e2cb5371e136bf90778ffaed0a
+  languageName: node
+  linkType: hard
+
 "@metamask/snaps-registry@npm:^4.0.0":
   version: 4.0.0
   resolution: "@metamask/snaps-registry@npm:4.0.0"
@@ -8986,6 +9194,22 @@ __metadata:
     "@noble/curves": "npm:^1.2.0"
     "@noble/hashes": "npm:^1.3.2"
   checksum: 10/62387701d0433402bbe93495f90e24f2df3bdff2b063402b029294fada62c9f389048a2c68a1e51b260cb10cec949dd0c80596bf6295abc4175f5039c486a108
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-rpc-methods@npm:^13.5.0":
+  version: 13.5.3
+  resolution: "@metamask/snaps-rpc-methods@npm:13.5.3"
+  dependencies:
+    "@metamask/key-tree": "npm:^10.1.1"
+    "@metamask/permission-controller": "npm:^11.0.6"
+    "@metamask/rpc-errors": "npm:^7.0.3"
+    "@metamask/snaps-sdk": "npm:^10.0.0"
+    "@metamask/snaps-utils": "npm:^11.6.0"
+    "@metamask/superstruct": "npm:^3.2.1"
+    "@metamask/utils": "npm:^11.8.1"
+    "@noble/hashes": "npm:^1.7.1"
+  checksum: 10/3474e7a7e3de18d8d6e2dd0b1adb43ba79d676bcbd5a9ecb41e85015524044a6371aa325872153835a19405cd5ce4e4656adbe28f339105b59d9e00085e48538
   languageName: node
   linkType: hard
 
@@ -9020,7 +9244,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^11.0.0, @metamask/snaps-utils@npm:^11.6.1, @metamask/snaps-utils@npm:^11.6.2, @metamask/snaps-utils@npm:^11.7.0":
+"@metamask/snaps-utils@npm:^11.0.0, @metamask/snaps-utils@npm:^11.5.0, @metamask/snaps-utils@npm:^11.6.0, @metamask/snaps-utils@npm:^11.6.1, @metamask/snaps-utils@npm:^11.6.2, @metamask/snaps-utils@npm:^11.7.0":
   version: 11.7.0
   resolution: "@metamask/snaps-utils@npm:11.7.0"
   dependencies:
@@ -9189,7 +9413,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:62.9.0, @metamask/transaction-controller@npm:^62.8.0":
+"@metamask/transaction-controller@npm:62.9.0, @metamask/transaction-controller@npm:^62.6.0, @metamask/transaction-controller@npm:^62.7.0, @metamask/transaction-controller@npm:^62.8.0":
   version: 62.9.0
   resolution: "@metamask/transaction-controller@npm:62.9.0"
   dependencies:
@@ -9353,7 +9577,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.5.0, @metamask/utils@npm:^11.8.0, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
+"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.5.0, @metamask/utils@npm:^11.8.0, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
   version: 11.9.0
   resolution: "@metamask/utils@npm:11.9.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7313,9 +7313,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:64.2.0":
-  version: 64.2.0
-  resolution: "@metamask/bridge-controller@npm:64.2.0"
+"@metamask/bridge-controller@npm:64.3.0":
+  version: 64.3.0
+  resolution: "@metamask/bridge-controller@npm:64.3.0"
   dependencies:
     "@ethersproject/address": "npm:^5.7.0"
     "@ethersproject/bignumber": "npm:^5.7.0"
@@ -7325,22 +7325,22 @@ __metadata:
     "@metamask/accounts-controller": "npm:^35.0.0"
     "@metamask/assets-controllers": "npm:^94.1.0"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/controller-utils": "npm:^11.17.0"
     "@metamask/gas-fee-controller": "npm:^26.0.0"
     "@metamask/keyring-api": "npm:^21.0.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/multichain-network-controller": "npm:^3.0.0"
-    "@metamask/network-controller": "npm:^27.0.0"
+    "@metamask/network-controller": "npm:^27.1.0"
     "@metamask/polling-controller": "npm:^16.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^3.0.0"
-    "@metamask/snaps-controllers": "npm:^14.0.1"
+    "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
+    "@metamask/snaps-controllers": "npm:^17.2.0"
     "@metamask/transaction-controller": "npm:^62.7.0"
-    "@metamask/utils": "npm:^11.8.1"
+    "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/3669dca650e7b0424a55c852f1cb4f1c73a4e3e5554b1b1311f5ec9aa3e13eb4d752a90851b7d40de876bfdcc42b325d355d07fbeb6cee471bd362c0044d762b
+  checksum: 10/c96b0cb96cbe3694bcd239594fa1d05b67001e556a97a344b368be5176da8f241cb2bc197b9fbd85086814e17f3a71d18a68885f665ad8f3f045744909e6384c
   languageName: node
   linkType: hard
 
@@ -8871,19 +8871,6 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/f22bae5e15763e77ec0e21f34b31d97a48fadb35590a5e75341c93b269cbdb702fcafb4bd7d4b9041977ca525b03b49b558a3800126faadf08e64b8787fb1cb3
-  languageName: node
-  linkType: hard
-
-"@metamask/remote-feature-flag-controller@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "@metamask/remote-feature-flag-controller@npm:3.1.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/utils": "npm:^11.8.1"
-    uuid: "npm:^8.3.2"
-  checksum: 10/38963a2e0980db9bb02a845c84118f558a30426c93fa2f8b0b7870b9c0f9317b8867f363df76dd80cd3a3ed41324b58aa049ae9a705362b0f73e829010980e4c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7344,24 +7344,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-status-controller@npm:^64.0.1, @metamask/bridge-status-controller@npm:^64.4.1":
-  version: 64.4.1
-  resolution: "@metamask/bridge-status-controller@npm:64.4.1"
+"@metamask/bridge-status-controller@npm:64.0.1":
+  version: 64.0.1
+  resolution: "@metamask/bridge-status-controller@npm:64.0.1"
   dependencies:
     "@metamask/accounts-controller": "npm:^35.0.0"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/bridge-controller": "npm:^64.4.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/bridge-controller": "npm:^64.0.0"
+    "@metamask/controller-utils": "npm:^11.16.0"
     "@metamask/gas-fee-controller": "npm:^26.0.0"
-    "@metamask/network-controller": "npm:^27.2.0"
+    "@metamask/network-controller": "npm:^27.0.0"
     "@metamask/polling-controller": "npm:^16.0.0"
-    "@metamask/snaps-controllers": "npm:^17.2.0"
+    "@metamask/snaps-controllers": "npm:^14.0.1"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^62.8.0"
-    "@metamask/utils": "npm:^11.9.0"
+    "@metamask/transaction-controller": "npm:^62.4.0"
+    "@metamask/utils": "npm:^11.8.1"
     bignumber.js: "npm:^9.1.2"
     uuid: "npm:^8.3.2"
-  checksum: 10/e6474f5e68eda62b67ab4e623b818f910f39b93e190e82e87cb37035e4bae40144eb51b8d0d123afec28897f32b1d60fb1cc73120debd6ea1154fac847c6d85a
+  checksum: 10/9051920b3cfdf0eb0c74193dd610835cb619b304d2774996d213217ad299de04e1a535105ee6d0e1f94b9c3acc9b5bfb5d0df31f1acda5a66893e5c0fa18cf56
   languageName: node
   linkType: hard
 
@@ -9400,7 +9400,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:62.9.0, @metamask/transaction-controller@npm:^62.6.0, @metamask/transaction-controller@npm:^62.7.0, @metamask/transaction-controller@npm:^62.8.0":
+"@metamask/transaction-controller@npm:62.9.0, @metamask/transaction-controller@npm:^62.4.0, @metamask/transaction-controller@npm:^62.6.0, @metamask/transaction-controller@npm:^62.7.0, @metamask/transaction-controller@npm:^62.8.0":
   version: 62.9.0
   resolution: "@metamask/transaction-controller@npm:62.9.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8407,13 +8407,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:27.1.0":
-  version: 27.1.0
-  resolution: "@metamask/network-controller@npm:27.1.0"
+"@metamask/network-controller@npm:^27.0.0, @metamask/network-controller@npm:^27.1.0, @metamask/network-controller@npm:^27.2.0":
+  version: 27.2.0
+  resolution: "@metamask/network-controller@npm:27.2.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.17.0"
-    "@metamask/error-reporting-service": "npm:^3.0.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
     "@metamask/eth-block-tracker": "npm:^15.0.0"
     "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
     "@metamask/eth-json-rpc-middleware": "npm:^22.0.1"
@@ -8423,7 +8422,7 @@ __metadata:
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/swappable-obj-proxy": "npm:^2.3.0"
-    "@metamask/utils": "npm:^11.8.1"
+    "@metamask/utils": "npm:^11.9.0"
     async-mutex: "npm:^0.5.0"
     fast-deep-equal: "npm:^3.1.3"
     immer: "npm:^9.0.6"
@@ -8431,7 +8430,7 @@ __metadata:
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/032e91853ebafc79edee2279427f0f5bd7e19fe036b021a6f5131f4c3c5e36975ae0b971cb53e8ea9300f262ca67a66ab2fca52209dba4b51ebdea9437231a36
+  checksum: 10/52f9523b30d1136c3a8cd466bf81bbf0ca5e9399ecc8b256054a09597940b1bddecb2bc117ba8f1872ba0b0dc55537521d2cbf2fb1b4c1aa741322879b2f7ba8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Initial support for `Max` button in MetaMask Pay, specifically Perps deposit and MUSD conversion.

Displays skeleton loaders in custom amount and pay token amount while quote is loading.

**Current Limitations**

- Does not support native tokens, since the gas cost is not subtracted in the Relay quote.
- Does not support gas fee tokens, since the gas cost can only be calculated after the quote is retrieved.
- Does not support Predict deposit, since initial deposits include additional transactions.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6498](https://github.com/MetaMask/MetaMask-planning/issues/6498)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

https://github.com/user-attachments/assets/8016c857-1b0d-46d6-8acf-52e65dde25ed

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a controller-driven “Max” amount flow and improved loading UX for MetaMask Pay in supported flows.
> 
> - Adds `isMaxAmount` state/selectors/hooks in pay data; toggled via `TransactionPayController.setIsMaxAmount` when selecting 100% and cleared on manual/partial edits
> - Updates UI: `CustomAmount`, `PayTokenAmount`, and keyboard now show skeletons while quotes load and disable Max for native pay tokens; `useTransactionPayToken` exposes `isNative`
> - Reads server-provided amounts: `transaction-details-hero` and transaction decoding prefer `metamaskPay.targetFiat` when present; refactors amount decoding into hooks
> - Enables Max in `PerpsDepositInfo` and `MusdConversionInfo`
> - Bumps deps: `@metamask/transaction-controller` to 62.9.0 and `@metamask/transaction-pay-controller` to 11.0.0; adds bridge controller packages
> - Comprehensive tests added/updated for hooks, components, and decode logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63708e6a68b81f67f5404deb1def5bc16cb2ed80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->