### PR TITLE
feat(predict): scaffold game details view for Live NFL

### DIFF
--- a/app/components/UI/Predict/components/PredictDetailsButtonsSkeleton/PredictDetailsButtonsSkeleton.test.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsButtonsSkeleton/PredictDetailsButtonsSkeleton.test.tsx
@@ -7,10 +7,10 @@ describe('PredictDetailsButtonsSkeleton', () => {
     const { getByTestId } = render(<PredictDetailsButtonsSkeleton />);
 
     expect(
-      getByTestId('predict-details-buttons-skeleton-button-yes'),
+      getByTestId('predict-details-buttons-skeleton-button-1'),
     ).toBeTruthy();
     expect(
-      getByTestId('predict-details-buttons-skeleton-button-no'),
+      getByTestId('predict-details-buttons-skeleton-button-2'),
     ).toBeTruthy();
   });
 
@@ -20,8 +20,8 @@ describe('PredictDetailsButtonsSkeleton', () => {
       <PredictDetailsButtonsSkeleton testID={customTestId} />,
     );
 
-    expect(getByTestId(`${customTestId}-button-yes`)).toBeTruthy();
-    expect(getByTestId(`${customTestId}-button-no`)).toBeTruthy();
+    expect(getByTestId(`${customTestId}-button-1`)).toBeTruthy();
+    expect(getByTestId(`${customTestId}-button-2`)).toBeTruthy();
   });
 
   it('matches snapshot', () => {

--- a/app/components/UI/Predict/components/PredictDetailsButtonsSkeleton/PredictDetailsButtonsSkeleton.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsButtonsSkeleton/PredictDetailsButtonsSkeleton.tsx
@@ -7,10 +7,6 @@ interface PredictDetailsButtonsSkeletonProps {
   testID?: string;
 }
 
-/**
- * Skeleton loader component for Predict market details action buttons
- * Displays loading placeholders for Yes/No action buttons
- */
 const PredictDetailsButtonsSkeleton: React.FC<
   PredictDetailsButtonsSkeletonProps
 > = ({ testID = 'predict-details-buttons-skeleton' }) => {
@@ -18,23 +14,21 @@ const PredictDetailsButtonsSkeleton: React.FC<
 
   return (
     <Box flexDirection={BoxFlexDirection.Row} twClassName="w-full gap-3 mt-4">
-      {/* Buy Yes Button - Green tint */}
       <Box twClassName="flex-1">
         <Skeleton
           width="100%"
           height={48}
-          style={tw.style('rounded-lg bg-success-muted')}
-          testID={`${testID}-button-yes`}
+          style={tw.style('rounded-xl')}
+          testID={`${testID}-button-1`}
         />
       </Box>
 
-      {/* Buy No Button - Red tint */}
       <Box twClassName="flex-1">
         <Skeleton
           width="100%"
           height={48}
-          style={tw.style('rounded-lg bg-error-muted')}
-          testID={`${testID}-button-no`}
+          style={tw.style('rounded-xl')}
+          testID={`${testID}-button-2`}
         />
       </Box>
     </Box>

--- a/app/components/UI/Predict/components/PredictDetailsButtonsSkeleton/__snapshots__/PredictDetailsButtonsSkeleton.test.tsx.snap
+++ b/app/components/UI/Predict/components/PredictDetailsButtonsSkeleton/__snapshots__/PredictDetailsButtonsSkeleton.test.tsx.snap
@@ -31,14 +31,13 @@ exports[`PredictDetailsButtonsSkeleton matches snapshot 1`] = `
     <View
       style={
         {
-          "backgroundColor": "#457a391a",
-          "borderRadius": 8,
+          "borderRadius": 12,
           "height": 48,
           "overflow": "hidden",
           "width": "100%",
         }
       }
-      testID="predict-details-buttons-skeleton-button-yes"
+      testID="predict-details-buttons-skeleton-button-1"
     >
       <View
         collapsable={false}
@@ -74,14 +73,13 @@ exports[`PredictDetailsButtonsSkeleton matches snapshot 1`] = `
     <View
       style={
         {
-          "backgroundColor": "#ca35421a",
-          "borderRadius": 8,
+          "borderRadius": 12,
           "height": 48,
           "overflow": "hidden",
           "width": "100%",
         }
       }
-      testID="predict-details-buttons-skeleton-button-no"
+      testID="predict-details-buttons-skeleton-button-2"
     >
       <View
         collapsable={false}

--- a/app/components/UI/Predict/components/PredictDetailsContentSkeleton/PredictDetailsContentSkeleton.test.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsContentSkeleton/PredictDetailsContentSkeleton.test.tsx
@@ -3,45 +3,16 @@ import { render } from '@testing-library/react-native';
 import PredictDetailsContentSkeleton from './PredictDetailsContentSkeleton';
 
 describe('PredictDetailsContentSkeleton', () => {
-  it('renders content skeleton with all outcome card elements', () => {
+  it('renders content skeleton with all elements', () => {
     const { getByTestId } = render(<PredictDetailsContentSkeleton />);
 
+    expect(getByTestId('predict-details-content-skeleton-line-1')).toBeTruthy();
     expect(
-      getByTestId('predict-details-content-skeleton-option-1'),
+      getByTestId('predict-details-content-skeleton-block-1'),
     ).toBeTruthy();
-
-    // Outcome Card 1
+    expect(getByTestId('predict-details-content-skeleton-line-2')).toBeTruthy();
     expect(
-      getByTestId('predict-details-content-skeleton-option-2-avatar'),
-    ).toBeTruthy();
-    expect(
-      getByTestId('predict-details-content-skeleton-option-2-title'),
-    ).toBeTruthy();
-    expect(
-      getByTestId('predict-details-content-skeleton-option-2-subtitle'),
-    ).toBeTruthy();
-    expect(
-      getByTestId('predict-details-content-skeleton-option-2-value-1'),
-    ).toBeTruthy();
-    expect(
-      getByTestId('predict-details-content-skeleton-option-2-value-2'),
-    ).toBeTruthy();
-
-    // Outcome Card 2
-    expect(
-      getByTestId('predict-details-content-skeleton-option-3-avatar'),
-    ).toBeTruthy();
-    expect(
-      getByTestId('predict-details-content-skeleton-option-3-title'),
-    ).toBeTruthy();
-    expect(
-      getByTestId('predict-details-content-skeleton-option-3-subtitle'),
-    ).toBeTruthy();
-    expect(
-      getByTestId('predict-details-content-skeleton-option-3-value-1'),
-    ).toBeTruthy();
-    expect(
-      getByTestId('predict-details-content-skeleton-option-3-value-2'),
+      getByTestId('predict-details-content-skeleton-block-2'),
     ).toBeTruthy();
   });
 
@@ -51,10 +22,10 @@ describe('PredictDetailsContentSkeleton', () => {
       <PredictDetailsContentSkeleton testID={customTestId} />,
     );
 
-    expect(getByTestId(`${customTestId}-option-1`)).toBeTruthy();
-    expect(getByTestId(`${customTestId}-option-2-avatar`)).toBeTruthy();
-    expect(getByTestId(`${customTestId}-option-2-title`)).toBeTruthy();
-    expect(getByTestId(`${customTestId}-option-3-avatar`)).toBeTruthy();
+    expect(getByTestId(`${customTestId}-line-1`)).toBeTruthy();
+    expect(getByTestId(`${customTestId}-block-1`)).toBeTruthy();
+    expect(getByTestId(`${customTestId}-line-2`)).toBeTruthy();
+    expect(getByTestId(`${customTestId}-block-2`)).toBeTruthy();
   });
 
   it('matches snapshot', () => {

--- a/app/components/UI/Predict/components/PredictDetailsContentSkeleton/PredictDetailsContentSkeleton.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsContentSkeleton/PredictDetailsContentSkeleton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, BoxFlexDirection } from '@metamask/design-system-react-native';
+import { Box } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
 
@@ -7,68 +7,42 @@ interface PredictDetailsContentSkeletonProps {
   testID?: string;
 }
 
-/**
- * Skeleton loader component for Predict market details content
- * Displays loading placeholders for outcome options
- */
 const PredictDetailsContentSkeleton: React.FC<
   PredictDetailsContentSkeletonProps
 > = ({ testID = 'predict-details-content-skeleton' }) => {
   const tw = useTailwind();
 
   return (
-    <Box twClassName="gap-4 my-8">
-      {/* Market Outcome Options */}
-      <Skeleton
-        width="25%"
-        height={20}
-        style={tw.style('rounded-full mb-2')}
-        testID={`${testID}-option-1`}
-      />
+    <Box twClassName="gap-6 my-8">
+      <Box twClassName="gap-3">
+        <Skeleton
+          width="40%"
+          height={16}
+          style={tw.style('rounded-md')}
+          testID={`${testID}-line-1`}
+        />
+        <Skeleton
+          width="100%"
+          height={120}
+          style={tw.style('rounded-xl')}
+          testID={`${testID}-block-1`}
+        />
+      </Box>
 
-      {/* Show 2 outcome cards */}
-      {[1, 2].map((index) => (
-        <Box
-          key={index}
-          flexDirection={BoxFlexDirection.Row}
-          twClassName="items-center gap-3 bg-muted rounded-lg p-4"
-        >
-          <Skeleton
-            width={48}
-            height={48}
-            style={tw.style('rounded-lg')}
-            testID={`${testID}-option-${index + 1}-avatar`}
-          />
-          <Box twClassName="flex-1 gap-2">
-            <Skeleton
-              width="100%"
-              height={20}
-              style={tw.style('rounded-md')}
-              testID={`${testID}-option-${index + 1}-title`}
-            />
-            <Skeleton
-              width="80%"
-              height={20}
-              style={tw.style('rounded-md')}
-              testID={`${testID}-option-${index + 1}-subtitle`}
-            />
-          </Box>
-          <Box twClassName="flex-1 gap-2 items-end">
-            <Skeleton
-              width="70%"
-              height={20}
-              style={tw.style('rounded-md')}
-              testID={`${testID}-option-${index + 1}-value-1`}
-            />
-            <Skeleton
-              width="50%"
-              height={20}
-              style={tw.style('rounded-md')}
-              testID={`${testID}-option-${index + 1}-value-2`}
-            />
-          </Box>
-        </Box>
-      ))}
+      <Box twClassName="gap-3">
+        <Skeleton
+          width="30%"
+          height={16}
+          style={tw.style('rounded-md')}
+          testID={`${testID}-line-2`}
+        />
+        <Skeleton
+          width="100%"
+          height={80}
+          style={tw.style('rounded-xl')}
+          testID={`${testID}-block-2`}
+        />
+      </Box>
     </Box>
   );
 };

--- a/app/components/UI/Predict/components/PredictDetailsContentSkeleton/__snapshots__/PredictDetailsContentSkeleton.test.tsx.snap
+++ b/app/components/UI/Predict/components/PredictDetailsContentSkeleton/__snapshots__/PredictDetailsContentSkeleton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PredictDetailsContentSkeleton matches snapshot 1`] = `
     [
       {
         "display": "flex",
-        "gap": 16,
+        "gap": 24,
         "marginBottom": 32,
         "marginTop": 32,
       },
@@ -16,47 +16,10 @@ exports[`PredictDetailsContentSkeleton matches snapshot 1`] = `
 >
   <View
     style={
-      {
-        "borderRadius": 9999,
-        "height": 20,
-        "marginBottom": 8,
-        "overflow": "hidden",
-        "width": "25%",
-      }
-    }
-    testID="predict-details-content-skeleton-option-1"
-  >
-    <View
-      collapsable={false}
-      pointerEvents="none"
-      style={
-        {
-          "backgroundColor": "#686e7d",
-          "borderRadius": 4,
-          "bottom": 0,
-          "left": 0,
-          "opacity": 0.2,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        }
-      }
-    />
-  </View>
-  <View
-    style={
       [
         {
-          "alignItems": "center",
-          "backgroundColor": "#3c4d9d0f",
-          "borderRadius": 8,
           "display": "flex",
-          "flexDirection": "row",
           "gap": 12,
-          "paddingBottom": 16,
-          "paddingLeft": 16,
-          "paddingRight": 16,
-          "paddingTop": 16,
         },
         undefined,
       ]
@@ -65,13 +28,13 @@ exports[`PredictDetailsContentSkeleton matches snapshot 1`] = `
     <View
       style={
         {
-          "borderRadius": 8,
-          "height": 48,
+          "borderRadius": 6,
+          "height": 16,
           "overflow": "hidden",
-          "width": 48,
+          "width": "40%",
         }
       }
-      testID="predict-details-content-skeleton-option-2-avatar"
+      testID="predict-details-content-skeleton-line-1"
     >
       <View
         collapsable={false}
@@ -92,162 +55,39 @@ exports[`PredictDetailsContentSkeleton matches snapshot 1`] = `
     </View>
     <View
       style={
-        [
-          {
-            "display": "flex",
-            "flexBasis": "0%",
-            "flexGrow": 1,
-            "flexShrink": 1,
-            "gap": 8,
-          },
-          undefined,
-        ]
+        {
+          "borderRadius": 12,
+          "height": 120,
+          "overflow": "hidden",
+          "width": "100%",
+        }
       }
+      testID="predict-details-content-skeleton-block-1"
     >
       <View
+        collapsable={false}
+        pointerEvents="none"
         style={
           {
-            "borderRadius": 6,
-            "height": 20,
-            "overflow": "hidden",
-            "width": "100%",
+            "backgroundColor": "#686e7d",
+            "borderRadius": 4,
+            "bottom": 0,
+            "left": 0,
+            "opacity": 0.2,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
           }
         }
-        testID="predict-details-content-skeleton-option-2-title"
-      >
-        <View
-          collapsable={false}
-          pointerEvents="none"
-          style={
-            {
-              "backgroundColor": "#686e7d",
-              "borderRadius": 4,
-              "bottom": 0,
-              "left": 0,
-              "opacity": 0.2,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-      </View>
-      <View
-        style={
-          {
-            "borderRadius": 6,
-            "height": 20,
-            "overflow": "hidden",
-            "width": "80%",
-          }
-        }
-        testID="predict-details-content-skeleton-option-2-subtitle"
-      >
-        <View
-          collapsable={false}
-          pointerEvents="none"
-          style={
-            {
-              "backgroundColor": "#686e7d",
-              "borderRadius": 4,
-              "bottom": 0,
-              "left": 0,
-              "opacity": 0.2,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-      </View>
-    </View>
-    <View
-      style={
-        [
-          {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexBasis": "0%",
-            "flexGrow": 1,
-            "flexShrink": 1,
-            "gap": 8,
-          },
-          undefined,
-        ]
-      }
-    >
-      <View
-        style={
-          {
-            "borderRadius": 6,
-            "height": 20,
-            "overflow": "hidden",
-            "width": "70%",
-          }
-        }
-        testID="predict-details-content-skeleton-option-2-value-1"
-      >
-        <View
-          collapsable={false}
-          pointerEvents="none"
-          style={
-            {
-              "backgroundColor": "#686e7d",
-              "borderRadius": 4,
-              "bottom": 0,
-              "left": 0,
-              "opacity": 0.2,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-      </View>
-      <View
-        style={
-          {
-            "borderRadius": 6,
-            "height": 20,
-            "overflow": "hidden",
-            "width": "50%",
-          }
-        }
-        testID="predict-details-content-skeleton-option-2-value-2"
-      >
-        <View
-          collapsable={false}
-          pointerEvents="none"
-          style={
-            {
-              "backgroundColor": "#686e7d",
-              "borderRadius": 4,
-              "bottom": 0,
-              "left": 0,
-              "opacity": 0.2,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-      </View>
+      />
     </View>
   </View>
   <View
     style={
       [
         {
-          "alignItems": "center",
-          "backgroundColor": "#3c4d9d0f",
-          "borderRadius": 8,
           "display": "flex",
-          "flexDirection": "row",
           "gap": 12,
-          "paddingBottom": 16,
-          "paddingLeft": 16,
-          "paddingRight": 16,
-          "paddingTop": 16,
         },
         undefined,
       ]
@@ -256,13 +96,13 @@ exports[`PredictDetailsContentSkeleton matches snapshot 1`] = `
     <View
       style={
         {
-          "borderRadius": 8,
-          "height": 48,
+          "borderRadius": 6,
+          "height": 16,
           "overflow": "hidden",
-          "width": 48,
+          "width": "30%",
         }
       }
-      testID="predict-details-content-skeleton-option-3-avatar"
+      testID="predict-details-content-skeleton-line-2"
     >
       <View
         collapsable={false}
@@ -283,146 +123,31 @@ exports[`PredictDetailsContentSkeleton matches snapshot 1`] = `
     </View>
     <View
       style={
-        [
-          {
-            "display": "flex",
-            "flexBasis": "0%",
-            "flexGrow": 1,
-            "flexShrink": 1,
-            "gap": 8,
-          },
-          undefined,
-        ]
+        {
+          "borderRadius": 12,
+          "height": 80,
+          "overflow": "hidden",
+          "width": "100%",
+        }
       }
+      testID="predict-details-content-skeleton-block-2"
     >
       <View
+        collapsable={false}
+        pointerEvents="none"
         style={
           {
-            "borderRadius": 6,
-            "height": 20,
-            "overflow": "hidden",
-            "width": "100%",
+            "backgroundColor": "#686e7d",
+            "borderRadius": 4,
+            "bottom": 0,
+            "left": 0,
+            "opacity": 0.2,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
           }
         }
-        testID="predict-details-content-skeleton-option-3-title"
-      >
-        <View
-          collapsable={false}
-          pointerEvents="none"
-          style={
-            {
-              "backgroundColor": "#686e7d",
-              "borderRadius": 4,
-              "bottom": 0,
-              "left": 0,
-              "opacity": 0.2,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-      </View>
-      <View
-        style={
-          {
-            "borderRadius": 6,
-            "height": 20,
-            "overflow": "hidden",
-            "width": "80%",
-          }
-        }
-        testID="predict-details-content-skeleton-option-3-subtitle"
-      >
-        <View
-          collapsable={false}
-          pointerEvents="none"
-          style={
-            {
-              "backgroundColor": "#686e7d",
-              "borderRadius": 4,
-              "bottom": 0,
-              "left": 0,
-              "opacity": 0.2,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-      </View>
-    </View>
-    <View
-      style={
-        [
-          {
-            "alignItems": "flex-end",
-            "display": "flex",
-            "flexBasis": "0%",
-            "flexGrow": 1,
-            "flexShrink": 1,
-            "gap": 8,
-          },
-          undefined,
-        ]
-      }
-    >
-      <View
-        style={
-          {
-            "borderRadius": 6,
-            "height": 20,
-            "overflow": "hidden",
-            "width": "70%",
-          }
-        }
-        testID="predict-details-content-skeleton-option-3-value-1"
-      >
-        <View
-          collapsable={false}
-          pointerEvents="none"
-          style={
-            {
-              "backgroundColor": "#686e7d",
-              "borderRadius": 4,
-              "bottom": 0,
-              "left": 0,
-              "opacity": 0.2,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-      </View>
-      <View
-        style={
-          {
-            "borderRadius": 6,
-            "height": 20,
-            "overflow": "hidden",
-            "width": "50%",
-          }
-        }
-        testID="predict-details-content-skeleton-option-3-value-2"
-      >
-        <View
-          collapsable={false}
-          pointerEvents="none"
-          style={
-            {
-              "backgroundColor": "#686e7d",
-              "borderRadius": 4,
-              "bottom": 0,
-              "left": 0,
-              "opacity": 0.2,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-      </View>
+      />
     </View>
   </View>
 </View>

--- a/app/components/UI/Predict/components/PredictDetailsHeaderSkeleton/PredictDetailsHeaderSkeleton.test.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsHeaderSkeleton/PredictDetailsHeaderSkeleton.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import PredictDetailsHeaderSkeleton from './PredictDetailsHeaderSkeleton';
 
-// Mock navigation
 const mockGoBack = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -11,7 +10,6 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
-// Mock safe area insets
 jest.mock('react-native-safe-area-context', () => ({
   ...jest.requireActual('react-native-safe-area-context'),
   useSafeAreaInsets: () => ({
@@ -29,11 +27,8 @@ describe('PredictDetailsHeaderSkeleton', () => {
     expect(
       getByTestId('predict-details-header-skeleton-back-button'),
     ).toBeTruthy();
-    expect(getByTestId('predict-details-header-skeleton-avatar')).toBeTruthy();
     expect(getByTestId('predict-details-header-skeleton-title')).toBeTruthy();
-    expect(
-      getByTestId('predict-details-header-skeleton-subtitle'),
-    ).toBeTruthy();
+    expect(getByTestId('predict-details-header-skeleton-share')).toBeTruthy();
   });
 
   it('renders with custom testID', () => {
@@ -43,9 +38,8 @@ describe('PredictDetailsHeaderSkeleton', () => {
     );
 
     expect(getByTestId(`${customTestId}-back-button`)).toBeTruthy();
-    expect(getByTestId(`${customTestId}-avatar`)).toBeTruthy();
     expect(getByTestId(`${customTestId}-title`)).toBeTruthy();
-    expect(getByTestId(`${customTestId}-subtitle`)).toBeTruthy();
+    expect(getByTestId(`${customTestId}-share`)).toBeTruthy();
   });
 
   it('matches snapshot', () => {

--- a/app/components/UI/Predict/components/PredictDetailsHeaderSkeleton/PredictDetailsHeaderSkeleton.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsHeaderSkeleton/PredictDetailsHeaderSkeleton.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   BoxFlexDirection,
   BoxAlignItems,
+  BoxJustifyContent,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Pressable } from 'react-native';
@@ -18,10 +19,6 @@ interface PredictDetailsHeaderSkeletonProps {
   testID?: string;
 }
 
-/**
- * Skeleton loader component for Predict market details header
- * Displays loading placeholders for back button, avatar, and title
- */
 const PredictDetailsHeaderSkeleton: React.FC<
   PredictDetailsHeaderSkeletonProps
 > = ({ testID = 'predict-details-header-skeleton' }) => {
@@ -30,47 +27,35 @@ const PredictDetailsHeaderSkeleton: React.FC<
   const insets = useSafeAreaInsets();
 
   return (
-    <Box twClassName="mb-6" style={{ paddingTop: insets.top + 12 }}>
-      {/* Back Arrow + Avatar + Title Row */}
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        twClassName="gap-4 mb-4"
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Between}
+      twClassName="pb-4"
+      style={{ paddingTop: insets.top + 12 }}
+    >
+      <Pressable
+        onPress={() => navigation.goBack()}
+        testID={`${testID}-back-button`}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
       >
-        {/* Back Arrow - Pressable */}
-        <Pressable
-          onPress={() => navigation.goBack()}
-          testID={`${testID}-back-button`}
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-        >
-          <Icon name={IconName.ArrowLeft} size={IconSize.Lg} />
-        </Pressable>
+        <Icon name={IconName.ArrowLeft} size={IconSize.Lg} />
+      </Pressable>
 
-        {/* Circle Avatar Skeleton */}
+      <Box twClassName="flex-1 mx-4">
         <Skeleton
-          width={40}
-          height={40}
-          style={tw.style('rounded-full')}
-          testID={`${testID}-avatar`}
+          width="60%"
+          height={20}
+          style={tw.style('rounded-md self-center')}
+          testID={`${testID}-title`}
         />
-
-        {/* Title Skeleton */}
-        <Box twClassName="flex-1">
-          <Skeleton
-            width="100%"
-            height={20}
-            style={tw.style('rounded-lg')}
-            testID={`${testID}-title`}
-          />
-        </Box>
       </Box>
 
-      {/* Subtitle Skeleton */}
       <Skeleton
-        width="75%"
-        height={20}
-        style={tw.style('rounded-lg')}
-        testID={`${testID}-subtitle`}
+        width={24}
+        height={24}
+        style={tw.style('rounded-md')}
+        testID={`${testID}-share`}
       />
     </Box>
   );

--- a/app/components/UI/Predict/components/PredictDetailsHeaderSkeleton/__snapshots__/PredictDetailsHeaderSkeleton.test.tsx.snap
+++ b/app/components/UI/Predict/components/PredictDetailsHeaderSkeleton/__snapshots__/PredictDetailsHeaderSkeleton.test.tsx.snap
@@ -5,8 +5,11 @@ exports[`PredictDetailsHeaderSkeleton matches snapshot 1`] = `
   style={
     [
       {
+        "alignItems": "center",
         "display": "flex",
-        "marginBottom": 24,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "paddingBottom": 16,
       },
       {
         "paddingTop": 12,
@@ -15,83 +18,85 @@ exports[`PredictDetailsHeaderSkeleton matches snapshot 1`] = `
   }
 >
   <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    hitSlop={
+      {
+        "bottom": 10,
+        "left": 10,
+        "right": 10,
+        "top": 10,
+      }
+    }
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    testID="predict-details-header-skeleton-back-button"
+  >
+    <SvgMock
+      color="#121314"
+      fill="currentColor"
+      height={24}
+      name="ArrowLeft"
+      style={
+        {
+          "height": 24,
+          "width": 24,
+        }
+      }
+      width={24}
+    />
+  </View>
+  <View
     style={
       [
         {
-          "alignItems": "center",
           "display": "flex",
-          "flexDirection": "row",
-          "gap": 16,
-          "marginBottom": 16,
+          "flexBasis": "0%",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "marginLeft": 16,
+          "marginRight": 16,
         },
         undefined,
       ]
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      hitSlop={
-        {
-          "bottom": 10,
-          "left": 10,
-          "right": 10,
-          "top": 10,
-        }
-      }
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      testID="predict-details-header-skeleton-back-button"
-    >
-      <SvgMock
-        color="#121314"
-        fill="currentColor"
-        height={24}
-        name="ArrowLeft"
-        style={
-          {
-            "height": 24,
-            "width": 24,
-          }
-        }
-        width={24}
-      />
-    </View>
-    <View
       style={
         {
-          "borderRadius": 9999,
-          "height": 40,
+          "alignSelf": "center",
+          "borderRadius": 6,
+          "height": 20,
           "overflow": "hidden",
-          "width": 40,
+          "width": "60%",
         }
       }
-      testID="predict-details-header-skeleton-avatar"
+      testID="predict-details-header-skeleton-title"
     >
       <View
         collapsable={false}
@@ -110,59 +115,17 @@ exports[`PredictDetailsHeaderSkeleton matches snapshot 1`] = `
         }
       />
     </View>
-    <View
-      style={
-        [
-          {
-            "display": "flex",
-            "flexBasis": "0%",
-            "flexGrow": 1,
-            "flexShrink": 1,
-          },
-          undefined,
-        ]
-      }
-    >
-      <View
-        style={
-          {
-            "borderRadius": 8,
-            "height": 20,
-            "overflow": "hidden",
-            "width": "100%",
-          }
-        }
-        testID="predict-details-header-skeleton-title"
-      >
-        <View
-          collapsable={false}
-          pointerEvents="none"
-          style={
-            {
-              "backgroundColor": "#686e7d",
-              "borderRadius": 4,
-              "bottom": 0,
-              "left": 0,
-              "opacity": 0.2,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-      </View>
-    </View>
   </View>
   <View
     style={
       {
-        "borderRadius": 8,
-        "height": 20,
+        "borderRadius": 6,
+        "height": 24,
         "overflow": "hidden",
-        "width": "75%",
+        "width": 24,
       }
     }
-    testID="predict-details-header-skeleton-subtitle"
+    testID="predict-details-header-skeleton-share"
   >
     <View
       collapsable={false}

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import PredictGameDetailsContent from './PredictGameDetailsContent';
+import { PredictMarket, PredictMarketStatus } from '../../types';
+
+const mockGoBack = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    goBack: mockGoBack,
+  }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  ...jest.requireActual('react-native-safe-area-context'),
+  SafeAreaView: ({ children, ...props }: { children: React.ReactNode }) => {
+    const { View } = jest.requireActual('react-native');
+    return <View {...props}>{children}</View>;
+  },
+  useSafeAreaInsets: () => ({
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  }),
+}));
+
+jest.mock('../PredictShareButton/PredictShareButton', () => {
+  const { View } = jest.requireActual('react-native');
+  return function MockPredictShareButton({ marketId }: { marketId?: string }) {
+    return (
+      <View
+        testID="predict-share-button"
+        accessibilityHint={`marketId:${marketId ?? 'undefined'}`}
+      />
+    );
+  };
+});
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => key),
+}));
+
+const createMockMarket = (
+  overrides: Partial<PredictMarket> = {},
+): PredictMarket =>
+  ({
+    id: 'test-market-id',
+    title: 'Test Game Market',
+    description: 'Test description',
+    image: 'https://example.com/image.png',
+    providerId: 'polymarket',
+    status: PredictMarketStatus.OPEN,
+    category: 'sports',
+    tags: ['NFL'],
+    outcomes: [
+      {
+        id: 'outcome-1',
+        marketId: 'test-market-id',
+        title: 'Team A',
+        groupItemTitle: 'Team A',
+        status: 'open',
+        volume: 1000,
+        tokens: [
+          {
+            id: 'token-1',
+            title: 'Team A',
+            price: 0.65,
+          },
+        ],
+      },
+    ],
+    endDate: '2024-12-31T23:59:59Z',
+    game: {
+      homeTeam: {
+        name: 'Team A',
+        abbreviation: 'TA',
+      },
+      awayTeam: {
+        name: 'Team B',
+        abbreviation: 'TB',
+      },
+      startTime: '2024-12-31T20:00:00Z',
+      status: 'scheduled',
+    },
+    ...overrides,
+  }) as PredictMarket;
+
+describe('PredictGameDetailsContent', () => {
+  const mockOnBack = jest.fn();
+  const mockOnRefresh = jest.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Header Rendering', () => {
+    it('renders the back button', () => {
+      const market = createMockMarket();
+
+      const { getByRole } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          refreshing={false}
+        />,
+      );
+
+      expect(getByRole('button')).toBeTruthy();
+    });
+
+    it('renders the market title', () => {
+      const market = createMockMarket({ title: 'NFL Game: Team A vs Team B' });
+
+      const { getByText } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          refreshing={false}
+        />,
+      );
+
+      expect(getByText('NFL Game: Team A vs Team B')).toBeTruthy();
+    });
+
+    it('renders the share button with market id', () => {
+      const market = createMockMarket({ id: 'game-market-123' });
+
+      const { getByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          refreshing={false}
+        />,
+      );
+
+      const shareButton = getByTestId('predict-share-button');
+
+      expect(shareButton).toBeTruthy();
+      expect(shareButton.props.accessibilityHint).toBe(
+        'marketId:game-market-123',
+      );
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('calls onBack when back button is pressed', () => {
+      const market = createMockMarket();
+
+      const { getByRole } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          refreshing={false}
+        />,
+      );
+
+      const backButton = getByRole('button');
+      fireEvent.press(backButton);
+
+      expect(mockOnBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Refresh Control', () => {
+    it('passes refreshing state to RefreshControl', () => {
+      const market = createMockMarket();
+
+      const { UNSAFE_getByType } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          refreshing
+        />,
+      );
+
+      const { ScrollView } = jest.requireActual('react-native');
+      const scrollView = UNSAFE_getByType(ScrollView);
+
+      expect(scrollView.props.refreshControl.props.refreshing).toBe(true);
+    });
+
+    it('passes onRefresh callback to RefreshControl', () => {
+      const market = createMockMarket();
+
+      const { UNSAFE_getByType } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          refreshing={false}
+        />,
+      );
+
+      const { ScrollView } = jest.requireActual('react-native');
+      const scrollView = UNSAFE_getByType(ScrollView);
+
+      expect(scrollView.props.refreshControl.props.onRefresh).toBe(
+        mockOnRefresh,
+      );
+    });
+  });
+
+  it('matches snapshot', () => {
+    const market = createMockMarket();
+
+    const tree = render(
+      <PredictGameDetailsContent
+        market={market}
+        onBack={mockOnBack}
+        onRefresh={mockOnRefresh}
+        refreshing={false}
+      />,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
@@ -107,7 +107,7 @@ describe('PredictGameDetailsContent', () => {
         />,
       );
 
-      expect(getByRole('button')).toBeTruthy();
+      expect(getByRole('button')).toBeOnTheScreen();
     });
 
     it('renders the market title', () => {
@@ -122,7 +122,7 @@ describe('PredictGameDetailsContent', () => {
         />,
       );
 
-      expect(getByText('NFL Game: Team A vs Team B')).toBeTruthy();
+      expect(getByText('NFL Game: Team A vs Team B')).toBeOnTheScreen();
     });
 
     it('renders the share button with market id', () => {
@@ -139,7 +139,7 @@ describe('PredictGameDetailsContent', () => {
 
       const shareButton = getByTestId('predict-share-button');
 
-      expect(shareButton).toBeTruthy();
+      expect(shareButton).toBeOnTheScreen();
       expect(shareButton.props.accessibilityHint).toBe(
         'marketId:game-market-123',
       );

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Pressable, RefreshControl, ScrollView } from 'react-native';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import Icon, {
+  IconName,
+  IconSize,
+} from '../../../../../component-library/components/Icons/Icon';
+import { useTheme } from '../../../../../util/theme';
+import { strings } from '../../../../../../locales/i18n';
+import PredictShareButton from '../PredictShareButton/PredictShareButton';
+import { PredictGameDetailsContentProps } from './PredictGameDetailsContent.types';
+
+const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
+  market,
+  onBack,
+  onRefresh,
+  refreshing,
+}) => {
+  const tw = useTailwind();
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <SafeAreaView
+      style={tw.style('flex-1 bg-default')}
+      edges={['left', 'right', 'bottom']}
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        twClassName="px-4 py-3"
+        style={{ paddingTop: insets.top + 12 }}
+      >
+        <Pressable
+          onPress={onBack}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          accessibilityRole="button"
+          accessibilityLabel={strings('predict.buttons.back')}
+        >
+          <Icon
+            name={IconName.ArrowLeft}
+            size={IconSize.Lg}
+            color={colors.icon.default}
+          />
+        </Pressable>
+
+        <Box twClassName="flex-1 mx-4">
+          <Text
+            variant={TextVariant.HeadingMd}
+            color={TextColor.TextDefault}
+            style={tw.style('text-center')}
+            numberOfLines={1}
+          >
+            {market.title}
+          </Text>
+        </Box>
+
+        <PredictShareButton marketId={market.id} />
+      </Box>
+
+      <ScrollView
+        style={tw.style('flex-1')}
+        contentContainerStyle={tw.style('flex-1')}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={colors.primary.default}
+            colors={[colors.primary.default]}
+          />
+        }
+      >
+        <Box twClassName="flex-1" />
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default PredictGameDetailsContent;

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.types.ts
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.types.ts
@@ -1,0 +1,8 @@
+import { PredictMarket } from '../../types';
+
+export interface PredictGameDetailsContentProps {
+  market: PredictMarket;
+  onBack: () => void;
+  onRefresh: () => Promise<void>;
+  refreshing: boolean;
+}

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/__snapshots__/PredictGameDetailsContent.test.tsx.snap
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/__snapshots__/PredictGameDetailsContent.test.tsx.snap
@@ -1,0 +1,183 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PredictGameDetailsContent matches snapshot 1`] = `
+<View
+  edges={
+    [
+      "left",
+      "right",
+      "bottom",
+    ]
+  }
+  style={
+    {
+      "backgroundColor": "#ffffff",
+      "flexBasis": "0%",
+      "flexGrow": 1,
+      "flexShrink": 1,
+    }
+  }
+>
+  <View
+    style={
+      [
+        {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "paddingBottom": 12,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "paddingTop": 12,
+        },
+        {
+          "paddingTop": 12,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityLabel="predict.buttons.back"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        {
+          "bottom": 10,
+          "left": 10,
+          "right": 10,
+          "top": 10,
+        }
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+    >
+      <SvgMock
+        color="#121314"
+        fill="currentColor"
+        height={24}
+        name="ArrowLeft"
+        style={
+          {
+            "height": 24,
+            "width": 24,
+          }
+        }
+        width={24}
+      />
+    </View>
+    <View
+      style={
+        [
+          {
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
+            "marginLeft": 16,
+            "marginRight": 16,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        numberOfLines={1}
+        style={
+          [
+            {
+              "color": "#121314",
+              "fontFamily": "Geist-Bold",
+              "fontSize": 18,
+              "fontWeight": 700,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            },
+            {
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        Test Game Market
+      </Text>
+    </View>
+    <View
+      accessibilityHint="marketId:test-market-id"
+      testID="predict-share-button"
+    />
+  </View>
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "flexBasis": "0%",
+        "flexGrow": 1,
+        "flexShrink": 1,
+      }
+    }
+    refreshControl={
+      <RefreshControlMock
+        colors={
+          [
+            "#4459ff",
+          ]
+        }
+        onRefresh={[MockFunction]}
+        refreshing={false}
+        tintColor="#4459ff"
+      />
+    }
+    style={
+      {
+        "flexBasis": "0%",
+        "flexGrow": 1,
+        "flexShrink": 1,
+      }
+    }
+  >
+    <RCTRefreshControl />
+    <View>
+      <View
+        style={
+          [
+            {
+              "display": "flex",
+              "flexBasis": "0%",
+              "flexGrow": 1,
+              "flexShrink": 1,
+            },
+            undefined,
+          ]
+        }
+      />
+    </View>
+  </RCTScrollView>
+</View>
+`;

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/index.ts
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/index.ts
@@ -1,0 +1,2 @@
+export { default } from './PredictGameDetailsContent';
+export type { PredictGameDetailsContentProps } from './PredictGameDetailsContent.types';

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -272,6 +272,21 @@ jest.mock('../../components/PredictShareButton/PredictShareButton', () => {
   };
 });
 
+jest.mock('../../components/PredictGameDetailsContent', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return function MockPredictGameDetailsContent({
+    market,
+  }: {
+    market: { title?: string };
+  }) {
+    return (
+      <View testID="predict-game-details-content">
+        <Text>{market?.title || 'Game Details'}</Text>
+      </View>
+    );
+  };
+});
+
 jest.mock('../../../../Base/TabBar', () => {
   const { View, Text } = jest.requireActual('react-native');
   return function MockTabBar({ textStyle }: { textStyle: object }) {
@@ -693,7 +708,11 @@ describe('PredictMarketDetails', () => {
     });
 
     it('hides share button when market is not loaded (shows skeleton)', () => {
-      setupPredictMarketDetailsTest({}, {}, { market: { market: null } });
+      setupPredictMarketDetailsTest(
+        {},
+        {},
+        { market: { isFetching: true, market: null } },
+      );
 
       expect(
         screen.queryByTestId('predict-share-button'),
@@ -3442,6 +3461,43 @@ describe('PredictMarketDetails', () => {
           screen.queryByText('predict.market_details.fee_exemption'),
         ).not.toBeOnTheScreen();
       });
+    });
+  });
+
+  describe('Game Details Content', () => {
+    it('renders PredictGameDetailsContent when market has game property', () => {
+      const gameMarket = createMockMarket({
+        title: 'NFL: Team A vs Team B',
+        game: {
+          homeTeam: { name: 'Team A', abbreviation: 'TA' },
+          awayTeam: { name: 'Team B', abbreviation: 'TB' },
+          startTime: '2024-12-31T20:00:00Z',
+          status: 'scheduled',
+        },
+      });
+
+      setupPredictMarketDetailsTest(gameMarket);
+
+      expect(
+        screen.getByTestId('predict-game-details-content'),
+      ).toBeOnTheScreen();
+      expect(screen.getByText('NFL: Team A vs Team B')).toBeOnTheScreen();
+    });
+
+    it('renders regular market details when market has no game property', () => {
+      const regularMarket = createMockMarket({
+        title: 'Will Bitcoin reach $100k?',
+        game: undefined,
+      });
+
+      setupPredictMarketDetailsTest(regularMarket);
+
+      expect(
+        screen.queryByTestId('predict-game-details-content'),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.getByTestId('predict-market-details-screen'),
+      ).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -654,10 +654,10 @@ describe('PredictMarketDetails', () => {
         screen.getByTestId('predict-details-header-skeleton-back-button'),
       ).toBeOnTheScreen();
       expect(
-        screen.getByTestId('predict-details-content-skeleton-option-1'),
+        screen.getByTestId('predict-details-content-skeleton-line-1'),
       ).toBeOnTheScreen();
       expect(
-        screen.getByTestId('predict-details-buttons-skeleton-button-yes'),
+        screen.getByTestId('predict-details-buttons-skeleton-button-1'),
       ).toBeOnTheScreen();
     });
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -736,8 +736,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   );
 
   const renderHeader = () => {
-    // Show skeleton header if no title/market data available
-    if (!title && !market?.title) {
+    if (isMarketFetching && !market) {
       return <PredictDetailsHeaderSkeleton />;
     }
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -80,6 +80,7 @@ import PredictDetailsHeaderSkeleton from '../../components/PredictDetailsHeaderS
 import PredictDetailsContentSkeleton from '../../components/PredictDetailsContentSkeleton';
 import PredictDetailsButtonsSkeleton from '../../components/PredictDetailsButtonsSkeleton';
 import PredictShareButton from '../../components/PredictShareButton/PredictShareButton';
+import PredictGameDetailsContent from '../../components/PredictGameDetailsContent';
 
 const PRICE_HISTORY_TIMEFRAMES: PredictPriceHistoryInterval[] = [
   PredictPriceHistoryInterval.ONE_HOUR,
@@ -1291,6 +1292,17 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     }
     return null;
   };
+
+  if (market?.game) {
+    return (
+      <PredictGameDetailsContent
+        market={market}
+        onBack={handleBackPress}
+        onRefresh={handleRefresh}
+        refreshing={isRefreshing}
+      />
+    );
+  }
 
   return (
     <SafeAreaView


### PR DESCRIPTION
## **Description**

This PR scaffolds the game details view for the Live NFL feature. When a user navigates to a market that has game data (`market.game` exists), the app now conditionally renders `PredictGameDetailsContent` instead of the regular market details.

**What's included:**
1. **PredictGameDetailsContent** - New scaffold component with simplified header (back button, centered title, share button) and empty body ready for future integration
2. **Generic loading skeletons** - Updated skeleton components to be content-agnostic, working for both game markets and regular markets:
   - Removed green/red colored buttons from `PredictDetailsButtonsSkeleton`
   - Simplified `PredictDetailsContentSkeleton` to generic blocks
   - Simplified `PredictDetailsHeaderSkeleton` to back + title skeleton + share placeholder

**Architecture decision:** Per the Live NFL architecture docs, there is NO separate game details route. The existing `MARKET_DETAILS` route renders game content when `market.game` exists.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/PRED-477

## **Manual testing steps**

```gherkin
Feature: Game Details View Scaffold

  Scenario: user views a game market loading state
    Given user is on the Predict feed with NFL markets visible

    When user taps on an NFL game market card
    Then user sees a generic loading skeleton (no colors, no market-specific layout)
    And the skeleton shows: back button | title skeleton | share placeholder
    And the content area shows generic gray blocks

  Scenario: user views a game market after loading
    Given user navigated to an NFL game market
    And the market data has loaded

    When the loading completes
    Then user sees the game details header (back button | game title | share button)
    And the body is empty (placeholder for future content)
    And pull-to-refresh is functional
```

## **Screenshots/Recordings**

### **Before**

Loading skeleton showed market-specific layout with green/red buttons and outcome cards

### **After**

Generic loading skeleton that works for both game and regular markets

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a dedicated game details content path and unifies loading states.
> 
> - Adds `PredictGameDetailsContent` (header with back/title/share, pull-to-refresh, empty body) and types; exported via `index.ts`
> - Updates `PredictMarketDetails` to render `PredictGameDetailsContent` when `market.game` exists; otherwise uses existing flow; adjusts header-skeleton condition
> - Generalizes skeletons for reuse: `PredictDetailsHeaderSkeleton` (back/title/share), `PredictDetailsContentSkeleton` (two lines + blocks), `PredictDetailsButtonsSkeleton` (two generic rounded buttons); updates testIDs
> - Refreshes snapshots and tests across affected components, and adds new tests for game content rendering and share/back behaviors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 201d851f1fca8ee6fd811c4becebd3d69e0acc30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->