### PR TITLE
fix: Relocate `DepositKeyboard` user interaction metrics into `useTransactionCustomAmount`

### DIFF
--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.test.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.test.tsx
@@ -4,11 +4,6 @@ import { DepositKeyboard, DepositKeyboardProps } from './deposit-keyboard';
 import { merge, noop } from 'lodash';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { otherControllersMock } from '../../__mocks__/controllers/other-controllers-mock';
-import { useConfirmationMetricEvents } from '../../hooks/metrics/useConfirmationMetricEvents';
-
-jest.mock('../../hooks/metrics/useConfirmationMetricEvents');
-
-const mockSetConfirmationMetric = jest.fn();
 
 function render(props: Partial<DepositKeyboardProps> = {}) {
   return renderWithProvider(
@@ -28,9 +23,6 @@ function render(props: Partial<DepositKeyboardProps> = {}) {
 describe('DepositKeyboard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (useConfirmationMetricEvents as jest.Mock).mockReturnValue({
-      setConfirmationMetric: mockSetConfirmationMetric,
-    });
   });
 
   it('calls onChange when digit pressed', () => {
@@ -41,30 +33,6 @@ describe('DepositKeyboard', () => {
     fireEvent.press(getByText('1'));
 
     expect(onChangeMock).toHaveBeenCalledWith('1');
-  });
-
-  it('sets manual metric when digit pressed', () => {
-    const { getByText } = render();
-
-    fireEvent.press(getByText('1'));
-
-    expect(mockSetConfirmationMetric).toHaveBeenCalledWith({
-      properties: {
-        mm_pay_amount_input_type: 'manual',
-      },
-    });
-  });
-
-  it('sets percentage metric when percentage button pressed', () => {
-    const { getByText } = render();
-
-    fireEvent.press(getByText('50%'));
-
-    expect(mockSetConfirmationMetric).toHaveBeenCalledWith({
-      properties: {
-        mm_pay_amount_input_type: '50%',
-      },
-    });
   });
 
   it('hides done button if input is empty', () => {

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
@@ -13,7 +13,6 @@ import { PERPS_CURRENCY } from '../../constants/perps';
 import { Skeleton } from '../../../../../component-library/components/Skeleton';
 import Keypad from '../../../../Base/Keypad/components';
 import { noop } from 'lodash';
-import { useConfirmationMetricEvents } from '../../hooks/metrics/useConfirmationMetricEvents';
 
 const PERCENTAGE_BUTTONS = [
   {
@@ -63,31 +62,20 @@ export const DepositKeyboard = memo(
   }: DepositKeyboardProps) => {
     const currentCurrency = PERPS_CURRENCY;
     const { styles } = useStyles(styleSheet, {});
-    const { setConfirmationMetric } = useConfirmationMetricEvents();
     const valueString = value.toString();
 
     const handleChange = useCallback(
       (data: KeypadChangeData) => {
-        setConfirmationMetric({
-          properties: {
-            mm_pay_amount_input_type: 'manual',
-          },
-        });
         onChange(data.value);
       },
-      [onChange, setConfirmationMetric],
+      [onChange],
     );
 
     const handlePercentagePress = useCallback(
       (percentage: number) => {
-        setConfirmationMetric({
-          properties: {
-            mm_pay_amount_input_type: `${percentage}%`,
-          },
-        });
         onPercentagePress(percentage);
       },
-      [onPercentagePress, setConfirmationMetric],
+      [onPercentagePress],
     );
 
     const buttons = useMemo(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This is a follow up PR about this comment: https://github.com/MetaMask/metamask-mobile/pull/24282#discussion_r2677934013

This has no functional change, just tiny refactor to keep metrics out of UI component code.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/pull/24282#discussion_r2677934013

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors amount input metric tracking out of the `DepositKeyboard` UI and into `useTransactionCustomAmount`, keeping metrics logic in hooks and simplifying the component.
> 
> - Removes `useConfirmationMetricEvents` and metric side effects from `DepositKeyboard`; handlers now only forward `onChange`/`onPercentagePress`
> - Adds metric emission in `useTransactionCustomAmount` for manual input and percentage selection via `setConfirmationMetric`
> - Updates tests: removes metric assertions from `deposit-keyboard.test.tsx`; adds coverage in `useTransactionCustomAmount.test.ts` for manual and percentage metrics; preserves existing behavior (buttons, visibility, calculations)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa9df7ba799484c38f4137b331995266881f392a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->