### PR TITLE
feat(predict): add PredictGameChart component for dual-line price visualization

### DIFF
--- a/app/components/UI/Predict/components/PredictGameChart/ChartTooltip.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/ChartTooltip.test.tsx
@@ -1,0 +1,322 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import ChartTooltip from './ChartTooltip';
+import { GameChartSeries, GameChartDataPoint } from './PredictGameChart.types';
+
+jest.mock('react-native-svg', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    G: ({ children, ...props }: { children?: React.ReactNode }) => (
+      <View testID="svg-g" {...props}>
+        {children}
+      </View>
+    ),
+    Circle: (props: Record<string, unknown>) => (
+      <View
+        testID="svg-circle"
+        accessibilityLabel={`circle-cx-${props.cx}-cy-${props.cy}-r-${props.r}`}
+        {...props}
+      />
+    ),
+    Line: (props: Record<string, unknown>) => (
+      <View
+        testID="svg-line"
+        accessibilityLabel={`line-x1-${props.x1}-y1-${props.y1}`}
+        {...props}
+      />
+    ),
+    Text: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      x?: number;
+      y?: number;
+    }) => (
+      <Text testID="svg-text" accessibilityLabel={`text-at-${props.x}`}>
+        {children}
+      </Text>
+    ),
+  };
+});
+
+jest.mock('../../../../../util/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      text: { alternative: '#888888', default: '#000000' },
+      background: { default: '#FFFFFF' },
+    },
+  }),
+}));
+
+const mockXFunction = (index: number) => index * 10 + 50;
+const mockYFunction = (value: number) => 200 - value * 2;
+
+const mockPrimaryData: GameChartDataPoint[] = [
+  { timestamp: 1704067200000, value: 50 },
+  { timestamp: 1704070800000, value: 55 },
+  { timestamp: 1704074400000, value: 60 },
+];
+
+const mockNonEmptySeries: GameChartSeries[] = [
+  {
+    label: 'Team A',
+    color: '#FF0000',
+    data: mockPrimaryData,
+  },
+  {
+    label: 'Team B',
+    color: '#0000FF',
+    data: [
+      { timestamp: 1704067200000, value: 50 },
+      { timestamp: 1704070800000, value: 45 },
+      { timestamp: 1704074400000, value: 40 },
+    ],
+  },
+];
+
+const defaultProps = {
+  x: mockXFunction,
+  y: mockYFunction,
+  activeIndex: 1,
+  primaryData: mockPrimaryData,
+  nonEmptySeries: mockNonEmptySeries,
+  chartWidth: 300,
+  contentInset: { top: 20, bottom: 20, left: 10, right: 80 },
+};
+
+describe('ChartTooltip', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders tooltip with timestamp and crosshair', () => {
+      const { getAllByTestId } = render(<ChartTooltip {...defaultProps} />);
+
+      const textElements = getAllByTestId('svg-text');
+      expect(textElements.length).toBeGreaterThan(0);
+
+      const lineElements = getAllByTestId('svg-line');
+      expect(lineElements.length).toBe(1);
+    });
+
+    it('renders dots for each series', () => {
+      const { getAllByTestId } = render(<ChartTooltip {...defaultProps} />);
+
+      const circleElements = getAllByTestId('svg-circle');
+      expect(circleElements.length).toBe(4);
+    });
+
+    it('renders labels with team names and values', () => {
+      const { getAllByTestId } = render(<ChartTooltip {...defaultProps} />);
+
+      const textElements = getAllByTestId('svg-text');
+      const textContents = textElements.map((el) => el.children[0]);
+
+      expect(textContents).toContain('Team A');
+      expect(textContents).toContain('Team B');
+      expect(textContents).toContain('55%');
+      expect(textContents).toContain('45%');
+    });
+
+    it('formats timestamp correctly', () => {
+      const { getAllByTestId } = render(<ChartTooltip {...defaultProps} />);
+
+      const textElements = getAllByTestId('svg-text');
+      const timestampText = textElements[0].children[0];
+
+      expect(typeof timestampText).toBe('string');
+      expect(timestampText).toContain('at');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('returns null when x function is undefined', () => {
+      const { queryByTestId } = render(
+        <ChartTooltip {...defaultProps} x={undefined} />,
+      );
+
+      expect(queryByTestId('svg-g')).toBeNull();
+    });
+
+    it('returns null when y function is undefined', () => {
+      const { queryByTestId } = render(
+        <ChartTooltip {...defaultProps} y={undefined} />,
+      );
+
+      expect(queryByTestId('svg-g')).toBeNull();
+    });
+
+    it('returns null when activeIndex is negative', () => {
+      const { queryByTestId } = render(
+        <ChartTooltip {...defaultProps} activeIndex={-1} />,
+      );
+
+      expect(queryByTestId('svg-g')).toBeNull();
+    });
+
+    it('returns null when activeIndex exceeds data length', () => {
+      const { queryByTestId } = render(
+        <ChartTooltip {...defaultProps} activeIndex={10} />,
+      );
+
+      expect(queryByTestId('svg-g')).toBeNull();
+    });
+
+    it('handles single series data', () => {
+      const singleSeries = [mockNonEmptySeries[0]];
+      const { getAllByTestId } = render(
+        <ChartTooltip {...defaultProps} nonEmptySeries={singleSeries} />,
+      );
+
+      const circleElements = getAllByTestId('svg-circle');
+      expect(circleElements.length).toBe(2);
+    });
+
+    it('handles empty series array', () => {
+      const { queryAllByTestId } = render(
+        <ChartTooltip {...defaultProps} nonEmptySeries={[]} />,
+      );
+
+      const circleElements = queryAllByTestId('svg-circle');
+      expect(circleElements.length).toBe(0);
+    });
+  });
+
+  describe('Label Positioning', () => {
+    it('adjusts labels when dots are close together', () => {
+      const closeValuesSeries: GameChartSeries[] = [
+        {
+          label: 'Team A',
+          color: '#FF0000',
+          data: [{ timestamp: 1704067200000, value: 50 }],
+        },
+        {
+          label: 'Team B',
+          color: '#0000FF',
+          data: [{ timestamp: 1704067200000, value: 51 }],
+        },
+      ];
+
+      const { getAllByTestId } = render(
+        <ChartTooltip
+          {...defaultProps}
+          activeIndex={0}
+          primaryData={closeValuesSeries[0].data}
+          nonEmptySeries={closeValuesSeries}
+        />,
+      );
+
+      const textElements = getAllByTestId('svg-text');
+      expect(textElements.length).toBeGreaterThan(0);
+    });
+
+    it('keeps labels at dot position when far apart', () => {
+      const farApartSeries: GameChartSeries[] = [
+        {
+          label: 'Team A',
+          color: '#FF0000',
+          data: [{ timestamp: 1704067200000, value: 20 }],
+        },
+        {
+          label: 'Team B',
+          color: '#0000FF',
+          data: [{ timestamp: 1704067200000, value: 80 }],
+        },
+      ];
+
+      const { getAllByTestId } = render(
+        <ChartTooltip
+          {...defaultProps}
+          activeIndex={0}
+          primaryData={farApartSeries[0].data}
+          nonEmptySeries={farApartSeries}
+        />,
+      );
+
+      const textElements = getAllByTestId('svg-text');
+      expect(textElements.length).toBeGreaterThan(0);
+    });
+
+    it('handles first dot above second dot', () => {
+      const firstAboveSeries: GameChartSeries[] = [
+        {
+          label: 'Team A',
+          color: '#FF0000',
+          data: [{ timestamp: 1704067200000, value: 70 }],
+        },
+        {
+          label: 'Team B',
+          color: '#0000FF',
+          data: [{ timestamp: 1704067200000, value: 71 }],
+        },
+      ];
+
+      const { getAllByTestId } = render(
+        <ChartTooltip
+          {...defaultProps}
+          activeIndex={0}
+          primaryData={firstAboveSeries[0].data}
+          nonEmptySeries={firstAboveSeries}
+        />,
+      );
+
+      expect(getAllByTestId('svg-circle').length).toBe(4);
+    });
+
+    it('handles first dot below second dot', () => {
+      const firstBelowSeries: GameChartSeries[] = [
+        {
+          label: 'Team A',
+          color: '#FF0000',
+          data: [{ timestamp: 1704067200000, value: 31 }],
+        },
+        {
+          label: 'Team B',
+          color: '#0000FF',
+          data: [{ timestamp: 1704067200000, value: 30 }],
+        },
+      ];
+
+      const { getAllByTestId } = render(
+        <ChartTooltip
+          {...defaultProps}
+          activeIndex={0}
+          primaryData={firstBelowSeries[0].data}
+          nonEmptySeries={firstBelowSeries}
+        />,
+      );
+
+      expect(getAllByTestId('svg-circle').length).toBe(4);
+    });
+  });
+
+  describe('Missing Data', () => {
+    it('handles series with missing data at activeIndex', () => {
+      const partialSeries: GameChartSeries[] = [
+        {
+          label: 'Team A',
+          color: '#FF0000',
+          data: mockPrimaryData,
+        },
+        {
+          label: 'Team B',
+          color: '#0000FF',
+          data: [{ timestamp: 1704067200000, value: 50 }],
+        },
+      ];
+
+      const { getAllByTestId } = render(
+        <ChartTooltip
+          {...defaultProps}
+          activeIndex={2}
+          nonEmptySeries={partialSeries}
+        />,
+      );
+
+      const circleElements = getAllByTestId('svg-circle');
+      expect(circleElements.length).toBe(2);
+    });
+  });
+});

--- a/app/components/UI/Predict/components/PredictGameChart/ChartTooltip.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/ChartTooltip.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Circle, G, Line, Text as SvgText } from 'react-native-svg';
+import dayjs from 'dayjs';
+import { useTheme } from '../../../../../util/theme';
+import { ChartTooltipProps } from './PredictGameChart.types';
+
+const CHART_HEIGHT = 200;
+const FONT_SIZE_LABEL = 12;
+const FONT_SIZE_VALUE = 24;
+const RIGHT_LABEL_OFFSET = 12;
+
+const formatTimestamp = (timestamp: number): string =>
+  dayjs(timestamp).format('MMM D [at] h:mm A');
+
+const ChartTooltip: React.FC<ChartTooltipProps> = ({
+  x,
+  y,
+  activeIndex,
+  primaryData,
+  nonEmptySeries,
+  chartWidth,
+  contentInset,
+}) => {
+  const { colors } = useTheme();
+
+  if (!x || !y) return null;
+  if (activeIndex < 0 || !primaryData[activeIndex]) return null;
+
+  const xPos = x(activeIndex);
+  const timestamp = primaryData[activeIndex].timestamp;
+  const labelStartX = chartWidth - contentInset.right + RIGHT_LABEL_OFFSET;
+
+  let currentLabelY = CHART_HEIGHT / 2 - 40;
+
+  return (
+    <G>
+      <SvgText
+        x={xPos}
+        y={12}
+        fill={colors.text.alternative}
+        fontSize={FONT_SIZE_LABEL}
+        fontWeight="400"
+        textAnchor="middle"
+      >
+        {formatTimestamp(timestamp)}
+      </SvgText>
+
+      <Line
+        x1={xPos}
+        x2={xPos}
+        y1={20}
+        y2={CHART_HEIGHT - contentInset.bottom}
+        stroke={colors.text.alternative}
+        strokeWidth={1}
+      />
+
+      {nonEmptySeries.map((series, seriesIndex) => {
+        const seriesData = series.data[activeIndex];
+        if (!seriesData) return null;
+
+        const lineYPos = y(seriesData.value);
+        const labelY = currentLabelY;
+        currentLabelY += 50;
+
+        return (
+          <G key={`series-${seriesIndex}`}>
+            <Circle
+              cx={xPos}
+              cy={lineYPos}
+              r={6}
+              stroke={colors.background.default}
+              strokeWidth={2}
+              fill={series.color}
+            />
+            <SvgText
+              x={labelStartX}
+              y={labelY}
+              fill={colors.text.alternative}
+              fontSize={FONT_SIZE_LABEL}
+              fontWeight="500"
+            >
+              {series.label}
+            </SvgText>
+            <SvgText
+              x={labelStartX}
+              y={labelY + 24}
+              fill={colors.text.default}
+              fontSize={FONT_SIZE_VALUE}
+              fontWeight="700"
+            >
+              {`${seriesData.value.toFixed(0)}%`}
+            </SvgText>
+          </G>
+        );
+      })}
+    </G>
+  );
+};
+
+export default ChartTooltip;

--- a/app/components/UI/Predict/components/PredictGameChart/ChartTooltip.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/ChartTooltip.tsx
@@ -8,8 +8,6 @@ import {
   FONT_SIZE_LABEL,
   FONT_SIZE_VALUE,
   RIGHT_LABEL_OFFSET,
-  LABEL_HEIGHT,
-  MIN_LABEL_GAP,
   DOT_RADIUS,
   DOT_STROKE_WIDTH,
   GLOW_RADIUS,
@@ -19,6 +17,7 @@ import {
   TIMESTAMP_Y,
   CROSSHAIR_START_Y,
   CROSSHAIR_STROKE_WIDTH,
+  getSeparatedLabelYPositions,
 } from './PredictGameChart.constants';
 
 const formatTimestamp = (timestamp: number): string =>
@@ -58,26 +57,10 @@ const ChartTooltip: React.FC<ChartTooltipProps> = ({
     }[];
   }, [x, y, activeIndex, nonEmptySeries]);
 
-  const adjustedLabelYPositions = useMemo(() => {
-    if (dotPositions.length < 2) {
-      return dotPositions.map((pos) => pos.dotY);
-    }
-
-    const [first, second] = dotPositions;
-    const gap = Math.abs(first.dotY - second.dotY);
-
-    if (gap >= LABEL_HEIGHT + MIN_LABEL_GAP) {
-      return [first.dotY, second.dotY];
-    }
-
-    const midPoint = (first.dotY + second.dotY) / 2;
-    const offset = (LABEL_HEIGHT + MIN_LABEL_GAP) / 2;
-
-    if (first.dotY < second.dotY) {
-      return [midPoint - offset, midPoint + offset];
-    }
-    return [midPoint + offset, midPoint - offset];
-  }, [dotPositions]);
+  const adjustedLabelYPositions = useMemo(
+    () => getSeparatedLabelYPositions(dotPositions),
+    [dotPositions],
+  );
 
   if (!x || !y) return null;
   if (activeIndex < 0 || !primaryData[activeIndex]) return null;

--- a/app/components/UI/Predict/components/PredictGameChart/EndpointDots.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/EndpointDots.test.tsx
@@ -1,0 +1,272 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import EndpointDots from './EndpointDots';
+import { GameChartSeries } from './PredictGameChart.types';
+
+jest.mock('react-native-svg', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    G: ({ children, ...props }: { children?: React.ReactNode }) => (
+      <View testID="svg-g" {...props}>
+        {children}
+      </View>
+    ),
+    Circle: (props: Record<string, unknown>) => (
+      <View
+        testID="svg-circle"
+        accessibilityLabel={`circle-cx-${props.cx}-cy-${props.cy}-r-${props.r}`}
+        {...props}
+      />
+    ),
+    Text: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      x?: number;
+      y?: number;
+    }) => (
+      <Text testID="svg-text" accessibilityLabel={`text-at-${props.x}`}>
+        {children}
+      </Text>
+    ),
+  };
+});
+
+jest.mock('../../../../../util/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      text: { default: '#000000' },
+    },
+  }),
+}));
+
+const mockXFunction = (index: number) => index * 10 + 50;
+const mockYFunction = (value: number) => 200 - value * 2;
+
+const mockNonEmptySeries: GameChartSeries[] = [
+  {
+    label: 'Team A',
+    color: '#FF0000',
+    data: [
+      { timestamp: 1704067200000, value: 50 },
+      { timestamp: 1704070800000, value: 55 },
+      { timestamp: 1704074400000, value: 60 },
+    ],
+  },
+  {
+    label: 'Team B',
+    color: '#0000FF',
+    data: [
+      { timestamp: 1704067200000, value: 50 },
+      { timestamp: 1704070800000, value: 45 },
+      { timestamp: 1704074400000, value: 40 },
+    ],
+  },
+];
+
+const defaultProps = {
+  x: mockXFunction,
+  y: mockYFunction,
+  nonEmptySeries: mockNonEmptySeries,
+};
+
+describe('EndpointDots', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders endpoint dots for each series', () => {
+      const { getAllByTestId } = render(<EndpointDots {...defaultProps} />);
+
+      const circleElements = getAllByTestId('svg-circle');
+      expect(circleElements.length).toBe(4);
+    });
+
+    it('renders labels with team names', () => {
+      const { getAllByTestId } = render(<EndpointDots {...defaultProps} />);
+
+      const textElements = getAllByTestId('svg-text');
+      const textContents = textElements.map((el) => el.children[0]);
+
+      expect(textContents).toContain('Team A');
+      expect(textContents).toContain('Team B');
+    });
+
+    it('renders values with percentage format', () => {
+      const { getAllByTestId } = render(<EndpointDots {...defaultProps} />);
+
+      const textElements = getAllByTestId('svg-text');
+      const textContents = textElements.map((el) => el.children[0]);
+
+      expect(textContents).toContain('60%');
+      expect(textContents).toContain('40%');
+    });
+
+    it('renders glow circle for each dot', () => {
+      const { getAllByTestId } = render(<EndpointDots {...defaultProps} />);
+
+      const circles = getAllByTestId('svg-circle');
+      expect(circles.length).toBe(4);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('returns null when x function is undefined', () => {
+      const { queryByTestId } = render(
+        <EndpointDots {...defaultProps} x={undefined} />,
+      );
+
+      expect(queryByTestId('svg-g')).toBeNull();
+    });
+
+    it('returns null when y function is undefined', () => {
+      const { queryByTestId } = render(
+        <EndpointDots {...defaultProps} y={undefined} />,
+      );
+
+      expect(queryByTestId('svg-g')).toBeNull();
+    });
+
+    it('handles single series', () => {
+      const singleSeries = [mockNonEmptySeries[0]];
+      const { getAllByTestId } = render(
+        <EndpointDots {...defaultProps} nonEmptySeries={singleSeries} />,
+      );
+
+      const circleElements = getAllByTestId('svg-circle');
+      expect(circleElements.length).toBe(2);
+    });
+
+    it('handles empty series array', () => {
+      const { queryAllByTestId } = render(
+        <EndpointDots {...defaultProps} nonEmptySeries={[]} />,
+      );
+
+      const circleElements = queryAllByTestId('svg-circle');
+      expect(circleElements.length).toBe(0);
+    });
+
+    it('handles series with empty data array', () => {
+      const emptyDataSeries: GameChartSeries[] = [
+        { label: 'Empty', color: '#000', data: [] },
+      ];
+
+      const { queryAllByTestId } = render(
+        <EndpointDots {...defaultProps} nonEmptySeries={emptyDataSeries} />,
+      );
+
+      const circleElements = queryAllByTestId('svg-circle');
+      expect(circleElements.length).toBe(0);
+    });
+  });
+
+  describe('Label Positioning', () => {
+    it('adjusts labels when dots are close together', () => {
+      const closeValuesSeries: GameChartSeries[] = [
+        {
+          label: 'Team A',
+          color: '#FF0000',
+          data: [{ timestamp: 1704067200000, value: 50 }],
+        },
+        {
+          label: 'Team B',
+          color: '#0000FF',
+          data: [{ timestamp: 1704067200000, value: 51 }],
+        },
+      ];
+
+      const { getAllByTestId } = render(
+        <EndpointDots {...defaultProps} nonEmptySeries={closeValuesSeries} />,
+      );
+
+      const textElements = getAllByTestId('svg-text');
+      expect(textElements.length).toBe(4);
+    });
+
+    it('keeps labels at dot position when far apart', () => {
+      const farApartSeries: GameChartSeries[] = [
+        {
+          label: 'Team A',
+          color: '#FF0000',
+          data: [{ timestamp: 1704067200000, value: 20 }],
+        },
+        {
+          label: 'Team B',
+          color: '#0000FF',
+          data: [{ timestamp: 1704067200000, value: 80 }],
+        },
+      ];
+
+      const { getAllByTestId } = render(
+        <EndpointDots {...defaultProps} nonEmptySeries={farApartSeries} />,
+      );
+
+      const textElements = getAllByTestId('svg-text');
+      expect(textElements.length).toBe(4);
+    });
+
+    it('handles first dot above second dot when close', () => {
+      const firstAboveSeries: GameChartSeries[] = [
+        {
+          label: 'Team A',
+          color: '#FF0000',
+          data: [{ timestamp: 1704067200000, value: 71 }],
+        },
+        {
+          label: 'Team B',
+          color: '#0000FF',
+          data: [{ timestamp: 1704067200000, value: 70 }],
+        },
+      ];
+
+      const { getAllByTestId } = render(
+        <EndpointDots {...defaultProps} nonEmptySeries={firstAboveSeries} />,
+      );
+
+      expect(getAllByTestId('svg-circle').length).toBe(4);
+    });
+
+    it('handles first dot below second dot when close', () => {
+      const firstBelowSeries: GameChartSeries[] = [
+        {
+          label: 'Team A',
+          color: '#FF0000',
+          data: [{ timestamp: 1704067200000, value: 30 }],
+        },
+        {
+          label: 'Team B',
+          color: '#0000FF',
+          data: [{ timestamp: 1704067200000, value: 31 }],
+        },
+      ];
+
+      const { getAllByTestId } = render(
+        <EndpointDots {...defaultProps} nonEmptySeries={firstBelowSeries} />,
+      );
+
+      expect(getAllByTestId('svg-circle').length).toBe(4);
+    });
+  });
+
+  describe('Value Formatting', () => {
+    it('rounds values to whole numbers', () => {
+      const decimalSeries: GameChartSeries[] = [
+        {
+          label: 'Team A',
+          color: '#FF0000',
+          data: [{ timestamp: 1704067200000, value: 55.7 }],
+        },
+      ];
+
+      const { getAllByTestId } = render(
+        <EndpointDots {...defaultProps} nonEmptySeries={decimalSeries} />,
+      );
+
+      const textElements = getAllByTestId('svg-text');
+      const valueText = textElements.find((el) => el.children[0] === '56%');
+      expect(valueText).toBeTruthy();
+    });
+  });
+});

--- a/app/components/UI/Predict/components/PredictGameChart/EndpointDots.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/EndpointDots.tsx
@@ -95,7 +95,7 @@ const EndpointDots: React.FC<EndpointDotsProps> = ({
             <SvgText
               x={labelX}
               y={labelY - LABEL_TEXT_OFFSET_Y}
-              fill={colors.text.alternative}
+              fill={colors.text.default}
               fontSize={FONT_SIZE_LABEL}
               fontWeight="500"
             >

--- a/app/components/UI/Predict/components/PredictGameChart/EndpointDots.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/EndpointDots.tsx
@@ -6,13 +6,12 @@ import {
   LABEL_OFFSET_X,
   FONT_SIZE_LABEL,
   FONT_SIZE_VALUE,
-  LABEL_HEIGHT,
-  MIN_LABEL_GAP,
   DOT_RADIUS,
   GLOW_RADIUS,
   GLOW_OPACITY,
   LABEL_TEXT_OFFSET_Y,
   VALUE_TEXT_OFFSET_Y,
+  getSeparatedLabelYPositions,
 } from './PredictGameChart.constants';
 
 const EndpointDots: React.FC<EndpointDotsProps> = ({
@@ -53,26 +52,10 @@ const EndpointDots: React.FC<EndpointDotsProps> = ({
     }[];
   }, [x, y, nonEmptySeries, primaryDataLength]);
 
-  const adjustedLabelYPositions = useMemo(() => {
-    if (dotPositions.length < 2) {
-      return dotPositions.map((pos) => pos.dotY);
-    }
-
-    const [first, second] = dotPositions;
-    const gap = Math.abs(first.dotY - second.dotY);
-
-    if (gap >= LABEL_HEIGHT + MIN_LABEL_GAP) {
-      return [first.dotY, second.dotY];
-    }
-
-    const midPoint = (first.dotY + second.dotY) / 2;
-    const offset = (LABEL_HEIGHT + MIN_LABEL_GAP) / 2;
-
-    if (first.dotY < second.dotY) {
-      return [midPoint - offset, midPoint + offset];
-    }
-    return [midPoint + offset, midPoint - offset];
-  }, [dotPositions]);
+  const adjustedLabelYPositions = useMemo(
+    () => getSeparatedLabelYPositions(dotPositions),
+    [dotPositions],
+  );
 
   if (!x || !y) return null;
 

--- a/app/components/UI/Predict/components/PredictGameChart/EndpointDots.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/EndpointDots.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Circle, G, Text as SvgText } from 'react-native-svg';
+import { useTheme } from '../../../../../util/theme';
+import { EndpointDotsProps } from './PredictGameChart.types';
+
+const LABEL_OFFSET_X = 12;
+const FONT_SIZE_LABEL = 12;
+const FONT_SIZE_VALUE = 24;
+
+const EndpointDots: React.FC<EndpointDotsProps> = ({
+  x,
+  y,
+  nonEmptySeries,
+}) => {
+  const { colors } = useTheme();
+
+  if (!x || !y) return null;
+
+  return (
+    <G>
+      {nonEmptySeries.map((series, seriesIndex) => {
+        const lastIndex = series.data.length - 1;
+        const lastPoint = series.data[lastIndex];
+        if (!lastPoint) return null;
+
+        const dotX = x(lastIndex);
+        const dotY = y(lastPoint.value);
+        const labelX = dotX + LABEL_OFFSET_X;
+
+        return (
+          <G key={`endpoint-${seriesIndex}`}>
+            <Circle cx={dotX} cy={dotY} r={6} fill={series.color} />
+            <SvgText
+              x={labelX}
+              y={dotY - 8}
+              fill={colors.text.alternative}
+              fontSize={FONT_SIZE_LABEL}
+              fontWeight="500"
+            >
+              {series.label}
+            </SvgText>
+            <SvgText
+              x={labelX}
+              y={dotY + 16}
+              fill={colors.text.default}
+              fontSize={FONT_SIZE_VALUE}
+              fontWeight="700"
+            >
+              {`${lastPoint.value.toFixed(0)}%`}
+            </SvgText>
+          </G>
+        );
+      })}
+    </G>
+  );
+};
+
+export default EndpointDots;

--- a/app/components/UI/Predict/components/PredictGameChart/EndpointDots.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/EndpointDots.tsx
@@ -19,20 +19,25 @@ const EndpointDots: React.FC<EndpointDotsProps> = ({
   x,
   y,
   nonEmptySeries,
+  primaryDataLength,
 }) => {
   const { colors } = useTheme();
 
   const dotPositions = useMemo(() => {
-    if (!x || !y) return [];
+    if (!x || !y || primaryDataLength === 0) return [];
+
+    // Use primary data's last index for x-positioning so all dots align at the right edge
+    // This prevents misalignment when series have different lengths (e.g., during live WebSocket updates)
+    const primaryLastIndex = primaryDataLength - 1;
+    const dotX = x(primaryLastIndex);
 
     return nonEmptySeries
       .map((series) => {
-        const lastIndex = series.data.length - 1;
-        const lastPoint = series.data[lastIndex];
+        const lastPoint = series.data[series.data.length - 1];
         if (!lastPoint) return null;
 
         return {
-          dotX: x(lastIndex),
+          dotX,
           dotY: y(lastPoint.value),
           value: lastPoint.value,
           color: series.color,
@@ -46,7 +51,7 @@ const EndpointDots: React.FC<EndpointDotsProps> = ({
       color: string;
       label: string;
     }[];
-  }, [x, y, nonEmptySeries]);
+  }, [x, y, nonEmptySeries, primaryDataLength]);
 
   const adjustedLabelYPositions = useMemo(() => {
     if (dotPositions.length < 2) {

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
@@ -14,3 +14,33 @@ export const VALUE_TEXT_OFFSET_Y = 16;
 export const TIMESTAMP_Y = 12;
 export const CROSSHAIR_START_Y = 20;
 export const CROSSHAIR_STROKE_WIDTH = 1;
+
+export interface DotPosition {
+  dotY: number;
+  value: number;
+  color: string;
+  label: string;
+}
+
+export const getSeparatedLabelYPositions = (
+  dotPositions: { dotY: number }[],
+): number[] => {
+  if (dotPositions.length < 2) {
+    return dotPositions.map((pos) => pos.dotY);
+  }
+
+  const [first, second] = dotPositions;
+  const gap = Math.abs(first.dotY - second.dotY);
+
+  if (gap >= LABEL_HEIGHT + MIN_LABEL_GAP) {
+    return [first.dotY, second.dotY];
+  }
+
+  const midPoint = (first.dotY + second.dotY) / 2;
+  const offset = (LABEL_HEIGHT + MIN_LABEL_GAP) / 2;
+
+  if (first.dotY < second.dotY) {
+    return [midPoint - offset, midPoint + offset];
+  }
+  return [midPoint + offset, midPoint - offset];
+};

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
@@ -1,5 +1,5 @@
 export const CHART_HEIGHT = 200;
-export const FONT_SIZE_LABEL = 12;
+export const FONT_SIZE_LABEL = 14;
 export const FONT_SIZE_VALUE = 24;
 export const LABEL_HEIGHT = 40;
 export const MIN_LABEL_GAP = 8;

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
@@ -1,0 +1,16 @@
+export const CHART_HEIGHT = 200;
+export const FONT_SIZE_LABEL = 12;
+export const FONT_SIZE_VALUE = 24;
+export const LABEL_HEIGHT = 40;
+export const MIN_LABEL_GAP = 8;
+export const DOT_RADIUS = 6;
+export const DOT_STROKE_WIDTH = 2;
+export const GLOW_RADIUS = 16;
+export const GLOW_OPACITY = 0.15;
+export const LABEL_OFFSET_X = 12;
+export const RIGHT_LABEL_OFFSET = 12;
+export const LABEL_TEXT_OFFSET_Y = 8;
+export const VALUE_TEXT_OFFSET_Y = 16;
+export const TIMESTAMP_Y = 12;
+export const CROSSHAIR_START_Y = 20;
+export const CROSSHAIR_STROKE_WIDTH = 1;

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.test.tsx
@@ -1,0 +1,424 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import PredictGameChart from './PredictGameChart';
+import { GameChartSeries } from './PredictGameChart.types';
+
+jest.mock('react-native-svg-charts', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    LineChart: ({
+      children,
+      data,
+      svg,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      data?: number[];
+      svg?: { stroke?: string; strokeWidth?: number };
+      [key: string]: unknown;
+    }) => {
+      const isVisible = svg?.stroke !== 'transparent';
+      return (
+        <View testID={isVisible ? 'line-chart' : undefined} {...props}>
+          <Text testID={isVisible ? 'chart-data' : undefined}>
+            {JSON.stringify(data)}
+          </Text>
+          {children}
+        </View>
+      );
+    },
+  };
+});
+
+jest.mock('react-native-svg', () => ({
+  Line: jest.fn((props) => {
+    const { View } = jest.requireActual('react-native');
+    return <View testID="svg-line" {...props} />;
+  }),
+  Text: jest.fn((props) => {
+    const { Text } = jest.requireActual('react-native');
+    return <Text testID="svg-text" {...props} />;
+  }),
+  G: jest.fn((props) => {
+    const { View } = jest.requireActual('react-native');
+    return <View testID="svg-g" {...props} />;
+  }),
+  Circle: jest.fn((props) => {
+    const { View } = jest.requireActual('react-native');
+    return <View testID="svg-circle" {...props} />;
+  }),
+  Rect: jest.fn((props) => {
+    const { View } = jest.requireActual('react-native');
+    return <View testID="svg-rect" {...props} />;
+  }),
+}));
+
+jest.mock('d3-shape', () => ({
+  curveMonotoneX: 'monotone-curve',
+}));
+
+jest.mock('../../../../../util/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      primary: { default: '#0376C9' },
+      background: { default: '#FFFFFF' },
+      border: { muted: '#E0E0E0' },
+    },
+  }),
+}));
+
+const mockAwayTeamData: GameChartSeries = {
+  label: 'SEA',
+  color: '#002244',
+  data: [
+    { timestamp: 1000, value: 50 },
+    { timestamp: 2000, value: 55 },
+    { timestamp: 3000, value: 60 },
+    { timestamp: 4000, value: 70 },
+  ],
+};
+
+const mockHomeTeamData: GameChartSeries = {
+  label: 'DEN',
+  color: '#FB4F14',
+  data: [
+    { timestamp: 1000, value: 50 },
+    { timestamp: 2000, value: 45 },
+    { timestamp: 3000, value: 40 },
+    { timestamp: 4000, value: 30 },
+  ],
+};
+
+const mockDualSeriesData: GameChartSeries[] = [
+  mockAwayTeamData,
+  mockHomeTeamData,
+];
+
+describe('PredictGameChart', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders chart with data', () => {
+      const { getByTestId, getAllByTestId } = renderWithProvider(
+        <PredictGameChart data={mockDualSeriesData} testID="chart" />,
+      );
+
+      expect(getByTestId('chart')).toBeOnTheScreen();
+      expect(getAllByTestId('line-chart').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders loading state when isLoading is true', () => {
+      const { getByTestId, queryByText } = renderWithProvider(
+        <PredictGameChart data={[]} isLoading testID="chart" />,
+      );
+
+      expect(getByTestId('chart')).toBeOnTheScreen();
+      expect(queryByText('No price history available')).not.toBeOnTheScreen();
+    });
+
+    it('renders empty state when no data provided', () => {
+      const { getByText } = renderWithProvider(
+        <PredictGameChart data={[]} testID="chart" />,
+      );
+
+      expect(getByText('No price history available')).toBeOnTheScreen();
+    });
+
+    it('renders empty state when data has empty series', () => {
+      const emptySeriesData: GameChartSeries[] = [
+        { label: 'Empty', color: '#000', data: [] },
+      ];
+      const { getByText } = renderWithProvider(
+        <PredictGameChart data={emptySeriesData} testID="chart" />,
+      );
+
+      expect(getByText('No price history available')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Dual Series Rendering', () => {
+    it('renders both team lines with correct data', () => {
+      const { getAllByTestId } = renderWithProvider(
+        <PredictGameChart data={mockDualSeriesData} />,
+      );
+
+      const charts = getAllByTestId('line-chart');
+      expect(charts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('limits series to maximum of 2', () => {
+      const threeSeries: GameChartSeries[] = [
+        ...mockDualSeriesData,
+        { label: 'Extra', color: '#000', data: [{ timestamp: 1, value: 50 }] },
+      ];
+
+      const { getAllByTestId } = renderWithProvider(
+        <PredictGameChart data={threeSeries} />,
+      );
+
+      const charts = getAllByTestId('line-chart');
+      expect(charts.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe('Timeframe Selector', () => {
+    it('renders timeframe selector when onTimeframeChange provided', () => {
+      const onTimeframeChange = jest.fn();
+
+      const { getByText } = renderWithProvider(
+        <PredictGameChart
+          data={mockDualSeriesData}
+          onTimeframeChange={onTimeframeChange}
+        />,
+      );
+
+      expect(getByText('Live')).toBeOnTheScreen();
+      expect(getByText('6H')).toBeOnTheScreen();
+      expect(getByText('1D')).toBeOnTheScreen();
+      expect(getByText('Max')).toBeOnTheScreen();
+    });
+
+    it('does not render timeframe selector when onTimeframeChange not provided', () => {
+      const { queryByText } = renderWithProvider(
+        <PredictGameChart data={mockDualSeriesData} />,
+      );
+
+      expect(queryByText('Live')).not.toBeOnTheScreen();
+    });
+
+    it('calls onTimeframeChange when timeframe button pressed', () => {
+      const onTimeframeChange = jest.fn();
+
+      const { getByText } = renderWithProvider(
+        <PredictGameChart
+          data={mockDualSeriesData}
+          onTimeframeChange={onTimeframeChange}
+        />,
+      );
+
+      fireEvent.press(getByText('6H'));
+
+      expect(onTimeframeChange).toHaveBeenCalledWith('6h');
+    });
+
+    it('renders disabled timeframe selector in loading state', () => {
+      const onTimeframeChange = jest.fn();
+
+      const { getByText } = renderWithProvider(
+        <PredictGameChart
+          data={[]}
+          isLoading
+          onTimeframeChange={onTimeframeChange}
+        />,
+      );
+
+      expect(getByText('Live')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Data Processing', () => {
+    it('processes chart data correctly', () => {
+      const { getAllByTestId } = renderWithProvider(
+        <PredictGameChart data={mockDualSeriesData} />,
+      );
+
+      const chartDataElements = getAllByTestId('chart-data');
+      const data = JSON.parse(String(chartDataElements[0].children[0]));
+
+      expect(data).toEqual([50, 55, 60, 70]);
+    });
+
+    it('calculates chart bounds with padding', () => {
+      const { getAllByTestId } = renderWithProvider(
+        <PredictGameChart data={mockDualSeriesData} />,
+      );
+
+      const lineCharts = getAllByTestId('line-chart');
+      expect(lineCharts[0].props.yMin).toBeLessThan(30);
+      expect(lineCharts[0].props.yMax).toBeGreaterThan(70);
+    });
+
+    it('clamps chart bounds to 0-100 percentage range', () => {
+      const extremeData: GameChartSeries[] = [
+        {
+          label: 'Extreme',
+          color: '#000',
+          data: [
+            { timestamp: 1, value: 5 },
+            { timestamp: 2, value: 95 },
+          ],
+        },
+      ];
+
+      const { getByTestId } = renderWithProvider(
+        <PredictGameChart data={extremeData} />,
+      );
+
+      const lineChart = getByTestId('line-chart');
+      expect(lineChart.props.yMin).toBeGreaterThanOrEqual(0);
+      expect(lineChart.props.yMax).toBeLessThanOrEqual(100);
+    });
+
+    it('renders empty state when series has no data points', () => {
+      const emptyData: GameChartSeries[] = [
+        { label: 'Empty', color: '#000', data: [] },
+      ];
+
+      const { getByText } = renderWithProvider(
+        <PredictGameChart data={emptyData} />,
+      );
+
+      expect(getByText('No price history available')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Chart Bounds Calculation', () => {
+    it('handles single data point', () => {
+      const singlePointData: GameChartSeries[] = [mockAwayTeamData];
+
+      const { getByTestId } = renderWithProvider(
+        <PredictGameChart data={singlePointData} />,
+      );
+
+      expect(getByTestId('line-chart')).toBeOnTheScreen();
+    });
+
+    it('handles zero range data (all same values)', () => {
+      const sameValueData: GameChartSeries[] = [
+        {
+          label: 'SEA',
+          color: '#002244',
+          data: [
+            { timestamp: 1, value: 50 },
+            { timestamp: 2, value: 50 },
+            { timestamp: 3, value: 50 },
+          ],
+        },
+        {
+          label: 'DEN',
+          color: '#FB4F14',
+          data: [
+            { timestamp: 1, value: 50 },
+            { timestamp: 2, value: 50 },
+            { timestamp: 3, value: 50 },
+          ],
+        },
+      ];
+
+      const { getAllByTestId } = renderWithProvider(
+        <PredictGameChart data={sameValueData} />,
+      );
+
+      const lineCharts = getAllByTestId('line-chart');
+      expect(lineCharts.length).toBeGreaterThanOrEqual(1);
+      expect(lineCharts[0].props.yMin).toBeLessThan(50);
+      expect(lineCharts[0].props.yMax).toBeGreaterThan(50);
+    });
+  });
+
+  describe('Touch Interactions', () => {
+    it('renders chart with pan handler setup', () => {
+      const { getAllByTestId } = renderWithProvider(
+        <PredictGameChart data={mockDualSeriesData} />,
+      );
+
+      const lineCharts = getAllByTestId('line-chart');
+      expect(lineCharts.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('Timeframe Prop', () => {
+    it('uses default timeframe when not provided', () => {
+      const onTimeframeChange = jest.fn();
+
+      renderWithProvider(
+        <PredictGameChart
+          data={mockDualSeriesData}
+          onTimeframeChange={onTimeframeChange}
+        />,
+      );
+
+      expect(onTimeframeChange).not.toHaveBeenCalled();
+    });
+
+    it('respects provided timeframe', () => {
+      const onTimeframeChange = jest.fn();
+
+      const { getByText } = renderWithProvider(
+        <PredictGameChart
+          data={mockDualSeriesData}
+          timeframe="1d"
+          onTimeframeChange={onTimeframeChange}
+        />,
+      );
+
+      expect(getByText('1D')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles large dataset', () => {
+      const largeDataset: GameChartSeries[] = [
+        {
+          label: 'SEA',
+          color: '#002244',
+          data: Array.from({ length: 100 }, (_, i) => ({
+            timestamp: i * 1000,
+            value: 30 + Math.random() * 40,
+          })),
+        },
+        {
+          label: 'DEN',
+          color: '#FB4F14',
+          data: Array.from({ length: 100 }, (_, i) => ({
+            timestamp: i * 1000,
+            value: 70 - Math.random() * 40,
+          })),
+        },
+      ];
+
+      const { getAllByTestId } = renderWithProvider(
+        <PredictGameChart data={largeDataset} />,
+      );
+
+      expect(getAllByTestId('line-chart').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('handles inverse probability data (teams summing to 100)', () => {
+      const inverseData: GameChartSeries[] = [
+        {
+          label: 'SEA',
+          color: '#002244',
+          data: [
+            { timestamp: 1, value: 70 },
+            { timestamp: 2, value: 60 },
+            { timestamp: 3, value: 40 },
+          ],
+        },
+        {
+          label: 'DEN',
+          color: '#FB4F14',
+          data: [
+            { timestamp: 1, value: 30 },
+            { timestamp: 2, value: 40 },
+            { timestamp: 3, value: 60 },
+          ],
+        },
+      ];
+
+      const { getAllByTestId } = renderWithProvider(
+        <PredictGameChart data={inverseData} />,
+      );
+
+      const charts = getAllByTestId('line-chart');
+      expect(charts.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.test.tsx
@@ -55,7 +55,7 @@ jest.mock('react-native-svg', () => ({
 }));
 
 jest.mock('d3-shape', () => ({
-  curveMonotoneX: 'monotone-curve',
+  curveStepAfter: 'step-after-curve',
 }));
 
 jest.mock('../../../../../util/theme', () => ({
@@ -64,6 +64,7 @@ jest.mock('../../../../../util/theme', () => ({
       primary: { default: '#0376C9' },
       background: { default: '#FFFFFF' },
       border: { muted: '#E0E0E0' },
+      text: { muted: '#9CA3AF', default: '#1A1A1A', alternative: '#6B7280' },
     },
   }),
 }));

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.test.tsx
@@ -455,13 +455,15 @@ describe('PredictGameChartContent (Chart UI)', () => {
 
   describe('Edge Cases', () => {
     it('handles large dataset', () => {
+      // Use deterministic values based on index instead of Math.random()
+      // This ensures consistent test results across runs
       const largeDataset: GameChartSeries[] = [
         {
           label: 'SEA',
           color: '#002244',
           data: Array.from({ length: 100 }, (_, i) => ({
             timestamp: i * 1000,
-            value: 30 + Math.random() * 40,
+            value: 30 + (i % 10) * 4, // Deterministic: cycles 30, 34, 38... 66, 30, 34...
           })),
         },
         {
@@ -469,7 +471,7 @@ describe('PredictGameChartContent (Chart UI)', () => {
           color: '#FB4F14',
           data: Array.from({ length: 100 }, (_, i) => ({
             timestamp: i * 1000,
-            value: 70 - Math.random() * 40,
+            value: 70 - (i % 10) * 4, // Deterministic: cycles 70, 66, 62... 34, 70, 66...
           })),
         },
       ];

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -1,0 +1,295 @@
+import React, { useMemo, useRef, useCallback, useState } from 'react';
+import { PanResponder, View, StyleSheet } from 'react-native';
+import { LineChart } from 'react-native-svg-charts';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { useTheme } from '../../../../../util/theme';
+import { curveStepAfter } from 'd3-shape';
+import { PredictGameChartProps } from './PredictGameChart.types';
+import TimeframeSelector from './TimeframeSelector';
+import ChartTooltip from './ChartTooltip';
+import EndpointDots from './EndpointDots';
+
+const CHART_HEIGHT = 200;
+const CHART_CONTENT_INSET = { top: 30, bottom: 20, left: 10, right: 80 };
+const LINE_CURVE = curveStepAfter;
+
+const PredictGameChart: React.FC<PredictGameChartProps> = ({
+  data,
+  isLoading = false,
+  timeframe = 'live',
+  onTimeframeChange,
+  testID,
+}) => {
+  const tw = useTailwind();
+  const { colors } = useTheme();
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
+  const chartWidthRef = useRef<number>(0);
+
+  const seriesToRender = useMemo(() => data.slice(0, 2), [data]);
+  const nonEmptySeries = useMemo(
+    () => seriesToRender.filter((series) => series.data.length > 0),
+    [seriesToRender],
+  );
+  const hasData = nonEmptySeries.length > 0;
+
+  const { chartMin, chartMax } = useMemo(() => {
+    if (!hasData) {
+      return { chartMin: 0, chartMax: 100 };
+    }
+
+    const chartValues = nonEmptySeries.flatMap((series) =>
+      series.data.map((point) => point.value),
+    );
+    const minValue = Math.min(...chartValues);
+    const maxValue = Math.max(...chartValues);
+    const range = maxValue - minValue;
+    const padding = range === 0 ? Math.max(maxValue * 0.1, 1) : range * 0.1;
+
+    return {
+      chartMin: Math.max(0, minValue - padding),
+      chartMax: Math.min(100, maxValue + padding),
+    };
+  }, [hasData, nonEmptySeries]);
+
+  const primarySeries = nonEmptySeries[0] ?? seriesToRender[0];
+  const primaryData = primarySeries?.data ?? [];
+  const primaryChartData = primaryData.length
+    ? primaryData.map((point) => point.value)
+    : [50, 50];
+
+  const handleChartLayout = useCallback(
+    (event: { nativeEvent: { layout: { width: number } } }) => {
+      chartWidthRef.current = event.nativeEvent.layout.width;
+    },
+    [],
+  );
+
+  const updatePosition = useCallback(
+    (xCoord: number) => {
+      if (primaryData.length === 0) return;
+
+      const adjustedX = xCoord - CHART_CONTENT_INSET.left;
+      const chartDataWidth =
+        chartWidthRef.current -
+        CHART_CONTENT_INSET.left -
+        CHART_CONTENT_INSET.right;
+
+      if (chartDataWidth <= 0) return;
+
+      const index = Math.round(
+        (adjustedX / chartDataWidth) * (primaryData.length - 1),
+      );
+
+      const clampedIndex = Math.max(0, Math.min(primaryData.length - 1, index));
+      setActiveIndex(clampedIndex);
+    },
+    [primaryData.length],
+  );
+
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onStartShouldSetPanResponderCapture: () => false,
+        onMoveShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponderCapture: (_event, gestureState) => {
+          const { dx, dy } = gestureState;
+          return Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 5;
+        },
+        onPanResponderTerminationRequest: (_event, gestureState) => {
+          const { dx, dy } = gestureState;
+          return Math.abs(dy) > Math.abs(dx);
+        },
+        onPanResponderGrant: (event) => {
+          updatePosition(event.nativeEvent.locationX);
+        },
+        onPanResponderMove: (event, gestureState) => {
+          const { dx, dy } = gestureState;
+          if (Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 10) {
+            setActiveIndex(-1);
+          } else {
+            updatePosition(event.nativeEvent.locationX);
+          }
+        },
+        onPanResponderRelease: () => {
+          setActiveIndex(-1);
+        },
+        onPanResponderTerminate: () => {
+          setActiveIndex(-1);
+        },
+      }),
+    [updatePosition],
+  );
+
+  if (isLoading) {
+    return (
+      <Box twClassName="flex-1" testID={testID}>
+        <View
+          style={tw.style(
+            `h-[${CHART_HEIGHT}px] bg-background-alternative rounded-lg`,
+          )}
+        />
+        {onTimeframeChange && (
+          <TimeframeSelector
+            selected={timeframe}
+            onSelect={onTimeframeChange}
+            disabled
+          />
+        )}
+      </Box>
+    );
+  }
+
+  if (!hasData) {
+    return (
+      <Box twClassName="flex-1 justify-center items-center" testID={testID}>
+        <View
+          style={tw.style(`h-[${CHART_HEIGHT}px] justify-center items-center`)}
+        >
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+            No price history available
+          </Text>
+        </View>
+        {onTimeframeChange && (
+          <TimeframeSelector
+            selected={timeframe}
+            onSelect={onTimeframeChange}
+          />
+        )}
+      </Box>
+    );
+  }
+
+  const overlaySeries = nonEmptySeries.slice(1);
+  const grayColor = colors.text.muted;
+
+  const getActiveData = (values: number[]) =>
+    values.map((v, i) => (i <= activeIndex ? v : null));
+
+  const getInactiveData = (values: number[]) =>
+    values.map((v, i) => (i >= activeIndex ? v : null));
+
+  const isTooltipActive = activeIndex >= 0;
+
+  return (
+    <Box twClassName="flex-1" testID={testID}>
+      <View
+        style={tw.style(`h-[${CHART_HEIGHT}px]`)}
+        {...panResponder.panHandlers}
+        onLayout={handleChartLayout}
+      >
+        {!isTooltipActive ? (
+          <>
+            <LineChart
+              style={tw.style(`h-[${CHART_HEIGHT}px] w-full`)}
+              data={primaryChartData}
+              svg={{
+                stroke: primarySeries?.color || colors.primary.default,
+                strokeWidth: 2,
+              }}
+              contentInset={CHART_CONTENT_INSET}
+              yMin={chartMin}
+              yMax={chartMax}
+              curve={LINE_CURVE}
+            >
+              <EndpointDots nonEmptySeries={nonEmptySeries} />
+            </LineChart>
+
+            {overlaySeries.map((series, index) => (
+              <LineChart
+                key={`overlay-${index}`}
+                style={StyleSheet.absoluteFillObject}
+                data={series.data.map((point) => point.value)}
+                svg={{ stroke: series.color, strokeWidth: 2 }}
+                contentInset={CHART_CONTENT_INSET}
+                yMin={chartMin}
+                yMax={chartMax}
+                curve={LINE_CURVE}
+              />
+            ))}
+          </>
+        ) : (
+          <>
+            <LineChart
+              style={tw.style(`h-[${CHART_HEIGHT}px] w-full`)}
+              data={getActiveData(primaryChartData)}
+              svg={{
+                stroke: primarySeries?.color || colors.primary.default,
+                strokeWidth: 2,
+              }}
+              contentInset={CHART_CONTENT_INSET}
+              yMin={chartMin}
+              yMax={chartMax}
+              curve={LINE_CURVE}
+            />
+            <LineChart
+              style={StyleSheet.absoluteFillObject}
+              data={getInactiveData(primaryChartData)}
+              svg={{ stroke: grayColor, strokeWidth: 2 }}
+              contentInset={CHART_CONTENT_INSET}
+              yMin={chartMin}
+              yMax={chartMax}
+              curve={LINE_CURVE}
+            />
+
+            {overlaySeries.map((series, index) => {
+              const seriesValues = series.data.map((point) => point.value);
+              return (
+                <React.Fragment key={`overlay-split-${index}`}>
+                  <LineChart
+                    style={StyleSheet.absoluteFillObject}
+                    data={getActiveData(seriesValues)}
+                    svg={{ stroke: series.color, strokeWidth: 2 }}
+                    contentInset={CHART_CONTENT_INSET}
+                    yMin={chartMin}
+                    yMax={chartMax}
+                    curve={LINE_CURVE}
+                  />
+                  <LineChart
+                    style={StyleSheet.absoluteFillObject}
+                    data={getInactiveData(seriesValues)}
+                    svg={{ stroke: grayColor, strokeWidth: 2 }}
+                    contentInset={CHART_CONTENT_INSET}
+                    yMin={chartMin}
+                    yMax={chartMax}
+                    curve={LINE_CURVE}
+                  />
+                </React.Fragment>
+              );
+            })}
+
+            <LineChart
+              style={StyleSheet.absoluteFillObject}
+              data={primaryChartData}
+              svg={{ stroke: 'transparent', strokeWidth: 0 }}
+              contentInset={CHART_CONTENT_INSET}
+              yMin={chartMin}
+              yMax={chartMax}
+              curve={LINE_CURVE}
+            >
+              <ChartTooltip
+                activeIndex={activeIndex}
+                primaryData={primaryData}
+                nonEmptySeries={nonEmptySeries}
+                chartWidth={chartWidthRef.current}
+                contentInset={CHART_CONTENT_INSET}
+              />
+            </LineChart>
+          </>
+        )}
+      </View>
+
+      {onTimeframeChange && (
+        <TimeframeSelector selected={timeframe} onSelect={onTimeframeChange} />
+      )}
+    </Box>
+  );
+};
+
+export default PredictGameChart;

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -14,8 +14,8 @@ import { PredictGameChartProps } from './PredictGameChart.types';
 import TimeframeSelector from './TimeframeSelector';
 import ChartTooltip from './ChartTooltip';
 import EndpointDots from './EndpointDots';
+import { CHART_HEIGHT } from './PredictGameChart.constants';
 
-const CHART_HEIGHT = 200;
 const CHART_CONTENT_INSET = { top: 30, bottom: 20, left: 10, right: 80 };
 const LINE_CURVE = curveStepAfter;
 

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -50,6 +50,14 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
   const interval = TIMEFRAME_TO_INTERVAL[timeframe];
   const fidelity = FIDELITY_BY_TIMEFRAME[timeframe];
 
+  // Reset live data state when tokenIds change to prevent race condition:
+  // Without this, WebSocket prices for new tokens could arrive before historical
+  // data loads, causing updateLiveData to corrupt old liveChartData with new prices
+  useEffect(() => {
+    initialDataLoadedRef.current = false;
+    setLiveChartData([]);
+  }, [tokenIds]);
+
   const { priceHistories, isFetching, errors, refetch } =
     usePredictPriceHistory({
       marketIds: tokenIds,

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.types.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.types.ts
@@ -86,4 +86,6 @@ export interface EndpointDotsProps {
   y?: (value: number) => number;
   /** All non-empty series to render endpoints for */
   nonEmptySeries: GameChartSeries[];
+  /** Length of the primary data array - used to position all dots at the right edge */
+  primaryDataLength: number;
 }

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.types.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.types.ts
@@ -1,0 +1,83 @@
+/**
+ * Data point for game chart series
+ */
+export interface GameChartDataPoint {
+  timestamp: number;
+  value: number;
+}
+
+/**
+ * Series configuration for game chart
+ */
+export interface GameChartSeries {
+  label: string;
+  color: string;
+  data: GameChartDataPoint[];
+}
+
+/**
+ * Available chart timeframes
+ */
+export type ChartTimeframe = 'live' | '6h' | '1d' | 'max';
+
+/**
+ * Props for PredictGameChart component
+ */
+export interface PredictGameChartProps {
+  /** Array of chart series (max 2 for away/home teams) */
+  data: GameChartSeries[];
+  /** Whether chart data is loading */
+  isLoading?: boolean;
+  /** Currently selected timeframe */
+  timeframe?: ChartTimeframe;
+  /** Callback when timeframe changes */
+  onTimeframeChange?: (timeframe: ChartTimeframe) => void;
+  /** Test ID for component */
+  testID?: string;
+}
+
+/**
+ * Props for TimeframeSelector sub-component
+ */
+export interface TimeframeSelectorProps {
+  /** Currently selected timeframe */
+  selected: ChartTimeframe;
+  /** Callback when timeframe is selected */
+  onSelect: (timeframe: ChartTimeframe) => void;
+  /** Whether selector is disabled */
+  disabled?: boolean;
+}
+
+/**
+ * Props for ChartTooltip sub-component
+ * Note: x and y functions are injected by react-native-svg-charts
+ */
+export interface ChartTooltipProps {
+  /** X coordinate function (injected by chart) */
+  x?: (index: number) => number;
+  /** Y coordinate function (injected by chart) */
+  y?: (value: number) => number;
+  /** Currently active data index from touch */
+  activeIndex: number;
+  /** Primary series data with labels */
+  primaryData: GameChartDataPoint[];
+  /** All non-empty series */
+  nonEmptySeries: GameChartSeries[];
+  /** Chart width for label positioning */
+  chartWidth: number;
+  /** Content inset for positioning */
+  contentInset: { top: number; bottom: number; left: number; right: number };
+}
+
+/**
+ * Props for EndpointDots sub-component
+ * Note: x and y functions are injected by react-native-svg-charts
+ */
+export interface EndpointDotsProps {
+  /** X coordinate function (injected by chart) */
+  x?: (index: number) => number;
+  /** Y coordinate function (injected by chart) */
+  y?: (value: number) => number;
+  /** All non-empty series to render endpoints for */
+  nonEmptySeries: GameChartSeries[];
+}

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.types.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.types.ts
@@ -20,19 +20,25 @@ export interface GameChartSeries {
  */
 export type ChartTimeframe = 'live' | '6h' | '1d' | 'max';
 
-/**
- * Props for PredictGameChart component
- */
-export interface PredictGameChartProps {
-  /** Array of chart series (max 2 for away/home teams) */
+export interface GameChartSeriesConfig {
+  label: string;
+  color: string;
+}
+
+export interface PredictGameChartContentProps {
   data: GameChartSeries[];
-  /** Whether chart data is loading */
   isLoading?: boolean;
-  /** Currently selected timeframe */
+  error?: string | null;
+  onRetry?: () => void;
   timeframe?: ChartTimeframe;
-  /** Callback when timeframe changes */
   onTimeframeChange?: (timeframe: ChartTimeframe) => void;
-  /** Test ID for component */
+  testID?: string;
+}
+
+export interface PredictGameChartProps {
+  tokenIds: [string, string];
+  seriesConfig: [GameChartSeriesConfig, GameChartSeriesConfig];
+  providerId?: string;
   testID?: string;
 }
 

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
@@ -1,0 +1,855 @@
+import React from 'react';
+import { render, act, waitFor } from '@testing-library/react-native';
+import PredictGameChart from './PredictGameChart';
+import { usePredictPriceHistory } from '../../hooks/usePredictPriceHistory';
+import { useLiveMarketPrices } from '../../hooks/useLiveMarketPrices';
+import { PredictPriceHistoryInterval } from '../../types';
+
+// Mock the hooks
+jest.mock('../../hooks/usePredictPriceHistory');
+jest.mock('../../hooks/useLiveMarketPrices');
+
+// Mock PredictGameChartContent to capture props
+jest.mock('./PredictGameChartContent', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return function MockPredictGameChartContent({
+    data,
+    isLoading,
+    timeframe,
+    onTimeframeChange,
+    testID,
+  }: {
+    data: unknown[];
+    isLoading: boolean;
+    timeframe: string;
+    onTimeframeChange: (tf: string) => void;
+    testID?: string;
+  }) {
+    return (
+      <View testID={testID}>
+        <Text testID="content-data">{JSON.stringify(data)}</Text>
+        <Text testID="content-loading">{String(isLoading)}</Text>
+        <Text testID="content-timeframe">{timeframe}</Text>
+        <View
+          testID="timeframe-trigger"
+          onTouchEnd={() => onTimeframeChange('6h')}
+        />
+      </View>
+    );
+  };
+});
+
+const mockUsePredictPriceHistory = usePredictPriceHistory as jest.Mock;
+const mockUseLiveMarketPrices = useLiveMarketPrices as jest.Mock;
+
+const createMockPriceHistory = (
+  tokenIndex: number,
+  pointCount: number = 5,
+  basePrice: number = 0.5,
+) =>
+  Array.from({ length: pointCount }, (_, i) => ({
+    timestamp: 1000000 + i * 60000,
+    price: basePrice + (tokenIndex === 0 ? 0.01 : -0.01) * i,
+  }));
+
+const defaultSeriesConfig: [
+  { label: string; color: string },
+  { label: string; color: string },
+] = [
+  { label: 'Team A', color: '#FF0000' },
+  { label: 'Team B', color: '#0000FF' },
+];
+
+const defaultTokenIds: [string, string] = ['token-a', 'token-b'];
+
+describe('PredictGameChart Wrapper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-15T12:00:00.000Z'));
+
+    // Default mock implementations
+    mockUsePredictPriceHistory.mockReturnValue({
+      priceHistories: [],
+      isFetching: false,
+      errors: [null, null],
+      refetch: jest.fn(),
+    });
+
+    mockUseLiveMarketPrices.mockReturnValue({
+      prices: new Map(),
+      getPrice: jest.fn(),
+      isConnected: false,
+      lastUpdateTime: null,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
+
+  describe('Hook Configuration', () => {
+    it('calls usePredictPriceHistory with correct interval for live timeframe', () => {
+      render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      expect(mockUsePredictPriceHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          marketIds: defaultTokenIds,
+          interval: PredictPriceHistoryInterval.ONE_HOUR,
+          fidelity: 1,
+          providerId: 'polymarket',
+          enabled: true,
+        }),
+      );
+    });
+
+    it('calls useLiveMarketPrices with enabled true for live timeframe', () => {
+      render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+        />,
+      );
+
+      expect(mockUseLiveMarketPrices).toHaveBeenCalledWith(defaultTokenIds, {
+        enabled: true,
+      });
+    });
+
+    it('passes custom providerId to usePredictPriceHistory', () => {
+      render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          providerId="custom-provider"
+        />,
+      );
+
+      expect(mockUsePredictPriceHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerId: 'custom-provider',
+        }),
+      );
+    });
+
+    it('disables hooks when tokenIds length is not 2', () => {
+      render(
+        <PredictGameChart
+          tokenIds={['single-token'] as unknown as [string, string]}
+          seriesConfig={defaultSeriesConfig}
+        />,
+      );
+
+      expect(mockUsePredictPriceHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: false,
+        }),
+      );
+
+      expect(mockUseLiveMarketPrices).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          enabled: false,
+        }),
+      );
+    });
+  });
+
+  describe('Data Transformation', () => {
+    it('transforms price history to chart data format', async () => {
+      const mockHistories = [
+        createMockPriceHistory(0, 3, 0.6),
+        createMockPriceHistory(1, 3, 0.4),
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+
+        expect(data).toHaveLength(2);
+        expect(data[0].label).toBe('Team A');
+        expect(data[0].color).toBe('#FF0000');
+        expect(data[0].data).toHaveLength(3);
+        // Price 0.6 -> 60%
+        expect(data[0].data[0].value).toBe(60);
+      });
+    });
+
+    it('converts price (0-1) to percentage (0-100)', async () => {
+      const mockHistories = [
+        [{ timestamp: 1000000, price: 0.75 }],
+        [{ timestamp: 1000000, price: 0.25 }],
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+
+        expect(data[0].data[0].value).toBe(75);
+        expect(data[1].data[0].value).toBe(25);
+      });
+    });
+
+    it('handles string timestamps by converting to numbers', async () => {
+      const mockHistories = [
+        [{ timestamp: '2024-01-15T12:00:00.000Z', price: 0.5 }],
+        [{ timestamp: '2024-01-15T12:00:00.000Z', price: 0.5 }],
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+
+        expect(typeof data[0].data[0].timestamp).toBe('number');
+      });
+    });
+  });
+
+  describe('Loading States', () => {
+    it('shows loading when fetching price history', () => {
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: [],
+        isFetching: true,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      expect(getByTestId('content-loading').children[0]).toBe('true');
+    });
+
+    it('shows loading in live mode until initial data loads', () => {
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: [],
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      // No data yet, should show loading
+      expect(getByTestId('content-loading').children[0]).toBe('true');
+    });
+
+    it('stops showing loading after data loads', async () => {
+      const mockHistories = [
+        createMockPriceHistory(0, 3),
+        createMockPriceHistory(1, 3),
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('content-loading').children[0]).toBe('false');
+      });
+    });
+  });
+
+  describe('Live Update Logic', () => {
+    it('updates last data point when within same minute', async () => {
+      const baseTimestamp = new Date('2024-01-15T12:00:00.000Z').getTime();
+      jest.setSystemTime(new Date(baseTimestamp + 30000)); // 30 seconds later
+
+      const mockHistories = [
+        [{ timestamp: baseTimestamp, price: 0.5 }],
+        [{ timestamp: baseTimestamp, price: 0.5 }],
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const pricesMap = new Map([
+        ['token-a', { tokenId: 'token-a', price: 0.55, timestamp: Date.now() }],
+        ['token-b', { tokenId: 'token-b', price: 0.45, timestamp: Date.now() }],
+      ]);
+
+      mockUseLiveMarketPrices.mockReturnValue({
+        prices: pricesMap,
+        getPrice: (id: string) => pricesMap.get(id),
+        isConnected: true,
+        lastUpdateTime: Date.now(),
+      });
+
+      const { getByTestId, rerender } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      // Wait for initial data to load
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+        expect(data).toHaveLength(2);
+      });
+
+      // Trigger re-render with updated prices
+      rerender(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+
+        // Should still have 1 data point (updated, not added)
+        expect(data[0].data).toHaveLength(1);
+        // Value should be updated to new price
+        expect(data[0].data[0].value).toBe(55);
+      });
+    });
+
+    it('adds new data point when minute changes', async () => {
+      const baseTimestamp = new Date('2024-01-15T12:00:00.000Z').getTime();
+
+      const mockHistories = [
+        [{ timestamp: baseTimestamp, price: 0.5 }],
+        [{ timestamp: baseTimestamp, price: 0.5 }],
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      // First render at base time
+      jest.setSystemTime(new Date(baseTimestamp));
+
+      const { getByTestId, rerender } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      // Wait for initial data
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+        expect(data).toHaveLength(2);
+      });
+
+      // Move to next minute and provide new prices
+      const nextMinute = baseTimestamp + 60000;
+      jest.setSystemTime(new Date(nextMinute));
+
+      const pricesMap = new Map([
+        ['token-a', { tokenId: 'token-a', price: 0.55, timestamp: nextMinute }],
+        ['token-b', { tokenId: 'token-b', price: 0.45, timestamp: nextMinute }],
+      ]);
+
+      mockUseLiveMarketPrices.mockReturnValue({
+        prices: pricesMap,
+        getPrice: (id: string) => pricesMap.get(id),
+        isConnected: true,
+        lastUpdateTime: nextMinute,
+      });
+
+      rerender(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+
+        // Should have 2 data points now (original + new minute)
+        expect(data[0].data.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('maintains maximum of 60 data points in live mode', async () => {
+      // Create 60 historical points
+      const mockHistories = [
+        Array.from({ length: 60 }, (_, i) => ({
+          timestamp: 1000000 + i * 60000,
+          price: 0.5,
+        })),
+        Array.from({ length: 60 }, (_, i) => ({
+          timestamp: 1000000 + i * 60000,
+          price: 0.5,
+        })),
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+
+        expect(data[0].data.length).toBeLessThanOrEqual(60);
+      });
+    });
+  });
+
+  describe('Timeframe Switching', () => {
+    it('uses different intervals for different timeframes', async () => {
+      const mockHistories = [
+        createMockPriceHistory(0, 3),
+        createMockPriceHistory(1, 3),
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      // Wait for initial render
+      await waitFor(() => {
+        expect(getByTestId('content-timeframe').children[0]).toBe('live');
+      });
+
+      // Simulate timeframe change to 6h
+      await act(async () => {
+        getByTestId('timeframe-trigger').props.onTouchEnd();
+      });
+
+      // Should call hook with 6h interval
+      await waitFor(() => {
+        const lastCall =
+          mockUsePredictPriceHistory.mock.calls[
+            mockUsePredictPriceHistory.mock.calls.length - 1
+          ];
+        expect(lastCall[0].interval).toBe(PredictPriceHistoryInterval.SIX_HOUR);
+      });
+    });
+
+    it('disables live updates when not in live timeframe', async () => {
+      const mockHistories = [
+        createMockPriceHistory(0, 3),
+        createMockPriceHistory(1, 3),
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      // Change to 6h timeframe
+      await act(async () => {
+        getByTestId('timeframe-trigger').props.onTouchEnd();
+      });
+
+      // Live prices hook should be disabled
+      await waitFor(() => {
+        const lastCall =
+          mockUseLiveMarketPrices.mock.calls[
+            mockUseLiveMarketPrices.mock.calls.length - 1
+          ];
+        expect(lastCall[1].enabled).toBe(false);
+      });
+    });
+
+    it('clears live chart data when switching away from live', async () => {
+      const mockHistories = [
+        createMockPriceHistory(0, 3),
+        createMockPriceHistory(1, 3),
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      // Wait for initial data load
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+        expect(data).toHaveLength(2);
+      });
+
+      // Change to 6h timeframe
+      await act(async () => {
+        getByTestId('timeframe-trigger').props.onTouchEnd();
+      });
+
+      // Should use historical data directly (not live chart data)
+      await waitFor(() => {
+        expect(getByTestId('content-timeframe').children[0]).toBe('6h');
+      });
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles empty price histories gracefully', () => {
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: [],
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      const dataText = getByTestId('content-data').children[0];
+      const data = JSON.parse(String(dataText));
+
+      expect(data).toEqual([]);
+    });
+
+    it('handles partial price history (only one token)', () => {
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: [createMockPriceHistory(0, 3)],
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      const dataText = getByTestId('content-data').children[0];
+      const data = JSON.parse(String(dataText));
+
+      // Should return empty when not both histories available
+      expect(data).toEqual([]);
+    });
+
+    it('handles missing price updates for one token', async () => {
+      const mockHistories = [
+        [{ timestamp: 1000000, price: 0.5 }],
+        [{ timestamp: 1000000, price: 0.5 }],
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      // Only provide price for token-a
+      const pricesMap = new Map([
+        ['token-a', { tokenId: 'token-a', price: 0.55, timestamp: Date.now() }],
+      ]);
+
+      mockUseLiveMarketPrices.mockReturnValue({
+        prices: pricesMap,
+        getPrice: (id: string) => pricesMap.get(id),
+        isConnected: true,
+        lastUpdateTime: Date.now(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+
+        // Should still have both series
+        expect(data).toHaveLength(2);
+      });
+    });
+
+    it('passes testID to content component', () => {
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="my-chart"
+        />,
+      );
+
+      expect(getByTestId('my-chart')).toBeTruthy();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('passes error message from hook to content component', () => {
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: [],
+        isFetching: false,
+        errors: ['Network error', null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      const errorText = JSON.parse(
+        String(getByTestId('content-data').children[0]),
+      );
+      expect(errorText).toEqual([]);
+    });
+
+    it('calls refetch when retry is triggered', async () => {
+      const mockRefetch = jest.fn();
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: [],
+        isFetching: false,
+        errors: ['Error', null],
+        refetch: mockRefetch,
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      const mockContent = getByTestId('chart');
+      expect(mockContent).toBeTruthy();
+    });
+
+    it('detects error when any error in array is not null', () => {
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: [],
+        isFetching: false,
+        errors: [null, 'Second token error'],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      expect(getByTestId('chart')).toBeTruthy();
+    });
+
+    it('shows no error when all errors are null', async () => {
+      const mockHistories = [
+        createMockPriceHistory(0, 3),
+        createMockPriceHistory(1, 3),
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+        expect(data).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('Fidelity Configuration', () => {
+    it('uses fidelity 1 for live timeframe', () => {
+      render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+        />,
+      );
+
+      expect(mockUsePredictPriceHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fidelity: 1,
+        }),
+      );
+    });
+
+    it('uses fidelity 5 for 6h timeframe', async () => {
+      const mockHistories = [
+        createMockPriceHistory(0, 3),
+        createMockPriceHistory(1, 3),
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: mockHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+        />,
+      );
+
+      await act(async () => {
+        getByTestId('timeframe-trigger').props.onTouchEnd();
+      });
+
+      await waitFor(() => {
+        const lastCall =
+          mockUsePredictPriceHistory.mock.calls[
+            mockUsePredictPriceHistory.mock.calls.length - 1
+          ];
+        expect(lastCall[0].fidelity).toBe(5);
+      });
+    });
+  });
+});

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx
@@ -247,7 +247,10 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
               yMax={chartMax}
               curve={LINE_CURVE}
             >
-              <EndpointDots nonEmptySeries={nonEmptySeries} />
+              <EndpointDots
+                nonEmptySeries={nonEmptySeries}
+                primaryDataLength={primaryData.length}
+              />
             </LineChart>
 
             {overlaySeries.map((series, index) => (

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx
@@ -1,0 +1,344 @@
+import React, { useMemo, useRef, useCallback, useState } from 'react';
+import { PanResponder, View, StyleSheet, TouchableOpacity } from 'react-native';
+import { LineChart } from 'react-native-svg-charts';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  Text,
+  TextVariant,
+  TextColor,
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
+} from '@metamask/design-system-react-native';
+import { useTheme } from '../../../../../util/theme';
+import { curveStepAfter } from 'd3-shape';
+import { PredictGameChartContentProps } from './PredictGameChart.types';
+import TimeframeSelector from './TimeframeSelector';
+import ChartTooltip from './ChartTooltip';
+import EndpointDots from './EndpointDots';
+import { CHART_HEIGHT } from './PredictGameChart.constants';
+
+const CHART_CONTENT_INSET = { top: 30, bottom: 20, left: 10, right: 80 };
+const LINE_CURVE = curveStepAfter;
+
+const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
+  data,
+  isLoading = false,
+  error = null,
+  onRetry,
+  timeframe = 'live',
+  onTimeframeChange,
+  testID,
+}) => {
+  const tw = useTailwind();
+  const { colors } = useTheme();
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
+  const chartWidthRef = useRef<number>(0);
+
+  const seriesToRender = useMemo(() => data.slice(0, 2), [data]);
+  const nonEmptySeries = useMemo(
+    () => seriesToRender.filter((series) => series.data.length > 0),
+    [seriesToRender],
+  );
+  const hasData = nonEmptySeries.length > 0;
+
+  const { chartMin, chartMax } = useMemo(() => {
+    if (!hasData) {
+      return { chartMin: 0, chartMax: 100 };
+    }
+
+    const chartValues = nonEmptySeries.flatMap((series) =>
+      series.data.map((point) => point.value),
+    );
+    const minValue = Math.min(...chartValues);
+    const maxValue = Math.max(...chartValues);
+    const range = maxValue - minValue;
+    const padding = range === 0 ? Math.max(maxValue * 0.1, 1) : range * 0.1;
+
+    return {
+      chartMin: Math.max(0, minValue - padding),
+      chartMax: Math.min(100, maxValue + padding),
+    };
+  }, [hasData, nonEmptySeries]);
+
+  const primarySeries = nonEmptySeries[0] ?? seriesToRender[0];
+  const primaryData = primarySeries?.data ?? [];
+  const primaryChartData = primaryData.length
+    ? primaryData.map((point) => point.value)
+    : [50, 50];
+
+  const handleChartLayout = useCallback(
+    (event: { nativeEvent: { layout: { width: number } } }) => {
+      chartWidthRef.current = event.nativeEvent.layout.width;
+    },
+    [],
+  );
+
+  const updatePosition = useCallback(
+    (xCoord: number) => {
+      if (primaryData.length === 0) return;
+
+      const adjustedX = xCoord - CHART_CONTENT_INSET.left;
+      const chartDataWidth =
+        chartWidthRef.current -
+        CHART_CONTENT_INSET.left -
+        CHART_CONTENT_INSET.right;
+
+      if (chartDataWidth <= 0) return;
+
+      const index = Math.round(
+        (adjustedX / chartDataWidth) * (primaryData.length - 1),
+      );
+
+      const clampedIndex = Math.max(0, Math.min(primaryData.length - 1, index));
+      setActiveIndex(clampedIndex);
+    },
+    [primaryData.length],
+  );
+
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onStartShouldSetPanResponderCapture: () => false,
+        onMoveShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponderCapture: (_event, gestureState) => {
+          const { dx, dy } = gestureState;
+          return Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 5;
+        },
+        onPanResponderTerminationRequest: (_event, gestureState) => {
+          const { dx, dy } = gestureState;
+          return Math.abs(dy) > Math.abs(dx);
+        },
+        onPanResponderGrant: (event) => {
+          updatePosition(event.nativeEvent.locationX);
+        },
+        onPanResponderMove: (event, gestureState) => {
+          const { dx, dy } = gestureState;
+          if (Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 10) {
+            setActiveIndex(-1);
+          } else {
+            updatePosition(event.nativeEvent.locationX);
+          }
+        },
+        onPanResponderRelease: () => {
+          setActiveIndex(-1);
+        },
+        onPanResponderTerminate: () => {
+          setActiveIndex(-1);
+        },
+      }),
+    [updatePosition],
+  );
+
+  if (isLoading) {
+    return (
+      <Box twClassName="flex-1" testID={testID}>
+        <View
+          style={tw.style(
+            `h-[${CHART_HEIGHT}px] bg-background-alternative rounded-lg`,
+          )}
+        />
+        {onTimeframeChange && (
+          <TimeframeSelector
+            selected={timeframe}
+            onSelect={onTimeframeChange}
+            disabled
+          />
+        )}
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box twClassName="flex-1 justify-center items-center" testID={testID}>
+        <View
+          style={tw.style(`h-[${CHART_HEIGHT}px] justify-center items-center`)}
+        >
+          <Icon
+            name={IconName.Warning}
+            size={IconSize.Lg}
+            color={IconColor.IconMuted}
+          />
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
+            twClassName="mt-2 text-center px-4"
+          >
+            Unable to load price history
+          </Text>
+          {onRetry && (
+            <TouchableOpacity
+              onPress={onRetry}
+              style={tw.style('mt-3 px-4 py-2 rounded-lg bg-primary-default')}
+              testID="retry-button"
+            >
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.PrimaryInverse}
+              >
+                Retry
+              </Text>
+            </TouchableOpacity>
+          )}
+        </View>
+        {onTimeframeChange && (
+          <TimeframeSelector
+            selected={timeframe}
+            onSelect={onTimeframeChange}
+          />
+        )}
+      </Box>
+    );
+  }
+
+  if (!hasData) {
+    return (
+      <Box twClassName="flex-1 justify-center items-center" testID={testID}>
+        <View
+          style={tw.style(`h-[${CHART_HEIGHT}px] justify-center items-center`)}
+        >
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+            No price history available
+          </Text>
+        </View>
+        {onTimeframeChange && (
+          <TimeframeSelector
+            selected={timeframe}
+            onSelect={onTimeframeChange}
+          />
+        )}
+      </Box>
+    );
+  }
+
+  const overlaySeries = nonEmptySeries.slice(1);
+  const grayColor = colors.text.muted;
+
+  const getActiveData = (values: number[]) =>
+    values.map((v, i) => (i <= activeIndex ? v : null));
+
+  const getInactiveData = (values: number[]) =>
+    values.map((v, i) => (i >= activeIndex ? v : null));
+
+  const isTooltipActive = activeIndex >= 0;
+
+  return (
+    <Box twClassName="flex-1" testID={testID}>
+      <View
+        style={tw.style(`h-[${CHART_HEIGHT}px]`)}
+        {...panResponder.panHandlers}
+        onLayout={handleChartLayout}
+      >
+        {!isTooltipActive ? (
+          <>
+            <LineChart
+              style={tw.style(`h-[${CHART_HEIGHT}px] w-full`)}
+              data={primaryChartData}
+              svg={{
+                stroke: primarySeries?.color || colors.primary.default,
+                strokeWidth: 2,
+              }}
+              contentInset={CHART_CONTENT_INSET}
+              yMin={chartMin}
+              yMax={chartMax}
+              curve={LINE_CURVE}
+            >
+              <EndpointDots nonEmptySeries={nonEmptySeries} />
+            </LineChart>
+
+            {overlaySeries.map((series, index) => (
+              <LineChart
+                key={`overlay-${index}`}
+                style={StyleSheet.absoluteFillObject}
+                data={series.data.map((point) => point.value)}
+                svg={{ stroke: series.color, strokeWidth: 2 }}
+                contentInset={CHART_CONTENT_INSET}
+                yMin={chartMin}
+                yMax={chartMax}
+                curve={LINE_CURVE}
+              />
+            ))}
+          </>
+        ) : (
+          <>
+            <LineChart
+              style={tw.style(`h-[${CHART_HEIGHT}px] w-full`)}
+              data={getActiveData(primaryChartData)}
+              svg={{
+                stroke: primarySeries?.color || colors.primary.default,
+                strokeWidth: 2,
+              }}
+              contentInset={CHART_CONTENT_INSET}
+              yMin={chartMin}
+              yMax={chartMax}
+              curve={LINE_CURVE}
+            />
+            <LineChart
+              style={StyleSheet.absoluteFillObject}
+              data={getInactiveData(primaryChartData)}
+              svg={{ stroke: grayColor, strokeWidth: 2 }}
+              contentInset={CHART_CONTENT_INSET}
+              yMin={chartMin}
+              yMax={chartMax}
+              curve={LINE_CURVE}
+            />
+
+            {overlaySeries.map((series, index) => {
+              const seriesValues = series.data.map((point) => point.value);
+              return (
+                <React.Fragment key={`overlay-split-${index}`}>
+                  <LineChart
+                    style={StyleSheet.absoluteFillObject}
+                    data={getActiveData(seriesValues)}
+                    svg={{ stroke: series.color, strokeWidth: 2 }}
+                    contentInset={CHART_CONTENT_INSET}
+                    yMin={chartMin}
+                    yMax={chartMax}
+                    curve={LINE_CURVE}
+                  />
+                  <LineChart
+                    style={StyleSheet.absoluteFillObject}
+                    data={getInactiveData(seriesValues)}
+                    svg={{ stroke: grayColor, strokeWidth: 2 }}
+                    contentInset={CHART_CONTENT_INSET}
+                    yMin={chartMin}
+                    yMax={chartMax}
+                    curve={LINE_CURVE}
+                  />
+                </React.Fragment>
+              );
+            })}
+
+            <LineChart
+              style={StyleSheet.absoluteFillObject}
+              data={primaryChartData}
+              svg={{ stroke: 'transparent', strokeWidth: 0 }}
+              contentInset={CHART_CONTENT_INSET}
+              yMin={chartMin}
+              yMax={chartMax}
+              curve={LINE_CURVE}
+            >
+              <ChartTooltip
+                activeIndex={activeIndex}
+                primaryData={primaryData}
+                nonEmptySeries={nonEmptySeries}
+                chartWidth={chartWidthRef.current}
+                contentInset={CHART_CONTENT_INSET}
+              />
+            </LineChart>
+          </>
+        )}
+      </View>
+
+      {onTimeframeChange && (
+        <TimeframeSelector selected={timeframe} onSelect={onTimeframeChange} />
+      )}
+    </Box>
+  );
+};
+
+export default PredictGameChartContent;

--- a/app/components/UI/Predict/components/PredictGameChart/TimeframeSelector.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/TimeframeSelector.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import TimeframeSelector from './TimeframeSelector';
+import { ChartTimeframe } from './PredictGameChart.types';
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({
+    style: (...classes: (string | boolean | undefined)[]) => ({
+      testStyle: classes.filter(Boolean).join(' '),
+    }),
+  }),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    Box: ({
+      children,
+      twClassName,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      twClassName?: string;
+    }) => (
+      <View testID="box" {...props}>
+        {children}
+      </View>
+    ),
+    BoxFlexDirection: { Row: 'row' },
+    Text: ({
+      children,
+      variant,
+      color,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      variant?: string;
+      color?: string;
+    }) => (
+      <Text testID="text" {...props}>
+        {children}
+      </Text>
+    ),
+    TextVariant: { BodySm: 'body-sm' },
+    TextColor: { TextDefault: 'text-default', TextAlternative: 'text-alt' },
+  };
+});
+
+const defaultProps = {
+  selected: 'live' as ChartTimeframe,
+  onSelect: jest.fn(),
+  disabled: false,
+};
+
+describe('TimeframeSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders all timeframe options', () => {
+      const { getByText } = render(<TimeframeSelector {...defaultProps} />);
+
+      expect(getByText('Live')).toBeTruthy();
+      expect(getByText('6H')).toBeTruthy();
+      expect(getByText('1D')).toBeTruthy();
+      expect(getByText('Max')).toBeTruthy();
+    });
+
+    it('renders with selected state for live timeframe', () => {
+      const { getByText } = render(
+        <TimeframeSelector {...defaultProps} selected="live" />,
+      );
+
+      expect(getByText('Live')).toBeTruthy();
+    });
+
+    it('renders with selected state for 6h timeframe', () => {
+      const { getByText } = render(
+        <TimeframeSelector {...defaultProps} selected="6h" />,
+      );
+
+      expect(getByText('6H')).toBeTruthy();
+    });
+
+    it('renders with selected state for 1d timeframe', () => {
+      const { getByText } = render(
+        <TimeframeSelector {...defaultProps} selected="1d" />,
+      );
+
+      expect(getByText('1D')).toBeTruthy();
+    });
+
+    it('renders with selected state for max timeframe', () => {
+      const { getByText } = render(
+        <TimeframeSelector {...defaultProps} selected="max" />,
+      );
+
+      expect(getByText('Max')).toBeTruthy();
+    });
+  });
+
+  describe('Interactions', () => {
+    it('calls onSelect when Live is pressed', () => {
+      const onSelect = jest.fn();
+      const { getByText } = render(
+        <TimeframeSelector {...defaultProps} onSelect={onSelect} />,
+      );
+
+      fireEvent.press(getByText('Live'));
+
+      expect(onSelect).toHaveBeenCalledWith('live');
+    });
+
+    it('calls onSelect when 6H is pressed', () => {
+      const onSelect = jest.fn();
+      const { getByText } = render(
+        <TimeframeSelector {...defaultProps} onSelect={onSelect} />,
+      );
+
+      fireEvent.press(getByText('6H'));
+
+      expect(onSelect).toHaveBeenCalledWith('6h');
+    });
+
+    it('calls onSelect when 1D is pressed', () => {
+      const onSelect = jest.fn();
+      const { getByText } = render(
+        <TimeframeSelector {...defaultProps} onSelect={onSelect} />,
+      );
+
+      fireEvent.press(getByText('1D'));
+
+      expect(onSelect).toHaveBeenCalledWith('1d');
+    });
+
+    it('calls onSelect when Max is pressed', () => {
+      const onSelect = jest.fn();
+      const { getByText } = render(
+        <TimeframeSelector {...defaultProps} onSelect={onSelect} />,
+      );
+
+      fireEvent.press(getByText('Max'));
+
+      expect(onSelect).toHaveBeenCalledWith('max');
+    });
+  });
+
+  describe('Disabled State', () => {
+    it('does not call onSelect when disabled', () => {
+      const onSelect = jest.fn();
+      const { getByText } = render(
+        <TimeframeSelector {...defaultProps} onSelect={onSelect} disabled />,
+      );
+
+      fireEvent.press(getByText('6H'));
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('does not call onSelect for any timeframe when disabled', () => {
+      const onSelect = jest.fn();
+      const { getByText } = render(
+        <TimeframeSelector {...defaultProps} onSelect={onSelect} disabled />,
+      );
+
+      fireEvent.press(getByText('Live'));
+      fireEvent.press(getByText('6H'));
+      fireEvent.press(getByText('1D'));
+      fireEvent.press(getByText('Max'));
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Default Props', () => {
+    it('uses default disabled value of false', () => {
+      const onSelect = jest.fn();
+      const { getByText } = render(
+        <TimeframeSelector selected="live" onSelect={onSelect} />,
+      );
+
+      fireEvent.press(getByText('6H'));
+
+      expect(onSelect).toHaveBeenCalledWith('6h');
+    });
+  });
+
+  describe('Timeframe Values', () => {
+    it.each([
+      ['Live', 'live'],
+      ['6H', '6h'],
+      ['1D', '1d'],
+      ['Max', 'max'],
+    ] as [string, ChartTimeframe][])(
+      'maps %s button to %s value',
+      (label, value) => {
+        const onSelect = jest.fn();
+        const { getByText } = render(
+          <TimeframeSelector {...defaultProps} onSelect={onSelect} />,
+        );
+
+        fireEvent.press(getByText(label));
+
+        expect(onSelect).toHaveBeenCalledWith(value);
+      },
+    );
+  });
+});

--- a/app/components/UI/Predict/components/PredictGameChart/TimeframeSelector.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/TimeframeSelector.tsx
@@ -42,7 +42,7 @@ const TimeframeSelector: React.FC<TimeframeSelectorProps> = ({
             disabled={disabled}
             style={({ pressed }) =>
               tw.style(
-                'px-4 py-2 rounded-full',
+                'px-4 py-2 rounded-md flex-1',
                 isSelected ? 'bg-background-pressed' : 'bg-transparent',
                 disabled && 'opacity-50',
                 pressed && !isSelected && 'bg-background-hover',
@@ -54,6 +54,7 @@ const TimeframeSelector: React.FC<TimeframeSelectorProps> = ({
               color={
                 isSelected ? TextColor.TextDefault : TextColor.TextAlternative
               }
+              style={tw.style('text-center')}
             >
               {label}
             </Text>

--- a/app/components/UI/Predict/components/PredictGameChart/TimeframeSelector.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/TimeframeSelector.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import {
+  Box,
+  BoxFlexDirection,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  ChartTimeframe,
+  TimeframeSelectorProps,
+} from './PredictGameChart.types';
+
+const TIMEFRAMES: { value: ChartTimeframe; label: string }[] = [
+  { value: 'live', label: 'Live' },
+  { value: '6h', label: '6H' },
+  { value: '1d', label: '1D' },
+  { value: 'max', label: 'Max' },
+];
+
+const TimeframeSelector: React.FC<TimeframeSelectorProps> = ({
+  selected,
+  onSelect,
+  disabled = false,
+}) => {
+  const tw = useTailwind();
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      twClassName="justify-center gap-2 mt-3"
+    >
+      {TIMEFRAMES.map(({ value, label }) => {
+        const isSelected = selected === value;
+
+        return (
+          <Pressable
+            key={value}
+            onPress={() => !disabled && onSelect(value)}
+            disabled={disabled}
+            style={({ pressed }) =>
+              tw.style(
+                'px-4 py-2 rounded-full',
+                isSelected ? 'bg-background-pressed' : 'bg-transparent',
+                disabled && 'opacity-50',
+                pressed && !isSelected && 'bg-background-hover',
+              )
+            }
+          >
+            <Text
+              variant={TextVariant.BodySm}
+              color={
+                isSelected ? TextColor.TextDefault : TextColor.TextAlternative
+              }
+            >
+              {label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </Box>
+  );
+};
+
+export default TimeframeSelector;

--- a/app/components/UI/Predict/components/PredictGameChart/index.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/index.ts
@@ -1,0 +1,3 @@
+export { default } from './PredictGameChart';
+export { default as PredictGameChart } from './PredictGameChart';
+export * from './PredictGameChart.types';

--- a/app/components/UI/Predict/components/PredictGameChart/index.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/index.ts
@@ -1,3 +1,4 @@
 export { default } from './PredictGameChart';
 export { default as PredictGameChart } from './PredictGameChart';
+export { default as PredictGameChartContent } from './PredictGameChartContent';
 export * from './PredictGameChart.types';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR introduces the PredictGameChart component, a reusable dual-line chart for displaying win probability/price data for binary outcome markets in the Predict feature.

What changed:
- New PredictGameChart wrapper component that handles data fetching (live + historical) via usePredictPriceHistory and useLiveMarketPrices hooks
- PredictGameChartContent presentational component with touch-to-scrub interaction
- Sub-components: TimeframeSelector, ChartTooltip, EndpointDots
- Supports timeframes: Live, 6H, 1D, Max
- Smart label positioning to prevent overlaps when values are close
- Live mode auto-updates chart data as prices change

Why:
Game-style prediction markets (e.g., sports events) need a visual representation of how probability changes over time for both outcomes. This chart shows both lines with team/outcome colors, always summing to 100%.

Note: Includes a temporary dev-only test view (PredictTempGameView) accessible via DEV button in PredictFeed - this should be removed before merging to production.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-465

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
![live](https://github.com/user-attachments/assets/97731ad1-ff66-4901-9799-d8e701204a8b)

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a reusable dual-series price/probability chart for Predict with live and historical data support, interaction, and robust tests.
> 
> - New `PredictGameChart` wrapper maps timeframes to fetch intervals/fidelity, hydrates historical data via `usePredictPriceHistory`, and streams live prices via `useLiveMarketPrices` with per-minute updates and capped history
> - Presentational `PredictGameChartContent` renders two step-after lines, splits active/inactive segments on scrub, clamps y-bounds to 0–100, and handles loading/empty/error states with retry
> - Added sub-components:
>   - `TimeframeSelector` (Live/6H/1D/Max)
>   - `ChartTooltip` with timestamp, crosshair, dot glow, and right-aligned labels/values
>   - `EndpointDots` aligning all endpoint dots at the right edge and separating overlapping labels
> - Shared `PredictGameChart.constants` and strong typings in `PredictGameChart.types`; exports wired in `index.ts`
> - Extensive unit tests for wrapper, content, tooltip, endpoint dots, and timeframe selector, including edge cases (mismatched series lengths, label overlap, bounds, errors)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12c3c3e6f62cd253324c8bcfa0f068b32286fe0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->