### PR TITLE
feat(predict): add team information to live sports game data

### DIFF
--- a/app/components/UI/Predict/constants/sports.ts
+++ b/app/components/UI/Predict/constants/sports.ts
@@ -1,0 +1,7 @@
+import { PredictSportsLeague } from '../types';
+
+/**
+ * Leagues with live game data support. Adding a league enables team caching,
+ * game parsing, and WebSocket subscriptions for that league.
+ */
+export const LIVE_SPORTS_LEAGUES: PredictSportsLeague[] = ['nfl'];

--- a/app/components/UI/Predict/constants/sports.ts
+++ b/app/components/UI/Predict/constants/sports.ts
@@ -5,3 +5,6 @@ import { PredictSportsLeague } from '../types';
  * game parsing, and WebSocket subscriptions for that league.
  */
 export const LIVE_SPORTS_LEAGUES: PredictSportsLeague[] = ['nfl'];
+
+export const isLiveSportsEnabled = (): boolean =>
+  Array.isArray(LIVE_SPORTS_LEAGUES) && LIVE_SPORTS_LEAGUES.length > 0;

--- a/app/components/UI/Predict/constants/sports.ts
+++ b/app/components/UI/Predict/constants/sports.ts
@@ -1,8 +1,13 @@
 import { PredictSportsLeague } from '../types';
 
 /**
- * Leagues with live game data support. Adding a league enables team caching,
- * game parsing, and WebSocket subscriptions for that league.
+ * Leagues with live game data support.
+ *
+ * To add a new league:
+ * 1. Add the league to `PredictSportsLeague` type in `../types/index.ts`
+ * 2. Add a slug pattern regex to `LEAGUE_SLUG_PATTERNS` in `../utils/gameParser.ts`
+ * 3. Add the league to this array
+ * 4. Add tests for the new league's slug parsing
  */
 export const LIVE_SPORTS_LEAGUES: PredictSportsLeague[] = ['nfl'];
 

--- a/app/components/UI/Predict/providers/polymarket/GameCache.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/GameCache.test.ts
@@ -42,9 +42,9 @@ const createMockMarketWithGame = (
       startTime: '2025-01-12T18:00:00Z',
       status: 'scheduled',
       league: 'nfl',
-      elapsed: '00:00',
-      period: 'NS',
-      score: '0-0',
+      elapsed: null,
+      period: null,
+      score: null,
       homeTeam: {
         id: 'team-1',
         name: 'Seattle Seahawks',
@@ -185,8 +185,8 @@ describe('GameCache', () => {
 
       const result = cache.overlayOnMarket(market);
 
-      expect(result.game?.score).toBe('0-0');
-      expect(result.game?.period).toBe('NS');
+      expect(result.game?.score).toBeNull();
+      expect(result.game?.period).toBeNull();
     });
 
     it('merges cached data onto market.game', () => {
@@ -204,7 +204,7 @@ describe('GameCache', () => {
       cache.updateGame('game-123', update);
       const result = cache.overlayOnMarket(market);
 
-      expect(result.game?.score).toBe('28-21');
+      expect(result.game?.score).toEqual({ away: 28, home: 21, raw: '28-21' });
       expect(result.game?.elapsed).toBe('08:42');
       expect(result.game?.period).toBe('Q3');
       expect(result.game?.status).toBe('ongoing');
@@ -247,7 +247,7 @@ describe('GameCache', () => {
       cache.updateGame('game-123', update);
       cache.overlayOnMarket(market);
 
-      expect(market.game?.score).toBe('0-0');
+      expect(market.game?.score).toBeNull();
     });
   });
 
@@ -271,8 +271,16 @@ describe('GameCache', () => {
 
       const results = cache.overlayOnMarkets(markets);
 
-      expect(results[0].game?.score).toBe('14-7');
-      expect(results[1].game?.score).toBe('21-14');
+      expect(results[0].game?.score).toEqual({
+        away: 14,
+        home: 7,
+        raw: '14-7',
+      });
+      expect(results[1].game?.score).toEqual({
+        away: 21,
+        home: 14,
+        raw: '21-14',
+      });
       expect(results[2].game).toBeUndefined();
     });
   });

--- a/app/components/UI/Predict/providers/polymarket/GameCache.ts
+++ b/app/components/UI/Predict/providers/polymarket/GameCache.ts
@@ -1,4 +1,5 @@
 import { GameUpdate, PredictMarket } from '../../types';
+import { parseScore } from '../../utils/gameParser';
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 60 * 1000;
@@ -65,9 +66,9 @@ export class GameCache {
       ...market,
       game: {
         ...market.game,
-        score: cachedUpdate.score,
-        elapsed: cachedUpdate.elapsed,
-        period: cachedUpdate.period,
+        score: parseScore(cachedUpdate.score),
+        elapsed: cachedUpdate.elapsed || null,
+        period: cachedUpdate.period || null,
         status: cachedUpdate.status,
         turn: cachedUpdate.turn,
       },

--- a/app/components/UI/Predict/providers/polymarket/TeamsCache.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/TeamsCache.test.ts
@@ -1,0 +1,359 @@
+import { TeamsCache } from './TeamsCache';
+import { PolymarketApiTeam } from './types';
+
+jest.mock('./utils', () => ({
+  getPolymarketEndpoints: jest.fn().mockReturnValue({
+    GAMMA_API_ENDPOINT: 'https://gamma-api.polymarket.com',
+  }),
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const createMockTeam = (
+  overrides: Partial<PolymarketApiTeam> = {},
+): PolymarketApiTeam => ({
+  id: 'team-1',
+  name: 'Seattle Seahawks',
+  logo: 'https://example.com/sea.png',
+  abbreviation: 'SEA',
+  color: '#002244',
+  alias: 'Seahawks',
+  ...overrides,
+});
+
+const mockNflTeams: PolymarketApiTeam[] = [
+  createMockTeam({
+    id: 'team-sea',
+    name: 'Seattle Seahawks',
+    abbreviation: 'SEA',
+    color: '#002244',
+    alias: 'Seahawks',
+  }),
+  createMockTeam({
+    id: 'team-den',
+    name: 'Denver Broncos',
+    abbreviation: 'DEN',
+    color: '#FB4F14',
+    alias: 'Broncos',
+  }),
+  createMockTeam({
+    id: 'team-sf',
+    name: 'San Francisco 49ers',
+    abbreviation: 'SF',
+    color: '#AA0000',
+    alias: '49ers',
+  }),
+];
+
+describe('TeamsCache', () => {
+  beforeEach(() => {
+    TeamsCache.resetInstance();
+    mockFetch.mockReset();
+    jest.clearAllMocks();
+  });
+
+  describe('singleton pattern', () => {
+    it('returns same instance on multiple calls', () => {
+      const instance1 = TeamsCache.getInstance();
+      const instance2 = TeamsCache.getInstance();
+
+      expect(instance1).toBe(instance2);
+    });
+
+    it('creates new instance after reset', () => {
+      const instance1 = TeamsCache.getInstance();
+      TeamsCache.resetInstance();
+      const instance2 = TeamsCache.getInstance();
+
+      expect(instance1).not.toBe(instance2);
+    });
+
+    it('clears cache data on reset', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockNflTeams,
+      });
+      const instance1 = TeamsCache.getInstance();
+      await instance1.ensureLeagueLoaded('nfl');
+
+      expect(instance1.isLeagueLoaded('nfl')).toBe(true);
+
+      TeamsCache.resetInstance();
+      const instance2 = TeamsCache.getInstance();
+
+      expect(instance2.isLeagueLoaded('nfl')).toBe(false);
+    });
+  });
+
+  describe('ensureLeagueLoaded', () => {
+    it('fetches teams from API on first call', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockNflTeams,
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureLeagueLoaded('nfl');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://gamma-api.polymarket.com/teams?league=nfl',
+      );
+    });
+
+    it('does not fetch again when already loaded', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockNflTeams,
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureLeagueLoaded('nfl');
+      await cache.ensureLeagueLoaded('nfl');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('deduplicates concurrent requests for same league', async () => {
+      let resolvePromise: (value: unknown) => void = () => undefined;
+      const fetchPromise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      mockFetch.mockReturnValue(fetchPromise);
+      const cache = TeamsCache.getInstance();
+
+      const promise1 = cache.ensureLeagueLoaded('nfl');
+      const promise2 = cache.ensureLeagueLoaded('nfl');
+      const promise3 = cache.ensureLeagueLoaded('nfl');
+
+      resolvePromise({
+        ok: true,
+        json: async () => mockNflTeams,
+      });
+
+      await Promise.all([promise1, promise2, promise3]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles API error gracefully', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureLeagueLoaded('nfl');
+
+      expect(cache.isLeagueLoaded('nfl')).toBe(false);
+    });
+
+    it('handles network error gracefully', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureLeagueLoaded('nfl');
+
+      expect(cache.isLeagueLoaded('nfl')).toBe(false);
+    });
+
+    it('handles invalid API response format', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ invalid: 'response' }),
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureLeagueLoaded('nfl');
+
+      expect(cache.isLeagueLoaded('nfl')).toBe(false);
+    });
+
+    it('skips teams without abbreviation', async () => {
+      const teamsWithMissingAbbr = [
+        createMockTeam({ abbreviation: 'SEA' }),
+        createMockTeam({ abbreviation: '' }),
+        createMockTeam({ abbreviation: 'DEN' }),
+      ];
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => teamsWithMissingAbbr,
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureLeagueLoaded('nfl');
+
+      expect(cache.getTeamCount('nfl')).toBe(2);
+    });
+  });
+
+  describe('ensureLeaguesLoaded', () => {
+    it('loads multiple leagues in parallel', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => mockNflTeams,
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureLeaguesLoaded(['nfl']);
+
+      expect(cache.isLeagueLoaded('nfl')).toBe(true);
+    });
+
+    it('does not refetch already loaded leagues', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => mockNflTeams,
+      });
+      const cache = TeamsCache.getInstance();
+      await cache.ensureLeagueLoaded('nfl');
+      mockFetch.mockClear();
+
+      await cache.ensureLeaguesLoaded(['nfl']);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('handles empty leagues array', async () => {
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureLeaguesLoaded([]);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getTeam', () => {
+    beforeEach(async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockNflTeams,
+      });
+      await TeamsCache.getInstance().ensureLeagueLoaded('nfl');
+    });
+
+    it('returns team by abbreviation (lowercase)', () => {
+      const cache = TeamsCache.getInstance();
+
+      const team = cache.getTeam('nfl', 'sea');
+
+      expect(team?.name).toBe('Seattle Seahawks');
+    });
+
+    it('returns team by abbreviation (uppercase)', () => {
+      const cache = TeamsCache.getInstance();
+
+      const team = cache.getTeam('nfl', 'SEA');
+
+      expect(team?.name).toBe('Seattle Seahawks');
+    });
+
+    it('returns team by abbreviation (mixed case)', () => {
+      const cache = TeamsCache.getInstance();
+
+      const team = cache.getTeam('nfl', 'SeA');
+
+      expect(team?.name).toBe('Seattle Seahawks');
+    });
+
+    it('returns undefined for unknown abbreviation', () => {
+      const cache = TeamsCache.getInstance();
+
+      const team = cache.getTeam('nfl', 'xyz');
+
+      expect(team).toBeUndefined();
+    });
+
+    it('returns undefined for unloaded league', () => {
+      const cache = TeamsCache.getInstance();
+
+      const team = cache.getTeam('nfl' as const, 'sea');
+      expect(team).toBeDefined();
+    });
+  });
+
+  describe('getNflTeam', () => {
+    beforeEach(async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockNflTeams,
+      });
+      await TeamsCache.getInstance().ensureLeagueLoaded('nfl');
+    });
+
+    it('returns NFL team by abbreviation', () => {
+      const cache = TeamsCache.getInstance();
+
+      const team = cache.getNflTeam('den');
+
+      expect(team?.name).toBe('Denver Broncos');
+    });
+
+    it('returns undefined for unknown NFL team', () => {
+      const cache = TeamsCache.getInstance();
+
+      const team = cache.getNflTeam('unknown');
+
+      expect(team).toBeUndefined();
+    });
+  });
+
+  describe('isLeagueLoaded', () => {
+    it('returns false for unloaded league', () => {
+      const cache = TeamsCache.getInstance();
+
+      expect(cache.isLeagueLoaded('nfl')).toBe(false);
+    });
+
+    it('returns true after successful load', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockNflTeams,
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureLeagueLoaded('nfl');
+
+      expect(cache.isLeagueLoaded('nfl')).toBe(true);
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all cached data', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockNflTeams,
+      });
+      const cache = TeamsCache.getInstance();
+      await cache.ensureLeagueLoaded('nfl');
+
+      expect(cache.isLeagueLoaded('nfl')).toBe(true);
+
+      cache.clear();
+
+      expect(cache.isLeagueLoaded('nfl')).toBe(false);
+    });
+  });
+
+  describe('getTeamCount', () => {
+    it('returns 0 for unloaded league', () => {
+      const cache = TeamsCache.getInstance();
+
+      expect(cache.getTeamCount('nfl')).toBe(0);
+    });
+
+    it('returns correct count after loading', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockNflTeams,
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureLeagueLoaded('nfl');
+
+      expect(cache.getTeamCount('nfl')).toBe(3);
+    });
+  });
+});

--- a/app/components/UI/Predict/providers/polymarket/TeamsCache.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/TeamsCache.test.ts
@@ -266,11 +266,13 @@ describe('TeamsCache', () => {
       expect(team).toBeUndefined();
     });
 
-    it('returns undefined for unloaded league', () => {
+    it('returns team from loaded league', () => {
       const cache = TeamsCache.getInstance();
 
-      const team = cache.getTeam('nfl' as const, 'sea');
+      const team = cache.getTeam('nfl', 'sea');
+
       expect(team).toBeDefined();
+      expect(team?.name).toBe('Seattle Seahawks');
     });
   });
 

--- a/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
+++ b/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
@@ -1,4 +1,5 @@
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
+import Logger from '../../../../../util/Logger';
 import { PredictSportsLeague } from '../../types';
 import { PolymarketApiTeam } from './types';
 import { getPolymarketEndpoints } from './utils';
@@ -86,18 +87,29 @@ export class TeamsCache {
       const response = await fetch(url);
 
       if (!response.ok) {
-        DevLogger.log(
-          `[TeamsCache] Failed to fetch teams for ${league}: ${response.status}`,
-        );
+        const errorMessage = `Failed to fetch teams for ${league}: ${response.status}`;
+        DevLogger.log(`[TeamsCache] ${errorMessage}`);
+        Logger.error(new Error(errorMessage), {
+          feature: 'predict',
+          provider: 'polymarket',
+          method: 'TeamsCache.fetchAndCacheTeams',
+          league,
+          statusCode: response.status,
+        });
         return;
       }
 
       const teams: PolymarketApiTeam[] = await response.json();
 
       if (!Array.isArray(teams)) {
-        DevLogger.log(
-          `[TeamsCache] Invalid response format for ${league} teams`,
-        );
+        const errorMessage = `Invalid response format for ${league} teams`;
+        DevLogger.log(`[TeamsCache] ${errorMessage}`);
+        Logger.error(new Error(errorMessage), {
+          feature: 'predict',
+          provider: 'polymarket',
+          method: 'TeamsCache.fetchAndCacheTeams',
+          league,
+        });
         return;
       }
 
@@ -119,6 +131,12 @@ export class TeamsCache {
         `[TeamsCache] Error fetching teams for ${league}:`,
         error instanceof Error ? error.message : 'Unknown error',
       );
+      Logger.error(error instanceof Error ? error : new Error(String(error)), {
+        feature: 'predict',
+        provider: 'polymarket',
+        method: 'TeamsCache.fetchAndCacheTeams',
+        league,
+      });
     }
   }
 }

--- a/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
+++ b/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
@@ -1,0 +1,124 @@
+import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
+import { PredictSportsLeague } from '../../types';
+import { PolymarketApiTeam } from './types';
+import { getPolymarketEndpoints } from './utils';
+
+export class TeamsCache {
+  private static instance: TeamsCache | null = null;
+  private cache: Map<PredictSportsLeague, Map<string, PolymarketApiTeam>> =
+    new Map();
+  private loadingPromises: Map<PredictSportsLeague, Promise<void>> = new Map();
+
+  // eslint-disable-next-line no-empty-function
+  private constructor() {}
+
+  static getInstance(): TeamsCache {
+    TeamsCache.instance ??= new TeamsCache();
+    return TeamsCache.instance;
+  }
+
+  static resetInstance(): void {
+    if (TeamsCache.instance) {
+      TeamsCache.instance.clear();
+      TeamsCache.instance = null;
+    }
+  }
+
+  async ensureLeagueLoaded(league: PredictSportsLeague): Promise<void> {
+    if (this.cache.has(league)) {
+      return;
+    }
+
+    const existingPromise = this.loadingPromises.get(league);
+    if (existingPromise) {
+      return existingPromise;
+    }
+
+    const loadPromise = this.fetchAndCacheTeams(league);
+    this.loadingPromises.set(league, loadPromise);
+
+    try {
+      await loadPromise;
+    } finally {
+      this.loadingPromises.delete(league);
+    }
+  }
+
+  async ensureLeaguesLoaded(leagues: PredictSportsLeague[]): Promise<void> {
+    await Promise.all(leagues.map((league) => this.ensureLeagueLoaded(league)));
+  }
+
+  getTeam(
+    league: PredictSportsLeague,
+    abbreviation: string,
+  ): PolymarketApiTeam | undefined {
+    const leagueCache = this.cache.get(league);
+    if (!leagueCache) {
+      return undefined;
+    }
+    return leagueCache.get(abbreviation.toLowerCase());
+  }
+
+  getNflTeam(abbreviation: string): PolymarketApiTeam | undefined {
+    return this.getTeam('nfl', abbreviation);
+  }
+
+  isLeagueLoaded(league: PredictSportsLeague): boolean {
+    return this.cache.has(league);
+  }
+
+  clear(): void {
+    this.cache.clear();
+    this.loadingPromises.clear();
+  }
+
+  getTeamCount(league: PredictSportsLeague): number {
+    return this.cache.get(league)?.size ?? 0;
+  }
+
+  private async fetchAndCacheTeams(league: PredictSportsLeague): Promise<void> {
+    const { GAMMA_API_ENDPOINT } = getPolymarketEndpoints();
+    const url = `${GAMMA_API_ENDPOINT}/teams?league=${league}`;
+
+    DevLogger.log(`[TeamsCache] Fetching teams for league: ${league}`);
+
+    try {
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        DevLogger.log(
+          `[TeamsCache] Failed to fetch teams for ${league}: ${response.status}`,
+        );
+        return;
+      }
+
+      const teams: PolymarketApiTeam[] = await response.json();
+
+      if (!Array.isArray(teams)) {
+        DevLogger.log(
+          `[TeamsCache] Invalid response format for ${league} teams`,
+        );
+        return;
+      }
+
+      const leagueCache = new Map<string, PolymarketApiTeam>();
+
+      for (const team of teams) {
+        if (team.abbreviation) {
+          leagueCache.set(team.abbreviation.toLowerCase(), team);
+        }
+      }
+
+      this.cache.set(league, leagueCache);
+
+      DevLogger.log(
+        `[TeamsCache] Cached ${leagueCache.size} teams for league: ${league}`,
+      );
+    } catch (error) {
+      DevLogger.log(
+        `[TeamsCache] Error fetching teams for ${league}:`,
+        error instanceof Error ? error.message : 'Unknown error',
+      );
+    }
+  }
+}

--- a/app/components/UI/Predict/providers/polymarket/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/types.ts
@@ -179,6 +179,13 @@ export interface PolymarketApiEvent {
   liquidity: number;
   volume: number;
   sortBy?: 'price' | 'ascending' | 'descending';
+  gameId?: string;
+  startTime?: string;
+  score?: string;
+  elapsed?: string;
+  period?: string;
+  live?: boolean;
+  ended?: boolean;
 }
 
 export interface PolymarketApiActivity {

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -128,15 +128,22 @@ export interface PredictSportTeam {
   alias: string; // Team alias (e.g., "Seahawks")
 }
 
+// Parsed score data
+export interface PredictGameScore {
+  away: number;
+  home: number;
+  raw: string; // Original "away-home" format (e.g., "21-14")
+}
+
 // Game data attached to market
 export interface PredictMarketGame {
   id: string;
   startTime: string;
   status: PredictGameStatus;
   league: PredictSportsLeague;
-  elapsed: string; // Game clock
-  period: string; // Current period (Q1, Q2, HT, Q3, Q4, OT, FT)
-  score: string; // "away-home" format (e.g., "21-14")
+  elapsed: string | null; // Game clock, null if not available
+  period: string | null; // Current period (Q1, Q2, HT, Q3, Q4, OT, FT), null if not available
+  score: PredictGameScore | null; // Parsed score with away/home values, null if not available
   homeTeam: PredictSportTeam;
   awayTeam: PredictSportTeam;
   turn?: string; // Team abbreviation with possession

--- a/app/components/UI/Predict/utils/gameParser.test.ts
+++ b/app/components/UI/Predict/utils/gameParser.test.ts
@@ -1,0 +1,681 @@
+import {
+  parseNflSlugTeams,
+  parseGameSlugTeams,
+  isNflGameEvent,
+  isLiveSportsEvent,
+  getEventLeague,
+  getGameStatus,
+  formatPeriodDisplay,
+  mapApiTeamToPredictTeam,
+  buildNflGameData,
+  buildGameData,
+} from './gameParser';
+import {
+  PolymarketApiEvent,
+  PolymarketApiTeam,
+} from '../providers/polymarket/types';
+import { PredictSportTeam, PredictSportsLeague } from '../types';
+
+const createMockApiTeam = (
+  overrides: Partial<PolymarketApiTeam> = {},
+): PolymarketApiTeam => ({
+  id: 'team-1',
+  name: 'Seattle Seahawks',
+  logo: 'https://example.com/sea.png',
+  abbreviation: 'SEA',
+  color: '#002244',
+  alias: 'Seahawks',
+  ...overrides,
+});
+
+const createMockEvent = (
+  overrides: Partial<PolymarketApiEvent> = {},
+): PolymarketApiEvent => ({
+  id: 'event-1',
+  slug: 'nfl-sea-den-2025-01-12',
+  title: 'Seattle Seahawks vs Denver Broncos',
+  description: 'NFL game',
+  icon: 'https://example.com/icon.png',
+  closed: false,
+  series: [],
+  markets: [],
+  tags: [
+    { id: '1', label: 'NFL', slug: 'nfl' },
+    { id: '2', label: 'Games', slug: 'games' },
+  ],
+  liquidity: 10000,
+  volume: 20000,
+  ...overrides,
+});
+
+describe('gameParser', () => {
+  describe('getEventLeague', () => {
+    it('returns "nfl" for event with nfl tag, games tag, and valid slug', () => {
+      const event = createMockEvent();
+
+      const result = getEventLeague(event);
+
+      expect(result).toBe('nfl');
+    });
+
+    it('returns null when missing nfl tag', () => {
+      const event = createMockEvent({
+        tags: [{ id: '2', label: 'Games', slug: 'games' }],
+      });
+
+      const result = getEventLeague(event);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when missing games tag', () => {
+      const event = createMockEvent({
+        tags: [{ id: '1', label: 'NFL', slug: 'nfl' }],
+      });
+
+      const result = getEventLeague(event);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for invalid slug format', () => {
+      const event = createMockEvent({
+        slug: 'some-other-market',
+      });
+
+      const result = getEventLeague(event);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when tags is not an array', () => {
+      const event = createMockEvent({
+        tags: undefined as unknown as [],
+      });
+
+      const result = getEventLeague(event);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('isLiveSportsEvent', () => {
+    it('returns true when event league is in enabled leagues', () => {
+      const event = createMockEvent();
+
+      const result = isLiveSportsEvent(event, ['nfl']);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when event league is not in enabled leagues', () => {
+      const event = createMockEvent();
+
+      const result = isLiveSportsEvent(event, []);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when event is not a sports event', () => {
+      const event = createMockEvent({
+        slug: 'some-other-market',
+        tags: [],
+      });
+
+      const result = isLiveSportsEvent(event, ['nfl']);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('parseGameSlugTeams', () => {
+    it('extracts team abbreviations from valid NFL slug', () => {
+      const result = parseGameSlugTeams('nfl-sea-den-2025-01-12', 'nfl');
+
+      expect(result).toEqual({
+        awayAbbreviation: 'sea',
+        homeAbbreviation: 'den',
+        dateString: '2025-01-12',
+      });
+    });
+
+    it('returns null for non-NFL slug', () => {
+      const result = parseGameSlugTeams('some-other-event', 'nfl');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for invalid date format', () => {
+      const result = parseGameSlugTeams('nfl-sea-den-01-12-2025', 'nfl');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('parseNflSlugTeams (deprecated)', () => {
+    it('extracts team abbreviations from valid NFL slug', () => {
+      const result = parseNflSlugTeams('nfl-sea-den-2025-01-12');
+
+      expect(result).toEqual({
+        awayAbbreviation: 'sea',
+        homeAbbreviation: 'den',
+        dateString: '2025-01-12',
+      });
+    });
+
+    it('returns null for non-NFL slug', () => {
+      const result = parseNflSlugTeams('some-other-event');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for invalid date format', () => {
+      const result = parseNflSlugTeams('nfl-sea-den-01-12-2025');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for missing team abbreviation', () => {
+      const result = parseNflSlugTeams('nfl-sea--2025-01-12');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for uppercase slug', () => {
+      const result = parseNflSlugTeams('NFL-SEA-DEN-2025-01-12');
+
+      expect(result).toBeNull();
+    });
+
+    it('extracts three-letter abbreviations', () => {
+      const result = parseNflSlugTeams('nfl-buf-nyj-2025-01-12');
+
+      expect(result).toEqual({
+        awayAbbreviation: 'buf',
+        homeAbbreviation: 'nyj',
+        dateString: '2025-01-12',
+      });
+    });
+  });
+
+  describe('isNflGameEvent (deprecated)', () => {
+    it('returns true for event with nfl tag, games tag, and valid slug', () => {
+      const event = createMockEvent();
+
+      const result = isNflGameEvent(event);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when missing nfl tag', () => {
+      const event = createMockEvent({
+        tags: [{ id: '2', label: 'Games', slug: 'games' }],
+      });
+
+      const result = isNflGameEvent(event);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when missing games tag', () => {
+      const event = createMockEvent({
+        tags: [{ id: '1', label: 'NFL', slug: 'nfl' }],
+      });
+
+      const result = isNflGameEvent(event);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false for invalid slug format', () => {
+      const event = createMockEvent({
+        slug: 'some-other-market',
+      });
+
+      const result = isNflGameEvent(event);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when tags is not an array', () => {
+      const event = createMockEvent({
+        tags: undefined as unknown as [],
+      });
+
+      const result = isNflGameEvent(event);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getGameStatus', () => {
+    it('returns "ended" when event.ended is true', () => {
+      const event = createMockEvent({ ended: true });
+
+      const result = getGameStatus(event);
+
+      expect(result).toBe('ended');
+    });
+
+    it('returns "ended" when event.closed is true', () => {
+      const event = createMockEvent({ closed: true });
+
+      const result = getGameStatus(event);
+
+      expect(result).toBe('ended');
+    });
+
+    it('returns "ended" when period is FT', () => {
+      const event = createMockEvent({ period: 'FT' });
+
+      const result = getGameStatus(event);
+
+      expect(result).toBe('ended');
+    });
+
+    it('returns "ended" when period is VFT', () => {
+      const event = createMockEvent({ period: 'VFT' });
+
+      const result = getGameStatus(event);
+
+      expect(result).toBe('ended');
+    });
+
+    it('returns "ongoing" when event.live is true', () => {
+      const event = createMockEvent({ live: true });
+
+      const result = getGameStatus(event);
+
+      expect(result).toBe('ongoing');
+    });
+
+    it('returns "ongoing" when score is non-zero', () => {
+      const event = createMockEvent({ score: '14-7' });
+
+      const result = getGameStatus(event);
+
+      expect(result).toBe('ongoing');
+    });
+
+    it('returns "ongoing" when elapsed has value', () => {
+      const event = createMockEvent({ elapsed: '12:34' });
+
+      const result = getGameStatus(event);
+
+      expect(result).toBe('ongoing');
+    });
+
+    it('returns "ongoing" when period is Q1', () => {
+      const event = createMockEvent({ period: 'Q1' });
+
+      const result = getGameStatus(event);
+
+      expect(result).toBe('ongoing');
+    });
+
+    it('returns "scheduled" for event with no game indicators', () => {
+      const event = createMockEvent();
+
+      const result = getGameStatus(event);
+
+      expect(result).toBe('scheduled');
+    });
+
+    it('returns "scheduled" when period is NS', () => {
+      const event = createMockEvent({ period: 'NS' });
+
+      const result = getGameStatus(event);
+
+      expect(result).toBe('scheduled');
+    });
+
+    it('returns "scheduled" when score is 0-0', () => {
+      const event = createMockEvent({ score: '0-0' });
+
+      const result = getGameStatus(event);
+
+      expect(result).toBe('scheduled');
+    });
+  });
+
+  describe('formatPeriodDisplay', () => {
+    it('returns "Halftime" for HT', () => {
+      expect(formatPeriodDisplay('HT')).toBe('Halftime');
+    });
+
+    it('returns "Overtime" for OT', () => {
+      expect(formatPeriodDisplay('OT')).toBe('Overtime');
+    });
+
+    it('returns "Final" for FT', () => {
+      expect(formatPeriodDisplay('FT')).toBe('Final');
+    });
+
+    it('returns "Final" for VFT', () => {
+      expect(formatPeriodDisplay('VFT')).toBe('Final');
+    });
+
+    it('returns original period for Q1', () => {
+      expect(formatPeriodDisplay('Q1')).toBe('Q1');
+    });
+
+    it('returns original period for Q4', () => {
+      expect(formatPeriodDisplay('Q4')).toBe('Q4');
+    });
+
+    it('handles lowercase input', () => {
+      expect(formatPeriodDisplay('ht')).toBe('Halftime');
+    });
+
+    it('handles whitespace', () => {
+      expect(formatPeriodDisplay('  HT  ')).toBe('Halftime');
+    });
+  });
+
+  describe('mapApiTeamToPredictTeam', () => {
+    it('maps all fields from API team to domain team', () => {
+      const apiTeam = createMockApiTeam();
+
+      const result = mapApiTeamToPredictTeam(apiTeam);
+
+      expect(result).toEqual({
+        id: 'team-1',
+        name: 'Seattle Seahawks',
+        logo: 'https://example.com/sea.png',
+        abbreviation: 'SEA',
+        color: '#002244',
+        alias: 'Seahawks',
+      });
+    });
+
+    it('preserves all API team properties', () => {
+      const apiTeam = createMockApiTeam({
+        id: 'custom-id',
+        name: 'Custom Team',
+        logo: 'https://custom.com/logo.png',
+        abbreviation: 'CUS',
+        color: '#FFFFFF',
+        alias: 'Customs',
+      });
+
+      const result = mapApiTeamToPredictTeam(apiTeam);
+
+      expect(result.id).toBe('custom-id');
+      expect(result.name).toBe('Custom Team');
+      expect(result.logo).toBe('https://custom.com/logo.png');
+      expect(result.abbreviation).toBe('CUS');
+      expect(result.color).toBe('#FFFFFF');
+      expect(result.alias).toBe('Customs');
+    });
+  });
+
+  describe('buildGameData', () => {
+    const seaTeam: PredictSportTeam = {
+      id: 'team-sea',
+      name: 'Seattle Seahawks',
+      logo: 'https://example.com/sea.png',
+      abbreviation: 'SEA',
+      color: '#002244',
+      alias: 'Seahawks',
+    };
+
+    const denTeam: PredictSportTeam = {
+      id: 'team-den',
+      name: 'Denver Broncos',
+      logo: 'https://example.com/den.png',
+      abbreviation: 'DEN',
+      color: '#FB4F14',
+      alias: 'Broncos',
+    };
+
+    const teamLookup = (
+      league: PredictSportsLeague,
+      abbr: string,
+    ): PredictSportTeam | undefined => {
+      if (league !== 'nfl') return undefined;
+      const teams: Record<string, PredictSportTeam> = {
+        sea: seaTeam,
+        den: denTeam,
+      };
+      return teams[abbr.toLowerCase()];
+    };
+
+    it('builds complete game data from event', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        startTime: '2025-01-12T18:00:00Z',
+        score: '14-7',
+        elapsed: '08:42',
+        period: 'Q2',
+        live: true,
+      });
+
+      const result = buildGameData(event, 'nfl', teamLookup);
+
+      expect(result).toEqual({
+        id: 'game-123',
+        startTime: '2025-01-12T18:00:00Z',
+        status: 'ongoing',
+        league: 'nfl',
+        elapsed: '08:42',
+        period: 'Q2',
+        score: '14-7',
+        homeTeam: denTeam,
+        awayTeam: seaTeam,
+      });
+    });
+
+    it('returns null when gameId is missing', () => {
+      const event = createMockEvent({ gameId: undefined });
+
+      const result = buildGameData(event, 'nfl', teamLookup);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when slug cannot be parsed', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        slug: 'invalid-slug',
+      });
+
+      const result = buildGameData(event, 'nfl', teamLookup);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when away team not found', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        slug: 'nfl-xyz-den-2025-01-12',
+      });
+
+      const result = buildGameData(event, 'nfl', teamLookup);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when home team not found', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        slug: 'nfl-sea-xyz-2025-01-12',
+      });
+
+      const result = buildGameData(event, 'nfl', teamLookup);
+
+      expect(result).toBeNull();
+    });
+
+    it('uses endDate as fallback for startTime', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        startTime: undefined,
+        endDate: '2025-01-12T21:00:00Z',
+      });
+
+      const result = buildGameData(event, 'nfl', teamLookup);
+
+      expect(result?.startTime).toBe('2025-01-12T21:00:00Z');
+    });
+
+    it('uses date from slug as last resort for startTime', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        startTime: undefined,
+        endDate: undefined,
+      });
+
+      const result = buildGameData(event, 'nfl', teamLookup);
+
+      expect(result?.startTime).toBe('2025-01-12T00:00:00Z');
+    });
+
+    it('defaults empty strings for missing game fields', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        score: undefined,
+        elapsed: undefined,
+        period: undefined,
+      });
+
+      const result = buildGameData(event, 'nfl', teamLookup);
+
+      expect(result?.score).toBe('');
+      expect(result?.elapsed).toBe('');
+      expect(result?.period).toBe('');
+    });
+  });
+
+  describe('buildNflGameData (deprecated)', () => {
+    const seaTeam: PredictSportTeam = {
+      id: 'team-sea',
+      name: 'Seattle Seahawks',
+      logo: 'https://example.com/sea.png',
+      abbreviation: 'SEA',
+      color: '#002244',
+      alias: 'Seahawks',
+    };
+
+    const denTeam: PredictSportTeam = {
+      id: 'team-den',
+      name: 'Denver Broncos',
+      logo: 'https://example.com/den.png',
+      abbreviation: 'DEN',
+      color: '#FB4F14',
+      alias: 'Broncos',
+    };
+
+    const teamLookup = (abbr: string): PredictSportTeam | undefined => {
+      const teams: Record<string, PredictSportTeam> = {
+        sea: seaTeam,
+        den: denTeam,
+      };
+      return teams[abbr.toLowerCase()];
+    };
+
+    it('builds complete game data from event', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        startTime: '2025-01-12T18:00:00Z',
+        score: '14-7',
+        elapsed: '08:42',
+        period: 'Q2',
+        live: true,
+      });
+
+      const result = buildNflGameData(event, teamLookup);
+
+      expect(result).toEqual({
+        id: 'game-123',
+        startTime: '2025-01-12T18:00:00Z',
+        status: 'ongoing',
+        league: 'nfl',
+        elapsed: '08:42',
+        period: 'Q2',
+        score: '14-7',
+        homeTeam: denTeam,
+        awayTeam: seaTeam,
+      });
+    });
+
+    it('returns null when gameId is missing', () => {
+      const event = createMockEvent({ gameId: undefined });
+
+      const result = buildNflGameData(event, teamLookup);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when slug cannot be parsed', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        slug: 'invalid-slug',
+      });
+
+      const result = buildNflGameData(event, teamLookup);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when away team not found', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        slug: 'nfl-xyz-den-2025-01-12',
+      });
+
+      const result = buildNflGameData(event, teamLookup);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when home team not found', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        slug: 'nfl-sea-xyz-2025-01-12',
+      });
+
+      const result = buildNflGameData(event, teamLookup);
+
+      expect(result).toBeNull();
+    });
+
+    it('uses endDate as fallback for startTime', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        startTime: undefined,
+        endDate: '2025-01-12T21:00:00Z',
+      });
+
+      const result = buildNflGameData(event, teamLookup);
+
+      expect(result?.startTime).toBe('2025-01-12T21:00:00Z');
+    });
+
+    it('uses date from slug as last resort for startTime', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        startTime: undefined,
+        endDate: undefined,
+      });
+
+      const result = buildNflGameData(event, teamLookup);
+
+      expect(result?.startTime).toBe('2025-01-12T00:00:00Z');
+    });
+
+    it('defaults empty strings for missing game fields', () => {
+      const event = createMockEvent({
+        gameId: 'game-123',
+        score: undefined,
+        elapsed: undefined,
+        period: undefined,
+      });
+
+      const result = buildNflGameData(event, teamLookup);
+
+      expect(result?.score).toBe('');
+      expect(result?.elapsed).toBe('');
+      expect(result?.period).toBe('');
+    });
+  });
+});

--- a/app/components/UI/Predict/utils/gameParser.ts
+++ b/app/components/UI/Predict/utils/gameParser.ts
@@ -1,0 +1,184 @@
+import {
+  PredictGameStatus,
+  PredictMarketGame,
+  PredictSportTeam,
+  PredictSportsLeague,
+} from '../types';
+import {
+  PolymarketApiEvent,
+  PolymarketApiTeam,
+} from '../providers/polymarket/types';
+
+const NFL_SLUG_PATTERN = /^nfl-([a-z]+)-([a-z]+)-(\d{4}-\d{2}-\d{2})$/;
+
+const LEAGUE_SLUG_PATTERNS: Record<PredictSportsLeague, RegExp> = {
+  nfl: NFL_SLUG_PATTERN,
+};
+
+export type TeamLookup = (
+  league: PredictSportsLeague,
+  abbreviation: string,
+) => PredictSportTeam | undefined;
+
+export interface ParsedGameSlug {
+  awayAbbreviation: string;
+  homeAbbreviation: string;
+  dateString: string;
+}
+
+export function getEventLeague(
+  event: PolymarketApiEvent,
+): PredictSportsLeague | null {
+  const tags = Array.isArray(event.tags) ? event.tags : [];
+  const hasGamesTag = tags.some((tag) => tag.slug === 'games');
+  if (!hasGamesTag) {
+    return null;
+  }
+
+  const leagues = Object.keys(LEAGUE_SLUG_PATTERNS) as PredictSportsLeague[];
+  for (const league of leagues) {
+    const hasLeagueTag = tags.some((tag) => tag.slug === league);
+    const pattern = LEAGUE_SLUG_PATTERNS[league];
+    const hasValidSlug = pattern.test(event.slug);
+    if (hasLeagueTag && hasValidSlug) {
+      return league;
+    }
+  }
+
+  return null;
+}
+
+export function isLiveSportsEvent(
+  event: PolymarketApiEvent,
+  enabledLeagues: PredictSportsLeague[],
+): boolean {
+  const league = getEventLeague(event);
+  return league !== null && enabledLeagues.includes(league);
+}
+
+export function parseGameSlugTeams(
+  slug: string,
+  league: PredictSportsLeague,
+): ParsedGameSlug | null {
+  const pattern = LEAGUE_SLUG_PATTERNS[league];
+  if (!pattern) {
+    return null;
+  }
+  const match = slug.match(pattern);
+  if (!match) {
+    return null;
+  }
+  return {
+    awayAbbreviation: match[1],
+    homeAbbreviation: match[2],
+    dateString: match[3],
+  };
+}
+
+/** @deprecated Use parseGameSlugTeams with league parameter instead */
+export function parseNflSlugTeams(slug: string): ParsedGameSlug | null {
+  return parseGameSlugTeams(slug, 'nfl');
+}
+
+/** @deprecated Use isLiveSportsEvent with LIVE_SPORTS_LEAGUES instead */
+export function isNflGameEvent(event: PolymarketApiEvent): boolean {
+  return getEventLeague(event) === 'nfl';
+}
+
+const NOT_STARTED_PERIODS = ['NS', 'NOT_STARTED', 'PRE', 'PREGAME', ''];
+const ENDED_PERIODS = ['FT', 'VFT'];
+
+export function formatPeriodDisplay(period: string): string {
+  const normalized = period.toUpperCase().trim();
+
+  switch (normalized) {
+    case 'HT':
+      return 'Halftime';
+    case 'OT':
+      return 'Overtime';
+    case 'FT':
+    case 'VFT':
+      return 'Final';
+    default:
+      return period;
+  }
+}
+
+export function getGameStatus(event: PolymarketApiEvent): PredictGameStatus {
+  const period = (event.period ?? '').toUpperCase();
+
+  if (event.ended || event.closed || ENDED_PERIODS.includes(period)) {
+    return 'ended';
+  }
+
+  if (event.live) {
+    return 'ongoing';
+  }
+
+  const isNotStartedPeriod = NOT_STARTED_PERIODS.includes(period);
+  const hasScore = event.score && event.score !== '0-0' && event.score !== '';
+  const hasElapsed = event.elapsed && event.elapsed !== '';
+  const hasActivePeriod = event.period && !isNotStartedPeriod;
+
+  if (hasScore || hasElapsed || hasActivePeriod) {
+    return 'ongoing';
+  }
+
+  return 'scheduled';
+}
+
+export function mapApiTeamToPredictTeam(
+  apiTeam: PolymarketApiTeam,
+): PredictSportTeam {
+  return {
+    id: apiTeam.id,
+    name: apiTeam.name,
+    logo: apiTeam.logo,
+    abbreviation: apiTeam.abbreviation,
+    color: apiTeam.color,
+    alias: apiTeam.alias,
+  };
+}
+
+export function buildGameData(
+  event: PolymarketApiEvent,
+  league: PredictSportsLeague,
+  teamLookup: TeamLookup,
+): PredictMarketGame | null {
+  if (!event.gameId) {
+    return null;
+  }
+
+  const parsedSlug = parseGameSlugTeams(event.slug, league);
+  if (!parsedSlug) {
+    return null;
+  }
+
+  const awayTeam = teamLookup(league, parsedSlug.awayAbbreviation);
+  const homeTeam = teamLookup(league, parsedSlug.homeAbbreviation);
+
+  if (!awayTeam || !homeTeam) {
+    return null;
+  }
+
+  return {
+    id: event.gameId,
+    startTime:
+      event.startTime ?? event.endDate ?? `${parsedSlug.dateString}T00:00:00Z`,
+    status: getGameStatus(event),
+    league,
+    elapsed: event.elapsed ?? '',
+    period: event.period ?? '',
+    score: event.score ?? '',
+    homeTeam,
+    awayTeam,
+  };
+}
+
+/** @deprecated Use buildGameData with league parameter instead */
+export function buildNflGameData(
+  event: PolymarketApiEvent,
+  teamLookup: (abbreviation: string) => PredictSportTeam | undefined,
+): PredictMarketGame | null {
+  return buildGameData(event, 'nfl', (_league, abbr) => teamLookup(abbr));
+}


### PR DESCRIPTION
## **Description**

This PR adds the ability to populate team information (name, logo, abbreviation, colors) into the `market.game` object for live sports markets.

**Why:** Live sports UI needs team data (logos, colors, names) to render game cards and details pages. Previously, the `market.game` object existed but had no team information populated.

**Solution:**
- **TeamsCache**: Singleton that fetches and caches team data from the Polymarket Gamma API (`/teams?league={league}`), keyed by league and team abbreviation
- **gameParser utilities**: Functions to extract league from event tags, parse game slugs for team abbreviations, and build complete game data with team objects
- **Integration**: `PolymarketProvider.getMarkets()` and `getMarketDetails()` now load team data and populate `market.game` with home/away team information

The implementation is designed to be league-agnostic via a `LIVE_SPORTS_LEAGUES` constant - adding a new league just requires adding it to that array.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-463

## **Manual testing steps**

```gherkin
Feature: Team information in live sports markets

  Scenario: user views sports markets with team data
    Given user has the Predict feature enabled
    And there are active NFL game markets

    When user navigates to the Sports category
    Then markets display with game data including team names, logos, and colors

  Scenario: user views market details for a sports game
    Given user has the Predict feature enabled
    And there is an active NFL game market

    When user taps on the market to view details
    Then the market details include home and away team information
    And team logos and colors are available for rendering
```

## **Screenshots/Recordings**

### **Before**

N/A - This is backend/data layer change, no UI changes in this PR.

### **After**

N/A - This is backend/data layer change, no UI changes in this PR.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces live sports team and game data plumbing with conditional enablement and extensive tests.
> 
> - Adds `LIVE_SPORTS_LEAGUES` and `isLiveSportsEnabled` flag to gate live sports features
> - New `TeamsCache` singleton fetches/caches teams from Gamma API and exposes lookups (with comprehensive tests)
> - New `gameParser` utilities to detect league, parse slugs, build `game` data, format period, and parse scores (tests included)
> - Updates types: `PredictMarketGame.score` becomes structured `{ away, home, raw }`; `elapsed`/`period` are nullable; Polymarket API event type extended with game fields
> - `GameCache` overlays parsed scores and null-safe clock/period; tests updated accordingly
> - `parsePolymarketEvents` now accepts options including `teamLookup`; builds `game` when available; `getParsedMarketsFromPolymarketApi` threads `teamLookup`
> - `PolymarketProvider.getMarkets`/`getMarketDetails` conditionally load leagues via `TeamsCache`, pass `teamLookup`, and only overlay `GameCache` when live sports enabled (tests cover enabled/disabled paths)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2896cb73d646cf1c2516b12486fdf428b3bb2b58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->