### PR TITLE
ci: Run stable-main check in merge queue

### DIFF
--- a/.github/workflows/block-stable-main-to-main.yml
+++ b/.github/workflows/block-stable-main-to-main.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize, edited]
     branches:
       - main
+  merge_group:
 
 jobs:
   check-branch:


### PR DESCRIPTION
## **Description**

The workflow to block stable sync branches from being squashed was misconfigured to not run on the merge queue. This resulted in the merge queue being blocked, as this check needs to be a required status check to be effective.

The workflow has been updated to trigger upon `merge_group`, which fixes the issue. It will be skipped for `merge_group` checks because the `if` condition on the job is never satisfied (`github.head_ref` is not set for `merge_group`), but `skipped` is enough to pass the required status check.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Workflow introduced here: https://github.com/MetaMask/metamask-mobile/pull/24366

The same fix has already been applied in the extension repo, here: https://github.com/MetaMask/metamask-extension/pull/39211

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CI to ensure the stable-main→main block check participates in merge queues.
> 
> - Adds `merge_group` trigger to `/.github/workflows/block-stable-main-to-main.yml`
> - Existing job remains gated by `if: startsWith(github.head_ref, 'stable-main-')` and the regex check for `stable-main-X.Y.Z`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f1bae7c930ee1c048c361f12d305f163e107818. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->