### PR TITLE
fix: set max display size for asset names in new swaps asset picker

### DIFF
--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -232,4 +232,38 @@ describe('TokenSelectorItem', () => {
       expect(getByText(expected)).toBeTruthy();
     });
   });
+
+  describe('text truncation', () => {
+    it('truncates long token names to 3 lines', () => {
+      const token = createMockTokenWithBalance({
+        name: 'Very Long Token Name That Should Be Truncated',
+      });
+
+      const { getByText } = render(
+        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+      );
+
+      const tokenNameElement = getByText(
+        'Very Long Token Name That Should Be Truncated',
+      );
+
+      expect(tokenNameElement.props.numberOfLines).toBe(3);
+    });
+
+    it('applies tail ellipsize mode to token names', () => {
+      const token = createMockTokenWithBalance({
+        name: 'Very Long Token Name That Should Be Truncated',
+      });
+
+      const { getByText } = render(
+        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+      );
+
+      const tokenNameElement = getByText(
+        'Very Long Token Name That Should Be Truncated',
+      );
+
+      expect(tokenNameElement.props.ellipsizeMode).toBe('tail');
+    });
+  });
 });

--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -234,7 +234,7 @@ describe('TokenSelectorItem', () => {
   });
 
   describe('text truncation', () => {
-    it('truncates long token names to 3 lines', () => {
+    it('truncates long token names to 2 lines', () => {
       const token = createMockTokenWithBalance({
         name: 'Very Long Token Name That Should Be Truncated',
       });
@@ -247,7 +247,7 @@ describe('TokenSelectorItem', () => {
         'Very Long Token Name That Should Be Truncated',
       );
 
-      expect(tokenNameElement.props.numberOfLines).toBe(3);
+      expect(tokenNameElement.props.numberOfLines).toBe(2);
     });
 
     it('applies tail ellipsize mode to token names', () => {

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -231,7 +231,12 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
                 </TagBase>
               )}
             </Box>
-            <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodyMD}
+              color={TextColor.Alternative}
+              numberOfLines={3}
+              ellipsizeMode="tail"
+            >
               {token.name}
             </Text>
           </Box>

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -234,7 +234,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
             <Text
               variant={TextVariant.BodyMD}
               color={TextColor.Alternative}
-              numberOfLines={3}
+              numberOfLines={2}
               ellipsizeMode="tail"
             >
               {token.name}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: set max display size for asset names in new swaps asset picker

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3754

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="333" height="720" alt="εικόνα" src="https://github.com/user-attachments/assets/8662dd0b-fef8-4e1f-87be-26748d9363cb" />


<!-- [screenshots/recordings] -->

### **After**

<img width="719" height="306" alt="εικόνα" src="https://github.com/user-attachments/assets/225b1069-7c10-4a8b-abcb-b692321d067c" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability of long asset names in the bridge token selector.
> 
> - In `TokenSelectorItem.tsx`, sets `numberOfLines={2}` and `ellipsizeMode="tail"` on the token name `Text`
> - Adds tests in `TokenSelectorItem.test.tsx` to verify two-line truncation and tail ellipsis
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a790ede641d717e3a7b0f713d44e1ee4b1a85e43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->