### PR TITLE
Inconsistent cap vol data

### DIFF
--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
@@ -465,19 +465,72 @@ describe('TrendingTokenRowItem', () => {
     ).toBeTruthy();
   });
 
-  it('renders with zero market cap and volume', () => {
+  it('hides market stats when both market cap and volume are zero', () => {
     const token = createMockToken({
       marketCap: 0,
       aggregatedUsdVolume: 0,
     });
 
-    const { getByText } = renderWithProvider(
+    const { queryByText } = renderWithProvider(
       <TrendingTokenRowItem token={token} />,
       { state: mockState },
       false,
     );
 
-    expect(getByText(/\$0\.00 cap • \$0\.00 vol/)).toBeTruthy();
+    // Market stats should not be displayed when both values are zero
+    expect(queryByText(/cap/)).toBeNull();
+    expect(queryByText(/vol/)).toBeNull();
+  });
+
+  it('hides market stats when both market cap and volume are undefined', () => {
+    const token = createMockToken({
+      marketCap: undefined,
+      aggregatedUsdVolume: undefined,
+    });
+
+    const { queryByText } = renderWithProvider(
+      <TrendingTokenRowItem token={token} />,
+      { state: mockState },
+      false,
+    );
+
+    // Market stats should not be displayed when both values are undefined
+    expect(queryByText(/cap/)).toBeNull();
+    expect(queryByText(/vol/)).toBeNull();
+  });
+
+  it('shows only volume when market cap is zero but volume is valid', () => {
+    const token = createMockToken({
+      marketCap: 0,
+      aggregatedUsdVolume: 974248822.2,
+    });
+
+    const { getByText, queryByText } = renderWithProvider(
+      <TrendingTokenRowItem token={token} />,
+      { state: mockState },
+      false,
+    );
+
+    // Should show volume only
+    expect(getByText(/\$974\.2M vol/)).toBeTruthy();
+    expect(queryByText(/cap/)).toBeNull();
+  });
+
+  it('shows only market cap when volume is zero but market cap is valid', () => {
+    const token = createMockToken({
+      marketCap: 75641301011.76,
+      aggregatedUsdVolume: 0,
+    });
+
+    const { getByText, queryByText } = renderWithProvider(
+      <TrendingTokenRowItem token={token} />,
+      { state: mockState },
+      false,
+    );
+
+    // Should show market cap only
+    expect(getByText(/\$76B cap/)).toBeTruthy();
+    expect(queryByText(/vol/)).toBeNull();
   });
 
   it('renders with very large market cap and volume', () => {

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -35,7 +35,7 @@ import {
   getNonEvmNetworkImageSourceByChainId,
 } from '../../../../../util/networks/customNetworks';
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
-import { formatMarketStats } from './utils';
+import { formatMarketStats, isValidMarketValue } from './utils';
 import { formatPrice } from '../../../Predict/utils/format';
 import { TimeOption } from '../TrendingTokensBottomSheet';
 import NetworkModals from '../../../NetworkModal';
@@ -205,6 +205,17 @@ const TrendingTokenRowItem = ({
     pricePercentChange !== undefined && !isNaN(pricePercentChange);
   const isPositiveChange = hasPercentageChange && pricePercentChange > 0;
 
+  // Memoize market stats formatting - returns null if both values are missing/zero
+  const marketStats = useMemo(
+    () => formatMarketStats(token.marketCap, token.aggregatedUsdVolume),
+    [token.marketCap, token.aggregatedUsdVolume],
+  );
+
+  // Check if we have any valid market data to display
+  const hasMarketData =
+    isValidMarketValue(token.marketCap) ||
+    isValidMarketValue(token.aggregatedUsdVolume);
+
   const handlePress = useCallback(() => {
     if (!assetParams) return;
 
@@ -298,12 +309,11 @@ const TrendingTokenRowItem = ({
               {token.name}
             </Text>
           </View>
-          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
-            {formatMarketStats(
-              token.marketCap ?? 0,
-              token.aggregatedUsdVolume ?? 0,
-            )}
-          </Text>
+          {hasMarketData && marketStats && (
+            <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+              {marketStats}
+            </Text>
+          )}
         </View>
         <View style={styles.rightContainer}>
           <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/utils.ts
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/utils.ts
@@ -24,11 +24,46 @@ export function formatCompactUSD(value: number): string {
 }
 
 /**
- * Formats market cap and volume as a combined string
- * @param marketCap - Market capitalization value
- * @param volume - Trading volume value
- * @returns Formatted string (e.g., "$13B cap • $34.2M vol")
+ * Checks if a market value is valid (not null, undefined, NaN, or zero)
+ * @param value - The value to check
+ * @returns true if the value is valid and greater than 0
  */
-export function formatMarketStats(marketCap: number, volume: number): string {
-  return `${formatCompactUSD(marketCap)} cap • ${formatCompactUSD(volume)} vol`;
+export function isValidMarketValue(
+  value: number | null | undefined,
+): value is number {
+  return value !== null && value !== undefined && !isNaN(value) && value > 0;
+}
+
+/**
+ * Formats market cap and volume as a combined string
+ * Returns null if both values are missing or zero (to indicate stats should be hidden)
+ * @param marketCap - Market capitalization value (can be null/undefined)
+ * @param volume - Trading volume value (can be null/undefined)
+ * @returns Formatted string (e.g., "$13B cap • $34.2M vol") or null if both values are invalid
+ */
+export function formatMarketStats(
+  marketCap: number | null | undefined,
+  volume: number | null | undefined,
+): string | null {
+  const hasMarketCap = isValidMarketValue(marketCap);
+  const hasVolume = isValidMarketValue(volume);
+
+  // Hide market stats entirely if both values are missing or zero
+  if (!hasMarketCap && !hasVolume) {
+    return null;
+  }
+
+  // Show both stats if both are valid
+  if (hasMarketCap && hasVolume) {
+    return `${formatCompactUSD(marketCap)} cap • ${formatCompactUSD(volume)} vol`;
+  }
+
+  // Show only market cap if volume is missing
+  if (hasMarketCap) {
+    return `${formatCompactUSD(marketCap)} cap`;
+  }
+
+  // Show only volume if market cap is missing
+  // At this point, hasVolume must be true since we've already checked !hasMarketCap && !hasVolume
+  return `${formatCompactUSD(volume as number)} vol`;
 }


### PR DESCRIPTION
Hide market cap and volume on the search page when values are missing or zero to prevent displaying misleading "$0.00" values.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e1c15f2-665d-4ce6-b97f-1d928afd6298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e1c15f2-665d-4ce6-b97f-1d928afd6298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

