### PR TITLE
fix: unified asset image rendering on asset picker

### DIFF
--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -30,7 +30,6 @@ jest.mock('../../../../component-library/hooks', () => ({
       badgeWrapper: {},
       noFeeBadge: {},
       selectedItemWrapperReset: {},
-      nativeTokenIcon: {},
     },
   }),
 }));
@@ -62,11 +61,6 @@ jest.mock(
 
 jest.mock('../../../../component-library/components/Avatars/Avatar', () => ({
   AvatarSize: { Md: 'Md' },
-}));
-
-jest.mock('../../../Base/TokenIcon', () => ({
-  __esModule: true,
-  default: () => null,
 }));
 
 jest.mock('../../../../component-library/base-components/TagBase', () => {
@@ -195,7 +189,7 @@ describe('TokenSelectorItem', () => {
       expect(getByText('TEST')).toBeTruthy();
     });
 
-    it('renders native token with TokenIcon when address is zero address', () => {
+    it('renders native token when address is zero address', () => {
       const token = createMockTokenWithBalance({
         address: ethers.constants.AddressZero,
         symbol: 'ETH',

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -18,7 +18,6 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../component-library/components/Texts/Text';
-import TokenIcon from '../../../Base/TokenIcon';
 import { Box } from '../../Box/Box';
 import { AlignItems, FlexDirection } from '../../Box/box.types';
 import { useStyles } from '../../../../component-library/hooks';
@@ -102,10 +101,6 @@ const createStyles = ({
     noFeeBadge: {
       marginLeft: 8,
       paddingHorizontal: 6,
-    },
-    nativeTokenIcon: {
-      width: 32,
-      height: 32,
     },
     childrenWrapper: {
       marginLeft: 12,
@@ -200,21 +195,16 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
               />
             }
           >
-            {isNative ? (
-              <TokenIcon
-                symbol={token.symbol}
-                icon={token.image}
-                medium
-                style={styles.nativeTokenIcon}
-                testID={`network-logo-${token.symbol}`}
-              />
-            ) : (
-              <AvatarToken
-                name={token.symbol}
-                imageSource={token.image ? { uri: token.image } : undefined}
-                size={AvatarSize.Md}
-              />
-            )}
+            <AvatarToken
+              name={token.symbol}
+              imageSource={token.image ? { uri: token.image } : undefined}
+              size={AvatarSize.Md}
+              testID={
+                isNative
+                  ? `network-logo-${token.symbol}`
+                  : `token-logo-${token.symbol}`
+              }
+            />
           </BadgeWrapper>
 
           {/* Token symbol and name */}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix an issue with native assets showing a fade in animation. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix an issue with native assets showing a fade in animation. 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3602

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x]  I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies token image rendering in `TokenSelectorItem` to use `AvatarToken` for both native and ERC20 assets.
> 
> - Replaced `TokenIcon` branch with a single `AvatarToken` and set `testID` to `network-logo-<symbol>` for native assets and `token-logo-<symbol>` otherwise
> - Removed unused `nativeTokenIcon` styles and `TokenIcon` mocks; updated test to reflect native token rendering without TokenIcon
> - No functional changes to balance/labels; visuals and tests now consistent across assets
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29b8f092651437ad336aba503e5887febb269e68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->