### PR TITLE
ci: handle smoke e2e reports when flask tests run

### DIFF
--- a/.github/workflows/run-e2e-smoke-tests-android.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android.yml
@@ -210,7 +210,18 @@ jobs:
           path: all-test-artifacts/
           pattern: 'test-e2e-*-android-*'
 
+      - name: Check if any tests ran
+        id: check-artifacts
+        run: |
+          if [ -d "all-test-artifacts" ] && [ "$(ls -A all-test-artifacts 2>/dev/null)" ]; then
+            echo "has_artifacts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_artifacts=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️ No test artifacts found - skipping report"
+          fi
+
       - name: Post Test Report
+        if: steps.check-artifacts.outputs.has_artifacts == 'true'
         uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3
         with:
           name: 'Android E2E Smoke Test Results'
@@ -221,12 +232,14 @@ jobs:
           list-tests: 'failed'
 
       - name: Upload all test artifacts (XMLs + Screenshots)
+        if: steps.check-artifacts.outputs.has_artifacts == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-smoke-android-all-test-artifacts
           path: all-test-artifacts/
 
       - name: Create mobile JSON test report
+        if: steps.check-artifacts.outputs.has_artifacts == 'true'
         id: create-json-report
         continue-on-error: true
         run: |

--- a/.github/workflows/run-e2e-smoke-tests-android.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android.yml
@@ -182,7 +182,7 @@ jobs:
   report-android-smoke-tests:
     name: Report Android Smoke Tests
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() && inputs.selected_tags != '[]' }}
+    if: ${{ !cancelled() && inputs.selected_tags != '[]' && inputs.selected_tags != '["FlaskBuildTests"]' }}
     needs:
       - trade-android-smoke
       - perps-android-smoke
@@ -210,18 +210,7 @@ jobs:
           path: all-test-artifacts/
           pattern: 'test-e2e-*-android-*'
 
-      - name: Check if any tests ran
-        id: check-artifacts
-        run: |
-          if [ -d "all-test-artifacts" ] && [ "$(ls -A all-test-artifacts 2>/dev/null)" ]; then
-            echo "has_artifacts=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_artifacts=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️ No test artifacts found - skipping report"
-          fi
-
       - name: Post Test Report
-        if: steps.check-artifacts.outputs.has_artifacts == 'true'
         uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3
         with:
           name: 'Android E2E Smoke Test Results'
@@ -232,14 +221,12 @@ jobs:
           list-tests: 'failed'
 
       - name: Upload all test artifacts (XMLs + Screenshots)
-        if: steps.check-artifacts.outputs.has_artifacts == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-smoke-android-all-test-artifacts
           path: all-test-artifacts/
 
       - name: Create mobile JSON test report
-        if: steps.check-artifacts.outputs.has_artifacts == 'true'
         id: create-json-report
         continue-on-error: true
         run: |

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -210,7 +210,18 @@ jobs:
           path: all-test-artifacts/
           pattern: 'test-e2e-*-ios-*'
 
+      - name: Check if any tests ran
+        id: check-artifacts
+        run: |
+          if [ -d "all-test-artifacts" ] && [ "$(ls -A all-test-artifacts 2>/dev/null)" ]; then
+            echo "has_artifacts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_artifacts=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️ No test artifacts found - skipping report"
+          fi
+
       - name: Post Test Report
+        if: steps.check-artifacts.outputs.has_artifacts == 'true'
         uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3
         with:
           name: 'iOS E2E Smoke Test Results'
@@ -221,12 +232,14 @@ jobs:
           list-tests: 'failed'
 
       - name: Upload all test artifacts (XMLs + Screenshots)
+        if: steps.check-artifacts.outputs.has_artifacts == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-smoke-ios-all-test-artifacts
           path: all-test-artifacts/
 
       - name: Create mobile JSON test report
+        if: steps.check-artifacts.outputs.has_artifacts == 'true'
         id: create-json-report
         continue-on-error: true
         run: |

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -182,7 +182,7 @@ jobs:
   report-ios-smoke-tests:
     name: Report iOS Smoke Tests
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() && inputs.selected_tags != '[]' }}
+    if: ${{ !cancelled() && inputs.selected_tags != '[]' && inputs.selected_tags != '["FlaskBuildTests"]' }}
     needs:
       - confirmations-redesigned-ios-smoke
       - trade-ios-smoke
@@ -210,18 +210,7 @@ jobs:
           path: all-test-artifacts/
           pattern: 'test-e2e-*-ios-*'
 
-      - name: Check if any tests ran
-        id: check-artifacts
-        run: |
-          if [ -d "all-test-artifacts" ] && [ "$(ls -A all-test-artifacts 2>/dev/null)" ]; then
-            echo "has_artifacts=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_artifacts=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️ No test artifacts found - skipping report"
-          fi
-
       - name: Post Test Report
-        if: steps.check-artifacts.outputs.has_artifacts == 'true'
         uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3
         with:
           name: 'iOS E2E Smoke Test Results'
@@ -232,14 +221,12 @@ jobs:
           list-tests: 'failed'
 
       - name: Upload all test artifacts (XMLs + Screenshots)
-        if: steps.check-artifacts.outputs.has_artifacts == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-smoke-ios-all-test-artifacts
           path: all-test-artifacts/
 
       - name: Create mobile JSON test report
-        if: steps.check-artifacts.outputs.has_artifacts == 'true'
         id: create-json-report
         continue-on-error: true
         run: |


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
  Smoke Test Workflows
  - Updated Report job conditions to skip when selected_tags is [] or ["FlaskBuildTests"] only
  - Removes unnecessary job runs when no smoke tests are selected

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines smoke test reporting conditions to avoid unnecessary report runs.
> 
> - In `run-e2e-smoke-tests-android.yml` and `run-e2e-smoke-tests-ios.yml`, the `report-*-smoke-tests` job `if` now checks `inputs.selected_tags != '[]' && inputs.selected_tags != '["FlaskBuildTests"]'`, preventing report execution when only Flask build tests are selected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc653947c8f5e86d47a4ac694362e2b94450c72c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->