### PR TITLE
feat(predict): cp-7.62.0 integrate UI components into game details view

### DIFF
--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
@@ -66,6 +66,79 @@ jest.mock('../PredictGameDetailsFooter/PredictGameAboutSheet', () => {
   };
 });
 
+jest.mock('../PredictSportTeamGradient', () => {
+  const { View } = jest.requireActual('react-native');
+  return function MockPredictSportTeamGradient({
+    children,
+    testID,
+    awayColor,
+    homeColor,
+  }: {
+    children: React.ReactNode;
+    testID?: string;
+    awayColor?: string;
+    homeColor?: string;
+  }) {
+    return (
+      <View
+        testID={testID}
+        accessibilityHint={`away:${awayColor ?? 'undefined'},home:${homeColor ?? 'undefined'}`}
+      >
+        {children}
+      </View>
+    );
+  };
+});
+
+jest.mock('../PredictSportScoreboard', () => {
+  const { View } = jest.requireActual('react-native');
+  const actualModule = jest.requireActual(
+    '../PredictSportScoreboard/PredictSportScoreboard.types',
+  );
+  return {
+    __esModule: true,
+    default: function MockPredictSportScoreboard({
+      testID,
+      gameState,
+      awayTeam,
+      homeTeam,
+    }: {
+      testID?: string;
+      gameState?: string;
+      awayTeam?: { abbreviation: string };
+      homeTeam?: { abbreviation: string };
+    }) {
+      return (
+        <View
+          testID={testID}
+          accessibilityHint={`state:${gameState ?? 'undefined'},away:${awayTeam?.abbreviation ?? 'undefined'},home:${homeTeam?.abbreviation ?? 'undefined'}`}
+        />
+      );
+    },
+    GameState: actualModule.GameState,
+    Possession: actualModule.Possession,
+    Winner: actualModule.Winner,
+  };
+});
+
+jest.mock('../PredictGameChart', () => {
+  const { View } = jest.requireActual('react-native');
+  return function MockPredictGameChart({
+    testID,
+    tokenIds,
+  }: {
+    testID?: string;
+    tokenIds?: string[];
+  }) {
+    return (
+      <View
+        testID={testID}
+        accessibilityHint={`tokens:${tokenIds?.join(',') ?? 'none'}`}
+      />
+    );
+  };
+});
+
 const mockGetRefHandlers = jest.fn(() => ({
   onOpenBottomSheet: jest.fn(),
   onCloseBottomSheet: jest.fn(),
@@ -83,6 +156,32 @@ jest.mock('../../hooks/usePredictBottomSheet', () => ({
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => key),
 }));
+
+const mockBaseGame = {
+  id: 'game-123',
+  homeTeam: {
+    id: 'team-home',
+    name: 'Team A',
+    abbreviation: 'TA',
+    color: '#FF0000',
+    alias: 'Team A',
+    logo: 'https://example.com/logo-a.png',
+  },
+  awayTeam: {
+    id: 'team-away',
+    name: 'Team B',
+    abbreviation: 'TB',
+    color: '#0000FF',
+    alias: 'Team B',
+    logo: 'https://example.com/logo-b.png',
+  },
+  startTime: '2024-12-31T20:00:00Z',
+  status: 'scheduled' as const,
+  league: 'nfl' as const,
+  elapsed: null,
+  period: null,
+  score: null,
+};
 
 const createMockMarket = (
   overrides: Partial<PredictMarket> = {},
@@ -119,18 +218,7 @@ const createMockMarket = (
       },
     ],
     endDate: '2024-12-31T23:59:59Z',
-    game: {
-      homeTeam: {
-        name: 'Team A',
-        abbreviation: 'TA',
-      },
-      awayTeam: {
-        name: 'Team B',
-        abbreviation: 'TB',
-      },
-      startTime: '2024-12-31T20:00:00Z',
-      status: 'scheduled',
-    },
+    game: mockBaseGame,
     ...overrides,
   }) as PredictMarket;
 
@@ -312,6 +400,231 @@ describe('PredictGameDetailsContent', () => {
       );
 
       expect(queryByTestId('predict-game-about-sheet')).toBeNull();
+    });
+  });
+
+  describe('Guard Conditions', () => {
+    it('returns null when market.game is undefined', () => {
+      const market = createMockMarket({ game: undefined });
+
+      const { toJSON } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      expect(toJSON()).toBeNull();
+    });
+
+    it('returns null when market has no outcomes', () => {
+      const market = createMockMarket({ outcomes: [] });
+
+      const { toJSON } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe('Gradient Integration', () => {
+    it('renders gradient with team colors', () => {
+      const market = createMockMarket();
+
+      const { getByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      const gradient = getByTestId('game-details-gradient');
+
+      expect(gradient).toBeOnTheScreen();
+      expect(gradient.props.accessibilityHint).toBe(
+        'away:#0000FF,home:#FF0000',
+      );
+    });
+  });
+
+  describe('Scoreboard Integration', () => {
+    it('renders scoreboard with team data', () => {
+      const market = createMockMarket();
+
+      const { getByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      const scoreboard = getByTestId('game-scoreboard');
+
+      expect(scoreboard).toBeOnTheScreen();
+      expect(scoreboard.props.accessibilityHint).toContain('away:TB');
+      expect(scoreboard.props.accessibilityHint).toContain('home:TA');
+    });
+
+    it('renders scoreboard with PreGame state for scheduled games', () => {
+      const market = createMockMarket();
+
+      const { getByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      const scoreboard = getByTestId('game-scoreboard');
+
+      expect(scoreboard.props.accessibilityHint).toContain('state:PreGame');
+    });
+
+    it('renders scoreboard with InProgress state for ongoing games', () => {
+      const market = createMockMarket({
+        game: {
+          ...mockBaseGame,
+          status: 'ongoing',
+          period: 'Q2',
+          elapsed: '5:30',
+          score: { away: 7, home: 14, raw: '7-14' },
+        },
+      });
+
+      const { getByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      const scoreboard = getByTestId('game-scoreboard');
+
+      expect(scoreboard.props.accessibilityHint).toContain('state:InProgress');
+    });
+
+    it('renders scoreboard with Final state for ended games', () => {
+      const market = createMockMarket({
+        game: {
+          ...mockBaseGame,
+          status: 'ended',
+          period: 'FT',
+          score: { away: 21, home: 28, raw: '21-28' },
+        },
+      });
+
+      const { getByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      const scoreboard = getByTestId('game-scoreboard');
+
+      expect(scoreboard.props.accessibilityHint).toContain('state:Final');
+    });
+
+    it('renders scoreboard with Halftime state when period is HT', () => {
+      const market = createMockMarket({
+        game: {
+          ...mockBaseGame,
+          status: 'ongoing',
+          period: 'HT',
+          score: { away: 10, home: 7, raw: '10-7' },
+        },
+      });
+
+      const { getByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      const scoreboard = getByTestId('game-scoreboard');
+
+      expect(scoreboard.props.accessibilityHint).toContain('state:Halftime');
+    });
+  });
+
+  describe('Chart Integration', () => {
+    it('renders chart with token IDs when two tokens exist', () => {
+      const market = createMockMarket();
+
+      const { getByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      const chart = getByTestId('game-chart');
+
+      expect(chart).toBeOnTheScreen();
+      expect(chart.props.accessibilityHint).toBe('tokens:token-1,token-2');
+    });
+
+    it('does not render chart when fewer than two tokens exist', () => {
+      const market = createMockMarket({
+        outcomes: [
+          {
+            id: 'outcome-1',
+            marketId: 'test-market-id',
+            title: 'Team A',
+            groupItemTitle: 'Team A',
+            status: 'open',
+            volume: 1000,
+            providerId: 'polymarket',
+            description: '',
+            image: '',
+            tokens: [{ id: 'token-1', title: 'Team A', price: 0.65 }],
+          },
+        ],
+      });
+
+      const { queryByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      expect(queryByTestId('game-chart')).toBeNull();
     });
   });
 

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
@@ -139,6 +139,24 @@ jest.mock('../PredictGameChart', () => {
   };
 });
 
+jest.mock('../PredictPicks/PredictPicks', () => {
+  const { View } = jest.requireActual('react-native');
+  return function MockPredictPicks({
+    testID,
+    market,
+  }: {
+    testID?: string;
+    market?: { id: string };
+  }) {
+    return (
+      <View
+        testID={testID}
+        accessibilityHint={`marketId:${market?.id ?? 'undefined'}`}
+      />
+    );
+  };
+});
+
 const mockGetRefHandlers = jest.fn(() => ({
   onOpenBottomSheet: jest.fn(),
   onCloseBottomSheet: jest.fn(),
@@ -625,6 +643,27 @@ describe('PredictGameDetailsContent', () => {
       );
 
       expect(queryByTestId('game-chart')).toBeNull();
+    });
+  });
+
+  describe('Picks Integration', () => {
+    it('renders picks component with market', () => {
+      const market = createMockMarket();
+
+      const { getByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      const picks = getByTestId('game-picks');
+
+      expect(picks).toBeOnTheScreen();
+      expect(picks.props.accessibilityHint).toBe('marketId:test-market-id');
     });
   });
 

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
@@ -32,6 +32,7 @@ import PredictSportScoreboard, {
   Winner,
 } from '../PredictSportScoreboard';
 import PredictGameChart from '../PredictGameChart';
+import PredictPicks from '../PredictPicks/PredictPicks';
 import { PredictGameScore, PredictGameStatus } from '../../types';
 
 const getGameState = (
@@ -222,7 +223,9 @@ const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
             </Box>
           )}
 
-          {/* TODO: Integrate PredictGamePositionsSection here */}
+          <Box twClassName="px-4 py-2">
+            <PredictPicks market={market} testID="game-picks" />
+          </Box>
         </ScrollView>
 
         <PredictGameDetailsFooter

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
@@ -25,6 +25,60 @@ import { PredictGameDetailsFooter } from '../PredictGameDetailsFooter';
 import PredictGameAboutSheet from '../PredictGameDetailsFooter/PredictGameAboutSheet';
 import { usePredictBottomSheet } from '../../hooks/usePredictBottomSheet';
 import { PredictGameDetailsContentProps } from './PredictGameDetailsContent.types';
+import PredictSportTeamGradient from '../PredictSportTeamGradient';
+import PredictSportScoreboard, {
+  GameState,
+  Possession,
+  Winner,
+} from '../PredictSportScoreboard';
+import PredictGameChart from '../PredictGameChart';
+import { PredictGameScore, PredictGameStatus } from '../../types';
+
+const getGameState = (
+  status: PredictGameStatus,
+  period: string | null,
+): GameState => {
+  if (status === 'scheduled') return GameState.PreGame;
+  if (status === 'ended') return GameState.Final;
+  if (period?.toUpperCase() === 'HT') return GameState.Halftime;
+  return GameState.InProgress;
+};
+
+const getPossession = (
+  turn: string | undefined,
+  awayAbbr: string,
+  homeAbbr: string,
+): Possession => {
+  if (!turn) return Possession.None;
+  const lowerTurn = turn.toLowerCase();
+  if (lowerTurn === awayAbbr.toLowerCase()) return Possession.Away;
+  if (lowerTurn === homeAbbr.toLowerCase()) return Possession.Home;
+  return Possession.None;
+};
+
+const getWinner = (score: PredictGameScore | null): Winner => {
+  if (!score) return Winner.None;
+  if (score.away > score.home) return Winner.Away;
+  if (score.home > score.away) return Winner.Home;
+  return Winner.None;
+};
+
+const formatGameDateTime = (
+  startTime: string,
+): { date: string; time: string } => {
+  const dateObj = new Date(startTime);
+  const date = dateObj.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+  const time = dateObj.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  });
+  return { date, time };
+};
 
 const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
   market,
@@ -50,83 +104,148 @@ const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
   }, [sheetHandlers]);
 
   const outcome = useMemo(() => market.outcomes[0], [market.outcomes]);
+  const game = market.game;
+  const tokenIds = useMemo(
+    () => (outcome?.tokens ?? []).map((t) => t.id),
+    [outcome?.tokens],
+  );
 
-  if (!outcome) {
+  const gameDateTime = useMemo(
+    () => (game ? formatGameDateTime(game.startTime) : null),
+    [game],
+  );
+
+  if (!outcome || !game) {
     return null;
   }
 
-  return (
-    <SafeAreaView
-      style={tw.style('flex-1 bg-default')}
-      edges={['left', 'right']}
-    >
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.Between}
-        twClassName="px-4 py-3"
-        style={{ paddingTop: insets.top + 12 }}
-      >
-        <Pressable
-          onPress={onBack}
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-          accessibilityRole="button"
-          accessibilityLabel={strings('predict.buttons.back')}
-        >
-          <Icon
-            name={IconName.ArrowLeft}
-            size={IconSize.Lg}
-            color={IconColor.IconDefault}
-          />
-        </Pressable>
+  const gameState = getGameState(game.status, game.period);
+  const possession = getPossession(
+    game.turn,
+    game.awayTeam.abbreviation,
+    game.homeTeam.abbreviation,
+  );
+  const winner =
+    gameState === GameState.Final ? getWinner(game.score) : Winner.None;
 
-        <Box twClassName="flex-1 mx-4">
-          <Text
-            variant={TextVariant.HeadingMd}
-            color={TextColor.TextDefault}
-            style={tw.style('text-center')}
-            numberOfLines={1}
+  return (
+    <PredictSportTeamGradient
+      awayColor={game.awayTeam.color}
+      homeColor={game.homeTeam.color}
+      style={tw.style('flex-1 bg-default')}
+      testID="game-details-gradient"
+    >
+      <SafeAreaView style={tw.style('flex-1')} edges={['left', 'right']}>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Between}
+          twClassName="px-4 py-3"
+          style={{ paddingTop: insets.top + 12 }}
+        >
+          <Pressable
+            onPress={onBack}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            accessibilityRole="button"
+            accessibilityLabel={strings('predict.buttons.back')}
           >
-            {market.title}
-          </Text>
+            <Icon
+              name={IconName.ArrowLeft}
+              size={IconSize.Lg}
+              color={IconColor.IconDefault}
+            />
+          </Pressable>
+
+          <Box twClassName="flex-1 mx-4">
+            <Text
+              variant={TextVariant.HeadingMd}
+              color={TextColor.TextDefault}
+              style={tw.style('text-center')}
+              numberOfLines={1}
+            >
+              {market.title}
+            </Text>
+          </Box>
+
+          <PredictShareButton marketId={market.id} />
         </Box>
 
-        <PredictShareButton marketId={market.id} />
-      </Box>
-
-      <ScrollView
-        style={tw.style('flex-1')}
-        contentContainerStyle={tw.style('pb-4')}
-        refreshControl={
-          <RefreshControl
-            refreshing={refreshing}
-            onRefresh={onRefresh}
-            tintColor={colors.primary.default}
-            colors={[colors.primary.default]}
+        <ScrollView
+          style={tw.style('flex-1')}
+          contentContainerStyle={tw.style('pb-4')}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor={colors.primary.default}
+              colors={[colors.primary.default]}
+            />
+          }
+        >
+          <PredictSportScoreboard
+            awayTeam={{
+              abbreviation: game.awayTeam.abbreviation,
+              color: game.awayTeam.color,
+            }}
+            homeTeam={{
+              abbreviation: game.homeTeam.abbreviation,
+              color: game.homeTeam.color,
+            }}
+            awayScore={game.score?.away}
+            homeScore={game.score?.home}
+            gameState={gameState}
+            eventTitle={market.title}
+            date={gameDateTime?.date}
+            time={gameDateTime?.time}
+            quarter={game.period ?? undefined}
+            possession={possession}
+            winner={winner}
+            testID="game-scoreboard"
           />
-        }
-      >
-        <Box twClassName="flex-1" />
-      </ScrollView>
 
-      <PredictGameDetailsFooter
-        market={market}
-        outcome={outcome}
-        onBetPress={onBetPress}
-        onClaimPress={onClaimPress}
-        onInfoPress={handleInfoPress}
-        claimableAmount={claimableAmount}
-        isLoading={isLoading}
-      />
+          {tokenIds.length === 2 && (
+            <Box twClassName="mt-4">
+              <PredictGameChart
+                tokenIds={tokenIds as [string, string]}
+                seriesConfig={[
+                  {
+                    label: game.awayTeam.abbreviation,
+                    color: game.awayTeam.color,
+                  },
+                  {
+                    label: game.homeTeam.abbreviation,
+                    color: game.homeTeam.color,
+                  },
+                ]}
+                testID="game-chart"
+              />
+            </Box>
+          )}
 
-      {isVisible && (
-        <PredictGameAboutSheet
-          ref={sheetRef}
-          description={market.description ?? ''}
-          onClose={handleSheetClosed}
+          {/* TODO: Integrate PredictGamePositionsSection here */}
+        </ScrollView>
+
+        <PredictGameDetailsFooter
+          market={market}
+          outcome={outcome}
+          onBetPress={onBetPress}
+          onClaimPress={onClaimPress}
+          onInfoPress={handleInfoPress}
+          claimableAmount={claimableAmount}
+          isLoading={isLoading}
+          awayColor={game.awayTeam.color}
+          homeColor={game.homeTeam.color}
         />
-      )}
-    </SafeAreaView>
+
+        {isVisible && (
+          <PredictGameAboutSheet
+            ref={sheetRef}
+            description={market.description ?? ''}
+            onClose={handleSheetClosed}
+          />
+        )}
+      </SafeAreaView>
+    </PredictSportTeamGradient>
   );
 };
 

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/__snapshots__/PredictGameDetailsContent.test.tsx.snap
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/__snapshots__/PredictGameDetailsContent.test.tsx.snap
@@ -185,6 +185,25 @@ exports[`PredictGameDetailsContent matches snapshot 1`] = `
             testID="game-chart"
           />
         </View>
+        <View
+          style={
+            [
+              {
+                "display": "flex",
+                "paddingBottom": 8,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "paddingTop": 8,
+              },
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityHint="marketId:test-market-id"
+            testID="game-picks"
+          />
+        </View>
       </View>
     </RCTScrollView>
     <View

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/__snapshots__/PredictGameDetailsContent.test.tsx.snap
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/__snapshots__/PredictGameDetailsContent.test.tsx.snap
@@ -2,155 +2,15 @@
 
 exports[`PredictGameDetailsContent matches snapshot 1`] = `
 <View
-  edges={
-    [
-      "left",
-      "right",
-    ]
-  }
-  style={
-    {
-      "backgroundColor": "#ffffff",
-      "flexBasis": "0%",
-      "flexGrow": 1,
-      "flexShrink": 1,
-    }
-  }
+  accessibilityHint="away:#0000FF,home:#FF0000"
+  testID="game-details-gradient"
 >
   <View
-    style={
+    edges={
       [
-        {
-          "alignItems": "center",
-          "display": "flex",
-          "flexDirection": "row",
-          "justifyContent": "space-between",
-          "paddingBottom": 12,
-          "paddingLeft": 16,
-          "paddingRight": 16,
-          "paddingTop": 12,
-        },
-        {
-          "paddingTop": 12,
-        },
+        "left",
+        "right",
       ]
-    }
-  >
-    <View
-      accessibilityLabel="predict.buttons.back"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      hitSlop={
-        {
-          "bottom": 10,
-          "left": 10,
-          "right": 10,
-          "top": 10,
-        }
-      }
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-    >
-      <SvgMock
-        fill="currentColor"
-        name="ArrowLeft"
-        style={
-          [
-            {
-              "color": "#121314",
-              "height": 24,
-              "width": 24,
-            },
-            undefined,
-          ]
-        }
-      />
-    </View>
-    <View
-      style={
-        [
-          {
-            "display": "flex",
-            "flexBasis": "0%",
-            "flexGrow": 1,
-            "flexShrink": 1,
-            "marginLeft": 16,
-            "marginRight": 16,
-          },
-          undefined,
-        ]
-      }
-    >
-      <Text
-        accessibilityRole="text"
-        numberOfLines={1}
-        style={
-          [
-            {
-              "color": "#121314",
-              "fontFamily": "Geist-Bold",
-              "fontSize": 18,
-              "fontWeight": 700,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            },
-            {
-              "textAlign": "center",
-            },
-          ]
-        }
-      >
-        Test Game Market
-      </Text>
-    </View>
-    <View
-      accessibilityHint="marketId:test-market-id"
-      testID="predict-share-button"
-    />
-  </View>
-  <RCTScrollView
-    contentContainerStyle={
-      {
-        "paddingBottom": 16,
-      }
-    }
-    refreshControl={
-      <RefreshControlMock
-        colors={
-          [
-            "#4459ff",
-          ]
-        }
-        onRefresh={[MockFunction]}
-        refreshing={false}
-        tintColor="#4459ff"
-      />
     }
     style={
       {
@@ -160,8 +20,81 @@ exports[`PredictGameDetailsContent matches snapshot 1`] = `
       }
     }
   >
-    <RCTRefreshControl />
-    <View>
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "paddingBottom": 12,
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "paddingTop": 12,
+          },
+          {
+            "paddingTop": 12,
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="predict.buttons.back"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        hitSlop={
+          {
+            "bottom": 10,
+            "left": 10,
+            "right": 10,
+            "top": 10,
+          }
+        }
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+      >
+        <SvgMock
+          fill="currentColor"
+          name="ArrowLeft"
+          style={
+            [
+              {
+                "color": "#121314",
+                "height": 24,
+                "width": 24,
+              },
+              undefined,
+            ]
+          }
+        />
+      </View>
       <View
         style={
           [
@@ -170,51 +103,129 @@ exports[`PredictGameDetailsContent matches snapshot 1`] = `
               "flexBasis": "0%",
               "flexGrow": 1,
               "flexShrink": 1,
+              "marginLeft": 16,
+              "marginRight": 16,
             },
             undefined,
           ]
         }
+      >
+        <Text
+          accessibilityRole="text"
+          numberOfLines={1}
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist-Bold",
+                "fontSize": 18,
+                "fontWeight": 700,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              {
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          Test Game Market
+        </Text>
+      </View>
+      <View
+        accessibilityHint="marketId:test-market-id"
+        testID="predict-share-button"
       />
     </View>
-  </RCTScrollView>
-  <View
-    testID="predict-game-details-footer"
-  >
-    <View
-      accessibilityState={
+    <RCTScrollView
+      contentContainerStyle={
         {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
+          "paddingBottom": 16,
         }
       }
-      accessibilityValue={
+      refreshControl={
+        <RefreshControlMock
+          colors={
+            [
+              "#4459ff",
+            ]
+          }
+          onRefresh={[MockFunction]}
+          refreshing={false}
+          tintColor="#4459ff"
+        />
+      }
+      style={
         {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
+          "flexBasis": "0%",
+          "flexGrow": 1,
+          "flexShrink": 1,
         }
       }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      testID="mock-info-button"
     >
-      <Text>
-        Info
-      </Text>
+      <RCTRefreshControl />
+      <View>
+        <View
+          accessibilityHint="state:PreGame,away:TB,home:TA"
+          testID="game-scoreboard"
+        />
+        <View
+          style={
+            [
+              {
+                "display": "flex",
+                "marginTop": 16,
+              },
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityHint="tokens:token-1,token-2"
+            testID="game-chart"
+          />
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      testID="predict-game-details-footer"
+    >
+      <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        testID="mock-info-button"
+      >
+        <Text>
+          Info
+        </Text>
+      </View>
     </View>
   </View>
 </View>

--- a/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.test.tsx
@@ -384,4 +384,47 @@ describe('PredictGameDetailsFooter', () => {
       expect(screen.getByText('$0 Vol')).toBeOnTheScreen();
     });
   });
+
+  describe('gradient integration', () => {
+    it('renders gradient when team colors are provided', () => {
+      const props = createDefaultProps({
+        awayColor: '#002244',
+        homeColor: '#FB4F14',
+      });
+
+      renderWithProvider(<PredictGameDetailsFooter {...props} />);
+
+      expect(
+        screen.getByTestId('game-details-footer-gradient'),
+      ).toBeOnTheScreen();
+    });
+
+    it('does not render gradient when colors are not provided', () => {
+      const props = createDefaultProps();
+
+      renderWithProvider(<PredictGameDetailsFooter {...props} />);
+
+      expect(screen.queryByTestId('game-details-footer-gradient')).toBeNull();
+    });
+
+    it('does not render gradient when only awayColor is provided', () => {
+      const props = createDefaultProps({
+        awayColor: '#002244',
+      });
+
+      renderWithProvider(<PredictGameDetailsFooter {...props} />);
+
+      expect(screen.queryByTestId('game-details-footer-gradient')).toBeNull();
+    });
+
+    it('does not render gradient when only homeColor is provided', () => {
+      const props = createDefaultProps({
+        homeColor: '#FB4F14',
+      });
+
+      renderWithProvider(<PredictGameDetailsFooter {...props} />);
+
+      expect(screen.queryByTestId('game-details-footer-gradient')).toBeNull();
+    });
+  });
 });

--- a/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.tsx
@@ -17,6 +17,7 @@ import { strings } from '../../../../../../locales/i18n';
 import { formatVolume } from '../../utils/format';
 import { PredictActionButtons } from '../PredictActionButtons';
 import { PredictGameDetailsFooterProps } from './PredictGameDetailsFooter.types';
+import PredictSportTeamGradient from '../PredictSportTeamGradient';
 
 const PredictGameDetailsFooter: React.FC<PredictGameDetailsFooterProps> = ({
   market,
@@ -27,6 +28,8 @@ const PredictGameDetailsFooter: React.FC<PredictGameDetailsFooterProps> = ({
   claimableAmount = 0,
   isLoading = false,
   testID = 'predict-game-details-footer',
+  awayColor,
+  homeColor,
 }) => {
   const insets = useSafeAreaInsets();
   const formattedVolume = useMemo(
@@ -42,9 +45,11 @@ const PredictGameDetailsFooter: React.FC<PredictGameDetailsFooterProps> = ({
     return null;
   }
 
-  return (
+  const hasGradient = awayColor && homeColor;
+
+  const content = (
     <Box
-      twClassName="px-4 pt-3 bg-default border-t border-muted"
+      twClassName={`px-4 pt-3 border-t border-muted ${hasGradient ? '' : 'bg-default'}`}
       style={{ paddingBottom: Math.max(insets.bottom, 16) }}
       testID={testID}
     >
@@ -98,6 +103,20 @@ const PredictGameDetailsFooter: React.FC<PredictGameDetailsFooterProps> = ({
       />
     </Box>
   );
+
+  if (hasGradient) {
+    return (
+      <PredictSportTeamGradient
+        awayColor={awayColor}
+        homeColor={homeColor}
+        testID={`${testID}-gradient`}
+      >
+        {content}
+      </PredictSportTeamGradient>
+    );
+  }
+
+  return content;
 };
 
 export default PredictGameDetailsFooter;

--- a/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.types.ts
+++ b/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.types.ts
@@ -13,6 +13,8 @@ export interface PredictGameDetailsFooterProps {
   claimableAmount?: number;
   isLoading?: boolean;
   testID?: string;
+  awayColor?: string;
+  homeColor?: string;
 }
 
 export interface PredictGameAboutSheetProps {


### PR DESCRIPTION
## **Description**

This PR integrates the visual UI components into `PredictGameDetailsContent` for the Live NFL Sports feature in Prediction Markets. The changes add team gradient backgrounds, a live scoreboard, price history chart, and user positions section to the game details screen.

**What changed:**
- Wrapped component with `PredictSportTeamGradient` for team-colored backgrounds
- Added `PredictSportScoreboard` at top showing game state, scores, and possession
- Added `PredictGameChart` below scoreboard for price history visualization
- Added `PredictPicks` section showing user positions with Cash Out functionality
- Passed team colors to footer for gradient background
- Added guards for undefined `market.game` and empty outcomes

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-481

## **Manual testing steps**

```gherkin
Feature: Game Details View Integration

  Scenario: user views game details for an NFL game
    Given user is on the Predict market list screen
    And there is an NFL game market available

    When user taps on the NFL game market
    Then user sees the game details screen with:
      - Team-colored gradient background
      - Scoreboard showing team abbreviations and scores
      - Price history chart with team colors
      - "Your picks" section (if user has positions)
      - Footer with team betting buttons

  Scenario: user views scoreboard during live game
    Given user is viewing game details for an in-progress game
    
    When the game status is "ongoing"
    Then scoreboard displays current quarter and time
    And scoreboard shows possession indicator
    And scores update in real-time

  Scenario: user cashes out a position
    Given user is viewing game details
    And user has an open position

    When user taps "Cash out" button
    Then user is navigated to the sell preview screen
```

## **Screenshots/Recordings**

### **Before**

N/A - New feature integration

### **After**

<!-- Screenshots to be added after visual verification -->
<img width="387" height="802" alt="Screenshot 2026-01-15 at 3 48 47 PM" src="https://github.com/user-attachments/assets/672611b5-af8e-45d2-bccf-6ac88b099709" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates core game UI into `PredictGameDetailsContent` and enhances footer styling/behavior.
> 
> - Wraps content with `PredictSportTeamGradient` and passes team colors to `PredictGameDetailsFooter` (conditional gradient rendering)
> - Adds `PredictSportScoreboard` with derived `gameState`, possession, and winner; formats date/time from `startTime`
> - Renders `PredictGameChart` when exactly two token IDs exist; adds `PredictPicks` section
> - Guards: return `null` when `market.game` is missing or `outcomes` is empty
> - Updates tests and snapshot to cover gradient, scoreboard states, chart visibility, picks, and footer gradient conditions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbee739379de9f9024e151d45e1e5ca448265728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->