### PR TITLE
feat(predict): add WebSocket manager for live NFL game updates

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/GameCache.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/GameCache.test.ts
@@ -1,0 +1,373 @@
+import { GameUpdate, PredictMarket, Recurrence } from '../../types';
+import { GameCache } from './GameCache';
+
+const createMockGameUpdate = (
+  overrides: Partial<GameUpdate> = {},
+): GameUpdate => ({
+  gameId: 'game-123',
+  score: '21-14',
+  elapsed: '12:34',
+  period: 'Q2',
+  status: 'ongoing',
+  turn: 'SEA',
+  ...overrides,
+});
+
+const createMockMarket = (
+  overrides: Partial<PredictMarket> = {},
+): PredictMarket => ({
+  id: 'market-1',
+  providerId: 'polymarket',
+  slug: 'test-market',
+  title: 'Test Market',
+  description: 'A test market',
+  image: 'https://example.com/image.png',
+  status: 'open',
+  recurrence: Recurrence.NONE,
+  category: 'sports',
+  tags: ['nfl'],
+  outcomes: [],
+  liquidity: 10000,
+  volume: 20000,
+  ...overrides,
+});
+
+const createMockMarketWithGame = (
+  gameId: string = 'game-123',
+  marketOverrides: Partial<PredictMarket> = {},
+): PredictMarket =>
+  createMockMarket({
+    game: {
+      id: gameId,
+      startTime: '2025-01-12T18:00:00Z',
+      status: 'scheduled',
+      league: 'nfl',
+      elapsed: '00:00',
+      period: 'NS',
+      score: '0-0',
+      homeTeam: {
+        id: 'team-1',
+        name: 'Seattle Seahawks',
+        logo: 'https://example.com/sea.png',
+        abbreviation: 'SEA',
+        color: '#002244',
+        alias: 'Seahawks',
+      },
+      awayTeam: {
+        id: 'team-2',
+        name: 'Denver Broncos',
+        logo: 'https://example.com/den.png',
+        abbreviation: 'DEN',
+        color: '#FB4F14',
+        alias: 'Broncos',
+      },
+    },
+    ...marketOverrides,
+  });
+
+describe('GameCache', () => {
+  beforeEach(() => {
+    GameCache.resetInstance();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('singleton pattern', () => {
+    it('returns same instance on multiple calls', () => {
+      const instance1 = GameCache.getInstance();
+      const instance2 = GameCache.getInstance();
+
+      expect(instance1).toBe(instance2);
+    });
+
+    it('creates new instance after reset', () => {
+      const instance1 = GameCache.getInstance();
+      GameCache.resetInstance();
+      const instance2 = GameCache.getInstance();
+
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+
+  describe('updateGame', () => {
+    it('stores game update in cache', () => {
+      const cache = GameCache.getInstance();
+      const update = createMockGameUpdate();
+
+      cache.updateGame('game-123', update);
+
+      expect(cache.getGame('game-123')).toEqual(update);
+    });
+
+    it('overwrites existing entry for same gameId', () => {
+      const cache = GameCache.getInstance();
+      const update1 = createMockGameUpdate({ score: '7-0' });
+      const update2 = createMockGameUpdate({ score: '14-7' });
+
+      cache.updateGame('game-123', update1);
+      cache.updateGame('game-123', update2);
+
+      expect(cache.getGame('game-123')?.score).toBe('14-7');
+    });
+
+    it('stores multiple games independently', () => {
+      const cache = GameCache.getInstance();
+      const update1 = createMockGameUpdate({ gameId: 'game-1', score: '7-0' });
+      const update2 = createMockGameUpdate({
+        gameId: 'game-2',
+        score: '21-14',
+      });
+
+      cache.updateGame('game-1', update1);
+      cache.updateGame('game-2', update2);
+
+      expect(cache.getGame('game-1')?.score).toBe('7-0');
+      expect(cache.getGame('game-2')?.score).toBe('21-14');
+    });
+  });
+
+  describe('getGame', () => {
+    it('returns null for non-existent game', () => {
+      const cache = GameCache.getInstance();
+
+      expect(cache.getGame('nonexistent')).toBeNull();
+    });
+
+    it('returns cached game data', () => {
+      const cache = GameCache.getInstance();
+      const update = createMockGameUpdate();
+
+      cache.updateGame('game-123', update);
+
+      expect(cache.getGame('game-123')).toEqual(update);
+    });
+
+    it('returns null and removes entry when stale', () => {
+      const cache = GameCache.getInstance();
+      const update = createMockGameUpdate();
+
+      cache.updateGame('game-123', update);
+      expect(cache.getCacheSize()).toBe(1);
+
+      jest.advanceTimersByTime(6 * 60 * 1000);
+
+      expect(cache.getGame('game-123')).toBeNull();
+      expect(cache.getCacheSize()).toBe(0);
+    });
+
+    it('returns data when not yet stale', () => {
+      const cache = GameCache.getInstance();
+      const update = createMockGameUpdate();
+
+      cache.updateGame('game-123', update);
+      jest.advanceTimersByTime(4 * 60 * 1000);
+
+      expect(cache.getGame('game-123')).toEqual(update);
+    });
+  });
+
+  describe('overlayOnMarket', () => {
+    it('returns market unchanged when no game property', () => {
+      const cache = GameCache.getInstance();
+      const market = createMockMarket();
+
+      const result = cache.overlayOnMarket(market);
+
+      expect(result).toEqual(market);
+    });
+
+    it('returns market unchanged when no cached data', () => {
+      const cache = GameCache.getInstance();
+      const market = createMockMarketWithGame();
+
+      const result = cache.overlayOnMarket(market);
+
+      expect(result.game?.score).toBe('0-0');
+      expect(result.game?.period).toBe('NS');
+    });
+
+    it('merges cached data onto market.game', () => {
+      const cache = GameCache.getInstance();
+      const update = createMockGameUpdate({
+        gameId: 'game-123',
+        score: '28-21',
+        elapsed: '08:42',
+        period: 'Q3',
+        status: 'ongoing',
+        turn: 'DEN',
+      });
+      const market = createMockMarketWithGame();
+
+      cache.updateGame('game-123', update);
+      const result = cache.overlayOnMarket(market);
+
+      expect(result.game?.score).toBe('28-21');
+      expect(result.game?.elapsed).toBe('08:42');
+      expect(result.game?.period).toBe('Q3');
+      expect(result.game?.status).toBe('ongoing');
+      expect(result.game?.turn).toBe('DEN');
+    });
+
+    it('preserves non-overlaid game properties', () => {
+      const cache = GameCache.getInstance();
+      const update = createMockGameUpdate({ gameId: 'game-123' });
+      const market = createMockMarketWithGame();
+
+      cache.updateGame('game-123', update);
+      const result = cache.overlayOnMarket(market);
+
+      expect(result.game?.id).toBe('game-123');
+      expect(result.game?.startTime).toBe('2025-01-12T18:00:00Z');
+      expect(result.game?.league).toBe('nfl');
+      expect(result.game?.homeTeam.abbreviation).toBe('SEA');
+      expect(result.game?.awayTeam.abbreviation).toBe('DEN');
+    });
+
+    it('preserves non-game market properties', () => {
+      const cache = GameCache.getInstance();
+      const update = createMockGameUpdate({ gameId: 'game-123' });
+      const market = createMockMarketWithGame();
+
+      cache.updateGame('game-123', update);
+      const result = cache.overlayOnMarket(market);
+
+      expect(result.id).toBe('market-1');
+      expect(result.title).toBe('Test Market');
+      expect(result.liquidity).toBe(10000);
+    });
+
+    it('does not mutate original market object', () => {
+      const cache = GameCache.getInstance();
+      const update = createMockGameUpdate({ score: '35-28' });
+      const market = createMockMarketWithGame();
+
+      cache.updateGame('game-123', update);
+      cache.overlayOnMarket(market);
+
+      expect(market.game?.score).toBe('0-0');
+    });
+  });
+
+  describe('overlayOnMarkets', () => {
+    it('overlays cached data onto multiple markets', () => {
+      const cache = GameCache.getInstance();
+      cache.updateGame(
+        'game-1',
+        createMockGameUpdate({ gameId: 'game-1', score: '14-7' }),
+      );
+      cache.updateGame(
+        'game-2',
+        createMockGameUpdate({ gameId: 'game-2', score: '21-14' }),
+      );
+
+      const markets = [
+        createMockMarketWithGame('game-1', { id: 'market-1' }),
+        createMockMarketWithGame('game-2', { id: 'market-2' }),
+        createMockMarket({ id: 'market-3' }),
+      ];
+
+      const results = cache.overlayOnMarkets(markets);
+
+      expect(results[0].game?.score).toBe('14-7');
+      expect(results[1].game?.score).toBe('21-14');
+      expect(results[2].game).toBeUndefined();
+    });
+  });
+
+  describe('pruneStaleEntries', () => {
+    it('removes entries older than TTL', () => {
+      const cache = GameCache.getInstance();
+      cache.updateGame('game-1', createMockGameUpdate({ gameId: 'game-1' }));
+
+      expect(cache.getCacheSize()).toBe(1);
+
+      jest.advanceTimersByTime(6 * 60 * 1000);
+      cache.pruneStaleEntries();
+
+      expect(cache.getCacheSize()).toBe(0);
+    });
+
+    it('keeps entries within TTL', () => {
+      const cache = GameCache.getInstance();
+      cache.updateGame('game-1', createMockGameUpdate({ gameId: 'game-1' }));
+
+      jest.advanceTimersByTime(4 * 60 * 1000);
+      cache.pruneStaleEntries();
+
+      expect(cache.getCacheSize()).toBe(1);
+    });
+
+    it('removes only stale entries', () => {
+      const cache = GameCache.getInstance();
+      cache.updateGame(
+        'game-old',
+        createMockGameUpdate({ gameId: 'game-old' }),
+      );
+
+      jest.advanceTimersByTime(4 * 60 * 1000);
+      cache.updateGame(
+        'game-new',
+        createMockGameUpdate({ gameId: 'game-new' }),
+      );
+
+      jest.advanceTimersByTime(2 * 60 * 1000);
+      cache.pruneStaleEntries();
+
+      expect(cache.getCacheSize()).toBe(1);
+      expect(cache.getGame('game-old')).toBeNull();
+      expect(cache.getGame('game-new')).not.toBeNull();
+    });
+
+    it('runs automatically via cleanup interval', () => {
+      const cache = GameCache.getInstance();
+      cache.updateGame('game-1', createMockGameUpdate({ gameId: 'game-1' }));
+
+      jest.advanceTimersByTime(6 * 60 * 1000);
+
+      expect(cache.getCacheSize()).toBe(0);
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all cached entries', () => {
+      const cache = GameCache.getInstance();
+      cache.updateGame('game-1', createMockGameUpdate({ gameId: 'game-1' }));
+      cache.updateGame('game-2', createMockGameUpdate({ gameId: 'game-2' }));
+
+      expect(cache.getCacheSize()).toBe(2);
+
+      cache.clear();
+
+      expect(cache.getCacheSize()).toBe(0);
+    });
+  });
+
+  describe('debug helpers', () => {
+    it('getCacheSize returns correct count', () => {
+      const cache = GameCache.getInstance();
+
+      expect(cache.getCacheSize()).toBe(0);
+
+      cache.updateGame('game-1', createMockGameUpdate({ gameId: 'game-1' }));
+      expect(cache.getCacheSize()).toBe(1);
+
+      cache.updateGame('game-2', createMockGameUpdate({ gameId: 'game-2' }));
+      expect(cache.getCacheSize()).toBe(2);
+    });
+
+    it('getCachedGameIds returns all cached game IDs', () => {
+      const cache = GameCache.getInstance();
+      cache.updateGame('game-1', createMockGameUpdate({ gameId: 'game-1' }));
+      cache.updateGame('game-2', createMockGameUpdate({ gameId: 'game-2' }));
+
+      const ids = cache.getCachedGameIds();
+
+      expect(ids).toContain('game-1');
+      expect(ids).toContain('game-2');
+      expect(ids).toHaveLength(2);
+    });
+  });
+});

--- a/app/components/UI/Predict/providers/polymarket/GameCache.ts
+++ b/app/components/UI/Predict/providers/polymarket/GameCache.ts
@@ -18,9 +18,7 @@ export class GameCache {
   }
 
   static getInstance(): GameCache {
-    if (!GameCache.instance) {
-      GameCache.instance = new GameCache();
-    }
+    GameCache.instance ??= new GameCache();
     return GameCache.instance;
   }
 

--- a/app/components/UI/Predict/providers/polymarket/GameCache.ts
+++ b/app/components/UI/Predict/providers/polymarket/GameCache.ts
@@ -1,0 +1,121 @@
+import { GameUpdate, PredictMarket } from '../../types';
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 60 * 1000;
+
+interface CacheEntry {
+  data: GameUpdate;
+  lastUpdate: number;
+}
+
+export class GameCache {
+  private static instance: GameCache | null = null;
+  private cache: Map<string, CacheEntry> = new Map();
+  private cleanupInterval: ReturnType<typeof setInterval> | null = null;
+
+  private constructor() {
+    this.startCleanupInterval();
+  }
+
+  static getInstance(): GameCache {
+    if (!GameCache.instance) {
+      GameCache.instance = new GameCache();
+    }
+    return GameCache.instance;
+  }
+
+  static resetInstance(): void {
+    if (GameCache.instance) {
+      GameCache.instance.cleanup();
+      GameCache.instance = null;
+    }
+  }
+
+  updateGame(gameId: string, update: GameUpdate): void {
+    this.cache.set(gameId, {
+      data: update,
+      lastUpdate: Date.now(),
+    });
+  }
+
+  getGame(gameId: string): GameUpdate | null {
+    const entry = this.cache.get(gameId);
+    if (!entry) {
+      return null;
+    }
+
+    const isStale = Date.now() - entry.lastUpdate > CACHE_TTL_MS;
+    if (isStale) {
+      this.cache.delete(gameId);
+      return null;
+    }
+
+    return entry.data;
+  }
+
+  overlayOnMarket(market: PredictMarket): PredictMarket {
+    if (!market.game) {
+      return market;
+    }
+
+    const cachedUpdate = this.getGame(market.game.id);
+    if (!cachedUpdate) {
+      return market;
+    }
+
+    return {
+      ...market,
+      game: {
+        ...market.game,
+        score: cachedUpdate.score,
+        elapsed: cachedUpdate.elapsed,
+        period: cachedUpdate.period,
+        status: cachedUpdate.status,
+        turn: cachedUpdate.turn,
+      },
+    };
+  }
+
+  overlayOnMarkets(markets: PredictMarket[]): PredictMarket[] {
+    return markets.map((m) => this.overlayOnMarket(m));
+  }
+
+  pruneStaleEntries(): void {
+    const now = Date.now();
+    for (const [gameId, entry] of this.cache.entries()) {
+      if (now - entry.lastUpdate > CACHE_TTL_MS) {
+        this.cache.delete(gameId);
+      }
+    }
+  }
+
+  private startCleanupInterval(): void {
+    this.cleanupInterval = setInterval(() => {
+      this.pruneStaleEntries();
+    }, CLEANUP_INTERVAL_MS);
+  }
+
+  private stopCleanupInterval(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
+    }
+  }
+
+  cleanup(): void {
+    this.stopCleanupInterval();
+    this.cache.clear();
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  getCacheSize(): number {
+    return this.cache.size;
+  }
+
+  getCachedGameIds(): string[] {
+    return Array.from(this.cache.keys());
+  }
+}

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -96,6 +96,7 @@ import {
   submitClobOrder,
 } from './utils';
 import { PredictFeeCollection } from '../../types/flags';
+import { GameCache } from './GameCache';
 
 export type SignTypedMessageFn = (
   params: TypedMessageParams,
@@ -188,7 +189,7 @@ export class PolymarketProvider implements PredictProvider {
         throw new Error('Failed to parse market details');
       }
 
-      return parsedMarket;
+      return GameCache.getInstance().overlayOnMarket(parsedMarket);
     } catch (error) {
       DevLogger.log('Error getting market details via Polymarket API:', error);
       throw error;
@@ -234,7 +235,7 @@ export class PolymarketProvider implements PredictProvider {
   public async getMarkets(params?: GetMarketsParams): Promise<PredictMarket[]> {
     try {
       const markets = await getParsedMarketsFromPolymarketApi(params);
-      return markets;
+      return GameCache.getInstance().overlayOnMarkets(markets);
     } catch (error) {
       DevLogger.log('Error getting markets via Polymarket API:', error);
 

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -330,7 +330,7 @@ describe('WebSocketManager', () => {
       );
     });
 
-    it('handles malformed JSON gracefully', () => {
+    it('ignores malformed JSON messages without calling callback', () => {
       const manager = WebSocketManager.getInstance();
       const callback = jest.fn();
 
@@ -655,7 +655,7 @@ describe('WebSocketManager', () => {
   });
 
   describe('getConnectionStatus', () => {
-    it('returns correct status', () => {
+    it('returns connection status with all fields populated', () => {
       const manager = WebSocketManager.getInstance();
 
       expect(manager.getConnectionStatus()).toEqual({

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -250,7 +250,7 @@ describe('WebSocketManager', () => {
       expect(callback2).toHaveBeenCalled();
     });
 
-    it('unsubscribes correctly', () => {
+    it('does not call callback after unsubscribe is invoked', () => {
       const manager = WebSocketManager.getInstance();
       const callback = jest.fn();
 

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -402,6 +402,36 @@ describe('WebSocketManager', () => {
       ]);
     });
 
+    it('maps price from price field not best_ask', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToMarketPrices(['token1'], callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].simulateMessage({
+        event_type: 'price_change',
+        market: 'market-1',
+        price_changes: [
+          {
+            asset_id: 'token1',
+            price: '0.50',
+            best_bid: '0.48',
+            best_ask: '0.52',
+          },
+        ],
+        timestamp: '2025-01-12T12:00:00Z',
+      });
+
+      expect(callback).toHaveBeenCalledWith([
+        {
+          tokenId: 'token1',
+          price: 0.5,
+          bestBid: 0.48,
+          bestAsk: 0.52,
+        },
+      ]);
+    });
+
     it('ignores non-price_change events', () => {
       const manager = WebSocketManager.getInstance();
       const callback = jest.fn();

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -1,0 +1,694 @@
+import { AppState, AppStateStatus } from 'react-native';
+import { GameCache } from './GameCache';
+import { WebSocketManager } from './WebSocketManager';
+
+jest.mock('./GameCache');
+
+const mockGameCacheInstance = {
+  updateGame: jest.fn(),
+  getGame: jest.fn(),
+  overlayOnMarket: jest.fn(),
+  overlayOnMarkets: jest.fn(),
+  pruneStaleEntries: jest.fn(),
+  cleanup: jest.fn(),
+  clear: jest.fn(),
+  getCacheSize: jest.fn(),
+  getCachedGameIds: jest.fn(),
+};
+
+(GameCache.getInstance as jest.Mock) = jest.fn(
+  () => mockGameCacheInstance as unknown as GameCache,
+);
+(GameCache.resetInstance as jest.Mock) = jest.fn();
+
+let mockWebSocketInstances: MockWebSocket[] = [];
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  url: string;
+  readyState = MockWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  send = jest.fn();
+  close = jest.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+  });
+
+  constructor(url: string) {
+    this.url = url;
+    mockWebSocketInstances.push(this);
+  }
+
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.({} as Event);
+  }
+
+  simulateClose(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({} as CloseEvent);
+  }
+
+  simulateMessage(data: object): void {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+
+  simulateError(): void {
+    this.onerror?.({} as Event);
+  }
+}
+
+let appStateCallback: ((state: AppStateStatus) => void) | null = null;
+const mockRemoveListener = jest.fn();
+
+(global as unknown as { WebSocket: typeof MockWebSocket }).WebSocket =
+  MockWebSocket;
+
+jest.mock('react-native', () => ({
+  AppState: {
+    addEventListener: jest.fn(),
+  },
+}));
+
+describe('WebSocketManager', () => {
+  beforeEach(() => {
+    WebSocketManager.resetInstance();
+    mockWebSocketInstances = [];
+    appStateCallback = null;
+    mockRemoveListener.mockClear();
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+
+    (AppState.addEventListener as jest.Mock).mockImplementation(
+      (
+        _event: string,
+        callback: (state: AppStateStatus) => void,
+      ): { remove: () => void } => {
+        appStateCallback = callback;
+        return { remove: mockRemoveListener };
+      },
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('singleton pattern', () => {
+    it('returns same instance on multiple calls', () => {
+      const instance1 = WebSocketManager.getInstance();
+      const instance2 = WebSocketManager.getInstance();
+
+      expect(instance1).toBe(instance2);
+    });
+
+    it('creates new instance after reset', () => {
+      const instance1 = WebSocketManager.getInstance();
+      WebSocketManager.resetInstance();
+      const instance2 = WebSocketManager.getInstance();
+
+      expect(instance1).not.toBe(instance2);
+    });
+
+    it('sets up AppState listener on instantiation', () => {
+      WebSocketManager.getInstance();
+
+      expect(AppState.addEventListener).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('game subscriptions', () => {
+    it('connects to sports WS when first subscription is made', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+
+      expect(mockWebSocketInstances).toHaveLength(1);
+      expect(mockWebSocketInstances[0].url).toBe(
+        'wss://sports-api.polymarket.com/ws',
+      );
+    });
+
+    it('reuses existing connection for second subscriber to same game', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+
+      manager.subscribeToGame('123', callback1);
+      manager.subscribeToGame('123', callback2);
+
+      expect(mockWebSocketInstances).toHaveLength(1);
+    });
+
+    it('reuses existing connection for subscriber to different game', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+
+      manager.subscribeToGame('123', callback1);
+      manager.subscribeToGame('456', callback2);
+
+      expect(mockWebSocketInstances).toHaveLength(1);
+    });
+
+    it('calls callback when game update is received for subscribed game', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].simulateMessage({
+        gameId: 123,
+        score: '21-14',
+        elapsed: '12:34',
+        period: 'Q2',
+        live: true,
+        ended: false,
+      });
+
+      expect(callback).toHaveBeenCalledWith({
+        gameId: '123',
+        score: '21-14',
+        elapsed: '12:34',
+        period: 'Q2',
+        status: 'ongoing',
+        turn: undefined,
+      });
+    });
+
+    it('updates GameCache when sports message received', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].simulateMessage({
+        gameId: 123,
+        score: '21-14',
+        elapsed: '12:34',
+        period: 'Q2',
+        live: true,
+        ended: false,
+      });
+
+      expect(mockGameCacheInstance.updateGame).toHaveBeenCalledWith('123', {
+        gameId: '123',
+        score: '21-14',
+        elapsed: '12:34',
+        period: 'Q2',
+        status: 'ongoing',
+        turn: undefined,
+      });
+    });
+
+    it('does not call callback for unrelated gameId', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].simulateMessage({
+        gameId: 456,
+        score: '7-0',
+        elapsed: '05:00',
+        period: 'Q1',
+        live: true,
+        ended: false,
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('calls multiple callbacks for same gameId', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+
+      manager.subscribeToGame('123', callback1);
+      manager.subscribeToGame('123', callback2);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].simulateMessage({
+        gameId: 123,
+        score: '21-14',
+        elapsed: '12:34',
+        period: 'Q2',
+        live: true,
+        ended: false,
+      });
+
+      expect(callback1).toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalled();
+    });
+
+    it('unsubscribes correctly', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      const unsubscribe = manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+
+      unsubscribe();
+
+      mockWebSocketInstances[0].simulateMessage({
+        gameId: 123,
+        score: '21-14',
+        elapsed: '12:34',
+        period: 'Q2',
+        live: true,
+        ended: false,
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('disconnects when all subscribers unsubscribe', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+
+      const unsubscribe1 = manager.subscribeToGame('123', callback1);
+      const unsubscribe2 = manager.subscribeToGame('456', callback2);
+      mockWebSocketInstances[0].simulateOpen();
+
+      expect(manager.getConnectionStatus().gameSubscriptionCount).toBe(2);
+
+      unsubscribe1();
+      expect(manager.getConnectionStatus().gameSubscriptionCount).toBe(1);
+
+      unsubscribe2();
+      expect(manager.getConnectionStatus().gameSubscriptionCount).toBe(0);
+      expect(mockWebSocketInstances[0].close).toHaveBeenCalled();
+    });
+
+    it('derives status as ended when event.ended is true', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].simulateMessage({
+        gameId: 123,
+        score: '28-21',
+        elapsed: '00:00',
+        period: 'FT',
+        live: false,
+        ended: true,
+      });
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ended' }),
+      );
+    });
+
+    it('derives status as scheduled when neither live nor ended', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].simulateMessage({
+        gameId: 123,
+        score: '0-0',
+        elapsed: '00:00',
+        period: 'NS',
+        live: false,
+        ended: false,
+      });
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'scheduled' }),
+      );
+    });
+
+    it('handles malformed JSON gracefully', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].onmessage?.({
+        data: 'not valid json',
+      } as MessageEvent);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('price subscriptions', () => {
+    it('connects to market WS when first subscription is made', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToMarketPrices(['token1', 'token2'], callback);
+
+      expect(mockWebSocketInstances).toHaveLength(1);
+      expect(mockWebSocketInstances[0].url).toBe(
+        'wss://ws-subscriptions-clob.polymarket.com/ws/market',
+      );
+    });
+
+    it('sends subscription message after connection opens', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToMarketPrices(['token1', 'token2'], callback);
+      mockWebSocketInstances[0].simulateOpen();
+
+      expect(mockWebSocketInstances[0].send).toHaveBeenCalledWith(
+        JSON.stringify({
+          type: 'market',
+          assets_ids: ['token1', 'token2'],
+        }),
+      );
+    });
+
+    it('calls callback with price updates for subscribed tokens', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToMarketPrices(['token1', 'token2'], callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].simulateMessage({
+        event_type: 'price_change',
+        market: 'market-1',
+        price_changes: [
+          {
+            asset_id: 'token1',
+            price: '0.65',
+            best_bid: '0.64',
+            best_ask: '0.65',
+          },
+        ],
+        timestamp: '2025-01-12T12:00:00Z',
+      });
+
+      expect(callback).toHaveBeenCalledWith([
+        {
+          tokenId: 'token1',
+          price: 0.65,
+          bestBid: 0.64,
+          bestAsk: 0.65,
+        },
+      ]);
+    });
+
+    it('ignores non-price_change events', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToMarketPrices(['token1'], callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].simulateMessage({
+        event_type: 'book',
+        market: 'market-1',
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('filters updates to only subscribed tokens', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToMarketPrices(['token1'], callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].simulateMessage({
+        event_type: 'price_change',
+        market: 'market-1',
+        price_changes: [
+          {
+            asset_id: 'token1',
+            price: '0.65',
+            best_bid: '0.64',
+            best_ask: '0.65',
+          },
+          {
+            asset_id: 'token2',
+            price: '0.35',
+            best_bid: '0.34',
+            best_ask: '0.35',
+          },
+        ],
+        timestamp: '2025-01-12T12:00:00Z',
+      });
+
+      expect(callback).toHaveBeenCalledWith([
+        expect.objectContaining({ tokenId: 'token1' }),
+      ]);
+    });
+
+    it('sends unsubscribe message when all callbacks removed', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      const unsubscribe = manager.subscribeToMarketPrices(
+        ['token1', 'token2'],
+        callback,
+      );
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].send.mockClear();
+
+      unsubscribe();
+
+      expect(mockWebSocketInstances[0].send).toHaveBeenCalledWith(
+        JSON.stringify({
+          operation: 'unsubscribe',
+          assets_ids: ['token1', 'token2'],
+        }),
+      );
+    });
+  });
+
+  describe('reconnection with exponential backoff', () => {
+    it('reconnects with increasing delay after connection closes', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].simulateClose();
+
+      expect(mockWebSocketInstances).toHaveLength(1);
+
+      jest.advanceTimersByTime(3000);
+      expect(mockWebSocketInstances).toHaveLength(2);
+
+      mockWebSocketInstances[1].simulateClose();
+      jest.advanceTimersByTime(6000);
+      expect(mockWebSocketInstances).toHaveLength(3);
+    });
+
+    it('stops reconnecting after max attempts', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      const initialInstanceCount = mockWebSocketInstances.length;
+
+      for (let i = 0; i < 5; i++) {
+        const currentIdx = initialInstanceCount - 1 + i;
+        mockWebSocketInstances[currentIdx].simulateClose();
+        jest.advanceTimersByTime((i + 1) * 3000);
+      }
+
+      const afterAttemptsCount = mockWebSocketInstances.length;
+      const lastIdx = afterAttemptsCount - 1;
+      mockWebSocketInstances[lastIdx].simulateClose();
+      jest.advanceTimersByTime(30000);
+
+      expect(mockWebSocketInstances).toHaveLength(afterAttemptsCount);
+    });
+
+    it('resets reconnect attempts on successful connection', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateClose();
+      jest.advanceTimersByTime(3000);
+
+      mockWebSocketInstances[1].simulateOpen();
+      mockWebSocketInstances[1].simulateClose();
+      jest.advanceTimersByTime(3000);
+
+      expect(mockWebSocketInstances).toHaveLength(3);
+    });
+
+    it('does not reconnect if no subscribers remain', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      const unsubscribe = manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+
+      unsubscribe();
+      mockWebSocketInstances[0].simulateClose();
+      jest.advanceTimersByTime(10000);
+
+      expect(mockWebSocketInstances).toHaveLength(1);
+    });
+  });
+
+  describe('AppState handling', () => {
+    it('disconnects on app background when connected', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+
+      expect(appStateCallback).not.toBeNull();
+      if (appStateCallback) {
+        appStateCallback('background');
+      }
+
+      expect(mockWebSocketInstances[0].readyState).toBe(MockWebSocket.CLOSED);
+    });
+
+    it('reconnects on app foreground if had active subscriptions', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+
+      const countBeforeBackground = mockWebSocketInstances.length;
+
+      if (appStateCallback) {
+        appStateCallback('background');
+        appStateCallback('active');
+      }
+
+      expect(mockWebSocketInstances.length).toBeGreaterThan(
+        countBeforeBackground,
+      );
+    });
+
+    it('does not reconnect on foreground if no subscriptions', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      const unsubscribe = manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+
+      unsubscribe();
+
+      const countAfterUnsubscribe = mockWebSocketInstances.length;
+
+      if (appStateCallback) {
+        appStateCallback('background');
+        appStateCallback('active');
+      }
+
+      expect(mockWebSocketInstances.length).toBe(countAfterUnsubscribe);
+    });
+  });
+
+  describe('ping/heartbeat', () => {
+    it('sends ping at configured interval after connection opens', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockWebSocketInstances[0].send.mockClear();
+
+      jest.advanceTimersByTime(50000);
+
+      expect(mockWebSocketInstances[0].send).toHaveBeenCalledWith('PING');
+    });
+
+    it('stops ping on disconnect', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      const unsubscribe = manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+
+      unsubscribe();
+      mockWebSocketInstances[0].send.mockClear();
+
+      jest.advanceTimersByTime(100000);
+
+      expect(mockWebSocketInstances[0].send).not.toHaveBeenCalledWith('PING');
+    });
+  });
+
+  describe('getConnectionStatus', () => {
+    it('returns correct status', () => {
+      const manager = WebSocketManager.getInstance();
+
+      expect(manager.getConnectionStatus()).toEqual({
+        sportsConnected: false,
+        marketConnected: false,
+        gameSubscriptionCount: 0,
+        priceSubscriptionCount: 0,
+      });
+
+      manager.subscribeToGame('123', jest.fn());
+      mockWebSocketInstances[0].simulateOpen();
+
+      manager.subscribeToMarketPrices(['token1'], jest.fn());
+      mockWebSocketInstances[1].simulateOpen();
+
+      expect(manager.getConnectionStatus()).toEqual({
+        sportsConnected: true,
+        marketConnected: true,
+        gameSubscriptionCount: 1,
+        priceSubscriptionCount: 1,
+      });
+    });
+  });
+
+  describe('cleanup', () => {
+    it('cleans up AppState listener on reset', () => {
+      mockRemoveListener.mockClear();
+
+      WebSocketManager.getInstance();
+      WebSocketManager.resetInstance();
+
+      expect(mockRemoveListener).toHaveBeenCalled();
+    });
+
+    it('closes all connections', () => {
+      const manager = WebSocketManager.getInstance();
+
+      manager.subscribeToGame('123', jest.fn());
+      mockWebSocketInstances[0].simulateOpen();
+
+      manager.subscribeToMarketPrices(['token1'], jest.fn());
+      mockWebSocketInstances[1].simulateOpen();
+
+      WebSocketManager.resetInstance();
+
+      expect(mockWebSocketInstances[0].close).toHaveBeenCalled();
+      expect(mockWebSocketInstances[1].close).toHaveBeenCalled();
+    });
+
+    it('clears all subscriptions', () => {
+      const manager = WebSocketManager.getInstance();
+
+      manager.subscribeToGame('123', jest.fn());
+      manager.subscribeToMarketPrices(['token1'], jest.fn());
+
+      expect(manager.getConnectionStatus().gameSubscriptionCount).toBe(1);
+      expect(manager.getConnectionStatus().priceSubscriptionCount).toBe(1);
+
+      WebSocketManager.resetInstance();
+      const newManager = WebSocketManager.getInstance();
+
+      expect(newManager.getConnectionStatus().gameSubscriptionCount).toBe(0);
+      expect(newManager.getConnectionStatus().priceSubscriptionCount).toBe(0);
+    });
+  });
+});

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
@@ -1,0 +1,487 @@
+import { AppState, AppStateStatus } from 'react-native';
+import { GameUpdate, PriceUpdate, PredictGameStatus } from '../../types';
+import { GameCache } from './GameCache';
+
+const SPORTS_WS_URL = 'wss://sports-api.polymarket.com/ws';
+const MARKET_WS_URL = 'wss://ws-subscriptions-clob.polymarket.com/ws/market';
+
+const RECONNECT_DELAY_MS = 3000;
+const MAX_RECONNECT_ATTEMPTS = 5;
+const PING_INTERVAL_MS = 50000;
+
+type GameUpdateCallback = (update: GameUpdate) => void;
+type PriceUpdateCallback = (updates: PriceUpdate[]) => void;
+
+interface SportsWebSocketEvent {
+  gameId: number;
+  leagueAbbreviation: string;
+  turn?: string;
+  score: string;
+  elapsed: string;
+  period: string;
+  live: boolean;
+  ended: boolean;
+}
+
+interface MarketWebSocketEvent {
+  event_type: string;
+  market: string;
+  price_changes?: {
+    asset_id: string;
+    price: string;
+    best_bid: string;
+    best_ask: string;
+  }[];
+  timestamp: string;
+}
+
+export class WebSocketManager {
+  private static instance: WebSocketManager | null = null;
+
+  private sportsWs: WebSocket | null = null;
+  private marketWs: WebSocket | null = null;
+
+  private gameSubscriptions: Map<string, Set<GameUpdateCallback>> = new Map();
+  private priceSubscriptions: Map<string, Set<PriceUpdateCallback>> = new Map();
+
+  private sportsReconnectAttempts = 0;
+  private marketReconnectAttempts = 0;
+  private sportsReconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+  private marketReconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  private sportsPingInterval: ReturnType<typeof setInterval> | null = null;
+  private marketPingInterval: ReturnType<typeof setInterval> | null = null;
+
+  private appStateSubscription: { remove: () => void } | null = null;
+
+  private constructor() {
+    this.setupAppStateListener();
+  }
+
+  static getInstance(): WebSocketManager {
+    if (!WebSocketManager.instance) {
+      WebSocketManager.instance = new WebSocketManager();
+    }
+    return WebSocketManager.instance;
+  }
+
+  static resetInstance(): void {
+    if (WebSocketManager.instance) {
+      WebSocketManager.instance.cleanup();
+      WebSocketManager.instance = null;
+    }
+  }
+
+  private setupAppStateListener(): void {
+    this.appStateSubscription = AppState.addEventListener(
+      'change',
+      this.handleAppStateChange,
+    );
+  }
+
+  private handleAppStateChange = (nextAppState: AppStateStatus): void => {
+    if (nextAppState === 'active') {
+      this.reconnectAll();
+    } else if (nextAppState === 'background') {
+      this.disconnectAll();
+    }
+  };
+
+  subscribeToGame(gameId: string, callback: GameUpdateCallback): () => void {
+    let callbacks = this.gameSubscriptions.get(gameId);
+    if (!callbacks) {
+      callbacks = new Set();
+      this.gameSubscriptions.set(gameId, callbacks);
+    }
+    callbacks.add(callback);
+
+    this.ensureSportsConnection();
+
+    return () => {
+      const callbacks = this.gameSubscriptions.get(gameId);
+      if (callbacks) {
+        callbacks.delete(callback);
+        if (callbacks.size === 0) {
+          this.gameSubscriptions.delete(gameId);
+        }
+      }
+
+      if (this.gameSubscriptions.size === 0) {
+        this.disconnectSports();
+      }
+    };
+  }
+
+  private ensureSportsConnection(): void {
+    if (this.sportsWs?.readyState === WebSocket.OPEN) {
+      return;
+    }
+    if (this.sportsWs?.readyState === WebSocket.CONNECTING) {
+      return;
+    }
+
+    this.connectSports();
+  }
+
+  private connectSports(): void {
+    this.cleanupSportsConnection();
+
+    try {
+      this.sportsWs = new WebSocket(SPORTS_WS_URL);
+
+      this.sportsWs.onopen = () => {
+        this.sportsReconnectAttempts = 0;
+        this.startSportsPing();
+      };
+
+      this.sportsWs.onclose = () => {
+        this.stopSportsPing();
+        this.scheduleSportsReconnect();
+      };
+
+      this.sportsWs.onerror = () => {
+        // Error will trigger onclose
+      };
+
+      this.sportsWs.onmessage = this.handleSportsMessage;
+    } catch {
+      this.scheduleSportsReconnect();
+    }
+  }
+
+  private handleSportsMessage = (event: WebSocketMessageEvent): void => {
+    try {
+      const data: SportsWebSocketEvent = JSON.parse(event.data);
+      const gameId = String(data.gameId);
+
+      const update: GameUpdate = {
+        gameId,
+        score: data.score,
+        elapsed: data.elapsed,
+        period: data.period,
+        status: this.deriveGameStatus(data),
+        turn: data.turn,
+      };
+
+      GameCache.getInstance().updateGame(gameId, update);
+
+      const callbacks = this.gameSubscriptions.get(gameId);
+      if (callbacks && callbacks.size > 0) {
+        callbacks.forEach((callback) => callback(update));
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  };
+
+  private deriveGameStatus(event: SportsWebSocketEvent): PredictGameStatus {
+    if (event.ended) {
+      return 'ended';
+    }
+    if (event.live) {
+      return 'ongoing';
+    }
+    return 'scheduled';
+  }
+
+  private scheduleSportsReconnect(): void {
+    if (this.gameSubscriptions.size === 0) {
+      return;
+    }
+
+    if (this.sportsReconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      return;
+    }
+
+    this.sportsReconnectAttempts++;
+    const delay = RECONNECT_DELAY_MS * this.sportsReconnectAttempts;
+
+    this.sportsReconnectTimeout = setTimeout(() => {
+      this.connectSports();
+    }, delay);
+  }
+
+  private startSportsPing(): void {
+    this.sportsPingInterval = setInterval(() => {
+      if (this.sportsWs?.readyState === WebSocket.OPEN) {
+        this.sportsWs.send('PING');
+      }
+    }, PING_INTERVAL_MS);
+  }
+
+  private stopSportsPing(): void {
+    if (this.sportsPingInterval) {
+      clearInterval(this.sportsPingInterval);
+      this.sportsPingInterval = null;
+    }
+  }
+
+  private cleanupSportsConnection(): void {
+    this.stopSportsPing();
+
+    if (this.sportsReconnectTimeout) {
+      clearTimeout(this.sportsReconnectTimeout);
+      this.sportsReconnectTimeout = null;
+    }
+
+    if (this.sportsWs) {
+      this.sportsWs.onopen = null;
+      this.sportsWs.onclose = null;
+      this.sportsWs.onerror = null;
+      this.sportsWs.onmessage = null;
+
+      if (
+        this.sportsWs.readyState === WebSocket.OPEN ||
+        this.sportsWs.readyState === WebSocket.CONNECTING
+      ) {
+        this.sportsWs.close();
+      }
+      this.sportsWs = null;
+    }
+  }
+
+  private disconnectSports(): void {
+    this.cleanupSportsConnection();
+    this.sportsReconnectAttempts = 0;
+  }
+
+  subscribeToMarketPrices(
+    tokenIds: string[],
+    callback: PriceUpdateCallback,
+  ): () => void {
+    const subscriptionKey = tokenIds.sort().join(',');
+
+    let callbacks = this.priceSubscriptions.get(subscriptionKey);
+    if (!callbacks) {
+      callbacks = new Set();
+      this.priceSubscriptions.set(subscriptionKey, callbacks);
+    }
+    callbacks.add(callback);
+
+    this.ensureMarketConnection(tokenIds);
+
+    return () => {
+      const callbacks = this.priceSubscriptions.get(subscriptionKey);
+      if (callbacks) {
+        callbacks.delete(callback);
+        if (callbacks.size === 0) {
+          this.priceSubscriptions.delete(subscriptionKey);
+          this.sendMarketUnsubscribe(tokenIds);
+        }
+      }
+
+      if (this.priceSubscriptions.size === 0) {
+        this.disconnectMarket();
+      }
+    };
+  }
+
+  private ensureMarketConnection(tokenIds: string[]): void {
+    if (this.marketWs?.readyState === WebSocket.OPEN) {
+      this.sendMarketSubscribe(tokenIds);
+      return;
+    }
+    if (this.marketWs?.readyState === WebSocket.CONNECTING) {
+      return;
+    }
+
+    this.connectMarket();
+  }
+
+  private connectMarket(): void {
+    this.cleanupMarketConnection();
+
+    try {
+      this.marketWs = new WebSocket(MARKET_WS_URL);
+
+      this.marketWs.onopen = () => {
+        this.marketReconnectAttempts = 0;
+        this.startMarketPing();
+        this.resubscribeAllMarkets();
+      };
+
+      this.marketWs.onclose = () => {
+        this.stopMarketPing();
+        this.scheduleMarketReconnect();
+      };
+
+      this.marketWs.onerror = () => {
+        // Error will trigger onclose
+      };
+
+      this.marketWs.onmessage = this.handleMarketMessage;
+    } catch {
+      this.scheduleMarketReconnect();
+    }
+  }
+
+  private handleMarketMessage = (event: WebSocketMessageEvent): void => {
+    try {
+      const data: MarketWebSocketEvent = JSON.parse(event.data);
+
+      if (data.event_type !== 'price_change' || !data.price_changes) {
+        return;
+      }
+
+      const updates: PriceUpdate[] = data.price_changes.map((change) => ({
+        tokenId: change.asset_id,
+        price: parseFloat(change.best_ask) || 0,
+        bestBid: parseFloat(change.best_bid) || 0,
+        bestAsk: parseFloat(change.best_ask) || 0,
+      }));
+
+      this.priceSubscriptions.forEach((callbacks, key) => {
+        const subscribedTokenIds = new Set(key.split(','));
+        const relevantUpdates = updates.filter((u) =>
+          subscribedTokenIds.has(u.tokenId),
+        );
+
+        if (relevantUpdates.length > 0) {
+          callbacks.forEach((callback) => callback(relevantUpdates));
+        }
+      });
+    } catch {
+      // Ignore parse errors
+    }
+  };
+
+  private sendMarketSubscribe(tokenIds: string[]): void {
+    if (this.marketWs?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    this.marketWs.send(
+      JSON.stringify({
+        type: 'market',
+        assets_ids: tokenIds,
+      }),
+    );
+  }
+
+  private sendMarketUnsubscribe(tokenIds: string[]): void {
+    if (this.marketWs?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    this.marketWs.send(
+      JSON.stringify({
+        operation: 'unsubscribe',
+        assets_ids: tokenIds,
+      }),
+    );
+  }
+
+  private resubscribeAllMarkets(): void {
+    const allTokenIds = new Set<string>();
+    this.priceSubscriptions.forEach((_, key) => {
+      key.split(',').forEach((id) => allTokenIds.add(id));
+    });
+
+    if (allTokenIds.size > 0) {
+      this.sendMarketSubscribe(Array.from(allTokenIds));
+    }
+  }
+
+  private scheduleMarketReconnect(): void {
+    if (this.priceSubscriptions.size === 0) {
+      return;
+    }
+
+    if (this.marketReconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      return;
+    }
+
+    this.marketReconnectAttempts++;
+    const delay = RECONNECT_DELAY_MS * this.marketReconnectAttempts;
+
+    this.marketReconnectTimeout = setTimeout(() => {
+      this.connectMarket();
+    }, delay);
+  }
+
+  private startMarketPing(): void {
+    this.marketPingInterval = setInterval(() => {
+      if (this.marketWs?.readyState === WebSocket.OPEN) {
+        this.marketWs.send('PING');
+      }
+    }, PING_INTERVAL_MS);
+  }
+
+  private stopMarketPing(): void {
+    if (this.marketPingInterval) {
+      clearInterval(this.marketPingInterval);
+      this.marketPingInterval = null;
+    }
+  }
+
+  private cleanupMarketConnection(): void {
+    this.stopMarketPing();
+
+    if (this.marketReconnectTimeout) {
+      clearTimeout(this.marketReconnectTimeout);
+      this.marketReconnectTimeout = null;
+    }
+
+    if (this.marketWs) {
+      this.marketWs.onopen = null;
+      this.marketWs.onclose = null;
+      this.marketWs.onerror = null;
+      this.marketWs.onmessage = null;
+
+      if (
+        this.marketWs.readyState === WebSocket.OPEN ||
+        this.marketWs.readyState === WebSocket.CONNECTING
+      ) {
+        this.marketWs.close();
+      }
+      this.marketWs = null;
+    }
+  }
+
+  private disconnectMarket(): void {
+    this.cleanupMarketConnection();
+    this.marketReconnectAttempts = 0;
+  }
+
+  private reconnectAll(): void {
+    this.sportsReconnectAttempts = 0;
+    this.marketReconnectAttempts = 0;
+
+    if (this.gameSubscriptions.size > 0) {
+      this.connectSports();
+    }
+    if (this.priceSubscriptions.size > 0) {
+      this.connectMarket();
+    }
+  }
+
+  private disconnectAll(): void {
+    this.disconnectSports();
+    this.disconnectMarket();
+  }
+
+  cleanup(): void {
+    this.disconnectAll();
+    this.gameSubscriptions.clear();
+    this.priceSubscriptions.clear();
+
+    if (this.appStateSubscription) {
+      this.appStateSubscription.remove();
+      this.appStateSubscription = null;
+    }
+  }
+
+  getConnectionStatus(): {
+    sportsConnected: boolean;
+    marketConnected: boolean;
+    gameSubscriptionCount: number;
+    priceSubscriptionCount: number;
+  } {
+    return {
+      sportsConnected: this.sportsWs?.readyState === WebSocket.OPEN,
+      marketConnected: this.marketWs?.readyState === WebSocket.OPEN,
+      gameSubscriptionCount: this.gameSubscriptions.size,
+      priceSubscriptionCount: this.priceSubscriptions.size,
+    };
+  }
+}

--- a/app/components/UI/Predict/providers/polymarket/index.ts
+++ b/app/components/UI/Predict/providers/polymarket/index.ts
@@ -1,0 +1,3 @@
+export { PolymarketProvider } from './PolymarketProvider';
+export { GameCache } from './GameCache';
+export { WebSocketManager } from './WebSocketManager';


### PR DESCRIPTION
## **Description**

This PR adds real-time WebSocket infrastructure for live NFL game updates in the Predict feature. It enables live score tracking, game state synchronization, and real-time price updates for NFL prediction markets.

**Why**: Users betting on live NFL games need real-time updates to make informed decisions. Without WebSocket connections, the app would require constant polling, creating poor UX and unnecessary server load.

**Solution**: Implemented a singleton WebSocket manager with two connection types:
- **Sports WS** (`wss://sports-api.polymarket.com/ws`): Live game state (scores, quarter, clock, possession)
- **Market WS** (`wss://ws-subscriptions-clob.polymarket.com/ws/market`): Real-time price updates

Key features:
- Auto-reconnection with exponential backoff
- GameCache singleton with 5-minute TTL for state persistence
- Subscription-based architecture with automatic cleanup
- 57 unit tests (23 GameCache + 34 WebSocketManager)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (Internal feature development)

## **Manual testing steps**

```gherkin
Feature: Live NFL WebSocket Updates

  Scenario: User views live NFL game market
    Given the app is running with Predict feature enabled
    And there is an active NFL game

    When user navigates to an NFL market details page
    Then WebSocket connections are established
    And live game updates appear in Metro console logs
    And price updates stream in real-time

  Scenario: WebSocket reconnects after disconnect
    Given user is viewing an NFL market with active WebSocket
    
    When the WebSocket connection is lost
    Then the manager automatically reconnects with backoff
    And subscriptions are restored
```

## **Screenshots/Recordings**

### **Before**

N/A - New feature

### **After**

WebSocket test logs visible in Metro bundler console showing:
- `🧪 [WS-TEST] 🏈 GAME UPDATE RECEIVED:` - Live game state
- `🧪 [WS-TEST] 💰 PRICE UPDATE RECEIVED:` - Real-time prices

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds real-time infrastructure and caching for Polymarket NFL markets.
> 
> - **New `WebSocketManager`**: Manages sports (`wss://sports-api.polymarket.com/ws`) and market (`wss://ws-subscriptions-clob.polymarket.com/ws/market`) sockets with subscriptions, PING heartbeats, exponential backoff reconnects, and AppState-aware connect/disconnect
> - **New `GameCache`**: Singleton with 5‑minute TTL, periodic pruning, and overlay helpers (`overlayOnMarket`/`overlayOnMarkets`) to merge live `GameUpdate` onto `market.game`
> - **Provider integration**: `PolymarketProvider.getMarkets`/`getMarketDetails` now apply `GameCache` overlays to API results
> - **Tests/exports**: Comprehensive unit tests for cache and WS manager; exports added in `index.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2aed48cd2514018be94bfacbfa3e6c0f1308357. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->