### PR TITLE
Buy screen incorrect token

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -4,10 +4,10 @@ import { useNavigation } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   Hex,
+  isCaipAssetType,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   CaipAssetType,
   CaipChainId,
-  isCaipAssetType,
   ///: END:ONLY_INCLUDE_IF
 } from '@metamask/utils';
 import I18n, { strings } from '../../../../locales/i18n';


### PR DESCRIPTION
Unconditionally import `isCaipAssetType` to fix incorrect token selection on the buy screen.

The `isCaipAssetType` function was conditionally imported based on the `keyring-snaps` feature flag but used unconditionally. When the flag was disabled, `isCaipAssetType` was `undefined`, leading to a TypeError. This error caused the `assetId` to become `undefined`, which then defaulted the "Buy" screen to Ethereum instead of the selected token.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf970af1-30d9-44c0-99ff-61261dd58635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf970af1-30d9-44c0-99ff-61261dd58635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

