### PR TITLE
test: fix snap management e2e (close browser before going to home screen)

### DIFF
--- a/e2e/pages/Browser/BrowserView.ts
+++ b/e2e/pages/Browser/BrowserView.ts
@@ -12,7 +12,7 @@ import {
   getDappUrl,
 } from '../../framework/fixtures/FixtureUtils';
 import { DEFAULT_TAB_ID } from '../../framework/Constants';
-import { Gestures, Matchers } from '../../framework';
+import { Gestures, Matchers, Utilities } from '../../framework';
 
 interface TransactionParams {
   [key: string]: string | number | boolean;
@@ -165,9 +165,17 @@ class Browser {
   }
 
   async tapCloseBrowserButton(): Promise<void> {
-    await Gestures.waitAndTap(this.closeBrowserButton, {
-      elemDescription: 'Close browser button',
-    });
+    await Utilities.executeWithRetry(
+      async () => {
+        await Gestures.waitAndTap(this.closeBrowserButton, {
+          elemDescription: 'Close browser button',
+        });
+      },
+      {
+        timeout: 10000,
+        description: 'Tap Close Browser Button',
+      },
+    );
   }
 
   // Legacy methods for backward compatibility with existing tests

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -395,6 +395,11 @@ class TestSnaps {
       elemDescription: 'OK button',
       waitForElementToDisappear: true,
     });
+
+    await Gestures.tap(this.getConnectSnapButton, {
+      elemDescription: 'Connect Snap button',
+      waitForElementToDisappear: true,
+    });
   }
 
   async fillMessage(

--- a/e2e/specs/snaps/test-snap-management.spec.ts
+++ b/e2e/specs/snaps/test-snap-management.spec.ts
@@ -7,6 +7,7 @@ import TestSnaps from '../../pages/Browser/TestSnaps';
 import SettingsView from '../../pages/Settings/SettingsView';
 import SnapSettingsView from '../../pages/Settings/SnapSettingsView';
 import { Assertions } from '../../framework';
+import BrowserView from '../../pages/Browser/BrowserView';
 
 jest.setTimeout(150_000);
 
@@ -35,6 +36,7 @@ describe(FlaskBuildTests('Snap Management Tests'), () => {
         skipReactNativeReload: true,
       },
       async () => {
+        await BrowserView.tapCloseBrowserButton();
         await TabBarComponent.tapSettings();
         await SettingsView.tapSnaps();
 
@@ -64,6 +66,7 @@ describe(FlaskBuildTests('Snap Management Tests'), () => {
         skipReactNativeReload: true,
       },
       async () => {
+        await BrowserView.tapCloseBrowserButton();
         await TabBarComponent.tapSettings();
         await SettingsView.tapSnaps();
 
@@ -94,6 +97,7 @@ describe(FlaskBuildTests('Snap Management Tests'), () => {
         skipReactNativeReload: true,
       },
       async () => {
+        await BrowserView.tapCloseBrowserButton();
         await TabBarComponent.tapSettings();
         await SettingsView.tapSnaps();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **What changed**
> 
> - **Hardened browser close action**: `BrowserView.tapCloseBrowserButton` now wraps `Gestures.waitAndTap` with `Utilities.executeWithRetry` (10s timeout, description), and imports `Utilities` in `BrowserView.ts`.
> - **Complete Snap install flow**: `TestSnaps.installSnap` now taps the final `getConnectSnapButton` after `OK` to finish connecting the snap.
> - **Stabilized Snap management specs**: Tests (`test-snap-management.spec.ts`) now call `BrowserView.tapCloseBrowserButton()` before navigating to Settings for disable/enable/remove flows, reducing flakiness; adds the necessary `BrowserView` import.
> 
> **Why it matters**
> 
> - Reduces E2E flakiness by making browser close resilient and ensuring the Snap connect sequence completes before proceeding to settings interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1f7d2f4c329a44fcad314abf4c559009c2503c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->