### PR TITLE
Search engine setting bug

### DIFF
--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -1086,6 +1086,15 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
     }, [sendActiveAccount, permittedEvmAccountsList]);
 
     /**
+     * Re-inject homepage scripts when search engine changes while on homepage
+     */
+    useEffect(() => {
+      if (isHomepage(resolvedUrlRef.current)) {
+        injectHomePageScripts();
+      }
+    }, [searchEngine, isHomepage, injectHomePageScripts]);
+
+    /**
      * Check when the ipfs gateway is enabled to hide the banner
      */
     useEffect(() => {


### PR DESCRIPTION
Add a `useEffect` hook to re-inject homepage scripts when the search engine setting changes while on the homepage.

This fixes a bug where changing the default search engine in settings was not reflected on the browser homepage because `window.__mmSearchEngine` was not updated after the initial page load.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9010817-8a4b-49ec-a9df-d50d1cf75edc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9010817-8a4b-49ec-a9df-d50d1cf75edc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

