### PR TITLE
Search nav bar hide

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -697,6 +697,12 @@ const HomeTabs = () => {
       return null;
     }
 
+    // Hide tab bar when on Explore search screen
+    const isInExploreSearch = currentStackRouteName === Routes.EXPLORE_SEARCH;
+    if (isInExploreSearch) {
+      return null;
+    }
+
     if (isKeyboardHidden) {
       return (
         <TabBar


### PR DESCRIPTION
Hide the bottom navigation bar when on the Explore search screen to improve UI/UX and provide more screen space for search results.

---
<a href="https://cursor.com/background-agent?bcId=bc-22c6bb5b-a659-40be-a421-08496e84184f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22c6bb5b-a659-40be-a421-08496e84184f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

