### PR TITLE
feat: Enhance Account Selector with Bottom Sheet Overlays

### DIFF
--- a/app/components/Views/AccountSelector/AccountSelector.test.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.test.tsx
@@ -200,29 +200,6 @@ jest.mock('../../../util/accounts/useAccountsOperationsLoadingStates', () => ({
     mockUseAccountsOperationsLoadingStates(),
 }));
 
-jest.mock(
-  '../../../component-library/components/BottomSheets/BottomSheetHeader',
-  () => {
-    const { View, Text } = jest.requireActual('react-native');
-    const MockBottomSheetHeader = (props: {
-      children: React.ReactNode;
-      onBack?: () => void;
-    }) => (
-      <View testID="bottom-sheet-header">
-        {typeof props.children === 'string' ? (
-          <Text>{props.children}</Text>
-        ) : (
-          props.children
-        )}
-      </View>
-    );
-    return {
-      __esModule: true,
-      default: MockBottomSheetHeader,
-    };
-  },
-);
-
 const mockRoute: AccountSelectorProps['route'] = {
   params: {
     onSelectAccount: jest.fn((address: string) => address),

--- a/app/components/Views/AccountSelector/AccountSelector.test.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.test.tsx
@@ -458,11 +458,11 @@ describe('AccountSelector', () => {
       fireEvent.press(addWalletButton);
 
       // Check for the "Add wallet" header text which indicates the component is rendered
-      expect(screen.getByText('Add wallet')).toBeDefined();
+      expect(screen.getByText('Add wallet')).toBeOnTheScreen();
 
       expect(
         screen.getByTestId(AddAccountBottomSheetSelectorsIDs.IMPORT_SRP_BUTTON),
-      ).toBeDefined();
+      ).toBeOnTheScreen();
 
       // Restore fake timers for other tests
       jest.useFakeTimers();
@@ -506,7 +506,7 @@ describe('AccountSelector', () => {
         screen.getByTestId(
           AddAccountBottomSheetSelectorsIDs.ADD_ETHEREUM_ACCOUNT_BUTTON,
         ),
-      ).toBeDefined();
+      ).toBeOnTheScreen();
 
       // Restore fake timers for other tests
       jest.useFakeTimers();

--- a/app/components/Views/AccountSelector/AccountSelector.test.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.test.tsx
@@ -873,7 +873,7 @@ describe('AccountSelector', () => {
       jest.useFakeTimers();
     });
 
-    it('switches between multichain screens in full-page mode', () => {
+    it('opens Add Wallet bottom sheet overlay in full-page mode', () => {
       // Arrange
       jest.useRealTimers();
       mockSelectFullPageAccountListEnabledFlag.mockReturnValue(true);
@@ -897,8 +897,13 @@ describe('AccountSelector', () => {
       // Act
       fireEvent.press(addButton);
 
-      // Assert: MultichainAddWalletActions screen is displayed
-      expect(screen.getByText('Add wallet')).toBeDefined();
+      // Assert: MultichainAddWalletActions bottom sheet is displayed on top
+      // There should be two "Add wallet" texts - button and header
+      expect(screen.getAllByText('Add wallet')).toHaveLength(2);
+      // Import SRP button should be visible in the overlay
+      expect(
+        screen.getByTestId(AddAccountBottomSheetSelectorsIDs.IMPORT_SRP_BUTTON),
+      ).toBeDefined();
 
       jest.useFakeTimers();
     });

--- a/app/components/Views/AccountSelector/AccountSelector.test.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.test.tsx
@@ -903,11 +903,11 @@ describe('AccountSelector', () => {
       // Import SRP button should be visible in the overlay
       expect(
         screen.getByTestId(AddAccountBottomSheetSelectorsIDs.IMPORT_SRP_BUTTON),
-      ).toBeDefined();
+      ).toBeOnTheScreen();
       // Account list should still be visible in background
       expect(
         screen.getByTestId(AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID),
-      ).toBeDefined();
+      ).toBeOnTheScreen();
 
       jest.useFakeTimers();
     });
@@ -938,19 +938,17 @@ describe('AccountSelector', () => {
 
       // Assert: AddAccountActions bottom sheet is displayed on top
       // There should be two "Create a new account" texts - one in the overlay header and one in the actions
-      expect(
-        screen.getAllByText('Create a new account').length,
-      ).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText('Create a new account')).toHaveLength(2);
       // Add Ethereum account button should be visible in the overlay
       expect(
         screen.getByTestId(
           AddAccountBottomSheetSelectorsIDs.ADD_ETHEREUM_ACCOUNT_BUTTON,
         ),
-      ).toBeDefined();
+      ).toBeOnTheScreen();
       // Account list should still be visible in background
       expect(
         screen.getByTestId(AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID),
-      ).toBeDefined();
+      ).toBeOnTheScreen();
 
       jest.useFakeTimers();
     });

--- a/app/components/Views/AccountSelector/AccountSelector.test.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.test.tsx
@@ -200,6 +200,22 @@ jest.mock('../../../util/accounts/useAccountsOperationsLoadingStates', () => ({
     mockUseAccountsOperationsLoadingStates(),
 }));
 
+jest.mock(
+  '../../../component-library/components/BottomSheets/BottomSheetHeader',
+  () => {
+    const { View, Text } = jest.requireActual('react-native');
+    return (props: { children: React.ReactNode; onBack?: () => void }) => (
+      <View testID="bottom-sheet-header">
+        {typeof props.children === 'string' ? (
+          <Text>{props.children}</Text>
+        ) : (
+          props.children
+        )}
+      </View>
+    );
+  },
+);
+
 const mockRoute: AccountSelectorProps['route'] = {
   params: {
     onSelectAccount: jest.fn((address: string) => address),

--- a/app/components/Views/AccountSelector/AccountSelector.test.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.test.tsx
@@ -873,7 +873,7 @@ describe('AccountSelector', () => {
       jest.useFakeTimers();
     });
 
-    it('opens Add Wallet bottom sheet overlay in full-page mode', () => {
+    it('opens Add Wallet bottom sheet overlay in full-page mode (multichain)', () => {
       // Arrange
       jest.useRealTimers();
       mockSelectFullPageAccountListEnabledFlag.mockReturnValue(true);
@@ -903,6 +903,53 @@ describe('AccountSelector', () => {
       // Import SRP button should be visible in the overlay
       expect(
         screen.getByTestId(AddAccountBottomSheetSelectorsIDs.IMPORT_SRP_BUTTON),
+      ).toBeDefined();
+      // Account list should still be visible in background
+      expect(
+        screen.getByTestId(AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID),
+      ).toBeDefined();
+
+      jest.useFakeTimers();
+    });
+
+    it('opens Add Account bottom sheet overlay in full-page mode (non-multichain)', () => {
+      // Arrange
+      jest.useRealTimers();
+      mockSelectFullPageAccountListEnabledFlag.mockReturnValue(true);
+      mockSelectMultichainAccountsState2Enabled.mockReturnValue(false);
+
+      renderScreen(
+        AccountSelectorWrapper,
+        {
+          name: Routes.SHEET.ACCOUNT_SELECTOR,
+        },
+        {
+          state: mockInitialState,
+        },
+        mockRoute.params,
+      );
+
+      const addButton = screen.getByTestId(
+        AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ADD_BUTTON_ID,
+      );
+
+      // Act
+      fireEvent.press(addButton);
+
+      // Assert: AddAccountActions bottom sheet is displayed on top
+      // There should be two "Create a new account" texts - one in the overlay header and one in the actions
+      expect(
+        screen.getAllByText('Create a new account').length,
+      ).toBeGreaterThanOrEqual(1);
+      // Add Ethereum account button should be visible in the overlay
+      expect(
+        screen.getByTestId(
+          AddAccountBottomSheetSelectorsIDs.ADD_ETHEREUM_ACCOUNT_BUTTON,
+        ),
+      ).toBeDefined();
+      // Account list should still be visible in background
+      expect(
+        screen.getByTestId(AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID),
       ).toBeDefined();
 
       jest.useFakeTimers();

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -455,7 +455,8 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
         </KeyboardAvoidingView>
 
         {/* Add Wallet bottom sheet overlay */}
-        {(screen === AccountSelectorScreens.AddAccountActions || screen === AccountSelectorScreens.MultichainAddWalletActions) && (
+        {(screen === AccountSelectorScreens.AddAccountActions ||
+          screen === AccountSelectorScreens.MultichainAddWalletActions) && (
           <BottomSheet
             onClose={handleBackToSelector}
             shouldNavigateBack={false}

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -455,26 +455,19 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
         </KeyboardAvoidingView>
 
         {/* Add Wallet bottom sheet overlay */}
-        {screen === AccountSelectorScreens.AddAccountActions && (
+        {(screen === AccountSelectorScreens.AddAccountActions || screen === AccountSelectorScreens.MultichainAddWalletActions) && (
           <BottomSheet
             onClose={handleBackToSelector}
             shouldNavigateBack={false}
           >
             <BottomSheetHeader onBack={handleBackToSelector}>
-              {strings('account_actions.add_account')}
+              {screen === AccountSelectorScreens.AddAccountActions
+                ? strings('account_actions.add_account')
+                : strings('multichain_accounts.add_wallet')}
             </BottomSheetHeader>
-            {renderAddAccountActions()}
-          </BottomSheet>
-        )}
-        {screen === AccountSelectorScreens.MultichainAddWalletActions && (
-          <BottomSheet
-            onClose={handleBackToSelector}
-            shouldNavigateBack={false}
-          >
-            <BottomSheetHeader onBack={handleBackToSelector}>
-              {strings('multichain_accounts.add_wallet')}
-            </BottomSheetHeader>
-            {renderMultichainAddWalletActions()}
+            {screen === AccountSelectorScreens.AddAccountActions
+              ? renderAddAccountActions()
+              : renderMultichainAddWalletActions()}
           </BottomSheet>
         )}
       </>

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -178,7 +178,6 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
 
   useLayoutEffect(() => {
     if (!isFullPageAccountList) return;
-    if (screen !== AccountSelectorScreens.AccountSelector) return;
 
     const onAnimationComplete = () => {
       endTrace({
@@ -196,7 +195,7 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
       () => runOnJS(onAnimationComplete)(),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isFullPageAccountList, screen]);
+  }, [isFullPageAccountList]);
 
   const closeModal = useCallback(() => {
     if (isFullPageAccountList) {
@@ -453,7 +452,10 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
 
         {/* Add Wallet bottom sheet overlay */}
         {screen === AccountSelectorScreens.AddAccountActions && (
-          <BottomSheet onClose={handleBackToSelector}>
+          <BottomSheet
+            onClose={handleBackToSelector}
+            shouldNavigateBack={false}
+          >
             <BottomSheetHeader onBack={handleBackToSelector}>
               {strings('account_actions.add_account')}
             </BottomSheetHeader>
@@ -461,7 +463,10 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
           </BottomSheet>
         )}
         {screen === AccountSelectorScreens.MultichainAddWalletActions && (
-          <BottomSheet onClose={handleBackToSelector}>
+          <BottomSheet
+            onClose={handleBackToSelector}
+            shouldNavigateBack={false}
+          >
             <BottomSheetHeader onBack={handleBackToSelector}>
               {strings('multichain_accounts.add_wallet')}
             </BottomSheetHeader>

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -162,6 +162,12 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
   const [keyboardAvoidingViewEnabled, setKeyboardAvoidingViewEnabled] =
     useState(false);
 
+  // Tracing for the account list rendering:
+  const isAccountSelector = useMemo(
+    () => screen === AccountSelectorScreens.AccountSelector,
+    [screen],
+  );
+
   // Animation using react-native-reanimated - only for full-page version
   const translateX = useSharedValue(screenWidth);
 
@@ -178,6 +184,7 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
 
   useLayoutEffect(() => {
     if (!isFullPageAccountList) return;
+    if (!isAccountSelector) return;
 
     const onAnimationComplete = () => {
       endTrace({
@@ -195,7 +202,7 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
       () => runOnJS(onAnimationComplete)(),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isFullPageAccountList]);
+  }, [isFullPageAccountList, isAccountSelector]);
 
   const closeModal = useCallback(() => {
     if (isFullPageAccountList) {
@@ -279,10 +286,6 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
   );
 
   // Tracing for the account list rendering:
-  const isAccountSelector = useMemo(
-    () => screen === AccountSelectorScreens.AccountSelector,
-    [screen],
-  );
   useEffect(() => {
     if (isAccountSelector) {
       trace({

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -33,6 +33,7 @@ import { MultichainAddWalletActions } from '../../../component-library/component
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheetHeader from '../../../component-library/components/BottomSheets/BottomSheetHeader';
 import HeaderCenter from '../../../component-library/components-temp/HeaderCenter';
 import Engine from '../../../core/Engine';
 import { selectFullPageAccountListEnabledFlag } from '../../../selectors/featureFlagController/fullPageAccountList';

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -424,10 +424,7 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
     opacity: backdropOpacity.value,
   }));
 
-  if (
-    isFullPageAccountList &&
-    screen === AccountSelectorScreens.AccountSelector
-  ) {
+  if (isFullPageAccountList) {
     return (
       <>
         <Animated.View style={[styles.backdrop, backdropStyle]} />
@@ -450,9 +447,27 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
               title={strings('accounts.accounts_title')}
               onBack={closeModal}
             />
-            {renderAccountScreens()}
+            {renderAccountSelector()}
           </Animated.View>
         </KeyboardAvoidingView>
+
+        {/* Add Wallet bottom sheet overlay */}
+        {screen === AccountSelectorScreens.AddAccountActions && (
+          <BottomSheet onClose={handleBackToSelector}>
+            <BottomSheetHeader onBack={handleBackToSelector}>
+              {strings('account_actions.add_account')}
+            </BottomSheetHeader>
+            {renderAddAccountActions()}
+          </BottomSheet>
+        )}
+        {screen === AccountSelectorScreens.MultichainAddWalletActions && (
+          <BottomSheet onClose={handleBackToSelector}>
+            <BottomSheetHeader onBack={handleBackToSelector}>
+              {strings('multichain_accounts.add_wallet')}
+            </BottomSheetHeader>
+            {renderMultichainAddWalletActions()}
+          </BottomSheet>
+        )}
       </>
     );
   }

--- a/app/selectors/featureFlagController/fullPageAccountList/index.ts
+++ b/app/selectors/featureFlagController/fullPageAccountList/index.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../util/remoteFeatureFlag';
 import { selectBasicFunctionalityEnabled } from '../../settings';
 
+// TODO: Remove hardcoded true when feature flag is properly configured
 const DEFAULT_FULL_PAGE_ACCOUNT_LIST_ENABLED = false;
 export const FULL_PAGE_ACCOUNT_LIST_FLAG_NAME = 'fullPageAccountList';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When using the full-page account list (controlled by feature flag), clicking "Add wallet" or "Add account" was replacing the entire view, causing a jarring UI transition. This PR fixes the UI inconsistency by rendering the add wallet/account actions as a BottomSheet overlay on top of the full-page account list, keeping the account list visible in the background.

**Changes:**

1. Modified the full-page mode rendering condition to always show the account list when isFullPageAccountList is true
2. Added BottomSheet overlays for AddAccountActions and MultichainAddWalletActions screens that appear on top of the full-page view
3. Moved isAccountSelector memoization earlier in the component to avoid dependency issues
4. Added comprehensive test coverage for the new overlay behavior
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
5. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: (Behind feature flag) Fixed UI inconsistency when adding accounts in full-page account list mode - actions now appear as a bottom sheet overlay

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-294

## **Manual testing steps**

```gherkin
Feature: Add wallet bottom sheet overlay in full-page account list

  Scenario: user opens Add Wallet overlay in full-page mode
    Given the fullPageAccountList feature flag is enabled
    And multichain accounts feature is enabled
    And user is viewing the full-page account selector

    When user taps the "Add wallet" button
    Then a bottom sheet overlay appears with "Add wallet" header
    And the account list remains visible in the background
    And the Import SRP button is visible in the overlay
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/d25e3ea8-96f7-4d2c-bc84-5dbbf95d6bfb


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/9ea59947-ed64-4111-af30-daa35cc9e9cb


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves full-page Account Selector UX by rendering add actions as a BottomSheet overlay while keeping the account list visible in the background.
> 
> - In `AccountSelector.tsx`, always render the account list in full-page mode and overlay `BottomSheet` for `AddAccountActions` or `MultichainAddWalletActions` with `BottomSheetHeader`; maintain animated backdrop/slide-in and adjust tracing by memoizing `isAccountSelector` earlier and updating effect deps
> - Update tests to assert overlay behavior for both multichain and non-multichain in full-page mode; add expectations for header/buttons, background list visibility, and switch to `toBeOnTheScreen` where appropriate
> - No change to flag behavior; keep full-page feature flag selector default and structure intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3faf8f4d671eab4e60541343c283fd62cd60f6be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->