### PR TITLE
refactor(NetworkMultiSelector): remove compactMode prop and introduce showActionLabels

### DIFF
--- a/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.test.tsx
+++ b/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.test.tsx
@@ -2475,7 +2475,6 @@ describe('NetworkMultiSelector', () => {
       expect(customNetworkProps.showPopularNetworkModal).toBe(true);
       expect(customNetworkProps.allowNetworkSwitch).toBe(false);
       expect(customNetworkProps.hideWarningIcons).toBe(true);
-      expect(customNetworkProps.compactMode).toBe(true);
       expect(customNetworkProps.isNetworkModalVisible).toBe(false);
       expect(typeof customNetworkProps.closeNetworkModal).toBe('function');
       expect(typeof customNetworkProps.toggleWarningModal).toBe('function');

--- a/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.tsx
+++ b/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.tsx
@@ -71,7 +71,6 @@ const CUSTOM_NETWORK_PROPS = {
   allowNetworkSwitch: false,
   hideWarningIcons: true,
   listHeader: strings('networks.additional_networks'),
-  compactMode: true,
 } as const;
 
 const NetworkMultiSelector = ({

--- a/app/components/Views/NetworkSelector/__snapshots__/NetworkSelector.test.tsx.snap
+++ b/app/components/Views/NetworkSelector/__snapshots__/NetworkSelector.test.tsx.snap
@@ -3829,21 +3829,23 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                           "flexDirection": "row",
                                         }
                                       }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
+                                    />
+                                    <View>
+                                      <SvgMock
+                                        color="#121314"
+                                        fill="currentColor"
+                                        height={24}
+                                        name="Add"
                                         style={
                                           {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Regular",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
+                                            "height": 24,
+                                            "margin": 0,
+                                            "padding": 0,
+                                            "width": 24,
                                           }
                                         }
-                                      >
-                                        Add
-                                      </Text>
+                                        width={24}
+                                      />
                                     </View>
                                   </TouchableOpacity>
                                   <TouchableOpacity
@@ -3972,21 +3974,23 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                           "flexDirection": "row",
                                         }
                                       }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
+                                    />
+                                    <View>
+                                      <SvgMock
+                                        color="#121314"
+                                        fill="currentColor"
+                                        height={24}
+                                        name="Add"
                                         style={
                                           {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Regular",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
+                                            "height": 24,
+                                            "margin": 0,
+                                            "padding": 0,
+                                            "width": 24,
                                           }
                                         }
-                                      >
-                                        Add
-                                      </Text>
+                                        width={24}
+                                      />
                                     </View>
                                   </TouchableOpacity>
                                   <TouchableOpacity
@@ -4099,21 +4103,23 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                           "flexDirection": "row",
                                         }
                                       }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
+                                    />
+                                    <View>
+                                      <SvgMock
+                                        color="#121314"
+                                        fill="currentColor"
+                                        height={24}
+                                        name="Add"
                                         style={
                                           {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Regular",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
+                                            "height": 24,
+                                            "margin": 0,
+                                            "padding": 0,
+                                            "width": 24,
                                           }
                                         }
-                                      >
-                                        Add
-                                      </Text>
+                                        width={24}
+                                      />
                                     </View>
                                   </TouchableOpacity>
                                   <TouchableOpacity
@@ -4226,21 +4232,23 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                           "flexDirection": "row",
                                         }
                                       }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
+                                    />
+                                    <View>
+                                      <SvgMock
+                                        color="#121314"
+                                        fill="currentColor"
+                                        height={24}
+                                        name="Add"
                                         style={
                                           {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Regular",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
+                                            "height": 24,
+                                            "margin": 0,
+                                            "padding": 0,
+                                            "width": 24,
                                           }
                                         }
-                                      >
-                                        Add
-                                      </Text>
+                                        width={24}
+                                      />
                                     </View>
                                   </TouchableOpacity>
                                   <TouchableOpacity
@@ -4353,21 +4361,23 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                           "flexDirection": "row",
                                         }
                                       }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
+                                    />
+                                    <View>
+                                      <SvgMock
+                                        color="#121314"
+                                        fill="currentColor"
+                                        height={24}
+                                        name="Add"
                                         style={
                                           {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Regular",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
+                                            "height": 24,
+                                            "margin": 0,
+                                            "padding": 0,
+                                            "width": 24,
                                           }
                                         }
-                                      >
-                                        Add
-                                      </Text>
+                                        width={24}
+                                      />
                                     </View>
                                   </TouchableOpacity>
                                   <TouchableOpacity
@@ -4480,21 +4490,23 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                           "flexDirection": "row",
                                         }
                                       }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
+                                    />
+                                    <View>
+                                      <SvgMock
+                                        color="#121314"
+                                        fill="currentColor"
+                                        height={24}
+                                        name="Add"
                                         style={
                                           {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Regular",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
+                                            "height": 24,
+                                            "margin": 0,
+                                            "padding": 0,
+                                            "width": 24,
                                           }
                                         }
-                                      >
-                                        Add
-                                      </Text>
+                                        width={24}
+                                      />
                                     </View>
                                   </TouchableOpacity>
                                   <TouchableOpacity
@@ -4607,21 +4619,23 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                           "flexDirection": "row",
                                         }
                                       }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
+                                    />
+                                    <View>
+                                      <SvgMock
+                                        color="#121314"
+                                        fill="currentColor"
+                                        height={24}
+                                        name="Add"
                                         style={
                                           {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Regular",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
+                                            "height": 24,
+                                            "margin": 0,
+                                            "padding": 0,
+                                            "width": 24,
                                           }
                                         }
-                                      >
-                                        Add
-                                      </Text>
+                                        width={24}
+                                      />
                                     </View>
                                   </TouchableOpacity>
                                   <TouchableOpacity
@@ -4734,21 +4748,23 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                           "flexDirection": "row",
                                         }
                                       }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
+                                    />
+                                    <View>
+                                      <SvgMock
+                                        color="#121314"
+                                        fill="currentColor"
+                                        height={24}
+                                        name="Add"
                                         style={
                                           {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Regular",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
+                                            "height": 24,
+                                            "margin": 0,
+                                            "padding": 0,
+                                            "width": 24,
                                           }
                                         }
-                                      >
-                                        Add
-                                      </Text>
+                                        width={24}
+                                      />
                                     </View>
                                   </TouchableOpacity>
                                   <TouchableOpacity
@@ -4861,21 +4877,23 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                           "flexDirection": "row",
                                         }
                                       }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
+                                    />
+                                    <View>
+                                      <SvgMock
+                                        color="#121314"
+                                        fill="currentColor"
+                                        height={24}
+                                        name="Add"
                                         style={
                                           {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Regular",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
+                                            "height": 24,
+                                            "margin": 0,
+                                            "padding": 0,
+                                            "width": 24,
                                           }
                                         }
-                                      >
-                                        Add
-                                      </Text>
+                                        width={24}
+                                      />
                                     </View>
                                   </TouchableOpacity>
                                 </View>

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
@@ -50,7 +50,7 @@ const CustomNetwork = ({
   showCompletionMessage = true,
   hideWarningIcons = false,
   allowNetworkSwitch = true,
-  compactMode = false,
+  showActionLabels = false,
   listHeader = '',
 }: CustomNetworkProps) => {
   const networkConfigurations = useSelector(selectNetworkConfigurations);
@@ -185,7 +185,7 @@ const CustomNetwork = ({
             networkConfiguration.chainId === selectedChainId ? (
               <CustomText link>{strings('networks.continue')}</CustomText>
             ) : (
-              !compactMode && (
+              showActionLabels && (
                 <Text variant={TextVariant.BodyMD}>
                   {networkConfiguration.isAdded
                     ? strings('networks.switch')
@@ -194,7 +194,7 @@ const CustomNetwork = ({
               )
             )}
           </View>
-          {compactMode && (
+          {!showActionLabels && (
             <View>
               <Icon
                 style={customNetworkStyles.icon}

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types.ts
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types.ts
@@ -95,7 +95,7 @@ export interface CustomNetworkProps {
    */
   allowNetworkSwitch?: boolean;
   /**
-   * Use compact UI with icons instead of text
+   * Show "Add"/"Switch" text labels instead of "+" icon
    */
-  compactMode?: boolean;
+  showActionLabels?: boolean;
 }

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -1633,6 +1633,7 @@ export class NetworkSettings extends PureComponent {
         showNetworkModal={this.showNetworkModal}
         switchTab={this.tabView}
         shouldNetworkSwitchPopToWallet={shouldNetworkSwitchPopToWallet}
+        showActionLabels
       />
     ) : (
       <SafeAreaView
@@ -2262,6 +2263,7 @@ export class NetworkSettings extends PureComponent {
                   shouldNetworkSwitchPopToWallet={
                     shouldNetworkSwitchPopToWallet
                   }
+                  showActionLabels
                 />
               </View>
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When selecting a network through dapp connection, the network list showed "Add" text for adding popular networks, while the token filter network list showed a "+" icon. This inconsistency was addressed by aligning both to use the "+" icon.

The compactMode prop was refactored to showActionLabels with inverted logic - the "+" icon is now the default behavior, and showActionLabels is used to opt-in for "Add"/"Switch" text labels (only needed in the full NetworkSettings screen).

## **Changelog**

CHANGELOG entry: Changed "Add" text to "+" icon for adding popular networks in dapp connection flow for UI consistency

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-321

## **Manual testing steps**

```gherkin
Feature: Add popular networks icon consistency

  Scenario: user views popular networks in dapp connection flow
    Given user has a dapp requesting network connection
    And user opens the network selector

    When user scrolls to the "Additional Networks" section
    Then user sees popular networks with a "+" icon on the right side
    And user does NOT see "Add" text
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/2ced488f-32a3-4b57-9798-7003ad55d4c3


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/defa82ba-7d69-4c94-9565-432ee6d1bbc4


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns popular network actions to use a "+" icon by default and introduces `showActionLabels` to opt-in to "Add"/"Switch" labels where needed.
> 
> - Replaces `compactMode` with `showActionLabels` in `CustomNetwork` props and implementation; inverted logic so icon is default
> - Updates `NetworkMultiSelector` to drop `compactMode` from `CUSTOM_NETWORK_PROPS` and forward new props
> - Passes `showActionLabels` from `NetworkSettings` where text labels are required
> - Refreshes tests and `NetworkSelector` snapshots to reflect the icon (`Svg Add`) instead of "Add" text
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8cc15cf8256286b4177fdf2ae7d60ea8a680d51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->