### PR TITLE
feat(predict): cp-7.62.0 add market highlights feature flag support

### DIFF
--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -92,7 +92,7 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
         awayColor={game?.awayTeam.color ?? '#1a2942'}
         homeColor={game?.homeTeam.color ?? '#3d2621'}
         borderRadius={16}
-        style={tw.style('w-full')}
+        style={tw.style('w-full my-[8px]')}
       >
         <Box twClassName="p-4">
           <Text

--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -1,4 +1,8 @@
-import { PredictFeeCollection, PredictLiveSportsFlag } from '../types/flags';
+import {
+  PredictFeeCollection,
+  PredictLiveSportsFlag,
+  PredictMarketHighlightsFlag,
+} from '../types/flags';
 
 export const DEFAULT_FEE_COLLECTION_FLAG = {
   enabled: true,
@@ -14,4 +18,9 @@ export const DEFAULT_FEE_COLLECTION_FLAG = {
 export const DEFAULT_LIVE_SPORTS_FLAG: PredictLiveSportsFlag = {
   enabled: false,
   leagues: [],
+};
+
+export const DEFAULT_MARKET_HIGHLIGHTS_FLAG: PredictMarketHighlightsFlag = {
+  enabled: false,
+  highlights: [],
 };

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -222,6 +222,7 @@ describe('PredictController', () => {
     // Create mock PolymarketProvider with required methods
     mockPolymarketProvider = {
       getMarkets: jest.fn(),
+      getMarketsByIds: jest.fn(),
       getPositions: jest.fn(),
       getMarketDetails: jest.fn(),
       getActivity: jest.fn(),
@@ -1782,6 +1783,342 @@ describe('PredictController', () => {
             providerId: 'nonexistent-provider',
           }),
         ).rejects.toThrow('Provider not available');
+      });
+    });
+  });
+
+  describe('getMarkets with market highlights', () => {
+    const createMockMarket = (id: string, category = 'trending') => ({
+      id,
+      providerId: 'polymarket',
+      title: `Market ${id}`,
+      category,
+      outcomes: ['YES', 'NO'],
+    });
+
+    const setMarketHighlightsFlag = (flag: {
+      enabled: boolean;
+      highlights: { category: string; markets: string[] }[];
+    }) => {
+      (
+        Engine.context.RemoteFeatureFlagController as any
+      ).state.remoteFeatureFlags.predictMarketHighlights = flag;
+    };
+
+    const clearMarketHighlightsFlag = () => {
+      delete (Engine.context.RemoteFeatureFlagController as any).state
+        .remoteFeatureFlags.predictMarketHighlights;
+    };
+
+    afterEach(() => {
+      clearMarketHighlightsFlag();
+    });
+
+    it('prepends highlighted markets when flag is enabled and offset is 0', async () => {
+      setMarketHighlightsFlag({
+        enabled: true,
+        highlights: [
+          { category: 'trending', markets: ['highlight-1', 'highlight-2'] },
+        ],
+      });
+
+      const regularMarkets = [
+        createMockMarket('regular-1'),
+        createMockMarket('regular-2'),
+      ];
+      const highlightedMarkets = [
+        createMockMarket('highlight-1'),
+        createMockMarket('highlight-2'),
+      ];
+
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getMarkets.mockResolvedValue(
+          regularMarkets as any,
+        );
+        mockPolymarketProvider.getMarketsByIds.mockResolvedValue(
+          highlightedMarkets as any,
+        );
+
+        const result = await controller.getMarkets({
+          providerId: 'polymarket',
+          category: 'trending',
+          offset: 0,
+        });
+
+        expect(result).toHaveLength(4);
+        expect(result[0].id).toBe('highlight-1');
+        expect(result[1].id).toBe('highlight-2');
+        expect(result[2].id).toBe('regular-1');
+        expect(result[3].id).toBe('regular-2');
+        expect(mockPolymarketProvider.getMarketsByIds).toHaveBeenCalledWith(
+          ['highlight-1', 'highlight-2'],
+          [],
+        );
+      });
+    });
+
+    it('skips highlights when offset is greater than 0', async () => {
+      setMarketHighlightsFlag({
+        enabled: true,
+        highlights: [{ category: 'trending', markets: ['highlight-1'] }],
+      });
+
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getMarkets.mockResolvedValue(
+          regularMarkets as any,
+        );
+
+        const result = await controller.getMarkets({
+          providerId: 'polymarket',
+          category: 'trending',
+          offset: 10,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('regular-1');
+        expect(mockPolymarketProvider.getMarketsByIds).not.toHaveBeenCalled();
+      });
+    });
+
+    it('skips highlights when flag is disabled', async () => {
+      setMarketHighlightsFlag({
+        enabled: false,
+        highlights: [{ category: 'trending', markets: ['highlight-1'] }],
+      });
+
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getMarkets.mockResolvedValue(
+          regularMarkets as any,
+        );
+
+        const result = await controller.getMarkets({
+          providerId: 'polymarket',
+          category: 'trending',
+          offset: 0,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('regular-1');
+        expect(mockPolymarketProvider.getMarketsByIds).not.toHaveBeenCalled();
+      });
+    });
+
+    it('skips highlights when category is not provided', async () => {
+      setMarketHighlightsFlag({
+        enabled: true,
+        highlights: [{ category: 'trending', markets: ['highlight-1'] }],
+      });
+
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getMarkets.mockResolvedValue(
+          regularMarkets as any,
+        );
+
+        const result = await controller.getMarkets({
+          providerId: 'polymarket',
+        });
+
+        expect(result).toHaveLength(1);
+        expect(mockPolymarketProvider.getMarketsByIds).not.toHaveBeenCalled();
+      });
+    });
+
+    it('skips highlights when category has no configured highlights', async () => {
+      setMarketHighlightsFlag({
+        enabled: true,
+        highlights: [{ category: 'crypto', markets: ['highlight-1'] }],
+      });
+
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getMarkets.mockResolvedValue(
+          regularMarkets as any,
+        );
+
+        const result = await controller.getMarkets({
+          providerId: 'polymarket',
+          category: 'trending',
+          offset: 0,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(mockPolymarketProvider.getMarketsByIds).not.toHaveBeenCalled();
+      });
+    });
+
+    it('filters duplicates from regular results when highlighted market appears in both', async () => {
+      setMarketHighlightsFlag({
+        enabled: true,
+        highlights: [{ category: 'trending', markets: ['duplicate-market'] }],
+      });
+
+      const regularMarkets = [
+        createMockMarket('regular-1'),
+        createMockMarket('duplicate-market'),
+        createMockMarket('regular-2'),
+      ];
+      const highlightedMarkets = [createMockMarket('duplicate-market')];
+
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getMarkets.mockResolvedValue(
+          regularMarkets as any,
+        );
+        mockPolymarketProvider.getMarketsByIds.mockResolvedValue(
+          highlightedMarkets as any,
+        );
+
+        const result = await controller.getMarkets({
+          providerId: 'polymarket',
+          category: 'trending',
+          offset: 0,
+        });
+
+        expect(result).toHaveLength(3);
+        expect(result[0].id).toBe('duplicate-market');
+        expect(result[1].id).toBe('regular-1');
+        expect(result[2].id).toBe('regular-2');
+      });
+    });
+
+    it('handles empty highlights array gracefully', async () => {
+      setMarketHighlightsFlag({
+        enabled: true,
+        highlights: [{ category: 'trending', markets: [] }],
+      });
+
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getMarkets.mockResolvedValue(
+          regularMarkets as any,
+        );
+
+        const result = await controller.getMarkets({
+          providerId: 'polymarket',
+          category: 'trending',
+          offset: 0,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('regular-1');
+        expect(mockPolymarketProvider.getMarketsByIds).not.toHaveBeenCalled();
+      });
+    });
+
+    it('handles getMarketsByIds failure gracefully', async () => {
+      setMarketHighlightsFlag({
+        enabled: true,
+        highlights: [{ category: 'trending', markets: ['highlight-1'] }],
+      });
+
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getMarkets.mockResolvedValue(
+          regularMarkets as any,
+        );
+        mockPolymarketProvider.getMarketsByIds.mockResolvedValue([]);
+
+        const result = await controller.getMarkets({
+          providerId: 'polymarket',
+          category: 'trending',
+          offset: 0,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('regular-1');
+      });
+    });
+
+    it('uses default flag when predictMarketHighlights is not in remote config', async () => {
+      clearMarketHighlightsFlag();
+
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getMarkets.mockResolvedValue(
+          regularMarkets as any,
+        );
+
+        const result = await controller.getMarkets({
+          providerId: 'polymarket',
+          category: 'trending',
+          offset: 0,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(mockPolymarketProvider.getMarketsByIds).not.toHaveBeenCalled();
+      });
+    });
+
+    it('fetches highlights for first page when offset is undefined', async () => {
+      setMarketHighlightsFlag({
+        enabled: true,
+        highlights: [{ category: 'trending', markets: ['highlight-1'] }],
+      });
+
+      const regularMarkets = [createMockMarket('regular-1')];
+      const highlightedMarkets = [createMockMarket('highlight-1')];
+
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getMarkets.mockResolvedValue(
+          regularMarkets as any,
+        );
+        mockPolymarketProvider.getMarketsByIds.mockResolvedValue(
+          highlightedMarkets as any,
+        );
+
+        const result = await controller.getMarkets({
+          providerId: 'polymarket',
+          category: 'trending',
+        });
+
+        expect(result).toHaveLength(2);
+        expect(result[0].id).toBe('highlight-1');
+        expect(result[1].id).toBe('regular-1');
+        expect(mockPolymarketProvider.getMarketsByIds).toHaveBeenCalled();
+      });
+    });
+
+    it('preserves order of highlighted markets from config', async () => {
+      setMarketHighlightsFlag({
+        enabled: true,
+        highlights: [
+          { category: 'trending', markets: ['third', 'first', 'second'] },
+        ],
+      });
+
+      const regularMarkets = [createMockMarket('regular-1')];
+      const highlightedMarkets = [
+        createMockMarket('third'),
+        createMockMarket('first'),
+        createMockMarket('second'),
+      ];
+
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getMarkets.mockResolvedValue(
+          regularMarkets as any,
+        );
+        mockPolymarketProvider.getMarketsByIds.mockResolvedValue(
+          highlightedMarkets as any,
+        );
+
+        const result = await controller.getMarkets({
+          providerId: 'polymarket',
+          category: 'trending',
+          offset: 0,
+        });
+
+        expect(result[0].id).toBe('third');
+        expect(result[1].id).toBe('first');
+        expect(result[2].id).toBe('second');
       });
     });
   });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -86,9 +86,14 @@ import { MATIC_CONTRACTS } from '../providers/polymarket/constants';
 import {
   DEFAULT_FEE_COLLECTION_FLAG,
   DEFAULT_LIVE_SPORTS_FLAG,
+  DEFAULT_MARKET_HIGHLIGHTS_FLAG,
 } from '../constants/flags';
 import { filterSupportedLeagues } from '../constants/sports';
-import { PredictFeeCollection, PredictLiveSportsFlag } from '../types/flags';
+import {
+  PredictFeeCollection,
+  PredictLiveSportsFlag,
+  PredictMarketHighlightsFlag,
+} from '../types/flags';
 
 /**
  * State shape for PredictController
@@ -476,6 +481,12 @@ export class PredictController extends BaseController<
         ? filterSupportedLeagues(liveSportsFlag.leagues ?? [])
         : [];
 
+      const marketHighlightsFlag =
+        (RemoteFeatureFlagController.state.remoteFeatureFlags
+          .predictMarketHighlights as unknown as
+          | PredictMarketHighlightsFlag
+          | undefined) ?? DEFAULT_MARKET_HIGHLIGHTS_FLAG;
+
       const paramsWithLiveSports = { ...params, liveSportsLeagues };
 
       const allMarkets = await Promise.all(
@@ -484,12 +495,40 @@ export class PredictController extends BaseController<
         ),
       );
 
-      //TODO: We need to sort the markets after merging them
-      const markets = allMarkets
+      let markets = allMarkets
         .flat()
         .filter((market): market is PredictMarket => market !== undefined);
 
-      // Clear any previous errors on successful call
+      const isFirstPage = !params.offset || params.offset === 0;
+      const shouldFetchHighlights =
+        marketHighlightsFlag.enabled && isFirstPage && params.category;
+
+      if (shouldFetchHighlights) {
+        const highlightedMarketIds =
+          marketHighlightsFlag.highlights.find(
+            (h) => h.category === params.category,
+          )?.markets ?? [];
+
+        if (highlightedMarketIds.length > 0) {
+          const provider = this.providers.get(
+            params.providerId ?? 'polymarket',
+          );
+
+          const highlightedMarkets =
+            (await provider?.getMarketsByIds?.(
+              highlightedMarketIds,
+              liveSportsLeagues,
+            )) ?? [];
+
+          const highlightedIdSet = new Set(highlightedMarketIds);
+          markets = markets.filter(
+            (market) => !highlightedIdSet.has(market.id),
+          );
+
+          markets = [...highlightedMarkets, ...markets];
+        }
+      }
+
       this.update((state) => {
         state.lastError = null;
         state.lastUpdateTimestamp = Date.now();

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -505,7 +505,7 @@ export class PredictController extends BaseController<
 
       if (shouldFetchHighlights) {
         const highlightedMarketIds =
-          marketHighlightsFlag.highlights.find(
+          (marketHighlightsFlag.highlights ?? []).find(
             (h) => h.category === params.category,
           )?.markets ?? [];
 
@@ -520,7 +520,7 @@ export class PredictController extends BaseController<
               liveSportsLeagues,
             )) ?? [];
 
-          const highlightedIdSet = new Set(highlightedMarketIds);
+          const highlightedIdSet = new Set(highlightedMarkets.map((m) => m.id));
           markets = markets.filter(
             (market) => !highlightedIdSet.has(market.id),
           );

--- a/app/components/UI/Predict/hooks/usePredictMarketData.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarketData.tsx
@@ -109,7 +109,7 @@ export const usePredictMarketData = (
               return;
             }
 
-            const hasMoreData = markets.length === pageSize;
+            const hasMoreData = markets.length >= pageSize;
             setHasMore(hasMoreData);
 
             if (isLoadMore) {

--- a/app/components/UI/Predict/mocks/remoteFeatureFlagMocks.ts
+++ b/app/components/UI/Predict/mocks/remoteFeatureFlagMocks.ts
@@ -1,4 +1,5 @@
 import { VersionGatedFeatureFlag } from '../../../../util/remoteFeatureFlag';
+import { PredictMarketHighlightsFlag } from '../types/flags';
 
 const mockEnabledPredictLDFlag = {
   enabled: true,
@@ -10,4 +11,19 @@ export const mockedPredictFeatureFlagsEnabledState: Record<
   VersionGatedFeatureFlag
 > = {
   predictTradingEnabled: mockEnabledPredictLDFlag,
+};
+
+export const mockPredictMarketHighlightsFlag: PredictMarketHighlightsFlag = {
+  enabled: true,
+  highlights: [
+    {
+      category: 'trending',
+      markets: ['market-highlight-1', 'market-highlight-2'],
+    },
+    { category: 'crypto', markets: ['market-highlight-3'] },
+    {
+      category: 'sports',
+      markets: ['market-highlight-4', 'market-highlight-5'],
+    },
+  ],
 };

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -231,6 +231,10 @@ export interface PredictProvider {
 
   // Market data
   getMarkets(params: GetMarketsParams): Promise<PredictMarket[]>;
+  getMarketsByIds?(
+    marketIds: string[],
+    liveSportsLeagues?: string[],
+  ): Promise<PredictMarket[]>;
   getMarketDetails(params: {
     marketId: string;
     liveSportsLeagues?: string[];

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -12,3 +12,13 @@ export interface PredictLiveSportsFlag {
   enabled: boolean;
   leagues: string[];
 }
+
+export interface PredictMarketHighlight {
+  category: string;
+  markets: string[];
+}
+
+export interface PredictMarketHighlightsFlag {
+  enabled: boolean;
+  highlights: PredictMarketHighlight[];
+}


### PR DESCRIPTION
## **Description**

This PR implements the `predictMarketHighlights` remote feature flag for the Predict feature, allowing specific markets to be highlighted at the top of category feeds.

**Why**: Product wants the ability to curate and promote specific markets per category (e.g., highlight trending sports events in the Sports category).

**Solution**: 
- Added new `predictMarketHighlights` feature flag with shape `{ enabled: boolean; highlights: { category: string; markets: string[] }[] }`
- When enabled and on first page (offset=0), fetch highlighted markets by ID and prepend them to regular results
- Filter duplicates from regular results to avoid showing the same market twice
- Preserve exact order from config for highlighted markets
- Support live sports overlays for highlighted markets

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-489

## **Manual testing steps**

```gherkin
Feature: Market Highlights

  Scenario: User sees highlighted markets at top of category feed
    Given the predictMarketHighlights flag is enabled with highlights for "trending" category
    And the highlights config contains market IDs ["market-1", "market-2"]

    When user navigates to the Trending category
    Then highlighted markets appear at the top of the feed
    And highlighted markets appear in the order specified in config
    And user can scroll down to see regular markets below highlights

  Scenario: Pagination continues working with highlights enabled
    Given the predictMarketHighlights flag is enabled with highlights for "trending" category

    When user scrolls to the bottom of the first page
    Then more markets are automatically loaded
    And infinite scroll continues to work normally
```

## **Screenshots/Recordings**

### **Before**

N/A - New feature

### **After**

<img width="382" height="797" alt="Screenshot 2026-01-16 at 5 05 44 PM" src="https://github.com/user-attachments/assets/28e23ce6-8bfb-45c1-b8be-d0c56bd69a8e" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces curated market highlights surfaced via remote config and fetched by ID.
> 
> - Adds `predictMarketHighlights` flag/types/defaults and mock; updates provider interface with optional `getMarketsByIds`
> - Updates `PredictController.getMarkets` to, on first page and matching `category`, fetch highlighted markets by ID, preserve config order, dedupe from regular results, and pass `liveSportsLeagues`
> - Implements `PolymarketProvider.getMarketsByIds` (parallel fetch, error-tolerant) and wiring in tests
> - Expands unit tests for controller/provider covering highlights behavior and edge cases
> - Tweaks `usePredictMarketData` pagination (`hasMore` when `>= pageSize`) and minor UI spacing on sport card
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58b311456fe59abdf52354ad46b4bdb58c8665fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->