### PR TITLE
feat: set NetworkManager bottom sheet to 75% height

### DIFF
--- a/app/components/UI/NetworkManager/index.styles.ts
+++ b/app/components/UI/NetworkManager/index.styles.ts
@@ -22,9 +22,6 @@ const createStyles = (params: { theme: Theme }) => {
   const textAlternative = colors.text.alternative;
 
   return StyleSheet.create({
-    scrollableTabView: {
-      flex: 1,
-    },
     // tab
     tabUnderlineStyle: {
       height: UNDERLINE_HEIGHT,

--- a/app/components/UI/NetworkManager/index.styles.ts
+++ b/app/components/UI/NetworkManager/index.styles.ts
@@ -4,12 +4,14 @@ import {
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
 import { Theme } from '../../../util/theme/models';
+import Device from '../../../util/device';
 
 const UNDERLINE_HEIGHT = 2;
 const TAB_PADDING_BOTTOM = 8;
 const TAB_PADDING_VERTICAL = 8;
 const DELETE_CONTAINER_PADDING_LEFT = 16;
 const DELETE_CONTAINER_PADDING_RIGHT = 8;
+const CONTAINER_HEIGHT_RATIO = 0.5; // 50%
 
 const BODY_MD_FONT_FAMILY = getFontFamily(TextVariant.BodyMD);
 
@@ -20,8 +22,14 @@ const createStyles = (params: { theme: Theme }) => {
   const borderMuted = colors.border.muted;
   const textDefault = colors.text.default;
   const textAlternative = colors.text.alternative;
+  const containerHeight = Device.getDeviceHeight() * CONTAINER_HEIGHT_RATIO;
 
   return StyleSheet.create({
+    // container
+    container: {
+      height: containerHeight,
+      maxHeight: containerHeight,
+    },
     // tab
     tabUnderlineStyle: {
       height: UNDERLINE_HEIGHT,

--- a/app/components/UI/NetworkManager/index.styles.ts
+++ b/app/components/UI/NetworkManager/index.styles.ts
@@ -4,14 +4,12 @@ import {
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
 import { Theme } from '../../../util/theme/models';
-import Device from '../../../util/device';
 
 const UNDERLINE_HEIGHT = 2;
 const TAB_PADDING_BOTTOM = 8;
 const TAB_PADDING_VERTICAL = 8;
 const DELETE_CONTAINER_PADDING_LEFT = 16;
 const DELETE_CONTAINER_PADDING_RIGHT = 8;
-const CONTAINER_HEIGHT_RATIO = 0.5; // 50%
 
 const BODY_MD_FONT_FAMILY = getFontFamily(TextVariant.BodyMD);
 
@@ -22,14 +20,8 @@ const createStyles = (params: { theme: Theme }) => {
   const borderMuted = colors.border.muted;
   const textDefault = colors.text.default;
   const textAlternative = colors.text.alternative;
-  const containerHeight = Device.getDeviceHeight() * CONTAINER_HEIGHT_RATIO;
 
   return StyleSheet.create({
-    // container
-    container: {
-      height: containerHeight,
-      maxHeight: containerHeight,
-    },
     // tab
     tabUnderlineStyle: {
       height: UNDERLINE_HEIGHT,

--- a/app/components/UI/NetworkManager/index.styles.ts
+++ b/app/components/UI/NetworkManager/index.styles.ts
@@ -5,9 +5,6 @@ import {
 } from '../../../component-library/components/Texts/Text';
 import { Theme } from '../../../util/theme/models';
 
-const SHEET_BORDER_RADIUS = 20;
-const TITLE_PADDING_TOP = 16;
-const TITLE_MARGIN_TOP = 4;
 const UNDERLINE_HEIGHT = 2;
 const TAB_PADDING_BOTTOM = 8;
 const TAB_PADDING_VERTICAL = 8;
@@ -20,26 +17,13 @@ const createStyles = (params: { theme: Theme }) => {
   const { theme } = params;
   const { colors, typography } = theme;
 
-  const backgroundDefault = colors.background.default;
   const borderMuted = colors.border.muted;
   const textDefault = colors.text.default;
   const textAlternative = colors.text.alternative;
 
   return StyleSheet.create({
-    // reusable modal
-    sheet: {
-      backgroundColor: backgroundDefault,
-      borderTopLeftRadius: SHEET_BORDER_RADIUS,
-      borderTopRightRadius: SHEET_BORDER_RADIUS,
-    },
-    // network tabs selectors
-    networkTabsSelectorWrapper: {
-      height: '100%',
-    },
-    networkTabsSelectorTitle: {
-      alignSelf: 'center',
-      paddingTop: TITLE_PADDING_TOP,
-      marginTop: TITLE_MARGIN_TOP,
+    scrollableTabView: {
+      flex: 1,
     },
     // tab
     tabUnderlineStyle: {

--- a/app/components/UI/NetworkManager/index.test.tsx
+++ b/app/components/UI/NetworkManager/index.test.tsx
@@ -565,6 +565,36 @@ jest.mock(
   }),
 );
 
+jest.mock('../../../component-library/components/Buttons/ButtonIcon', () => {
+  const { TouchableOpacity } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ onPress }: { onPress?: () => void }) => (
+      <TouchableOpacity testID="button-icon" onPress={onPress} />
+    ),
+    ButtonIconSizes: {
+      Sm: 'sm',
+      Md: 'md',
+      Lg: 'lg',
+    },
+  };
+});
+
+jest.mock(
+  '../../../component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader',
+  () => {
+    const { View: RNView, Text: RNText } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: ({ children }: { children: React.ReactNode }) => (
+        <RNView testID="header">
+          <RNText>{children}</RNText>
+        </RNView>
+      ),
+    };
+  },
+);
+
 jest.mock('../../../component-library/components/Buttons/Button', () => ({
   ButtonVariants: {
     Primary: 'primary',
@@ -734,18 +764,6 @@ describe('NetworkManager Component', () => {
       expect(getByTestId('custom-network-selector')).toBeOnTheScreen();
     });
 
-    it('should apply correct container styles with safe area insets', () => {
-      const { getByTestId } = renderComponent();
-      const modal = getByTestId('main-bottom-sheet');
-
-      expect(modal.props.style).toEqual([
-        {
-          paddingTop: 44 + 800 * 0.02, // safeAreaInsets.top + Device.getDeviceHeight() * 0.02
-          paddingBottom: 34, // safeAreaInsets.bottom
-        },
-      ]);
-    });
-
     it('should set initial tab to popular networks when selectedCount > 0', () => {
       (useNetworksByNamespace as jest.Mock).mockReturnValue({
         selectedCount: 3,
@@ -859,7 +877,7 @@ describe('NetworkManager Component', () => {
 
   describe('Network Deletion Workflow', () => {
     it('should show confirmation modal when delete is pressed', async () => {
-      const { getByTestId } = renderComponent();
+      const { getAllByTestId, getByTestId } = renderComponent();
 
       const openModalButton = getByTestId('open-modal-button');
       fireEvent.press(openModalButton);
@@ -871,13 +889,15 @@ describe('NetworkManager Component', () => {
 
       expect(mockOnCloseBottomSheet).toHaveBeenCalled();
       await waitFor(() => {
-        expect(getByTestId('header')).toBeOnTheScreen();
+        // There are now multiple headers (main sheet + delete modal)
+        const headers = getAllByTestId('header');
+        expect(headers.length).toBeGreaterThan(0);
         expect(getByTestId('bottom-sheet-footer')).toBeOnTheScreen();
       });
     });
 
     it('should display correct network name in delete confirmation', async () => {
-      const { getByTestId, getByText } = renderComponent();
+      const { getAllByTestId, getByTestId, getByText } = renderComponent();
 
       const openModalButton = getByTestId('open-modal-button');
       fireEvent.press(openModalButton);
@@ -888,7 +908,9 @@ describe('NetworkManager Component', () => {
       });
 
       await waitFor(() => {
-        expect(getByTestId('header')).toBeOnTheScreen();
+        // There are now multiple headers (main sheet + delete modal)
+        const headers = getAllByTestId('header');
+        expect(headers.length).toBeGreaterThan(0);
         // The network name appears as part of a larger text string, use partial match
         expect(getByText(/Ethereum Mainnet/)).toBeOnTheScreen();
         expect(getByText(/app_settings\.network_delete/)).toBeOnTheScreen();

--- a/app/components/UI/NetworkManager/index.test.tsx
+++ b/app/components/UI/NetworkManager/index.test.tsx
@@ -132,6 +132,7 @@ jest.mock('../../hooks/useMetrics', () => ({
   useMetrics: () => ({
     trackEvent: mockTrackEvent,
     createEventBuilder: mockCreateEventBuilder,
+    addTraitsToUser: mockAddTraitsToUser,
   }),
   MetaMetricsEvents: {
     ASSET_FILTER_SELECTED: 'asset_filter_selected',

--- a/app/components/UI/NetworkManager/index.tsx
+++ b/app/components/UI/NetworkManager/index.tsx
@@ -117,7 +117,7 @@ const NetworkManager = () => {
     return getEnabledNetworks(enabledNetworksByNamespace);
   }, [enabledNetworksByNamespace]);
 
-  const [showNetworkMenuModal, setNetworkMenuModal] =
+  const [showNetworkMenuModal, setShowNetworkMenuModal] =
     useState<NetworkMenuModalState>(initialNetworkMenuModal);
   const [showConfirmDeleteModal, setShowConfirmDeleteModal] =
     useState<ShowConfirmDeleteModalState>(initialShowConfirmDeleteModal);
@@ -215,7 +215,7 @@ const NetworkManager = () => {
   );
 
   const openModal = useCallback((networkMenuModal: NetworkMenuModalState) => {
-    setNetworkMenuModal((prev) => ({
+    setShowNetworkMenuModal((prev) => ({
       ...prev,
       ...networkMenuModal,
       isVisible: true,
@@ -224,7 +224,7 @@ const NetworkManager = () => {
   }, []);
 
   const closeModal = useCallback(() => {
-    setNetworkMenuModal(initialNetworkMenuModal);
+    setShowNetworkMenuModal(initialNetworkMenuModal);
     networkMenuSheetRef.current?.onCloseBottomSheet();
   }, []);
 

--- a/app/components/UI/NetworkManager/index.tsx
+++ b/app/components/UI/NetworkManager/index.tsx
@@ -118,7 +118,7 @@ const NetworkManager = () => {
     return getEnabledNetworks(enabledNetworksByNamespace);
   }, [enabledNetworksByNamespace]);
 
-  const [showNetworkMenuModal, setShowNetworkMenuModal] =
+  const [showNetworkMenuModal, setNetworkMenuModal] =
     useState<NetworkMenuModalState>(initialNetworkMenuModal);
   const [showConfirmDeleteModal, setShowConfirmDeleteModal] =
     useState<ShowConfirmDeleteModalState>(initialShowConfirmDeleteModal);
@@ -226,7 +226,7 @@ const NetworkManager = () => {
   );
 
   const openModal = useCallback((networkMenuModal: NetworkMenuModalState) => {
-    setShowNetworkMenuModal((prev) => ({
+    setNetworkMenuModal((prev) => ({
       ...prev,
       ...networkMenuModal,
       isVisible: true,
@@ -235,7 +235,7 @@ const NetworkManager = () => {
   }, []);
 
   const closeModal = useCallback(() => {
-    setShowNetworkMenuModal(initialNetworkMenuModal);
+    setNetworkMenuModal(initialNetworkMenuModal);
     networkMenuSheetRef.current?.onCloseBottomSheet();
   }, []);
 

--- a/app/components/UI/NetworkManager/index.tsx
+++ b/app/components/UI/NetworkManager/index.tsx
@@ -2,7 +2,6 @@
 import { View } from 'react-native';
 import React, { useRef, useMemo, useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import ScrollableTabView, {
   ChangeTabProperties,
@@ -30,9 +29,7 @@ import { useStyles } from '../../../component-library/hooks/useStyles';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../component-library/components/BottomSheets/BottomSheet';
-import Text, {
-  TextVariant,
-} from '../../../component-library/components/Texts/Text';
+import Text from '../../../component-library/components/Texts/Text';
 import { IconName } from '../../../component-library/components/Icons/Icon';
 import AccountAction from '../../Views/AccountAction';
 import NetworkMultiSelector from '../NetworkMultiSelector/NetworkMultiSelector';
@@ -91,7 +88,6 @@ const NetworkManager = () => {
   const { colors } = useTheme();
   const { styles } = useStyles(createStyles, { colors });
   const { trackEvent, createEventBuilder } = useMetrics();
-  const safeAreaInsets = useSafeAreaInsets();
   const { selectedCount } = useNetworksByNamespace({
     networkType: NetworkType.Popular,
   });
@@ -160,11 +156,11 @@ const NetworkManager = () => {
   const containerStyle = useMemo(
     () => [
       {
-        paddingTop: safeAreaInsets.top + Device.getDeviceHeight() * 0.02,
-        paddingBottom: safeAreaInsets.bottom,
+        height: Device.getDeviceHeight() * 0.5,
+        maxHeight: Device.getDeviceHeight() * 0.5,
       },
     ],
-    [safeAreaInsets.top, safeAreaInsets.bottom],
+    [],
   );
 
   const defaultTabProps = useMemo(
@@ -368,37 +364,33 @@ const NetworkManager = () => {
       <BottomSheet
         testID={NETWORK_MULTI_SELECTOR_TEST_IDS.NETWORK_MANAGER_BOTTOM_SHEET}
         ref={sheetRef}
-        style={containerStyle}
         shouldNavigateBack
       >
-        <View style={styles.sheet}>
-          <Text
-            variant={TextVariant.HeadingMD}
-            style={styles.networkTabsSelectorTitle}
+        <View style={containerStyle}>
+          <BottomSheetHeader
+            onClose={() => sheetRef.current?.onCloseBottomSheet()}
           >
             {strings('wallet.networks')}
-          </Text>
+          </BottomSheetHeader>
 
-          <View style={styles.networkTabsSelectorWrapper}>
-            <ScrollableTabView
-              renderTabBar={renderTabBar}
-              onChangeTab={onChangeTab}
-              initialPage={initialTabIndexRef.current ?? 0}
-            >
-              <NetworkMultiSelector
-                {...defaultTabProps}
-                openModal={openModal}
-                dismissModal={dismissModal}
-                openRpcModal={openRpcModal}
-              />
-              <CustomNetworkSelector
-                {...customTabProps}
-                openModal={openModal}
-                dismissModal={dismissModal}
-                openRpcModal={openRpcModal}
-              />
-            </ScrollableTabView>
-          </View>
+          <ScrollableTabView
+            renderTabBar={renderTabBar}
+            onChangeTab={onChangeTab}
+            initialPage={initialTabIndexRef.current ?? 0}
+          >
+            <NetworkMultiSelector
+              {...defaultTabProps}
+              openModal={openModal}
+              dismissModal={dismissModal}
+              openRpcModal={openRpcModal}
+            />
+            <CustomNetworkSelector
+              {...customTabProps}
+              openModal={openModal}
+              dismissModal={dismissModal}
+              openRpcModal={openRpcModal}
+            />
+          </ScrollableTabView>
         </View>
 
         {showNetworkMenuModal.isVisible && (

--- a/app/components/UI/NetworkManager/index.tsx
+++ b/app/components/UI/NetworkManager/index.tsx
@@ -33,6 +33,7 @@ import { IconName } from '../../../component-library/components/Icons/Icon';
 import AccountAction from '../../Views/AccountAction';
 import NetworkMultiSelector from '../NetworkMultiSelector/NetworkMultiSelector';
 import CustomNetworkSelector from '../CustomNetworkSelector/CustomNetworkSelector';
+import Device from '../../../util/device';
 import Routes from '../../../constants/navigation/Routes';
 import { createNavigationDetails } from '../../../util/navigation/navUtils';
 import { selectNetworkConfigurationsByCaipChainId } from '../../../selectors/networkController';
@@ -150,6 +151,16 @@ const NetworkManager = () => {
     });
     return evmConfigs;
   }, [networkConfigurations]);
+
+  const containerStyle = useMemo(
+    () => [
+      {
+        height: Device.getDeviceHeight() * 0.5,
+        maxHeight: Device.getDeviceHeight() * 0.5,
+      },
+    ],
+    [],
+  );
 
   const defaultTabProps = useMemo(
     () => ({
@@ -352,7 +363,7 @@ const NetworkManager = () => {
         ref={sheetRef}
         shouldNavigateBack
       >
-        <View style={styles.container}>
+        <View style={containerStyle}>
           <BottomSheetHeader
             onClose={() => sheetRef.current?.onCloseBottomSheet()}
           >

--- a/app/components/UI/NetworkManager/index.tsx
+++ b/app/components/UI/NetworkManager/index.tsx
@@ -13,7 +13,6 @@ import { toHex } from '@metamask/controller-utils';
 // external dependencies
 import Engine from '../../../core/Engine';
 import { removeItemFromChainIdList } from '../../../util/metrics/MultichainAPI/networkMetricUtils';
-import { MetaMetrics } from '../../../core/Analytics';
 import { useTheme } from '../../../util/theme';
 import { MetaMetricsEvents, useMetrics } from '../../hooks/useMetrics';
 import { strings } from '../../../../locales/i18n';
@@ -87,7 +86,7 @@ const NetworkManager = () => {
   const navigation = useNavigation();
   const { colors } = useTheme();
   const { styles } = useStyles(createStyles, { colors });
-  const { trackEvent, createEventBuilder } = useMetrics();
+  const { trackEvent, createEventBuilder, addTraitsToUser } = useMetrics();
   const { selectedCount } = useNetworksByNamespace({
     networkType: NetworkType.Popular,
   });
@@ -119,7 +118,7 @@ const NetworkManager = () => {
     return getEnabledNetworks(enabledNetworksByNamespace);
   }, [enabledNetworksByNamespace]);
 
-  const [showNetworkMenuModal, setNetworkMenuModal] =
+  const [showNetworkMenuModal, setShowNetworkMenuModal] =
     useState<NetworkMenuModalState>(initialNetworkMenuModal);
   const [showConfirmDeleteModal, setShowConfirmDeleteModal] =
     useState<ShowConfirmDeleteModalState>(initialShowConfirmDeleteModal);
@@ -227,7 +226,7 @@ const NetworkManager = () => {
   );
 
   const openModal = useCallback((networkMenuModal: NetworkMenuModalState) => {
-    setNetworkMenuModal((prev) => ({
+    setShowNetworkMenuModal((prev) => ({
       ...prev,
       ...networkMenuModal,
       isVisible: true,
@@ -236,7 +235,7 @@ const NetworkManager = () => {
   }, []);
 
   const closeModal = useCallback(() => {
-    setNetworkMenuModal(initialNetworkMenuModal);
+    setShowNetworkMenuModal(initialNetworkMenuModal);
     networkMenuSheetRef.current?.onCloseBottomSheet();
   }, []);
 
@@ -307,13 +306,11 @@ const NetworkManager = () => {
       NetworkController.removeNetwork(chainId);
       disableNetwork(showConfirmDeleteModal.caipChainId);
 
-      MetaMetrics.getInstance().addTraitsToUser(
-        removeItemFromChainIdList(chainId),
-      );
+      addTraitsToUser(removeItemFromChainIdList(chainId));
 
       setShowConfirmDeleteModal(initialShowConfirmDeleteModal);
     }
-  }, [showConfirmDeleteModal, disableNetwork]);
+  }, [showConfirmDeleteModal, disableNetwork, addTraitsToUser]);
 
   const cancelButtonProps: ButtonProps = useMemo(
     () => ({
@@ -376,11 +373,7 @@ const NetworkManager = () => {
           <ScrollableTabView
             renderTabBar={renderTabBar}
             onChangeTab={onChangeTab}
-<<<<<<< HEAD
             initialPage={initialTabIndexRef.current ?? 0}
-=======
-            initialPage={defaultTabIndex}
->>>>>>> ee28089539 (chore: removing unused styles)
           >
             <NetworkMultiSelector
               {...defaultTabProps}

--- a/app/components/UI/NetworkManager/index.tsx
+++ b/app/components/UI/NetworkManager/index.tsx
@@ -376,7 +376,11 @@ const NetworkManager = () => {
           <ScrollableTabView
             renderTabBar={renderTabBar}
             onChangeTab={onChangeTab}
+<<<<<<< HEAD
             initialPage={initialTabIndexRef.current ?? 0}
+=======
+            initialPage={defaultTabIndex}
+>>>>>>> ee28089539 (chore: removing unused styles)
           >
             <NetworkMultiSelector
               {...defaultTabProps}

--- a/app/components/UI/NetworkManager/index.tsx
+++ b/app/components/UI/NetworkManager/index.tsx
@@ -155,8 +155,8 @@ const NetworkManager = () => {
   const containerStyle = useMemo(
     () => [
       {
-        height: Device.getDeviceHeight() * 0.5,
-        maxHeight: Device.getDeviceHeight() * 0.5,
+        height: Device.getDeviceHeight() * 0.75,
+        maxHeight: Device.getDeviceHeight() * 0.75,
       },
     ],
     [],

--- a/app/components/UI/NetworkManager/index.tsx
+++ b/app/components/UI/NetworkManager/index.tsx
@@ -33,7 +33,6 @@ import { IconName } from '../../../component-library/components/Icons/Icon';
 import AccountAction from '../../Views/AccountAction';
 import NetworkMultiSelector from '../NetworkMultiSelector/NetworkMultiSelector';
 import CustomNetworkSelector from '../CustomNetworkSelector/CustomNetworkSelector';
-import Device from '../../../util/device';
 import Routes from '../../../constants/navigation/Routes';
 import { createNavigationDetails } from '../../../util/navigation/navUtils';
 import { selectNetworkConfigurationsByCaipChainId } from '../../../selectors/networkController';
@@ -151,16 +150,6 @@ const NetworkManager = () => {
     });
     return evmConfigs;
   }, [networkConfigurations]);
-
-  const containerStyle = useMemo(
-    () => [
-      {
-        height: Device.getDeviceHeight() * 0.5,
-        maxHeight: Device.getDeviceHeight() * 0.5,
-      },
-    ],
-    [],
-  );
 
   const defaultTabProps = useMemo(
     () => ({
@@ -363,7 +352,7 @@ const NetworkManager = () => {
         ref={sheetRef}
         shouldNavigateBack
       >
-        <View style={containerStyle}>
+        <View style={styles.container}>
           <BottomSheetHeader
             onClose={() => sheetRef.current?.onCloseBottomSheet()}
           >


### PR DESCRIPTION
## **Description**

Modified the NetworkManager component to display the Networks bottom sheet at 75% of screen height instead of expanding based on content. This provides a more consistent and predictable UI experience when users open the Networks modal.

**What is the reason for the change?**
The Networks bottom sheet was expanding to fit all content, there is a design decision that there should be no BottomSheets that open 100% height see ticket.

**What is the improvement/solution?**
Constrained the NetworkManager bottom sheet to exactly 75% of the screen height with proper scrolling for content that exceeds this space. Also added a close button (X icon) in the header for improved UX.

## **Changelog**

CHANGELOG entry: Updated Networks bottom sheet to open at 50% screen height with improved header and close button

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-237

## **Manual testing steps**

```gherkin
Feature: Networks bottom sheet height constraint

  Scenario: user opens Networks bottom sheet
    Given the user is on the wallet home screen
    
    When user taps on the network selector button
    Then the Networks bottom sheet should open to exactly 75% of screen height
    And the sheet should display a close button (X) in the top-right corner
    And the content should be scrollable
    
  Scenario: user interacts with Networks bottom sheet
    Given the Networks bottom sheet is open at 75% height
    
    When user scrolls through the network list
    Then the sheet should remain at 75% height
    And only the content should scroll
    
  Scenario: user closes Networks bottom sheet
    Given the Networks bottom sheet is open
    
    When user taps the close button (X)
    Then the bottom sheet should close with animation
    And user should return to the home screen
    
  Scenario: user swipes to dismiss bottom sheet
    Given the Networks bottom sheet is open
    
    When user swipes down on the sheet
    Then the bottom sheet should dismiss
```

## **Screenshots/Recordings**

### **Before**

Networks bottom sheet expanded to fit all content (100% height) and no close button

https://github.com/user-attachments/assets/da2023a4-bdd9-4980-8ce5-d634ba524119

### **After**

Networks bottom sheet constrained to 75% of screen height with scrollable content and close button

https://github.com/user-attachments/assets/7f8c2ab5-94c5-4997-adf8-fdf45c0159df

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## Technical Details

**Changes made:**

1. **NetworkManager** (Primary Fix):
   - Wrapped BottomSheet content in a View with fixed height constraint
   - Added `BottomSheetHeader` with close button
   - Created `scrollableTabView` style with `flex: 1`
   - Removed unused imports and variables

2. **NetworkSelector** (Bonus Migration):
   - Migrated from deprecated `ReusableModal` to `BottomSheet` component
   - Added close button and 75% height constraint
   - Cleaned up deprecated styles

**Key insight:**
The BottomSheetDialog uses `onLayout` to measure content height for animation. By placing the height constraint on a wrapper View inside the BottomSheet (rather than on the BottomSheet component itself), we ensure the measured height is exactly 75%.

**Files changed:**
- `app/components/UI/NetworkManager/index.tsx`
- `app/components/UI/NetworkManager/index.styles.ts`
- `app/components/Views/NetworkSelector/NetworkSelector.tsx`
- `app/components/Views/NetworkSelector/NetworkSelector.styles.ts`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Imposes a fixed-height Networks bottom sheet and modernizes header/metrics usage.
> 
> - Wraps BottomSheet content in a container with `height`/`maxHeight` at `75%` of device height; removes safe-area-based sizing and legacy sheet/title styles
> - Replaces inline title `Text` with `BottomSheetHeader` providing a close action; adjusts layout to place `ScrollableTabView` directly within the container
> - Refactors metrics: replaces `MetaMetrics.getInstance().addTraitsToUser` with `useMetrics().addTraitsToUser`; updates delete flow to use this and keeps analytics tab tracking
> - Adds RPC selection modal wiring and EVM-only config mapping for `RpcSelectionModal`
> - Renames `setNetworkMenuModal` -> `setShowNetworkMenuModal` and minor cleanup of unused imports
> - Updates tests/mocks for new header and button icon components, removes safe-area style assertion, and adapts deletion confirmation assertions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d5c0ddcaf12e0fb364db4519abd2f34039f4b6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->