### PR TITLE
Explore page tab behavior

### DIFF
--- a/app/components/Views/TrendingView/TrendingView.test.tsx
+++ b/app/components/Views/TrendingView/TrendingView.test.tsx
@@ -251,7 +251,11 @@ describe('TrendingView', () => {
       expect(getByText('99')).toBeOnTheScreen();
     });
 
-    it('navigates to TrendingBrowser when button is pressed', () => {
+    it('opens new tab with portfolio URL when no tabs exist', () => {
+      mockUseSelector.mockImplementation(
+        createMockSelectorImplementation({ browserTabsCount: 0 }),
+      );
+
       const { getByTestId } = render(
         <NavigationContainer>
           <TrendingView />
@@ -271,6 +275,25 @@ describe('TrendingView', () => {
           }),
         }),
       );
+    });
+
+    it('opens browser without creating new tab when tabs already exist', () => {
+      mockUseSelector.mockImplementation(
+        createMockSelectorImplementation({ browserTabsCount: 3 }),
+      );
+
+      const { getByTestId } = render(
+        <NavigationContainer>
+          <TrendingView />
+        </NavigationContainer>,
+      );
+
+      const browserButton = getByTestId('trending-view-browser-button');
+      fireEvent.press(browserButton);
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BROWSER.HOME, {
+        screen: Routes.BROWSER.VIEW,
+      });
     });
   });
 

--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -133,15 +133,23 @@ export const ExploreFeed: React.FC = () => {
   );
 
   const handleBrowserPress = useCallback(() => {
-    navigation.navigate(Routes.BROWSER.HOME, {
-      screen: Routes.BROWSER.VIEW,
-      params: {
-        newTabUrl: portfolioUrl.href,
-        timestamp: Date.now(),
-        fromTrending: true,
-      },
-    });
-  }, [navigation, portfolioUrl.href]);
+    // If there are existing tabs, just open the browser without creating a new tab
+    // Otherwise, create a new tab with the portfolio URL
+    if (browserTabsCount > 0) {
+      navigation.navigate(Routes.BROWSER.HOME, {
+        screen: Routes.BROWSER.VIEW,
+      });
+    } else {
+      navigation.navigate(Routes.BROWSER.HOME, {
+        screen: Routes.BROWSER.VIEW,
+        params: {
+          newTabUrl: portfolioUrl.href,
+          timestamp: Date.now(),
+          fromTrending: true,
+        },
+      });
+    }
+  }, [navigation, portfolioUrl.href, browserTabsCount]);
 
   const handleSearchPress = useCallback(() => {
     navigation.navigate(Routes.EXPLORE_SEARCH);


### PR DESCRIPTION
Conditionally open a new browser tab from the Explore page, only when no tabs are currently open, to provide a more intuitive user experience.

Previously, clicking the browser icon on the Explore page always opened a new tab, even if other tabs were already open. This change ensures that if tabs already exist, the browser is simply opened to the last active tab.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8471192-5fb9-4f05-a235-b56ec4b31283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e8471192-5fb9-4f05-a235-b56ec4b31283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

