### PR TITLE
fix: Add mock response for Hyperliquid info endpoint

### DIFF
--- a/e2e/api-mocking/mock-responses/defaults/index.ts
+++ b/e2e/api-mocking/mock-responses/defaults/index.ts
@@ -306,6 +306,11 @@ export const DEFAULT_MOCKS = {
       },
     },
     ...(DEFAULT_REWARDS_MOCKS.POST || []),
+    {
+      urlEndpoint: /^https:\/\/api\.hyperliquid\.xyz\/info$/,
+      responseCode: 200,
+      response: [],
+    },
   ],
   PUT: [...(USER_STORAGE_MOCK.PUT || [])],
   DELETE: [],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes e2e tests, see https://github.com/MetaMask/metamask-mobile/pull/20390#discussion_r2695412179

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/pull/20390#discussion_r2695412179

## **Manual testing steps**

NA

## **Screenshots/Recordings**

NA

### **Before**

NA
### **After**

NA
## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a default mock for the Hyperliquid info API used during e2e runs.
> 
> - Adds `POST` mock for `https://api.hyperliquid.xyz/info` in `e2e/api-mocking/mock-responses/defaults/index.ts`, returning `[]` with `200` to prevent external calls during tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe4bf07a0de9cae753a0e3398369e1a0d3c91583. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->