### PR TITLE
MetaMask IAB network bug

### DIFF
--- a/app/components/UI/AccountRightButton/AccountRightButton.types.ts
+++ b/app/components/UI/AccountRightButton/AccountRightButton.types.ts
@@ -1,4 +1,10 @@
 export interface AccountRightButtonProps {
   selectedAddress: string;
   onPress: () => void;
+  /**
+   * Optional active URL to derive hostname from.
+   * When provided, this takes precedence over route.params?.url
+   * This is needed for the browser fullscreen mode where route params may be stale.
+   */
+  activeUrl?: string;
 }

--- a/app/components/UI/AccountRightButton/index.tsx
+++ b/app/components/UI/AccountRightButton/index.tsx
@@ -63,6 +63,7 @@ const styles = StyleSheet.create({
 const AccountRightButton = ({
   selectedAddress,
   onPress,
+  activeUrl,
 }: AccountRightButtonProps) => {
   // Placeholder ref for dismissing keyboard. Works when the focused input is within a Webview.
   const placeholderInputRef = useRef<TextInput>(null);
@@ -156,7 +157,8 @@ const AccountRightButton = ({
 
   const route = useRoute<RouteProp<Record<string, { url: string }>, string>>();
   // url is defined if opened while in a dapp
-  const currentUrl = route.params?.url;
+  // Use activeUrl prop if provided (for browser fullscreen mode), otherwise fall back to route params
+  const currentUrl = activeUrl || route.params?.url;
   let hostname;
   if (currentUrl) {
     hostname = new UrlParser(currentUrl)?.origin;

--- a/app/components/UI/BrowserUrlBar/BrowserUrlBar.tsx
+++ b/app/components/UI/BrowserUrlBar/BrowserUrlBar.tsx
@@ -136,6 +136,7 @@ const BrowserUrlBar = forwardRef<BrowserUrlBarRef, BrowserUrlBarProps>(
           <AccountRightButton
             selectedAddress={selectedAddress}
             onPress={handleAccountRightButtonPress}
+            activeUrl={activeUrl}
           />
         );
       }
@@ -175,6 +176,7 @@ const BrowserUrlBar = forwardRef<BrowserUrlBarRef, BrowserUrlBarProps>(
       styles.closeButton,
       styles.cancelButton,
       styles.cancelButtonText,
+      activeUrl,
     ]);
 
     useImperativeHandle(ref, () => ({


### PR DESCRIPTION
Pass `activeUrl` to `AccountRightButton` to fix the network icon not updating in fullscreen browser mode.

The `AccountRightButton` component, which displays the network icon when not connected to a dApp, was relying on `route.params?.url` to determine the current hostname. In fullscreen browser mode, these route parameters could become stale when the network changed, leading to the network icon not reflecting the active network. By explicitly passing the `activeUrl` from `BrowserUrlBar`, the `AccountRightButton` now uses the most current URL to derive network information, ensuring the icon updates correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-f069a795-ed3e-43d7-b5ae-73612b6d9454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f069a795-ed3e-43d7-b5ae-73612b6d9454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

