### PR TITLE
fix(tron): max energy and bandwidth incorrectly set to 1 instead of 0 cp-7.61.6

### DIFF
--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/useTronResources.test.ts
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/useTronResources.test.ts
@@ -76,14 +76,14 @@ describe('useTronResources', () => {
     expect(result.current.energy).toEqual({
       type: 'energy',
       current: 0,
-      max: 1,
+      max: 0,
       percentage: 0,
     });
 
     expect(result.current.bandwidth).toEqual({
       type: 'bandwidth',
       current: 0,
-      max: 1,
+      max: 0,
       percentage: 0,
     });
   });

--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/useTronResources.ts
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/useTronResources.ts
@@ -21,8 +21,9 @@ function createResource(
   max: number,
 ): TronResource {
   const currentBN = new BigNumber(current);
-  const maxBN = new BigNumber(max);
-  const percentageBN = currentBN.dividedBy(maxBN).multipliedBy(100);
+  // Use max of 1 only for percentage calculation to avoid division by zero
+  const divisor = new BigNumber(Math.max(1, max));
+  const percentageBN = currentBN.dividedBy(divisor).multipliedBy(100);
 
   const percentage = BigNumber.min(
     100,
@@ -32,7 +33,7 @@ function createResource(
   return {
     type,
     current,
-    max,
+    max, // Keep actual max for display (can be 0)
     percentage,
   };
 }
@@ -91,12 +92,9 @@ export const useTronResources = (): {
     const maxEnergyValue = parseValue(maxEnergy?.balance);
     const maxBandwidthValue = parseValue(maxBandwidth?.balance);
 
-    const energyMax = Math.max(1, maxEnergyValue);
-    const bandwidthMax = Math.max(1, maxBandwidthValue);
-
     return {
-      energy: createResource('energy', energyCurrent, energyMax),
-      bandwidth: createResource('bandwidth', bandwidthCurrent, bandwidthMax),
+      energy: createResource('energy', energyCurrent, maxEnergyValue),
+      bandwidth: createResource('bandwidth', bandwidthCurrent, maxBandwidthValue),
     };
   }, [tronResources]);
 };

--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/useTronResources.ts
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/useTronResources.ts
@@ -94,7 +94,11 @@ export const useTronResources = (): {
 
     return {
       energy: createResource('energy', energyCurrent, maxEnergyValue),
-      bandwidth: createResource('bandwidth', bandwidthCurrent, maxBandwidthValue),
+      bandwidth: createResource(
+        'bandwidth',
+        bandwidthCurrent,
+        maxBandwidthValue,
+      ),
     };
   }, [tronResources]);
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix Tron resources calculation and default value.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Tron resource max handling and safe percentage calculation.
> 
> - `useTronResources`: passes actual `max` values (can be `0`) to `createResource`; percentage uses `Math.max(1, max)` to avoid divide-by-zero while preserving displayed `max`
> - Tests updated to expect `max: 0` when no resources exist; existing parsing and capping behaviors verified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0c7e87c866ee9cfe37628fdeabb71f3817033b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->