### PR TITLE
Trending tokens liquidity filter

### DIFF
--- a/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.test.ts
+++ b/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.test.ts
@@ -1,4 +1,7 @@
-import { useTrendingRequest } from './useTrendingRequest';
+import {
+  useTrendingRequest,
+  DEFAULT_MIN_LIQUIDITY_USD,
+} from './useTrendingRequest';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { act, waitFor } from '@testing-library/react-native';
 // eslint-disable-next-line import/no-namespace
@@ -260,6 +263,62 @@ describe('useTrendingRequest', () => {
     expect(spyGetTrendingTokens).toHaveBeenCalledWith(
       expect.objectContaining({
         chainIds: customChainIds,
+      }),
+    );
+
+    spyGetTrendingTokens.mockRestore();
+  });
+
+  it('uses default minimum liquidity to filter low-liquidity tokens', async () => {
+    const spyGetTrendingTokens = jest.spyOn(
+      assetsControllers,
+      'getTrendingTokens',
+    );
+    const mockResults: assetsControllers.TrendingAsset[] = [];
+    spyGetTrendingTokens.mockResolvedValue(mockResults as never);
+
+    renderHookWithProvider(() =>
+      useTrendingRequest({
+        chainIds: ['eip155:1'],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(spyGetTrendingTokens).toHaveBeenCalledTimes(1);
+    });
+
+    expect(spyGetTrendingTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        minLiquidity: DEFAULT_MIN_LIQUIDITY_USD,
+      }),
+    );
+
+    spyGetTrendingTokens.mockRestore();
+  });
+
+  it('allows overriding the default minimum liquidity', async () => {
+    const spyGetTrendingTokens = jest.spyOn(
+      assetsControllers,
+      'getTrendingTokens',
+    );
+    const mockResults: assetsControllers.TrendingAsset[] = [];
+    spyGetTrendingTokens.mockResolvedValue(mockResults as never);
+
+    const customMinLiquidity = 100000;
+    renderHookWithProvider(() =>
+      useTrendingRequest({
+        chainIds: ['eip155:1'],
+        minLiquidity: customMinLiquidity,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(spyGetTrendingTokens).toHaveBeenCalledTimes(1);
+    });
+
+    expect(spyGetTrendingTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        minLiquidity: customMinLiquidity,
       }),
     );
 

--- a/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
+++ b/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
@@ -8,6 +8,13 @@ import { useStableArray } from '../../../Perps/hooks/useStableArray';
 import { TRENDING_NETWORKS_LIST } from '../../utils/trendingNetworksList';
 
 /**
+ * Default minimum liquidity threshold in USD to filter out low-liquidity tokens.
+ * This helps prevent showing highly volatile tokens with minimal trading activity
+ * that can display extreme price swings due to their low liquidity.
+ */
+export const DEFAULT_MIN_LIQUIDITY_USD = 50000;
+
+/**
  * Hook for handling trending tokens request
  * @returns {Object} An object containing the trending tokens results, loading state, error, and a function to trigger fetch
  */
@@ -23,7 +30,7 @@ export const useTrendingRequest = (options: {
   const {
     chainIds: providedChainIds = [],
     sortBy = 'h24_trending',
-    minLiquidity = 0,
+    minLiquidity = DEFAULT_MIN_LIQUIDITY_USD,
     minVolume24hUsd = 0,
     maxVolume24hUsd,
     minMarketCap = 0,


### PR DESCRIPTION
Set a default minimum liquidity for trending tokens to filter out highly volatile, low-liquidity assets.

Previously, the `useTrendingRequest` hook defaulted `minLiquidity` to `0`, which meant no liquidity filtering was applied. This allowed tokens with very low trading volume and high volatility to appear at the top of trending lists, especially when sorted by price change. This change introduces a default minimum liquidity of $50,000 USD to ensure more relevant and stable tokens are displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ae0fe18-031c-4c17-8f80-968ec2b8f725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ae0fe18-031c-4c17-8f80-968ec2b8f725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

