### PR TITLE
fix: enable Jest to force exit and detect open handles in CI

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -21,6 +21,12 @@ module.exports = {
     args: {
       $0: 'jest',
       config: 'e2e/jest.e2e.config.js',
+      // CI only: Force Jest to exit after all tests complete, preventing indefinite hangs
+      // from open handles (sockets, timers). Also detect what's keeping Jest open.
+      ...(process.env.CI && {
+        forceExit: true,
+        detectOpenHandles: true,
+      }),
     },
     detached: process.env.CI ? true : false,
     jest: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->


  - Prevent E2E tests from hanging for 30 minutes after test timeouts
  - Add diagnostic logging for open handles in CI

  ## Problem
  E2E tests that timeout (5 minutes) cause the entire workflow to hang for 30 minutes because Jest waits indefinitely for open handles (sockets, timers) to close. The test results are already determined, but Jest never exits.

  Example from logs:
  Test Suites: 1 failed, 5 passed, 6 total
  Tests:       1 failed, 9 passed, 10 total
  ...
  Jest did not exit one second after the test run has completed.
  'This usually means that there are asynchronous operations that weren't stopped in your tests.
  Then the workflow times out 25 minutes later.

  ## Solution
  Add `forceExit` and `detectOpenHandles` Jest flags in CI only:
  - `forceExit`: Forces Jest to exit after all tests complete, even with open handles
  - `detectOpenHandles`: Logs what's keeping Jest open (helps identify cleanup issues)

  These flags only apply in CI (`process.env.CI`), so local development is unaffected.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures CI E2E runs terminate promptly and provide diagnostics for lingering async handles.
> 
> - In `.detoxrc.js`, adds CI-only Jest args in `testRunner.args`: `forceExit: true` and `detectOpenHandles: true`
> - Commented to clarify CI-only behavior; local development remains unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 947ee0be3cade7118d251a9b3ae8b2618e2e8fb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->