### PR TITLE
feat(predict): cp-7.62.0 render PredictMarketSportCard for NFL game markets

### DIFF
--- a/app/components/UI/Predict/components/PredictMarket/PredictMarket.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarket/PredictMarket.test.tsx
@@ -27,6 +27,15 @@ jest.mock('../PredictMarketMultiple', () => {
   ));
 });
 
+jest.mock('../PredictMarketSportCard', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return jest.fn(({ market }) => (
+    <View testID="predict-market-sport-card">
+      <Text>PredictMarketSportCard: {market.title}</Text>
+    </View>
+  ));
+});
+
 const mockSingleOutcome: PredictOutcome = {
   id: 'test-outcome-1',
   providerId: 'test-provider',
@@ -121,6 +130,65 @@ const mockMultipleMarket: PredictMarketType = {
   volume: 1000000,
 };
 
+const mockNflGameOutcome: PredictOutcome = {
+  id: 'nfl-outcome-1',
+  providerId: 'test-provider',
+  marketId: 'nfl-market-1',
+  title: 'Seahawks vs Broncos',
+  description: 'NFL game prediction',
+  image: 'https://example.com/nfl.png',
+  status: 'open',
+  tokens: [
+    { id: 'token-sea', title: 'Seahawks', price: 0.55 },
+    { id: 'token-den', title: 'Broncos', price: 0.45 },
+  ],
+  volume: 500000,
+  groupItemTitle: 'NFL',
+  negRisk: false,
+  tickSize: '0.01',
+};
+
+const mockNflMarket: PredictMarketType = {
+  id: 'nfl-market-1',
+  providerId: 'test-provider',
+  slug: 'seahawks-vs-broncos',
+  title: 'Seahawks vs Broncos',
+  description: 'NFL game prediction market',
+  image: 'https://example.com/nfl.png',
+  status: 'open',
+  recurrence: Recurrence.NONE,
+  category: 'sports',
+  tags: ['nfl'],
+  outcomes: [mockNflGameOutcome],
+  liquidity: 1000000,
+  volume: 1000000,
+  game: {
+    id: 'nfl-game-1',
+    startTime: '2025-01-20T18:00:00Z',
+    status: 'scheduled',
+    league: 'nfl',
+    elapsed: null,
+    period: null,
+    score: null,
+    homeTeam: {
+      id: 'den',
+      name: 'Denver Broncos',
+      logo: 'https://example.com/broncos.png',
+      abbreviation: 'DEN',
+      color: '#FC4C02',
+      alias: 'Broncos',
+    },
+    awayTeam: {
+      id: 'sea',
+      name: 'Seattle Seahawks',
+      logo: 'https://example.com/seahawks.png',
+      abbreviation: 'SEA',
+      color: '#002244',
+      alias: 'Seahawks',
+    },
+  },
+};
+
 const initialState = {
   engine: {
     backgroundState,
@@ -154,5 +222,35 @@ describe('PredictMarket', () => {
     expect(
       getByText('PredictMarketSingle: Bitcoin Single Market'),
     ).toBeOnTheScreen();
+  });
+
+  it('renders PredictMarketSportCard for NFL game markets', () => {
+    const { getByTestId } = setupPredictMarketTest(mockNflMarket);
+
+    expect(getByTestId('predict-market-sport-card')).toBeOnTheScreen();
+  });
+
+  it('passes market prop correctly to PredictMarketSportCard for NFL markets', () => {
+    const { getByText } = setupPredictMarketTest(mockNflMarket);
+
+    expect(
+      getByText('PredictMarketSportCard: Seahawks vs Broncos'),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders PredictMarketSingle for single-outcome market without NFL game', () => {
+    const { getByTestId, queryByTestId } =
+      setupPredictMarketTest(mockSingleMarket);
+
+    expect(getByTestId('predict-market-single')).toBeOnTheScreen();
+    expect(queryByTestId('predict-market-sport-card')).toBeNull();
+  });
+
+  it('renders PredictMarketMultiple for multi-outcome market without NFL game', () => {
+    const { getByTestId, queryByTestId } =
+      setupPredictMarketTest(mockMultipleMarket);
+
+    expect(getByTestId('predict-market-multiple')).toBeOnTheScreen();
+    expect(queryByTestId('predict-market-sport-card')).toBeNull();
   });
 });

--- a/app/components/UI/Predict/components/PredictMarket/PredictMarket.tsx
+++ b/app/components/UI/Predict/components/PredictMarket/PredictMarket.tsx
@@ -4,6 +4,7 @@ import { PredictEntryPoint } from '../../types/navigation';
 import { PredictEventValues } from '../../constants/eventNames';
 import PredictMarketSingle from '../PredictMarketSingle';
 import PredictMarketMultiple from '../PredictMarketMultiple';
+import PredictMarketSportCard from '../PredictMarketSportCard';
 
 interface PredictMarketProps {
   market: PredictMarketType;
@@ -18,6 +19,16 @@ const PredictMarket: React.FC<PredictMarketProps> = ({
   entryPoint = PredictEventValues.ENTRY_POINT.PREDICT_FEED,
   isCarousel = false,
 }) => {
+  if (market.game?.league === 'nfl') {
+    return (
+      <PredictMarketSportCard
+        market={market}
+        testID={testID}
+        entryPoint={entryPoint}
+      />
+    );
+  }
+
   if (market.outcomes.length === 1) {
     return (
       <PredictMarketSingle


### PR DESCRIPTION
## **Description**

This PR adds conditional rendering to display the specialized `PredictMarketSportCard` component for prediction markets associated with NFL games.

**Reason for change:**
Markets with NFL game data should use the dedicated sports card component that shows team colors, scoreboard, and game status instead of the generic single/multiple outcome cards.

**Solution:**
- Added a check in `PredictMarket` component that renders `PredictMarketSportCard` when `market.game?.league === 'nfl'`
- This check occurs before the outcome count checks, ensuring NFL markets always use the sport card
- Non-NFL markets continue to use `PredictMarketSingle` or `PredictMarketMultiple` based on outcome count

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-487

## **Manual testing steps**

```gherkin
Feature: NFL game market card rendering

  Scenario: user views NFL game market in prediction feed
    Given user has access to prediction markets
    And there is an NFL game market available

    When user views the prediction feed
    Then the NFL market displays using PredictMarketSportCard
    And shows team colors, abbreviations, and scoreboard

  Scenario: user views non-NFL market in prediction feed
    Given user has access to prediction markets
    And there is a crypto/politics market available

    When user views the prediction feed
    Then the market displays using PredictMarketSingle or PredictMarketMultiple
    And does not show sports-specific UI elements
```

## **Screenshots/Recordings**

<!-- N/A - Logic change with no visual changes -->

### **Before**

<!-- N/A -->

### **After**

<img width="382" height="811" alt="Screenshot 2026-01-16 at 12 25 02 PM" src="https://github.com/user-attachments/assets/ebb73135-e270-4275-a2b0-9ecf16f57c55" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prioritizes sports-specific rendering for NFL markets.
> 
> - In `PredictMarket.tsx`, conditionally returns `PredictMarketSportCard` when `market.game?.league === 'nfl'`, before outcome-based checks; otherwise renders `PredictMarketSingle` or `PredictMarketMultiple` as before
> - Updates `PredictMarket.test.tsx` to mock `PredictMarketSportCard` and add tests covering NFL rendering, prop passing, and that non-NFL single/multi markets still render the respective components
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0181afba2991e9dcef3c8d5e2ff72ae081399c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->