### PR TITLE
Trending perps display bug

### DIFF
--- a/app/components/UI/Perps/utils/marketDataTransform.ts
+++ b/app/components/UI/Perps/utils/marketDataTransform.ts
@@ -230,11 +230,13 @@ export function transformMarketData(
     const marketSource = dex || undefined;
 
     // Determine market type:
-    // 1. Check explicit mapping (e.g., 'xyz:GOLD' → 'commodity')
-    // 2. Default HIP-3 DEX markets to 'equity' (stocks) if not mapped
-    // 3. Main DEX markets remain undefined (crypto)
-    const marketType: MarketType | undefined =
-      assetMarketTypes?.[symbol] || (dex ? 'equity' : undefined);
+    // 1. Check explicit mapping (e.g., 'xyz:GOLD' → 'commodity', 'xyz:TSLA' → 'equity')
+    // 2. If not in mapping, remain undefined (crypto) - this includes:
+    //    - Main DEX assets (no prefix)
+    //    - HIP-3 DEX crypto assets (e.g., 'xyz:BTC' if not mapped)
+    // Note: We no longer default HIP-3 DEX markets to 'equity' as this incorrectly
+    // classified crypto assets like BTC that may exist on HIP-3 DEXs
+    const marketType: MarketType | undefined = assetMarketTypes?.[symbol];
 
     return {
       symbol,


### PR DESCRIPTION
Stop incorrectly classifying unmapped HIP-3 DEX crypto assets as 'equity' to fix BTC appearing in both Stocks and Crypto sections.

Previously, `transformMarketData` defaulted any unmapped asset from a HIP-3 DEX (e.g., `xyz:BTC`) to `marketType: 'equity'`. This caused crypto assets to appear in the "Stocks" section, while their main DEX counterparts appeared correctly in "Crypto". The fix ensures only explicitly mapped assets receive a specific `marketType`, leaving unmapped HIP-3 crypto assets as `undefined` (correctly treated as crypto).

---
<a href="https://cursor.com/background-agent?bcId=bc-18bee684-5902-4c95-a42a-b9c54060c3a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18bee684-5902-4c95-a42a-b9c54060c3a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

