### PR TITLE
ci: Skip merge queue if pull request is up-to-date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
         shell: bash
 
   unit-tests:
-    name: Unit tests
+    name: Unit tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
     if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,7 +475,9 @@ jobs:
   smart-e2e-selection:
     name: 'Smart E2E Selection'
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true' && !github.event.pull_request.head.repo.fork }}
+    if: ${{ (github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true') && !github.event.pull_request.head.repo.fork }}
+    needs:
+      - check-skip-merge-queue
     continue-on-error: true
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,23 @@ concurrency:
   cancel-in-progress: ${{ !(contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/stable')) }}
 
 jobs:
+  check-skip-merge-queue:
+    name: Check if pull request can skip merge queue
+    runs-on: ubuntu-latest
+    outputs:
+      skip-merge-queue: ${{ steps.check-skip-merge-queue.outputs.up-to-date }}
+    steps:
+      - name: Check pull request merge queue status
+        id: check-skip-merge-queue
+        if: github.event_name == 'merge_group'
+        uses: MetaMask/github-tools/.github/actions/check-skip-merge-queue@v1
+
   check-diff:
+    name: Check diff
     runs-on: macos-latest
+    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    needs:
+      - check-skip-merge-queue
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -64,7 +79,11 @@ jobs:
           fi
 
   dedupe:
+    name: Dedupe
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    needs:
+      - check-skip-merge-queue
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -96,7 +115,11 @@ jobs:
           fi
 
   git-safe-dependencies:
+    name: Run `@lavamoat/git-safe-dependencies`
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    needs:
+      - check-skip-merge-queue
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -121,7 +144,11 @@ jobs:
           command: yarn git-safe-dependencies
 
   scripts:
+    name: Run `${{ matrix.scripts }}`
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    needs:
+      - check-skip-merge-queue
     strategy:
       matrix:
         scripts:
@@ -160,7 +187,11 @@ jobs:
           fi
 
   js-bundle-size-check:
+    name: JS bundle size check
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    needs:
+      - check-skip-merge-queue
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -193,6 +224,7 @@ jobs:
           retention-days: 7
 
   ship-js-bundle-size-check:
+    name: Ship JS bundle size check
     runs-on: ubuntu-latest
     needs: [js-bundle-size-check]
     if: ${{ github.ref == 'refs/heads/main' }}
@@ -214,6 +246,9 @@ jobs:
   check-workflows:
     name: Check workflows
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    needs:
+      - check-skip-merge-queue
     steps:
       - uses: actions/checkout@v4
       - name: Download actionlint
@@ -225,7 +260,11 @@ jobs:
         shell: bash
 
   unit-tests:
+    name: Unit tests
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    needs:
+      - check-skip-merge-queue
     strategy:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -384,7 +423,11 @@ jobs:
           fi
 
   component-view-tests:
+    name: Component view tests
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    needs:
+      - check-skip-merge-queue
     strategy:
       matrix:
         shard: [1, 2]
@@ -432,7 +475,7 @@ jobs:
   smart-e2e-selection:
     name: 'Smart E2E Selection'
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true' && !github.event.pull_request.head.repo.fork }}
     continue-on-error: true
     permissions:
       contents: read
@@ -631,6 +674,7 @@ jobs:
         run: node .github/scripts/e2e-report-fixture-validation.mjs
 
   sonar-cloud:
+    name: SonarCloud analysis
     runs-on: ubuntu-latest
     needs: merge-unit-and-component-view-tests
     if: ${{ !cancelled() && github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
@@ -675,6 +719,7 @@ jobs:
           done
 
   sonar-cloud-quality-gate-status:
+    name: SonarCloud quality gate status
     runs-on: ubuntu-latest
     needs: sonar-cloud
     if: ${{ !cancelled() && github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
@@ -790,14 +835,23 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     needs:
+      - check-skip-merge-queue
       - all-jobs-pass
       - needs_e2e_build
       - e2e-smoke-tests-android
       - e2e-smoke-tests-ios
       - e2e-smoke-tests-android-flask
       - e2e-smoke-tests-ios-flask
+    env:
+      SKIPPED: ${{ needs.check-skip-merge-queue.outputs.skip-merge-queue == 'true' }}
     steps:
       - run: |
+          # If the merge queue was skipped, consider all jobs as passed
+          if [[ "$SKIPPED" == "true" ]]; then
+            echo "Merge queue skipped, considering all jobs as passed"
+            exit 0
+          fi
+
           # Check if all non-E2E jobs passed
           if [[ "${{ needs.all-jobs-pass.outputs.ALL_JOBS_PASSED }}" != "true" ]]; then
             echo "Non-E2E jobs failed"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This adds a new action which determines whether a pull request in the merge queue is up-to-date, meaning:

- The pull request is based on the latest commit on `main`.
- The pull request is the first in the merge queue.

In this case, all status checks have already passed on the branch, and running in the merge queue would be redundant, meaning we can skip the merge queue checks.

The same thing was implemented in the extension here: MetaMask/metamask-extension#38966

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI behavior for `merge_group` events by conditionally skipping most checks, which could let an incorrect “up-to-date” determination bypass required validations if the action/logic is wrong.
> 
> **Overview**
> Adds a new `check-skip-merge-queue` job to detect when a PR in the merge queue is already up-to-date (and first in queue) via `MetaMask/github-tools`.
> 
> When that flag is true, most CI jobs (lint/test/dedupe/workflow checks/bundle size and smart E2E selection) are **skipped** during `merge_group` runs, and `check-all-jobs-pass` treats the workflow as passed to avoid redundant merge-queue executions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e04991a94043f02e0ddcecb344bec9ff49c11e1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->