### PR TITLE
feat: rewards end of season metal card claim

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -126,6 +126,7 @@ import RewardsBottomSheetModal from '../../UI/Rewards/components/RewardsBottomSh
 import RewardsClaimBottomSheetModal from '../../UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal';
 import RewardOptInAccountGroupModal from '../../UI/Rewards/components/Settings/RewardOptInAccountGroupModal';
 import ReferralBottomSheetModal from '../../UI/Rewards/components/ReferralBottomSheetModal';
+import MetalCardClaimBottomSheet from '../../UI/Rewards/components/MetalCardClaimBottomSheet/MetalCardClaimBottomSheet';
 import { selectRewardsSubscriptionId } from '../../../selectors/rewards';
 import { getImportTokenNavbarOptions } from '../../UI/Navbar';
 import {
@@ -277,6 +278,10 @@ const RewardsHome = () => (
     <Stack.Screen
       name={Routes.MODAL.REWARDS_REFERRAL_BOTTOM_SHEET_MODAL}
       component={ReferralBottomSheetModal}
+    />
+    <Stack.Screen
+      name={Routes.MODAL.REWARDS_METAL_CARD_CLAIM_BOTTOM_SHEET}
+      component={MetalCardClaimBottomSheet}
     />
   </Stack.Navigator>
 );

--- a/app/components/UI/Rewards/components/MetalCardClaimBottomSheet/MetalCardClaimBottomSheet.test.tsx
+++ b/app/components/UI/Rewards/components/MetalCardClaimBottomSheet/MetalCardClaimBottomSheet.test.tsx
@@ -1,0 +1,582 @@
+import React, { ReactNode } from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import MetalCardClaimBottomSheet from './MetalCardClaimBottomSheet';
+
+// Mock useClaimReward hook
+const mockClaimReward = jest.fn();
+const mockClearClaimRewardError = jest.fn();
+
+const mockUseClaimRewardState: {
+  claimReward: jest.Mock;
+  isClaimingReward: boolean;
+  claimRewardError: string | undefined;
+  clearClaimRewardError: jest.Mock;
+} = {
+  claimReward: mockClaimReward,
+  isClaimingReward: false,
+  claimRewardError: undefined,
+  clearClaimRewardError: mockClearClaimRewardError,
+};
+
+jest.mock('../../hooks/useClaimReward', () => ({
+  __esModule: true,
+  default: () => mockUseClaimRewardState,
+}));
+
+// Mock useRewardsToast hook
+const mockShowToast = jest.fn();
+const mockSuccessToast = jest.fn().mockReturnValue({
+  variant: 'icon',
+  iconName: 'confirmation',
+});
+
+jest.mock('../../hooks/useRewardsToast', () => ({
+  __esModule: true,
+  default: () => ({
+    showToast: mockShowToast,
+    RewardsToastOptions: {
+      success: mockSuccessToast,
+    },
+  }),
+}));
+
+// Mock navigation
+const mockGoBack = jest.fn();
+const mockNavigation = {
+  goBack: mockGoBack,
+};
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => mockNavigation,
+}));
+
+// Mock useMetrics hook
+const mockTrackEvent = jest.fn();
+const mockCreateEventBuilder = jest.fn(() => ({
+  addProperties: jest.fn().mockReturnThis(),
+  build: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../../../hooks/useMetrics', () => ({
+  useMetrics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+  MetaMetricsEvents: {
+    REWARDS_REWARD_VIEWED: 'REWARDS_REWARD_VIEWED',
+    REWARDS_REWARD_CLAIMED: 'REWARDS_REWARD_CLAIMED',
+  },
+}));
+
+// Mock RewardsErrorBanner
+jest.mock('../RewardsErrorBanner', () => {
+  const ReactMock = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ title, description }: { title: string; description: string }) =>
+      ReactMock.createElement(
+        View,
+        { testID: 'rewards-error-banner' },
+        ReactMock.createElement(Text, { testID: 'error-title' }, title),
+        ReactMock.createElement(
+          Text,
+          { testID: 'error-description' },
+          description,
+        ),
+      ),
+  };
+});
+
+// Mock strings
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => {
+    const translations: Record<string, string> = {
+      'rewards.metal_card_claim.title': 'Metal Card Claim',
+      'rewards.metal_card_claim.description': 'Enter your details to claim.',
+      'rewards.metal_card_claim.contact_info': 'Contact information',
+      'rewards.metal_card_claim.email_label': 'Email',
+      'rewards.metal_card_claim.telegram_label': 'Telegram (optional)',
+      'rewards.metal_card_claim.telegram_placeholder': '@username',
+      'rewards.metal_card_claim.submit_button': 'Submit',
+      'rewards.metal_card_claim.email_validation_error': 'Invalid email',
+      'rewards.unlocked_rewards.reward_claimed': 'Reward claimed!',
+      'rewards.claim_reward_error.title': 'Claim Error',
+    };
+    return translations[key] || key;
+  }),
+}));
+
+// Mock BottomSheet component
+jest.mock(
+  '../../../../../component-library/components/BottomSheets/BottomSheet',
+  () => {
+    const ReactMock = jest.requireActual('react');
+    const { View } = jest.requireActual('react-native');
+    return ReactMock.forwardRef(
+      ({ children }: { children: ReactNode }, _ref: unknown) =>
+        ReactMock.createElement(View, { testID: 'bottom-sheet' }, children),
+    );
+  },
+);
+
+// Mock BottomSheetHeader
+jest.mock(
+  '../../../../../component-library/components/BottomSheets/BottomSheetHeader',
+  () => {
+    const ReactMock = jest.requireActual('react');
+    const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: ({
+        children,
+        onClose,
+      }: {
+        children: ReactNode;
+        onClose: () => void;
+      }) =>
+        ReactMock.createElement(
+          View,
+          { testID: 'bottom-sheet-header' },
+          ReactMock.createElement(Text, null, children),
+          ReactMock.createElement(TouchableOpacity, {
+            testID: 'header-close-button',
+            onPress: onClose,
+          }),
+        ),
+    };
+  },
+);
+
+// Mock TextField component
+jest.mock('../../../../../component-library/components/Form/TextField', () => {
+  const ReactMock = jest.requireActual('react');
+  const { TextInput } = jest.requireActual('react-native');
+
+  const MockTextFieldComponent = (props: {
+    placeholder?: string;
+    onChangeText: (text: string) => void;
+    value: string;
+    isError?: boolean;
+    isDisabled?: boolean;
+    keyboardType?: string;
+  }) =>
+    ReactMock.createElement(TextInput, {
+      testID:
+        props.keyboardType === 'email-address'
+          ? 'email-input'
+          : 'telegram-input',
+      placeholder: props.placeholder,
+      onChangeText: props.onChangeText,
+      value: props.value,
+      'data-error': props.isError,
+      editable: !props.isDisabled,
+    });
+
+  return {
+    __esModule: true,
+    default: MockTextFieldComponent,
+    TextFieldSize: {
+      Lg: 'lg',
+    },
+  };
+});
+
+// Mock design system components
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactMock = jest.requireActual('react');
+  const {
+    View,
+    Text: RNText,
+    TouchableOpacity,
+  } = jest.requireActual('react-native');
+  return {
+    ButtonVariant: {
+      Primary: 'primary',
+      Secondary: 'secondary',
+    },
+    ButtonSize: {
+      Lg: 'lg',
+    },
+    BoxFlexDirection: {
+      Column: 'column',
+    },
+    BoxAlignItems: {
+      Start: 'start',
+      Center: 'center',
+    },
+    BoxJustifyContent: {
+      Center: 'center',
+    },
+    TextVariant: {
+      BodyMd: 'bodyMd',
+      BodySm: 'bodySm',
+    },
+    Box: ({ children, ...props }: { children: ReactNode }) =>
+      ReactMock.createElement(View, props, children),
+    Button: ({
+      children,
+      onPress,
+      disabled,
+      isLoading,
+    }: {
+      children: ReactNode;
+      onPress: () => void;
+      disabled: boolean;
+      isLoading?: boolean;
+    }) =>
+      ReactMock.createElement(
+        TouchableOpacity,
+        {
+          testID: 'submit-button',
+          onPress,
+          disabled,
+          'data-loading': isLoading,
+          accessibilityState: disabled ? { disabled: true } : undefined,
+        },
+        ReactMock.createElement(RNText, null, children),
+      ),
+    Text: ({ children, ...props }: { children: ReactNode }) =>
+      ReactMock.createElement(RNText, props, children),
+  };
+});
+
+// Mock useTailwind
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({
+    style: jest.fn().mockImplementation((...args: unknown[]) => ({ ...args })),
+  }),
+}));
+
+// Mock KeyboardAwareScrollView
+jest.mock('react-native-keyboard-aware-scroll-view', () => {
+  const ReactMock = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    KeyboardAwareScrollView: ({ children }: { children: ReactNode }) =>
+      ReactMock.createElement(View, { testID: 'keyboard-scroll' }, children),
+  };
+});
+
+// Mock validateEmail
+jest.mock('../../utils/formatUtils', () => ({
+  validateEmail: jest.fn((email: string) =>
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email),
+  ),
+}));
+
+interface TestRouteParams {
+  rewardId: string;
+  seasonRewardId: string;
+}
+
+const defaultRoute: { params: TestRouteParams } = {
+  params: {
+    rewardId: 'reward-123',
+    seasonRewardId: 'season-reward-1',
+  },
+};
+
+describe('MetalCardClaimBottomSheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseClaimRewardState.isClaimingReward = false;
+    mockUseClaimRewardState.claimRewardError = undefined;
+  });
+
+  describe('rendering', () => {
+    it('renders the bottom sheet', () => {
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('bottom-sheet')).toBeOnTheScreen();
+    });
+
+    it('renders the header with title', () => {
+      const { getByTestId, getByText } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('bottom-sheet-header')).toBeOnTheScreen();
+      expect(getByText('Metal Card Claim')).toBeOnTheScreen();
+    });
+
+    it('renders email and telegram input fields', () => {
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('email-input')).toBeOnTheScreen();
+      expect(getByTestId('telegram-input')).toBeOnTheScreen();
+    });
+
+    it('renders the submit button', () => {
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('submit-button')).toBeOnTheScreen();
+    });
+  });
+
+  describe('email input', () => {
+    it('updates email value when typing', () => {
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const emailInput = getByTestId('email-input');
+      fireEvent.changeText(emailInput, 'test@example.com');
+
+      expect(emailInput.props.value).toBe('test@example.com');
+    });
+
+    it('displays validation error for email without domain', async () => {
+      const { getByTestId, getByText } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const emailInput = getByTestId('email-input');
+      fireEvent.changeText(emailInput, 'invalidemail');
+
+      const submitButton = getByTestId('submit-button');
+      await act(async () => {
+        fireEvent.press(submitButton);
+      });
+
+      expect(getByText('Invalid email')).toBeOnTheScreen();
+    });
+
+    it('clears validation error when editing email', async () => {
+      const { getByTestId, getByText, queryByText } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const emailInput = getByTestId('email-input');
+      fireEvent.changeText(emailInput, 'invalid');
+
+      const submitButton = getByTestId('submit-button');
+      await act(async () => {
+        fireEvent.press(submitButton);
+      });
+
+      expect(getByText('Invalid email')).toBeOnTheScreen();
+
+      fireEvent.changeText(emailInput, 'test@example.com');
+
+      expect(queryByText('Invalid email')).toBeNull();
+    });
+  });
+
+  describe('telegram input', () => {
+    it('updates telegram value when typing', () => {
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const telegramInput = getByTestId('telegram-input');
+      fireEvent.changeText(telegramInput, '@user123');
+
+      expect(telegramInput.props.value).toBe('@user123');
+    });
+  });
+
+  describe('claim reward flow', () => {
+    it('calls claimReward with email when submitting', async () => {
+      mockClaimReward.mockResolvedValue(undefined);
+
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const emailInput = getByTestId('email-input');
+      fireEvent.changeText(emailInput, 'test@example.com');
+
+      const submitButton = getByTestId('submit-button');
+      await act(async () => {
+        fireEvent.press(submitButton);
+      });
+
+      expect(mockClaimReward).toHaveBeenCalledWith('reward-123', {
+        data: {
+          email: 'test@example.com',
+        },
+      });
+    });
+
+    it('includes telegram handle in claim data when provided', async () => {
+      mockClaimReward.mockResolvedValue(undefined);
+
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const emailInput = getByTestId('email-input');
+      fireEvent.changeText(emailInput, 'test@example.com');
+
+      const telegramInput = getByTestId('telegram-input');
+      fireEvent.changeText(telegramInput, '@user123');
+
+      const submitButton = getByTestId('submit-button');
+      await act(async () => {
+        fireEvent.press(submitButton);
+      });
+
+      expect(mockClaimReward).toHaveBeenCalledWith('reward-123', {
+        data: {
+          email: 'test@example.com',
+          telegramHandle: '@user123',
+        },
+      });
+    });
+
+    it('closes modal and shows toast on successful claim', async () => {
+      mockClaimReward.mockResolvedValue(undefined);
+
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const emailInput = getByTestId('email-input');
+      fireEvent.changeText(emailInput, 'test@example.com');
+
+      const submitButton = getByTestId('submit-button');
+      await act(async () => {
+        fireEvent.press(submitButton);
+      });
+
+      expect(mockGoBack).toHaveBeenCalled();
+      expect(mockShowToast).toHaveBeenCalled();
+    });
+
+    it('keeps modal open when claim fails', async () => {
+      mockClaimReward.mockRejectedValue(new Error('Claim failed'));
+
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const emailInput = getByTestId('email-input');
+      fireEvent.changeText(emailInput, 'test@example.com');
+
+      const submitButton = getByTestId('submit-button');
+      await act(async () => {
+        fireEvent.press(submitButton);
+      });
+
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loading and error states', () => {
+    it('disables submit button when claiming reward', () => {
+      mockUseClaimRewardState.isClaimingReward = true;
+
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const submitButton = getByTestId('submit-button');
+      expect(submitButton).toBeDisabled();
+    });
+
+    it('shows loading state when claiming reward', () => {
+      mockUseClaimRewardState.isClaimingReward = true;
+
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const submitButton = getByTestId('submit-button');
+      expect(submitButton.props['data-loading']).toBe(true);
+    });
+
+    it('displays error banner when claim fails', () => {
+      mockUseClaimRewardState.claimRewardError = 'Something went wrong';
+
+      const { getByTestId, getByText } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('rewards-error-banner')).toBeOnTheScreen();
+      expect(getByText('Something went wrong')).toBeOnTheScreen();
+    });
+
+    it('hides error banner when loading', () => {
+      mockUseClaimRewardState.isClaimingReward = true;
+      mockUseClaimRewardState.claimRewardError = 'Something went wrong';
+
+      const { queryByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      expect(queryByTestId('rewards-error-banner')).toBeNull();
+    });
+
+    it('disables input fields when claiming reward', () => {
+      mockUseClaimRewardState.isClaimingReward = true;
+
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const emailInput = getByTestId('email-input');
+      const telegramInput = getByTestId('telegram-input');
+
+      expect(emailInput.props.editable).toBe(false);
+      expect(telegramInput.props.editable).toBe(false);
+    });
+  });
+
+  describe('navigation', () => {
+    it('calls goBack when header close button pressed', () => {
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const closeButton = getByTestId('header-close-button');
+      fireEvent.press(closeButton);
+
+      expect(mockGoBack).toHaveBeenCalled();
+    });
+  });
+
+  describe('analytics tracking', () => {
+    it('tracks reward viewed event on mount', () => {
+      render(<MetalCardClaimBottomSheet route={defaultRoute} />);
+
+      expect(mockTrackEvent).toHaveBeenCalled();
+      expect(mockCreateEventBuilder).toHaveBeenCalled();
+    });
+
+    it('tracks reward viewed event only once on re-renders', () => {
+      const { rerender } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      rerender(<MetalCardClaimBottomSheet route={defaultRoute} />);
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('tracks reward claimed event on successful claim', async () => {
+      mockClaimReward.mockResolvedValue(undefined);
+
+      const { getByTestId } = render(
+        <MetalCardClaimBottomSheet route={defaultRoute} />,
+      );
+
+      const emailInput = getByTestId('email-input');
+      fireEvent.changeText(emailInput, 'test@example.com');
+
+      const submitButton = getByTestId('submit-button');
+      await act(async () => {
+        fireEvent.press(submitButton);
+      });
+
+      // First call is REWARD_VIEWED on mount, second is REWARD_CLAIMED
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/app/components/UI/Rewards/components/MetalCardClaimBottomSheet/MetalCardClaimBottomSheet.tsx
+++ b/app/components/UI/Rewards/components/MetalCardClaimBottomSheet/MetalCardClaimBottomSheet.tsx
@@ -1,0 +1,279 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useNavigation } from '@react-navigation/native';
+import {
+  BoxFlexDirection,
+  ButtonVariant,
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Button,
+  ButtonSize,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import { strings } from '../../../../../../locales/i18n';
+import TextField, {
+  TextFieldSize,
+} from '../../../../../component-library/components/Form/TextField';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import useClaimReward from '../../hooks/useClaimReward';
+import useRewardsToast from '../../hooks/useRewardsToast';
+import RewardsErrorBanner from '../RewardsErrorBanner';
+import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
+import { ClaimRewardDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
+import { validateEmail } from '../../utils/formatUtils';
+
+interface MetalCardClaimBottomSheetProps {
+  route: {
+    params: {
+      rewardId: string;
+      seasonRewardId: string;
+    };
+  };
+}
+
+/**
+ * Bottom sheet modal for claiming MetaMask Metal Card rewards.
+ * Users provide their email and telegram contact info to claim the reward.
+ */
+const MetalCardClaimBottomSheet = ({
+  route,
+}: MetalCardClaimBottomSheetProps) => {
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const navigation = useNavigation();
+  const tw = useTailwind();
+  const { showToast: showRewardsToast, RewardsToastOptions } =
+    useRewardsToast();
+  const { claimReward, isClaimingReward, claimRewardError } = useClaimReward();
+  const { trackEvent, createEventBuilder } = useMetrics();
+
+  const [email, setEmail] = useState('');
+  const [telegram, setTelegram] = useState('');
+  const [emailValidationError, setEmailValidationError] = useState(false);
+
+  const { rewardId, seasonRewardId } = route.params;
+  const title = strings('rewards.metal_card_claim.title');
+  const hasTrackedRewardViewed = useRef(false);
+
+  const handleEmailChange = useCallback((text: string) => {
+    setEmail(text);
+    setEmailValidationError(false);
+  }, []);
+
+  const handleModalClose = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const showToast = useCallback(() => {
+    showRewardsToast(
+      RewardsToastOptions.success(
+        strings('rewards.unlocked_rewards.reward_claimed'),
+        title,
+      ),
+    );
+  }, [RewardsToastOptions, showRewardsToast, title]);
+
+  useEffect(() => {
+    if (!hasTrackedRewardViewed.current) {
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.REWARDS_REWARD_VIEWED)
+          .addProperties({
+            reward_id: seasonRewardId,
+            reward_name: title,
+          })
+          .build(),
+      );
+      hasTrackedRewardViewed.current = true;
+    }
+  }, [trackEvent, createEventBuilder, seasonRewardId, title]);
+
+  const handleClaimReward = useCallback(async () => {
+    // Validate email before submitting
+    if (!validateEmail(email.trim())) {
+      setEmailValidationError(true);
+      return;
+    }
+
+    const claimData: ClaimRewardDto = {
+      data: {
+        email: email.trim(),
+      },
+    };
+
+    if (telegram.trim()) {
+      claimData.data = {
+        ...claimData.data,
+        telegramHandle: telegram.trim(),
+      };
+    }
+
+    try {
+      await claimReward(rewardId, claimData);
+
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.REWARDS_REWARD_CLAIMED)
+          .addProperties({
+            reward_id: seasonRewardId,
+            reward_name: title,
+          })
+          .build(),
+      );
+
+      handleModalClose();
+      showToast();
+    } catch {
+      // keep modal open to display error message
+    }
+  }, [
+    claimReward,
+    handleModalClose,
+    email,
+    telegram,
+    rewardId,
+    seasonRewardId,
+    title,
+    showToast,
+    trackEvent,
+    createEventBuilder,
+  ]);
+
+  const confirmAction = useMemo(
+    () => ({
+      label: strings('rewards.metal_card_claim.submit_button'),
+      onPress: handleClaimReward,
+      variant: ButtonVariant.Primary,
+      loading: isClaimingReward,
+      disabled: isClaimingReward,
+    }),
+    [handleClaimReward, isClaimingReward],
+  );
+
+  const renderError = () => {
+    if (claimRewardError && !isClaimingReward) {
+      return (
+        <Box twClassName="w-full mb-4">
+          <RewardsErrorBanner
+            title={strings('rewards.claim_reward_error.title')}
+            description={claimRewardError}
+          />
+        </Box>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <BottomSheet ref={sheetRef} keyboardAvoidingViewEnabled={false}>
+      <BottomSheetHeader onClose={handleModalClose}>{title}</BottomSheetHeader>
+      <KeyboardAwareScrollView
+        keyboardShouldPersistTaps="handled"
+        enableOnAndroid
+        extraScrollHeight={20}
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Column}
+          alignItems={BoxAlignItems.Start}
+          justifyContent={BoxJustifyContent.Center}
+          twClassName="px-4 pb-4"
+        >
+          {/* Description */}
+          <Box twClassName="w-full mb-4">
+            <Text
+              variant={TextVariant.BodyMd}
+              twClassName="text-text-alternative"
+            >
+              {strings('rewards.metal_card_claim.description')}
+            </Text>
+          </Box>
+
+          {/* Contact Info */}
+          <Box twClassName="w-full mb-4">
+            <Text
+              variant={TextVariant.BodyMd}
+              twClassName="text-text-alternative"
+            >
+              {strings('rewards.metal_card_claim.contact_info')}
+            </Text>
+          </Box>
+
+          {/* Email Input */}
+          <Box twClassName="w-full mb-4">
+            <Text variant={TextVariant.BodyMd} twClassName="mb-2">
+              {strings('rewards.metal_card_claim.email_label')}
+            </Text>
+            <TextField
+              textAlignVertical="center"
+              textAlign="left"
+              onChangeText={handleEmailChange}
+              value={email}
+              isError={emailValidationError}
+              size={TextFieldSize.Lg}
+              style={tw.style('bg-background-pressed')}
+              keyboardType="email-address"
+              autoCapitalize="none"
+              isDisabled={isClaimingReward}
+            />
+            {emailValidationError && (
+              <Text
+                variant={TextVariant.BodySm}
+                twClassName="text-error-default mt-1"
+              >
+                {strings('rewards.metal_card_claim.email_validation_error')}
+              </Text>
+            )}
+          </Box>
+
+          {/* Telegram Input */}
+          <Box twClassName="w-full mb-6">
+            <Text variant={TextVariant.BodyMd} twClassName="mb-2">
+              {strings('rewards.metal_card_claim.telegram_label')}
+            </Text>
+            <TextField
+              textAlignVertical="center"
+              textAlign="left"
+              placeholder={strings(
+                'rewards.metal_card_claim.telegram_placeholder',
+              )}
+              onChangeText={setTelegram}
+              value={telegram}
+              size={TextFieldSize.Lg}
+              style={tw.style('bg-background-pressed')}
+              autoCapitalize="none"
+              isDisabled={isClaimingReward}
+            />
+          </Box>
+
+          {/* Error Banner */}
+          {renderError()}
+
+          {/* Submit Button */}
+          <Box twClassName="w-full">
+            <Button
+              variant={confirmAction.variant}
+              size={ButtonSize.Lg}
+              onPress={confirmAction.onPress}
+              disabled={confirmAction.disabled}
+              isLoading={confirmAction.loading}
+              twClassName="w-full"
+            >
+              {confirmAction.label}
+            </Button>
+          </Box>
+        </Box>
+      </KeyboardAwareScrollView>
+    </BottomSheet>
+  );
+};
+
+export default MetalCardClaimBottomSheet;

--- a/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.test.tsx
+++ b/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.test.tsx
@@ -236,13 +236,22 @@ jest.mock('../RewardItem/RewardItem', () => {
     default: ({
       seasonReward,
       testID,
+      isLocked,
+      isEndOfSeasonReward,
+      canPressToNavigateToInfo,
     }: {
       seasonReward: SeasonRewardDto;
       testID?: string;
+      isLocked?: boolean;
+      isEndOfSeasonReward?: boolean;
+      canPressToNavigateToInfo?: boolean;
     }) =>
       ReactActual.createElement(
         View,
-        { testID: testID || 'reward-item' },
+        {
+          testID: testID || 'reward-item',
+          accessibilityLabel: `isLocked:${isLocked},isEndOfSeasonReward:${isEndOfSeasonReward},canPressToNavigateToInfo:${canPressToNavigateToInfo}`,
+        },
         ReactActual.createElement(Text, {}, seasonReward.name),
       ),
   };
@@ -835,5 +844,60 @@ describe('PreviousSeasonUnlockedRewards', () => {
     render(<PreviousSeasonUnlockedRewards />);
 
     expect(mockHasMinimumRequiredVersion).toHaveBeenCalledWith('2.0.0');
+  });
+
+  it('passes isLocked=false to RewardItem for end of season rewards', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectUnlockedRewards) return [mockUnlockedReward1];
+      if (selector === selectUnlockedRewardLoading) return false;
+      if (selector === selectUnlockedRewardError) return false;
+      if (selector === selectSeasonTiers) return mockSeasonTiers;
+      if (selector === selectCurrentTier) return { pointsNeeded: 100 };
+      if (selector === selectSeasonShouldInstallNewVersion) return undefined;
+      return undefined;
+    });
+
+    const { getByTestId } = render(<PreviousSeasonUnlockedRewards />);
+
+    const rewardItem = getByTestId('reward-item');
+    expect(rewardItem.props.accessibilityLabel).toContain('isLocked:false');
+  });
+
+  it('passes isEndOfSeasonReward=true to RewardItem', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectUnlockedRewards) return [mockUnlockedReward1];
+      if (selector === selectUnlockedRewardLoading) return false;
+      if (selector === selectUnlockedRewardError) return false;
+      if (selector === selectSeasonTiers) return mockSeasonTiers;
+      if (selector === selectCurrentTier) return { pointsNeeded: 100 };
+      if (selector === selectSeasonShouldInstallNewVersion) return undefined;
+      return undefined;
+    });
+
+    const { getByTestId } = render(<PreviousSeasonUnlockedRewards />);
+
+    const rewardItem = getByTestId('reward-item');
+    expect(rewardItem.props.accessibilityLabel).toContain(
+      'isEndOfSeasonReward:true',
+    );
+  });
+
+  it('passes canPressToNavigateToInfo=false to RewardItem', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectUnlockedRewards) return [mockUnlockedReward1];
+      if (selector === selectUnlockedRewardLoading) return false;
+      if (selector === selectUnlockedRewardError) return false;
+      if (selector === selectSeasonTiers) return mockSeasonTiers;
+      if (selector === selectCurrentTier) return { pointsNeeded: 100 };
+      if (selector === selectSeasonShouldInstallNewVersion) return undefined;
+      return undefined;
+    });
+
+    const { getByTestId } = render(<PreviousSeasonUnlockedRewards />);
+
+    const rewardItem = getByTestId('reward-item');
+    expect(rewardItem.props.accessibilityLabel).toContain(
+      'canPressToNavigateToInfo:false',
+    );
   });
 });

--- a/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.tsx
+++ b/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.tsx
@@ -158,10 +158,10 @@ const PreviousSeasonUnlockedRewards = () => {
                           ) as SeasonRewardDto
                       }
                       canPressToNavigateToInfo={false}
-                      isLocked
                       isLast={unlockedReward === endOfSeasonRewards.at(-1)}
                       isEndOfSeasonReward
                       compact
+                      isLocked={false}
                     />
                   ))}
                 </Box>

--- a/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.tsx
+++ b/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.tsx
@@ -129,6 +129,8 @@ const PreviousSeasonUnlockedRewards = () => {
                       ?.find(
                         (sr) => sr.id === unlockedReward.seasonRewardId,
                       ) as SeasonRewardDto;
+                    const isClaimable =
+                      seasonReward?.rewardType === SeasonRewardType.METAL_CARD;
                     return (
                       <RewardItem
                         key={unlockedReward.id}
@@ -137,8 +139,8 @@ const PreviousSeasonUnlockedRewards = () => {
                         isLast={unlockedReward === endOfSeasonRewards.at(-1)}
                         isEndOfSeasonReward
                         compact
-                        isLocked={false}
-                        onPress={handleRewardPress}
+                        isLocked={!isClaimable}
+                        onPress={isClaimable ? handleRewardPress : undefined}
                       />
                     );
                   })}

--- a/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.tsx
+++ b/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.tsx
@@ -1,30 +1,17 @@
 import React, { useCallback, useMemo } from 'react';
-import { Linking, Platform } from 'react-native';
 import {
   Box,
   BoxFlexDirection,
   BoxAlignItems,
-  IconColor,
-  IconName,
-  IconSize,
   Text,
   TextVariant,
   FontWeight,
   BoxJustifyContent,
-  Icon,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import {
-  MM_APP_STORE_LINK,
-  MM_PLAY_STORE_LINK,
-} from '../../../../../constants/urls';
-import generateDeviceAnalyticsMetaData from '../../../../../util/metrics';
-import { RewardsMetricsButtons } from '../../utils';
-import { useMetrics, MetaMetricsEvents } from '../../../../hooks/useMetrics';
-import {
   selectUnlockedRewards,
   selectSeasonTiers,
-  selectSeasonShouldInstallNewVersion,
   selectUnlockedRewardLoading,
   selectUnlockedRewardError,
   selectCurrentTier,
@@ -33,6 +20,7 @@ import { useSelector } from 'react-redux';
 import {
   RewardDto,
   SeasonRewardDto,
+  SeasonRewardType,
 } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import { useUnlockedRewards } from '../../hooks/useUnlockedRewards';
 import RewardsSeasonEndedNoUnlockedRewardsImage from '../../../../../images/rewards/rewards-season-ended-no-unlocked-rewards.svg';
@@ -41,10 +29,11 @@ import { Skeleton } from '../../../../../component-library/components/Skeleton';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import RewardItem from '../RewardItem/RewardItem';
 import { useTheme } from '../../../../../util/theme';
-import { hasMinimumRequiredVersion } from '../../../../../util/remoteFeatureFlag';
+import Routes from '../../../../../constants/navigation/Routes';
+import { useNavigation } from '@react-navigation/native';
 
 const PreviousSeasonUnlockedRewards = () => {
-  const { trackEvent, createEventBuilder } = useMetrics();
+  const navigation = useNavigation();
   const { fetchUnlockedRewards } = useUnlockedRewards();
   const tw = useTailwind();
   const theme = useTheme();
@@ -53,32 +42,20 @@ const PreviousSeasonUnlockedRewards = () => {
   const unlockedRewardsError = useSelector(selectUnlockedRewardError);
   const seasonTiers = useSelector(selectSeasonTiers);
   const currentTier = useSelector(selectCurrentTier);
-  const seasonMinimumVersion = useSelector(selectSeasonShouldInstallNewVersion);
-
-  const shouldInstallNewVersion = useMemo(
-    () =>
-      seasonMinimumVersion && !hasMinimumRequiredVersion(seasonMinimumVersion),
-    [seasonMinimumVersion],
+  const handleRewardPress = useCallback(
+    (rewardId: string, seasonReward: SeasonRewardDto) => {
+      if (seasonReward.rewardType === SeasonRewardType.METAL_CARD) {
+        navigation.navigate(
+          Routes.MODAL.REWARDS_METAL_CARD_CLAIM_BOTTOM_SHEET,
+          {
+            rewardId,
+            seasonRewardId: seasonReward.id,
+          },
+        );
+      }
+    },
+    [navigation],
   );
-
-  const openAppStore = useCallback(() => {
-    const storeUrl =
-      Platform.OS === 'ios' ? MM_APP_STORE_LINK : MM_PLAY_STORE_LINK;
-
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED)
-        .addProperties({
-          ...generateDeviceAnalyticsMetaData(),
-          button_type: RewardsMetricsButtons.VISIT_APP_STORE,
-          store_url: storeUrl,
-        })
-        .build(),
-    );
-
-    Linking.openURL(storeUrl).catch((error) => {
-      console.warn('Error opening MetaMask store:', error);
-    });
-  }, [trackEvent, createEventBuilder]);
 
   const endOfSeasonRewards = useMemo(() => {
     if (unlockedRewards != null && unlockedRewards !== undefined) {
@@ -146,74 +123,25 @@ const PreviousSeasonUnlockedRewards = () => {
                 twClassName="gap-4 w-full"
               >
                 <Box twClassName="flex-col">
-                  {endOfSeasonRewards?.map((unlockedReward: RewardDto) => (
-                    <RewardItem
-                      key={unlockedReward.id}
-                      reward={unlockedReward}
-                      seasonReward={
-                        seasonTiers
-                          ?.flatMap((tier) => tier.rewards)
-                          ?.find(
-                            (sr) => sr.id === unlockedReward.seasonRewardId,
-                          ) as SeasonRewardDto
-                      }
-                      canPressToNavigateToInfo={false}
-                      isLast={unlockedReward === endOfSeasonRewards.at(-1)}
-                      isEndOfSeasonReward
-                      compact
-                      isLocked={false}
-                    />
-                  ))}
-                </Box>
-
-                <Box twClassName="flex-row justify-center items-center w-full">
-                  <Icon
-                    name={
-                      shouldInstallNewVersion
-                        ? IconName.Danger
-                        : IconName.Question
-                    }
-                    size={IconSize.Sm}
-                    color={IconColor.IconAlternative}
-                  />
-                  <Text
-                    variant={TextVariant.BodySm}
-                    twClassName="text-alternative ml-1"
-                  >
-                    {shouldInstallNewVersion ? (
-                      <>
-                        <Text
-                          variant={TextVariant.BodySm}
-                          twClassName="text-alternative underline"
-                          onPress={openAppStore}
-                        >
-                          {strings(
-                            'rewards.previous_season_summary.update_metamask_version',
-                            {
-                              version: seasonMinimumVersion,
-                            },
-                          )}
-                        </Text>
-                        <Text
-                          variant={TextVariant.BodySm}
-                          twClassName="text-alternative"
-                        >
-                          {strings(
-                            'rewards.previous_season_summary.to_claim_rewards',
-                          )}
-                        </Text>
-                      </>
-                    ) : (
-                      <Text
-                        variant={TextVariant.BodySm}
-                        twClassName="text-alternative"
-                      >
-                        {strings(
-                          'rewards.previous_season_summary.check_back_soon',
-                        )}
-                      </Text>
-                    )}
-                  </Text>
+                  {endOfSeasonRewards?.map((unlockedReward: RewardDto) => {
+                    const seasonReward = seasonTiers
+                      ?.flatMap((tier) => tier.rewards)
+                      ?.find(
+                        (sr) => sr.id === unlockedReward.seasonRewardId,
+                      ) as SeasonRewardDto;
+                    return (
+                      <RewardItem
+                        key={unlockedReward.id}
+                        reward={unlockedReward}
+                        seasonReward={seasonReward}
+                        isLast={unlockedReward === endOfSeasonRewards.at(-1)}
+                        isEndOfSeasonReward
+                        compact
+                        isLocked={false}
+                        onPress={handleRewardPress}
+                      />
+                    );
+                  })}
                 </Box>
               </Box>
             ) : (

--- a/app/components/UI/Rewards/utils/formatUtils.test.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.test.ts
@@ -11,6 +11,7 @@ import {
   formatUTCDate,
   formatRewardsMusdDepositPayloadDate,
   resolveTemplate,
+  validateEmail,
 } from './formatUtils';
 import { IconName } from '@metamask/design-system-react-native';
 import { getTimeDifferenceFromNow } from '../../../../util/date';
@@ -247,7 +248,7 @@ describe('formatUtils', () => {
       expect(result).toBe('1m');
     });
 
-    it('returns hours and minutes when days are zero', () => {
+    it('returns hours and minutes with double-digit values when days are zero', () => {
       // Given: 0 days, 12 hours, 30 minutes remaining
       mockGetTimeDifferenceFromNow.mockReturnValue({
         days: 0,
@@ -260,7 +261,7 @@ describe('formatUtils', () => {
       // When: formatting time remaining
       const result = formatTimeRemaining(endDate);
 
-      // Then: should return hours and minutes format
+      // Then: returns hours and minutes format
       expect(result).toBe('12h 30m');
     });
 
@@ -1178,6 +1179,24 @@ describe('formatUtils', () => {
       expect(resolveTemplate(template, values)).toBe(
         'Static string with no tokens',
       );
+    });
+  });
+
+  describe('validateEmail', () => {
+    it('returns true for valid email with standard format', () => {
+      const email = 'user@example.com';
+
+      const result = validateEmail(email);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false for email missing domain after @', () => {
+      const email = 'user@';
+
+      const result = validateEmail(email);
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -179,3 +179,11 @@ export const resolveTemplate = (
     /\${(\w+)}/g,
     (match, placeholder) => values[placeholder] || match,
   );
+
+const emailRegex =
+  /^[-!#$%&'*+/0-9=?A-Z^_a-z`{|}~](\.?[-!#$%&'*+/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
+
+export const validateEmail = (email: string): boolean => {
+  if (!email || email.split('@').length !== 2) return false;
+  return emailRegex.test(email);
+};

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -114,7 +114,7 @@ const Routes = {
     REWARDS_INTRO_MODAL: 'RewardsIntroModal',
     REWARDS_OPTIN_ACCOUNT_GROUP_MODAL: 'RewardOptInAccountGroupModal',
     REWARDS_REFERRAL_BOTTOM_SHEET_MODAL: 'RewardsReferralBottomSheetModal',
-    OTA_UPDATES_MODAL: 'OTAUpdatesModal',
+    REWARDS_METAL_CARD_CLAIM_BOTTOM_SHEET: 'MetalCardClaimBottomSheet',
   },
   ONBOARDING: {
     ROOT_NAV: 'OnboardingRootNav',

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -114,6 +114,7 @@ const Routes = {
     REWARDS_INTRO_MODAL: 'RewardsIntroModal',
     REWARDS_OPTIN_ACCOUNT_GROUP_MODAL: 'RewardOptInAccountGroupModal',
     REWARDS_REFERRAL_BOTTOM_SHEET_MODAL: 'RewardsReferralBottomSheetModal',
+    OTA_UPDATES_MODAL: 'OTAUpdatesModal',
     REWARDS_METAL_CARD_CLAIM_BOTTOM_SHEET: 'MetalCardClaimBottomSheet',
   },
   ONBOARDING: {

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -443,6 +443,7 @@ export interface SeasonRewardDto {
   isEndOfSeasonReward?: boolean;
   endOfSeasonName?: string;
   endOfSeasonShortDescription?: string;
+  claimEndDate?: string;
 }
 
 export enum SeasonRewardType {
@@ -564,6 +565,7 @@ export type SeasonRewardDtoState = {
   isEndOfSeasonReward?: boolean;
   endOfSeasonName?: string;
   endOfSeasonShortDescription?: string;
+  claimEndDate?: string;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -451,6 +451,7 @@ export enum SeasonRewardType {
   PERPS_DISCOUNT = 'PERPS_DISCOUNT',
   POINTS_BOOST = 'POINTS_BOOST',
   ALPHA_FOX_INVITE = 'ALPHA_FOX_INVITE',
+  METAL_CARD = 'METAL_CARD',
 }
 
 export interface SeasonDto {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6901,6 +6901,16 @@
     "claim_reward_error": {
       "title": "Failed to claim reward"
     },
+    "metal_card_claim": {
+      "title": "Claim your reward",
+      "description": "The MetaMask Metal Card is subject to eligibility and isn't available in all regions. If you don't qualify, you'll receive an exclusive premium merch reward instead.",
+      "contact_info": "Share your contact info and you'll hear back within 2 weeks from @MidwitMilhouse on Telegram or christian.montoya@consensys.net.",
+      "email_label": "Email",
+      "email_validation_error": "Please enter a valid email address",
+      "telegram_label": "Telegram handle",
+      "telegram_placeholder": "Optional",
+      "submit_button": "Claim"
+    },
     "accounts_opt_in_state_error": {
       "error_fetching_title": "Accounts couldn’t be loaded",
       "error_fetching_description": "Check your connection and try again.",


### PR DESCRIPTION
## **Description**

Allows users who've reached the appropriate tier to claim the metal card reward.

## **Changelog**

CHANGELOG entry: allow metal card rewards claim when season 1 ends

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-911

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables claiming the end-of-season Metal Card reward and improves end-of-season reward UX.
> 
> - Add `MetalCardClaimBottomSheet` modal with email validation, optional Telegram handle, metrics, error banner, and success toast; register route `REWARDS_METAL_CARD_CLAIM_BOTTOM_SHEET` in navigators
> - Update `PreviousSeasonUnlockedRewards` to show Metal Card rewards as claimable and navigate to the new sheet; simplify messaging by removing store/version prompts
> - Enhance `RewardItem` with end-of-season logic: claim expiry (`claimEndDate`), time-left display, claimed/expired labels, disabled states, claim button variant/size tweaks, onPress override, and claim URL interpolation; block actions when locked/claimed/expired
> - Extend rewards types and utils: add `SeasonRewardType.METAL_CARD`, `claimEndDate` on season rewards, `validateEmail`, new i18n strings
> - Add/adjust tests for the new modal, previous season list, reward item behavior, and format utils
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cab01c3d95edc7af939a94eba1c4a27c8b4883a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->