### PR TITLE
fix: regex in typed-data parsing cp-7.62.0

### DIFF
--- a/app/components/Views/confirmations/utils/signature.test.ts
+++ b/app/components/Views/confirmations/utils/signature.test.ts
@@ -89,6 +89,91 @@ describe('Signature Utils', () => {
         parseAndNormalizeSignTypedData('');
       }).toThrow(new Error('Unexpected end of JSON input'));
     });
+
+    describe('nested value spoofing protection', () => {
+      it('ignores nested value fields and uses actual message.value (spoofing attack prevention)', () => {
+        // Attack scenario: attacker includes a nested object with a large "value" field
+        // to trick the UI into showing a different amount than what will be signed
+        const maliciousData = JSON.stringify({
+          message: {
+            evil: { value: 999999999999999 }, // Nested value that should be ignored
+            value: 1, // Actual value that will be signed
+          },
+        });
+        const result = parseAndNormalizeSignTypedData(maliciousData);
+
+        // The actual message.value should be used, not the nested one
+        expect(result.message.value).toBe('1');
+      });
+
+      it('ignores deeply nested value fields with large numbers', () => {
+        // Use raw JSON string to avoid JS number precision loss in the test itself
+        const maliciousData =
+          '{"message": {"nested": {"deeper": {"value": 888888888888888888888888888888}}, "value": 100}}';
+        const result = parseAndNormalizeSignTypedData(maliciousData);
+
+        expect(result.message.value).toBe('100');
+      });
+
+      it('ignores value fields in arrays within message', () => {
+        const maliciousData = JSON.stringify({
+          message: {
+            items: [{ value: 777777777777777 }, { value: 666666666666666 }],
+            value: 50,
+          },
+        });
+        const result = parseAndNormalizeSignTypedData(maliciousData);
+
+        expect(result.message.value).toBe('50');
+      });
+
+      it('extracts large value correctly when it is the actual message.value', () => {
+        const largeValue = '999999999999999999999999999999';
+        const legitimateData = JSON.stringify({
+          message: {
+            otherField: 'some data',
+            value: largeValue,
+          },
+        });
+        const result = parseAndNormalizeSignTypedData(legitimateData);
+
+        expect(result.message.value).toBe(largeValue);
+      });
+
+      it('extracts large value when nested objects come after message.value', () => {
+        // Large value at message.value, with nested objects after it
+        const data =
+          '{"message": {"value": 123456789012345678901234567890, "nested": {"value": 1}}}';
+        const result = parseAndNormalizeSignTypedData(data);
+
+        expect(result.message.value).toBe('123456789012345678901234567890');
+      });
+
+      it('handles escaped quotes in string values correctly', () => {
+        const data = JSON.stringify({
+          message: {
+            description: 'A string with "value": 999999999999999 inside',
+            value: 42,
+          },
+        });
+        const result = parseAndNormalizeSignTypedData(data);
+
+        expect(result.message.value).toBe('42');
+      });
+
+      it('handles message.value as string (not numeric) correctly', () => {
+        const data = JSON.stringify({
+          message: {
+            evil: { value: 999999999999999 },
+            value: '123',
+          },
+        });
+        const result = parseAndNormalizeSignTypedData(data);
+
+        // String values are not matched by the large value regex, so JSON.parse result is used
+        expect(result.message.value).toBe('123');
+      });
+    });
   });
 
   describe('isRecognizedPermit', () => {

--- a/app/components/Views/confirmations/utils/signature.ts
+++ b/app/components/Views/confirmations/utils/signature.ts
@@ -156,8 +156,14 @@ export const sanitizeParsedMessage = (
   return { value: sanitizedStruct, type: primaryType };
 };
 
+/**
+ * Regex to extract large numeric values from message.value.
+ * Uses [^{}]* instead of [^}]* to prevent matching nested "value" fields -
+ * by excluding both { and }, the regex stops at any nested object boundary,
+ * ensuring only top-level message.value is matched.
+ */
 const REGEX_MESSAGE_VALUE_LARGE =
-  /"message"\s*:\s*\{[^}]*"value"\s*:\s*(\d{15,})/u;
+  /"message"\s*:\s*\{[^{}]*"value"\s*:\s*(\d{15,})/u;
 
 /** Returns the value of the message if it is a digit greater than 15 digits */
 function extractLargeMessageValue(

--- a/e2e/api-mocking/mock-e2e-allowlist.ts
+++ b/e2e/api-mocking/mock-e2e-allowlist.ts
@@ -52,4 +52,5 @@ export const ALLOWLISTED_URLS = [
   'https://signature-insights.api.cx.metamask.io/v1/signature?chainId=0x1',
   'https://price.api.cx.metamask.io/v1/exchange-rates?baseCurrency=usd',
   'https://api.hyperliquid.xyz/exchange',
+  'https://api.hyperliquid.xyz/info',
 ];


### PR DESCRIPTION
## **Description**
Fix regex in typed-data parsing.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6624

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens typed-data parsing to prevent UI spoofing from nested `value` fields.
> 
> - Updates `REGEX_MESSAGE_VALUE_LARGE` to use `[^{}]*` so only top-level `message.value` is matched, ensuring large numbers are parsed correctly from the intended field
> - Adds tests covering nested/deeply nested `value` fields, arrays, ordering, escaped quotes, and string-valued `message.value`
> - Extends e2e allowlist with `https://api.hyperliquid.xyz/info`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad592b01bdfb71af3d8592c6799a48a29c82bfa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->