### PR TITLE
Bitcoin network bug fix

### DIFF
--- a/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.constants.ts
+++ b/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.constants.ts
@@ -24,6 +24,7 @@ export const NETWORK_MULTI_SELECTOR_TEST_IDS = {
 } as const;
 
 export enum NetworkToCaipChainId {
+  BITCOIN = 'bip122:000000000019d6689c085ae165831e93',
   SOLANA = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
   ETHEREUM = 'eip155:1',
   LINEA = 'eip155:59144',

--- a/app/components/UI/Trending/utils/trendingNetworksList.ts
+++ b/app/components/UI/Trending/utils/trendingNetworksList.ts
@@ -104,6 +104,15 @@ export const TRENDING_NETWORKS_LIST: ProcessedNetwork[] = [
   },
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   {
+    id: NetworkToCaipChainId.BITCOIN,
+    name: 'Bitcoin',
+    caipChainId: NetworkToCaipChainId.BITCOIN,
+    isSelected: false,
+    imageSource: getNetworkImageSource({
+      chainId: NetworkToCaipChainId.BITCOIN,
+    }),
+  },
+  {
     id: NetworkToCaipChainId.SOLANA,
     name: 'Solana',
     caipChainId: NetworkToCaipChainId.SOLANA,


### PR DESCRIPTION
Add Bitcoin to the trending networks list to make it visible on the Explore/Trending pages when the `keyring-snaps` feature is enabled.

---
<a href="https://cursor.com/background-agent?bcId=bc-984aa964-a89c-4bc6-b6b3-f6f9fe91e57c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-984aa964-a89c-4bc6-b6b3-f6f9fe91e57c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

