### PR TITLE
fix(predict): default predictTradingEnabled flag to true when remote unavailable

### DIFF
--- a/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
+++ b/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
@@ -244,6 +244,30 @@ exports[`MainNavigator matches rendered snapshot 1`] = `
   />
   <Screen
     component={[Function]}
+    name="Predict"
+    options={
+      {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
+      }
+    }
+  />
+  <Screen
+    component={[Function]}
+    name="PredictModals"
+    options={
+      {
+        "animationEnabled": false,
+        "cardStyle": {
+          "backgroundColor": "transparent",
+          "cardStyleInterpolator": [Function],
+        },
+        "headerShown": false,
+      }
+    }
+  />
+  <Screen
+    component={[Function]}
     headerStyle={
       {
         "borderBottomWidth": 0,

--- a/app/components/UI/Predict/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.test.ts
@@ -54,9 +54,8 @@ describe('Predict Feature Flag Selectors', () => {
     });
 
     describe('remote flag precedence', () => {
-      it('returns true when remote flag enabled overrides local flag false', () => {
+      it('returns true when remote flag is enabled', () => {
         mockHasMinimumRequiredVersion.mockReturnValue(true);
-        process.env.MM_PREDICT_ENABLED = 'false';
         const stateWithEnabledRemoteFlag = {
           engine: {
             backgroundState: {
@@ -78,9 +77,8 @@ describe('Predict Feature Flag Selectors', () => {
         expect(result).toBe(true);
       });
 
-      it('returns false when remote flag disabled overrides local flag true', () => {
+      it('returns false when remote flag is disabled', () => {
         mockHasMinimumRequiredVersion.mockReturnValue(true);
-        process.env.MM_PREDICT_ENABLED = 'true';
         const stateWithDisabledRemoteFlag = {
           engine: {
             backgroundState: {
@@ -104,7 +102,6 @@ describe('Predict Feature Flag Selectors', () => {
 
       it('returns false when app version below minimum required version', () => {
         mockHasMinimumRequiredVersion.mockReturnValue(false);
-        process.env.MM_PREDICT_ENABLED = 'true';
         const stateWithVersionCheckFailure = {
           engine: {
             backgroundState: {
@@ -127,10 +124,8 @@ describe('Predict Feature Flag Selectors', () => {
       });
     });
 
-    describe('local flag fallback', () => {
-      it('falls back to local flag when remote flag is invalid', () => {
-        // Note: Cannot reliably test MM_PREDICT_ENABLED=true in Jest due to process.env limitations
-        // This tests the default case where the env var is not set (returns false)
+    describe('default fallback', () => {
+      it('defaults to true when remote flag is invalid', () => {
         const stateWithInvalidRemoteFlag = {
           engine: {
             backgroundState: {
@@ -148,11 +143,11 @@ describe('Predict Feature Flag Selectors', () => {
         };
 
         const result = selectPredictEnabledFlag(stateWithInvalidRemoteFlag);
-        expect(result).toBe(false);
+
+        expect(result).toBe(true);
       });
 
-      it('returns false from local flag when remote flag is null', () => {
-        process.env.MM_PREDICT_ENABLED = 'false';
+      it('defaults to true when remote flag is null', () => {
         const stateWithInvalidRemoteFlag = {
           engine: {
             backgroundState: {
@@ -168,18 +163,16 @@ describe('Predict Feature Flag Selectors', () => {
 
         const result = selectPredictEnabledFlag(stateWithInvalidRemoteFlag);
 
-        expect(result).toBe(false);
+        expect(result).toBe(true);
       });
 
-      it('falls back to local flag when remote feature flags are empty', () => {
-        // Note: Cannot reliably test MM_PREDICT_ENABLED=true in Jest due to process.env limitations
-        // This tests the default case where the env var is not set (returns false)
+      it('defaults to true when remote feature flags are empty', () => {
         const result = selectPredictEnabledFlag(mockedEmptyFlagsState);
-        expect(result).toBe(false);
+
+        expect(result).toBe(true);
       });
 
-      it('returns false from local flag when controller is undefined', () => {
-        process.env.MM_PREDICT_ENABLED = 'false';
+      it('defaults to true when controller is undefined', () => {
         const stateWithUndefinedController = {
           engine: {
             backgroundState: {
@@ -190,7 +183,7 @@ describe('Predict Feature Flag Selectors', () => {
 
         const result = selectPredictEnabledFlag(stateWithUndefinedController);
 
-        expect(result).toBe(false);
+        expect(result).toBe(true);
       });
     });
   });

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -9,8 +9,7 @@ import {
  * Selector for Predict trading feature enablement
  *
  * Uses version-gated feature flag `predictTradingEnabled` from remote config.
- * Falls back to local environment variable MM_PREDICT_ENABLED if remote flag
- * is unavailable or invalid.
+ * Falls back to `true` if remote flag is unavailable or invalid.
  *
  * Version gating ensures users have minimum app version (7.60.0) to access feature.
  *
@@ -19,12 +18,11 @@ import {
 export const selectPredictEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {
-    const localFlag = process.env.MM_PREDICT_ENABLED === 'true';
     const remoteFlag =
       remoteFeatureFlags?.predictTradingEnabled as unknown as VersionGatedFeatureFlag;
 
-    // Fallback to local flag if remote flag is not available
-    return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
+    // Default to `true` if remote flag is not available
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? true;
   },
 );
 


### PR DESCRIPTION
## **Description**

This change modifies the `selectPredictEnabledFlag` selector to default to `true` when the remote feature flag is unavailable or invalid, rather than falling back to the `MM_PREDICT_ENABLED` environment variable.

**Reason for change:** The Predict feature has been live for a while, so it's unlikely we need to disable it. Falling back to an env variable caused potential flaky behavior where fetch failures could randomly disable the feature for users.

**Solution:** Default to `true` when remote config is unavailable, ensuring a consistent user experience.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

- https://consensyssoftware.atlassian.net/browse/PRED-455

## **Manual testing steps**

```gherkin
Feature: Predict feature flag default behavior

  Scenario: Feature remains enabled when remote config unavailable
    Given the app cannot fetch remote feature flags

    When user navigates to the Predict feature
    Then the Predict feature is accessible
```

## **Screenshots/Recordings**

N/A - Logic change only, no UI impact.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures Predict remains enabled when remote config is unavailable, removing reliance on a local env fallback.
> 
> - Updates `selectPredictEnabledFlag` to return `true` when `predictTradingEnabled` is missing/invalid, keeping version gating via `validatedVersionGatedFeatureFlag`
> - Refactors unit tests to remove `MM_PREDICT_ENABLED` dependency and assert default-to-true behavior across invalid/absent remote flag scenarios; retains version checks
> - Updates `MainNavigator` snapshot to include `Predict` and `PredictModals` routes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b89bf5a8ec74157154db2ef7f9e49bad097bd75e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->