### PR TITLE
feat(predict): cp-7.62.0 improve chart loading state and timestamp positioning

### DIFF
--- a/app/components/UI/Predict/components/PredictGameChart/ChartTooltip.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/ChartTooltip.tsx
@@ -17,6 +17,7 @@ import {
   TIMESTAMP_Y,
   CROSSHAIR_START_Y,
   CROSSHAIR_STROKE_WIDTH,
+  TIMESTAMP_TEXT_HALF_WIDTH,
   getSeparatedLabelYPositions,
 } from './PredictGameChart.constants';
 
@@ -69,15 +70,30 @@ const ChartTooltip: React.FC<ChartTooltipProps> = ({
   const timestamp = primaryData[activeIndex].timestamp;
   const labelStartX = chartWidth - contentInset.right + RIGHT_LABEL_OFFSET;
 
+  const chartDataRight = chartWidth - contentInset.right;
+  const isNearLeftEdge = xPos < contentInset.left + TIMESTAMP_TEXT_HALF_WIDTH;
+  const isNearRightEdge = xPos > chartDataRight - TIMESTAMP_TEXT_HALF_WIDTH;
+
+  const timestampAnchor = isNearLeftEdge
+    ? 'start'
+    : isNearRightEdge
+      ? 'end'
+      : 'middle';
+  const timestampX = isNearLeftEdge
+    ? contentInset.left
+    : isNearRightEdge
+      ? chartDataRight
+      : xPos;
+
   return (
     <G>
       <SvgText
-        x={xPos}
+        x={timestampX}
         y={TIMESTAMP_Y}
         fill={colors.text.alternative}
         fontSize={FONT_SIZE_LABEL}
         fontWeight="400"
-        textAnchor="middle"
+        textAnchor={timestampAnchor}
       >
         {formatTimestamp(timestamp)}
       </SvgText>

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
@@ -14,6 +14,7 @@ export const VALUE_TEXT_OFFSET_Y = 16;
 export const TIMESTAMP_Y = 12;
 export const CROSSHAIR_START_Y = 20;
 export const CROSSHAIR_STROKE_WIDTH = 1;
+export const TIMESTAMP_TEXT_HALF_WIDTH = 75;
 
 export interface DotPosition {
   dotY: number;

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -36,6 +36,14 @@ const FIDELITY_BY_TIMEFRAME: Record<ChartTimeframe, number> = {
 const getMinuteTimestamp = (timestamp: number): number =>
   Math.floor(timestamp / 60000) * 60000;
 
+/**
+ * Converts a timestamp to milliseconds.
+ * Detects if timestamp is in seconds (10 digits) or milliseconds (13 digits).
+ * Unix timestamps in seconds are typically < 10 billion (until year 2286).
+ */
+const toMilliseconds = (timestamp: number): number =>
+  timestamp < 10_000_000_000 ? timestamp * 1000 : timestamp;
+
 const PredictGameChart: React.FC<PredictGameChartProps> = ({
   tokenIds,
   seriesConfig,
@@ -76,7 +84,7 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
         data: history.map((point) => ({
           timestamp:
             typeof point.timestamp === 'number'
-              ? point.timestamp
+              ? toMilliseconds(point.timestamp)
               : new Date(point.timestamp).getTime(),
           value: Number((point.price * 100).toFixed(2)),
         })),
@@ -160,9 +168,12 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
   }, [refetch]);
 
   const chartData = isLive ? liveChartData : historicalChartData;
+  const hasChartData =
+    chartData.length >= 2 &&
+    chartData[0]?.data?.length > 0 &&
+    chartData[1]?.data?.length > 0;
   const isLoading =
-    isFetching ||
-    (isLive && !initialDataLoadedRef.current && chartData.length === 0);
+    isFetching || !hasChartData || (isLive && !initialDataLoadedRef.current);
 
   const hasErrors = errors.some((error) => error !== null);
   const errorMessage = hasErrors

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef, useCallback, useState } from 'react';
-import { PanResponder, View } from 'react-native';
+import { ActivityIndicator, PanResponder, View } from 'react-native';
 import { LineChart } from 'react-native-svg-charts';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
@@ -139,8 +139,10 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
     return (
       <Box twClassName="flex-1" testID={testID}>
         <Box
-          twClassName={`h-[${CHART_HEIGHT}px] bg-background-alternative rounded-lg`}
-        />
+          twClassName={`h-[${CHART_HEIGHT}px] bg-transparent rounded-lg items-center justify-center`}
+        >
+          <ActivityIndicator color={colors.primary.default} />
+        </Box>
         {onTimeframeChange && (
           <TimeframeSelector
             selected={timeframe}

--- a/app/components/UI/Predict/components/PredictGameChart/TimeframeSelector.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/TimeframeSelector.tsx
@@ -30,7 +30,7 @@ const TimeframeSelector: React.FC<TimeframeSelectorProps> = ({
   return (
     <Box
       flexDirection={BoxFlexDirection.Row}
-      twClassName="justify-center gap-2 mt-3"
+      twClassName="justify-center gap-2 pt-2 px-4"
     >
       {TIMEFRAMES.map(({ value, label }) => {
         const isSelected = selected === value;

--- a/app/components/UI/Predict/components/PredictPicks/PredictPicks.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPicks.tsx
@@ -101,7 +101,7 @@ const PredictPicks: React.FC<PredictPicksProps> = ({
           </Box>
           <Button
             variant={ButtonVariant.Secondary}
-            twClassName="py-3 px-4 bg-muted/5"
+            twClassName="py-3 px-4 light:bg-muted/5"
             onPress={() => onCashOut(position)}
             testID={`predict-picks-cash-out-button-${position.id}`}
           >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Add ActivityIndicator spinner during chart loading instead of blank background
- Implement dynamic timestamp positioning to prevent text overflow at chart edges
  - Anchor timestamp to left when near left boundary
  - Anchor timestamp to right when near right boundary
  - Center timestamp when in the middle of the chart
- Fix timestamp conversion to handle both seconds and milliseconds formats
- Improve chart data loading detection to check for actual data presence
- Fix TimeframeSelector padding for better spacing
- Fix PredictPicks cash out button background for light mode only

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

https://www.loom.com/share/d3841593361b418e81f6034dae4a2cb2

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves chart usability and data handling with better loading UX, timestamp rendering, and parsing.
> 
> - Implements edge-aware tooltip timestamp: clamps `x` to chart bounds and switches `textAnchor` between `start`/`middle`/`end` using `TIMESTAMP_TEXT_HALF_WIDTH`
> - Adds `toMilliseconds` to normalize seconds vs milliseconds timestamps for history data
> - Refines loading detection: require both series to have data; updates `isLoading` and initial live data logic
> - Replaces blank loading state with centered `ActivityIndicator`; disables `TimeframeSelector` while loading
> - UI polish: adjust `TimeframeSelector` padding; set PredictPicks cash-out button background for light mode only
> - Tests: expand `ChartTooltip` tests to cover timestamp edge positioning and update SVG `Text` mock to include `textAnchor`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cb500d3f151fcac731b5ebeaaf54e615fdb2080. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->