### PR TITLE
fix: show new msg when token not found on search

### DIFF
--- a/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.test.tsx
+++ b/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.test.tsx
@@ -100,6 +100,31 @@ jest.mock('../../../../util/navigation/navUtils', () => ({
   ),
 }));
 
+jest.mock(
+  '../../TrendingView/components/EmptyErrorState/EmptyErrorTrendingState',
+  () => {
+    const { View, Text } = jest.requireActual('react-native');
+    return jest.fn(({ onRetry }: { onRetry?: () => void }) => (
+      <View testID="empty-error-trending-state">
+        <Text>Trending tokens is not available</Text>
+        {onRetry && <View testID="retry-button" onTouchEnd={onRetry} />}
+      </View>
+    ));
+  },
+);
+
+jest.mock(
+  '../../TrendingView/components/EmptyErrorState/EmptySearchResultState',
+  () => {
+    const { View, Text } = jest.requireActual('react-native');
+    return jest.fn(() => (
+      <View testID="empty-search-result-state">
+        <Text>No tokens found</Text>
+      </View>
+    ));
+  },
+);
+
 jest.mock('../../../UI/Trending/components/TrendingTokensBottomSheet', () => {
   const { View } = jest.requireActual('react-native');
   return {
@@ -336,7 +361,7 @@ describe('TrendingTokensFullView', () => {
     expect(skeletons[0]).toBeOnTheScreen();
   });
 
-  it('displays empty error state when results are empty', () => {
+  it('displays empty error state when results are empty without search query', () => {
     mockUseTrendingSearch.mockReturnValue({
       data: [],
       isLoading: false,
@@ -350,6 +375,31 @@ describe('TrendingTokensFullView', () => {
     );
 
     expect(getByText('Trending tokens is not available')).toBeOnTheScreen();
+  });
+
+  it('displays empty search result state when search returns no results', () => {
+    mockUseTrendingSearch.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    const { getByText, getByTestId } = renderWithProvider(
+      <TrendingTokensFullView />,
+      { state: mockState },
+      false,
+    );
+
+    // Open search
+    const searchIcon = getByTestId('search-icon');
+    fireEvent.press(searchIcon);
+
+    // Type search query
+    const searchInput = getByTestId('trending-search-input');
+    fireEvent.changeText(searchInput, 'nonexistenttoken');
+
+    expect(getByTestId('empty-search-result-state')).toBeOnTheScreen();
+    expect(getByText('No tokens found')).toBeOnTheScreen();
   });
 
   it('displays trending tokens list when data is loaded', () => {

--- a/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.test.tsx
+++ b/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.test.tsx
@@ -391,11 +391,11 @@ describe('TrendingTokensFullView', () => {
     );
 
     // Open search
-    const searchIcon = getByTestId('search-icon');
-    fireEvent.press(searchIcon);
+    const searchToggle = getByTestId('trending-tokens-header-search-toggle');
+    fireEvent.press(searchToggle);
 
     // Type search query
-    const searchInput = getByTestId('trending-search-input');
+    const searchInput = getByTestId('trending-tokens-header-search-bar');
     fireEvent.changeText(searchInput, 'nonexistenttoken');
 
     expect(getByTestId('empty-search-result-state')).toBeOnTheScreen();

--- a/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.tsx
+++ b/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.tsx
@@ -42,6 +42,7 @@ import {
 import { sortTrendingTokens } from '../../../UI/Trending/utils/sortTrendingTokens';
 import { useTrendingSearch } from '../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
 import EmptyErrorTrendingState from '../../TrendingView/components/EmptyErrorState/EmptyErrorTrendingState';
+import EmptySearchResultState from '../../TrendingView/components/EmptyErrorState/EmptySearchResultState';
 
 interface TrendingTokensNavigationParamList {
   [key: string]: undefined | object;
@@ -391,7 +392,11 @@ const TrendingTokensFullView = () => {
           ))}
         </View>
       ) : (searchResults as TrendingAsset[]).length === 0 ? (
-        <EmptyErrorTrendingState onRetry={handleRefresh} />
+        searchQuery.trim().length > 0 ? (
+          <EmptySearchResultState />
+        ) : (
+          <EmptyErrorTrendingState onRetry={handleRefresh} />
+        )
       ) : (
         <View style={styles.listContainer}>
           <TrendingTokensList

--- a/app/components/Views/TrendingView/components/EmptyErrorState/EmptySearchResultState.test.tsx
+++ b/app/components/Views/TrendingView/components/EmptyErrorState/EmptySearchResultState.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import EmptySearchResultState from './EmptySearchResultState';
+
+describe('EmptySearchResultState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders empty search result state with title and description', () => {
+    const { getByText } = render(<EmptySearchResultState />);
+
+    expect(getByText('No tokens found')).toBeDefined();
+    expect(getByText('We were not able to find this token')).toBeDefined();
+  });
+
+  it('renders with correct test ID', () => {
+    const { getByTestId } = render(<EmptySearchResultState />);
+
+    expect(getByTestId('empty-search-result-state')).toBeDefined();
+  });
+
+  it('does not render try again button', () => {
+    const { queryByText } = render(<EmptySearchResultState />);
+
+    expect(queryByText('Try again')).toBeNull();
+  });
+});

--- a/app/components/Views/TrendingView/components/EmptyErrorState/EmptySearchResultState.test.tsx
+++ b/app/components/Views/TrendingView/components/EmptyErrorState/EmptySearchResultState.test.tsx
@@ -10,14 +10,14 @@ describe('EmptySearchResultState', () => {
   it('renders empty search result state with title and description', () => {
     const { getByText } = render(<EmptySearchResultState />);
 
-    expect(getByText('No tokens found')).toBeDefined();
-    expect(getByText('We were not able to find this token')).toBeDefined();
+    expect(getByText('No tokens found')).toBeOnTheScreen();
+    expect(getByText('We were not able to find this token')).toBeOnTheScreen();
   });
 
   it('renders with correct test ID', () => {
     const { getByTestId } = render(<EmptySearchResultState />);
 
-    expect(getByTestId('empty-search-result-state')).toBeDefined();
+    expect(getByTestId('empty-search-result-state')).toBeOnTheScreen();
   });
 
   it('does not render try again button', () => {

--- a/app/components/Views/TrendingView/components/EmptyErrorState/EmptySearchResultState.tsx
+++ b/app/components/Views/TrendingView/components/EmptyErrorState/EmptySearchResultState.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+
+const EmptySearchResultState: React.FC = () => (
+  <Box
+    testID="empty-search-result-state"
+    twClassName="flex-col pt-9 pb-24 justify-center items-center gap-3 flex-1"
+  >
+    <Box twClassName="flex-col w-[337px] items-stretch">
+      <Text
+        variant={TextVariant.HeadingSm}
+        twClassName="text-default text-center self-stretch mb-2"
+      >
+        {strings('trending.empty_search_result_state.title')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        twClassName="text-alternative text-center self-stretch font-medium"
+      >
+        {strings('trending.empty_search_result_state.description')}
+      </Text>
+    </Box>
+  </Box>
+);
+
+export default EmptySearchResultState;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7334,6 +7334,10 @@
       "title": "Trending tokens is not available",
       "description": "We can't fetch this page right now",
       "try_again": "Try again"
+    },
+    "empty_search_result_state": {
+      "title": "No tokens found",
+      "description": "We were not able to find this token"
     }
   },
   "ota_update_modal": {


### PR DESCRIPTION

## **Description**

Show a custom msg when user searches for a token that is not found

## **Changelog**

CHANGELOG entry: show custom error msg page when user searches for token not found on trending page 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/24566

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a dedicated empty search state for Trending Tokens and wires it into the full view with tests and i18n.
> 
> - Introduces `EmptySearchResultState` (design-system layout) with new i18n strings: `trending.empty_search_result_state.{title,description}`
> - Updates `TrendingTokensFullView` to render `EmptySearchResultState` when `searchQuery.trim().length > 0` and no results; otherwise falls back to `EmptyErrorTrendingState`; loading still shows skeletons
> - Extends tests: new specs for `EmptySearchResultState`; updates `TrendingTokensFullView` tests to cover empty-without-search vs empty-with-search paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0db66980cb5f37e3e9dc5f739fc596c96c7310e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->