### PR TITLE
fix: show Swaps CTA for trending tokens on asset details page

### DIFF
--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -22,7 +22,6 @@ import {
   TX_UNAPPROVED,
 } from '../../../constants/transaction';
 import AppConstants from '../../../core/AppConstants';
-import { swapsTokensMultiChainObjectSelector } from '../../../reducers/swaps';
 import FIRST_PARTY_CONTRACT_NAMES from '../../../constants/first-party-contracts';
 import {
   selectNetworkClientId,
@@ -264,7 +263,6 @@ class Asset extends PureComponent {
      * Array of ERC20 assets
      */
     tokens: PropTypes.array,
-    swapsTokens: PropTypes.object,
     searchDiscoverySwapsTokens: PropTypes.array,
     swapsTransactions: PropTypes.object,
     /**
@@ -607,7 +605,6 @@ class Asset extends PureComponent {
     const isSwapsAssetAllowed = getIsSwapsAssetAllowed({
       asset,
       searchDiscoverySwapsTokens: this.props.searchDiscoverySwapsTokens,
-      swapsTokens: this.props.swapsTokens,
     });
 
     const displaySwapsButton = isSwapsAssetAllowed && AppConstants.SWAPS.ACTIVE;
@@ -846,7 +843,6 @@ const mapStateToProps = (state, { route }) => {
   ///: END:ONLY_INCLUDE_IF
 
   return {
-    swapsTokens: swapsTokensMultiChainObjectSelector(state),
     searchDiscoverySwapsTokens: selectSupportedSwapTokenAddressesForChainId(
       state,
       route.params.chainId,

--- a/app/components/Views/Asset/utils.test.ts
+++ b/app/components/Views/Asset/utils.test.ts
@@ -3,11 +3,6 @@ import { getIsSwapsAssetAllowed } from './utils';
 import { SolScope } from '@metamask/keyring-api';
 
 describe('getIsSwapsAssetAllowed', () => {
-  const mockSwapsTokens = {
-    '0xtoken1': { symbol: 'TOKEN1' },
-    '0xtoken2': { symbol: 'TOKEN2' },
-  };
-
   const mockSearchDiscoverySwapsTokens = ['0xtoken3', '0xtoken4'];
 
   describe('EVM assets', () => {
@@ -20,7 +15,6 @@ describe('getIsSwapsAssetAllowed', () => {
           chainId: '0x1',
         },
         searchDiscoverySwapsTokens: mockSearchDiscoverySwapsTokens,
-        swapsTokens: mockSwapsTokens,
       });
       expect(result).toBe(true);
     });
@@ -34,7 +28,6 @@ describe('getIsSwapsAssetAllowed', () => {
           chainId: '0x1',
         },
         searchDiscoverySwapsTokens: mockSearchDiscoverySwapsTokens,
-        swapsTokens: mockSwapsTokens,
       });
       expect(result).toBe(true);
     });
@@ -49,12 +42,11 @@ describe('getIsSwapsAssetAllowed', () => {
           isFromSearch: true,
         },
         searchDiscoverySwapsTokens: mockSearchDiscoverySwapsTokens,
-        swapsTokens: mockSwapsTokens,
       });
       expect(result).toBe(true);
     });
 
-    it('should return true for tokens in swaps tokens list', () => {
+    it('should return true for all other EVM tokens', () => {
       const result = getIsSwapsAssetAllowed({
         asset: {
           isETH: false,
@@ -63,35 +55,6 @@ describe('getIsSwapsAssetAllowed', () => {
           chainId: '0x1',
         },
         searchDiscoverySwapsTokens: mockSearchDiscoverySwapsTokens,
-        swapsTokens: mockSwapsTokens,
-      });
-      expect(result).toBe(true);
-    });
-
-    it('should return false for tokens not in either list', () => {
-      const result = getIsSwapsAssetAllowed({
-        asset: {
-          isETH: false,
-          isNative: false,
-          address: '0xunknown',
-          chainId: '0x1',
-        },
-        searchDiscoverySwapsTokens: mockSearchDiscoverySwapsTokens,
-        swapsTokens: mockSwapsTokens,
-      });
-      expect(result).toBe(false);
-    });
-
-    it('should handle case-insensitive address matching', () => {
-      const result = getIsSwapsAssetAllowed({
-        asset: {
-          isETH: false,
-          isNative: false,
-          address: '0XTOKEN1',
-          chainId: '0x1',
-        },
-        searchDiscoverySwapsTokens: mockSearchDiscoverySwapsTokens,
-        swapsTokens: mockSwapsTokens,
       });
       expect(result).toBe(true);
     });
@@ -107,7 +70,6 @@ describe('getIsSwapsAssetAllowed', () => {
           chainId: SolScope.Mainnet,
         },
         searchDiscoverySwapsTokens: mockSearchDiscoverySwapsTokens,
-        swapsTokens: mockSwapsTokens,
       });
       expect(result).toBe(true);
     });

--- a/app/components/Views/Asset/utils.ts
+++ b/app/components/Views/Asset/utils.ts
@@ -7,7 +7,6 @@ import { isSwapsAllowed } from '../../UI/Swaps/utils';
 export const getIsSwapsAssetAllowed = ({
   asset,
   searchDiscoverySwapsTokens,
-  swapsTokens,
 }: {
   asset: {
     isETH: boolean;
@@ -17,7 +16,6 @@ export const getIsSwapsAssetAllowed = ({
     isFromSearch?: boolean;
   };
   searchDiscoverySwapsTokens: string[];
-  swapsTokens: Record<string, unknown>;
 }) => {
   let isSwapsAssetAllowed;
   if (asset.isETH || asset.isNative) {
@@ -28,7 +26,8 @@ export const getIsSwapsAssetAllowed = ({
       asset.address?.toLowerCase(),
     );
   } else {
-    isSwapsAssetAllowed = asset.address?.toLowerCase() in swapsTokens;
+    // show Swaps CTA for EVM assets as tokens on Trending list will not be in SwapsController.swapsTokens
+    isSwapsAssetAllowed = true;
   }
 
   // Solana Swaps

--- a/app/selectors/featureFlagController/assetsTrendingTokens/index.ts
+++ b/app/selectors/featureFlagController/assetsTrendingTokens/index.ts
@@ -89,6 +89,9 @@ export const isAssetsTrendingTokensFeatureEnabled = (
 export const selectAssetsTrendingTokensEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean => {
+    // TODO: REMOVE - Forced to true for testing
+    return true;
+
     const { trendingTokens: assetsTrendingTokensEnabled } = remoteFeatureFlags;
     const envOverride =
       process.env.OVERRIDE_REMOTE_FEATURE_FLAGS &&

--- a/app/selectors/featureFlagController/assetsTrendingTokens/index.ts
+++ b/app/selectors/featureFlagController/assetsTrendingTokens/index.ts
@@ -89,9 +89,6 @@ export const isAssetsTrendingTokensFeatureEnabled = (
 export const selectAssetsTrendingTokensEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean => {
-    // TODO: REMOVE - Forced to true for testing
-    return true;
-
     const { trendingTokens: assetsTrendingTokensEnabled } = remoteFeatureFlags;
     const envOverride =
       process.env.OVERRIDE_REMOTE_FEATURE_FLAGS &&


### PR DESCRIPTION
## **Description**

Show the Swaps CTA for EVM assets on the asset details page because tokens on the Trending list will not be in `SwapsController.swapsTokens`.

The previous logic checked if a token was in the swapsTokens list, but trending tokens from search aren't added to that list, so the Swap button was hidden for those tokens.

## **Changelog**

CHANGELOG entry: Fixed Swap button not showing for trending tokens on asset details page

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3687

## **Manual testing steps**

```gherkin
Feature: Swaps CTA on trending token details

  Scenario: user views a trending token from search
    Given app is on the home screen

    When user searches for a trending token and taps on it
    Then the Swap button should be visible on the asset details page
```

## **Screenshots/Recordings**

### **Before**

<!-- Swap button not visible for trending tokens -->

### **After**

<!-- Swap button visible for trending tokens -->


https://github.com/user-attachments/assets/55cd9fd4-1a24-436e-af4a-ff8924d071c3



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the Swap button is visible for EVM assets, including trending tokens from search, by simplifying the allow logic and removing dependency on `swapsTokens`.
> 
> - Updates `getIsSwapsAssetAllowed` to return true for non-native EVM assets; ETH/native still gated by `isSwapsAllowed`; Solana/Tron explicitly allowed
> - Removes `swapsTokens` prop and `swapsTokensMultiChainObjectSelector` usage from `Asset/index.js` and `mapStateToProps`
> - Adjusts `getIsSwapsAssetAllowed` tests to reflect new logic (remove `swapsTokens` cases; assert true for other EVM tokens)
> - Keeps discovery-based allowlist via `searchDiscoverySwapsTokens`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 211868ab0ebfaec515faa7292ac2a3db33c0aa8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->