### PR TITLE
fix: fix apr issue display value cp-7.61.6

### DIFF
--- a/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
@@ -888,7 +888,7 @@ const EarnInputView = () => {
         navBarEventOptions,
         ///: BEGIN:ONLY_INCLUDE_IF(tron)
         earnToken,
-        tronApyPercent,
+        isTronEnabled ? tronApyPercent : null,
         ///: END:ONLY_INCLUDE_IF
       ),
     );
@@ -904,6 +904,7 @@ const EarnInputView = () => {
     earnToken?.name,
     earnToken,
     ///: BEGIN:ONLY_INCLUDE_IF(tron)
+    isTronEnabled,
     tronApyPercent,
     ///: END:ONLY_INCLUDE_IF
   ]);

--- a/app/components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.tsx
@@ -347,7 +347,7 @@ const EarnWithdrawInputView = () => {
         navBarEventOptions,
         ///: BEGIN:ONLY_INCLUDE_IF(tron)
         receiptTokenToUse,
-        tronApyPercent,
+        isTronEnabled ? tronApyPercent : null,
         ///: END:ONLY_INCLUDE_IF
       ),
     );
@@ -359,6 +359,7 @@ const EarnWithdrawInputView = () => {
     isLending,
     tokenLabel,
     ///: BEGIN:ONLY_INCLUDE_IF(tron)
+    isTronEnabled,
     receiptTokenToUse,
     tronApyPercent,
     ///: END:ONLY_INCLUDE_IF


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix APY display to show the token specific rate instead of always showing Tron APY.
<img width="255" height="67" alt="Screenshot 2026-01-09 at 19 16 22" src="https://github.com/user-attachments/assets/2e37edec-1ace-43e1-8ef8-44b47547ad5e" />
<img width="259" height="68" alt="Screenshot 2026-01-09 at 19 16 35" src="https://github.com/user-attachments/assets/a951c31c-a82f-4be0-8f75-cea9f99428fa" />

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures APY shown in the staking navbar is token-appropriate rather than always using Tron APY.
> 
> - In `EarnInputView` and `EarnWithdrawInputView`, pass `isTronEnabled ? tronApyPercent : null` to `getStakingNavbar` (instead of always `tronApyPercent`)
> - Add `isTronEnabled` to the respective `useEffect` dependency arrays to keep the navbar state in sync
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce8515ca05c59670006d8fa4c7fef1cc4fe0e5ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->