### PR TITLE
fix: MUSD-181 prevent dedupliation of transactions with the 0x0 hash

### DIFF
--- a/app/components/UI/Transactions/utils.test.ts
+++ b/app/components/UI/Transactions/utils.test.ts
@@ -192,5 +192,17 @@ describe('filterDuplicateOutgoingTransactions', () => {
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('3');
     });
+
+    it("preserves transactions when hash is placeholder '0x0'", () => {
+      const PLACEHOLDER_HASH = '0x0';
+      const transactions = [
+        createTransaction('1', 'musdConversion', PLACEHOLDER_HASH, '100'),
+        createTransaction('2', 'musdConversion', PLACEHOLDER_HASH, '100'),
+      ];
+
+      const result = filterDuplicateOutgoingTransactions(transactions);
+
+      expect(result).toEqual(transactions);
+    });
   });
 });

--- a/app/components/UI/Transactions/utils.ts
+++ b/app/components/UI/Transactions/utils.ts
@@ -15,7 +15,9 @@ export const filterDuplicateOutgoingTransactions = (
   }
 
   return transactions.filter((currentTx, currentIndex) => {
-    if (!currentTx.hash) {
+    // Treat placeholder hash ('0x0') as "no hash" to avoid deduping unrelated tx metas
+    // (e.g., MetaMask Pay intent/wrapper transactions that never receive a real tx hash).
+    if (!currentTx.hash || currentTx.hash === '0x0') {
       return true; // Keep transactions without a hash
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This fix prevents filtering of transactions with the "0x0" hash in the activity view.

### Reason for change
mUSD conversions were being filtered out and hidden on the activity view since they all have the 0x0 hash.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: prevent filtering of transactions with 0x0 hash in activity view

## **Related issues**

Fixes: [MUSD-181: MUSD conversions aren't appearing in activity list](https://consensyssoftware.atlassian.net/browse/MUSD-181)

## **Manual testing steps**

```gherkin
Feature: Transaction history preserves distinct outgoing transactions with placeholder hashes

  Scenario: user views transaction history with multiple outgoing transactions that have a placeholder hash
    Given user has multiple outgoing transactions recorded in activity with a placeholder hash value ("0x0")

    When user opens the activity / transaction history list
    Then each of those outgoing transactions is displayed as a separate entry
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
Single mUSD Conversion shown in activity list despite user performing multiple conversions
<img width="505" height="1012" alt="image" src="https://github.com/user-attachments/assets/430583c3-af24-407c-91f2-dbef62b52e93" />

### **After**

<!-- [screenshots/recordings] -->
All mUSD Conversions displayed in activity list
<img width="505" height="1012" alt="image" src="https://github.com/user-attachments/assets/f027d5f8-9153-4c26-8923-741c575f0de7" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents unintended filtering of transactions that use the placeholder hash `0x0`.
> 
> - Updates `filterDuplicateOutgoingTransactions` to treat `hash === '0x0'` as absent so these entries are never deduped
> - Adds a unit test in `utils.test.ts` verifying transactions with `0x0` hash are preserved
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3969d6573eb7e6fb5774096a35a2b1eecb0e51ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->