### PR TITLE
chore: refactor create-cherry-pick-pr.yml 

### DIFF
--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -35,5 +35,8 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME:  ${{ github.event.inputs.branch_name }}
+          COMMIT_HASH:  ${{ github.event.inputs.commit_hash }}
+          PR_NUMBER:    ${{ github.event.inputs.PR_number }}
         run: |
-          ./scripts/create-cherry-pick-pr.sh ${{ github.event.inputs.branch_name }} ${{ github.event.inputs.commit_hash }} ${{ github.event.inputs.PR_number }}
+          ./scripts/create-cherry-pick-pr.sh "$BRANCH_NAME" "$COMMIT_HASH" "$PR_NUMBER"

--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -19,17 +19,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout and setup high risk environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
-          fetch-depth: 0
-          ref: ${{ vars.branch_name }}
-          token: ${{ secrets.BUG_REPORT_TOKEN }}
-      - name: Get Node.js version
-        id: nvm
-        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+          is-high-risk-environment: false
       - name: Create Cherry Pick PR
         id: create-cherry-pick-pr
         shell: bash


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request updates the create cherry pick workflow to pass untrusted GitHub values as ENV variables instead of raw inputs to the `run` section of the workflow. This helps ensure we are setting good patterns, and eliminates the risk of command injection from an employee who invokes this workflow.

Alternatively, if this action is no longer used we can delete it entirely (this is the approach the extension platform team is taking)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

CHANGELOG entry: null

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

No issue exists

## **Manual testing steps**

After merging this pull request, run the workflow to confirm it still works as intended

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes and simplifies the cherry-pick workflow.
> 
> - Replace `actions/checkout` + Node setup steps with `MetaMask/action-checkout-and-setup@v1` (`is-high-risk-environment: false`)
> - Pass workflow inputs as env vars (`BRANCH_NAME`, `COMMIT_HASH`, `PR_NUMBER`) to `create-cherry-pick-pr.sh` and quote args in `run`
> - Remove `fetch-depth`, `ref`, custom token usage, and Node version detection/setup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8428b764775827a77721da8ee72b7b1a7d7a612. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->