### PR TITLE
feat: Add simulation receiving value for Predict withdraw metrics

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -3793,7 +3793,19 @@ describe('PredictController', () => {
         expect(result).toBeDefined();
         expect(result?.updateTransaction).toBeDefined();
 
-        const testTransaction = {
+        const testTransaction: {
+          txParams: {
+            from: string;
+            to: string;
+            data: string;
+            gas?: string;
+            gasLimit?: string;
+          };
+          assetsFiatValues?: {
+            receiving?: string;
+            sending?: string;
+          };
+        } = {
           txParams: {
             from: '0xFrom',
             to: '0xOldTarget',
@@ -3805,6 +3817,9 @@ describe('PredictController', () => {
 
         expect(testTransaction.txParams.data).toBe('0xmodifieddata');
         expect(testTransaction.txParams.to).toBe('0xPredictAddress');
+        expect(testTransaction.assetsFiatValues).toEqual({
+          receiving: '100',
+        });
       });
     });
 

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -2156,6 +2156,10 @@ export class PredictController extends BaseController<
         transaction.txParams.data = callData;
         transaction.txParams.to = this.state.withdrawTransaction
           ?.predictAddress as Hex;
+        transaction.assetsFiatValues = {
+          ...transaction.assetsFiatValues,
+          receiving: String(amount),
+        };
         // Only update gas if estimation succeeded
         if (updatedGas) {
           transaction.txParams.gas = updatedGas;

--- a/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
@@ -4,8 +4,6 @@ import { merge } from 'lodash';
 import { MetaMetrics } from '../../../../Analytics';
 import { TRANSACTION_EVENTS } from '../../../../Analytics/events/confirmations';
 import { MetricsEventBuilder } from '../../../../Analytics/MetricsEventBuilder';
-import { selectIsPna25FlagEnabled } from '../../../../../selectors/featureFlagController/legalNotices';
-import { selectIsPna25Acknowledged } from '../../../../../selectors/legalNotices';
 import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
 import { getSmartTransactionMetricsProperties } from '../../../../../util/smart-transactions';
 import {
@@ -77,8 +75,6 @@ const mockSelectShouldUseSmartTransaction = jest.mocked(
 const mockGetSmartTransactionMetricsProperties = jest.mocked(
   getSmartTransactionMetricsProperties,
 );
-const mockSelectIsPna25FlagEnabled = jest.mocked(selectIsPna25FlagEnabled);
-const mockSelectIsPna25Acknowledged = jest.mocked(selectIsPna25Acknowledged);
 
 const mockSmartTransactionMetricsProperties = {
   smart_transaction_timed_out: false,
@@ -330,57 +326,6 @@ describe('Transaction Metric Event Handlers', () => {
           builder_sensitive_test: true,
         }),
       );
-    });
-
-    describe('hash property', () => {
-      it('included when extensionUxPna25 is enabled and pna25 is acknowledged', async () => {
-        mockSelectIsPna25FlagEnabled.mockReturnValue(true);
-        mockSelectIsPna25Acknowledged.mockReturnValue(true);
-
-        await handleTransactionFinalizedEventForMetrics(
-          mockTransactionMeta,
-          mockTransactionMetricRequest,
-        );
-
-        expect(mockEventBuilder.addProperties).toHaveBeenCalledWith(
-          expect.objectContaining({
-            transaction_hash: mockTransactionMeta.hash,
-          }),
-        );
-      });
-
-      describe('not included', () => {
-        it('extensionUxPna25 flag is disabled', async () => {
-          mockSelectIsPna25FlagEnabled.mockReturnValue(false);
-          mockSelectIsPna25Acknowledged.mockReturnValue(true);
-
-          await handleTransactionFinalizedEventForMetrics(
-            mockTransactionMeta,
-            mockTransactionMetricRequest,
-          );
-
-          expect(mockEventBuilder.addProperties).not.toHaveBeenCalledWith(
-            expect.objectContaining({
-              transaction_hash: mockTransactionMeta.hash,
-            }),
-          );
-        });
-        it('pna25 is not acknowledged', async () => {
-          mockSelectIsPna25FlagEnabled.mockReturnValue(true);
-          mockSelectIsPna25Acknowledged.mockReturnValue(false);
-
-          await handleTransactionFinalizedEventForMetrics(
-            mockTransactionMeta,
-            mockTransactionMetricRequest,
-          );
-
-          expect(mockEventBuilder.addProperties).not.toHaveBeenCalledWith(
-            expect.objectContaining({
-              transaction_hash: mockTransactionMeta.hash,
-            }),
-          );
-        });
-      });
     });
   });
 });


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Predict withdraw transactions were missing `simulation_receiving_assets_total_value`, limiting visibility into total value withdrawn.

Attach `assetsFiatValues.receiving` to Predict withdraw transactions during signing and add tests to verify the value is emitted through the metrics pipeline.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6392

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds missing simulation receiving value for Predict withdraws and validates metrics propagation.
> 
> - Updates `PredictController.beforeSign` to set updated `txParams` and `assetsFiatValues.receiving` (stringified amount), and conditionally apply gas estimates
> - Extends tests: `PredictController.test` asserts `assetsFiatValues.receiving`; `metrics.test` verifies `simulation_receiving_assets_total_value` is included when present and adds coverage for Smart Transactions metrics properties
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 574d483c2fc2877b7deee7a7aacf035152b20486. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->