### PR TITLE
test: adds iOS flask e2e tests

### DIFF
--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -2,6 +2,21 @@ name: Build iOS E2E Apps
 
 on:
   workflow_call:
+    outputs:
+      app-uploaded:
+        description: 'Whether the app was successfully uploaded'
+        value: ${{ jobs.build-ios-apps.outputs.app-uploaded }}
+    inputs:
+      build_type:
+        description: 'The type of build to perform'
+        required: false
+        default: 'main'
+        type: string
+      metamask_environment:
+        description: 'The environment to build for'
+        required: false
+        default: 'qa'
+        type: string
 
 permissions:
   contents: read
@@ -20,8 +35,8 @@ jobs:
       XCODE_BUILD_SETTINGS: 'COMPILER_INDEX_STORE_ENABLE=NO'
       GITHUB_CI: 'true' # This ensures it's available during pod install
       PLATFORM: ios
-      METAMASK_ENVIRONMENT: qa
-      METAMASK_BUILD_TYPE: main
+      METAMASK_ENVIRONMENT: ${{ inputs.metamask_environment }}
+      METAMASK_BUILD_TYPE: ${{ inputs.build_type }}
       IS_TEST: true
       E2E: 'true'
       IGNORE_BOXLOGS_DEVELOPMENT: true
@@ -226,7 +241,7 @@ jobs:
         id: upload-app
         uses: actions/upload-artifact@v4
         with:
-          name: MetaMask.app
+          name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
           path: ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
           retention-days: 7
           if-no-files-found: error
@@ -239,7 +254,7 @@ jobs:
         if: ${{ steps.cache-restore.outputs.cache-hit == 'true' || steps.cache-restore-main.outputs.cache-hit == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: index.js.map
+          name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-index.js.map
           path: sourcemaps/ios/index.js.map
           retention-days: 7
           if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,23 @@ jobs:
         }}
     secrets: inherit
 
+  e2e-smoke-tests-ios-flask:
+    name: 'iOS Flask E2E Smoke Tests'
+    if: ${{ github.event_name != 'merge_group' && needs.needs_e2e_build.outputs.ios_changed == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    needs: [needs_e2e_build, ios-tests-ready, smart-e2e-selection]
+    uses: ./.github/workflows/run-e2e-smoke-tests-ios-flask.yml
+    with:
+      changed_files: ${{ needs.needs_e2e_build.outputs.changed_files }}
+      selected_tags: >-
+        ${{
+          (needs.smart-e2e-selection.outputs.ai_confidence >= 80 && needs.smart-e2e-selection.outputs.ai_e2e_test_tags) ||
+          '["ALL"]'
+        }}
+    secrets: inherit
+
   js-bundle-size-check:
     runs-on: ubuntu-latest
     steps:
@@ -604,6 +621,7 @@ jobs:
       - e2e-smoke-tests-android
       - e2e-smoke-tests-ios
       - e2e-smoke-tests-android-flask
+      - e2e-smoke-tests-ios-flask
     steps:
       - run: |
           # Check if all non-E2E jobs passed
@@ -629,9 +647,15 @@ jobs:
               exit 1
             fi
 
-            FLASK_RESULT="${{ needs.e2e-smoke-tests-android-flask.result }}"
-            if [[ "$FLASK_RESULT" == "failure" ]] || [[ "$FLASK_RESULT" == "cancelled" ]]; then
-              echo "Android Flask E2E tests failed (result: $FLASK_RESULT)"
+            ANDROID_FLASK_RESULT="${{ needs.e2e-smoke-tests-android-flask.result }}"
+            if [[ "$ANDROID_FLASK_RESULT" == "failure" ]] || [[ "$ANDROID_FLASK_RESULT" == "cancelled" ]]; then
+              echo "Android Flask E2E tests failed (result: $ANDROID_FLASK_RESULT)"
+              exit 1
+            fi
+
+            IOS_FLASK_RESULT="${{ needs.e2e-smoke-tests-ios-flask.result }}"
+            if [[ "$IOS_FLASK_RESULT" == "failure" ]] || [[ "$IOS_FLASK_RESULT" == "cancelled" ]]; then
+              echo "iOS Flask E2E tests failed (result: $IOS_FLASK_RESULT)"
               exit 1
             fi
           fi

--- a/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
@@ -1,0 +1,165 @@
+name: iOS Flask E2E Smoke Tests
+
+on:
+  workflow_call:
+    inputs:
+      selected_tags:
+        description: 'JSON array of selected tags from Smart E2E selection'
+        required: false
+        type: string
+        default: '["ALL"]'
+      changed_files:
+        description: 'Changed files'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  repack-ios-flask-apps:
+    if: contains(fromJson(inputs.selected_tags), 'ALL') || contains(fromJson(inputs.selected_tags), 'FlaskBuildTests')
+    name: 'Repack iOS Flask Apps'
+    runs-on: ghcr.io/cirruslabs/macos-runner:sequoia
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: yarn install --immutable
+
+      - name: Setup project
+        run: yarn setup:github-ci --no-build-android
+
+      - name: Download Main iOS App artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+          pattern: main-*-MetaMask.app
+
+      - name: Setup Main iOS App artifacts
+        run: |
+          mkdir -p ios/build/Build/Products/Release-iphonesimulator/
+          cp -R artifacts/main-qa-MetaMask.app ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
+
+      - name: Repack Main iOS App
+        run: node scripts/repack.js
+        env:
+          PLATFORM: ios
+          METAMASK_ENVIRONMENT: e2e
+          METAMASK_BUILD_TYPE: flask
+          IS_TEST: 'true'
+          E2E: 'true'
+          IGNORE_BOXLOGS_DEVELOPMENT: 'true'
+          GITHUB_CI: 'true'
+          CI: 'true'
+          NODE_OPTIONS: '--max-old-space-size=8192'
+          BRIDGE_USE_DEV_APIS: 'true'
+          RAMP_INTERNAL_BUILD: 'true'
+          SEEDLESS_ONBOARDING_ENABLED: 'true'
+          MM_NOTIFICATIONS_UI_ENABLED: 'true'
+          MM_SECURITY_ALERTS_API_ENABLED: 'true'
+          FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN: ${{ secrets.FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN }}
+          FEATURES_ANNOUNCEMENTS_SPACE_ID: ${{ secrets.FEATURES_ANNOUNCEMENTS_SPACE_ID }}
+          SEGMENT_WRITE_KEY_QA: ${{ secrets.SEGMENT_WRITE_KEY_QA }}
+          SEGMENT_WRITE_KEY_FLASK: ${{ secrets.SEGMENT_WRITE_KEY_FLASK }}
+          SEGMENT_PROXY_URL_QA: ${{ secrets.SEGMENT_PROXY_URL_QA }}
+          SEGMENT_PROXY_URL_FLASK: ${{ secrets.SEGMENT_PROXY_URL_FLASK }}
+          SEGMENT_DELETE_API_SOURCE_ID_QA: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_QA }}
+          SEGMENT_DELETE_API_SOURCE_ID_FLASK: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_FLASK }}
+          SEGMENT_REGULATIONS_ENDPOINT_QA: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_QA }}
+          SEGMENT_REGULATIONS_ENDPOINT_FLASK: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_FLASK }}
+          MM_SENTRY_DSN_TEST: ${{ secrets.MM_SENTRY_DSN_TEST }}
+          MM_SENTRY_AUTH_TOKEN: ${{ secrets.MM_SENTRY_AUTH_TOKEN }}
+          MAIN_IOS_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_IOS_GOOGLE_CLIENT_ID_UAT }}
+          FLASK_IOS_GOOGLE_CLIENT_ID_PROD: ${{ secrets.FLASK_IOS_GOOGLE_CLIENT_ID_PROD }}
+          MAIN_IOS_GOOGLE_REDIRECT_URI_UAT: ${{ secrets.MAIN_IOS_GOOGLE_REDIRECT_URI_UAT }}
+          FLASK_IOS_GOOGLE_REDIRECT_URI_PROD: ${{ secrets.FLASK_IOS_GOOGLE_REDIRECT_URI_PROD }}
+          MAIN_ANDROID_APPLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_APPLE_CLIENT_ID_UAT }}
+          FLASK_ANDROID_APPLE_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_APPLE_CLIENT_ID_PROD }}
+          MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT }}
+          FLASK_ANDROID_GOOGLE_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_GOOGLE_CLIENT_ID_PROD }}
+          MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT }}
+          FLASK_ANDROID_GOOGLE_SERVER_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_GOOGLE_SERVER_CLIENT_ID_PROD }}
+          GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
+          GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
+          MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+
+      - name: Upload Repacked iOS Flask App
+        uses: actions/upload-artifact@v4
+        with:
+          name: flask-e2e-MetaMask.app
+          path: ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
+          retention-days: 1
+
+  flask-ios-smoke:
+    if: contains(fromJson(inputs.selected_tags), 'ALL') || contains(fromJson(inputs.selected_tags), 'FlaskBuildTests')
+    needs: [repack-ios-flask-apps]
+    strategy:
+      matrix:
+        split: [1, 2, 3]
+      fail-fast: false
+    uses: ./.github/workflows/run-e2e-workflow.yml
+    with:
+      test-suite-name: flask-ios-smoke-${{ matrix.split }}
+      platform: ios
+      test_suite_tag: 'FlaskBuildTests'
+      split_number: ${{ matrix.split }}
+      total_splits: 3
+      changed_files: ${{ inputs.changed_files }}
+      build_type: 'flask'
+    secrets: inherit
+
+  report-ios-smoke-tests:
+    name: Report iOS Flask Smoke Tests
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && (contains(fromJson(inputs.selected_tags), 'ALL') || contains(fromJson(inputs.selected_tags), 'FlaskBuildTests')) }}
+    needs:
+      - flask-ios-smoke
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Download shards test artifacts (XMLs + Screenshots)
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          path: all-test-artifacts/
+          pattern: 'test-e2e-*-ios-*'
+
+      - name: Post Test Report
+        uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3
+        with:
+          name: 'iOS Flask E2E Smoke Test Results'
+          path: 'all-test-artifacts/**/junit.xml'
+          reporter: 'jest-junit'
+          fail-on-error: false
+          list-suites: 'failed'
+          list-tests: 'failed'
+
+      - name: Upload all test artifacts (XMLs + Screenshots)
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-smoke-ios-flask-all-test-artifacts
+          path: all-test-artifacts/

--- a/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
@@ -125,6 +125,7 @@ jobs:
       total_splits: 3
       changed_files: ${{ inputs.changed_files }}
       build_type: 'flask'
+      metamask_environment: 'e2e'
     secrets: inherit
 
   report-ios-smoke-tests:

--- a/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
@@ -30,11 +30,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup iOS Environment
+        timeout-minutes: 15
+        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1
         with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
+          platform: ios
+          setup-simulator: false
 
       - name: Install dependencies
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -33,6 +33,8 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 4
       changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
     secrets: inherit
 
   trade-ios-smoke:
@@ -49,6 +51,8 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 1
       changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
     secrets: inherit
 
   perps-ios-smoke:
@@ -65,6 +69,8 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 1
       changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
     secrets: inherit
 
   wallet-platform-ios-smoke:
@@ -81,6 +87,8 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 2
       changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
     secrets: inherit
 
   identity-ios-smoke:
@@ -97,6 +105,8 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 2
       changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
     secrets: inherit
 
   accounts-ios-smoke:
@@ -113,6 +123,8 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 1
       changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
     secrets: inherit
 
   network-abstraction-ios-smoke:
@@ -129,6 +141,8 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 2
       changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
     secrets: inherit
 
   network-expansion-ios-smoke:
@@ -145,6 +159,8 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 2
       changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
     secrets: inherit
 
   prediction-market-ios-smoke:
@@ -161,6 +177,8 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 1
       changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
     secrets: inherit
 
   card-ios-smoke:
@@ -177,6 +195,8 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 1
       changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
     secrets: inherit
 
   ramps-ios-smoke:
@@ -193,6 +213,8 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 1
       changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
     secrets: inherit
 
   multichain-api-ios-smoke:
@@ -209,6 +231,8 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 1
       changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
     secrets: inherit
 
   report-ios-smoke-tests:

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -58,7 +58,7 @@ jobs:
       test-apk-target-path: ${{ steps.determine-target-paths.outputs.test-apk-target-path }}
 
     env:
-      PREBUILT_IOS_APP_PATH: artifacts/MetaMask.app
+      PREBUILT_IOS_APP_PATH: artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
       METAMASK_ENVIRONMENT: ${{ inputs.metamask_environment }}
       METAMASK_BUILD_TYPE: ${{ inputs.build_type }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app.config.js
+++ b/app.config.js
@@ -89,7 +89,10 @@ module.exports = {
         : 'io.metamask', // Required for @expo/repack-app Android repacking
   },
   ios: {
-    bundleIdentifier: 'io.metamask.MetaMask',
+    bundleIdentifier:
+      process.env.METAMASK_BUILD_TYPE === 'flask'
+        ? 'io.metamask.MetaMask-Flask'
+        : 'io.metamask.MetaMask', // Required for @expo/repack-app iOS repacking
     usesAppleSignIn: true,
     jsEngine: 'hermes',
   },

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -245,7 +245,9 @@ class TestSnaps {
       TestSnapViewSelectorWebIDS[buttonLocator],
     );
     await Gestures.scrollToWebViewPort(webElement);
-    await Gestures.tapWebElement(webElement);
+    await Gestures.tap(webElement, {
+      elemDescription: `tapButton:: ${buttonLocator}`,
+    });
   }
 
   async tapOkButton() {

--- a/e2e/specs/snaps/test-snap-network-access.spec.ts
+++ b/e2e/specs/snaps/test-snap-network-access.spec.ts
@@ -41,6 +41,12 @@ describe(FlaskBuildTests('Network Access Snap Tests'), () => {
         );
 
         // Use WebSockets
+        // Disable synchronization on iOS before starting WebSocket to prevent
+        // Detox from hanging due to the open connection keeping the app "busy"
+        if (device.getPlatform() === 'ios') {
+          await device.disableSynchronization();
+        }
+
         const webSocketUrl = `ws://localhost:${getAnvilPortForTest()}`;
         await TestSnaps.fillMessage('webSocketUrlInput', webSocketUrl);
         await TestSnaps.tapButton('startWebSocket');

--- a/e2e/specs/snaps/test-snap-preinstalled.spec.ts
+++ b/e2e/specs/snaps/test-snap-preinstalled.spec.ts
@@ -11,12 +11,6 @@ jest.setTimeout(150_000);
 
 const eventToTrack = 'Test Event';
 
-const navigateToDappAndShowPreinstalledDialog = async () => {
-  await loginToApp();
-  await navigateToBrowserView();
-  await TestSnaps.navigateToTestSnap();
-};
-
 describe(FlaskBuildTests('Preinstalled Snap Tests'), () => {
   it.todo('displays the Snap settings page');
 
@@ -31,7 +25,9 @@ describe(FlaskBuildTests('Preinstalled Snap Tests'), () => {
         skipReactNativeReload: true,
       },
       async ({ mockServer }) => {
-        await navigateToDappAndShowPreinstalledDialog();
+        await loginToApp();
+        await navigateToBrowserView();
+        await TestSnaps.navigateToTestSnap();
         await TestSnaps.tapButton('showPreinstalledDialogButton');
 
         await Assertions.expectTextDisplayed(

--- a/tests/api-mocking/mock-responses/defaults/polymarket-apis.ts
+++ b/tests/api-mocking/mock-responses/defaults/polymarket-apis.ts
@@ -11,28 +11,6 @@ export const POLYMARKET_API_MOCKS = {
         blocked: false, // Set to false to allow access in tests
       },
     },
-    {
-      urlEndpoint:
-        'https://tx-sentinel-polygon-mainnet.api.cx.metamask.io/network',
-      responseCode: 200,
-      response: {
-        name: 'Polygon Mainnet',
-        group: 'polygon',
-        chainID: 137,
-        nativeCurrency: {
-          name: 'POL',
-          symbol: 'POL',
-          decimals: 18,
-        },
-        network: 'polygon-mainnet',
-        explorer: 'https://polygonscan.com/',
-        confirmations: true,
-        smartTransactions: false,
-        relayTransactions: true,
-        hidden: false,
-        sendBundle: false,
-      },
-    },
   ],
   POST: [],
   PUT: [],

--- a/tests/api-mocking/mock-responses/defaults/polymarket-apis.ts
+++ b/tests/api-mocking/mock-responses/defaults/polymarket-apis.ts
@@ -11,6 +11,28 @@ export const POLYMARKET_API_MOCKS = {
         blocked: false, // Set to false to allow access in tests
       },
     },
+    {
+      urlEndpoint:
+        'https://tx-sentinel-polygon-mainnet.api.cx.metamask.io/network',
+      responseCode: 200,
+      response: {
+        name: 'Polygon Mainnet',
+        group: 'polygon',
+        chainID: 137,
+        nativeCurrency: {
+          name: 'POL',
+          symbol: 'POL',
+          decimals: 18,
+        },
+        network: 'polygon-mainnet',
+        explorer: 'https://polygonscan.com/',
+        confirmations: true,
+        smartTransactions: false,
+        relayTransactions: true,
+        hidden: false,
+        sendBundle: false,
+      },
+    },
   ],
   POST: [],
   PUT: [],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR adds iOS Flask runs along side the existing Android ones. It follows the same approach as Android does for the builds, taking advantage of the main build and repacking it with the flask code. 

The main`ci.yml` now passes in Built type and MetaMask environment as a parameter and the build job now takes it and builds the corresponding artifact.

iOS Flask passing run: https://github.com/MetaMask/metamask-mobile/actions/runs/21626290091/job/62330880758 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1099

## **Manual testing steps**
No manual testing steps apply. 
iOS Flask passing run: [MetaMask/metamask-mobile/actions/runs/21626290091/job/62330880758](https://github.com/MetaMask/metamask-mobile/actions/runs/21626290091/job/62330880758)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI orchestration and artifact naming for iOS builds, plus alters iOS `bundleIdentifier` selection for `flask`, which could break E2E pipelines or repack/signing if misconfigured.
> 
> **Overview**
> Adds an **iOS Flask E2E smoke-test lane** to CI, including a new `run-e2e-smoke-tests-ios-flask.yml` workflow that repacks a `main` iOS `.app` into a `flask` build and runs `FlaskBuildTests` shards.
> 
> Makes iOS E2E build/test workflows **parameterized by `build_type` and `metamask_environment`**, updating artifact names and `PREBUILT_IOS_APP_PATH` wiring so multiple iOS build variants can be downloaded and executed in `run-e2e-workflow.yml`.
> 
> Updates app/test behavior to support the new lane: iOS `bundleIdentifier` now switches for `METAMASK_BUILD_TYPE=flask`, and Snap E2E tests include stability tweaks (Detox iOS WebSocket sync disable, improved tap helper, and combined preinstalled-snap test to reuse `mockServer`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f96af0a036193f4e4a1e19b948d2f0f5fe9a95b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->