### PR TITLE
feat: Enable conditional gasless deposits for Perps and Predict

### DIFF
--- a/app/components/UI/Perps/controllers/PerpsController.test.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.test.ts
@@ -13,6 +13,10 @@ import {
   type PerpsControllerMessenger,
 } from './PerpsController';
 import { PERPS_ERROR_CODES } from './perpsErrorCodes';
+import {
+  GasFeeEstimateLevel,
+  GasFeeEstimateType,
+} from '@metamask/transaction-controller';
 import type { IPerpsProvider } from './types';
 import { HyperLiquidProvider } from './providers/HyperLiquidProvider';
 import { createMockHyperLiquidProvider } from '../__mocks__/providerMocks';
@@ -23,6 +27,10 @@ import { MarketDataService } from './services/MarketDataService';
 import { TradingService } from './services/TradingService';
 import { AccountService } from './services/AccountService';
 import { DataLakeService } from './services/DataLakeService';
+import {
+  ARBITRUM_MAINNET_CHAIN_ID_HEX,
+  USDC_ARBITRUM_MAINNET_ADDRESS,
+} from '../constants/hyperLiquidConfig';
 import Engine from '../../../../core/Engine';
 
 jest.mock('./providers/HyperLiquidProvider');
@@ -104,11 +112,23 @@ jest.mock('../../../../core/Engine', () => {
     ]),
   };
 
+  const mockTransactionController = {
+    estimateGasFee: jest.fn(),
+    estimateGas: jest.fn(),
+  };
+
+  const mockAccountTrackerController = {
+    state: {
+      accountsByChainId: {},
+    },
+  };
+
   const mockEngineContext = {
     RewardsController: mockRewardsController,
     NetworkController: mockNetworkController,
     AccountTreeController: mockAccountTreeController,
-    TransactionController: {},
+    TransactionController: mockTransactionController,
+    AccountTrackerController: mockAccountTrackerController,
   };
 
   // Return as default export to match the actual Engine import
@@ -2213,6 +2233,7 @@ describe('PerpsController', () => {
       to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
       value: '0x0',
       data: '0x',
+      gas: '0x186a0',
     };
 
     const mockDepositId = 'deposit-123';
@@ -2234,6 +2255,34 @@ describe('PerpsController', () => {
         .fn()
         .mockReturnValue(mockNetworkClientId);
 
+      Engine.context.TransactionController.estimateGasFee = jest
+        .fn()
+        .mockResolvedValue({
+          estimates: {
+            type: GasFeeEstimateType.FeeMarket,
+            [GasFeeEstimateLevel.Low]: {
+              maxFeePerGas: '0x3b9aca00',
+              maxPriorityFeePerGas: '0x1',
+            },
+            [GasFeeEstimateLevel.Medium]: {
+              maxFeePerGas: '0x3b9aca00',
+              maxPriorityFeePerGas: '0x1',
+            },
+            [GasFeeEstimateLevel.High]: {
+              maxFeePerGas: '0x3b9aca00',
+              maxPriorityFeePerGas: '0x1',
+            },
+          },
+        });
+
+      Engine.context.AccountTrackerController.state.accountsByChainId = {
+        [mockAssetChainId]: {
+          [mockTransaction.from.toLowerCase()]: {
+            balance: '0xde0b6b3a7640000',
+          },
+        },
+      };
+
       // Mock TransactionController with promise-based result
       Engine.context.TransactionController.addTransaction = jest
         .fn()
@@ -2248,6 +2297,7 @@ describe('PerpsController', () => {
       delete (Engine.context.NetworkController as any)
         .findNetworkClientIdByChainId;
       delete (Engine.context.TransactionController as any).addTransaction;
+      delete (Engine.context.TransactionController as any).estimateGasFee;
       jest.clearAllMocks();
     });
 
@@ -2297,7 +2347,48 @@ describe('PerpsController', () => {
         origin: 'metamask',
         type: 'perpsDeposit',
         skipInitialGasEstimate: true,
+        gasFeeToken: undefined,
       });
+    });
+
+    it('adds gasFeeToken for Arbitrum USDC deposits', async () => {
+      markControllerAsInitialized();
+      controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
+
+      Engine.context.AccountTrackerController.state.accountsByChainId = {
+        [ARBITRUM_MAINNET_CHAIN_ID_HEX]: {
+          [mockTransaction.from.toLowerCase()]: {
+            balance: '0x0',
+          },
+        },
+      };
+
+      jest.spyOn(DepositService, 'prepareTransaction').mockResolvedValueOnce({
+        transaction: {
+          ...mockTransaction,
+          to: USDC_ARBITRUM_MAINNET_ADDRESS,
+        },
+        assetChainId: ARBITRUM_MAINNET_CHAIN_ID_HEX,
+        currentDepositId: mockDepositId,
+      });
+
+      await controller.depositWithConfirmation('100');
+
+      expect(
+        Engine.context.TransactionController.addTransaction,
+      ).toHaveBeenCalledWith(
+        {
+          ...mockTransaction,
+          to: USDC_ARBITRUM_MAINNET_ADDRESS,
+        },
+        {
+          networkClientId: mockNetworkClientId,
+          origin: 'metamask',
+          type: 'perpsDeposit',
+          skipInitialGasEstimate: true,
+          gasFeeToken: USDC_ARBITRUM_MAINNET_ADDRESS,
+        },
+      );
     });
 
     it('throws error when controller not initialized', async () => {

--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -13,8 +13,13 @@ import {
   TransactionControllerTransactionSubmittedEvent,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
 import Engine from '../../../../core/Engine';
-import { USDC_SYMBOL } from '../constants/hyperLiquidConfig';
+import {
+  ARBITRUM_MAINNET_CHAIN_ID_HEX,
+  USDC_ARBITRUM_MAINNET_ADDRESS,
+  USDC_SYMBOL,
+} from '../constants/hyperLiquidConfig';
 import {
   LastTransactionResult,
   TransactionStatus,
@@ -1380,6 +1385,14 @@ export class PerpsController extends BaseController<
       const networkClientId =
         NetworkController.findNetworkClientIdByChainId(assetChainId);
 
+      const gasFeeToken =
+        transaction.to &&
+        assetChainId.toLowerCase() === ARBITRUM_MAINNET_CHAIN_ID_HEX &&
+        transaction.to.toLowerCase() ===
+          USDC_ARBITRUM_MAINNET_ADDRESS.toLowerCase()
+          ? (transaction.to as Hex)
+          : undefined;
+
       // addTransaction shows the confirmation screen and returns a promise
       // The promise will resolve when transaction completes or reject if cancelled/failed
       const { result, transactionMeta } =
@@ -1388,6 +1401,7 @@ export class PerpsController extends BaseController<
           origin: 'metamask',
           type: TransactionType.perpsDeposit,
           skipInitialGasEstimate: true,
+          gasFeeToken,
         });
 
       // Store the transaction ID and try to get amount from transaction

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -13,6 +13,7 @@ import {
 } from '@metamask/transaction-controller';
 import type { NetworkState } from '@metamask/network-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
+import type { Hex } from '@metamask/utils';
 
 import Engine from '../../../../core/Engine';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
@@ -2599,7 +2600,7 @@ describe('PredictController', () => {
       mockPolymarketProvider.prepareDeposit.mockResolvedValue({
         transactions: mockTransactions,
         chainId: mockChainId,
-        gasFeeToken: MATIC_CONTRACTS.collateral,
+        gasFeeToken: MATIC_CONTRACTS.collateral as Hex,
       });
 
       (addTransactionBatch as jest.Mock).mockResolvedValue({

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -2599,6 +2599,7 @@ describe('PredictController', () => {
       mockPolymarketProvider.prepareDeposit.mockResolvedValue({
         transactions: mockTransactions,
         chainId: mockChainId,
+        gasFeeToken: MATIC_CONTRACTS.collateral,
       });
 
       (addTransactionBatch as jest.Mock).mockResolvedValue({

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -79,7 +79,10 @@ import { ensureError } from '../utils/predictErrorHandler';
 import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../constants/errors';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { GEO_BLOCKED_COUNTRIES } from '../constants/geoblock';
-import { MATIC_CONTRACTS } from '../providers/polymarket/constants';
+import {
+  MATIC_CONTRACTS,
+  POLYGON_MAINNET_CHAIN_ID,
+} from '../providers/polymarket/constants';
 import { DEFAULT_FEE_COLLECTION_FLAG } from '../constants/flags';
 import { PredictFeeCollection } from '../types/flags';
 
@@ -1767,6 +1770,12 @@ export class PredictController extends BaseController<
         state.pendingDeposits[params.providerId][signer.address] = 'pending';
       });
 
+      const polygonChainId = numberToHex(POLYGON_MAINNET_CHAIN_ID);
+      const gasFeeToken =
+        chainId.toLowerCase() === polygonChainId.toLowerCase()
+          ? (MATIC_CONTRACTS.collateral as Hex)
+          : undefined;
+
       const batchResult = await addTransactionBatch({
         from: signer.address as Hex,
         origin: ORIGIN_METAMASK,
@@ -1776,6 +1785,7 @@ export class PredictController extends BaseController<
         disableUpgrade: true,
         skipInitialGasEstimate: true,
         transactions,
+        gasFeeToken,
       });
 
       if (!batchResult?.batchId) {

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -79,10 +79,7 @@ import { ensureError } from '../utils/predictErrorHandler';
 import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../constants/errors';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { GEO_BLOCKED_COUNTRIES } from '../constants/geoblock';
-import {
-  MATIC_CONTRACTS,
-  POLYGON_MAINNET_CHAIN_ID,
-} from '../providers/polymarket/constants';
+import { MATIC_CONTRACTS } from '../providers/polymarket/constants';
 import { DEFAULT_FEE_COLLECTION_FLAG } from '../constants/flags';
 import { PredictFeeCollection } from '../types/flags';
 
@@ -1746,7 +1743,7 @@ export class PredictController extends BaseController<
         throw new Error('Deposit preparation returned undefined');
       }
 
-      const { transactions, chainId } = depositPreparation;
+      const { transactions, chainId, gasFeeToken } = depositPreparation;
 
       if (!transactions || transactions.length === 0) {
         throw new Error('No transactions returned from deposit preparation');
@@ -1769,12 +1766,6 @@ export class PredictController extends BaseController<
           state.pendingDeposits[params.providerId] || {};
         state.pendingDeposits[params.providerId][signer.address] = 'pending';
       });
-
-      const polygonChainId = numberToHex(POLYGON_MAINNET_CHAIN_ID);
-      const gasFeeToken =
-        chainId.toLowerCase() === polygonChainId.toLowerCase()
-          ? (MATIC_CONTRACTS.collateral as Hex)
-          : undefined;
 
       const batchResult = await addTransactionBatch({
         from: signer.address as Hex,

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -1419,9 +1419,15 @@ export class PolymarketProvider implements PredictProvider {
       type: TransactionType.predictDeposit,
     });
 
+    const chainId = CHAIN_IDS.POLYGON;
+    const isPolygonChain =
+      chainId.toLowerCase() ===
+      numberToHex(POLYGON_MAINNET_CHAIN_ID).toLowerCase();
+
     return {
-      chainId: CHAIN_IDS.POLYGON,
+      chainId,
       transactions,
+      gasFeeToken: isPolygonChain ? (collateral as Hex) : undefined,
     };
   }
 

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -167,6 +167,7 @@ export interface PrepareDepositResponse {
     };
     type?: TransactionType;
   }[];
+  gasFeeToken?: Hex;
 }
 
 export interface GetPredictWalletParams {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Gate gas fee token usage for Perps (Arbitrum USDC) and Predict (Polygon USDC.e).

Add shared helper for gas-fee-token eligibility and update controller tests.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6352

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements chain/token-gated gasless-style deposits by wiring `gasFeeToken` into submission paths where eligible.
> 
> - Perps: In `PerpsController.depositWithConfirmation`, set `gasFeeToken` when `assetChainId` is `ARBITRUM_MAINNET_CHAIN_ID_HEX` and `transaction.to` equals `USDC_ARBITRUM_MAINNET_ADDRESS`; pass to `TransactionController.addTransaction` (skips initial gas estimate). Added `Hex` and chain/token constants.
> - Predict: `PolymarketProvider.prepareDeposit` now returns `gasFeeToken` (Polygon only, set to collateral) and `PredictController.depositWithConfirmation` forwards it to `addTransactionBatch`.
> - Types: Extend `PrepareDepositResponse` to include optional `gasFeeToken`.
> - Tests: Update Perps/Predict controller tests to mock `estimateGas/estimateGasFee`, account balances, and assert `gasFeeToken` is set when conditions match (and `undefined` otherwise).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 894892bc7a6868051ce1766bdf4cbd919bd61106. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->