### PR TITLE
chore: Removed extra padding for import private key

### DIFF
--- a/app/components/Views/ImportPrivateKey/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ImportPrivateKey/__snapshots__/index.test.tsx.snap
@@ -316,7 +316,6 @@ exports[`ImportPrivateKey render matches snapshot 1`] = `
                       style={
                         {
                           "flex": 1,
-                          "marginTop": 48,
                         }
                       }
                     >

--- a/app/components/Views/ImportPrivateKey/styles.ts
+++ b/app/components/Views/ImportPrivateKey/styles.ts
@@ -11,7 +11,6 @@ const createStyles = (
   StyleSheet.create({
     mainWrapper: {
       flex: 1,
-      marginTop: 48,
     },
     topOverlay: {
       flex: 1,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Removes unnecessary `marginTop: 48` from the Import Private Key screen's main wrapper style. The screen uses `SafeAreaView` which already handles the top safe area inset, so this additional margin was creating excessive spacing above the header.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Import Private Key Screen Layout

  Scenario: User views Import Account screen with correct spacing
    Given the user is logged in

    When user navigates to Settings > Accounts > Add account or hardware wallet > Import account
    Then the Import Account header should appear with appropriate spacing below the status bar
    And there should be no excessive gap above the back button and title
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-01-14 at 10 27 19" src="https://github.com/user-attachments/assets/3707b18f-f229-4b69-a34c-e2226cfb5b97" />

<!-- [screenshots/recordings] -->

### **After**
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-01-14 at 10 35 22" src="https://github.com/user-attachments/assets/87fcb7ce-cb8b-4cac-90e0-f8aa60fc9e0c" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates unnecessary spacing at the top of the Import Private Key screen.
> 
> - Removes `marginTop: 48` from `createStyles().mainWrapper` in `styles.ts`, relying on `SafeAreaView` for insets
> - Updates snapshot in `__snapshots__/index.test.tsx.snap` to reflect new layout
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7990aeb18759f1af0bef6191ce92b579308210c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->