### PR TITLE
fix: use screenshortDeterrent in login screen

### DIFF
--- a/app/components/Views/Login/index.test.tsx
+++ b/app/components/Views/Login/index.test.tsx
@@ -156,6 +156,10 @@ jest.mock('rive-react-native', () => ({
   Alignment: { Center: 'center' },
 }));
 
+jest.mock('../../UI/ScreenshotDeterrent', () => ({
+  ScreenshotDeterrent: () => null,
+}));
+
 // Mock safe area context
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -103,6 +103,7 @@ import { selectIsSeedlessPasswordOutdated } from '../../../selectors/seedlessOnb
 import { LoginOptionsSwitch } from '../../UI/LoginOptionsSwitch';
 import FoxAnimation from '../../UI/FoxAnimation/FoxAnimation';
 import { isE2E } from '../../../util/test/utils';
+import { ScreenshotDeterrent } from '../../UI/ScreenshotDeterrent';
 
 // In android, having {} will cause the styles to update state
 // using a constant will prevent this
@@ -593,6 +594,7 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
             <FoxAnimation hasFooter={false} trigger={startFoxAnimation} />
           </TouchableOpacity>
         )}
+        <ScreenshotDeterrent enabled isSRP={false} hasNavigation />
       </SafeAreaView>
     </ErrorBoundary>
   );

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -594,7 +594,7 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
             <FoxAnimation hasFooter={false} trigger={startFoxAnimation} />
           </TouchableOpacity>
         )}
-        <ScreenshotDeterrent enabled isSRP={false} hasNavigation />
+        <ScreenshotDeterrent enabled isSRP={false} />
       </SafeAreaView>
     </ErrorBoundary>
   );

--- a/app/components/Views/Login/index2.test.tsx
+++ b/app/components/Views/Login/index2.test.tsx
@@ -129,6 +129,10 @@ jest.mock('../../../multichain-accounts/remote-feature-flag', () => ({
     mockIsMultichainAccountsState2Enabled(),
 }));
 
+jest.mock('../../UI/ScreenshotDeterrent', () => ({
+  ScreenshotDeterrent: () => null,
+}));
+
 describe('Login test suite 2', () => {
   const createMockReduxStore = (
     stateOverrides?: RecursivePartial<RootState>,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds the ScreenshotDeterrent to the login screen page. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added ScreenshotDeterrent to the login page to prevent screenshots and recordings on the page.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1365

## **Manual testing steps**

```gherkin
Feature: Screenshot deterrent

  Scenario: user starts a recording
    Given user is at the login screen

    When user tries to enter the password
    Then watches the recording, the screen is black. 
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/df2b6ce8-2753-47f6-b9d3-b66e5c8c06c0



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates screenshot/recording protection on the login screen.
> 
> - Imports and renders `ScreenshotDeterrent` in `app/components/Views/Login/index.tsx` with `enabled` and `isSRP={false}`
> - Updates test suites (`index.test.tsx`, `index2.test.tsx`) to mock `../../UI/ScreenshotDeterrent` to avoid UI side effects during tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3faadaa1487272c057342321c25435d991684e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->