### PR TITLE
fix: replace address copy overlay with toast notification

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.test.tsx
@@ -63,7 +63,7 @@ describe('MultichainAddressRow', () => {
     const mockCallback = jest.fn();
     const copyParams = {
       callback: mockCallback,
-      successMessage: 'Copied to clipboard!',
+      toastMessage: 'Address copied',
     };
 
     const { getByTestId } = render(
@@ -126,14 +126,14 @@ describe('MultichainAddressRow', () => {
     expect(component).toBeTruthy();
   });
 
-  it('shows success message when copy is triggered', () => {
+  it('calls callback when copy button is pressed', async () => {
     const mockCallback = jest.fn();
     const copyParams = {
       callback: mockCallback,
-      successMessage: 'Copied to clipboard!',
+      toastMessage: 'Address copied',
     };
 
-    const { getByTestId, queryByText } = render(
+    const { getByTestId } = render(
       <MultichainAddressRow
         {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS}
         copyParams={copyParams}
@@ -145,8 +145,8 @@ describe('MultichainAddressRow', () => {
     // Simulate pressing the copy button
     fireEvent.press(copyButton);
 
-    // Success message should be displayed
-    expect(queryByText(copyParams.successMessage)).toBeTruthy();
+    // Callback should be called
+    expect(mockCallback).toHaveBeenCalled();
   });
 
   it('renders custom icons with proper callbacks', () => {
@@ -175,15 +175,43 @@ describe('MultichainAddressRow', () => {
     expect(mockIconCallback).toHaveBeenCalled();
   });
 
-  it('does not display success message if copyParams is not provided', () => {
-    const { queryByText } = render(
+  it('shows toast when copy button is pressed and toastRef is provided', async () => {
+    const mockCallback = jest.fn();
+    const mockShowToast = jest.fn();
+    const mockToastRef = {
+      current: {
+        showToast: mockShowToast,
+        closeToast: jest.fn(),
+      },
+    };
+    const copyParams = {
+      callback: mockCallback,
+      toastRef: mockToastRef,
+      toastMessage: 'Address copied',
+    };
+
+    const { getByTestId } = render(
       <MultichainAddressRow
         {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS}
-        copyParams={undefined}
+        copyParams={copyParams}
       />,
     );
 
-    expect(queryByText('Copied to clipboard!')).toBeNull();
+    const copyButton = getByTestId(MULTICHAIN_ADDRESS_ROW_COPY_BUTTON_TEST_ID);
+
+    // Simulate pressing the copy button
+    fireEvent.press(copyButton);
+
+    // Wait for async operations
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Toast should be called with Plain variant (no icon)
+    expect(mockShowToast).toHaveBeenCalled();
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: expect.stringContaining('Plain'),
+      }),
+    );
   });
 
   it('renders truncated address correctly when copyParams is missing', () => {
@@ -208,15 +236,5 @@ describe('MultichainAddressRow', () => {
 
     const actionsContainer = getByTestId(MULTICHAIN_ADDRESS_ROW_TEST_ID);
     expect(actionsContainer).toBeTruthy();
-  });
-
-  it('completes animation steps for green flash', () => {
-    const { getByTestId } = render(
-      <MultichainAddressRow {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS} />,
-    );
-
-    // Check animation overlay exists
-    const overlay = getByTestId(MULTICHAIN_ADDRESS_ROW_TEST_ID);
-    expect(overlay).toBeTruthy();
   });
 });

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.types.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.types.ts
@@ -28,11 +28,12 @@ export interface CopyParams {
    */
   callback: () => Promise<void>;
   /**
-   * Optional toast ref for showing toast notification
+   * Technically optional to keep types simple but toast ref for showing toast notification
+   * should always be present if copyParams is used. This ensures consistent behavior
    */
   toastRef?: React.RefObject<ToastRef>;
   /**
-   * Optional custom toast message (defaults to localized "Address copied to clipboard")
+   * Required toast message. Specify what is being copied e.g. "Address copied", "Private key copied", etc
    */
   toastMessage: string;
 }

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.types.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.types.ts
@@ -1,5 +1,6 @@
 import { CaipChainId } from '@metamask/utils';
 import { IconName } from '@metamask/design-system-react-native';
+import type { ToastRef } from '../../../components/Toast/Toast.types';
 
 export interface Icon {
   /**
@@ -23,13 +24,17 @@ export interface Icon {
  */
 export interface CopyParams {
   /**
-   * Success message
-   */
-  successMessage?: string;
-  /**
    * Callback function to execute when the copy action is successful
    */
   callback: () => Promise<void>;
+  /**
+   * Optional toast ref for showing toast notification
+   */
+  toastRef?: React.RefObject<ToastRef>;
+  /**
+   * Optional custom toast message (defaults to localized "Address copied to clipboard")
+   */
+  toastMessage: string;
 }
 
 export interface MultichainAddressRowProps {

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/__snapshots__/MultichainAddressRow.test.tsx.snap
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/__snapshots__/MultichainAddressRow.test.tsx.snap
@@ -22,21 +22,6 @@ exports[`MultichainAddressRow renders MultichainAddressRow correctly 1`] = `
   testID="multichain-address-row"
 >
   <View
-    collapsable={false}
-    pointerEvents="none"
-    style={
-      {
-        "backgroundColor": "#457a391a",
-        "bottom": 0,
-        "left": 0,
-        "opacity": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      }
-    }
-  />
-  <View
     style={
       {
         "alignItems": "center",

--- a/app/component-library/components/Toast/index.ts
+++ b/app/component-library/components/Toast/index.ts
@@ -1,3 +1,3 @@
 export { default } from './Toast';
-export { ToastVariants } from './Toast.types';
+export { ToastVariants, ButtonIconVariant } from './Toast.types';
 export { ToastContext, ToastContextWrapper } from './Toast.context';

--- a/app/components/Views/AddressSelector/__snapshots__/AddressSelector.test.tsx.snap
+++ b/app/components/Views/AddressSelector/__snapshots__/AddressSelector.test.tsx.snap
@@ -710,21 +710,6 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                                             testID="multichain-address-row"
                                           >
                                             <View
-                                              collapsable={false}
-                                              pointerEvents="none"
-                                              style={
-                                                {
-                                                  "backgroundColor": "#457a391a",
-                                                  "bottom": 0,
-                                                  "left": 0,
-                                                  "opacity": 0,
-                                                  "position": "absolute",
-                                                  "right": 0,
-                                                  "top": 0,
-                                                }
-                                              }
-                                            />
-                                            <View
                                               style={
                                                 {
                                                   "alignItems": "center",
@@ -906,21 +891,6 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                                             testID="multichain-address-row"
                                           >
                                             <View
-                                              collapsable={false}
-                                              pointerEvents="none"
-                                              style={
-                                                {
-                                                  "backgroundColor": "#457a391a",
-                                                  "bottom": 0,
-                                                  "left": 0,
-                                                  "opacity": 0,
-                                                  "position": "absolute",
-                                                  "right": 0,
-                                                  "top": 0,
-                                                }
-                                              }
-                                            />
-                                            <View
                                               style={
                                                 {
                                                   "alignItems": "center",
@@ -1086,21 +1056,6 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                                             }
                                             testID="multichain-address-row"
                                           >
-                                            <View
-                                              collapsable={false}
-                                              pointerEvents="none"
-                                              style={
-                                                {
-                                                  "backgroundColor": "#457a391a",
-                                                  "bottom": 0,
-                                                  "left": 0,
-                                                  "opacity": 0,
-                                                  "position": "absolute",
-                                                  "right": 0,
-                                                  "top": 0,
-                                                }
-                                              }
-                                            />
                                             <View
                                               style={
                                                 {
@@ -1268,21 +1223,6 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                                             testID="multichain-address-row"
                                           >
                                             <View
-                                              collapsable={false}
-                                              pointerEvents="none"
-                                              style={
-                                                {
-                                                  "backgroundColor": "#457a391a",
-                                                  "bottom": 0,
-                                                  "left": 0,
-                                                  "opacity": 0,
-                                                  "position": "absolute",
-                                                  "right": 0,
-                                                  "top": 0,
-                                                }
-                                              }
-                                            />
-                                            <View
                                               style={
                                                 {
                                                   "alignItems": "center",
@@ -1448,21 +1388,6 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                                             }
                                             testID="multichain-address-row"
                                           >
-                                            <View
-                                              collapsable={false}
-                                              pointerEvents="none"
-                                              style={
-                                                {
-                                                  "backgroundColor": "#457a391a",
-                                                  "bottom": 0,
-                                                  "left": 0,
-                                                  "opacity": 0,
-                                                  "position": "absolute",
-                                                  "right": 0,
-                                                  "top": 0,
-                                                }
-                                              }
-                                            />
                                             <View
                                               style={
                                                 {
@@ -1630,21 +1555,6 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                                             testID="multichain-address-row"
                                           >
                                             <View
-                                              collapsable={false}
-                                              pointerEvents="none"
-                                              style={
-                                                {
-                                                  "backgroundColor": "#457a391a",
-                                                  "bottom": 0,
-                                                  "left": 0,
-                                                  "opacity": 0,
-                                                  "position": "absolute",
-                                                  "right": 0,
-                                                  "top": 0,
-                                                }
-                                              }
-                                            />
-                                            <View
                                               style={
                                                 {
                                                   "alignItems": "center",
@@ -1811,21 +1721,6 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                                             testID="multichain-address-row"
                                           >
                                             <View
-                                              collapsable={false}
-                                              pointerEvents="none"
-                                              style={
-                                                {
-                                                  "backgroundColor": "#457a391a",
-                                                  "bottom": 0,
-                                                  "left": 0,
-                                                  "opacity": 0,
-                                                  "position": "absolute",
-                                                  "right": 0,
-                                                  "top": 0,
-                                                }
-                                              }
-                                            />
-                                            <View
                                               style={
                                                 {
                                                   "alignItems": "center",
@@ -1991,21 +1886,6 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                                             }
                                             testID="multichain-address-row"
                                           >
-                                            <View
-                                              collapsable={false}
-                                              pointerEvents="none"
-                                              style={
-                                                {
-                                                  "backgroundColor": "#457a391a",
-                                                  "bottom": 0,
-                                                  "left": 0,
-                                                  "opacity": 0,
-                                                  "position": "absolute",
-                                                  "right": 0,
-                                                  "top": 0,
-                                                }
-                                              }
-                                            />
                                             <View
                                               style={
                                                 {

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useLayoutEffect } from 'react';
+import React, { useCallback, useContext, useLayoutEffect } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
@@ -20,8 +20,9 @@ import Routes from '../../../../constants/navigation/Routes';
 import styleSheet from './styles';
 import type { AddressListProps, AddressItem } from './types';
 import ClipboardManager from '../../../../core/ClipboardManager';
-import { strings } from '../../../../../locales/i18n';
 import getHeaderCenterNavbarOptions from '../../../../component-library/components-temp/HeaderCenter/getHeaderCenterNavbarOptions';
+import { ToastContext } from '../../../../component-library/components/Toast';
+import { strings } from '../../../../../locales/i18n';
 
 export const createAddressListNavigationDetails =
   createNavigationDetails<AddressListProps>(
@@ -36,6 +37,7 @@ export const createAddressListNavigationDetails =
 export const AddressList = () => {
   const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
+  const { toastRef } = useContext(ToastContext);
 
   const { groupId, title, onLoad } = useParams<AddressListProps>();
 
@@ -56,8 +58,9 @@ export const AddressList = () => {
           networkName={item.networkName}
           address={item.account.address}
           copyParams={{
-            successMessage: strings('multichain_accounts.address_list.copied'),
+            toastMessage: strings('multichain_accounts.address_list.copied'),
             callback: copyAddressToClipboard,
+            toastRef,
           }}
           icons={[
             {
@@ -83,7 +86,7 @@ export const AddressList = () => {
         />
       );
     },
-    [navigation, groupId],
+    [navigation, groupId, toastRef],
   );
 
   useLayoutEffect(() => {

--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useRef,
   useMemo,
+  useContext,
 } from 'react';
 import { View, TextInput, Linking } from 'react-native';
 import { useSelector } from 'react-redux';
@@ -27,6 +28,7 @@ import SheetHeader from '../../../../component-library/components/Sheet/SheetHea
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../component-library/components/BottomSheets/BottomSheet';
+import { ToastContext } from '../../../../component-library/components/Toast';
 import Banner, {
   BannerVariant,
   BannerAlertSeverity,
@@ -83,6 +85,7 @@ export const PrivateKeyList = () => {
   const { groupId, title } = useParams<PrivateKeyListParams>();
 
   const { styles } = useStyles(styleSheet, {});
+  const { toastRef } = useContext(ToastContext);
   const sheetRef = useRef<BottomSheetRef>(null);
   const [password, setPassword] = useState<string>('');
   const [wrongPassword, setWrongPassword] = useState<boolean>(false);
@@ -183,9 +186,8 @@ export const PrivateKeyList = () => {
         networkName={item.networkName}
         address={item.account.address}
         copyParams={{
-          successMessage: strings(
-            'multichain_accounts.private_key_list.copied',
-          ),
+          toastMessage: strings('multichain_accounts.private_key_list.copied'),
+          toastRef,
           callback: async () => {
             await ClipboardManager.setStringExpire(
               privateKeys[item.account.id],
@@ -194,7 +196,7 @@ export const PrivateKeyList = () => {
         }}
       />
     ),
-    [privateKeys],
+    [privateKeys, toastRef],
   );
 
   const renderPassword = useCallback(


### PR DESCRIPTION
## **Description**

This PR updates "Address copied" confirmation in the receiving address bottom sheet. Previously, tapping the copy button would show a green background overlay with a success message replacing the address text. This has been replaced with a standard toast notification to align with the app's established pattern for copy confirmations.

**What is the reason for the change?**
The current implementation uses an inline green overlay animation which is inconsistent with how copy confirmations are shown elsewhere in the app (e.g., `useCopyClipboard` hook, `AddressCopy` component).

**What is the improvement/solution?**
- Replaced the green background overlay animation with a toast notification
- Toast shows "Address copied to clipboard"
- Maintains brief icon feedback (Copy → CopySuccess for 400ms) for immediate visual confirmation
- Updated `MultichainAddressRow` component to use `ToastContext`
- Updated `AddressList` to pass `toastRef` to the component

## **Changelog**

CHANGELOG entry: Updated address copy confirmation to show a toast notification instead of inline overlay

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-314

## **Manual testing steps**

```gherkin
Feature: Address copy confirmation

  Scenario: user copies address from receiving address list
    Given user is on the networks address screen
    
    When user taps the "Copy" icon button

    Then a toast notification appears at the bottom of the screen
    And the toast shows "Address copied to clipboard"
    And the toast auto-dismisses after ~2.75 seconds or can be dismissed by tapping close button
    And no green overlay appears on the address row
    And the address text is not replaced with a success message
```

## **Screenshots/Recordings**

### **Before**
Green overlay animation with success message replacing address text

https://github.com/user-attachments/assets/ab055a05-7171-4464-8ecc-079d9cbf9673

### **After**
Toast notification at bottom

https://github.com/user-attachments/assets/d0178752-9c92-4380-a8ba-14b3150a3e16

Note: Toast messages have been updated since screen recording above

<img width="391" height="91" alt="Screenshot 2026-01-19 at 1 48 44 PM" src="https://github.com/user-attachments/assets/59733bff-ca7a-4270-9f72-2c3082d4ba67" />
<img width="359" height="84" alt="Screenshot 2026-01-19 at 1 49 16 PM" src="https://github.com/user-attachments/assets/5c76d6c1-55f3-4abd-996e-4e3474764413" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces inline copy confirmation with standardized toast feedback and minimal icon state change.
> 
> - Refactors `MultichainAddressRow`: removes animated overlay and success text; adds toast support via `copyParams.toastRef` + required `toastMessage`; shows `CopySuccess` icon for 400ms
> - Updates types: remove `successMessage`; add `toastRef` and `toastMessage` to `CopyParams`
> - Integrates `ToastContext` in `AddressList` and `PrivateKeyList` to pass `toastRef`; preserves clipboard callbacks
> - Exports `ButtonIconVariant` from `components/Toast`; adjusts tests and snapshots to match new behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f36cc88108cd57e74c0dc45ca51119f6cee5ad3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->