### PR TITLE
fix: android scroll issue on reveal srp bottom sheet

### DIFF
--- a/app/components/UI/SRPList/SRPList.styles.ts
+++ b/app/components/UI/SRPList/SRPList.styles.ts
@@ -7,20 +7,20 @@ import { Theme } from '../../../util/theme/models';
  *
  * @returns StyleSheet object.
  */
-const styleSheet = (params: { theme: Theme }) => {
-  const { theme } = params;
+const styleSheet = (params: { theme: Theme; vars: { maxHeight: number } }) => {
+  const {
+    theme,
+    vars: { maxHeight },
+  } = params;
   const { colors } = theme;
 
   return StyleSheet.create({
     base: {
-      display: 'flex',
-      alignItems: 'flex-start',
-      justifyContent: 'center',
-      flexShrink: 1,
       paddingVertical: 16,
       paddingHorizontal: 16,
       backgroundColor: colors.background.default,
       margin: 8,
+      maxHeight,
     },
     accountInputContainer: {
       width: '100%',
@@ -69,10 +69,11 @@ const styleSheet = (params: { theme: Theme }) => {
       gap: 16,
     },
     srpListContentContainer: {
-      display: 'flex',
-      maxWidth: '100%',
       paddingVertical: 4,
       rowGap: 16,
+    },
+    flatList: {
+      flexGrow: 0,
     },
   });
 };

--- a/app/components/UI/SRPList/SRPList.tsx
+++ b/app/components/UI/SRPList/SRPList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { FlatList, View } from 'react-native';
+import { Dimensions, View } from 'react-native';
+import { FlatList } from 'react-native-gesture-handler';
 import { strings } from '../../../../locales/i18n';
 import { SRPListProps } from './SRPList.types';
 import { useStyles } from '../../hooks/useStyles';
@@ -19,7 +20,8 @@ const SRPList = ({
   // trigger sync SRP when SRP list is shown
   useSyncSRPs();
 
-  const { styles } = useStyles(styleSheet, {});
+  const maxHeight = Dimensions.get('window').height * 0.7;
+  const { styles } = useStyles(styleSheet, { maxHeight });
   const hdKeyringsWithSnapAccounts = useHdKeyringsWithSnapAccounts();
   const { trackEvent, createEventBuilder } = useMetrics();
 
@@ -29,6 +31,7 @@ const SRPList = ({
       testID={SRPListSelectorsIDs.SRP_LIST}
     >
       <FlatList
+        style={styles.flatList}
         data={hdKeyringsWithSnapAccounts}
         contentContainerStyle={styles.srpListContentContainer}
         renderItem={({ item, index }) => (

--- a/app/components/UI/SRPList/SRPList.tsx
+++ b/app/components/UI/SRPList/SRPList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dimensions, View } from 'react-native';
+import { useWindowDimensions, View } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import { strings } from '../../../../locales/i18n';
 import { SRPListProps } from './SRPList.types';
@@ -20,7 +20,8 @@ const SRPList = ({
   // trigger sync SRP when SRP list is shown
   useSyncSRPs();
 
-  const maxHeight = Dimensions.get('window').height * 0.7;
+  const { height: windowHeight } = useWindowDimensions();
+  const maxHeight = windowHeight * 0.7;
   const { styles } = useStyles(styleSheet, { maxHeight });
   const hdKeyringsWithSnapAccounts = useHdKeyringsWithSnapAccounts();
   const { trackEvent, createEventBuilder } = useMetrics();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In the reveal SRP flow, the user cannot scroll the accounts list inside the component with the SRP once this one is expanded

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: bug fix where a user couldn't scroll through the SRP reveal bottom sheet on Android

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/19999
Jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-1366

## **Manual testing steps**

```gherkin
Feature: reveal SRP screen

  Scenario: user wants to see all of one SRP's accounts on Android
    Given user has multiple SRPs with more than 10 EVM accounts in each

    When user goes to settings > security > reveal SRP > XX accounts
    Then user is able to scroll down the list of accounts without issues
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/aa56fcd7-781d-44d1-a97a-6a853a33f32a

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves Android scrolling issues in the SRP reveal bottom sheet by constraining list height and enabling nested scrolling.
> 
> - Updates `SRPList` to use `useWindowDimensions` and pass `vars.maxHeight` (~70% of window height) to `styleSheet`
> - Adds `maxHeight` to `SRPList.styles.ts` and a `flatList` style (`flexGrow: 0`) to prevent over-expansion
> - Switches `FlatList` to `react-native-gesture-handler` and enables `scrollEnabled`/`nestedScrollEnabled`
> - Cleans up redundant flex styles in `base` and `srpListContentContainer`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5650b939b49f243e004b88ab01794d76cb5f507. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->