### PR TITLE
feat(predict): replace hardcoded live sports config with remote feature flag

### DIFF
--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -1,4 +1,4 @@
-import { PredictFeeCollection } from '../types/flags';
+import { PredictFeeCollection, PredictLiveSportsFlag } from '../types/flags';
 
 export const DEFAULT_FEE_COLLECTION_FLAG = {
   enabled: true,
@@ -10,3 +10,8 @@ export const DEFAULT_FEE_COLLECTION_FLAG = {
   providerFee: 0.02, // 2%
   waiveList: [],
 } satisfies PredictFeeCollection;
+
+export const DEFAULT_LIVE_SPORTS_FLAG: PredictLiveSportsFlag = {
+  enabled: false,
+  leagues: [],
+};

--- a/app/components/UI/Predict/constants/sports.ts
+++ b/app/components/UI/Predict/constants/sports.ts
@@ -9,7 +9,11 @@ import { PredictSportsLeague } from '../types';
  * 3. Add the league to this array
  * 4. Add tests for the new league's slug parsing
  */
-export const LIVE_SPORTS_LEAGUES: PredictSportsLeague[] = ['nfl'];
+export const SUPPORTED_SPORTS_LEAGUES: PredictSportsLeague[] = ['nfl'];
 
-export const isLiveSportsEnabled = (): boolean =>
-  Array.isArray(LIVE_SPORTS_LEAGUES) && LIVE_SPORTS_LEAGUES.length > 0;
+export const filterSupportedLeagues = (
+  leagues: string[],
+): PredictSportsLeague[] =>
+  leagues.filter((league): league is PredictSportsLeague =>
+    SUPPORTED_SPORTS_LEAGUES.includes(league as PredictSportsLeague),
+  );

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -104,6 +104,10 @@ jest.mock('../../../../core/Engine', () => ({
             providerFee: 0.02,
             waiveList: [],
           },
+          predictLiveSports: {
+            enabled: false,
+            leagues: [],
+          },
         },
       },
     },
@@ -538,6 +542,7 @@ describe('PredictController', () => {
         expect(controller.state.lastUpdateTimestamp).toBeGreaterThan(0);
         expect(mockPolymarketProvider.getMarketDetails).toHaveBeenCalledWith({
           marketId: 'market-1',
+          liveSportsLeagues: [],
         });
       });
     });
@@ -562,6 +567,7 @@ describe('PredictController', () => {
         expect(result).toEqual(mockMarket);
         expect(mockPolymarketProvider.getMarketDetails).toHaveBeenCalledWith({
           marketId: 'market-2',
+          liveSportsLeagues: [],
         });
       });
     });
@@ -633,6 +639,7 @@ describe('PredictController', () => {
         expect(result).toEqual(mockMarket);
         expect(mockPolymarketProvider.getMarketDetails).toHaveBeenCalledWith({
           marketId: '123',
+          liveSportsLeagues: [],
         });
       });
     });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -473,7 +473,7 @@ export class PredictController extends BaseController<
           .predictLiveSports as unknown as PredictLiveSportsFlag | undefined) ??
         DEFAULT_LIVE_SPORTS_FLAG;
       const liveSportsLeagues = liveSportsFlag.enabled
-        ? filterSupportedLeagues(liveSportsFlag.leagues)
+        ? filterSupportedLeagues(liveSportsFlag.leagues ?? [])
         : [];
 
       const paramsWithLiveSports = { ...params, liveSportsLeagues };
@@ -581,7 +581,7 @@ export class PredictController extends BaseController<
           .predictLiveSports as unknown as PredictLiveSportsFlag | undefined) ??
         DEFAULT_LIVE_SPORTS_FLAG;
       const liveSportsLeagues = liveSportsFlag.enabled
-        ? filterSupportedLeagues(liveSportsFlag.leagues)
+        ? filterSupportedLeagues(liveSportsFlag.leagues ?? [])
         : [];
 
       const market = await provider.getMarketDetails({

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -14,10 +14,7 @@ import {
   isSmartContractAddress,
 } from '../../../../../util/transactions';
 import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../../constants/errors';
-import {
-  isLiveSportsEnabled,
-  LIVE_SPORTS_LEAGUES,
-} from '../../constants/sports';
+import { SUPPORTED_SPORTS_LEAGUES } from '../../constants/sports';
 import {
   GetPriceHistoryParams,
   GetPriceParams,
@@ -177,8 +174,10 @@ export class PolymarketProvider implements PredictProvider {
 
   public async getMarketDetails({
     marketId,
+    liveSportsLeagues = [],
   }: {
     marketId: string;
+    liveSportsLeagues?: string[];
   }): Promise<PredictMarket> {
     if (!marketId) {
       throw new Error('marketId is required');
@@ -189,15 +188,17 @@ export class PolymarketProvider implements PredictProvider {
         marketId,
       });
 
-      const liveSportsEnabled = isLiveSportsEnabled();
+      const liveSportsEnabled = liveSportsLeagues.length > 0;
 
       if (liveSportsEnabled) {
-        await TeamsCache.getInstance().ensureLeaguesLoaded(LIVE_SPORTS_LEAGUES);
+        await TeamsCache.getInstance().ensureLeaguesLoaded(
+          liveSportsLeagues as typeof SUPPORTED_SPORTS_LEAGUES,
+        );
       }
 
       const teamLookup = liveSportsEnabled
         ? (
-            league: (typeof LIVE_SPORTS_LEAGUES)[number],
+            league: (typeof SUPPORTED_SPORTS_LEAGUES)[number],
             abbreviation: string,
           ) => TeamsCache.getInstance().getTeam(league, abbreviation)
         : undefined;
@@ -258,15 +259,18 @@ export class PolymarketProvider implements PredictProvider {
 
   public async getMarkets(params?: GetMarketsParams): Promise<PredictMarket[]> {
     try {
-      const liveSportsEnabled = isLiveSportsEnabled();
+      const liveSportsLeagues = params?.liveSportsLeagues ?? [];
+      const liveSportsEnabled = liveSportsLeagues.length > 0;
 
       if (liveSportsEnabled) {
-        await TeamsCache.getInstance().ensureLeaguesLoaded(LIVE_SPORTS_LEAGUES);
+        await TeamsCache.getInstance().ensureLeaguesLoaded(
+          liveSportsLeagues as typeof SUPPORTED_SPORTS_LEAGUES,
+        );
       }
 
       const teamLookup = liveSportsEnabled
         ? (
-            league: (typeof LIVE_SPORTS_LEAGUES)[number],
+            league: (typeof SUPPORTED_SPORTS_LEAGUES)[number],
             abbreviation: string,
           ) => TeamsCache.getInstance().getTeam(league, abbreviation)
         : undefined;

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -40,6 +40,9 @@ export interface GetMarketsParams {
   // Pagination
   offset?: number;
   limit?: number;
+
+  // Live sports configuration
+  liveSportsLeagues?: string[];
 }
 
 export interface Signer {
@@ -228,7 +231,10 @@ export interface PredictProvider {
 
   // Market data
   getMarkets(params: GetMarketsParams): Promise<PredictMarket[]>;
-  getMarketDetails(params: { marketId: string }): Promise<PredictMarket>;
+  getMarketDetails(params: {
+    marketId: string;
+    liveSportsLeagues?: string[];
+  }): Promise<PredictMarket>;
   getPriceHistory(
     params: GetPriceHistoryParams,
   ): Promise<PredictPriceHistoryPoint[]>;

--- a/app/components/UI/Predict/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.test.ts
@@ -1,4 +1,4 @@
-import { selectPredictEnabledFlag, selectPredictLiveNflEnabled } from '.';
+import { selectPredictEnabledFlag } from '.';
 import mockedEngine from '../../../../../core/__mocks__/MockedEngine';
 import {
   mockedState,
@@ -32,7 +32,6 @@ describe('Predict Feature Flag Selectors', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.MM_PREDICT_ENABLED;
-    delete process.env.MM_PREDICT_LIVE_NFL_ENABLED;
     mockHasMinimumRequiredVersion = jest.spyOn(
       remoteFeatureFlagModule,
       'hasMinimumRequiredVersion',
@@ -42,7 +41,6 @@ describe('Predict Feature Flag Selectors', () => {
 
   afterEach(() => {
     delete process.env.MM_PREDICT_ENABLED;
-    delete process.env.MM_PREDICT_LIVE_NFL_ENABLED;
     mockHasMinimumRequiredVersion?.mockRestore();
   });
 
@@ -189,174 +187,6 @@ describe('Predict Feature Flag Selectors', () => {
         };
 
         const result = selectPredictEnabledFlag(stateWithUndefinedController);
-
-        expect(result).toBe(false);
-      });
-    });
-  });
-
-  describe('selectPredictLiveNflEnabled', () => {
-    it('returns true for enabled version-gated flag with valid version', () => {
-      mockHasMinimumRequiredVersion.mockReturnValue(true);
-      const stateWithEnabledRemoteFlag = {
-        engine: {
-          backgroundState: {
-            RemoteFeatureFlagController: {
-              remoteFeatureFlags: {
-                predictLiveNflEnabled: {
-                  enabled: true,
-                  minimumVersion: '1.0.0',
-                },
-              },
-              cacheTimestamp: 0,
-            },
-          },
-        },
-      };
-
-      const result = selectPredictLiveNflEnabled(stateWithEnabledRemoteFlag);
-
-      expect(result).toBe(true);
-    });
-
-    describe('remote flag precedence', () => {
-      it('returns true when remote flag enabled overrides local flag false', () => {
-        mockHasMinimumRequiredVersion.mockReturnValue(true);
-        process.env.MM_PREDICT_LIVE_NFL_ENABLED = 'false';
-        const stateWithEnabledRemoteFlag = {
-          engine: {
-            backgroundState: {
-              RemoteFeatureFlagController: {
-                remoteFeatureFlags: {
-                  predictLiveNflEnabled: {
-                    enabled: true,
-                    minimumVersion: '1.0.0',
-                  },
-                },
-                cacheTimestamp: 0,
-              },
-            },
-          },
-        };
-
-        const result = selectPredictLiveNflEnabled(stateWithEnabledRemoteFlag);
-
-        expect(result).toBe(true);
-      });
-
-      it('returns false when remote flag disabled overrides local flag true', () => {
-        mockHasMinimumRequiredVersion.mockReturnValue(true);
-        process.env.MM_PREDICT_LIVE_NFL_ENABLED = 'true';
-        const stateWithDisabledRemoteFlag = {
-          engine: {
-            backgroundState: {
-              RemoteFeatureFlagController: {
-                remoteFeatureFlags: {
-                  predictLiveNflEnabled: {
-                    enabled: false,
-                    minimumVersion: '1.0.0',
-                  },
-                },
-                cacheTimestamp: 0,
-              },
-            },
-          },
-        };
-
-        const result = selectPredictLiveNflEnabled(stateWithDisabledRemoteFlag);
-
-        expect(result).toBe(false);
-      });
-
-      it('returns false when app version below minimum required version', () => {
-        mockHasMinimumRequiredVersion.mockReturnValue(false);
-        process.env.MM_PREDICT_LIVE_NFL_ENABLED = 'true';
-        const stateWithVersionCheckFailure = {
-          engine: {
-            backgroundState: {
-              RemoteFeatureFlagController: {
-                remoteFeatureFlags: {
-                  predictLiveNflEnabled: {
-                    enabled: true,
-                    minimumVersion: '99.0.0',
-                  },
-                },
-                cacheTimestamp: 0,
-              },
-            },
-          },
-        };
-
-        const result = selectPredictLiveNflEnabled(
-          stateWithVersionCheckFailure,
-        );
-
-        expect(result).toBe(false);
-      });
-    });
-
-    describe('local flag fallback', () => {
-      it('falls back to local flag when remote flag is invalid', () => {
-        const stateWithInvalidRemoteFlag = {
-          engine: {
-            backgroundState: {
-              RemoteFeatureFlagController: {
-                remoteFeatureFlags: {
-                  predictLiveNflEnabled: {
-                    enabled: 'invalid',
-                    minimumVersion: 123,
-                  },
-                },
-                cacheTimestamp: 0,
-              },
-            },
-          },
-        };
-
-        const result = selectPredictLiveNflEnabled(stateWithInvalidRemoteFlag);
-
-        expect(result).toBe(false);
-      });
-
-      it('returns false from local flag when remote flag is null', () => {
-        process.env.MM_PREDICT_LIVE_NFL_ENABLED = 'false';
-        const stateWithNullRemoteFlag = {
-          engine: {
-            backgroundState: {
-              RemoteFeatureFlagController: {
-                remoteFeatureFlags: {
-                  predictLiveNflEnabled: null,
-                },
-                cacheTimestamp: 0,
-              },
-            },
-          },
-        };
-
-        const result = selectPredictLiveNflEnabled(stateWithNullRemoteFlag);
-
-        expect(result).toBe(false);
-      });
-
-      it('falls back to local flag when remote feature flags are empty', () => {
-        const result = selectPredictLiveNflEnabled(mockedEmptyFlagsState);
-
-        expect(result).toBe(false);
-      });
-
-      it('returns false from local flag when controller is undefined', () => {
-        process.env.MM_PREDICT_LIVE_NFL_ENABLED = 'false';
-        const stateWithUndefinedController = {
-          engine: {
-            backgroundState: {
-              RemoteFeatureFlagController: undefined,
-            },
-          },
-        };
-
-        const result = selectPredictLiveNflEnabled(
-          stateWithUndefinedController,
-        );
 
         expect(result).toBe(false);
       });

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -39,23 +39,3 @@ export const selectPredictGtmOnboardingModalEnabledFlag = createSelector(
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
-
-/**
- * Selector for Predict Live NFL feature enablement
- *
- * Uses version-gated feature flag `predictLiveNflEnabled` from remote config.
- * Falls back to local environment variable MM_PREDICT_LIVE_NFL_ENABLED if remote flag
- * is unavailable or invalid.
- *
- * @returns {boolean} True if feature is enabled and version requirement is met
- */
-export const selectPredictLiveNflEnabled = createSelector(
-  selectRemoteFeatureFlags,
-  (remoteFeatureFlags) => {
-    const localFlag = process.env.MM_PREDICT_LIVE_NFL_ENABLED === 'true';
-    const remoteFlag =
-      remoteFeatureFlags?.predictLiveNflEnabled as unknown as VersionGatedFeatureFlag;
-
-    return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
-  },
-);

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -7,3 +7,8 @@ export interface PredictFeeCollection {
   providerFee: number;
   waiveList: string[];
 }
+
+export interface PredictLiveSportsFlag {
+  enabled: boolean;
+  leagues: string[];
+}


### PR DESCRIPTION
## **Description**

Replaces the hardcoded `LIVE_SPORTS_LEAGUES` configuration with a remote feature flag (`predictLiveSports`), allowing live sports functionality to be enabled/disabled and leagues to be configured remotely without app updates.

**Motivation**: The live sports feature needs to be controllable via remote config to enable gradual rollout and quick disabling if issues arise.

**Solution**:
- Added `PredictLiveSportsFlag` type: `{ enabled: boolean; leagues: string[] }`
- Added `DEFAULT_LIVE_SPORTS_FLAG` constant (disabled by default, empty leagues)
- Renamed `LIVE_SPORTS_LEAGUES` to `SUPPORTED_SPORTS_LEAGUES` (defines what the app supports)
- Added `filterSupportedLeagues()` helper to validate remote config against supported leagues
- Updated `PredictController.getMarkets()` and `getMarket()` to read the flag from `RemoteFeatureFlagController`
- Updated provider interfaces to accept `liveSportsLeagues` parameter
- Removed the now-unused `selectPredictLiveNflEnabled` selector and `isLiveSportsEnabled()` function

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-464

## **Manual testing steps**

```gherkin
Feature: Live Sports Remote Feature Flag

  Scenario: Live sports disabled by default
    Given the predictLiveSports flag is not set in remote config
    When user views prediction markets
    Then live sports markets are not fetched

  Scenario: Live sports enabled via remote config
    Given the predictLiveSports flag is { enabled: true, leagues: ["nfl"] }
    When user views prediction markets
    Then NFL live sports markets are included in results

  Scenario: Unsupported league filtered out
    Given the predictLiveSports flag is { enabled: true, leagues: ["nfl", "mlb"] }
    When user views prediction markets
    Then only NFL markets are fetched (mlb not in SUPPORTED_SPORTS_LEAGUES)
```

## **Screenshots/Recordings**

### **Before**

N/A - Internal refactor, no UI changes

### **After**

N/A - Internal refactor, no UI changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables remotely configurable live sports by validating and passing leagues to market fetches.
> 
> - Add `PredictLiveSportsFlag` and `DEFAULT_LIVE_SPORTS_FLAG`; introduce `SUPPORTED_SPORTS_LEAGUES` and `filterSupportedLeagues` to validate remote config
> - `PredictController.getMarkets()`/`getMarket()` read `RemoteFeatureFlagController.predictLiveSports`, compute `liveSportsLeagues`, and pass to providers
> - Update provider types/interfaces to accept `liveSportsLeagues`; `PolymarketProvider` uses provided leagues (removes `isLiveSportsEnabled` and `LIVE_SPORTS_LEAGUES`), loads `TeamsCache` conditionally, and overlays game data only when leagues provided
> - Remove `selectPredictLiveNflEnabled` selector and related tests; refresh tests across controller/provider to cover enabled/disabled and undefined leagues paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68f8e7df4b6f23537124b0023aae92ab0f51b4a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->