### PR TITLE
feat: add workflow to cancel and rerun CI on 'skip-smart-e2e-selection' label

### DIFF
--- a/.github/workflows/rerun-ci-on-smart-selection-label.yml
+++ b/.github/workflows/rerun-ci-on-smart-selection-label.yml
@@ -1,0 +1,86 @@
+name: Rerun CI on skip-smart-e2e-selection label
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  REPO: ${{ github.repository }}
+  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+jobs:
+  rerun-ci:
+    if: github.event.label.name == 'skip-smart-e2e-selection'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel running CI workflows
+        id: cancel
+        run: |
+          echo "Looking for CI runs on commit $HEAD_SHA..."
+
+          CANCELLED=false
+          while read -r RUN_ID; do
+            if [ -n "$RUN_ID" ]; then
+              echo "Cancelling run $RUN_ID..."
+              gh run cancel "$RUN_ID" --repo "$REPO" || true
+              CANCELLED=true
+            fi
+          done < <(gh run list \
+            --repo "$REPO" \
+            --commit "$HEAD_SHA" \
+            --workflow "ci.yml" \
+            --json databaseId,status \
+            --jq '.[] | select(.status == "in_progress" or .status == "queued") | .databaseId')
+
+          echo "cancelled=$CANCELLED" >> $GITHUB_OUTPUT
+
+      - name: Find latest CI workflow run
+        id: find
+        run: |
+          LATEST_RUN_ID=$(gh run list \
+            --repo "$REPO" \
+            --commit "$HEAD_SHA" \
+            --workflow "ci.yml" \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+
+          if [ -z "$LATEST_RUN_ID" ] || [ "$LATEST_RUN_ID" = "null" ]; then
+            echo "No CI workflow run found for commit $HEAD_SHA"
+            exit 0
+          fi
+
+          echo "run_id=$LATEST_RUN_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for cancellation to complete
+        if: steps.cancel.outputs.cancelled == 'true' && steps.find.outputs.run_id
+        run: |
+          RUN_ID="${{ steps.find.outputs.run_id }}"
+          MAX_WAIT=300
+          ELAPSED=0
+
+          echo "Waiting up to ${MAX_WAIT}s for workflow to finish cancelling..."
+
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status --jq '.status')
+            echo "Status: $STATUS (${ELAPSED}s elapsed)"
+
+            if [ "$STATUS" != "in_progress" ] && [ "$STATUS" != "queued" ]; then
+              echo "Workflow ready for rerun"
+              break
+            fi
+
+            sleep 15
+            ELAPSED=$((ELAPSED + 15))
+          done
+
+      - name: Rerun CI workflow
+        if: steps.find.outputs.run_id
+        run: |
+          RUN_ID="${{ steps.find.outputs.run_id }}"
+          echo "Re-running workflow $RUN_ID..."
+          gh run rerun "$RUN_ID" --repo "$REPO"
+          echo "CI workflow re-triggered successfully"

--- a/.github/workflows/rerun-ci-on-smart-selection-label.yml
+++ b/.github/workflows/rerun-ci-on-smart-selection-label.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Cancel running CI workflows
         id: cancel
         run: |
-          echo "Looking for CI runs on commit $HEAD_SHA..."
+          echo "Looking for CI runs on branch $HEAD_REF..."
 
           CANCELLED=false
           while read -r RUN_ID; do
@@ -30,7 +30,7 @@ jobs:
             fi
           done < <(gh run list \
             --repo "$REPO" \
-            --commit "$HEAD_SHA" \
+            --branch "$HEAD_REF" \
             --workflow "ci.yml" \
             --json databaseId,status \
             --jq '.[] | select(.status == "in_progress" or .status == "queued") | .databaseId')
@@ -42,14 +42,14 @@ jobs:
         run: |
           LATEST_RUN_ID=$(gh run list \
             --repo "$REPO" \
-            --commit "$HEAD_SHA" \
+            --branch "$HEAD_REF" \
             --workflow "ci.yml" \
             --limit 1 \
             --json databaseId \
             --jq '.[0].databaseId')
 
           if [ -z "$LATEST_RUN_ID" ] || [ "$LATEST_RUN_ID" = "null" ]; then
-            echo "No CI workflow run found for commit $HEAD_SHA"
+            echo "No CI workflow run found for branch $HEAD_REF"
             exit 0
           fi
 

--- a/.github/workflows/rerun-ci-on-smart-selection-label.yml
+++ b/.github/workflows/rerun-ci-on-smart-selection-label.yml
@@ -7,7 +7,7 @@ on:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   REPO: ${{ github.repository }}
-  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  HEAD_REF: ${{ github.head_ref }}
 
 jobs:
   rerun-ci:

--- a/.github/workflows/rerun-ci-on-smart-selection-label.yml
+++ b/.github/workflows/rerun-ci-on-smart-selection-label.yml
@@ -77,6 +77,12 @@ jobs:
             ELAPSED=$((ELAPSED + 15))
           done
 
+          FINAL_STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status --jq '.status')
+          if [ "$FINAL_STATUS" = "in_progress" ] || [ "$FINAL_STATUS" = "queued" ]; then
+            echo "Timeout: workflow still $FINAL_STATUS after ${MAX_WAIT}s"
+            exit 1
+          fi
+
       - name: Rerun CI workflow
         if: steps.find.outputs.run_id
         run: |

--- a/.github/workflows/rerun-ci-on-smart-selection-label.yml
+++ b/.github/workflows/rerun-ci-on-smart-selection-label.yml
@@ -59,7 +59,7 @@ jobs:
         if: steps.cancel.outputs.cancelled == 'true' && steps.find.outputs.run_id
         run: |
           RUN_ID="${{ steps.find.outputs.run_id }}"
-          MAX_WAIT=300
+          MAX_WAIT=600
           ELAPSED=0
 
           echo "Waiting up to ${MAX_WAIT}s for workflow to finish cancelling..."

--- a/.github/workflows/rerun-ci-on-smart-selection-label.yml
+++ b/.github/workflows/rerun-ci-on-smart-selection-label.yml
@@ -35,7 +35,7 @@ jobs:
             --json databaseId,status \
             --jq '.[] | select(.status == "in_progress" or .status == "queued") | .databaseId')
 
-          echo "cancelled=$CANCELLED" >> $GITHUB_OUTPUT
+          echo "cancelled=$CANCELLED" >> "$GITHUB_OUTPUT"
 
       - name: Find latest CI workflow run
         id: find
@@ -53,7 +53,7 @@ jobs:
             exit 0
           fi
 
-          echo "run_id=$LATEST_RUN_ID" >> $GITHUB_OUTPUT
+          echo "run_id=$LATEST_RUN_ID" >> "$GITHUB_OUTPUT"
 
       - name: Wait for cancellation to complete
         if: steps.cancel.outputs.cancelled == 'true' && steps.find.outputs.run_id


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## Summary
  - Add workflow to automatically cancel and rerun CI when `skip-smart-e2e-selection` label is added or removed from a PR

  ## Problem
  When the Smart E2E Selection job has already run in a CI pipeline, adding the `skip-smart-e2e-selection` label does not take effect until the entire CI pipeline is manually re-run. This creates friction for developers who want to skip the smart selection after seeing initial results.

  ## Solution
  New workflow (`rerun-ci-on-smart-selection-label.yml`) that:
  - Triggers when `skip-smart-e2e-selection` label is added or removed
  - Cancels any running CI workflow for the PR
  - Waits for cancellation to complete
  - Re-runs the CI so the label change takes effect

  ## Test plan
  - [x] Open a PR and let CI start running
  - [x] Add `skip-smart-e2e-selection` label
  - [x] Verify the running CI is cancelled and a new run starts
  - [x] Verify the new run respects the label (skips smart selection)
  - [x] Remove the label and verify CI reruns again

# Tests
https://github.com/MetaMask/metamask-mobile/actions/runs/21003575481/job/60379905766?pr=24525
https://github.com/MetaMask/metamask-mobile/actions/runs/21004264752/job/60382302944?pr=24525

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Adds GitHub Actions workflow to re-trigger CI based on label changes**
> 
> - New `rerun-ci-on-smart-selection-label.yml` triggers on PR `labeled`/`unlabeled` events for `skip-smart-e2e-selection`
> - Cancels in-progress/queued `ci.yml` runs on the PR branch via `gh run cancel`, waits up to 5 minutes for cancellation
> - Finds the latest CI run and re-runs it to ensure the label change takes effect
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41e598e9402f85bcc9ad6a3891b7625e94278ba8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->