### PR TITLE
Dependabot qrcode svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   "resolutions": {
     "json-schema": "^0.4.0",
     "node-fetch": "^2.6.7",
-    "node-forge": "1.3.2",
+    "node-forge": "1.3.3",
     "xml2js": ">=0.5.0",
     "@metamask/react-native-payments/validator": "^13.7.0",
     "minimist": "1.2.6",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
   "resolutions": {
     "json-schema": "^0.4.0",
     "node-fetch": "^2.6.7",
+    "node-forge": "1.3.2",
     "xml2js": ">=0.5.0",
     "@metamask/react-native-payments/validator": "^13.7.0",
     "minimist": "1.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35671,10 +35671,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:1.3.1, node-forge@npm:^1, node-forge@npm:^1.2.1, node-forge@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "node-forge@npm:1.3.1"
-  checksum: 10/05bab6868633bf9ad4c3b1dd50ec501c22ffd69f556cdf169a00998ca1d03e8107a6032ba013852f202035372021b845603aeccd7dfcb58cdb7430013b3daa8d
+"node-forge@npm:1.3.2":
+  version: 1.3.2
+  resolution: "node-forge@npm:1.3.2"
+  checksum: 10/dcc54aaffe0cf52367214a20c0032aa9b209d9095dd14526504f1972d1900a07e96046b3684cb0c8d0cc3d48744dd18e02b7b447ab28fac615ffb850beeabf18
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -35671,10 +35671,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:1.3.2":
-  version: 1.3.2
-  resolution: "node-forge@npm:1.3.2"
-  checksum: 10/dcc54aaffe0cf52367214a20c0032aa9b209d9095dd14526504f1972d1900a07e96046b3684cb0c8d0cc3d48744dd18e02b7b447ab28fac615ffb850beeabf18
+"node-forge@npm:1.3.3":
+  version: 1.3.3
+  resolution: "node-forge@npm:1.3.3"
+  checksum: 10/f41c31b9296771a4b8c955d58417471712f54f324603a35f8e6cbac19d5e6eaaf5fd5fd14584dfedecbf46a05438ded6eee60a5f2f0822fc5061aaa073cfc75d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update `node-forge` to version 1.3.2 to address a Dependabot security vulnerability.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e9c9a5e-5bbb-403f-930f-f32df9c6547a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e9c9a5e-5bbb-403f-930f-f32df9c6547a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

