### PR TITLE
feat: set trending token as dest when navigating to swaps

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -1795,70 +1795,99 @@ describe('AssetOverview', () => {
 });
 
 describe('getSwapTokens', () => {
-  const mockBridgeToken = {
-    address: '0x123',
-    chainId: '0x1' as const,
-    decimals: 18,
-    symbol: 'TEST',
-    name: 'Test Token',
-    image: 'https://example.com/test.png',
-  };
-
-  it('returns native token as source and bridgeToken as dest when asset is from trending', () => {
+  it('returns native token as source and asset as dest when asset is from trending', () => {
     const trendingAsset = {
       ...asset,
       isFromTrending: true,
     };
 
-    const result = getSwapTokens(trendingAsset, mockBridgeToken);
+    const result = getSwapTokens(trendingAsset);
 
-    expect(result.sourceToken).toEqual(
-      expect.objectContaining({
-        symbol: 'ETH',
-        chainId: '0x1',
-      }),
-    );
-    expect(result.destToken).toEqual(mockBridgeToken);
+    // sourceToken is the native token for the chain
+    expect(result.sourceToken).toEqual({
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: MOCK_CHAIN_ID,
+      decimals: 18,
+      image: '',
+      name: 'Ether',
+      symbol: 'ETH',
+    });
+    // destToken is the bridgeToken built from the asset
+    expect(result.destToken).toEqual({
+      ...trendingAsset,
+      address: trendingAsset.address,
+      chainId: MOCK_CHAIN_ID,
+      decimals: trendingAsset.decimals,
+      symbol: trendingAsset.symbol,
+      name: trendingAsset.name,
+      image: trendingAsset.image,
+    });
   });
 
-  it('returns bridgeToken as source and undefined dest when asset is not from trending', () => {
+  it('returns asset as source and undefined dest when asset is not from trending', () => {
     const regularAsset = {
       ...asset,
       isFromTrending: false,
     };
 
-    const result = getSwapTokens(regularAsset, mockBridgeToken);
+    const result = getSwapTokens(regularAsset);
 
-    expect(result.sourceToken).toEqual(mockBridgeToken);
+    // sourceToken is the bridgeToken built from the asset
+    expect(result.sourceToken).toEqual({
+      ...regularAsset,
+      address: regularAsset.address,
+      chainId: MOCK_CHAIN_ID,
+      decimals: regularAsset.decimals,
+      symbol: regularAsset.symbol,
+      name: regularAsset.name,
+      image: regularAsset.image,
+    });
     expect(result.destToken).toBeUndefined();
   });
 
-  it('returns bridgeToken as source when asset has no isFromTrending property', () => {
-    const result = getSwapTokens(asset, mockBridgeToken);
+  it('returns asset as source when asset has no isFromTrending property', () => {
+    const result = getSwapTokens(asset);
 
-    expect(result.sourceToken).toEqual(mockBridgeToken);
+    // sourceToken is the bridgeToken built from the asset
+    expect(result.sourceToken).toEqual({
+      ...asset,
+      address: asset.address,
+      chainId: MOCK_CHAIN_ID,
+      decimals: asset.decimals,
+      symbol: asset.symbol,
+      name: asset.name,
+      image: asset.image,
+    });
     expect(result.destToken).toBeUndefined();
   });
 
   it('returns native token for the correct chain when asset is from trending on different chain', () => {
-    const polygonBridgeToken = {
-      ...mockBridgeToken,
-      chainId: '0x89' as const,
-      symbol: 'USDC',
-    };
     const trendingAssetOnPolygon = {
       ...asset,
       chainId: '0x89',
       isFromTrending: true,
     };
 
-    const result = getSwapTokens(trendingAssetOnPolygon, polygonBridgeToken);
+    const result = getSwapTokens(trendingAssetOnPolygon);
 
-    expect(result.sourceToken).toEqual(
-      expect.objectContaining({
-        chainId: '0x89',
-      }),
-    );
-    expect(result.destToken).toEqual(polygonBridgeToken);
+    // sourceToken is the native token for Polygon
+    expect(result.sourceToken).toEqual({
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: '0x89',
+      decimals: 18,
+      image: '',
+      name: 'Polygon',
+      symbol: 'POL',
+    });
+    // destToken is the bridgeToken built from the asset
+    expect(result.destToken).toEqual({
+      ...trendingAssetOnPolygon,
+      address: trendingAssetOnPolygon.address,
+      chainId: '0x89',
+      decimals: trendingAssetOnPolygon.decimals,
+      symbol: trendingAssetOnPolygon.symbol,
+      name: trendingAssetOnPolygon.name,
+      image: trendingAssetOnPolygon.image,
+    });
   });
 });

--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -299,6 +299,11 @@ const assetFromSearch = {
   isFromSearch: true,
 };
 
+const assetFromTrending = {
+  ...asset,
+  isFromTrending: true,
+};
+
 describe('AssetOverview', () => {
   const mockSendNonEvmAsset = jest.fn();
 
@@ -1053,6 +1058,31 @@ describe('AssetOverview', () => {
     await Promise.resolve();
 
     // Should navigate to bridge view
+    expect(navigate).toHaveBeenCalledWith('Bridge', {
+      screen: 'BridgeView',
+      params: expect.objectContaining({
+        bridgeViewMode: 'Unified',
+        sourcePage: 'MainView',
+      }),
+    });
+  });
+
+  it('navigates to bridge for buy when coming from trending tokens', async () => {
+    const { getByTestId } = renderWithProvider(
+      <AssetOverview
+        asset={assetFromTrending}
+        displayBuyButton
+        displaySwapsButton
+      />,
+      { state: mockInitialState },
+    );
+
+    const swapButton = getByTestId('token-swap-button');
+    fireEvent.press(swapButton);
+
+    await Promise.resolve();
+
+    // Navigates to Bridge with unified mode
     expect(navigate).toHaveBeenCalledWith('Bridge', {
       screen: 'BridgeView',
       params: expect.objectContaining({

--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -1890,4 +1890,35 @@ describe('getSwapTokens', () => {
       image: trendingAssetOnPolygon.image,
     });
   });
+
+  it('returns default pair token as sourceToken and native gas token as destToken when asset is native gas token', () => {
+    const nativeGasToken = {
+      ...asset,
+      address: '0x0000000000000000000000000000000000000000',
+      isETH: true,
+    };
+
+    const result = getSwapTokens(nativeGasToken);
+
+    // sourceToken is the default pair token for mainnet (mUSD)
+    expect(result.sourceToken).toEqual({
+      symbol: 'mUSD',
+      name: 'MetaMask USD',
+      address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+      decimals: 6,
+      image:
+        'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xaca92e438df0b2401ff60da7e4337b687a2435da.png',
+      chainId: MOCK_CHAIN_ID,
+    });
+    // destToken is the native gas token
+    expect(result.destToken).toEqual({
+      ...nativeGasToken,
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: MOCK_CHAIN_ID,
+      decimals: nativeGasToken.decimals,
+      symbol: nativeGasToken.symbol,
+      name: nativeGasToken.name,
+      image: nativeGasToken.image,
+    });
+  });
 });

--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -78,6 +78,7 @@ import {
   isAssetFromTrending,
 } from '../Bridge/hooks/useSwapBridgeNavigation';
 import { NATIVE_SWAPS_TOKEN_ADDRESS } from '../../../constants/bridge';
+import { getNativeSourceToken } from '../Bridge/utils/tokenUtils';
 import { TraceName, endTrace } from '../../../util/trace';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { selectMultichainAssetsRates } from '../../../selectors/multichain';
@@ -214,13 +215,16 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
   );
 
   // If coming from trending tokens list (explore page), user likely wants to BUY the token
-  // so we place it in the destination position. Otherwise, they likely want to SELL.
+  // so we place it in the destination position with native token of same chain as source.
+  // Otherwise, they likely want to SELL.
   const wantsToBuyToken = isAssetFromTrending(asset);
 
   const { goToSwaps, networkModal } = useSwapBridgeNavigation({
     location: SwapBridgeNavigationLocation.TokenDetails,
     sourcePage: 'MainView',
-    sourceToken: wantsToBuyToken ? undefined : bridgeToken,
+    sourceToken: wantsToBuyToken
+      ? getNativeSourceToken(bridgeToken.chainId)
+      : bridgeToken,
     destToken: wantsToBuyToken ? bridgeToken : undefined,
   });
 

--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -117,14 +117,23 @@ import { BridgeToken } from '../Bridge/types';
  * Otherwise, we assume they want to SELL, so the asset is the source.
  *
  * @param asset - The token asset being viewed
- * @param bridgeToken - The bridge-formatted token
  * @returns Object containing sourceToken and destToken for swap navigation
  */
 export const getSwapTokens = (
   asset: TokenI,
-  bridgeToken: BridgeToken,
 ): { sourceToken: BridgeToken; destToken: BridgeToken | undefined } => {
   const wantsToBuyToken = isAssetFromTrending(asset);
+
+  // Build bridge token from asset
+  const bridgeToken: BridgeToken = {
+    ...asset,
+    address: asset.address ?? NATIVE_SWAPS_TOKEN_ADDRESS,
+    chainId: asset.chainId as Hex | CaipChainId,
+    decimals: asset.decimals,
+    symbol: asset.symbol,
+    name: asset.name,
+    image: asset.image,
+  };
 
   if (wantsToBuyToken) {
     return {
@@ -231,21 +240,7 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
     vsCurrency: currentCurrency,
   });
 
-  // Build bridge token from asset
-  const bridgeToken: BridgeToken = useMemo(
-    () => ({
-      ...asset,
-      address: asset.address ?? NATIVE_SWAPS_TOKEN_ADDRESS,
-      chainId: asset.chainId as Hex,
-      decimals: asset.decimals,
-      symbol: asset.symbol,
-      name: asset.name,
-      image: asset.image,
-    }),
-    [asset],
-  );
-
-  const { sourceToken, destToken } = getSwapTokens(asset, bridgeToken);
+  const { sourceToken, destToken } = getSwapTokens(asset);
 
   const { goToSwaps, networkModal } = useSwapBridgeNavigation({
     location: SwapBridgeNavigationLocation.TokenDetails,

--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -218,14 +218,16 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
   // so we place it in the destination position with native token of same chain as source.
   // Otherwise, they likely want to SELL.
   const wantsToBuyToken = isAssetFromTrending(asset);
+  const sourceToken = wantsToBuyToken
+    ? getNativeSourceToken(bridgeToken.chainId)
+    : bridgeToken;
+  const destToken = wantsToBuyToken ? bridgeToken : undefined;
 
   const { goToSwaps, networkModal } = useSwapBridgeNavigation({
     location: SwapBridgeNavigationLocation.TokenDetails,
     sourcePage: 'MainView',
-    sourceToken: wantsToBuyToken
-      ? getNativeSourceToken(bridgeToken.chainId)
-      : bridgeToken,
-    destToken: wantsToBuyToken ? bridgeToken : undefined,
+    sourceToken,
+    destToken,
   });
 
   // Hook for handling non-EVM asset sending

--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
@@ -36,6 +36,19 @@ import {
 import { areAddressesEqual } from '../../../../../util/address';
 import TrendingFeedSessionManager from '../../../Trending/services/TrendingFeedSessionManager';
 
+/**
+ * When navigating to the Asset view from trending tokens list, we add a property
+ * to indicate the user's intent is to BUY the token (not sell).
+ *
+ * This is used to determine whether the token should be pre-filled as the
+ * destination token (buy) rather than source token (sell) in the swap flow.
+ */
+export const isAssetFromTrending = (asset: unknown) =>
+  typeof asset === 'object' &&
+  asset !== null &&
+  'isFromTrending' in asset &&
+  asset.isFromTrending === true;
+
 export enum SwapBridgeNavigationLocation {
   TabBar = 'TabBar',
   TokenDetails = 'TokenDetails',

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
@@ -557,6 +557,7 @@ describe('TrendingTokenRowItem', () => {
         pricePercentChange1d: 3.44,
         isNative: false,
         isETH: false,
+        isFromTrending: true,
       });
     });
 
@@ -614,6 +615,7 @@ describe('TrendingTokenRowItem', () => {
         pricePercentChange1d: 3.44,
         isNative: true,
         isETH: true,
+        isFromTrending: true,
       });
     });
 
@@ -671,6 +673,7 @@ describe('TrendingTokenRowItem', () => {
         pricePercentChange1d: 3.44,
         isNative: true,
         isETH: false,
+        isFromTrending: true,
       });
     });
 

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -163,6 +163,7 @@ const getAssetNavigationParams = (token: TrendingAsset) => {
       : undefined,
     isNative: isNativeToken,
     isETH: isNativeToken && hexChainId === '0x1',
+    isFromTrending: true,
   };
 };
 

--- a/app/selectors/featureFlagController/assetsTrendingTokens/index.ts
+++ b/app/selectors/featureFlagController/assetsTrendingTokens/index.ts
@@ -89,6 +89,9 @@ export const isAssetsTrendingTokensFeatureEnabled = (
 export const selectAssetsTrendingTokensEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean => {
+    // TEMP: Force enable explore/trending feature for testing
+    return true;
+
     const { trendingTokens: assetsTrendingTokensEnabled } = remoteFeatureFlags;
     const envOverride =
       process.env.OVERRIDE_REMOTE_FEATURE_FLAGS &&

--- a/app/selectors/featureFlagController/assetsTrendingTokens/index.ts
+++ b/app/selectors/featureFlagController/assetsTrendingTokens/index.ts
@@ -89,9 +89,6 @@ export const isAssetsTrendingTokensFeatureEnabled = (
 export const selectAssetsTrendingTokensEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean => {
-    // TEMP: Force enable explore/trending feature for testing
-    return true;
-
     const { trendingTokens: assetsTrendingTokensEnabled } = remoteFeatureFlags;
     const envOverride =
       process.env.OVERRIDE_REMOTE_FEATURE_FLAGS &&


### PR DESCRIPTION
## **Description**

When navigating to swaps from a trending token:
1. The source token is set to the native gas token of the same chain as the trending token
2. The destination token is set as the trending token

If the trending token happens to be the native gas token:
1. Source: default dest token for that chain (usually a stablecoin like USDC, USDT)
2. Dest: native gas token

This provides a better UX since users can immediately swap using the native token of that chain.

You will need to force `selectAssetsTrendingTokensEnabled` to return `true` to test this feature for now.

## **Changelog**

CHANGELOG entry: Set trending token as the dest token when navigating to swaps

## **Related issues**

Fixes: SWAPS-3688

## **Manual testing steps**

```gherkin
Feature: Trending token swap navigation

  Scenario: user taps swap from a trending token on network
    Given user is viewing a trending token on network

    When user taps the Swap button
    Then the swap source token should be native token
    And the swap destination token should be the trending token
```

## **Screenshots/Recordings**

### **Before**

<!-- Source token was always ETH on mainnet -->

### **After**

<!-- Source token is now native token of the trending token's chain -->


https://github.com/user-attachments/assets/4a87dfae-031b-4a91-89a9-225fda808c5f



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves swap/bridge prefill logic and integrates Trending tokens intent.
> 
> - Add `getSwapTokens` in `AssetOverview` to compute `sourceToken`/`destToken` based on context: native gas tokens use default pair → native; trending tokens use native → asset; otherwise asset → (unspecified)
> - Pass computed tokens to `useSwapBridgeNavigation` and export `isAssetFromTrending`; leverage `isNativeAddress`, `getNativeSourceToken`, and `getDefaultDestToken`
> - Mark Trending navigation with `isFromTrending` in `TrendingTokenRowItem` so Asset view enters buy mode; update tests accordingly
> - Extend tests: capture hook args, add cases for trending/non-trending, cross-chain, native token paths, and unit tests for `getSwapTokens`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e695bdc78ed28f70729e4272e4abb936c37c3c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->