### PR TITLE
fix: Filter out duplicate JSON-RPC requests

### DIFF
--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -99,6 +99,7 @@ import { isRelaySupported } from '../../util/transactions/transaction-relay';
 import { selectSmartTransactionsEnabled } from '../../selectors/smartTransactionsController';
 import { AccountTreeController } from '@metamask/account-tree-controller';
 import { createTrustSignalsMiddleware } from '../RPCMethods/TrustSignalsMiddleware';
+import createDupeReqFilterStream from './createDupeReqFilterStream';
 
 const legacyNetworkId = () => {
   const { networksMetadata, selectedNetworkClientId } =
@@ -551,7 +552,9 @@ export class BackgroundBridge extends EventEmitter {
     // setup connection
     const providerStream = createEngineStream({ engine: this.engine });
 
-    pump(outStream, providerStream, outStream, (err) => {
+    const filterStream = createDupeReqFilterStream();
+
+    pump(outStream, filterStream, providerStream, outStream, (err) => {
       // handle any middleware cleanup
       this.engine.destroy();
       if (err) Logger.log('Error with provider stream conn', err);
@@ -582,7 +585,9 @@ export class BackgroundBridge extends EventEmitter {
     this.notifyTronAccountChangedForCurrentAccount();
     ///: END:ONLY_INCLUDE_IF
 
-    pump(outStream, providerStream, outStream, (err) => {
+    const filterStream = createDupeReqFilterStream();
+
+    pump(outStream, filterStream, providerStream, outStream, (err) => {
       // handle any middleware cleanup
       this.multichainEngine.destroy();
       if (err) Logger.log('Error with provider stream conn', err);

--- a/app/core/BackgroundBridge/createDupeReqFilterStream.test.ts
+++ b/app/core/BackgroundBridge/createDupeReqFilterStream.test.ts
@@ -1,0 +1,391 @@
+// eslint-disable-next-line import/no-nodejs-modules
+import NodeStream from 'node:stream';
+import ReadableStream, { Transform } from 'readable-stream';
+
+import type { JsonRpcNotification, JsonRpcRequest } from '@metamask/utils';
+import createDupeReqFilterStream, {
+  THREE_MINUTES,
+} from './createDupeReqFilterStream';
+
+function createTestStream(output: JsonRpcRequest[] = [], S = Transform) {
+  const transformStream = createDupeReqFilterStream();
+  const testOutStream = new S({
+    transform: (chunk: JsonRpcRequest, _, cb) => {
+      output.push(chunk);
+      cb();
+    },
+    objectMode: true,
+  });
+
+  transformStream.pipe(testOutStream);
+
+  return transformStream;
+}
+
+function runStreamTest(
+  requests: (JsonRpcRequest | JsonRpcNotification)[] = [],
+  advanceTimersTime = 10,
+  S = Transform,
+) {
+  return new Promise((resolve, reject) => {
+    const output: JsonRpcRequest[] = [];
+    const testStream = createTestStream(output, S);
+
+    testStream
+      .on('finish', () => resolve(output))
+      .on('error', (err) => reject(err));
+
+    requests.forEach((request) => testStream.write(request));
+    testStream.end();
+
+    jest.advanceTimersByTime(advanceTimersTime);
+  });
+}
+
+describe('createDupeReqFilterStream', () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ now: 10 });
+  });
+
+  it('lets through requests with ids being seen for the first time', async () => {
+    const requests = [
+      { id: 1, method: 'foo' },
+      { id: 2, method: 'bar' },
+    ].map((request) => ({ ...request, jsonrpc: '2.0' as const }));
+
+    const expectedOutput = [
+      { id: 1, method: 'foo' },
+      { id: 2, method: 'bar' },
+    ].map((output) => ({ ...output, jsonrpc: '2.0' }));
+
+    const output = await runStreamTest(requests);
+    expect(output).toEqual(expectedOutput);
+  });
+
+  it('does not let through the request if the id has been seen before', async () => {
+    const requests = [
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' }, // duplicate
+    ].map((request) => ({ ...request, jsonrpc: '2.0' as const }));
+
+    const expectedOutput = [{ id: 1, method: 'foo' }].map((output) => ({
+      ...output,
+      jsonrpc: '2.0',
+    }));
+
+    const output = await runStreamTest(requests);
+    expect(output).toEqual(expectedOutput);
+  });
+
+  it("lets through requests if they don't have an id", async () => {
+    const requests = [{ method: 'notify1' }, { method: 'notify2' }].map(
+      (request) => ({ ...request, jsonrpc: '2.0' as const }),
+    );
+
+    const expectedOutput = [{ method: 'notify1' }, { method: 'notify2' }].map(
+      (output) => ({ ...output, jsonrpc: '2.0' }),
+    );
+
+    const output = await runStreamTest(requests);
+    expect(output).toEqual(expectedOutput);
+  });
+
+  it('handles a mix of request types', async () => {
+    const requests = [
+      { id: 1, method: 'foo' },
+      { method: 'notify1' },
+      { id: 1, method: 'foo' },
+      { id: 2, method: 'bar' },
+      { method: 'notify2' },
+      { id: 2, method: 'bar' },
+      { id: 3, method: 'baz' },
+    ].map((request) => ({ ...request, jsonrpc: '2.0' as const }));
+
+    const expectedOutput = [
+      { id: 1, method: 'foo' },
+      { method: 'notify1' },
+      { id: 2, method: 'bar' },
+      { method: 'notify2' },
+      { id: 3, method: 'baz' },
+    ].map((output) => ({ ...output, jsonrpc: '2.0' }));
+
+    const output = await runStreamTest(requests);
+    expect(output).toEqual(expectedOutput);
+  });
+
+  it('expires single id after three minutes', () => {
+    const output: JsonRpcRequest[] = [];
+    const testStream = createTestStream(output);
+
+    const requests1 = [
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+    ];
+    const expectedOutputBeforeExpiryTime = [{ id: 1, method: 'foo' }];
+
+    requests1.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputBeforeExpiryTime);
+
+    const requests2 = [
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+    ];
+    const expectedOutputAfterExpiryTime = [
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+    ];
+
+    jest.advanceTimersByTime(THREE_MINUTES);
+
+    requests2.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputAfterExpiryTime);
+  });
+
+  it('does not expire single id after less than three', () => {
+    const output: JsonRpcRequest[] = [];
+    const testStream = createTestStream(output);
+
+    const requests1 = [
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+    ];
+    const expectedOutputBeforeTimeElapses = [{ id: 1, method: 'foo' }];
+
+    requests1.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputBeforeTimeElapses);
+
+    const requests2 = [
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+    ];
+    const expectedOutputAfterTimeElapses = expectedOutputBeforeTimeElapses;
+
+    jest.advanceTimersByTime(THREE_MINUTES - 1);
+
+    requests2.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputAfterTimeElapses);
+  });
+
+  it('expires multiple ids after three minutes', () => {
+    const output: JsonRpcRequest[] = [];
+    const testStream = createTestStream(output);
+
+    const requests1 = [
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+      { id: 2, method: 'bar' },
+      { id: 2, method: 'bar' },
+      { id: 3, method: 'baz' },
+      { id: 3, method: 'baz' },
+    ];
+    const expectedOutputBeforeExpiryTime = [
+      { id: 1, method: 'foo' },
+      { id: 2, method: 'bar' },
+      { id: 3, method: 'baz' },
+    ];
+
+    requests1.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputBeforeExpiryTime);
+
+    const requests2 = [
+      { id: 3, method: 'baz' },
+      { id: 3, method: 'baz' },
+      { id: 2, method: 'bar' },
+      { id: 2, method: 'bar' },
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+    ];
+    const expectedOutputAfterExpiryTime = [
+      { id: 1, method: 'foo' },
+      { id: 2, method: 'bar' },
+      { id: 3, method: 'baz' },
+      { id: 3, method: 'baz' },
+      { id: 2, method: 'bar' },
+      { id: 1, method: 'foo' },
+    ];
+
+    jest.advanceTimersByTime(THREE_MINUTES);
+
+    requests2.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputAfterExpiryTime);
+  });
+
+  it('expires single id in three minute intervals', () => {
+    const output: JsonRpcRequest[] = [];
+    const testStream = createTestStream(output);
+
+    const requests1 = [
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+    ];
+    const expectedOutputBeforeExpiryTime = [{ id: 1, method: 'foo' }];
+
+    requests1.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputBeforeExpiryTime);
+
+    const requests2 = [
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+    ];
+    const expectedOutputAfterFirstExpiryTime = [
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+    ];
+
+    jest.advanceTimersByTime(THREE_MINUTES);
+
+    requests2.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputAfterFirstExpiryTime);
+
+    const requests3 = [
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+    ];
+    const expectedOutputAfterSecondExpiryTime = [
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+      { id: 1, method: 'foo' },
+    ];
+
+    jest.advanceTimersByTime(THREE_MINUTES);
+
+    requests3.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputAfterSecondExpiryTime);
+  });
+
+  it('expires somes ids at intervals while not expiring others', () => {
+    const output: JsonRpcRequest[] = [];
+    const testStream = createTestStream(output);
+
+    const requests1 = [
+      { id: 1, method: 'foo' },
+      { id: 2, method: 'bar' },
+    ];
+    const expectedOutputBeforeExpiryTime = [
+      { id: 1, method: 'foo' },
+      { id: 2, method: 'bar' },
+    ];
+
+    requests1.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputBeforeExpiryTime);
+
+    const requests2 = [{ id: 3, method: 'baz' }];
+    const expectedOutputAfterFirstExpiryTime = [
+      { id: 1, method: 'foo' },
+      { id: 2, method: 'bar' },
+      { id: 3, method: 'baz' },
+    ];
+
+    jest.advanceTimersByTime(THREE_MINUTES - 1);
+
+    requests2.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputAfterFirstExpiryTime);
+
+    const requests3 = [
+      { id: 1, method: 'foo' },
+      { id: 2, method: 'bar' },
+      { id: 3, method: 'baz' },
+      { id: 4, method: 'buzz' },
+    ];
+    const expectedOutputAfterSecondExpiryTime = [
+      { id: 1, method: 'foo' },
+      { id: 2, method: 'bar' },
+      { id: 3, method: 'baz' },
+      { id: 1, method: 'foo' },
+      { id: 2, method: 'bar' },
+      { id: 4, method: 'buzz' },
+    ];
+
+    jest.advanceTimersByTime(THREE_MINUTES - 1);
+
+    requests3.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputAfterSecondExpiryTime);
+  });
+
+  it('handles running expiry job without seeing any ids', () => {
+    const output: JsonRpcRequest[] = [];
+    const testStream = createTestStream(output);
+
+    const requests1 = [{ id: 1, method: 'foo' }];
+    const expectedOutputBeforeExpiryTime = [{ id: 1, method: 'foo' }];
+
+    requests1.forEach((request) => testStream.write(request));
+    expect(output).toEqual(expectedOutputBeforeExpiryTime);
+
+    jest.advanceTimersByTime(THREE_MINUTES + 1);
+
+    expect(output).toEqual(expectedOutputBeforeExpiryTime);
+  });
+
+  [
+    ['node:stream', NodeStream] as [string, typeof NodeStream],
+    // Redundantly include used version twice for regression-detection purposes
+    ['readable-stream', ReadableStream] as [string, typeof ReadableStream],
+  ].forEach(([name, streamsImpl]) => {
+    describe(`Using Streams implementation: ${name}`, () => {
+      [
+        ['Duplex', streamsImpl.Duplex] as [string, typeof streamsImpl.Duplex],
+        ['Transform', streamsImpl.Transform] as [
+          string,
+          typeof streamsImpl.Transform,
+        ],
+        ['Writable', streamsImpl.Writable] as [
+          string,
+          typeof streamsImpl.Writable,
+        ],
+      ].forEach(([className, S]) => {
+        it(`handles a mix of request types coming through a ${className} stream`, async () => {
+          const requests = [
+            { id: 1, method: 'foo' },
+            { method: 'notify1' },
+            { id: 1, method: 'foo' },
+            { id: 2, method: 'bar' },
+            { method: 'notify2' },
+            { id: 2, method: 'bar' },
+            { id: 3, method: 'baz' },
+          ];
+
+          const expectedOutput = [
+            { id: 1, method: 'foo' },
+            { method: 'notify1' },
+            { id: 2, method: 'bar' },
+            { method: 'notify2' },
+            { id: 3, method: 'baz' },
+          ];
+
+          const output: JsonRpcRequest[] = [];
+          const testStream = createDupeReqFilterStream();
+          const testOutStream = new S({
+            transform: (chunk: JsonRpcRequest, _, cb) => {
+              output.push(chunk);
+              cb();
+            },
+            objectMode: true,
+          });
+
+          testOutStream._write = (
+            chunk: JsonRpcRequest,
+            _: BufferEncoding,
+            callback: (error?: Error | null) => void,
+          ) => {
+            output.push(chunk);
+            callback();
+          };
+
+          testStream.pipe(testOutStream);
+
+          requests.forEach((request) => testStream.write(request));
+
+          expect(output).toEqual(expectedOutput);
+        });
+      });
+    });
+  });
+});

--- a/app/core/BackgroundBridge/createDupeReqFilterStream.ts
+++ b/app/core/BackgroundBridge/createDupeReqFilterStream.ts
@@ -11,7 +11,7 @@ export const THREE_MINUTES = inMilliseconds(3, Duration.Minute);
 const makeExpirySet = () => {
   const map: Map<string | number | null, number> = new Map();
 
-  setInterval(() => {
+  const timerId = setInterval(() => {
     const cutoffTime = Date.now() - THREE_MINUTES;
 
     for (const [id, timestamp] of map.entries()) {
@@ -37,6 +37,14 @@ const makeExpirySet = () => {
       }
       return false;
     },
+
+    /**
+     * Destroy the set and tear down the underlying timer.
+     */
+    destroy() {
+      map.clear();
+      clearInterval(timerId);
+    },
   };
 };
 
@@ -61,6 +69,10 @@ export default function createDupeReqFilterStream() {
         console.debug(`RPC request with id "${chunk.id}" already seen.`);
         cb();
       }
+    },
+    destroy(error, cb) {
+      seenRequestIds.destroy();
+      cb(error);
     },
     objectMode: true,
   });

--- a/app/core/BackgroundBridge/createDupeReqFilterStream.ts
+++ b/app/core/BackgroundBridge/createDupeReqFilterStream.ts
@@ -1,0 +1,67 @@
+import { Transform } from 'readable-stream';
+import { Duration, inMilliseconds, type JsonRpcRequest } from '@metamask/utils';
+
+export const THREE_MINUTES = inMilliseconds(3, Duration.Minute);
+
+/**
+ * Creates a set abstraction whose values expire after three minutes.
+ *
+ * @returns The expiry set.
+ */
+const makeExpirySet = () => {
+  const map: Map<string | number | null, number> = new Map();
+
+  setInterval(() => {
+    const cutoffTime = Date.now() - THREE_MINUTES;
+
+    for (const [id, timestamp] of map.entries()) {
+      if (timestamp <= cutoffTime) {
+        map.delete(id);
+      } else {
+        break;
+      }
+    }
+  }, THREE_MINUTES);
+
+  return {
+    /**
+     * Attempts to add a value to the set.
+     *
+     * @param value - The value to add.
+     * @returns `true` if the value was added, and `false` if it already existed.
+     */
+    add(value: string | number | null) {
+      if (!map.has(value)) {
+        map.set(value, Date.now());
+        return true;
+      }
+      return false;
+    },
+  };
+};
+
+/**
+ * Returns a transform stream that filters out requests whose ids we've already seen.
+ * Ignores JSON-RPC notifications, i.e. requests with an `undefined` id.
+ *
+ * @returns The stream object.
+ */
+export default function createDupeReqFilterStream() {
+  const seenRequestIds = makeExpirySet();
+  return new Transform({
+    transform(chunk: JsonRpcRequest, _, cb) {
+      // JSON-RPC notifications have no ids; our only recourse is to let them through.
+      const hasNoId = chunk.id === undefined;
+      const requestNotYetSeen = seenRequestIds.add(chunk.id);
+
+      if (hasNoId || requestNotYetSeen) {
+        cb(null, chunk);
+      } else {
+        // eslint-disable-next-line no-console
+        console.debug(`RPC request with id "${chunk.id}" already seen.`);
+        cb();
+      }
+    },
+    objectMode: true,
+  });
+}

--- a/app/core/BackgroundBridge/createDupeReqFilterStream.ts
+++ b/app/core/BackgroundBridge/createDupeReqFilterStream.ts
@@ -39,7 +39,7 @@ const makeExpirySet = () => {
     },
 
     /**
-     * Destroy the set and tear down the underlying timer.
+     * Clear the map and tear down the underlying timer.
      */
     destroy() {
       map.clear();

--- a/app/core/Engine/controllers/snaps/execution-service-init.test.ts
+++ b/app/core/Engine/controllers/snaps/execution-service-init.test.ts
@@ -66,6 +66,7 @@ describe('ExecutionServiceInit', () => {
         setupProviderConnection,
       }));
 
+      // @ts-expect-error The stream type doesn't match because of a version mismatch.
       setupSnapProvider(snapId, connectionStream);
 
       expect(setupProviderConnection).toHaveBeenCalled();

--- a/app/core/Engine/controllers/snaps/execution-service-init.ts
+++ b/app/core/Engine/controllers/snaps/execution-service-init.ts
@@ -65,6 +65,7 @@ export const executionServiceInit: ControllerInitFunction<
   return {
     controller: new WebViewExecutionService({
       messenger: controllerMessenger,
+      // @ts-expect-error The stream type doesn't match because of a version mismatch.
       setupSnapProvider,
       createWebView,
       removeWebView,

--- a/package.json
+++ b/package.json
@@ -338,6 +338,7 @@
     "@tradle/react-native-http": "2.0.1",
     "@types/he": "^1.2.3",
     "@types/react-test-renderer": "^18.0.0",
+    "@types/readable-stream": "^2.3.9",
     "@viem/anvil": "^0.0.10",
     "@walletconnect/client": "^1.8.0",
     "@walletconnect/core": "^2.19.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18218,6 +18218,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/readable-stream@npm:^2.3.9":
+  version: 2.3.15
+  resolution: "@types/readable-stream@npm:2.3.15"
+  dependencies:
+    "@types/node": "npm:*"
+    safe-buffer: "npm:~5.1.1"
+  checksum: 10/49b51e56f9cc401cb31c72973a7565ef4208d7e2465a789843104ec0fcbe609727b0b5bf4682fbec773c7f7bd14858e5dba739fd85e14d8a85e41185d65984d3
+  languageName: node
+  linkType: hard
+
 "@types/readdir-glob@npm:*":
   version: 1.1.1
   resolution: "@types/readdir-glob@npm:1.1.1"
@@ -34246,6 +34256,7 @@ __metadata:
     "@types/react-native-vector-icons": "npm:^6.4.13"
     "@types/react-native-video": "npm:^5.0.14"
     "@types/react-test-renderer": "npm:^18.0.0"
+    "@types/readable-stream": "npm:^2.3.9"
     "@types/redux-mock-store": "npm:^1.0.3"
     "@types/semver": "npm:^7"
     "@types/serve-handler": "npm:^6.1.4"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Copies `createDupeReqFilterStream.ts` from the extension repo and applies it to the provider stream in `BackgroundBridge`. This filters out any duplicate requests received from the dapp. It is possible for the RPC requests to be duplicated due to the "replay functionality" found here: https://github.com/MetaMask/metamask-mobile/blob/main/scripts/inpage-bridge/src/provider.js#L131

Feedback required.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate JSON-RPC requests from reaching the engines.
> 
> - Add `createDupeReqFilterStream` with a three-minute expiry for seen request ids; comprehensive unit tests in `createDupeReqFilterStream.test.ts`
> - Insert filter into `BackgroundBridge` pump chain for both `setupProviderConnectionEip1193` and `setupProviderConnectionCaip` (between `outStream` and `providerStream`)
> - Add `@types/readable-stream` to dependencies and update lockfile; annotate snaps execution setup with `@ts-expect-error` for stream type mismatch
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31f54935178140dd265bc6bd73f97f4237c076e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->