### PR TITLE
refactor(perps): differentiate screen_type for perps screen viewed events

### DIFF
--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -178,7 +178,7 @@ const PerpsHomeView = () => {
     conditions: [!isAnyLoading],
     properties: {
       [PerpsEventProperties.SCREEN_TYPE]:
-        PerpsEventValues.SCREEN_TYPE.HOMESCREEN,
+        PerpsEventValues.SCREEN_TYPE.PERPS_HOME,
       [PerpsEventProperties.SOURCE]: source,
       [PerpsEventProperties.HAS_PERP_BALANCE]: hasPerpBalance,
       ...(buttonClicked && {

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -92,7 +92,7 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
     ],
     properties: {
       [PerpsEventProperties.SCREEN_TYPE]:
-        PerpsEventValues.SCREEN_TYPE.HOMESCREEN,
+        PerpsEventValues.SCREEN_TYPE.WALLET_HOME_PERPS_TAB,
       [PerpsEventProperties.OPEN_POSITION]: positions?.length || 0,
     },
   });

--- a/app/components/UI/Perps/constants/eventNames.ts
+++ b/app/components/UI/Perps/constants/eventNames.ts
@@ -245,7 +245,9 @@ export const PerpsEventValues = {
     MARKET_LIST: 'market_list',
     ASSET_DETAILS: 'asset_details',
     TRADING: 'trading',
-    HOMESCREEN: 'homescreen',
+    HOMESCREEN: 'homescreen', // Legacy - use WALLET_HOME_PERPS_TAB or PERPS_HOME instead
+    WALLET_HOME_PERPS_TAB: 'wallet_home_perps_tab',
+    PERPS_HOME: 'perps_home',
     POSITION_CLOSE: 'position_close',
     LEVERAGE: 'leverage',
     TUTORIAL: 'tutorial',


### PR DESCRIPTION
## **Description**

Previously, both `PerpsTabView` (the Perps tab on wallet home screen) and `PerpsHomeView` (the dedicated Perps home screen) were using the same `screen_type` value (`homescreen`) for `PERPS_SCREEN_VIEWED` analytics events. This made it impossible to distinguish between the two screens in analytics dashboards.

This PR introduces two distinct screen type values:
- `wallet_home_perps_tab` - Used when viewing the Perps tab within the wallet home screen
- `perps_home` - Used when viewing the full dedicated Perps home screen

The legacy `HOMESCREEN` value is preserved with a comment indicating it should not be used for new implementations.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1835

## **Manual testing steps**

```gherkin
Feature: Perps screen analytics differentiation

  Scenario: user views Perps tab on wallet home
    Given user is on the wallet home screen
    When user taps on the Perps tab
    Then PERPS_SCREEN_VIEWED event is fired with screen_type: "wallet_home_perps_tab"

  Scenario: user navigates to Perps home screen
    Given user is on any screen in the app
    When user navigates to the Perps home screen (via manage balance or navigation)
    Then PERPS_SCREEN_VIEWED event is fired with screen_type: "perps_home"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Separates analytics tracking to uniquely identify Perps views across app surfaces.
> 
> - Updates `PerpsTabView` to emit `PERPS_SCREEN_VIEWED` with `screen_type` `wallet_home_perps_tab`
> - Updates `PerpsHomeView` to emit `PERPS_SCREEN_VIEWED` with `screen_type` `perps_home`
> - Extends `constants/eventNames.ts` with `WALLET_HOME_PERPS_TAB` and `PERPS_HOME`; marks `HOMESCREEN` as legacy
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3fbd9797ee4e99fcdadb0f1292b77768d74d8b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->