### PR TITLE
fix: include hip3 dexes when building position map on init cp-7.61.6

### DIFF
--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.test.ts
@@ -2172,6 +2172,17 @@ describe('HyperLiquidSubscriptionService', () => {
     it('should include TP/SL orders in the orders list', async () => {
       const mockCallback = jest.fn();
 
+      // Create service with enabledDexs to skip DEX discovery wait
+      const hip3Service = new HyperLiquidSubscriptionService(
+        mockClientService,
+        mockWalletService,
+        true, // hip3Enabled
+        [], // enabledDexs - empty but we'll call updateFeatureFlags
+      );
+
+      // Simulate DEX discovery by calling updateFeatureFlags
+      await hip3Service.updateFeatureFlags(true, [''], [], []);
+
       mockSubscriptionClient.clearinghouseState.mockImplementation(
         (_params: any, callback: any) => {
           setTimeout(() => {
@@ -2249,7 +2260,7 @@ describe('HyperLiquidSubscriptionService', () => {
         },
       );
 
-      const unsubscribe = service.subscribeToOrders({
+      const unsubscribe = hip3Service.subscribeToOrders({
         callback: mockCallback,
       });
 
@@ -3729,6 +3740,9 @@ describe('HyperLiquidSubscriptionService', () => {
       const positionCallback = jest.fn();
       const mockUnsubscribe = jest.fn().mockResolvedValue(undefined);
 
+      // Simulate DEX discovery to skip the wait
+      await service.updateFeatureFlags(true, [''], [], []);
+
       mockSubscriptionClient.webData3.mockImplementation(
         (_params: any, callback: any) => {
           setTimeout(() => {
@@ -3930,6 +3944,9 @@ describe('HyperLiquidSubscriptionService', () => {
       const allTypesMarketDataCallback = jest.fn();
       const mockUnsubscribe = jest.fn().mockResolvedValue(undefined);
       const mockSubscription = { unsubscribe: mockUnsubscribe };
+
+      // Simulate DEX discovery to skip the wait
+      await service.updateFeatureFlags(true, [''], [], []);
 
       mockSubscriptionClient.allMids.mockImplementation((cb: any) => {
         setTimeout(() => {

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -1375,6 +1375,9 @@ export class HyperLiquidSubscriptionService {
               this.dexPositionsCache.set(cacheKey, positionsWithTPSL);
             }
 
+            // Mark this DEX as initialized (has sent first data)
+            this.initializedDexs.add(cacheKey);
+
             // Trigger aggregation and notify subscribers
             this.aggregateAndNotifySubscribers();
           }

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -61,6 +61,15 @@ export class HyperLiquidSubscriptionService {
   private blocklistMarkets: string[]; // Market filtering (blocklist)
   private discoveredDexNames: string[] = []; // DEX order for mapping webData3 perpDexStates indices
 
+  // DEX discovery synchronization - allows subscriptions to wait for HIP-3 DEX discovery
+  private dexDiscoveryPromise: Promise<void> | null = null;
+  private dexDiscoveryResolver: (() => void) | null = null;
+
+  // Track DEXs for synchronized position notifications
+  // Ensures all DEXs send initial data before notifying subscribers
+  private expectedDexs: Set<string> = new Set();
+  private initializedDexs: Set<string> = new Set();
+
   // Subscriber collections
   private readonly priceSubscribers = new Map<
     string,
@@ -298,6 +307,38 @@ export class HyperLiquidSubscriptionService {
   }
 
   /**
+   * Wait for DEX discovery to complete (with timeout)
+   * Used when HIP-3 is enabled but enabledDexs hasn't been populated yet.
+   * This allows subscriptions to wait for DEX discovery before creating per-DEX subscriptions.
+   */
+  private async waitForDexDiscovery(timeoutMs: number = 5000): Promise<void> {
+    // Already have DEXs, no need to wait
+    if (this.enabledDexs.length > 0) {
+      return;
+    }
+
+    // Create promise if not exists
+    if (!this.dexDiscoveryPromise) {
+      this.dexDiscoveryPromise = new Promise<void>((resolve) => {
+        this.dexDiscoveryResolver = resolve;
+      });
+    }
+
+    // Wait with timeout
+    const timeoutPromise = new Promise<void>((_, reject) => {
+      setTimeout(() => reject(new Error('DEX discovery timeout')), timeoutMs);
+    });
+
+    try {
+      await Promise.race([this.dexDiscoveryPromise, timeoutPromise]);
+    } catch {
+      DevLogger.log(
+        'DEX discovery wait timed out, proceeding with main DEX only',
+      );
+    }
+  }
+
+  /**
    * Update feature flags for HIP-3 support
    * Called when provider configuration changes at runtime
    * Note: Market filtering is NOT applied in subscription service - only in Provider
@@ -318,6 +359,13 @@ export class HyperLiquidSubscriptionService {
     this.allowlistMarkets = allowlistMarkets;
     this.blocklistMarkets = blocklistMarkets;
     this.discoveredDexNames = enabledDexs; // Store DEX order for webData3 index mapping
+
+    // Resolve any pending DEX discovery wait now that DEXs are available
+    if (this.dexDiscoveryResolver && enabledDexs.length > 0) {
+      this.dexDiscoveryResolver();
+      this.dexDiscoveryPromise = null;
+      this.dexDiscoveryResolver = null;
+    }
 
     DevLogger.log('Feature flags updated:', {
       previousHip3Enabled,
@@ -911,6 +959,18 @@ export class HyperLiquidSubscriptionService {
       return;
     }
 
+    // Wait for DEX discovery if HIP-3 is enabled but DEXs haven't been discovered yet
+    // This ensures HIP-3 subscriptions are created together with main DEX
+    if (this.hip3Enabled && this.enabledDexs.length === 0) {
+      DevLogger.log(
+        'Waiting for DEX discovery before creating subscriptions...',
+      );
+      await this.waitForDexDiscovery();
+      DevLogger.log('DEX discovery complete, proceeding with subscriptions', {
+        enabledDexs: this.enabledDexs,
+      });
+    }
+
     return new Promise<void>((resolve, reject) => {
       // Choose channel based on HIP-3 master switch
       if (!this.hip3Enabled) {
@@ -1035,6 +1095,11 @@ export class HyperLiquidSubscriptionService {
           '', // Main DEX
           ...this.enabledDexs.filter((d) => this.isDexEnabled(d)),
         ];
+
+        // Track expected DEXs for synchronized notifications
+        // Clear previous tracking and set new expected DEXs
+        this.expectedDexs = new Set(dexsToSubscribe);
+        this.initializedDexs = new Set();
 
         // Set up individual subscriptions for each DEX
         const subscriptionPromises: Promise<void>[] = [];
@@ -1222,6 +1287,9 @@ export class HyperLiquidSubscriptionService {
             this.dexPositionsCache.set(cacheKey, positionsWithTPSL);
             this.dexAccountCache.set(cacheKey, accountState);
 
+            // Mark this DEX as initialized (has sent first data)
+            this.initializedDexs.add(cacheKey);
+
             // Trigger aggregation and notify subscribers
             this.aggregateAndNotifySubscribers();
           }
@@ -1322,12 +1390,34 @@ export class HyperLiquidSubscriptionService {
    * Used by both webData3 callback and fallback subscription callbacks
    */
   private aggregateAndNotifySubscribers(): void {
-    // Aggregate data from all DEX caches
-    const aggregatedPositions = Array.from(
-      this.dexPositionsCache.values(),
-    ).flat();
+    // Wait for all expected DEXs to send initial data before notifying
+    // This ensures positions from all DEXs appear simultaneously
+    if (this.expectedDexs.size > 0) {
+      const allDexsInitialized = Array.from(this.expectedDexs).every((dex) =>
+        this.initializedDexs.has(dex),
+      );
+      if (!allDexsInitialized) {
+        DevLogger.log('Waiting for all DEXs to send initial data', {
+          expected: Array.from(this.expectedDexs),
+          initialized: Array.from(this.initializedDexs),
+        });
+        return; // Don't notify yet - waiting for more DEXs
+      }
+    }
 
-    const aggregatedOrders = Array.from(this.dexOrdersCache.values()).flat();
+    // Aggregate data from all DEX caches
+    // Order: Main DEX (crypto perps) first, then HIP-3 DEXs
+    const mainDexPositions = this.dexPositionsCache.get('') || [];
+    const hip3DexPositions = Array.from(this.dexPositionsCache.entries())
+      .filter(([key]) => key !== '')
+      .flatMap(([, positions]) => positions);
+    const aggregatedPositions = [...mainDexPositions, ...hip3DexPositions];
+
+    const mainDexOrders = this.dexOrdersCache.get('') || [];
+    const hip3DexOrders = Array.from(this.dexOrdersCache.entries())
+      .filter(([key]) => key !== '')
+      .flatMap(([, orders]) => orders);
+    const aggregatedOrders = [...mainDexOrders, ...hip3DexOrders];
 
     const aggregatedAccount = this.aggregateAccountStates();
 
@@ -1445,6 +1535,10 @@ export class HyperLiquidSubscriptionService {
       this.dexPositionsCache.clear();
       this.dexOrdersCache.clear();
       this.dexAccountCache.clear();
+
+      // Clear DEX tracking for synchronized notifications
+      this.expectedDexs.clear();
+      this.initializedDexs.clear();
 
       // Clear aggregated caches
       this.cachedPositions = null;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

After the HIP-3 refactor that replaced webData3 with individual clearinghouseState/openOrders subscriptions, HIP-3 market positions were not showing up on initial load. Additionally, when they did appear (e.g., after switching accounts), there was a ~1 second delay between crypto perps and HIP-3 positions appearing.

**Root Cause**

A race condition between subscription creation and DEX discovery:
1. HyperLiquidSubscriptionService initializes with empty `enabledDexs`
subscribeToPositions() creates subscriptions using empty `enabledDexs` (main DEX only)
2. DEX discovery runs asynchronously via `buildAssetMapping()`
3. `updateFeatureFlags()` is called with discovered DEXs, but subscriptions already exist for main DEX only
4. HIP-3 positions never appear because no subscriptions were created for HIP-3 DEXs

Why switching accounts worked: Account switching triggers `reconnectWithNewContext()` which performs a full reinitialization. During reconnection, `buildAssetMapping() `(DEX discovery) completes before `createUserDataSubscription()` is called, so `enabledDexs` is already populated and HIP-3 subscriptions are correctly created.

**Solution**

1. Promise-based DEX discovery wait
Added `dexDiscoveryPromise` and `dexDiscoveryResolver `fields
`createUserDataSubscription()` waits for DEX discovery when HIP-3 is enabled but `enabledDexs` is empty
`updateFeatureFlags()` resolves the promise when DEXs are discovered
5-second timeout prevents indefinite waiting
2. Synchronized position subscription notifications
Added `expectedDexs` and `initializedDexs` tracking sets
`aggregateAndNotifySubscribers()` waits for ALL expected DEXs to send initial data before notifying
Ensures crypto and HIP-3 positions appear simultaneously
3. Consistent position ordering
Modified aggregation to always show main DEX (crypto perps) first, then HIP-3 positions

**Error handling:**

1. Failed DEX subscriptions are removed from `expectedDexs` so they don't block notifications for other DEXs
2. Both `ensureClearinghouseStateSubscription` and `ensureOpenOrdersSubscription` mark DEXs as initialize

Changes to `HyperLiquidSubscriptionService.ts`:

- Added DEX discovery synchronization promise mechanism
- Added expectedDexs/initializedDexs tracking for synchronized notifications
- Added wait logic in createUserDataSubscription() for HIP-3 DEX discovery
- Modified aggregateAndNotifySubscribers() to wait for all DEXs before notifying
- Modified aggregation ordering to put main DEX first
- Added initializedDexs.add() to both subscription callbacks
- Added expectedDexs.delete() in catch blocks for failed subscriptions
- Added cleanup for tracking state in cleanupSharedWebData3Subscription()
- Updated tests to call updateFeatureFlags() to simulate DEX discovery before subscribing in HyperLiquidSubscriptionService.test.ts

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes bug where hip3 positions were not loaded on initial PerpsContext load

## **Related issues**

Fixes: 

## **Manual testing steps**

Verified crypto and HIP-3 positions appear simultaneously on initial load
Verified position ordering (crypto first, HIP-3 second)
Verified account switching still works correctly
Verified that TP/SL still works as intended

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/e70a47f5-f6e7-4b0b-931b-d8d666806511

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves HIP-3 multi-DEX handling and subscription lifecycle to deliver consistent, aggregated user data.
> 
> - Introduces DEX discovery synchronization (`waitForDexDiscovery`) and resolves pending waits in `updateFeatureFlags`
> - Tracks `expectedDexs`/`initializedDexs` to delay notifications until all DEXs send initial data; orders aggregation preserves main DEX first
> - When HIP-3 is enabled, establishes per-DEX `clearinghouseState` and `openOrders` subscriptions upon feature-flag updates if user-data subscribers exist
> - `subscribeTo...` waits for DEX discovery before creating HIP-3 subscriptions; error paths avoid blocking other DEX updates
> - Aggregation and caches updated to merge per-DEX positions/orders/account; clearing `clearAll` resets DEX tracking
> - Tests adjusted to simulate DEX discovery and verify restoration and TP/SL inclusion in orders
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67f8a9aad1c84c9782d28d59920562dc7702db20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->