### PR TITLE
fix: Fix Snaps E2E after browser UX changes

### DIFF
--- a/e2e/specs/snaps/test-snap-management.spec.ts
+++ b/e2e/specs/snaps/test-snap-management.spec.ts
@@ -7,6 +7,7 @@ import TestSnaps from '../../pages/Browser/TestSnaps';
 import SettingsView from '../../pages/Settings/SettingsView';
 import SnapSettingsView from '../../pages/Settings/SnapSettingsView';
 import { Assertions } from '../../framework';
+import BrowserView from '../../pages/Browser/BrowserView';
 
 jest.setTimeout(150_000);
 
@@ -35,6 +36,7 @@ describe(FlaskBuildTests('Snap Management Tests'), () => {
         skipReactNativeReload: true,
       },
       async () => {
+        await BrowserView.tapCloseBrowserButton();
         await TabBarComponent.tapSettings();
         await SettingsView.tapSnaps();
 
@@ -64,6 +66,7 @@ describe(FlaskBuildTests('Snap Management Tests'), () => {
         skipReactNativeReload: true,
       },
       async () => {
+        await BrowserView.tapCloseBrowserButton();
         await TabBarComponent.tapSettings();
         await SettingsView.tapSnaps();
 
@@ -94,6 +97,7 @@ describe(FlaskBuildTests('Snap Management Tests'), () => {
         skipReactNativeReload: true,
       },
       async () => {
+        await BrowserView.tapCloseBrowserButton();
         await TabBarComponent.tapSettings();
         await SettingsView.tapSnaps();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix Snaps E2Es which are currently blocking main due to not being run on an earlier PR which introduced new UX that the E2Es aren't designed for.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Snap management E2E tests to align with new browser UX.
> 
> - Adds `BrowserView` import and calls `BrowserView.tapCloseBrowserButton()` before navigating to `Settings` in the disable/enable/remove Snap tests to ensure the browser view is closed prior to settings navigation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf0d93d5833d8c725e69ebb46c7f8fd45a249abf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->