### PR TITLE
feat(predict): cp-7.62.0 add live price updates to action buttons

### DIFF
--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.test.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.test.tsx
@@ -25,7 +25,9 @@ const mockUseLiveMarketPrices = useLiveMarketPrices as jest.MockedFunction<
   typeof useLiveMarketPrices
 >;
 
-const createMockGetPrice = (priceMap: Map<string, PriceUpdate>) => (tokenId: string) => priceMap.get(tokenId);
+const createMockGetPrice =
+  (priceMap: Map<string, PriceUpdate>) => (tokenId: string) =>
+    priceMap.get(tokenId);
 
 const createMockOutcome = (overrides = {}): PredictOutcome => ({
   id: 'outcome-1',

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.test.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.test.tsx
@@ -7,7 +7,9 @@ import {
   PredictOutcome,
   PredictMarketStatus,
   Recurrence,
+  PriceUpdate,
 } from '../../types';
+import { useLiveMarketPrices } from '../../hooks/useLiveMarketPrices';
 
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string, params?: Record<string, string>) => {
@@ -17,6 +19,13 @@ jest.mock('../../../../../../locales/i18n', () => ({
     return key;
   }),
 }));
+
+jest.mock('../../hooks/useLiveMarketPrices');
+const mockUseLiveMarketPrices = useLiveMarketPrices as jest.MockedFunction<
+  typeof useLiveMarketPrices
+>;
+
+const createMockGetPrice = (priceMap: Map<string, PriceUpdate>) => (tokenId: string) => priceMap.get(tokenId);
 
 const createMockOutcome = (overrides = {}): PredictOutcome => ({
   id: 'outcome-1',
@@ -92,6 +101,12 @@ const createDefaultProps = (overrides = {}) => ({
 describe('PredictActionButtons', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseLiveMarketPrices.mockReturnValue({
+      prices: new Map(),
+      getPrice: () => undefined,
+      isConnected: false,
+      lastUpdateTime: null,
+    });
   });
 
   describe('loading state', () => {
@@ -305,6 +320,131 @@ describe('PredictActionButtons', () => {
 
       expect(screen.getByText('YES · 65¢')).toBeOnTheScreen();
       expect(screen.getByText('NO · 35¢')).toBeOnTheScreen();
+    });
+  });
+
+  describe('live price updates', () => {
+    it('displays live prices when available', () => {
+      const priceMap = new Map<string, PriceUpdate>([
+        [
+          'token-yes',
+          { tokenId: 'token-yes', price: 0.72, bestBid: 0.71, bestAsk: 0.73 },
+        ],
+        [
+          'token-no',
+          { tokenId: 'token-no', price: 0.28, bestBid: 0.27, bestAsk: 0.29 },
+        ],
+      ]);
+      mockUseLiveMarketPrices.mockReturnValue({
+        prices: priceMap,
+        getPrice: createMockGetPrice(priceMap),
+        isConnected: true,
+        lastUpdateTime: Date.now(),
+      });
+      const props = createDefaultProps();
+
+      renderWithProvider(<PredictActionButtons {...props} />);
+
+      expect(screen.getByText('YES · 72¢')).toBeOnTheScreen();
+      expect(screen.getByText('NO · 28¢')).toBeOnTheScreen();
+    });
+
+    it('falls back to static prices when live prices unavailable', () => {
+      mockUseLiveMarketPrices.mockReturnValue({
+        prices: new Map(),
+        getPrice: () => undefined,
+        isConnected: false,
+        lastUpdateTime: null,
+      });
+      const props = createDefaultProps();
+
+      renderWithProvider(<PredictActionButtons {...props} />);
+
+      expect(screen.getByText('YES · 65¢')).toBeOnTheScreen();
+      expect(screen.getByText('NO · 35¢')).toBeOnTheScreen();
+    });
+
+    it('uses partial live prices with fallback for missing tokens', () => {
+      const priceMap = new Map<string, PriceUpdate>([
+        [
+          'token-yes',
+          { tokenId: 'token-yes', price: 0.8, bestBid: 0.79, bestAsk: 0.81 },
+        ],
+      ]);
+      mockUseLiveMarketPrices.mockReturnValue({
+        prices: priceMap,
+        getPrice: createMockGetPrice(priceMap),
+        isConnected: true,
+        lastUpdateTime: Date.now(),
+      });
+      const props = createDefaultProps();
+
+      renderWithProvider(<PredictActionButtons {...props} />);
+
+      expect(screen.getByText('YES · 80¢')).toBeOnTheScreen();
+      expect(screen.getByText('NO · 35¢')).toBeOnTheScreen();
+    });
+
+    it('subscribes with correct token IDs', () => {
+      const props = createDefaultProps();
+
+      renderWithProvider(<PredictActionButtons {...props} />);
+
+      expect(mockUseLiveMarketPrices).toHaveBeenCalledWith(
+        ['token-yes', 'token-no'],
+        { enabled: true },
+      );
+    });
+
+    it('disables subscription when market is closed', () => {
+      const props = createDefaultProps({
+        market: createMockMarket({ status: PredictMarketStatus.CLOSED }),
+      });
+
+      renderWithProvider(<PredictActionButtons {...props} />);
+
+      expect(mockUseLiveMarketPrices).toHaveBeenCalledWith(
+        ['token-yes', 'token-no'],
+        { enabled: false },
+      );
+    });
+
+    it('disables subscription when loading', () => {
+      const props = createDefaultProps({ isLoading: true });
+
+      renderWithProvider(<PredictActionButtons {...props} />);
+
+      expect(mockUseLiveMarketPrices).toHaveBeenCalledWith(
+        ['token-yes', 'token-no'],
+        { enabled: false },
+      );
+    });
+
+    it('displays live prices for game markets', () => {
+      const priceMap = new Map<string, PriceUpdate>([
+        [
+          'token-yes',
+          { tokenId: 'token-yes', price: 0.55, bestBid: 0.54, bestAsk: 0.56 },
+        ],
+        [
+          'token-no',
+          { tokenId: 'token-no', price: 0.45, bestBid: 0.44, bestAsk: 0.46 },
+        ],
+      ]);
+      mockUseLiveMarketPrices.mockReturnValue({
+        prices: priceMap,
+        getPrice: createMockGetPrice(priceMap),
+        isConnected: true,
+        lastUpdateTime: Date.now(),
+      });
+      const props = createDefaultProps({
+        market: createMockGameMarket(),
+      });
+
+      renderWithProvider(<PredictActionButtons {...props} />);
+
+      expect(screen.getByText('SEA · 55¢')).toBeOnTheScreen();
+      expect(screen.getByText('DEN · 45¢')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.test.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.test.tsx
@@ -177,6 +177,20 @@ describe('PredictActionButtons', () => {
 
       expect(screen.queryByText(/Claim/)).not.toBeOnTheScreen();
     });
+
+    it('renders claim button without amount for game markets', () => {
+      const mockOnClaimPress = jest.fn();
+      const props = createDefaultProps({
+        market: createMockGameMarket(),
+        claimableAmount: 50.25,
+        onClaimPress: mockOnClaimPress,
+      });
+
+      renderWithProvider(<PredictActionButtons {...props} />);
+
+      expect(screen.getByTestId('action-buttons-claim')).toBeOnTheScreen();
+      expect(screen.queryByText('Claim $50.25')).not.toBeOnTheScreen();
+    });
   });
 
   describe('bet buttons for standard markets', () => {

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -99,6 +99,11 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
       return;
     }
 
+    // Only initialize live chart data once - don't reset on subsequent historical data refetches
+    if (initialDataLoadedRef.current) {
+      return;
+    }
+
     if (
       historicalChartData.length === 2 &&
       historicalChartData[0].data.length > 0

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -109,7 +109,8 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
 
     if (
       historicalChartData.length === 2 &&
-      historicalChartData[0].data.length > 0
+      historicalChartData[0].data.length > 0 &&
+      historicalChartData[1].data.length > 0
     ) {
       setLiveChartData(historicalChartData);
       initialDataLoadedRef.current = true;

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -99,8 +99,11 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
       return;
     }
 
-    // Only initialize live chart data once - don't reset on subsequent historical data refetches
     if (initialDataLoadedRef.current) {
+      return;
+    }
+
+    if (isFetching) {
       return;
     }
 
@@ -111,7 +114,7 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
       setLiveChartData(historicalChartData);
       initialDataLoadedRef.current = true;
     }
-  }, [isLive, historicalChartData]);
+  }, [isLive, historicalChartData, isFetching]);
 
   const updateLiveData = useCallback(() => {
     if (!isLive || !initialDataLoadedRef.current || prices.size === 0) return;

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
@@ -320,6 +320,51 @@ describe('PredictGameChart Wrapper', () => {
         expect(getByTestId('content-loading').children[0]).toBe('false');
       });
     });
+
+    it('remains loading when first series has data but second series is empty', async () => {
+      const incompleteHistories = [createMockPriceHistory(0, 3, 0.6), []];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: incompleteHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId, rerender } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      expect(getByTestId('content-loading').children[0]).toBe('true');
+
+      const completeHistories = [
+        createMockPriceHistory(0, 3, 0.6),
+        createMockPriceHistory(1, 3, 0.4),
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: completeHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      rerender(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('content-loading').children[0]).toBe('false');
+      });
+    });
   });
 
   describe('Live Update Logic', () => {

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
@@ -68,7 +68,6 @@ describe('PredictGameChart Wrapper', () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2024-01-15T12:00:00.000Z'));
 
-    // Default mock implementations
     mockUsePredictPriceHistory.mockReturnValue({
       priceHistories: [],
       isFetching: false,
@@ -192,7 +191,6 @@ describe('PredictGameChart Wrapper', () => {
         expect(data[0].label).toBe('Team A');
         expect(data[0].color).toBe('#FF0000');
         expect(data[0].data).toHaveLength(3);
-        // Price 0.6 -> 60%
         expect(data[0].data[0].value).toBe(60);
       });
     });
@@ -591,6 +589,83 @@ describe('PredictGameChart Wrapper', () => {
 
         expect(data[0].data[0].value).toBe(65);
         expect(data[1].data[0].value).toBe(40);
+      });
+    });
+
+    it('preserves accumulated live data when historical data refetches', async () => {
+      const baseTimestamp = new Date('2024-01-15T12:00:00.000Z').getTime();
+      jest.setSystemTime(new Date(baseTimestamp + 30000));
+
+      const initialHistories = [
+        [{ timestamp: baseTimestamp, price: 0.5 }],
+        [{ timestamp: baseTimestamp, price: 0.5 }],
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: initialHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      const pricesMap = new Map([
+        [
+          'token-a',
+          { tokenId: 'token-a', price: 0.7, timestamp: baseTimestamp + 30000 },
+        ],
+        [
+          'token-b',
+          { tokenId: 'token-b', price: 0.3, timestamp: baseTimestamp + 30000 },
+        ],
+      ]);
+
+      mockUseLiveMarketPrices.mockReturnValue({
+        prices: pricesMap,
+        getPrice: (id: string) => pricesMap.get(id),
+        isConnected: true,
+        lastUpdateTime: baseTimestamp + 30000,
+      });
+
+      const { getByTestId, rerender } = render(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+        expect(data[0].data[0].value).toBe(70);
+      });
+
+      const refetchedHistories = [
+        [{ timestamp: baseTimestamp, price: 0.45 }],
+        [{ timestamp: baseTimestamp, price: 0.55 }],
+      ];
+
+      mockUsePredictPriceHistory.mockReturnValue({
+        priceHistories: refetchedHistories,
+        isFetching: false,
+        errors: [null, null],
+        refetch: jest.fn(),
+      });
+
+      rerender(
+        <PredictGameChart
+          tokenIds={defaultTokenIds}
+          seriesConfig={defaultSeriesConfig}
+          testID="chart"
+        />,
+      );
+
+      await waitFor(() => {
+        const dataText = getByTestId('content-data').children[0];
+        const data = JSON.parse(String(dataText));
+
+        expect(data[0].data[0].value).toBe(70);
+        expect(data[1].data[0].value).toBe(30);
       });
     });
   });

--- a/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.test.tsx
@@ -33,6 +33,15 @@ jest.mock('../../../../../../locales/i18n', () => ({
   }),
 }));
 
+jest.mock('../../hooks/useLiveMarketPrices', () => ({
+  useLiveMarketPrices: () => ({
+    prices: new Map(),
+    getPrice: jest.fn(),
+    isConnected: false,
+    lastUpdateTime: null,
+  }),
+}));
+
 const createMockOutcome = (overrides = {}): PredictOutcome => ({
   id: 'outcome-1',
   providerId: 'polymarket',

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
@@ -51,6 +51,16 @@ jest.mock('../../hooks/usePredictActionGuard', () => ({
   }),
 }));
 
+// Mock useLiveMarketPrices
+jest.mock('../../hooks/useLiveMarketPrices', () => ({
+  useLiveMarketPrices: () => ({
+    prices: new Map(),
+    getPrice: jest.fn(),
+    isConnected: false,
+    lastUpdateTime: null,
+  }),
+}));
+
 jest.mock('../PredictSportScoreboard/PredictSportScoreboard', () => {
   const { View, Text } = jest.requireActual('react-native');
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Integrate useLiveMarketPrices hook into PredictActionButtons to display
real-time prices from WebSocket connection. The component now:

- Subscribes to live price updates for YES/NO tokens
- Displays live prices when available with automatic fallback to static prices
- Disables subscription when market is closed or component is loading
- Works for both standard markets and game markets

Includes comprehensive test coverage for live price functionality.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-490

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds real-time pricing to Predict action buttons and improves live chart robustness.
> 
> - Integrates `useLiveMarketPrices` in `PredictActionButtons` to display live YES/NO prices with static fallback; subscription enabled only when market is open and not loading; supports game markets; hides dollar amount on claim for game markets
> - Refines `PredictGameChart` live mode: only initializes when both series have data and not fetching, prevents re-initialization, requires both series to render, and preserves accumulated live data across refetches
> - Extensive tests: new coverage for live prices and subscription gating in `PredictActionButtons.test.tsx`; additional wrapper tests for loading states, partial histories, live minute-update behavior, and data preservation in `PredictGameChart.wrapper.test.tsx`; minor test hooks mocks in related components
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9d1f1cc7c56cf4e72c83b16220a480aa5b1e08e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->