### PR TITLE
fix: bip39 words bar ui fixes

### DIFF
--- a/app/components/UI/SrpInputGrid/SrpInputGrid.styles.ts
+++ b/app/components/UI/SrpInputGrid/SrpInputGrid.styles.ts
@@ -12,6 +12,7 @@ export const createStyles = (colors: Colors) =>
     seedPhraseRoot: {
       flexDirection: 'column' as const,
       gap: 4,
+      marginTop: 8,
       marginBottom: 24,
     },
     seedPhraseContainer: {

--- a/app/components/UI/SrpInputGrid/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/SrpInputGrid/__snapshots__/index.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`SrpInputGrid renders with custom uniqueId 1`] = `
       "flexDirection": "column",
       "gap": 4,
       "marginBottom": 24,
+      "marginTop": 8,
     }
   }
 >
@@ -258,6 +259,7 @@ exports[`SrpInputGrid renders with disabled state 1`] = `
       "flexDirection": "column",
       "gap": 4,
       "marginBottom": 24,
+      "marginTop": 8,
     }
   }
 >
@@ -509,6 +511,7 @@ exports[`SrpInputGrid renders with empty seed phrase 1`] = `
       "flexDirection": "column",
       "gap": 4,
       "marginBottom": 24,
+      "marginTop": 8,
     }
   }
 >
@@ -760,6 +763,7 @@ exports[`SrpInputGrid renders with multiple words 1`] = `
       "flexDirection": "column",
       "gap": 4,
       "marginBottom": 24,
+      "marginTop": 8,
     }
   }
 >

--- a/app/components/UI/SrpWordSuggestions/SrpWordSuggestions.styles.ts
+++ b/app/components/UI/SrpWordSuggestions/SrpWordSuggestions.styles.ts
@@ -1,4 +1,4 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
 import { Colors } from '../../../util/theme/models';
 
 /**
@@ -8,9 +8,13 @@ import { Colors } from '../../../util/theme/models';
 export const createStyles = (colors: Colors) =>
   StyleSheet.create({
     suggestionContainer: {
-      paddingVertical: 1,
-      paddingHorizontal: 48,
-      backgroundColor: colors.background.default,
+      paddingVertical: 10,
+      paddingLeft: Platform.select({
+        ios: 48,
+        android: 20,
+        default: 48,
+      }),
+      backgroundColor: colors.background.section,
     },
     suggestionListContent: {
       alignItems: 'center' as const,
@@ -23,7 +27,7 @@ export const createStyles = (colors: Colors) =>
       minWidth: 60,
       alignItems: 'center' as const,
       justifyContent: 'center' as const,
-      backgroundColor: colors.background.section,
+      backgroundColor: colors.background.subsection,
     },
     suggestionPressed: {
       opacity: 0.7,

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/__snapshots__/index.test.tsx.snap
@@ -495,6 +495,7 @@ exports[`ImportFromSecretRecoveryPhrase Import a wallet UI render matches snapsh
                                     "flexDirection": "column",
                                     "gap": 4,
                                     "marginBottom": 24,
+                                    "marginTop": 8,
                                   }
                                 }
                               >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* bip39 Words bar background and word background color change.
* padding changes for words bar suggestions.
* 8dp margin between the 'Enter your SRP' and input box
* Jira: https://consensyssoftware.atlassian.net/browse/SL-446
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

* bip39 words bar background and word background color change
* padding changes for words bar suggestions.
## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="338" height="725" alt="Screenshot 2026-01-09 at 7 00 28 PM" src="https://github.com/user-attachments/assets/a41c2d9c-0203-4c8e-b8a9-bc291fa744f2" />
<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/4bb0ca97-77ec-45a9-8aa3-1dd3695d758b


https://github.com/user-attachments/assets/332a4424-f6da-41d2-8221-2809824e76d6


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates styling for `SrpWordSuggestions` to improve spacing and theme alignment.
> 
> - `suggestionContainer`: increases vertical padding, introduces platform-specific `paddingLeft` (iOS/default 48, Android 20), and switches background to `colors.background.section`
> - `suggestionButton`: changes background to `colors.background.subsection`
> - Imports `Platform` to support platform-specific padding
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b38cbf87d9d50959531a987f4a2660d003ad255. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->