### PR TITLE
feat(send): support `InsufficientBalanceToCoverFee` error response from Snaps

### DIFF
--- a/app/components/Views/confirmations/hooks/send/useAmountValidation.ts
+++ b/app/components/Views/confirmations/hooks/send/useAmountValidation.ts
@@ -141,6 +141,8 @@ function mapSnapErrorCodeIntoTranslation(errorCode: string): string {
   switch (errorCode) {
     case 'InsufficientBalance':
       return strings('send.insufficient_funds');
+    case 'InsufficientBalanceToCoverFee':
+      return strings('send.insufficient_balance_to_cover_fee');
     case 'Invalid':
     default:
       return strings('send.invalid_value');

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -618,6 +618,7 @@
     "available": "available",
     "invalid_value": "Invalid value",
     "insufficient_funds": "Insufficient funds",
+    "insufficient_balance_to_cover_fee": "Insufficient balance to cover fees",
     "continue": "Continue",
     "unit": "unit",
     "units": "units",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We were missing support for a type of error that can occur on the Send flow where a user inserts an amount but does not have enough balance to cover its fees.

## **Changelog**

CHANGELOG entry: Add support for `InsufficientBalanceToCoverFee` error response from Snaps

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6627

## **Manual testing steps**

1. Using a Tron account that has a certain amount of USDT tokens but very few TRX and no energy
2. Try to send USDT to another address
3. Error message should show up, "Insufficient balance to cover fees"

## **Screenshots/Recordings**

### **Before**

<img width="976" height="1756" alt="image" src="https://github.com/user-attachments/assets/49126583-87b2-4382-a4e9-d66a2ea7bbe3" />

### **After**

<img width="974" height="1442" alt="image" src="https://github.com/user-attachments/assets/0eb6c10b-dac1-428b-ac83-933a69833544" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds handling for a new Snap validation error in the send flow and covers it with tests.
> 
> - Map Snap error code `InsufficientBalanceToCoverFee` to `strings('send.insufficient_balance_to_cover_fee')` in `useAmountValidation`
> - Add English i18n key `send.insufficient_balance_to_cover_fee`
> - Update tests in `useAmountValidation.test.ts`:
>   - Mock `validateAmountMultichain` and clear mocks before each test
>   - Add test asserting the new error maps to "Insufficient balance to cover fees"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ff3112bcb2bf1a45c13533e571433b2ea1ca35a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->