### PR TITLE
fix: add white background to QR code for dark mode scanning

### DIFF
--- a/app/components/UI/ReceiveRequest/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/ReceiveRequest/__snapshots__/index.test.tsx.snap
@@ -360,6 +360,7 @@ exports[`ReceiveRequest render matches snapshot 1`] = `
                             style={
                               [
                                 {
+                                  "backgroundColor": "#ffffff",
                                   "borderColor": "#b7bbc866",
                                   "borderRadius": 16,
                                   "borderWidth": 1,
@@ -963,6 +964,7 @@ exports[`ReceiveRequest render with different ticker matches snapshot 1`] = `
                             style={
                               [
                                 {
+                                  "backgroundColor": "#ffffff",
                                   "borderColor": "#b7bbc866",
                                   "borderRadius": 16,
                                   "borderWidth": 1,
@@ -1566,6 +1568,7 @@ exports[`ReceiveRequest render without buy matches snapshot 1`] = `
                             style={
                               [
                                 {
+                                  "backgroundColor": "#ffffff",
                                   "borderColor": "#b7bbc866",
                                   "borderRadius": 16,
                                   "borderWidth": 1,

--- a/app/components/UI/ReceiveRequest/index.js
+++ b/app/components/UI/ReceiveRequest/index.js
@@ -197,7 +197,7 @@ class ReceiveRequest extends PureComponent {
             alignItems={BoxAlignItems.Center}
             twClassName="px-4 py-6"
           >
-            <Box twClassName="p-6 border border-muted rounded-2xl">
+            <Box twClassName="p-6 border border-muted rounded-2xl bg-white">
               <QRCode
                 logo={PNG_MM_LOGO_PATH}
                 logoSize={32}

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
@@ -81,7 +81,7 @@ export const ShareAddressQR = () => {
         alignItems={BoxAlignItems.Center}
         twClassName="px-4 py-6"
       >
-        <Box twClassName="p-6 border border-muted rounded-2xl">
+        <Box twClassName="p-6 border border-muted rounded-2xl bg-white">
           <QRCode
             value={address}
             size={200}


### PR DESCRIPTION
## **Description**

The QR code generated on the mobile app needs a white border/background to ensure it can be scanned properly in dark mode. This change adds a white background to QR code containers in:
- `ReceiveRequest` component
- `ShareAddressQR` component

This matches the existing pattern used in other QR code components like `AddressQRCode`, `PaymentRequestSuccess`, and `AnimatedQRCode`.

## **Changelog**

CHANGELOG entry: Fixed QR code scanning in dark mode by adding white background

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-347

## **Manual testing steps**

```gherkin
Feature: QR code visibility in dark mode

  Scenario: user views QR code in dark mode
    Given user has dark mode enabled
    And user is on the Receive screen or Share Address QR sheet

    When user views the QR code
    Then the QR code has a white background
    And the QR code can be scanned by external devices
```

## **Screenshots/Recordings**

### **Before**

QR code container had transparent/dark background making it difficult to scan in dark mode.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/682fcf28-d060-414f-8dc6-7b851def6a2e" />


### **After**

QR code now has white background ensuring proper contrast for scanning.

<img width="300" alt="qr_after_dark" src="https://github.com/user-attachments/assets/5c6b3988-90eb-4aa6-bd09-da49ba37ba9a" />
<img width="300" alt="qr_after_light" src="https://github.com/user-attachments/assets/5fbdd4d7-ae00-42ab-b0ce-3323c23651b7" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves QR scan reliability in dark mode by enforcing a white container background.
> 
> - Adds `bg-white` to QR containers in `ReceiveRequest` and `ShareAddressQR`
> - Updates `ReceiveRequest` snapshots to reflect `backgroundColor: #ffffff`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd7fcb3837d6ad61c7639897ad6318ed70c52b66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->