### PR TITLE
test: adds transaction_hash coverage in Transaction Finalized event

### DIFF
--- a/e2e/api-mocking/mock-responses/feature-flags-mocks.ts
+++ b/e2e/api-mocking/mock-responses/feature-flags-mocks.ts
@@ -150,3 +150,7 @@ export const remoteFeatureFlagPredictEnabled = (enabled = true) => ({
     minimumVersion: '7.60.0',
   },
 });
+
+export const remoteFeatureFlagExtensionUxPna25 = (enabled = true) => ({
+  extensionUxPna25: enabled,
+});

--- a/e2e/framework/Constants.ts
+++ b/e2e/framework/Constants.ts
@@ -1,6 +1,12 @@
 /* eslint-disable import/no-nodejs-modules */
 import path from 'path';
 import { GanacheHardfork } from './types';
+import { DEFAULT_ANVIL_PORT } from '../seeder/anvil-manager';
+
+// The RPC URL for the local node
+// This should be used in fixtures where a url is needed.
+// The port is then translated to the actual allocated port
+export const LOCAL_NODE_RPC_URL = `http://localhost:${DEFAULT_ANVIL_PORT}`;
 
 // Port Constants
 // Fallback ports - used in fixture data (app's persisted state)

--- a/e2e/seeder/anvil-manager.ts
+++ b/e2e/seeder/anvil-manager.ts
@@ -203,10 +203,10 @@ class AnvilManager implements Resource {
    * @returns {Promise<Block | undefined>} Block
    */
   async getBlockByNumber(blockNumber: bigint): Promise<Block | undefined> {
-    logger.debug(`Getting block by number: ${blockNumber}...`);
+    logger.debug(`Getting block by number: ${blockNumber}`);
     const { publicClient } = this.getProvider();
     const block = await publicClient.getBlock({ blockNumber });
-    logger.debug(`Block: ${JSON.stringify(block)}`);
+    logger.debug(`Got block with ${block.transactions.length} transaction(s)`);
     return block;
   }
 

--- a/e2e/seeder/anvil-manager.ts
+++ b/e2e/seeder/anvil-manager.ts
@@ -7,6 +7,7 @@ import { AnvilPort } from '../framework/fixtures/FixtureUtils';
 import { AnvilNodeOptions, ServerStatus, Resource } from '../framework/types';
 import { createLogger } from '../framework/logger';
 import PortManager, { ResourceType } from '../framework/PortManager';
+import { Block } from 'viem';
 
 const logger = createLogger({
   name: 'AnvilManager',
@@ -182,6 +183,31 @@ class AnvilManager implements Resource {
     const logs = await publicClient.getLogs();
 
     return logs;
+  }
+
+  /**
+   * Get latest block number
+   * @returns {Promise<bigint>} Latest block number
+   */
+  async getLatestBlockNumber(): Promise<bigint> {
+    logger.debug('Getting latest block number...');
+    const { publicClient } = this.getProvider();
+    const blockNumber = await publicClient.getBlockNumber();
+    logger.debug(`Latest block number: ${blockNumber}`);
+    return blockNumber;
+  }
+
+  /**
+   * Get block by number
+   * @param {bigint} blockNumber - Block number
+   * @returns {Promise<Block | undefined>} Block
+   */
+  async getBlockByNumber(blockNumber: bigint): Promise<Block | undefined> {
+    logger.debug(`Getting block by number: ${blockNumber}...`);
+    const { publicClient } = this.getProvider();
+    const block = await publicClient.getBlock({ blockNumber });
+    logger.debug(`Block: ${JSON.stringify(block)}`);
+    return block;
   }
 
   /**

--- a/e2e/specs/send/metricsValidationHelper.ts
+++ b/e2e/specs/send/metricsValidationHelper.ts
@@ -1,0 +1,35 @@
+import { Mockttp } from 'mockttp';
+import { AnvilManager } from '../../seeder/anvil-manager';
+import { LocalNode } from '../../framework';
+import { getEventsPayloads } from '../analytics/helpers';
+
+export const validateTransactionHashInTransactionFinalizedEvent = async (
+  localNodes?: LocalNode[],
+  mockServer?: Mockttp,
+) => {
+  // Validate txHash in Transaction Finalized Event
+  const localNode = localNodes?.[0];
+  if (!(localNode instanceof AnvilManager) || !mockServer) {
+    throw new Error(
+      'Expected first localNode to be an AnvilManager instance and mockServer to be defined',
+    );
+  }
+
+  // Get latest transaction from the local node
+  const latestBlockNumber = await localNode.getLatestBlockNumber();
+  const block = await localNode.getBlockByNumber(latestBlockNumber);
+  const latestTransaction = block?.transactions[0];
+
+  const events = await getEventsPayloads(mockServer);
+  const transactionFinalizedEvent = events.find(
+    (event) => event.event === 'Transaction Finalized',
+  );
+  const eventTxHash = transactionFinalizedEvent?.properties.transaction_hash;
+
+  if (latestTransaction !== eventTxHash) {
+    throw new Error(
+      `Transaction hash mismatch: expected ${latestTransaction}, got ${eventTxHash}. 
+        Transaction Hash is not matching with the latest transaction on the local node.`,
+    );
+  }
+};

--- a/e2e/specs/send/metricsValidationHelper.ts
+++ b/e2e/specs/send/metricsValidationHelper.ts
@@ -20,11 +20,30 @@ export const validateTransactionHashInTransactionFinalizedEvent = async (
   const block = await localNode.getBlockByNumber(latestBlockNumber);
   const latestTransaction = block?.transactions[0];
 
+  if (!latestTransaction) {
+    throw new Error(
+      `No transactions found in block ${latestBlockNumber}. Expected at least one transaction.`,
+    );
+  }
+
   const events = await getEventsPayloads(mockServer);
   const transactionFinalizedEvent = events.find(
     (event) => event.event === 'Transaction Finalized',
   );
-  const eventTxHash = transactionFinalizedEvent?.properties.transaction_hash;
+
+  if (!transactionFinalizedEvent) {
+    throw new Error(
+      'Transaction Finalized event not found in analytics events.',
+    );
+  }
+
+  const eventTxHash = transactionFinalizedEvent.properties?.transaction_hash;
+
+  if (!eventTxHash) {
+    throw new Error(
+      'Transaction Finalized event does not contain a transaction_hash property.',
+    );
+  }
 
   if (latestTransaction !== eventTxHash) {
     throw new Error(

--- a/e2e/specs/send/send-native-token.spec.ts
+++ b/e2e/specs/send/send-native-token.spec.ts
@@ -4,13 +4,16 @@ import SendView from '../../pages/Send/RedesignedSendView';
 import TabBarComponent from '../../pages/wallet/TabBarComponent';
 import WalletView from '../../pages/wallet/WalletView';
 import { Assertions } from '../../framework';
-import { DappVariants } from '../../framework/Constants';
+import { DappVariants, LOCAL_NODE_RPC_URL } from '../../framework/Constants';
 import { SmokeConfirmationsRedesigned } from '../../tags';
-import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
 import { loginToApp } from '../../viewHelper';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import { LocalNode } from '../../framework/types';
-import { AnvilManager } from '../../seeder/anvil-manager';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
+import { remoteFeatureFlagExtensionUxPna25 } from '../../api-mocking/mock-responses/feature-flags-mocks';
+import { Mockttp } from 'mockttp';
+import { setupMockRequest } from '../../api-mocking/helpers/mockHelpers';
+import { validateTransactionHashInTransactionFinalizedEvent } from './metricsValidationHelper';
 
 const RECIPIENT = '0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb';
 
@@ -23,28 +26,43 @@ describe(SmokeConfirmationsRedesigned('Send native asset'), () => {
             dappVariant: DappVariants.TEST_DAPP,
           },
         ],
-        fixture: ({ localNodes }: { localNodes?: LocalNode[] }) => {
-          const node = localNodes?.[0] as unknown as AnvilManager;
-          const rpcPort =
-            node instanceof AnvilManager
-              ? (node.getPort() ?? AnvilPort())
-              : undefined;
+        fixture: new FixtureBuilder()
+          .withNetworkController({
+            providerConfig: {
+              chainId: '0x539',
+              rpcUrl: LOCAL_NODE_RPC_URL,
+              type: 'custom',
+              nickname: 'Local RPC',
+              ticker: 'ETH',
+            },
+          })
+          .withMetaMetricsOptIn()
+          .withPreferencesController({})
+          .build(),
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await setupRemoteFeatureFlagsMock(
+            mockServer,
+            remoteFeatureFlagExtensionUxPna25(true),
+          );
 
-          return new FixtureBuilder()
-            .withNetworkController({
-              providerConfig: {
-                chainId: '0x539',
-                rpcUrl: `http://localhost:${rpcPort ?? AnvilPort()}`,
-                type: 'custom',
-                nickname: 'Local RPC',
-                ticker: 'ETH',
-              },
-            })
-            .build();
+          await setupMockRequest(mockServer, {
+            requestMethod: 'PUT',
+            url: /https:\/\/authentication\.api\.cx\.metamask\.io\/api\/v2\/profile\/accounts/i,
+            response: {
+              message: 'OK',
+            },
+            responseCode: 200,
+          });
         },
         restartDevice: true,
       },
-      async () => {
+      async ({
+        localNodes,
+        mockServer,
+      }: {
+        localNodes?: LocalNode[];
+        mockServer?: Mockttp;
+      }) => {
         await loginToApp();
         await device.disableSynchronization();
         // send 5 ETH
@@ -57,6 +75,13 @@ describe(SmokeConfirmationsRedesigned('Send native asset'), () => {
         await FooterActions.tapConfirmButton();
         await TabBarComponent.tapActivity();
         await Assertions.expectTextDisplayed('Confirmed');
+
+        // Validate txHash in Transaction Finalized Event.
+        // Makes the test fail if the txHash is not matching with the latest transaction on the local node.
+        await validateTransactionHashInTransactionFinalizedEvent(
+          localNodes,
+          mockServer,
+        );
 
         // send 50% ETH
         await TabBarComponent.tapWallet();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Adds coverage for transaction_hash property in Transaction Finalized event.

### Additions
- added `getLatestBlockNumber`, `getBlockByNumber` to Anvil Manager

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds automated validation that analytics report the correct `transaction_hash`.
> 
> - New `metricsValidationHelper` checks `Transaction Finalized` event’s `transaction_hash` against the latest tx from the local Anvil node
> - Extends `AnvilManager` with `getLatestBlockNumber` and `getBlockByNumber`
> - Introduces `LOCAL_NODE_RPC_URL` for consistent local RPC configuration
> - Adds `remoteFeatureFlagExtensionUxPna25` mock and sets up related remote feature flag/auth mocks in tests
> - Updates `send-native-token.spec` to use local RPC, opt into MetaMetrics, and run the new validation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7898ebb976759a705263b0ea94578b8972d479f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->