### PR TITLE
feat(predict): add feature flag and data types for Live NFL sports

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/types.ts
@@ -342,3 +342,23 @@ export interface OrderBook {
   tick_size: string;
   neg_risk: boolean;
 }
+
+export interface PolymarketApiTeam {
+  id: string;
+  name: string;
+  logo: string;
+  abbreviation: string;
+  color: string;
+  alias: string;
+}
+
+export interface PolymarketApiGameEvent {
+  gameId?: string;
+  startTime?: string;
+  score?: string;
+  elapsed?: string;
+  period?: string;
+  live?: boolean;
+  ended?: boolean;
+  closed?: boolean;
+}

--- a/app/components/UI/Predict/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.test.ts
@@ -1,4 +1,4 @@
-import { selectPredictEnabledFlag } from '.';
+import { selectPredictEnabledFlag, selectPredictLiveNflEnabled } from '.';
 import mockedEngine from '../../../../../core/__mocks__/MockedEngine';
 import {
   mockedState,
@@ -32,6 +32,7 @@ describe('Predict Feature Flag Selectors', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.MM_PREDICT_ENABLED;
+    delete process.env.MM_PREDICT_LIVE_NFL_ENABLED;
     mockHasMinimumRequiredVersion = jest.spyOn(
       remoteFeatureFlagModule,
       'hasMinimumRequiredVersion',
@@ -41,6 +42,7 @@ describe('Predict Feature Flag Selectors', () => {
 
   afterEach(() => {
     delete process.env.MM_PREDICT_ENABLED;
+    delete process.env.MM_PREDICT_LIVE_NFL_ENABLED;
     mockHasMinimumRequiredVersion?.mockRestore();
   });
 
@@ -187,6 +189,174 @@ describe('Predict Feature Flag Selectors', () => {
         };
 
         const result = selectPredictEnabledFlag(stateWithUndefinedController);
+
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('selectPredictLiveNflEnabled', () => {
+    it('returns true for enabled version-gated flag with valid version', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+      const stateWithEnabledRemoteFlag = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictLiveNflEnabled: {
+                  enabled: true,
+                  minimumVersion: '1.0.0',
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPredictLiveNflEnabled(stateWithEnabledRemoteFlag);
+
+      expect(result).toBe(true);
+    });
+
+    describe('remote flag precedence', () => {
+      it('returns true when remote flag enabled overrides local flag false', () => {
+        mockHasMinimumRequiredVersion.mockReturnValue(true);
+        process.env.MM_PREDICT_LIVE_NFL_ENABLED = 'false';
+        const stateWithEnabledRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  predictLiveNflEnabled: {
+                    enabled: true,
+                    minimumVersion: '1.0.0',
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPredictLiveNflEnabled(stateWithEnabledRemoteFlag);
+
+        expect(result).toBe(true);
+      });
+
+      it('returns false when remote flag disabled overrides local flag true', () => {
+        mockHasMinimumRequiredVersion.mockReturnValue(true);
+        process.env.MM_PREDICT_LIVE_NFL_ENABLED = 'true';
+        const stateWithDisabledRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  predictLiveNflEnabled: {
+                    enabled: false,
+                    minimumVersion: '1.0.0',
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPredictLiveNflEnabled(stateWithDisabledRemoteFlag);
+
+        expect(result).toBe(false);
+      });
+
+      it('returns false when app version below minimum required version', () => {
+        mockHasMinimumRequiredVersion.mockReturnValue(false);
+        process.env.MM_PREDICT_LIVE_NFL_ENABLED = 'true';
+        const stateWithVersionCheckFailure = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  predictLiveNflEnabled: {
+                    enabled: true,
+                    minimumVersion: '99.0.0',
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPredictLiveNflEnabled(
+          stateWithVersionCheckFailure,
+        );
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('local flag fallback', () => {
+      it('falls back to local flag when remote flag is invalid', () => {
+        const stateWithInvalidRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  predictLiveNflEnabled: {
+                    enabled: 'invalid',
+                    minimumVersion: 123,
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPredictLiveNflEnabled(stateWithInvalidRemoteFlag);
+
+        expect(result).toBe(false);
+      });
+
+      it('returns false from local flag when remote flag is null', () => {
+        process.env.MM_PREDICT_LIVE_NFL_ENABLED = 'false';
+        const stateWithNullRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  predictLiveNflEnabled: null,
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPredictLiveNflEnabled(stateWithNullRemoteFlag);
+
+        expect(result).toBe(false);
+      });
+
+      it('falls back to local flag when remote feature flags are empty', () => {
+        const result = selectPredictLiveNflEnabled(mockedEmptyFlagsState);
+
+        expect(result).toBe(false);
+      });
+
+      it('returns false from local flag when controller is undefined', () => {
+        process.env.MM_PREDICT_LIVE_NFL_ENABLED = 'false';
+        const stateWithUndefinedController = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: undefined,
+            },
+          },
+        };
+
+        const result = selectPredictLiveNflEnabled(
+          stateWithUndefinedController,
+        );
 
         expect(result).toBe(false);
       });

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -39,3 +39,23 @@ export const selectPredictGtmOnboardingModalEnabledFlag = createSelector(
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
+
+/**
+ * Selector for Predict Live NFL feature enablement
+ *
+ * Uses version-gated feature flag `predictLiveNflEnabled` from remote config.
+ * Falls back to local environment variable MM_PREDICT_LIVE_NFL_ENABLED if remote flag
+ * is unavailable or invalid.
+ *
+ * @returns {boolean} True if feature is enabled and version requirement is met
+ */
+export const selectPredictLiveNflEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const localFlag = process.env.MM_PREDICT_LIVE_NFL_ENABLED === 'true';
+    const remoteFlag =
+      remoteFeatureFlags?.predictLiveNflEnabled as unknown as VersionGatedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
+  },
+);

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -98,6 +98,7 @@ export type PredictMarket = {
   outcomes: PredictOutcome[];
   liquidity: number;
   volume: number;
+  game?: PredictMarketGame;
 };
 
 export type PredictSeries = {
@@ -110,6 +111,53 @@ export type PredictCategory =
   | 'sports'
   | 'crypto'
   | 'politics';
+
+// Sports league types
+export type PredictSportsLeague = 'nfl';
+
+// Game status
+export type PredictGameStatus = 'scheduled' | 'ongoing' | 'ended';
+
+// Team data
+export interface PredictSportTeam {
+  id: string;
+  name: string;
+  logo: string;
+  abbreviation: string; // e.g., "SEA", "DEN"
+  color: string; // Team primary color (hex)
+  alias: string; // Team alias (e.g., "Seahawks")
+}
+
+// Game data attached to market
+export interface PredictMarketGame {
+  id: string;
+  startTime: string;
+  status: PredictGameStatus;
+  league: PredictSportsLeague;
+  elapsed: string; // Game clock
+  period: string; // Current period (Q1, Q2, HT, Q3, Q4, OT, FT)
+  score: string; // "away-home" format (e.g., "21-14")
+  homeTeam: PredictSportTeam;
+  awayTeam: PredictSportTeam;
+  turn?: string; // Team abbreviation with possession
+}
+
+// Live update types for WebSocket data
+export interface GameUpdate {
+  gameId: string;
+  score: string;
+  elapsed: string;
+  period: string;
+  status: PredictGameStatus;
+  turn?: string;
+}
+
+export interface PriceUpdate {
+  tokenId: string;
+  price: number;
+  bestBid: number;
+  bestAsk: number;
+}
 
 export type PredictOutcome = {
   id: string;

--- a/app/components/UI/Predict/types/navigation.ts
+++ b/app/components/UI/Predict/types/navigation.ts
@@ -30,6 +30,7 @@ export interface PredictNavigationParamList extends ParamListBase {
     entryPoint?: PredictEntryPoint;
     title?: string;
     image?: string;
+    isGame?: boolean;
   };
   PredictSellPreview: {
     market: PredictMarket;


### PR DESCRIPTION
## **Description**

Adds the foundational feature flag and TypeScript types for the Predict Live NFL feature. This is Task 00 from the Live NFL implementation plan and unblocks all subsequent development work.

**Reason for change:**
The Live NFL feature requires new data structures to represent game state (teams, scores, periods, game status) and a feature flag to gate the rollout.

**Solution:**
- Added `selectPredictLiveNflEnabled` feature flag selector with remote config and local env fallback (`MM_PREDICT_LIVE_NFL_ENABLED`)
- Added game-related TypeScript types: `PredictSportsLeague`, `PredictGameStatus`, `PredictSportTeam`, `PredictMarketGame`, `GameUpdate`, `PriceUpdate`
- Extended `PredictMarket` type with optional `game` property
- Updated navigation params with `isGame` flag
- Added Polymarket API types for team and game event data

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (internal infrastructure task)

## **Manual testing steps**

```gherkin
Feature: Live NFL Feature Flag and Types

  Scenario: Feature flag returns true when remote flag is enabled
    Given the remote feature flag predictLiveNflEnabled is set to enabled with valid version
    
    When selectPredictLiveNflEnabled selector is called
    Then it returns true

  Scenario: Feature flag falls back to local env var
    Given the remote feature flag is not configured
    And MM_PREDICT_LIVE_NFL_ENABLED environment variable is set to "true"
    
    When selectPredictLiveNflEnabled selector is called
    Then it returns true

  Scenario: Types compile without errors
    Given the new types are added to the codebase
    
    When TypeScript compilation runs
    Then no type errors are reported
```

## **Screenshots/Recordings**

### **Before**

N/A - Infrastructure task (no UI changes)

### **After**

N/A - Infrastructure task (no UI changes)

**Test Results:**
```
PASS app/components/UI/Predict/selectors/featureFlags/index.test.ts
  Predict Feature Flag Selectors
    selectPredictLiveNflEnabled
      ✓ returns true for enabled version-gated flag with valid version
      remote flag precedence
        ✓ returns true when remote flag enabled overrides local flag false
        ✓ returns false when remote flag disabled overrides local flag true
        ✓ returns false when app version below minimum required version
      local flag fallback
        ✓ falls back to local flag when remote flag is invalid
        ✓ returns false from local flag when remote flag is null
        ✓ falls back to local flag when remote feature flags are empty
        ✓ returns false from local flag when controller is undefined

Test Suites: 1 passed, 1 total
Tests:       27 passed, 27 total
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes the foundation for Live NFL in Predict with a version-gated feature flag and new game data structures.
> 
> - Adds `selectPredictLiveNflEnabled` selector (remote `predictLiveNflEnabled` with env fallback `MM_PREDICT_LIVE_NFL_ENABLED`) and comprehensive tests
> - Extends Predict types: `PredictSportsLeague`, `PredictGameStatus`, `PredictSportTeam`, `PredictMarketGame`, `GameUpdate`, `PriceUpdate`; adds optional `game` to `PredictMarket`
> - Updates navigation params: `PredictMarketDetails` now supports `isGame`
> - Expands Polymarket API types with `PolymarketApiTeam` and `PolymarketApiGameEvent`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1592a1c8b36253075c9703d5bf4919a51d83f59c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->