### PR TITLE
fix: supply missing accountType field on token object

### DIFF
--- a/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 import { Hex, CaipChainId } from '@metamask/utils';
+import { BtcAccountType } from '@metamask/keyring-api';
 import { useBalancesByAssetId } from './index';
 import { useTokensWithBalance } from '../useTokensWithBalance';
 import {
@@ -221,6 +222,34 @@ describe('useBalancesByAssetId', () => {
         balanceFiat: undefined,
         tokenFiatAmount: undefined,
         currencyExchangeRate: undefined,
+        accountType: undefined,
+      });
+    });
+
+    it('includes accountType when token has accountType', () => {
+      const mockTokens = [
+        createMockTokenWithBalance({
+          address: '0xbtctoken',
+          balance: '1.5',
+          balanceFiat: '$45000',
+          tokenFiatAmount: 45000,
+          accountType: BtcAccountType.P2wpkh,
+        }),
+      ];
+      mockUseTokensWithBalance.mockReturnValue(mockTokens);
+
+      const { result } = renderHook(() =>
+        useBalancesByAssetId({
+          chainIds: [MOCK_CHAIN_IDS_HEX.ethereum as Hex],
+        }),
+      );
+
+      expect(result.current.balancesByAssetId['0x1/erc20:0xbtctoken']).toEqual({
+        balance: '1.5',
+        balanceFiat: '$45000',
+        tokenFiatAmount: 45000,
+        currencyExchangeRate: 1,
+        accountType: BtcAccountType.P2wpkh,
       });
     });
   });

--- a/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.ts
+++ b/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@metamask/bridge-controller';
 import { useTokensWithBalance } from '../useTokensWithBalance';
 import { CaipChainId, Hex } from '@metamask/utils';
+import { BridgeToken } from '../../types';
 
 /**
  * Interface for the balance data stored in the lookup map
@@ -14,6 +15,7 @@ export interface BalanceData {
   balanceFiat?: string;
   tokenFiatAmount?: number;
   currencyExchangeRate?: number;
+  accountType?: BridgeToken['accountType'];
 }
 
 /**
@@ -52,6 +54,7 @@ export const useBalancesByAssetId = ({
           balanceFiat: token.balanceFiat,
           tokenFiatAmount: token.tokenFiatAmount,
           currencyExchangeRate: token.currencyExchangeRate,
+          accountType: token.accountType,
         };
       }
     });

--- a/app/components/UI/Bridge/hooks/useTokensWithBalances.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalances.ts
@@ -73,6 +73,7 @@ export const useTokensWithBalances = (
           balanceFiat: balanceData.balanceFiat,
           tokenFiatAmount: balanceData.tokenFiatAmount,
           currencyExchangeRate: balanceData.currencyExchangeRate,
+          accountType: balanceData.accountType,
         };
       }
       return token;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add missing field to token images to allow asset labels to be rendered.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Add missing field to token images to allow asset labels to be rendered.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3748

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `accountType` is included and preserved across balance lookups and token merging.
> 
> - Extend `BalanceData` with `accountType` and include it when building `balancesByAssetId` in `useBalancesByAssetId`
> - Merge `accountType` from `balancesByAssetId` into tokens in `useTokensWithBalances`
> - Add/expand tests in `useBalancesByAssetId/index.test.ts` and `useTokensWithBalances.test.ts` to cover presence/absence of `accountType` and preserve other optional fields
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5c13065ff434103d6daf0a3baaa4f8b31cb9d2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->