### PR TITLE
fix: use v3 for historical prices for EVM

### DIFF
--- a/app/components/hooks/useTokenHistoricalPrices.ts
+++ b/app/components/hooks/useTokenHistoricalPrices.ts
@@ -119,11 +119,13 @@ const useTokenHistoricalPrices = ({
 
           setPrices(transformedResult);
         } else {
-          const baseUri = 'https://price.api.cx.metamask.io/v1';
+          const baseUri = 'https://price.api.cx.metamask.io/v3';
+          const decimalChainId = getDecimalChainId(chainId);
+          const caipChainId = `eip155:${decimalChainId}`;
+          // CAIP-19 format: eip155:{chainId}/erc20:{address}
+          const assetIdentifier = `erc20:${address}`;
           const uri = new URL(
-            `${baseUri}/chains/${getDecimalChainId(
-              chainId,
-            )}/historical-prices/${address}`,
+            `${baseUri}/historical-prices/${caipChainId}/${assetIdentifier}`,
           );
           uri.searchParams.set(
             'timePeriod',


### PR DESCRIPTION
## **Description**

use v3 for EVM historical prices instead of V1 price api.
Api platform team has made improvements on the v3 api; they added geckoterminal as provider for historical prices, hence it should have more coverage for prices.

## **Changelog**

CHANGELOG entry: using v3 api to get historical prices for asset details page instead of v1

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->


### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/69625f29-0394-4bcc-bec3-a553b8f2704f



### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/ea15d185-c35e-4495-b124-2b9baf1c0aef


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Switch EVM historical price fetch to v3**
> 
> - In `useTokenHistoricalPrices`, replace v1 `price.api` endpoint with v3 and change path to use CAIP-2/CAIP-19 (`eip155:{chainId}` and `erc20:{address}`) for EVM assets
> - Preserve existing query params (`timePeriod`, `vsCurrency`, optional `from`/`to`) and 204 handling; non-EVM flow unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e2fd835a7e6f7c4edc171c0eda63f2eab147d5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->