### PR TITLE
fix: fix buy button for trending

### DIFF
--- a/app/components/UI/Ramp/hooks/useRampNavigation.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import {
@@ -15,6 +15,27 @@ import {
 } from '../../../../reducers/fiatOrders';
 import { createRampUnsupportedModalNavigationDetails } from '../components/RampUnsupportedModal/RampUnsupportedModal';
 import { createEligibilityFailedModalNavigationDetails } from '../components/EligibilityFailedModal/EligibilityFailedModal';
+import { useRampTokens, RampsToken } from './useRampTokens';
+
+/**
+ * Check if the assetId is in the list of supported ramp tokens
+ * @param assetId - CAIP-19 asset ID (e.g., 'eip155:8453/erc20:0x...')
+ * @param tokens - List of supported tokens from the API
+ * @returns true if the token is found in the list, false otherwise
+ */
+const isAssetInTokenList = (
+  assetId: string,
+  tokens: RampsToken[] | null,
+): boolean => {
+  if (!tokens || tokens.length === 0) return false;
+
+  // Normalize the assetId for case-insensitive comparison
+  const normalizedAssetId = assetId.toLowerCase();
+
+  return tokens.some(
+    (token) => token.assetId.toLowerCase() === normalizedAssetId,
+  );
+};
 
 enum RampMode {
   AGGREGATOR = 'AGGREGATOR',
@@ -34,6 +55,13 @@ export const useRampNavigation = () => {
   const navigation = useNavigation();
   const isRampsUnifiedV1Enabled = useRampsUnifiedV1Enabled();
   const rampRoutingDecision = useSelector(getRampRoutingDecision);
+  const { allTokens: depositTokens } = useRampTokens();
+
+  // Memoized check for whether an asset is supported by the deposit flow
+  const isDepositSupportedAsset = useMemo(
+    () => (assetId: string) => isAssetInTokenList(assetId, depositTokens),
+    [depositTokens],
+  );
 
   const goToBuy = useCallback(
     (
@@ -72,8 +100,17 @@ export const useRampNavigation = () => {
         }
 
         // If assetId is provided, route based on rampRoutingDecision
+        // But first check if the asset is in the deposit token list
         if (rampRoutingDecision === UnifiedRampRoutingType.DEPOSIT) {
-          navigation.navigate(...createDepositNavigationDetails(intent));
+          // Only route to deposit if the token is supported by the deposit flow
+          // Otherwise, fall back to aggregator for unsupported tokens/chains
+          if (intent.assetId && !isDepositSupportedAsset(intent.assetId)) {
+            navigation.navigate(
+              ...createRampNavigationDetails(AggregatorRampType.BUY, intent),
+            );
+          } else {
+            navigation.navigate(...createDepositNavigationDetails(intent));
+          }
         } else if (rampRoutingDecision === UnifiedRampRoutingType.AGGREGATOR) {
           navigation.navigate(
             ...createRampNavigationDetails(AggregatorRampType.BUY, intent),
@@ -91,7 +128,12 @@ export const useRampNavigation = () => {
         );
       }
     },
-    [navigation, isRampsUnifiedV1Enabled, rampRoutingDecision],
+    [
+      navigation,
+      isRampsUnifiedV1Enabled,
+      rampRoutingDecision,
+      isDepositSupportedAsset,
+    ],
   );
 
   /**


### PR DESCRIPTION
## **Description**

When a user tries to buy a token via the unified ramp flow, the routing decision (DEPOSIT vs AGGREGATOR) was previously based only on the user's region. This caused issues when users in deposit-supported regions tried to buy tokens on chains not supported by the deposit flow (e.g., Base chain tokens) - they would be incorrectly routed to the deposit flow, which would then default to showing mUSD on Mainnet instead of the requested token.

**Solution:**
- Added dynamic token support validation using `useRampTokens` hook to check if the requested `assetId` is in the deposit flow's supported token list
- When routing decision is DEPOSIT but the requested token is NOT in the deposit token list, the flow now correctly falls back to the aggregator flow
- Token matching is case-insensitive to handle address checksum variations

## **Changelog**

CHANGELOG entry: Fixed a bug where buying tokens on unsupported chains (e.g., Base) would incorrectly route to the deposit flow and show the wrong token

## **Related issues**

Fixes: <!-- Add Jira/GitHub issue link here -->

## **Manual testing steps**

> ⚠️ **Testing prerequisite:** You must force `isAssetsTrendingTokensFeatureEnabled` to `true` in `app/selectors/featureFlagController/assetsTrendingTokens/index.ts` to access the Trending tab and test this flow.


```gherkin
Feature: Ramp navigation smart routing for unsupported deposit tokens
Background:
Given isAssetsTrendingTokensFeatureEnabled is forced to return true
Scenario: User buys a Base chain token in a deposit-eligible region
Given the user is in a region where deposit flow is enabled
And the user navigates to the Trending tab
And the user selects a Base chain token (e.g., eip155:8453/erc20:0x...)
When the user taps "Buy" on the token
Then the user is routed to the aggregator flow (not deposit)
And the correct Base token is pre-selected
Scenario: User buys an Ethereum Mainnet token in a deposit-eligible region
Given the user is in a region where deposit flow is enabled
And the user navigates to the Trending tab
And the user selects an Ethereum Mainnet token that is in the deposit token list
When the user taps "Buy" on the token
Then the user is routed to the deposit flow
And the correct Mainnet token is pre-selected
```


## **Screenshots/Recordings**

### **Before**


https://github.com/user-attachments/assets/dadd3f61-b2a1-48fc-81f5-158591725dc5



<!-- User clicking "Buy" on a Base token gets routed to deposit flow and sees mUSD on Mainnet instead -->

### **After**

<!-- User clicking "Buy" on a Base token gets routed to aggregator flow and sees the correct Base token -->



https://github.com/user-attachments/assets/436d4ddb-7442-4021-8973-71c2cbfd66f2


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Smart routing update in `useRampNavigation`:** Adds `useRampTokens`-powered validation (`isAssetInTokenList`) to only route to `DEPOSIT` when the `assetId` exists in the deposit token list; otherwise routes to `AGGREGATOR`. Matching is case-insensitive and handles empty token lists by falling back to aggregator.
> - **Perf/structure:** Memoizes deposit support check with `useMemo` and updates hook dependencies.
> - **Tests:** Expands `useRampNavigation.test.ts` to cover deposit-supported/unsupported assets, null routing decisions, and uppercase `assetId` cases; mocks `useRampTokens` and deposit token lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92bbf54a5cc877c69baeff442aaaa7edd44d32a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->