### PR TITLE
Trending list token name fix

### DIFF
--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
@@ -300,6 +300,18 @@ describe('TrendingTokenRowItem', () => {
     expect(getByText('Ethereum')).toBeTruthy();
   });
 
+  it('renders token symbol as fallback when name is missing', () => {
+    const token = createMockToken({ name: '', symbol: 'ETH' });
+
+    const { getByText } = renderWithProvider(
+      <TrendingTokenRowItem token={token} />,
+      { state: mockState },
+      false,
+    );
+
+    expect(getByText('ETH')).toBeTruthy();
+  });
+
   it('renders market stats with formatted values', () => {
     const token = createMockToken({
       marketCap: 75641301011.76,

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -295,7 +295,7 @@ const TrendingTokenRowItem = ({
               numberOfLines={1}
               ellipsizeMode="tail"
             >
-              {token.name}
+              {token.name || token.symbol}
             </Text>
           </View>
           <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>


### PR DESCRIPTION
Fixes a bug where some token names were not showing in the trending list by adding a fallback to `token.symbol` when `token.name` is missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-2eaf0af1-229d-4839-abd3-849248a50629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2eaf0af1-229d-4839-abd3-849248a50629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

