### PR TITLE
fix: [Trending] wrong skeleton on prediction search

### DIFF
--- a/app/components/Views/TrendingView/components/ExploreSearchResults/ExploreSearchResults.tsx
+++ b/app/components/Views/TrendingView/components/ExploreSearchResults/ExploreSearchResults.tsx
@@ -128,6 +128,9 @@ const ExploreSearchResults: React.FC<ExploreSearchResultsProps> = ({
       if (!section) return null;
 
       if (item.type === 'skeleton') {
+        if (section.OverrideSkeletonSearch) {
+          return <section.OverrideSkeletonSearch />;
+        }
         return <section.Skeleton />;
       }
 

--- a/app/components/Views/TrendingView/sections.config.tsx
+++ b/app/components/Views/TrendingView/sections.config.tsx
@@ -47,6 +47,7 @@ interface SectionConfig {
     navigation: NavigationProp<ParamListBase>;
   }>;
   Skeleton: React.ComponentType;
+  OverrideSkeletonSearch?: React.ComponentType;
   Section: React.ComponentType<{
     sectionId: SectionId;
     data: unknown[];
@@ -161,6 +162,8 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
       <PredictMarketRowItem market={item as PredictMarketType} />
     ),
     Skeleton: () => <PredictMarketSkeleton isCarousel />,
+    // Using sites skeleton cause PredictMarketSkeleton has too much spacing
+    OverrideSkeletonSearch: SiteSkeleton,
     Section: SectionCarrousel,
     useSectionData: (searchQuery) => {
       const { marketData, isFetching, refetch } = usePredictMarketData({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The skeleton used for the search view in predictions is too big compared to the actual row item, instead we should use a smaller skeleton

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix incorrect skeleton used for predictions when searching in main explore page

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2277

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/3c62d52d-1e33-4ac2-8a4d-7612e20a9118


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/b310b411-e4ef-414d-9402-37b1f3f8ec99


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Uses a smaller skeleton for prediction search results and enables per-section overrides.
> 
> - Adds optional `OverrideSkeletonSearch` to `sections.config` and renders it in `ExploreSearchResults` when list items are `skeleton`
> - Sets `predictions` section `OverrideSkeletonSearch` to `SiteSkeleton` (keeps existing `Skeleton` for non-search contexts)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e189b79a0afe11ad795c86e69a84befec3b0d5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->