### PR TITLE
fix(bridge): prevent stale token balance showing when switching Solana tokens

### DIFF
--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -414,7 +414,7 @@ export const TokenInputArea = forwardRef<
                 >
                   <Text
                     color={
-                      isInsufficientBalance
+                      isInsufficientBalance && isSourceToken
                         ? TextColor.Error
                         : TextColor.Alternative
                     }

--- a/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
@@ -71,6 +71,13 @@ export const useLatestBalance = (token: {
   );
   const previousToken = usePrevious(token);
 
+  // Reset balance when token changes to prevent stale data from previous token
+  useEffect(() => {
+    if (previousToken?.address !== token.address) {
+      setBalance(undefined);
+    }
+  }, [previousToken?.address, token.address]);
+
   // Returns native non-EVM asset and non-EVM tokens, contains balance and fiat values
   // Balance and fiat values are not truncated
   const nonEvmTokens = useNonEvmTokensWithBalance();
@@ -137,7 +144,8 @@ export const useLatestBalance = (token: {
           nonEvmToken.chainId === chainId,
       )?.balance;
 
-      if (displayBalance && token.decimals) {
+      // Use explicit undefined check instead of truthiness to handle "0" balance correctly
+      if (displayBalance !== undefined && token.decimals) {
         setBalance({
           displayBalance,
           atomicBalance: parseUnits(displayBalance, token.decimals),

--- a/app/components/UI/Bridge/hooks/useLatestBalance/useLatestBalance.test.tsx
+++ b/app/components/UI/Bridge/hooks/useLatestBalance/useLatestBalance.test.tsx
@@ -60,6 +60,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '1.0',
         atomicBalance: BigNumber.from('1000000000000000000'),
+        assetId: 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
       });
     });
   });
@@ -79,6 +80,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '1.0',
         atomicBalance: BigNumber.from('1000000'),
+        assetId: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
       });
     });
   });
@@ -102,6 +104,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '100.123',
         atomicBalance: BigNumber.from('100123000000'),
+        assetId: solanaNativeTokenAddress,
       });
     });
   });
@@ -125,6 +128,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '20000.456',
         atomicBalance: BigNumber.from('20000456000'),
+        assetId: solanaToken2Address,
       });
     });
   });
@@ -166,6 +170,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '1.0',
         atomicBalance: BigNumber.from('1000000000000000000'),
+        assetId: 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
       });
     });
   });
@@ -193,6 +198,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '1.0',
         atomicBalance: BigNumber.from('1000000000000000000'),
+        assetId: 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
       });
     });
   });
@@ -237,6 +243,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '1.0',
         atomicBalance: BigNumber.from('1000000'),
+        assetId: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
       });
     });
   });
@@ -258,6 +265,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '1.0',
         atomicBalance: BigNumber.from('1000000000000000000'),
+        assetId: 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
       });
     });
   });
@@ -279,6 +287,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '1.0',
         atomicBalance: BigNumber.from('1000000000000000000'),
+        assetId: 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
       });
     });
   });
@@ -299,6 +308,7 @@ describe('useLatestBalance', () => {
     expect(result.current).toEqual({
       displayBalance: '5.5',
       atomicBalance: BigNumber.from('5500000'),
+      assetId: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
     });
 
     // After fetching it should update to the fetched balance
@@ -306,6 +316,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '1.0',
         atomicBalance: BigNumber.from('1000000'),
+        assetId: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
       });
     });
   });
@@ -327,6 +338,7 @@ describe('useLatestBalance', () => {
     expect(result.current).toEqual({
       displayBalance: '10.0',
       atomicBalance: BigNumber.from('10000000000000000000'),
+      assetId: undefined,
     });
   });
 
@@ -351,6 +363,7 @@ describe('useLatestBalance', () => {
     expect(result.current).toEqual({
       displayBalance: '100.0',
       atomicBalance: BigNumber.from('100000000000'),
+      assetId: undefined,
     });
   });
 
@@ -372,6 +385,8 @@ describe('useLatestBalance', () => {
     expect(result.current).toEqual({
       displayBalance: '50.0',
       atomicBalance: BigNumber.from('50000000000000000000'),
+      assetId:
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:0x1234567890123456789012345678901234567890',
     });
   });
 
@@ -401,6 +416,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '100.0',
         atomicBalance: BigNumber.from('100000000000000000000'),
+        assetId: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
       });
     });
 
@@ -427,6 +443,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '50.0',
         atomicBalance: BigNumber.from('50000000000000000000'),
+        assetId: 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
       });
     });
 
@@ -447,6 +464,7 @@ describe('useLatestBalance', () => {
         expect(result.current).toEqual({
           displayBalance: '1.0',
           atomicBalance: BigNumber.from('1000000'),
+          assetId: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
         });
       });
     });
@@ -474,6 +492,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '25.0',
         atomicBalance: BigNumber.from('25000000000000000000'),
+        assetId: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
       });
     });
 
@@ -523,6 +542,7 @@ describe('useLatestBalance', () => {
       expect(resultAfterSwitch.current).toEqual({
         displayBalance: '10.0',
         atomicBalance: BigNumber.from('10000000000000000000'),
+        assetId: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
       });
     });
   });
@@ -622,6 +642,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '0',
         atomicBalance: BigNumber.from('0'),
+        assetId: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
       });
     });
 
@@ -658,6 +679,7 @@ describe('useLatestBalance', () => {
       expect(result.current).toEqual({
         displayBalance: '0.000000000000000001',
         atomicBalance: BigNumber.from('1'),
+        assetId: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
       });
     });
   });


### PR DESCRIPTION
## **Description**

When switching between Solana tokens in the Bridge/Swaps UI, selecting a token with zero or undefined balance would incorrectly display the previous token's balance. This was caused by stale state not being cleared when switching tokens, and a truthiness check that failed for "0" balance.

## **Changelog**

CHANGELOG entry: Fixed a bug where switching Solana tokens showed incorrect balance

## **Related issues**

Fixes: SWAPS-3686

## **Manual testing steps**

```gherkin
Feature: Solana token balance display

  Scenario: user switches to a token with zero balance
    Given user is on Bridge/Swaps with Solana network selected
    And user has selected a token with non-zero balance

    When user switches to a different token with zero balance
    Then the balance should show zero (not the previous token's balance)
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A - requires manual testing -->


https://github.com/user-attachments/assets/56bfa669-e086-49c3-bf16-da537422004b



### **After**

<!-- N/A - requires manual testing -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.