### PR TITLE
test: enable previously skipped test for claiming winnings via market details

### DIFF
--- a/e2e/specs/predict/predict-claim-positions.spec.ts
+++ b/e2e/specs/predict/predict-claim-positions.spec.ts
@@ -157,7 +157,7 @@ describe(SmokePredictions('Claim winnings:'), () => {
   });
 
   // Disabling this test as it is currently blocking CI
-  it.skip('claim winnings via market details', async () => {
+  it('claim winnings via market details', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder().withPolygon().build(),


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This commit re-enables the test for claiming winnings through market details, which was previously skipped due to blocking CI. The test is now active and will run as part of the CI pipeline.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Claim Prediction Winnings
  As a user with winning prediction positions
  I want to claim my winnings from market details
  So that I can receive my earnings

  Background:
    Given the user is logged into the MetaMask app
    And the user has a winning prediction position
    And the user has a lost prediction position
    And the Predictions feature is enabled

  Scenario: Claim button is not visible on lost positions
    Given the user is on the Predictions tab
    When the user taps on a lost position
    Then the market details page should be visible
    And the Claim button should not be visible

  Scenario: Claim button is visible on winning positions
    Given the user is on the Predictions tab
    When the user taps on a winning position
    Then the market details page should be visible
    And the Claim button should be visible

  Scenario: Successfully claim winnings via market details
    Given the user is on the Predictions tab
    And the user has navigated to a winning position's details
    When the user taps the Claim Winnings button
    And the user confirms the claim transaction
    Then the Claim button should no longer be visible on the details page
    And the user should be returned to the wallet view
    And the Claim button should not be visible on the Predictions tab
    And all resolved positions should be removed from the UI
    And the balance should be updated to "$48.16"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Scope**
> - Unskips `claim winnings via market details` E2E in `e2e/specs/predict/predict-claim-positions.spec.ts` by changing `it.skip` to `it`.
> 
> **What the test covers**
> - Claims winnings from a winning position’s details page, verifies claim button visibility rules, applies post-claim mocks, and confirms UI updates (no claim button, resolved positions removed, balance `$48.16`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a3b29e0a31bbf506faa4b392cf6d1818483beca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->