### PR TITLE
fix: watch asset origin metadata

### DIFF
--- a/app/components/Views/confirmations/legacy/components/WatchAssetRequest/index.js
+++ b/app/components/Views/confirmations/legacy/components/WatchAssetRequest/index.js
@@ -164,7 +164,7 @@ const WatchAssetRequest = ({
         <ApproveTransactionHeader
           chainId={chainId}
           origin={currentPageInformation?.url}
-          url={activeTabUrl}
+          url={currentPageInformation?.url ?? activeTabUrl}
           from={suggestedAssetMeta.interactingAddress}
           asset={{
             address,

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -961,7 +961,22 @@ export const getRpcMethodMiddleware = ({
         }),
 
       wallet_watchAsset: async () =>
-        RPCMethods.wallet_watchAsset({ req, res, hostname, checkTabActive }),
+        RPCMethods.wallet_watchAsset({
+          req,
+          res,
+          hostname,
+          checkTabActive,
+          pageMeta: {
+            url: url.current,
+            title: title.current,
+            icon: icon.current,
+            channelId,
+            analytics: {
+              request_source: getSource(),
+              request_platform: analytics?.platform,
+            },
+          },
+        }),
 
       metamask_removeFavorite: async () => {
         checkTabActive();

--- a/app/core/RPCMethods/wallet_watchAsset.test.ts
+++ b/app/core/RPCMethods/wallet_watchAsset.test.ts
@@ -181,6 +181,12 @@ describe('wallet_watchAsset', () => {
       type: ERC20,
       interactingAddress: '0xc4955c0d639d99699bfd7ec54d9fafee40e4d272',
       networkClientId: '0x1',
+      origin: '',
+      pageMeta: undefined,
+      requestMetadata: {
+        origin: '',
+        pageMeta: undefined,
+      },
     });
   });
 
@@ -228,6 +234,12 @@ describe('wallet_watchAsset', () => {
       type: ERC20,
       interactingAddress: '0xc4955c0d639d99699bfd7ec54d9fafee40e4d272',
       networkClientId: '0x1',
+      origin: '',
+      pageMeta: undefined,
+      requestMetadata: {
+        origin: '',
+        pageMeta: undefined,
+      },
     });
   });
 });

--- a/app/core/RPCMethods/wallet_watchAsset.ts
+++ b/app/core/RPCMethods/wallet_watchAsset.ts
@@ -12,7 +12,12 @@ import {
   selectNetworkClientId,
 } from '../../selectors/networkController';
 import { isValidAddress } from 'ethereumjs-util';
-import { JsonRpcRequest, PendingJsonRpcResponse } from '@metamask/utils';
+import {
+  getSafeJson,
+  Json,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
 import { MESSAGE_TYPE } from '../createTracingMiddleware';
 
 export const wallet_watchAsset = async ({
@@ -105,6 +110,11 @@ export const wallet_watchAsset = async ({
   const finalTokenSymbol = fetchedSymbol ?? symbol;
   const finalTokenDecimals = fetchedDecimals ?? decimals;
 
+  const safePageMeta =
+    _pageMeta !== undefined
+      ? getSafeJson<Record<string, Json>>(_pageMeta)
+      : undefined;
+
   await TokensController.watchAsset({
     asset: {
       address,
@@ -117,10 +127,10 @@ export const wallet_watchAsset = async ({
     interactingAddress,
     networkClientId,
     origin: requestOrigin,
-    pageMeta: _pageMeta,
+    pageMeta: safePageMeta,
     requestMetadata: {
       origin: requestOrigin,
-      pageMeta: _pageMeta,
+      pageMeta: safePageMeta,
     },
   });
 

--- a/app/core/RPCMethods/wallet_watchAsset.ts
+++ b/app/core/RPCMethods/wallet_watchAsset.ts
@@ -20,6 +20,7 @@ export const wallet_watchAsset = async ({
   res,
   hostname,
   checkTabActive,
+  pageMeta: _pageMeta,
 }: {
   req: JsonRpcRequest<{
     options: {
@@ -35,6 +36,16 @@ export const wallet_watchAsset = async ({
   res: PendingJsonRpcResponse<any>;
   hostname: string;
   checkTabActive: () => true | undefined;
+  pageMeta?: {
+    url?: string;
+    title?: string;
+    icon?: unknown;
+    channelId?: string;
+    analytics?: {
+      request_source?: string;
+      request_platform?: string | boolean;
+    };
+  };
 }) => {
   const { AssetsContractController } = Engine.context;
   if (!req.params) {
@@ -53,6 +64,7 @@ export const wallet_watchAsset = async ({
   const networkClientId = selectNetworkClientId(state);
 
   checkTabActive();
+  const requestOrigin = _pageMeta?.url ?? hostname;
 
   const isValidTokenAddress = isValidAddress(address);
 
@@ -104,6 +116,12 @@ export const wallet_watchAsset = async ({
     type,
     interactingAddress,
     networkClientId,
+    origin: requestOrigin,
+    pageMeta: _pageMeta,
+    requestMetadata: {
+      origin: requestOrigin,
+      pageMeta: _pageMeta,
+    },
   });
 
   res.result = true;


### PR DESCRIPTION
Pass page meta and origin into watchAsset approvals so the UI displays the requesting dapp instead of the active tab.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/mobile-planning/issues/2395

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="466" height="978" alt="Screenshot 2026-01-16 at 10 16 53" src="https://github.com/user-attachments/assets/76139f4d-8fe7-4555-8f0a-5f6dfd2866c9" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns watch-asset requests with the requesting dapp’s metadata so approvals display the correct origin.
> 
> - Plumbs `pageMeta` (url/title/icon/channelId/analytics) through RPC middleware into `wallet_watchAsset`; derive `origin` from `pageMeta.url` or `hostname`.
> - In `wallet_watchAsset`, sanitize `pageMeta` via `getSafeJson` and forward `origin`, `pageMeta`, and `requestMetadata` to `TokensController.watchAsset`; adjust tests to assert these fields.
> - UI: `ApproveTransactionHeader` `url` now falls back to `currentPageInformation?.url ?? activeTabUrl` to show the requesting page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3051d87e973ed61a68d9120700182dcbd1a9d3c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->