### PR TITLE
refactor(NetworkManager): improve network deletion logic and add popular network handling

### DIFF
--- a/app/components/UI/CustomNetworkSelector/CustomNetworkSelector.test.tsx
+++ b/app/components/UI/CustomNetworkSelector/CustomNetworkSelector.test.tsx
@@ -18,7 +18,11 @@ import { useNetworksToUse } from '../../hooks/useNetworksToUse/useNetworksToUse'
 import CustomNetworkSelector from './CustomNetworkSelector';
 import { CustomNetworkItem } from './CustomNetworkSelector.types';
 import { selectMultichainAccountsState2Enabled } from '../../../selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts';
-import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
+import {
+  selectIsEvmNetworkSelected,
+  selectSelectedNonEvmNetworkChainId,
+} from '../../../selectors/multichainNetworkController';
+import { selectEvmChainId } from '../../../selectors/networkController';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 
 jest.mock('../../../core/Multichain/utils', () => ({
@@ -45,6 +49,12 @@ jest.mock('@metamask/utils', () => ({
 
 jest.mock('@metamask/controller-utils', () => ({
   toHex: jest.fn(),
+}));
+
+jest.mock('@metamask/bridge-controller', () => ({
+  formatChainIdToCaip: jest.fn(
+    (chainId: string) => `eip155:${parseInt(chainId, 16)}`,
+  ),
 }));
 
 jest.mock('../../../../locales/i18n', () => ({
@@ -111,6 +121,7 @@ jest.mock('../../../util/device', () => ({
 
 jest.mock('../../../selectors/networkController', () => ({
   selectEvmNetworkConfigurationsByChainId: jest.fn(),
+  selectEvmChainId: jest.fn(),
   createProviderConfig: jest.fn(),
 }));
 
@@ -159,6 +170,7 @@ jest.mock('@shopify/flash-list', () => {
 
 jest.mock('../../../selectors/multichainNetworkController', () => ({
   selectIsEvmNetworkSelected: jest.fn(),
+  selectSelectedNonEvmNetworkChainId: jest.fn(),
 }));
 
 // Mock store setup
@@ -300,6 +312,12 @@ describe('CustomNetworkSelector', () => {
       }
       if (selector === mockSelectIsEvmNetworkSelected) {
         return true;
+      }
+      if (selector === selectEvmChainId) {
+        return '0x1'; // Ethereum mainnet
+      }
+      if (selector === selectSelectedNonEvmNetworkChainId) {
+        return 'solana:mainnet';
       }
       return undefined;
     });

--- a/app/components/UI/NetworkManager/index.test.tsx
+++ b/app/components/UI/NetworkManager/index.test.tsx
@@ -817,7 +817,7 @@ describe('NetworkManager Component', () => {
         expect(
           getByTestId('account-action-transaction.edit'),
         ).toBeOnTheScreen();
-        expect(queryByTestId('account_action-app_settings.delete')).toBeNull();
+        expect(queryByTestId('account-action-app_settings.delete')).toBeNull();
       });
     });
 

--- a/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.test.tsx
+++ b/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.test.tsx
@@ -83,8 +83,15 @@ jest.mock('../../hooks/useNetworksToUse/useNetworksToUse', () => ({
   useNetworksToUse: jest.fn(),
 }));
 
+jest.mock('../../hooks/useAddPopularNetwork', () => ({
+  useAddPopularNetwork: jest.fn(() => ({
+    addPopularNetwork: jest.fn(),
+  })),
+}));
+
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
+  useDispatch: jest.fn(() => jest.fn()),
   Provider: jest.requireActual('react-redux').Provider,
 }));
 

--- a/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.tsx
+++ b/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../hooks/useNetworksByNamespace/useNetworksByNamespace';
 import { useNetworkSelection } from '../../hooks/useNetworkSelection/useNetworkSelection';
 import { useNetworksToUse } from '../../hooks/useNetworksToUse/useNetworksToUse';
+import { useAddPopularNetwork } from '../../hooks/useAddPopularNetwork';
 import { useSelector } from 'react-redux';
 import {
   selectEvmNetworkConfigurationsByChainId,
@@ -147,6 +148,18 @@ const NetworkMultiSelector = ({
       networks: networksToUse,
     });
 
+  const { addPopularNetwork } = useAddPopularNetwork();
+
+  /**
+   * Handler for adding a popular network directly without confirmation.
+   */
+  const handleAddPopularNetwork = useCallback(
+    async (networkConfiguration: ExtendedNetwork) => {
+      await addPopularNetwork(networkConfiguration);
+    },
+    [addPopularNetwork],
+  );
+
   const selectedChainIds = useMemo(
     () =>
       Object.keys(enabledNetworksByNamespace[namespace] || {}).filter(
@@ -198,6 +211,8 @@ const NetworkMultiSelector = ({
       toggleWarningModal,
       showNetworkModal,
       customNetworksList: PopularList,
+      skipConfirmation: true,
+      onNetworkAdd: handleAddPopularNetwork,
     }),
     [
       modalState.showPopularNetworkModal,
@@ -205,6 +220,7 @@ const NetworkMultiSelector = ({
       onCancel,
       toggleWarningModal,
       showNetworkModal,
+      handleAddPopularNetwork,
     ],
   );
 

--- a/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.test.tsx
+++ b/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.test.tsx
@@ -466,6 +466,38 @@ describe('NetworkMultiSelectorList', () => {
       expect(mockParseCaipChainId).toHaveBeenCalledWith('eip155:1');
       expect(mockToHex).toHaveBeenCalledWith('1');
     });
+
+    it('falls back to EVM chain ID when non-EVM chain ID is undefined', () => {
+      // When isEvmSelected is false but nonEvmChainId is undefined,
+      // selectedChainIdCaip should fall back to EVM chain ID to prevent
+      // displayEdit from incorrectly evaluating to true for all networks
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === mockSelectEvmChainId) {
+          return '0x1';
+        }
+        if (selector === mockSelectSelectedNonEvmNetworkChainId) {
+          return undefined; // Simulate undefined non-EVM chain ID
+        }
+        if (selector === mockSelectIsEvmNetworkSelected) {
+          return false; // Non-EVM is selected, but chain ID is undefined
+        }
+        return undefined;
+      });
+
+      const ethereumNetwork: Network = {
+        id: 'eip155:1',
+        name: 'Ethereum Mainnet',
+        isSelected: false,
+        imageSource: { uri: 'ethereum.png' },
+        caipChainId: 'eip155:1' as CaipChainId,
+      };
+
+      const props = { ...defaultProps, networks: [ethereumNetwork] };
+      render(<NetworkMultiSelectorList {...props} />);
+
+      // formatChainIdToCaip should be called with EVM chain ID as fallback
+      expect(mockFormatChainIdToCaip).toHaveBeenCalledWith('0x1');
+    });
   });
 
   describe('RPC Selection', () => {

--- a/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.test.tsx
+++ b/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.test.tsx
@@ -9,7 +9,10 @@ import { debounce, type DebouncedFunc } from 'lodash';
 import { useStyles } from '../../../component-library/hooks/index.ts';
 import { isTestNet } from '../../../util/networks/index.js';
 import { selectEvmChainId } from '../../../selectors/networkController';
-import { selectSelectedNonEvmNetworkChainId , selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
+import {
+  selectSelectedNonEvmNetworkChainId,
+  selectIsEvmNetworkSelected,
+} from '../../../selectors/multichainNetworkController';
 import NetworkMultiSelectorList from './NetworkMultiSelectorList';
 import {
   NetworkMultiSelectorListProps,

--- a/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.test.tsx
+++ b/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.test.tsx
@@ -8,8 +8,8 @@ import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { debounce, type DebouncedFunc } from 'lodash';
 import { useStyles } from '../../../component-library/hooks/index.ts';
 import { isTestNet } from '../../../util/networks/index.js';
-import { selectChainId } from '../../../selectors/networkController';
-import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
+import { selectEvmChainId } from '../../../selectors/networkController';
+import { selectSelectedNonEvmNetworkChainId , selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 import NetworkMultiSelectorList from './NetworkMultiSelectorList';
 import {
   NetworkMultiSelectorListProps,
@@ -70,7 +70,11 @@ jest.mock('../../../util/networks/index.js', () => ({
 
 jest.mock('../../../selectors/networkController', () => ({
   selectEvmChainId: jest.fn(),
-  selectChainId: jest.fn(),
+}));
+
+jest.mock('../../../selectors/multichainNetworkController', () => ({
+  selectIsEvmNetworkSelected: jest.fn(),
+  selectSelectedNonEvmNetworkChainId: jest.fn(),
 }));
 
 jest.mock('../../../util/hideProtocolFromUrl', () =>
@@ -179,9 +183,13 @@ describe('NetworkMultiSelectorList', () => {
   const mockDebounce = debounce as jest.MockedFunction<typeof debounce>;
   const mockUseStyles = useStyles as jest.MockedFunction<typeof useStyles>;
   const mockIsTestNet = isTestNet as jest.MockedFunction<typeof isTestNet>;
-  const mockSelectChainId = selectChainId as jest.MockedFunction<
-    typeof selectChainId
+  const mockSelectEvmChainId = selectEvmChainId as jest.MockedFunction<
+    typeof selectEvmChainId
   >;
+  const mockSelectSelectedNonEvmNetworkChainId =
+    selectSelectedNonEvmNetworkChainId as jest.MockedFunction<
+      typeof selectSelectedNonEvmNetworkChainId
+    >;
   const mockSelectIsEvmNetworkSelected =
     selectIsEvmNetworkSelected as jest.MockedFunction<
       typeof selectIsEvmNetworkSelected
@@ -234,8 +242,11 @@ describe('NetworkMultiSelectorList', () => {
 
     // Setup useSelector to return different values based on the selector function
     mockUseSelector.mockImplementation((selector) => {
-      if (selector === mockSelectChainId) {
+      if (selector === mockSelectEvmChainId) {
         return '0x1';
+      }
+      if (selector === mockSelectSelectedNonEvmNetworkChainId) {
+        return 'solana:mainnet';
       }
       if (selector === mockSelectIsEvmNetworkSelected) {
         return true;
@@ -282,9 +293,9 @@ describe('NetworkMultiSelectorList', () => {
       expect(mockUseSafeAreaInsets).toHaveBeenCalled();
     });
 
-    it('calls useSelector with selectChainId', () => {
+    it('calls useSelector with selectEvmChainId', () => {
       render(<NetworkMultiSelectorList {...defaultProps} />);
-      expect(mockUseSelector).toHaveBeenCalledWith(mockSelectChainId);
+      expect(mockUseSelector).toHaveBeenCalledWith(mockSelectEvmChainId);
     });
 
     it('calls useStyles with styleSheet', () => {
@@ -416,8 +427,11 @@ describe('NetworkMultiSelectorList', () => {
 
       // Set useSelector to return different values based on the selector
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === mockSelectChainId) {
+        if (selector === mockSelectEvmChainId) {
           return '0x1';
+        }
+        if (selector === mockSelectSelectedNonEvmNetworkChainId) {
+          return 'solana:mainnet';
         }
         if (selector === mockSelectIsEvmNetworkSelected) {
           // return false for isEvmSelected

--- a/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.tsx
+++ b/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.tsx
@@ -18,7 +18,6 @@ import {
   KnownCaipNamespace,
 } from '@metamask/utils';
 import { toHex } from '@metamask/controller-utils';
-import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { debounce } from 'lodash';
 
 // External dependencies.
@@ -33,7 +32,6 @@ import Text, {
   TextColor,
 } from '../../../component-library/components/Texts/Text/index.ts';
 import { isTestNet } from '../../../util/networks/index.js';
-import { selectChainId } from '../../../selectors/networkController';
 import hideProtocolFromUrl from '../../../util/hideProtocolFromUrl';
 import hideKeyFromUrl from '../../../util/hideKeyFromUrl';
 
@@ -54,7 +52,12 @@ import {
   ITEM_TYPE_NETWORK,
   SELECT_ALL_NETWORKS_SECTION_ID,
 } from './NetworkMultiSelectorList.constants';
-import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
+import {
+  selectIsEvmNetworkSelected,
+  selectSelectedNonEvmNetworkChainId,
+} from '../../../selectors/multichainNetworkController';
+import { selectEvmChainId } from '../../../selectors/networkController';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { NETWORK_MULTI_SELECTOR_TEST_IDS } from '../NetworkMultiSelector/NetworkMultiSelector.constants';
 import { selectMultichainAccountsState2Enabled } from '../../../selectors/featureFlagController/multichainAccounts/index.ts';
 import { getGasFeesSponsoredNetworkEnabled } from '../../../selectors/featureFlagController/gasFeesSponsored/index.ts';
@@ -88,9 +91,15 @@ const NetworkMultiSelectList = ({
   const networkListRef = useRef<any>(null);
   const networksLengthRef = useRef<number>(0);
   const safeAreaInsets = useSafeAreaInsets();
-  const selectedChainId = useSelector(selectChainId);
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
-  const selectedChainIdCaip = formatChainIdToCaip(selectedChainId);
+  const evmChainId = useSelector(selectEvmChainId);
+  const nonEvmChainId = useSelector(selectSelectedNonEvmNetworkChainId);
+  // Use the appropriate chain ID based on whether EVM is selected
+  // For EVM: convert hex chain ID to CAIP format (e.g., "0x1" -> "eip155:1")
+  // For non-EVM: use the already CAIP-formatted chain ID (e.g., "solana:mainnet")
+  const selectedChainIdCaip = isEvmSelected
+    ? formatChainIdToCaip(evmChainId)
+    : nonEvmChainId;
   const isMultichainAccountsState2Enabled = useSelector(
     selectMultichainAccountsState2Enabled,
   );

--- a/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.tsx
+++ b/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.tsx
@@ -97,9 +97,11 @@ const NetworkMultiSelectList = ({
   // Use the appropriate chain ID based on whether EVM is selected
   // For EVM: convert hex chain ID to CAIP format (e.g., "0x1" -> "eip155:1")
   // For non-EVM: use the already CAIP-formatted chain ID (e.g., "solana:mainnet")
+  // Fallback to EVM chain ID if non-EVM chain ID is undefined (prevents edit/delete
+  // options from incorrectly appearing on all networks)
   const selectedChainIdCaip = isEvmSelected
     ? formatChainIdToCaip(evmChainId)
-    : nonEvmChainId;
+    : (nonEvmChainId ?? formatChainIdToCaip(evmChainId));
   const isMultichainAccountsState2Enabled = useSelector(
     selectMultichainAccountsState2Enabled,
   );

--- a/app/components/Views/NetworkSelector/NetworkSelector.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.tsx
@@ -66,6 +66,7 @@ import CustomNetwork from '../Settings/NetworksSettings/NetworkSettings/CustomNe
 import { NetworksSelectorSelectorsIDs } from '../../../../e2e/selectors/Settings/NetworksView.selectors';
 import { PopularList } from '../../../util/networks/customNetworks';
 import NetworkSearchTextInput from './NetworkSearchTextInput';
+import { useAddPopularNetwork } from '../../hooks/useAddPopularNetwork';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import BottomSheetHeader from '../../../component-library/components/BottomSheets/BottomSheetHeader';
 import AccountAction from '../AccountAction';
@@ -183,6 +184,8 @@ const NetworkSelector = () => {
     domainIsConnectedDapp,
     networkName: selectedNetworkName,
   } = useNetworkInfo(origin);
+
+  const { addPopularNetwork } = useAddPopularNetwork();
 
   const isSendFlow =
     route.params?.source === NETWORK_SELECTOR_SOURCES.SEND_FLOW;
@@ -317,6 +320,16 @@ const NetworkSelector = () => {
         : hideKeyFromUrl(networkConfiguration.rpcUrl),
     });
   };
+
+  /**
+   * Handler for adding a popular network directly without confirmation.
+   */
+  const handleAddPopularNetwork = useCallback(
+    async (networkConfiguration: ExtendedNetwork) => {
+      await addPopularNetwork(networkConfiguration);
+    },
+    [addPopularNetwork],
+  );
 
   const onCancel = () => {
     setShowPopularNetworkModal(false);
@@ -805,6 +818,8 @@ const NetworkSelector = () => {
           showCompletionMessage={false}
           showPopularNetworkModal
           hideWarningIcons
+          skipConfirmation
+          onNetworkAdd={handleAddPopularNetwork}
         />
       </View>
     );

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useCallback } from 'react';
 import NetworkModals from '../../../../../UI/NetworkModal';
 import { View, TouchableOpacity } from 'react-native';
 import { useSelector } from 'react-redux';
@@ -52,6 +52,8 @@ const CustomNetwork = ({
   allowNetworkSwitch = true,
   showActionLabels = false,
   listHeader = '',
+  skipConfirmation = false,
+  onNetworkAdd,
 }: CustomNetworkProps) => {
   const networkConfigurations = useSelector(selectNetworkConfigurations);
   const selectedChainId = useSelector(selectChainId);
@@ -103,6 +105,20 @@ const CustomNetwork = ({
     ? supportedNetworkList
     : supportedNetworkList.filter((n) => !n.isAdded);
 
+  const handleNetworkPress = useCallback(
+    (networkConfiguration: Network & { isAdded: boolean }) => {
+      // When skipConfirmation is true and we have onNetworkAdd callback,
+      // add the network directly without showing the confirmation modal
+      if (skipConfirmation && onNetworkAdd) {
+        onNetworkAdd(networkConfiguration);
+      } else {
+        // Fallback to showing the modal for confirmation
+        showNetworkModal(networkConfiguration);
+      }
+    },
+    [skipConfirmation, onNetworkAdd, showNetworkModal],
+  );
+
   if (filteredPopularList.length === 0 && showCompletionMessage) {
     return (
       <EmptyPopularList goToCustomNetwork={() => switchTab?.goToPage?.(1)} />
@@ -133,7 +149,7 @@ const CustomNetwork = ({
         <TouchableOpacity
           key={index}
           style={networkSettingsStyles.popularNetwork}
-          onPress={() => showNetworkModal(networkConfiguration)}
+          onPress={() => handleNetworkPress(networkConfiguration)}
         >
           <View style={networkSettingsStyles.popularWrapper}>
             <View style={networkSettingsStyles.popularNetworkImage}>

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
@@ -106,13 +106,15 @@ const CustomNetwork = ({
     : supportedNetworkList.filter((n) => !n.isAdded);
 
   const handleNetworkPress = useCallback(
-    (networkConfiguration: Network & { isAdded: boolean }) => {
+    async (networkConfiguration: Network & { isAdded: boolean }) => {
       // When skipConfirmation is true and we have onNetworkAdd callback,
       // add the network directly without showing the confirmation modal
       if (skipConfirmation && onNetworkAdd) {
-        onNetworkAdd(networkConfiguration).catch((error) => {
+        try {
+          await onNetworkAdd(networkConfiguration);
+        } catch (error) {
           console.error('Failed to add network:', error);
-        });
+        }
       } else {
         // Fallback to showing the modal for confirmation
         showNetworkModal(networkConfiguration);

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
@@ -110,7 +110,9 @@ const CustomNetwork = ({
       // When skipConfirmation is true and we have onNetworkAdd callback,
       // add the network directly without showing the confirmation modal
       if (skipConfirmation && onNetworkAdd) {
-        onNetworkAdd(networkConfiguration);
+        onNetworkAdd(networkConfiguration).catch((error) => {
+          console.error('Failed to add network:', error);
+        });
       } else {
         // Fallback to showing the modal for confirmation
         showNetworkModal(networkConfiguration);

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types.ts
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types.ts
@@ -98,4 +98,15 @@ export interface CustomNetworkProps {
    * Show "Add"/"Switch" text labels instead of "+" icon
    */
   showActionLabels?: boolean;
+  /**
+   * Skip the confirmation modal and add the network directly.
+   * When true, networks from the popular list will be added without showing the confirmation modal.
+   * This improves UX for curated/vetted networks that don't require additional confirmation.
+   */
+  skipConfirmation?: boolean;
+  /**
+   * Callback to directly add a network without showing the confirmation modal.
+   * Used when skipConfirmation is true.
+   */
+  onNetworkAdd?: (networkConfiguration: Network) => Promise<void>;
 }

--- a/app/components/hooks/useAddPopularNetwork/index.ts
+++ b/app/components/hooks/useAddPopularNetwork/index.ts
@@ -1,0 +1,1 @@
+export { useAddPopularNetwork, default } from './useAddPopularNetwork';

--- a/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.test.ts
+++ b/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.test.ts
@@ -3,8 +3,7 @@ import { useAddPopularNetwork } from './useAddPopularNetwork';
 import Engine from '../../../core/Engine';
 import { useDispatch, useSelector } from 'react-redux';
 import { useMetrics } from '../useMetrics';
-import { useNetworksByNamespace } from '../useNetworksByNamespace/useNetworksByNamespace';
-import { useNetworkSelection } from '../useNetworkSelection/useNetworkSelection';
+import { useNetworkEnablement } from '../useNetworkEnablement/useNetworkEnablement';
 import { networkSwitched } from '../../../actions/onboardNetwork';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { Network } from '../../Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
@@ -19,13 +18,8 @@ jest.mock('../useMetrics', () => ({
   useMetrics: jest.fn(),
 }));
 
-jest.mock('../useNetworksByNamespace/useNetworksByNamespace', () => ({
-  useNetworksByNamespace: jest.fn(),
-  NetworkType: { Popular: 'popular' },
-}));
-
-jest.mock('../useNetworkSelection/useNetworkSelection', () => ({
-  useNetworkSelection: jest.fn(),
+jest.mock('../useNetworkEnablement/useNetworkEnablement', () => ({
+  useNetworkEnablement: jest.fn(),
 }));
 
 jest.mock('../../../core/Engine', () => ({
@@ -64,7 +58,7 @@ describe('useAddPopularNetwork', () => {
   const mockTrackEvent = jest.fn();
   const mockCreateEventBuilder = jest.fn();
   const mockAddTraitsToUser = jest.fn();
-  const mockSelectNetwork = jest.fn();
+  const mockEnableNetwork = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -80,11 +74,8 @@ describe('useAddPopularNetwork', () => {
       }),
       addTraitsToUser: mockAddTraitsToUser,
     });
-    (useNetworksByNamespace as jest.Mock).mockReturnValue({
-      networks: [],
-    });
-    (useNetworkSelection as jest.Mock).mockReturnValue({
-      selectNetwork: mockSelectNetwork,
+    (useNetworkEnablement as jest.Mock).mockReturnValue({
+      enableNetwork: mockEnableNetwork,
     });
 
     (
@@ -213,7 +204,8 @@ describe('useAddPopularNetwork', () => {
       await result.current.addPopularNetwork(mockNetwork);
     });
 
-    expect(mockSelectNetwork).toHaveBeenCalledWith('0x89');
+    // enableNetwork is called with CAIP chain ID format (eip155:137 for 0x89)
+    expect(mockEnableNetwork).toHaveBeenCalledWith('eip155:137');
   });
 
   it('adds user traits when adding a new network', async () => {

--- a/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.test.ts
+++ b/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.test.ts
@@ -1,0 +1,272 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useAddPopularNetwork } from './useAddPopularNetwork';
+import Engine from '../../../core/Engine';
+import { useDispatch, useSelector } from 'react-redux';
+import { useMetrics } from '../useMetrics';
+import { useNetworksByNamespace } from '../useNetworksByNamespace/useNetworksByNamespace';
+import { useNetworkSelection } from '../useNetworkSelection/useNetworkSelection';
+import { networkSwitched } from '../../../actions/onboardNetwork';
+import { MetaMetricsEvents } from '../../../core/Analytics';
+import { Network } from '../../Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
+
+// Mock dependencies
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../useMetrics', () => ({
+  useMetrics: jest.fn(),
+}));
+
+jest.mock('../useNetworksByNamespace/useNetworksByNamespace', () => ({
+  useNetworksByNamespace: jest.fn(),
+  NetworkType: { Popular: 'popular' },
+}));
+
+jest.mock('../useNetworkSelection/useNetworkSelection', () => ({
+  useNetworkSelection: jest.fn(),
+}));
+
+jest.mock('../../../core/Engine', () => ({
+  context: {
+    NetworkController: {
+      addNetwork: jest.fn(),
+      updateNetwork: jest.fn(),
+    },
+    MultichainNetworkController: {
+      setActiveNetwork: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../../actions/onboardNetwork', () => ({
+  networkSwitched: jest.fn(),
+}));
+
+jest.mock('../../../util/metrics/MultichainAPI/networkMetricUtils', () => ({
+  addItemToChainIdList: jest.fn().mockReturnValue({ chainIds: ['0x89'] }),
+}));
+
+const createMockNetwork = (overrides?: Partial<Network>): Network => ({
+  chainId: '0x89',
+  nickname: 'Polygon',
+  ticker: 'MATIC',
+  rpcUrl: 'https://polygon-rpc.com',
+  rpcPrefs: {
+    blockExplorerUrl: 'https://polygonscan.com',
+  },
+  ...overrides,
+});
+
+describe('useAddPopularNetwork', () => {
+  const mockDispatch = jest.fn();
+  const mockTrackEvent = jest.fn();
+  const mockCreateEventBuilder = jest.fn();
+  const mockAddTraitsToUser = jest.fn();
+  const mockSelectNetwork = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useDispatch as jest.Mock).mockReturnValue(mockDispatch);
+    (useSelector as jest.Mock).mockReturnValue({});
+    (useMetrics as jest.Mock).mockReturnValue({
+      trackEvent: mockTrackEvent,
+      createEventBuilder: mockCreateEventBuilder.mockReturnValue({
+        addProperties: jest.fn().mockReturnValue({
+          build: jest.fn().mockReturnValue({ event: 'test' }),
+        }),
+      }),
+      addTraitsToUser: mockAddTraitsToUser,
+    });
+    (useNetworksByNamespace as jest.Mock).mockReturnValue({
+      networks: [],
+    });
+    (useNetworkSelection as jest.Mock).mockReturnValue({
+      selectNetwork: mockSelectNetwork,
+    });
+
+    (
+      Engine.context.NetworkController.addNetwork as jest.Mock
+    ).mockResolvedValue({
+      rpcEndpoints: [{ networkClientId: 'test-client-id' }],
+      defaultRpcEndpointIndex: 0,
+    });
+    (
+      Engine.context.MultichainNetworkController.setActiveNetwork as jest.Mock
+    ).mockResolvedValue(undefined);
+  });
+
+  it('adds a new network when it does not exist', async () => {
+    const mockNetwork = createMockNetwork();
+    const { result } = renderHook(() => useAddPopularNetwork());
+
+    await act(async () => {
+      await result.current.addPopularNetwork(mockNetwork);
+    });
+
+    expect(Engine.context.NetworkController.addNetwork).toHaveBeenCalledWith({
+      chainId: '0x89',
+      blockExplorerUrls: ['https://polygonscan.com'],
+      defaultRpcEndpointIndex: 0,
+      defaultBlockExplorerUrlIndex: 0,
+      name: 'Polygon',
+      nativeCurrency: 'MATIC',
+      rpcEndpoints: [
+        {
+          url: 'https://polygon-rpc.com',
+          failoverUrls: undefined,
+          name: 'Polygon',
+          type: 'custom',
+        },
+      ],
+    });
+  });
+
+  it('updates existing network when it already exists', async () => {
+    const mockNetwork = createMockNetwork();
+    const existingNetwork = {
+      chainId: '0x89',
+      name: 'Polygon',
+      rpcEndpoints: [{ networkClientId: 'existing-client-id' }],
+      defaultRpcEndpointIndex: 0,
+    };
+
+    (useSelector as jest.Mock).mockReturnValue({
+      '0x89': existingNetwork,
+    });
+
+    (
+      Engine.context.NetworkController.updateNetwork as jest.Mock
+    ).mockResolvedValue({
+      rpcEndpoints: [{ networkClientId: 'updated-client-id' }],
+      defaultRpcEndpointIndex: 0,
+    });
+
+    const { result } = renderHook(() => useAddPopularNetwork());
+
+    await act(async () => {
+      await result.current.addPopularNetwork(mockNetwork);
+    });
+
+    expect(Engine.context.NetworkController.updateNetwork).toHaveBeenCalledWith(
+      '0x89',
+      existingNetwork,
+      { replacementSelectedRpcEndpointIndex: 0 },
+    );
+    expect(Engine.context.NetworkController.addNetwork).not.toHaveBeenCalled();
+  });
+
+  it('tracks RPC_ADDED analytics event', async () => {
+    const mockNetwork = createMockNetwork();
+    const { result } = renderHook(() => useAddPopularNetwork());
+
+    await act(async () => {
+      await result.current.addPopularNetwork(mockNetwork);
+    });
+
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+      MetaMetricsEvents.RPC_ADDED,
+    );
+    expect(mockTrackEvent).toHaveBeenCalled();
+  });
+
+  it('switches to the network after adding when shouldSwitchNetwork is true', async () => {
+    const mockNetwork = createMockNetwork();
+    const { result } = renderHook(() => useAddPopularNetwork());
+
+    await act(async () => {
+      await result.current.addPopularNetwork(mockNetwork, true);
+    });
+
+    expect(
+      Engine.context.MultichainNetworkController.setActiveNetwork,
+    ).toHaveBeenCalledWith('test-client-id');
+    expect(mockDispatch).toHaveBeenCalledWith(
+      networkSwitched({
+        networkUrl: 'https://polygon-rpc.com',
+        networkStatus: true,
+      }),
+    );
+  });
+
+  it('does not switch network when shouldSwitchNetwork is false', async () => {
+    const mockNetwork = createMockNetwork();
+    const { result } = renderHook(() => useAddPopularNetwork());
+
+    await act(async () => {
+      await result.current.addPopularNetwork(mockNetwork, false);
+    });
+
+    expect(
+      Engine.context.MultichainNetworkController.setActiveNetwork,
+    ).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('updates network filter after adding network', async () => {
+    const mockNetwork = createMockNetwork();
+    const { result } = renderHook(() => useAddPopularNetwork());
+
+    await act(async () => {
+      await result.current.addPopularNetwork(mockNetwork);
+    });
+
+    expect(mockSelectNetwork).toHaveBeenCalledWith('0x89');
+  });
+
+  it('adds user traits when adding a new network', async () => {
+    const mockNetwork = createMockNetwork();
+    const { result } = renderHook(() => useAddPopularNetwork());
+
+    await act(async () => {
+      await result.current.addPopularNetwork(mockNetwork);
+    });
+
+    expect(mockAddTraitsToUser).toHaveBeenCalled();
+  });
+
+  it('handles network without block explorer URL', async () => {
+    const mockNetwork = createMockNetwork({
+      rpcPrefs: {
+        blockExplorerUrl: '',
+      },
+    });
+
+    const { result } = renderHook(() => useAddPopularNetwork());
+
+    await act(async () => {
+      await result.current.addPopularNetwork(mockNetwork);
+    });
+
+    expect(Engine.context.NetworkController.addNetwork).toHaveBeenCalledWith(
+      expect.objectContaining({
+        blockExplorerUrls: [],
+        defaultBlockExplorerUrlIndex: undefined,
+      }),
+    );
+  });
+
+  it('handles network with failover RPC URLs', async () => {
+    const mockNetwork = createMockNetwork({
+      failoverRpcUrls: ['https://polygon-rpc-backup.com'],
+    });
+
+    const { result } = renderHook(() => useAddPopularNetwork());
+
+    await act(async () => {
+      await result.current.addPopularNetwork(mockNetwork);
+    });
+
+    expect(Engine.context.NetworkController.addNetwork).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpcEndpoints: [
+          expect.objectContaining({
+            failoverUrls: ['https://polygon-rpc-backup.com'],
+          }),
+        ],
+      }),
+    );
+  });
+});

--- a/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.ts
+++ b/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.ts
@@ -1,0 +1,153 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Hex } from '@metamask/utils';
+import { RpcEndpointType } from '@metamask/network-controller';
+import { toHex } from '@metamask/controller-utils';
+
+import Engine from '../../../core/Engine';
+import { networkSwitched } from '../../../actions/onboardNetwork';
+import { MetaMetricsEvents } from '../../../core/Analytics';
+import { useMetrics } from '../useMetrics';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../selectors/networkController';
+import { addItemToChainIdList } from '../../../util/metrics/MultichainAPI/networkMetricUtils';
+import { Network } from '../../Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
+import {
+  useNetworksByNamespace,
+  NetworkType,
+} from '../useNetworksByNamespace/useNetworksByNamespace';
+import { useNetworkSelection } from '../useNetworkSelection/useNetworkSelection';
+
+interface UseAddPopularNetworkResult {
+  /**
+   * Adds a popular network directly without confirmation.
+   * If the network is already added, it will switch to it.
+   * @param networkConfiguration - The network configuration from PopularList
+   * @param shouldSwitchNetwork - Whether to switch to the network after adding (default: true)
+   * @returns Promise that resolves when the network is added/switched
+   */
+  addPopularNetwork: (
+    networkConfiguration: Network,
+    shouldSwitchNetwork?: boolean,
+  ) => Promise<void>;
+}
+
+/**
+ * Hook for adding popular networks directly without showing a confirmation modal.
+ *
+ * This hook is specifically designed for networks from the curated PopularList,
+ * which have already been vetted, so no additional user confirmation is required.
+ */
+export const useAddPopularNetwork = (): UseAddPopularNetworkResult => {
+  const dispatch = useDispatch();
+  const { trackEvent, createEventBuilder, addTraitsToUser } = useMetrics();
+  const networkConfigurationByChainId = useSelector(
+    selectEvmNetworkConfigurationsByChainId,
+  );
+
+  const { networks } = useNetworksByNamespace({
+    networkType: NetworkType.Popular,
+  });
+  const { selectNetwork } = useNetworkSelection({
+    networks,
+  });
+
+  const addPopularNetwork = useCallback(
+    async (
+      networkConfiguration: Network,
+      shouldSwitchNetwork: boolean = true,
+    ): Promise<void> => {
+      const { NetworkController, MultichainNetworkController } = Engine.context;
+
+      const {
+        chainId,
+        nickname,
+        ticker,
+        rpcUrl,
+        failoverRpcUrls,
+        rpcPrefs: { blockExplorerUrl },
+      } = networkConfiguration;
+
+      const hexChainId = toHex(chainId) as Hex;
+      const existingNetwork = networkConfigurationByChainId[hexChainId];
+
+      // Track the RPC_ADDED event for popular networks
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.RPC_ADDED)
+          .addProperties({
+            chain_id: hexChainId,
+            source: 'Popular network list',
+            symbol: ticker,
+            rpc_url_index: 0,
+          })
+          .build(),
+      );
+
+      let networkClientId: string | undefined;
+
+      if (existingNetwork) {
+        // Network already exists - update it and switch to it
+        const updatedNetwork = await NetworkController.updateNetwork(
+          existingNetwork.chainId,
+          existingNetwork,
+          existingNetwork.chainId === hexChainId
+            ? {
+                replacementSelectedRpcEndpointIndex:
+                  existingNetwork.defaultRpcEndpointIndex,
+              }
+            : undefined,
+        );
+
+        networkClientId =
+          updatedNetwork?.rpcEndpoints?.[updatedNetwork.defaultRpcEndpointIndex]
+            ?.networkClientId;
+      } else {
+        // Network doesn't exist - add it
+        const addedNetwork = await NetworkController.addNetwork({
+          chainId: hexChainId,
+          blockExplorerUrls: blockExplorerUrl ? [blockExplorerUrl] : [],
+          defaultRpcEndpointIndex: 0,
+          defaultBlockExplorerUrlIndex: blockExplorerUrl ? 0 : undefined,
+          name: nickname,
+          nativeCurrency: ticker,
+          rpcEndpoints: [
+            {
+              url: rpcUrl,
+              failoverUrls: failoverRpcUrls,
+              name: nickname,
+              type: RpcEndpointType.Custom,
+            },
+          ],
+        });
+
+        addTraitsToUser(addItemToChainIdList(hexChainId));
+
+        networkClientId =
+          addedNetwork?.rpcEndpoints?.[addedNetwork.defaultRpcEndpointIndex]
+            ?.networkClientId;
+      }
+
+      // Update network filter to include this network
+      selectNetwork(hexChainId);
+
+      if (shouldSwitchNetwork && networkClientId) {
+        // Switch to the network
+        await MultichainNetworkController.setActiveNetwork(networkClientId);
+        dispatch(networkSwitched({ networkUrl: rpcUrl, networkStatus: true }));
+      }
+    },
+    [
+      networkConfigurationByChainId,
+      trackEvent,
+      createEventBuilder,
+      addTraitsToUser,
+      selectNetwork,
+      dispatch,
+    ],
+  );
+
+  return {
+    addPopularNetwork,
+  };
+};
+
+export default useAddPopularNetwork;

--- a/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.ts
+++ b/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.ts
@@ -11,11 +11,8 @@ import { useMetrics } from '../useMetrics';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../selectors/networkController';
 import { addItemToChainIdList } from '../../../util/metrics/MultichainAPI/networkMetricUtils';
 import { Network } from '../../Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
-import {
-  useNetworksByNamespace,
-  NetworkType,
-} from '../useNetworksByNamespace/useNetworksByNamespace';
-import { useNetworkSelection } from '../useNetworkSelection/useNetworkSelection';
+import { useNetworkEnablement } from '../useNetworkEnablement/useNetworkEnablement';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
 
 interface UseAddPopularNetworkResult {
   /**
@@ -44,12 +41,7 @@ export const useAddPopularNetwork = (): UseAddPopularNetworkResult => {
     selectEvmNetworkConfigurationsByChainId,
   );
 
-  const { networks } = useNetworksByNamespace({
-    networkType: NetworkType.Popular,
-  });
-  const { selectNetwork } = useNetworkSelection({
-    networks,
-  });
+  const { enableNetwork } = useNetworkEnablement();
 
   const addPopularNetwork = useCallback(
     async (
@@ -126,8 +118,8 @@ export const useAddPopularNetwork = (): UseAddPopularNetworkResult => {
             ?.networkClientId;
       }
 
-      // Update network filter to include this network
-      selectNetwork(hexChainId);
+      // Update network filter to include this network (without switching - we handle that below)
+      enableNetwork(formatChainIdToCaip(hexChainId));
 
       if (shouldSwitchNetwork && networkClientId) {
         // Switch to the network
@@ -140,7 +132,7 @@ export const useAddPopularNetwork = (): UseAddPopularNetworkResult => {
       trackEvent,
       createEventBuilder,
       addTraitsToUser,
-      selectNetwork,
+      enableNetwork,
       dispatch,
     ],
   );

--- a/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.ts
+++ b/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.ts
@@ -75,6 +75,7 @@ export const useAddPopularNetwork = (): UseAddPopularNetworkResult => {
       );
 
       let networkClientId: string | undefined;
+      let actualRpcUrl: string = rpcUrl;
 
       if (existingNetwork) {
         // Network already exists - update it and switch to it
@@ -89,9 +90,13 @@ export const useAddPopularNetwork = (): UseAddPopularNetworkResult => {
             : undefined,
         );
 
-        networkClientId =
-          updatedNetwork?.rpcEndpoints?.[updatedNetwork.defaultRpcEndpointIndex]
-            ?.networkClientId;
+        const defaultEndpoint =
+          updatedNetwork?.rpcEndpoints?.[
+            updatedNetwork.defaultRpcEndpointIndex
+          ];
+        networkClientId = defaultEndpoint?.networkClientId;
+        // Use the actual RPC URL from the existing network, not the PopularList config
+        actualRpcUrl = defaultEndpoint?.url ?? rpcUrl;
       } else {
         // Network doesn't exist - add it
         const addedNetwork = await NetworkController.addNetwork({
@@ -124,7 +129,9 @@ export const useAddPopularNetwork = (): UseAddPopularNetworkResult => {
       if (shouldSwitchNetwork && networkClientId) {
         // Switch to the network
         await MultichainNetworkController.setActiveNetwork(networkClientId);
-        dispatch(networkSwitched({ networkUrl: rpcUrl, networkStatus: true }));
+        dispatch(
+          networkSwitched({ networkUrl: actualRpcUrl, networkStatus: true }),
+        );
       }
     },
     [

--- a/e2e/specs/networks/add-popular-networks.spec.ts
+++ b/e2e/specs/networks/add-popular-networks.spec.ts
@@ -1,5 +1,4 @@
 import { SmokeNetworkAbstractions } from '../../tags';
-import NetworkApprovalBottomSheet from '../../pages/Network/NetworkApprovalBottomSheet';
 import { loginToApp } from '../../viewHelper';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
@@ -12,7 +11,7 @@ describe(SmokeNetworkAbstractions('Add all popular networks'), () => {
     jest.setTimeout(170000);
   });
 
-  it('Add all popular networks to verify the empty list content', async () => {
+  it('adds a popular network directly without confirmation modal', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder().withPopularNetworks().build(),
@@ -26,9 +25,11 @@ describe(SmokeNetworkAbstractions('Add all popular networks'), () => {
           NetworkListModal.popularNetworksContainer,
         );
 
+        // Tap on a popular network - it should be added directly without confirmation
         await NetworkListModal.scrollToBottomOfNetworkMultiSelector();
         await NetworkListModal.tapNetworkMenuButton('Arbitrum');
-        await NetworkApprovalBottomSheet.tapApproveButton();
+
+        // Network is added immediately, no approval modal needed
         await NetworkListModal.tapOnCustomTab();
         await NetworkListModal.swipeToDismissNetworkMultiSelectorModal();
         await WalletView.verifyTokenNetworkFilterText('Arbitrum');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR removes the extra confirmation bottom sheet when adding a network from the popular networks list, streamlining the user experience.

**What is the reason for the change?**
Popular networks have already been vetted by MetaMask, so requiring an additional confirmation step is unnecessary friction for users.

**What is the improvement/solution?**
- Created a new `useAddPopularNetwork` hook that adds networks directly without showing a confirmation modal
- Updated `CustomNetwork` component to support `skipConfirmation` and `onNetworkAdd` props
- Integrated the hook into `NetworkSelector` and `NetworkMultiSelector` components
- Fixed a bug where deleting a network would unexpectedly switch the active network to Sepolia
- Fixed a bug where the NetworkManager tab would switch from "Popular" to "Custom" after adding/deleting a network
- Replaced deprecated `selectChainId` selector with proper non-deprecated alternatives (`selectEvmChainId`, `selectSelectedNonEvmNetworkChainId`)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removed extra confirmation when adding networks from the popular networks list for faster network setup

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-307

## **Manual testing steps**

```gherkin
Feature: Add popular network without confirmation

  Scenario: user adds a popular network from Network Selector
    Given user is on the wallet screen with Network Selector open
    And user navigates to the "Popular" networks tab

    When user taps on a popular network (e.g., Monad, Base, Arbitrum)
    Then the network is added immediately without a confirmation modal
    And the user is switched to the newly added network

  Scenario: user deletes a non-active network
    Given user has multiple networks added
    And user is viewing a network that is NOT currently active

    When user opens the network menu and taps "Delete"
    And confirms the deletion
    Then the network is deleted
    And the active network remains unchanged (does not switch to Sepolia)
    And the current tab (Popular/Custom) remains unchanged
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/b4aef725-4ff9-4698-b96a-f28c78bddc62


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/5101de90-bc55-4b7d-a818-c1c4a8ef8de8


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Add popular networks without confirmation**: New `useAddPopularNetwork` hook adds curated networks directly (optionally switches to them) and updates the filter; integrated into `NetworkSelector` and `NetworkMultiSelector`. `CustomNetwork` now supports `skipConfirmation` and `onNetworkAdd`.
> - **Safer deletion flow**: `NetworkManager` now removes networks and only disables them in filters (no auto-switch). Prevents deleting the active network and testnets from `CustomNetworkSelector`.
> - **Tab stability**: Capture initial tab index to avoid switching between Popular/Custom when networks are added/removed.
> - **Selector cleanup and CAIP handling**: Replaced deprecated `selectChainId` with `selectEvmChainId`/`selectSelectedNonEvmNetworkChainId`; consistent CAIP chain ID derivation with EVM fallback.
> - **Tests**: Updated unit tests and added E2E to ensure direct-add flow (no approval modal) and correct deletion behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50893dc4e60e09f37c8aa741a2eaac1e29dadce0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->