### PR TITLE
feat: enhance market data formatting with localization support

### DIFF
--- a/app/util/number/index.js
+++ b/app/util/number/index.js
@@ -959,31 +959,40 @@ export const safeBNToHex = (value) => {
 
 /**
  * Formats a potentially large number to the nearest unit.
- * e.g. 1T for trillions, 2.3B for billions, 4.56M for millions, 7,890 for thousands, etc.
+ * e.g. 1T for trillions, 2.3B for billions, 4.56M for millions, 7.89K for thousands, etc.
  *
- * @param t - An I18nContext translator.
+ * @param i18n - An I18nContext translator with a `t` method.
  * @param number - The number to format.
+ * @param options - Optional formatting options.
+ * @param options.decimals - Number of decimal places (default: 2).
+ * @param options.includeK - Whether to include K suffix for thousands (default: false for backward compatibility).
  * @returns A localized string of the formatted number + unit.
  */
-export const localizeLargeNumber = (i18n, number) => {
+export const localizeLargeNumber = (i18n, number, options = {}) => {
+  const { decimals = 2, includeK = false } = options;
   const oneTrillion = 1000000000000;
   const oneBillion = 1000000000;
   const oneMillion = 1000000;
+  const oneThousand = 1000;
 
   if (number >= oneTrillion) {
-    return `${(number / oneTrillion).toFixed(2)}${i18n.t(
+    return `${(number / oneTrillion).toFixed(decimals)}${i18n.t(
       'token.trillion_abbreviation',
     )}`;
   } else if (number >= oneBillion) {
-    return `${(number / oneBillion).toFixed(2)}${i18n.t(
+    return `${(number / oneBillion).toFixed(decimals)}${i18n.t(
       'token.billion_abbreviation',
     )}`;
   } else if (number >= oneMillion) {
-    return `${(number / oneMillion).toFixed(2)}${i18n.t(
+    return `${(number / oneMillion).toFixed(decimals)}${i18n.t(
       'token.million_abbreviation',
     )}`;
+  } else if (includeK && number >= oneThousand) {
+    return `${(number / oneThousand).toFixed(decimals)}${i18n.t(
+      'token.thousand_abbreviation',
+    )}`;
   }
-  return number.toFixed(2);
+  return number.toFixed(decimals);
 };
 
 export const convertDecimalToPercentage = (decimal) => {

--- a/app/util/number/index.test.ts
+++ b/app/util/number/index.test.ts
@@ -434,6 +434,7 @@ describe('Number utils :: localizeLargeNumber', () => {
           'token.trillion_abbreviation': 'T',
           'token.billion_abbreviation': 'B',
           'token.million_abbreviation': 'M',
+          'token.thousand_abbreviation': 'K',
         };
         return translations[key];
       }),
@@ -481,6 +482,35 @@ describe('Number utils :: localizeLargeNumber', () => {
 
     expect(localizeLargeNumber(i18n, million)).toBe('1.00M');
     expect(i18n.t).toHaveBeenCalledWith('token.million_abbreviation');
+  });
+
+  it('should include K suffix for thousands when includeK is true', () => {
+    const number = 150000;
+    const result = localizeLargeNumber(i18n, number, { includeK: true });
+    expect(result).toBe('150.00K');
+    expect(i18n.t).toHaveBeenCalledWith('token.thousand_abbreviation');
+  });
+
+  it('should not include K suffix for thousands when includeK is false (default)', () => {
+    const number = 150000;
+    const result = localizeLargeNumber(i18n, number);
+    expect(result).toBe('150000.00');
+    expect(i18n.t).not.toHaveBeenCalled();
+  });
+
+  it('should support custom decimals option', () => {
+    const number = 1500000;
+    const result = localizeLargeNumber(i18n, number, { decimals: 1 });
+    expect(result).toBe('1.5M');
+  });
+
+  it('should support includeK with custom decimals', () => {
+    const number = 150000;
+    const result = localizeLargeNumber(i18n, number, {
+      includeK: true,
+      decimals: 0,
+    });
+    expect(result).toBe('150K');
   });
 });
 

--- a/app/util/number/index.test.ts
+++ b/app/util/number/index.test.ts
@@ -441,35 +441,35 @@ describe('Number utils :: localizeLargeNumber', () => {
     };
   });
 
-  it('should localize numbers in the trillions correctly', () => {
+  it('localizes numbers in the trillions correctly', () => {
     const number = 1500000000000;
     const result = localizeLargeNumber(i18n, number);
     expect(result).toBe('1.50T');
     expect(i18n.t).toHaveBeenCalledWith('token.trillion_abbreviation');
   });
 
-  it('should localize numbers in the billions correctly', () => {
+  it('localizes numbers in the billions correctly', () => {
     const number = 1500000000;
     const result = localizeLargeNumber(i18n, number);
     expect(result).toBe('1.50B');
     expect(i18n.t).toHaveBeenCalledWith('token.billion_abbreviation');
   });
 
-  it('should localize numbers in the millions correctly', () => {
+  it('localizes numbers in the millions correctly', () => {
     const number = 1500000;
     const result = localizeLargeNumber(i18n, number);
     expect(result).toBe('1.50M');
     expect(i18n.t).toHaveBeenCalledWith('token.million_abbreviation');
   });
 
-  it('should format numbers below one million correctly', () => {
+  it('formats numbers below one million correctly', () => {
     const number = 123456.789;
     const result = localizeLargeNumber(i18n, number);
     expect(result).toBe('123456.79');
     expect(i18n.t).not.toHaveBeenCalled();
   });
 
-  it('should handle exact boundary conditions correctly', () => {
+  it('handles exact boundary conditions correctly', () => {
     const trillion = 1000000000000;
     const billion = 1000000000;
     const million = 1000000;
@@ -484,27 +484,27 @@ describe('Number utils :: localizeLargeNumber', () => {
     expect(i18n.t).toHaveBeenCalledWith('token.million_abbreviation');
   });
 
-  it('should include K suffix for thousands when includeK is true', () => {
+  it('includes K suffix for thousands when includeK is true', () => {
     const number = 150000;
     const result = localizeLargeNumber(i18n, number, { includeK: true });
     expect(result).toBe('150.00K');
     expect(i18n.t).toHaveBeenCalledWith('token.thousand_abbreviation');
   });
 
-  it('should not include K suffix for thousands when includeK is false (default)', () => {
+  it('does not include K suffix for thousands when includeK is false (default)', () => {
     const number = 150000;
     const result = localizeLargeNumber(i18n, number);
     expect(result).toBe('150000.00');
     expect(i18n.t).not.toHaveBeenCalled();
   });
 
-  it('should support custom decimals option', () => {
+  it('supports custom decimals option', () => {
     const number = 1500000;
     const result = localizeLargeNumber(i18n, number, { decimals: 1 });
     expect(result).toBe('1.5M');
   });
 
-  it('should support includeK with custom decimals', () => {
+  it('supports includeK with custom decimals', () => {
     const number = 150000;
     const result = localizeLargeNumber(i18n, number, {
       includeK: true,
@@ -528,7 +528,7 @@ describe('Number utils :: hexToBN', () => {
   it('hexToBN', () => {
     expect(hexToBN('0x539').toNumber()).toBe(1337);
   });
-  it('should handle non string values', () => {
+  it('handles non string values', () => {
     const newBN = new BN4(1);
     expect(hexToBN(newBN)).toBe(newBN);
   });
@@ -679,7 +679,7 @@ describe('Number utils :: balanceToFiat', () => {
     expect(balanceToFiat(0.0001, 0.1, 0.1, 'usd')).toEqual('$0.00');
   });
 
-  it('should returns undefined if balanceToFiat conversionRate is undefined', () => {
+  it('returns undefined if balanceToFiat conversionRate is undefined', () => {
     expect(balanceToFiat(0.1, undefined, 0.1, 'usd')).toEqual(undefined);
   });
 });
@@ -708,7 +708,7 @@ describe('Number utils :: renderFiat', () => {
 });
 
 describe('toHexadecimal', () => {
-  it('should convert to hexadecimal', () => {
+  it('converts to hexadecimal', () => {
     expect(toHexadecimal('001')).toEqual('1');
     expect(toHexadecimal('0x01')).toEqual('0x01');
     expect(toHexadecimal(2)).toEqual('2');
@@ -721,7 +721,7 @@ describe('toHexadecimal', () => {
 });
 
 describe('Number utils :: fastSplit', () => {
-  it('should split ', () => {
+  it('splits string', () => {
     expect(fastSplit('1650000007.7')).toEqual('1650000007');
     expect(fastSplit('1650000007')).toEqual('1650000007');
     expect(fastSplit('test string', ' ')).toEqual('test');
@@ -729,7 +729,7 @@ describe('Number utils :: fastSplit', () => {
 });
 
 describe('Number utils :: safeNumberToBN', () => {
-  it('should safe convert a string type positive decimal number to BN', () => {
+  it('safely converts a string type positive decimal number to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN('1650000007.7');
@@ -742,7 +742,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a number type positive decimal number to BN', () => {
+  it('safely converts a number type positive decimal number to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN(1650000007.7);
@@ -755,7 +755,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a string type positive integer to BN', () => {
+  it('safely converts a string type positive integer to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN('16500');
@@ -768,7 +768,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a number type positive integer to BN', () => {
+  it('safely converts a number type positive integer to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN(16500);
@@ -781,7 +781,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a string type negative decimal number to BN', () => {
+  it('safely converts a string type negative decimal number to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN('-1650000007.7');
@@ -794,7 +794,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a number type negative decimal number to BN', () => {
+  it('safely converts a number type negative decimal number to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN(-1650000007.7);
@@ -807,7 +807,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a string type negative integer to BN', () => {
+  it('safely converts a string type negative integer to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN('-16500');
@@ -820,7 +820,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a number type negative integer to BN', () => {
+  it('safely converts a number type negative integer to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN(-16500);
@@ -833,7 +833,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a positive hex to BN', () => {
+  it('safely converts a positive hex to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN('75BCD15');
@@ -846,7 +846,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a positive hex with 0x prefix to BN', () => {
+  it('safely converts a positive hex with 0x prefix to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN('0x75BCD15');
@@ -859,7 +859,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a negative hex to BN', () => {
+  it('safely converts a negative hex to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN('-75BCD15');
@@ -872,7 +872,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a negative hex with 0x prefix to BN', () => {
+  it('safely converts a negative hex with 0x prefix to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN('-0x75BCD15');
@@ -885,7 +885,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a decimal zero to BN', () => {
+  it('safely converts a decimal zero to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN('0');
@@ -898,7 +898,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a hex zero to BN', () => {
+  it('safely converts a hex zero to BN', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN('0x0');
@@ -911,7 +911,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert an invalid hex string to zero', () => {
+  it('safely converts an invalid hex string to zero', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN('0xNaN');
@@ -924,7 +924,7 @@ describe('Number utils :: safeNumberToBN', () => {
     expect(result.length).toEqual(expected.length);
   });
 
-  it('should safe convert a NaN object', () => {
+  it('safely converts a NaN object', () => {
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = safeNumberToBN(NaN);
@@ -939,7 +939,7 @@ describe('Number utils :: safeNumberToBN', () => {
 });
 
 describe('Number utils :: isNumber', () => {
-  it('should be a valid number ', () => {
+  it('is a valid number', () => {
     expect(isNumber('1650.7')).toBe(true);
     expect(isNumber('1000')).toBe(true);
     expect(isNumber('0.0001')).toBe(true);
@@ -947,7 +947,7 @@ describe('Number utils :: isNumber', () => {
     expect(isNumber('1')).toBe(true);
   });
 
-  it('should not be a valid number ', () => {
+  it('is not a valid number', () => {
     expect(isNumber('..7')).toBe(false);
     expect(isNumber('1..1')).toBe(false);
     expect(isNumber('0..')).toBe(false);
@@ -964,7 +964,7 @@ describe('Number utils :: isNumber', () => {
 });
 
 describe('Number utils :: isNumberValue', () => {
-  it('should return true for valid number types', () => {
+  it('returns true for valid number types', () => {
     expect(isNumberValue(1650.7)).toBe(true);
     expect(isNumberValue(1000)).toBe(true);
     expect(isNumberValue(0.0001)).toBe(true);
@@ -973,7 +973,7 @@ describe('Number utils :: isNumberValue', () => {
     expect(isNumberValue(1e-10)).toBe(true);
   });
 
-  it('should be a valid number string types', () => {
+  it('is a valid number string type', () => {
     expect(isNumberValue('1650.7')).toBe(true);
     expect(isNumberValue('1000')).toBe(true);
     expect(isNumberValue('.01')).toBe(true);
@@ -984,7 +984,7 @@ describe('Number utils :: isNumberValue', () => {
     expect(isNumberValue('1e-10')).toBe(true);
   });
 
-  it('should not be a valid number ', () => {
+  it('is not a valid number value', () => {
     expect(isNumberValue('..7')).toBe(false);
     expect(isNumberValue('1..1')).toBe(false);
     expect(isNumberValue('0..')).toBe(false);
@@ -1000,13 +1000,13 @@ describe('Number utils :: isNumberValue', () => {
 });
 
 describe('Number utils :: dotAndCommaDecimalFormatter', () => {
-  it('should return the number if it does not contain a dot or comma', () => {
+  it('returns the number if it does not contain a dot or comma', () => {
     expect(dotAndCommaDecimalFormatter('1650')).toBe('1650');
   });
-  it('should return the number if it contains a dot', () => {
+  it('returns the number if it contains a dot', () => {
     expect(dotAndCommaDecimalFormatter('1650.7')).toBe('1650.7');
   });
-  it('should replace the comma with a decimal with a comma if it contains a dot', () => {
+  it('replaces the comma with a decimal with a comma if it contains a dot', () => {
     expect(dotAndCommaDecimalFormatter('1650,7')).toBe('1650.7');
   });
 });
@@ -1102,25 +1102,25 @@ describe('Number utils :: isZeroValue', () => {
 });
 
 describe('Number utils :: formatValueToMatchTokenDecimals', () => {
-  it('should return a formatted value if the submitted decimals is 0', () => {
+  it('returns a formatted value if the submitted decimals is 0', () => {
     expect(formatValueToMatchTokenDecimals('1.0', 0)).toBe('1');
   });
-  it('should return the value if value is null', () => {
+  it('returns the value if value is null', () => {
     expect(formatValueToMatchTokenDecimals(null, 18)).toBe(null);
   });
-  it('should return the value if the decimal is undefined', () => {
+  it('returns the value if the decimal is undefined', () => {
     expect(formatValueToMatchTokenDecimals('1', undefined)).toBe('1');
   });
-  it('should return a formatted value if the decimal is null', () => {
+  it('returns a formatted value if the decimal is null', () => {
     expect(formatValueToMatchTokenDecimals('1', null)).toBe('1');
   });
-  it('should return the value if the decimal is not a number', () => {
+  it('returns the value if the decimal is not a number', () => {
     expect(formatValueToMatchTokenDecimals('1', 'a')).toBe('1');
   });
-  it('should return the value if the value decimal is equal to or less than the submitted decimal', () => {
+  it('returns the value if the value decimal is equal to or less than the submitted decimal', () => {
     expect(formatValueToMatchTokenDecimals('1.2348', 4)).toBe('1.2348');
   });
-  it('should return a formatted value if the value decimal is greater than the submitted decimal', () => {
+  it('returns a formatted value if the value decimal is greater than the submitted decimal', () => {
     expect(formatValueToMatchTokenDecimals('1.234567', 4)).toBe('1.2346');
   });
 });

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -2521,6 +2521,7 @@
     "billion_abbreviation": "Mrd.",
     "trillion_abbreviation": "Trill.",
     "million_abbreviation": "Mio.",
+    "thousand_abbreviation": "Tsd.",
     "token_details": "Token-Details",
     "contract_address": "Contract-Adresse",
     "token_list": "Token-Liste",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2543,6 +2543,7 @@
     "billion_abbreviation": "B",
     "trillion_abbreviation": "T",
     "million_abbreviation": "M",
+    "thousand_abbreviation": "K",
     "token_details": "Token details",
     "contract_address": "Contract address",
     "token_list": "Token list",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -2521,6 +2521,7 @@
     "billion_abbreviation": "Mrd",
     "trillion_abbreviation": "B",
     "million_abbreviation": "M",
+    "thousand_abbreviation": "k",
     "token_details": "Détails du jeton",
     "contract_address": "Adresse du contrat",
     "token_list": "Liste des jetons",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR implements number shortening with abbreviations (K/M/B/T) and increases font size for better readability on the Asset Overview (Token Details) page, addressing UX feedback.

**Changes:**

1. **Number Formatting**: Market cap, Total Volume, Circulating Supply, and Fully Diluted values now display with compact suffixes (K for thousands, M for millions, B for billions, T for trillions) while preserving 2 decimal places
2. **Font Size**: Increased font size from BodySM to BodyMD for better readability of numeric values
3. **Code Simplification**: Refactored to use existing localizeLargeNumber utility function instead of introducing complex new formatting logic, reducing code duplication and maintenance burden
4. **Locale Support**: Maintains proper locale-specific formatting (decimal separators, currency symbol placement, French spacing conventions)

**Example**:
**Before**: $74,206,968,488.05
**After**: $74.21B

The implementation leverages the existing localizeLargeNumber function with a new includeK option to support thousands abbreviation, ensuring consistency with other parts of the app that use similar number formatting.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
5. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved readability of market data on Token Details page by shortening large numbers with abbreviations (K/M/B/T) and increasing font size

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-171

## **Manual testing steps**

```gherkin
Feature: Token Details Market Data Formatting

  Scenario: user views token details with large market values
    Given user is on the Token Details page for a token with market data
    When user views the Market Details section
    Then market cap, total volume, circulating supply, and fully diluted values should display with K/M/B/T suffixes
    And values should show 2 decimal places (e.g., "$74.21B", "1.00M")
    And font size should be larger (BodyMD instead of BodySM) for better readability
    And currency symbols should be positioned correctly based on locale (e.g., "$74.21B" for en-US, "1,00 M €" for fr-FR)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="398" height="830" alt="Screenshot 2026-01-15 at 13 30 36" src="https://github.com/user-attachments/assets/63232577-09d9-4cc3-9219-53c31838fa6e" />

<!-- [screenshots/recordings] -->

### **After**
<img width="391" height="834" alt="Screenshot 2026-01-15 at 13 24 57" src="https://github.com/user-attachments/assets/6ee83b45-99e0-4856-a26c-5a4d86101c23" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability and consistency of market data with locale-aware compact formatting.
> 
> - Refactors `marketDetails` to format `marketCap`, `totalVolume`, `circulatingSupply`, and `fullyDiluted` via `localizeLargeNumber` (includes K/M/B/T) and `Intl` for decimal separators and currency symbol placement; applies French non‑breaking space and lowercase `k`
> - Enhances `localizeLargeNumber` with `decimals` and `includeK` options; supports thousands (`K`) and updates unit logic
> - Adds `token.thousand_abbreviation` to `en`, `de`, and `fr` locales
> - Expands unit tests for number localization (including thousands and custom decimals) and updates test descriptions for clarity
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f14a011a0b22e4fa3227e58ef754a9d0260f12a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->