### PR TITLE
feat(ramps): add rampsUnifiedBuyV2 feature flag support

### DIFF
--- a/app/components/UI/Ramp/hooks/useRampsUnifiedV1Enabled.ts
+++ b/app/components/UI/Ramp/hooks/useRampsUnifiedV1Enabled.ts
@@ -1,22 +1,9 @@
 import { useSelector } from 'react-redux';
-import { getVersion } from 'react-native-device-info';
-import compareVersions from 'compare-versions';
 import {
   selectRampsUnifiedBuyV1ActiveFlag,
   selectRampsUnifiedBuyV1MinimumVersionFlag,
 } from '../../../../selectors/featureFlagController/ramps/rampsUnifiedBuyV1';
-
-function hasMinimumRequiredVersion(
-  minRequiredVersion: string | null | undefined,
-  isUnifiedV1Enabled: boolean,
-) {
-  if (!minRequiredVersion) return false;
-  const currentVersion = getVersion();
-  return (
-    isUnifiedV1Enabled &&
-    compareVersions.compare(currentVersion, minRequiredVersion, '>=')
-  );
-}
+import { hasMinimumRequiredVersion } from '../utils/hasMinimumRequiredVersion';
 
 export default function useRampsUnifiedV1Enabled() {
   const rampsUnifiedBuyV1MinimumVersionFlag = useSelector(

--- a/app/components/UI/Ramp/hooks/useRampsUnifiedV2Enabled.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsUnifiedV2Enabled.test.ts
@@ -1,0 +1,219 @@
+import initialRootState, {
+  backgroundState,
+} from '../../../../util/test/initial-root-state';
+import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
+import useRampsUnifiedV2Enabled from './useRampsUnifiedV2Enabled';
+import { getVersion } from 'react-native-device-info';
+
+function mockInitialState({
+  rampsUnifiedBuyV2ActiveFlag = true,
+  rampsUnifiedBuyV2MinimumVersionFlag,
+}: {
+  rampsUnifiedBuyV2ActiveFlag?: boolean;
+  rampsUnifiedBuyV2MinimumVersionFlag?: string | null;
+} = {}) {
+  return {
+    ...initialRootState,
+    engine: {
+      backgroundState: {
+        ...backgroundState,
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags: {
+            rampsUnifiedBuyV2: {
+              active: rampsUnifiedBuyV2ActiveFlag,
+              ...(rampsUnifiedBuyV2MinimumVersionFlag !== undefined && {
+                minimumVersion: rampsUnifiedBuyV2MinimumVersionFlag,
+              }),
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn(),
+}));
+
+describe('useRampsUnifiedV2Enabled', () => {
+  const mockGetVersion = jest.mocked(getVersion);
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('Build flag precedence', () => {
+    it('returns true when build flag is set to "true" regardless of remote flags', () => {
+      process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED = 'true';
+      mockGetVersion.mockReturnValue('1.0.0');
+
+      const { result } = renderHookWithProvider(
+        () => useRampsUnifiedV2Enabled(),
+        {
+          state: mockInitialState({
+            rampsUnifiedBuyV2ActiveFlag: false,
+            rampsUnifiedBuyV2MinimumVersionFlag: '2.0.0',
+          }),
+        },
+      );
+
+      expect(result.current).toBe(true);
+    });
+
+    it('returns false when build flag is set to "false" regardless of remote flags', () => {
+      process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED = 'false';
+      mockGetVersion.mockReturnValue('2.0.0');
+
+      const { result } = renderHookWithProvider(
+        () => useRampsUnifiedV2Enabled(),
+        {
+          state: mockInitialState({
+            rampsUnifiedBuyV2ActiveFlag: true,
+            rampsUnifiedBuyV2MinimumVersionFlag: '1.0.0',
+          }),
+        },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('returns true when build flag is set to "true" even with version mismatch', () => {
+      process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED = 'true';
+      mockGetVersion.mockReturnValue('1.0.0');
+
+      const { result } = renderHookWithProvider(
+        () => useRampsUnifiedV2Enabled(),
+        {
+          state: mockInitialState({
+            rampsUnifiedBuyV2ActiveFlag: true,
+            rampsUnifiedBuyV2MinimumVersionFlag: '2.0.0',
+          }),
+        },
+      );
+
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe('Remote feature flag behavior when build flag is not set', () => {
+    it('returns true when unified V2 is enabled and version meets the minimum requirement', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const { result } = renderHookWithProvider(
+        () => useRampsUnifiedV2Enabled(),
+        {
+          state: mockInitialState({
+            rampsUnifiedBuyV2ActiveFlag: true,
+            rampsUnifiedBuyV2MinimumVersionFlag: '7.63.0',
+          }),
+        },
+      );
+
+      expect(result.current).toBe(true);
+    });
+
+    it('returns false when unified V2 is disabled', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const { result } = renderHookWithProvider(
+        () => useRampsUnifiedV2Enabled(),
+        {
+          state: mockInitialState({
+            rampsUnifiedBuyV2ActiveFlag: false,
+            rampsUnifiedBuyV2MinimumVersionFlag: '7.63.0',
+          }),
+        },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('returns false when version does not meet the minimum requirement', () => {
+      mockGetVersion.mockReturnValue('7.0.0');
+
+      const { result } = renderHookWithProvider(
+        () => useRampsUnifiedV2Enabled(),
+        {
+          state: mockInitialState({
+            rampsUnifiedBuyV2ActiveFlag: true,
+            rampsUnifiedBuyV2MinimumVersionFlag: '7.63.0',
+          }),
+        },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('returns false when minimum version is not defined', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const { result } = renderHookWithProvider(
+        () => useRampsUnifiedV2Enabled(),
+        {
+          state: mockInitialState({
+            rampsUnifiedBuyV2ActiveFlag: true,
+            rampsUnifiedBuyV2MinimumVersionFlag: null,
+          }),
+        },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('returns false when minimum version is undefined', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const { result } = renderHookWithProvider(
+        () => useRampsUnifiedV2Enabled(),
+        {
+          state: mockInitialState({
+            rampsUnifiedBuyV2ActiveFlag: true,
+            rampsUnifiedBuyV2MinimumVersionFlag: undefined,
+          }),
+        },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('returns true when version equals minimum version exactly', () => {
+      mockGetVersion.mockReturnValue('7.63.0');
+
+      const { result } = renderHookWithProvider(
+        () => useRampsUnifiedV2Enabled(),
+        {
+          state: mockInitialState({
+            rampsUnifiedBuyV2ActiveFlag: true,
+            rampsUnifiedBuyV2MinimumVersionFlag: '7.63.0',
+          }),
+        },
+      );
+
+      expect(result.current).toBe(true);
+    });
+
+    it('returns false when both active flag and minimum version are not set', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const { result } = renderHookWithProvider(
+        () => useRampsUnifiedV2Enabled(),
+        {
+          state: mockInitialState({
+            rampsUnifiedBuyV2ActiveFlag: false,
+            rampsUnifiedBuyV2MinimumVersionFlag: null,
+          }),
+        },
+      );
+
+      expect(result.current).toBe(false);
+    });
+  });
+});

--- a/app/components/UI/Ramp/hooks/useRampsUnifiedV2Enabled.ts
+++ b/app/components/UI/Ramp/hooks/useRampsUnifiedV2Enabled.ts
@@ -1,0 +1,33 @@
+import { useSelector } from 'react-redux';
+import {
+  selectRampsUnifiedBuyV2ActiveFlag,
+  selectRampsUnifiedBuyV2MinimumVersionFlag,
+} from '../../../../selectors/featureFlagController/ramps/rampsUnifiedBuyV2';
+import { hasMinimumRequiredVersion } from '../utils/hasMinimumRequiredVersion';
+
+export default function useRampsUnifiedV2Enabled() {
+  const rampsUnifiedBuyV2MinimumVersionFlag = useSelector(
+    selectRampsUnifiedBuyV2MinimumVersionFlag,
+  );
+  const rampsUnifiedBuyV2ActiveFlag = useSelector(
+    selectRampsUnifiedBuyV2ActiveFlag,
+  );
+
+  const rampsUnifiedBuyV2BuildFlag =
+    process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED;
+
+  // if build flag is defined, it takes precedence over remote feature flag
+  if (
+    rampsUnifiedBuyV2BuildFlag === 'true' ||
+    rampsUnifiedBuyV2BuildFlag === 'false'
+  ) {
+    return rampsUnifiedBuyV2BuildFlag === 'true';
+  }
+
+  const isRampsUnifiedV2Enabled = hasMinimumRequiredVersion(
+    rampsUnifiedBuyV2MinimumVersionFlag,
+    rampsUnifiedBuyV2ActiveFlag,
+  );
+
+  return isRampsUnifiedV2Enabled;
+}

--- a/app/components/UI/Ramp/utils/hasMinimumRequiredVersion.test.ts
+++ b/app/components/UI/Ramp/utils/hasMinimumRequiredVersion.test.ts
@@ -1,0 +1,108 @@
+import { getVersion } from 'react-native-device-info';
+import { hasMinimumRequiredVersion } from './hasMinimumRequiredVersion';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn(),
+}));
+
+describe('hasMinimumRequiredVersion', () => {
+  const mockGetVersion = jest.mocked(getVersion);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when feature is enabled', () => {
+    it('returns true when current version exceeds minimum version', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const result = hasMinimumRequiredVersion('7.63.0', true);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true when current version equals minimum version', () => {
+      mockGetVersion.mockReturnValue('7.63.0');
+
+      const result = hasMinimumRequiredVersion('7.63.0', true);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when current version is below minimum version', () => {
+      mockGetVersion.mockReturnValue('7.0.0');
+
+      const result = hasMinimumRequiredVersion('7.63.0', true);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when minimum version is null', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const result = hasMinimumRequiredVersion(null, true);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when minimum version is undefined', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const result = hasMinimumRequiredVersion(undefined, true);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when minimum version is empty string', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const result = hasMinimumRequiredVersion('', true);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when feature is disabled', () => {
+    it('returns false even when version meets requirement', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const result = hasMinimumRequiredVersion('7.63.0', false);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when minimum version is null', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const result = hasMinimumRequiredVersion(null, false);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('version comparison edge cases', () => {
+    it('handles patch version comparison correctly', () => {
+      mockGetVersion.mockReturnValue('7.63.1');
+
+      const result = hasMinimumRequiredVersion('7.63.0', true);
+
+      expect(result).toBe(true);
+    });
+
+    it('handles minor version comparison correctly', () => {
+      mockGetVersion.mockReturnValue('7.64.0');
+
+      const result = hasMinimumRequiredVersion('7.63.0', true);
+
+      expect(result).toBe(true);
+    });
+
+    it('handles major version comparison correctly', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const result = hasMinimumRequiredVersion('7.63.0', true);
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/app/components/UI/Ramp/utils/hasMinimumRequiredVersion.test.ts
+++ b/app/components/UI/Ramp/utils/hasMinimumRequiredVersion.test.ts
@@ -81,7 +81,7 @@ describe('hasMinimumRequiredVersion', () => {
   });
 
   describe('version comparison edge cases', () => {
-    it('handles patch version comparison correctly', () => {
+    it('returns true when patch version exceeds minimum version', () => {
       mockGetVersion.mockReturnValue('7.63.1');
 
       const result = hasMinimumRequiredVersion('7.63.0', true);
@@ -89,7 +89,7 @@ describe('hasMinimumRequiredVersion', () => {
       expect(result).toBe(true);
     });
 
-    it('handles minor version comparison correctly', () => {
+    it('returns true when minor version exceeds minimum version', () => {
       mockGetVersion.mockReturnValue('7.64.0');
 
       const result = hasMinimumRequiredVersion('7.63.0', true);
@@ -97,7 +97,7 @@ describe('hasMinimumRequiredVersion', () => {
       expect(result).toBe(true);
     });
 
-    it('handles major version comparison correctly', () => {
+    it('returns true when major version exceeds minimum version', () => {
       mockGetVersion.mockReturnValue('8.0.0');
 
       const result = hasMinimumRequiredVersion('7.63.0', true);

--- a/app/components/UI/Ramp/utils/hasMinimumRequiredVersion.ts
+++ b/app/components/UI/Ramp/utils/hasMinimumRequiredVersion.ts
@@ -1,0 +1,22 @@
+import { getVersion } from 'react-native-device-info';
+import compareVersions from 'compare-versions';
+
+/**
+ * Checks if the current app version meets the minimum required version
+ * and the feature is enabled.
+ *
+ * @param minRequiredVersion - The minimum version required for the feature
+ * @param isFeatureEnabled - Whether the feature is enabled via remote flag
+ * @returns true if the feature is enabled AND current version >= minimum version
+ */
+export function hasMinimumRequiredVersion(
+  minRequiredVersion: string | null | undefined,
+  isFeatureEnabled: boolean,
+): boolean {
+  if (!minRequiredVersion) return false;
+  const currentVersion = getVersion();
+  return (
+    isFeatureEnabled &&
+    compareVersions.compare(currentVersion, minRequiredVersion, '>=')
+  );
+}

--- a/app/selectors/featureFlagController/ramps/rampsUnifiedBuyV2.test.ts
+++ b/app/selectors/featureFlagController/ramps/rampsUnifiedBuyV2.test.ts
@@ -1,0 +1,165 @@
+import {
+  RampsUnifiedBuyV2Config,
+  selectRampsUnifiedBuyV2Config,
+  selectRampsUnifiedBuyV2ActiveFlag,
+  selectRampsUnifiedBuyV2MinimumVersionFlag,
+} from './rampsUnifiedBuyV2';
+import { selectRemoteFeatureFlags } from '..';
+import { FeatureFlags } from '@metamask/remote-feature-flag-controller';
+
+describe('RampsUnifiedBuyV2 selectors', () => {
+  const mockRemoteFeatureFlags: ReturnType<typeof selectRemoteFeatureFlags> & {
+    rampsUnifiedBuyV2: RampsUnifiedBuyV2Config;
+  } = {
+    rampsUnifiedBuyV2: {
+      active: true,
+      minimumVersion: '7.63.0',
+    },
+  };
+
+  const mockEmptyRemoteFeatureFlags = {};
+
+  describe('selectRampsUnifiedBuyV2Config', () => {
+    it('returns the rampsUnifiedBuyV2Config when it exists', () => {
+      const result = selectRampsUnifiedBuyV2Config.resultFunc(
+        mockRemoteFeatureFlags,
+      );
+
+      expect(result).toEqual(mockRemoteFeatureFlags.rampsUnifiedBuyV2);
+    });
+
+    it('returns an empty object when rampsUnifiedBuyV2Config does not exist', () => {
+      const result = selectRampsUnifiedBuyV2Config.resultFunc(
+        mockEmptyRemoteFeatureFlags,
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it('returns an empty object when remoteFeatureFlags is null', () => {
+      const result = selectRampsUnifiedBuyV2Config.resultFunc(
+        null as unknown as FeatureFlags,
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it('returns an empty object when remoteFeatureFlags is undefined', () => {
+      const result = selectRampsUnifiedBuyV2Config.resultFunc(
+        undefined as unknown as FeatureFlags,
+      );
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('selectRampsUnifiedBuyV2ActiveFlag', () => {
+    it('returns true when active is set to true', () => {
+      const result = selectRampsUnifiedBuyV2ActiveFlag.resultFunc(
+        mockRemoteFeatureFlags.rampsUnifiedBuyV2,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when active is set to false', () => {
+      const mockConfigWithActiveFalse: RampsUnifiedBuyV2Config = {
+        active: false,
+        minimumVersion: '7.63.0',
+      };
+
+      const result = selectRampsUnifiedBuyV2ActiveFlag.resultFunc(
+        mockConfigWithActiveFalse,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when active is not set', () => {
+      const result = selectRampsUnifiedBuyV2ActiveFlag.resultFunc({});
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when active is null', () => {
+      const mockConfigWithActiveNull: RampsUnifiedBuyV2Config = {
+        active: null as unknown as boolean,
+        minimumVersion: '7.63.0',
+      };
+
+      const result = selectRampsUnifiedBuyV2ActiveFlag.resultFunc(
+        mockConfigWithActiveNull,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when active is undefined', () => {
+      const mockConfigWithActiveUndefined: RampsUnifiedBuyV2Config = {
+        active: undefined as unknown as boolean,
+        minimumVersion: '7.63.0',
+      };
+
+      const result = selectRampsUnifiedBuyV2ActiveFlag.resultFunc(
+        mockConfigWithActiveUndefined,
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('selectRampsUnifiedBuyV2MinimumVersionFlag', () => {
+    it('returns the minimumVersion when it exists', () => {
+      const result = selectRampsUnifiedBuyV2MinimumVersionFlag.resultFunc(
+        mockRemoteFeatureFlags.rampsUnifiedBuyV2,
+      );
+
+      expect(result).toBe('7.63.0');
+    });
+
+    it('returns null when minimumVersion is not set', () => {
+      const result = selectRampsUnifiedBuyV2MinimumVersionFlag.resultFunc({});
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when minimumVersion is null', () => {
+      const mockConfigWithVersionNull: RampsUnifiedBuyV2Config = {
+        active: true,
+        minimumVersion: null as unknown as string,
+      };
+
+      const result = selectRampsUnifiedBuyV2MinimumVersionFlag.resultFunc(
+        mockConfigWithVersionNull,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when minimumVersion is undefined', () => {
+      const mockConfigWithVersionUndefined: RampsUnifiedBuyV2Config = {
+        active: true,
+        minimumVersion: undefined,
+      };
+
+      const result = selectRampsUnifiedBuyV2MinimumVersionFlag.resultFunc(
+        mockConfigWithVersionUndefined,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns the minimumVersion when it is an empty string', () => {
+      const mockConfigWithEmptyVersion: RampsUnifiedBuyV2Config = {
+        active: true,
+        minimumVersion: '',
+      };
+
+      const result = selectRampsUnifiedBuyV2MinimumVersionFlag.resultFunc(
+        mockConfigWithEmptyVersion,
+      );
+
+      expect(result).toBe('');
+    });
+  });
+});

--- a/app/selectors/featureFlagController/ramps/rampsUnifiedBuyV2.ts
+++ b/app/selectors/featureFlagController/ramps/rampsUnifiedBuyV2.ts
@@ -1,0 +1,34 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '..';
+
+export interface RampsUnifiedBuyV2Config {
+  active?: boolean;
+  minimumVersion?: string;
+}
+
+const FLAG_KEY = 'rampsUnifiedBuyV2';
+
+export const selectRampsUnifiedBuyV2Config = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const rampsUnifiedBuyV2Config = remoteFeatureFlags?.[FLAG_KEY];
+    return (rampsUnifiedBuyV2Config ?? {}) as RampsUnifiedBuyV2Config;
+  },
+);
+
+export const selectRampsUnifiedBuyV2ActiveFlag = createSelector(
+  selectRampsUnifiedBuyV2Config,
+  (rampsUnifiedBuyV2Config) => {
+    const rampsUnifiedBuyV2ActiveFlag = rampsUnifiedBuyV2Config?.active;
+    return rampsUnifiedBuyV2ActiveFlag ?? false;
+  },
+);
+
+export const selectRampsUnifiedBuyV2MinimumVersionFlag = createSelector(
+  selectRampsUnifiedBuyV2Config,
+  (rampsUnifiedBuyV2Config) => {
+    const rampsUnifiedBuyV2MinimumVersion =
+      rampsUnifiedBuyV2Config?.minimumVersion;
+    return rampsUnifiedBuyV2MinimumVersion ?? null;
+  },
+);

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -27,6 +27,8 @@ const newOverrides = [
       'app/core/Engine/controllers/ramps-controller/ramps-service-init.test.ts',
       'app/components/UI/Ramp/hooks/useRampsUnifiedV1Enabled.ts',
       'app/components/UI/Ramp/hooks/useRampsUnifiedV1Enabled.test.ts',
+      'app/components/UI/Ramp/hooks/useRampsUnifiedV2Enabled.ts',
+      'app/components/UI/Ramp/hooks/useRampsUnifiedV2Enabled.test.ts',
       'app/components/UI/Ramp/hooks/useRampsSmartRouting.ts',
       'app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts',
       'app/components/UI/Ramp/hooks/useRampTokens.ts',

--- a/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
+++ b/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
@@ -288,6 +288,12 @@ const DEFAULT_FEATURE_FLAGS_ARRAY: Record<string, unknown>[] = [
       active: false,
     },
   },
+  {
+    rampsUnifiedBuyV2: {
+      minimumVersion: '7.63.0',
+      active: false,
+    },
+  },
 ];
 
 /**


### PR DESCRIPTION
## **Description**

This PR adds support for the `rampsUnifiedBuyV2` LaunchDarkly feature flag to enable Phase 2 of the Unified Buy feature.

**What is the reason for the change?**
- As part of the Unified Buy 2026 Phase 2 initiative (TRAM-2958), we need a new feature flag to control the V2 implementation independently from V1.

**What is the improvement/solution?**
- Added V2 selectors for the `rampsUnifiedBuyV2` remote feature flag
- Added `useRampsUnifiedV2Enabled` hook with:
  - Build flag override support (`MM_RAMPS_UNIFIED_BUY_V2_ENABLED`)
  - Remote feature flag via Redux selectors
  - Minimum version checking (7.63.0)
- Extracted `hasMinimumRequiredVersion` to a shared utility (DRY refactor)
- Updated V1 hook to use the shared utility
- Added V2 flag configuration to E2E remote feature flags mock

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3027

## **Manual testing steps**

```gherkin
Feature: rampsUnifiedBuyV2 feature flag

  Scenario: V2 flag is disabled by default
    Given the app is running with remote feature flags loaded
    When the rampsUnifiedBuyV2 flag has active: false
    Then useRampsUnifiedV2Enabled returns false

  Scenario: V2 flag is enabled when active and version meets requirement
    Given the app is running version 7.63.0 or higher
    When the rampsUnifiedBuyV2 flag has active: true and minimumVersion: 7.63.0
    Then useRampsUnifiedV2Enabled returns true

  Scenario: Build flag overrides remote flag
    Given MM_RAMPS_UNIFIED_BUY_V2_ENABLED is set to "true"
    When the remote flag has active: false
    Then useRampsUnifiedV2Enabled returns true (build flag takes precedence)
```

## **Screenshots/Recordings**

N/A - No UI changes, this is infrastructure code for feature flagging.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Phase 2 flagging for Unified Buy with build-time override and version gating, plus shared utility reuse.
> 
> - New `rampsUnifiedBuyV2` selectors and `useRampsUnifiedV2Enabled` hook (respects `MM_RAMPS_UNIFIED_BUY_V2_ENABLED` and remote flags with minimum version)
> - Extracts `hasMinimumRequiredVersion` to `utils/hasMinimumRequiredVersion` and updates `useRampsUnifiedV1Enabled` to use it
> - Adds comprehensive tests for V2 hook, V2 selectors, and the version-check util
> - Updates `babel.config.tests.js` to avoid inlining env vars for new files
> - Extends E2E remote feature flags mock to include `rampsUnifiedBuyV2` default config
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3a487fc1b629c833f5eaccdc31fbebbe6a85067. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->