### PR TITLE
fix: do not render loader when market price fetch fail

### DIFF
--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -3,6 +3,11 @@ import { render, fireEvent } from '@testing-library/react-native';
 import { TokenSelectorItem } from './TokenSelectorItem';
 import { ethers } from 'ethers';
 import { createMockTokenWithBalance } from '../testUtils/fixtures';
+import {
+  TOKEN_BALANCE_LOADING,
+  TOKEN_BALANCE_LOADING_UPPERCASE,
+  TOKEN_RATE_UNDEFINED,
+} from '../../Tokens/constants';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(() => []),
@@ -230,6 +235,88 @@ describe('TokenSelectorItem', () => {
       );
 
       expect(getByText(expected)).toBeTruthy();
+    });
+  });
+
+  describe('balance display states', () => {
+    it('does not render balance text when balance is loading (lowercase)', () => {
+      const token = createMockTokenWithBalance({
+        balanceFiat: TOKEN_BALANCE_LOADING,
+      });
+
+      const { queryByText } = render(
+        <TokenSelectorItem
+          token={token}
+          onPress={mockOnPress}
+          shouldShowBalance
+        />,
+      );
+
+      expect(queryByText(TOKEN_BALANCE_LOADING)).toBeNull();
+    });
+
+    it('does not render balance text when balance is loading (uppercase)', () => {
+      const token = createMockTokenWithBalance({
+        balanceFiat: TOKEN_BALANCE_LOADING_UPPERCASE,
+      });
+
+      const { queryByText } = render(
+        <TokenSelectorItem
+          token={token}
+          onPress={mockOnPress}
+          shouldShowBalance
+        />,
+      );
+
+      expect(queryByText(TOKEN_BALANCE_LOADING_UPPERCASE)).toBeNull();
+    });
+
+    it('renders nothing when balance rate is undefined', () => {
+      const token = createMockTokenWithBalance({
+        balanceFiat: TOKEN_RATE_UNDEFINED,
+      });
+
+      const { queryByText } = render(
+        <TokenSelectorItem
+          token={token}
+          onPress={mockOnPress}
+          shouldShowBalance
+        />,
+      );
+
+      expect(queryByText(TOKEN_RATE_UNDEFINED)).toBeNull();
+    });
+
+    it('renders fiat balance when balance is available', () => {
+      const token = createMockTokenWithBalance({
+        balanceFiat: '$1,234.56',
+      });
+
+      const { getByText } = render(
+        <TokenSelectorItem
+          token={token}
+          onPress={mockOnPress}
+          shouldShowBalance
+        />,
+      );
+
+      expect(getByText('$1,234.56')).toBeTruthy();
+    });
+
+    it('does not render balance when shouldShowBalance is false', () => {
+      const token = createMockTokenWithBalance({
+        balanceFiat: '$1,234.56',
+      });
+
+      const { queryByText } = render(
+        <TokenSelectorItem
+          token={token}
+          onPress={mockOnPress}
+          shouldShowBalance={false}
+        />,
+      );
+
+      expect(queryByText('$1,234.56')).toBeNull();
     });
   });
 

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -28,6 +28,7 @@ import { fontStyles } from '../../../../styles/common';
 import {
   TOKEN_BALANCE_LOADING,
   TOKEN_BALANCE_LOADING_UPPERCASE,
+  TOKEN_RATE_UNDEFINED,
 } from '../../Tokens/constants';
 import generateTestId from '../../../../../wdio/utils/generateTestId';
 import { getAssetTestId } from '../../../../../wdio/screen-objects/testIDs/Screens/WalletView.testIds';
@@ -247,7 +248,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
               (balance === TOKEN_BALANCE_LOADING ||
               balance === TOKEN_BALANCE_LOADING_UPPERCASE ? (
                 <View style={styles.skeleton} />
-              ) : (
+              ) : balance === TOKEN_RATE_UNDEFINED ? null : (
                 <Text variant={TextVariant.BodyLGMedium}>{balance}</Text>
               ))}
             {secondaryBalance ? (

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -119,6 +119,29 @@ interface TokenSelectorItemProps {
   isNoFeeAsset?: boolean;
 }
 
+const FiatBalanceView = ({
+  balance,
+  isSelected,
+}: {
+  balance?: string;
+  isSelected: boolean;
+}) => {
+  const { styles } = useStyles(createStyles, { isSelected });
+
+  if (!balance || balance === TOKEN_RATE_UNDEFINED) {
+    return null;
+  }
+
+  if (
+    balance === TOKEN_BALANCE_LOADING ||
+    balance === TOKEN_BALANCE_LOADING_UPPERCASE
+  ) {
+    return <View style={styles.skeleton} />;
+  }
+
+  return <Text variant={TextVariant.BodyLGMedium}>{balance}</Text>;
+};
+
 export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
   token,
   onPress,
@@ -244,13 +267,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
 
           {/* Token balance and fiat value */}
           <Box style={styles.balance} gap={4}>
-            {balance &&
-              (balance === TOKEN_BALANCE_LOADING ||
-              balance === TOKEN_BALANCE_LOADING_UPPERCASE ? (
-                <View style={styles.skeleton} />
-              ) : balance === TOKEN_RATE_UNDEFINED ? null : (
-                <Text variant={TextVariant.BodyLGMedium}>{balance}</Text>
-              ))}
+            <FiatBalanceView balance={balance} isSelected={isSelected} />
             {secondaryBalance ? (
               secondaryBalance === TOKEN_BALANCE_LOADING ||
               secondaryBalance === TOKEN_BALANCE_LOADING_UPPERCASE ? (

--- a/app/components/UI/Tokens/util/deriveBalanceFromAssetMarketDetails.test.ts
+++ b/app/components/UI/Tokens/util/deriveBalanceFromAssetMarketDetails.test.ts
@@ -89,7 +89,7 @@ describe('deriveBalanceFromAssetMarketDetails', () => {
     });
   });
 
-  it('returns balanceFiat and TOKEN_BALANCE_LOADING if token conversionRate is not available', () => {
+  it('returns balanceFiat and TOKEN_RATE_UNDEFINED if token conversionRate is not available', () => {
     const result = deriveBalanceFromAssetMarketDetails(
       asset,
       tokenExchangeRates,
@@ -99,7 +99,7 @@ describe('deriveBalanceFromAssetMarketDetails', () => {
     );
 
     expect(result).toEqual({
-      balanceFiat: 'tokenBalanceLoading',
+      balanceFiat: TOKEN_RATE_UNDEFINED,
       balanceValueFormatted: '100 ABC',
     });
   });

--- a/app/components/UI/Tokens/util/deriveBalanceFromAssetMarketDetails.ts
+++ b/app/components/UI/Tokens/util/deriveBalanceFromAssetMarketDetails.ts
@@ -49,7 +49,7 @@ export const deriveBalanceFromAssetMarketDetails = (
 
   if (!conversionRate)
     return {
-      balanceFiat: asset.isETH ? asset.balanceFiat : TOKEN_BALANCE_LOADING,
+      balanceFiat: asset.isETH ? asset.balanceFiat : TOKEN_RATE_UNDEFINED,
       balanceValueFormatted,
     };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Do not render loader when market price fetch fail

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: do not render loader when market price fetch fail

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3694

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents misleading loaders when market data fails and tightens balance rendering logic.
> 
> - Extracts `FiatBalanceView` in `TokenSelectorItem` to render a skeleton only for `TOKEN_BALANCE_LOADING` states and render nothing for `TOKEN_RATE_UNDEFINED`; integrates it into the balance section
> - Updates `TokenSelectorItem.test.tsx` to cover lowercase/uppercase loading tokens, undefined rate, available fiat balance, and `shouldShowBalance` off
> - Adjusts `deriveBalanceFromAssetMarketDetails` to return `TOKEN_RATE_UNDEFINED` for tokens when `conversionRate` is missing (preserving ETH behavior); updates tests to match
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9061bb5df04881c890c893637af0cead3abbfc7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->