### PR TITLE
Browser tab limit fix

### DIFF
--- a/app/components/Views/TrendingView/TrendingView.test.tsx
+++ b/app/components/Views/TrendingView/TrendingView.test.tsx
@@ -127,7 +127,7 @@ describe('TrendingView', () => {
   const createMockSelectorImplementation =
     (
       overrides: {
-        browserTabs?: Array<{ id: number; url: string }>;
+        browserTabs?: { id: number; url: string }[];
         multichainEnabled?: boolean;
         basicFunctionalityEnabled?: boolean;
       } = {},

--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -22,6 +22,8 @@ import AppConstants from '../../../core/AppConstants';
 import { useBuildPortfolioUrl } from '../../hooks/useBuildPortfolioUrl';
 import { useTheme } from '../../../util/theme';
 import Routes from '../../../constants/navigation/Routes';
+import { isPortfolioUrl } from '../../../util/url';
+import { BrowserTab } from '../../UI/Tokens/types';
 import ExploreSearchBar from './components/ExploreSearchBar/ExploreSearchBar';
 import QuickActions from './components/QuickActions/QuickActions';
 import SectionHeader from './components/SectionHeader/SectionHeader';
@@ -125,23 +127,38 @@ export const ExploreFeed: React.FC = () => {
 
   const portfolioUrl = buildPortfolioUrlWithMetrics(AppConstants.PORTFOLIO.URL);
 
-  const browserTabsCount = useSelector(
-    (state: { browser: { tabs: unknown[] } }) => state.browser.tabs.length,
+  const browserTabs = useSelector(
+    (state: { browser: { tabs: BrowserTab[] } }) => state.browser.tabs,
   );
+  const browserTabsCount = browserTabs.length;
   const isBasicFunctionalityEnabled = useSelector(
     selectBasicFunctionalityEnabled,
   );
 
   const handleBrowserPress = useCallback(() => {
+    // Check if a portfolio tab already exists to avoid triggering "max tabs" modal
+    // when the user just wants to view existing tabs
+    const existingPortfolioTab = browserTabs?.find(({ url }: BrowserTab) =>
+      isPortfolioUrl(url),
+    );
+
+    const params = existingPortfolioTab
+      ? {
+          existingTabId: existingPortfolioTab.id,
+          timestamp: Date.now(),
+          fromTrending: true,
+        }
+      : {
+          newTabUrl: portfolioUrl.href,
+          timestamp: Date.now(),
+          fromTrending: true,
+        };
+
     navigation.navigate(Routes.BROWSER.HOME, {
       screen: Routes.BROWSER.VIEW,
-      params: {
-        newTabUrl: portfolioUrl.href,
-        timestamp: Date.now(),
-        fromTrending: true,
-      },
+      params,
     });
-  }, [navigation, portfolioUrl.href]);
+  }, [navigation, portfolioUrl.href, browserTabs]);
 
   const handleSearchPress = useCallback(() => {
     navigation.navigate(Routes.EXPLORE_SEARCH);


### PR DESCRIPTION
Prevent "Maximum tabs reached" modal from incorrectly appearing when tapping the browser tab indicator in the Explore/Trending view.

The previous implementation always attempted to open a new tab, triggering the modal if 5 tabs were already open, even when the user's intent was to view existing tabs. This PR now checks for an existing portfolio tab and navigates to it if found, otherwise it proceeds to open a new tab.

---
<a href="https://cursor.com/background-agent?bcId=bc-36e7b873-0180-4f86-bba6-217b5fc33f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36e7b873-0180-4f86-bba6-217b5fc33f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

