### PR TITLE
Token search result ordering

### DIFF
--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
@@ -70,7 +70,12 @@ export const useTrendingSearch = (
       }
     });
 
-    return Array.from(resultMap.values());
+    // Sort combined results by market cap (descending) so most relevant tokens appear first
+    return Array.from(resultMap.values()).sort((a, b) => {
+      const aMarketCap = a.marketCap ?? 0;
+      const bMarketCap = b.marketCap ?? 0;
+      return bMarketCap - aMarketCap;
+    });
   }, [searchQuery, trendingResults, searchResults]);
 
   return {


### PR DESCRIPTION
Sort combined token search results by market cap to show more relevant tokens first.

The `useTrendingSearch` hook previously combined trending and search API results without any specific sorting. This could lead to less popular tokens appearing higher in the search results than more established tokens. By sorting the combined results by market cap in descending order, users will now see the most relevant and popular tokens at the top of their search results.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d72eea5-c040-472b-a111-faa2bf47ab53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d72eea5-c040-472b-a111-faa2bf47ab53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

