### PR TITLE
Trending tokens bug fix

### DIFF
--- a/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
+++ b/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
@@ -38,6 +38,10 @@ export const useTrendingRequest = (options: {
     return TRENDING_NETWORKS_LIST.map((network) => network.caipChainId);
   }, [providedChainIds]);
 
+  // Only exclude stablecoins and blue-chip tokens when querying multiple networks.
+  // For single network queries, show all trending tokens to provide a fuller list.
+  const shouldExcludeLabels = providedChainIds.length !== 1;
+
   // Track the current request ID to prevent stale results from overwriting current ones
   const requestIdRef = useRef(0);
 
@@ -73,8 +77,11 @@ export const useTrendingRequest = (options: {
         maxVolume24hUsd,
         minMarketCap,
         maxMarketCap,
+        // Only exclude stablecoins/blue-chips when querying multiple networks
         // TODO: Remove type assertion once @metamask/assets-controllers types are updated
-        excludeLabels: ['stable_coin', 'blue_chip'],
+        ...(shouldExcludeLabels && {
+          excludeLabels: ['stable_coin', 'blue_chip'],
+        }),
       } as Parameters<typeof getTrendingTokens>[0]);
       // Only update state if this is still the current request
       if (currentRequestId === requestIdRef.current) {
@@ -100,6 +107,7 @@ export const useTrendingRequest = (options: {
     maxVolume24hUsd,
     minMarketCap,
     maxMarketCap,
+    shouldExcludeLabels,
   ]);
 
   // Automatically trigger fetch when options change


### PR DESCRIPTION
Conditionally apply `excludeLabels` filter in `useTrendingRequest` to show a fuller list of trending tokens for single-network queries.

Previously, the `excludeLabels` filter (for stablecoins and blue-chip tokens) was applied unconditionally. This resulted in very few trending tokens being displayed when a single network like Arbitrum or Polygon was selected, as many popular tokens on these networks were filtered out. The fix ensures that this filter is only applied when querying multiple networks or all networks, providing a more comprehensive list for single-network selections.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae018246-fc5c-4d43-8f06-64022b74539f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae018246-fc5c-4d43-8f06-64022b74539f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

