### PR TITLE
fix(predict): cp-7.62.0 use bestAsk from live price updates (buy)

### DIFF
--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.test.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.test.tsx
@@ -361,8 +361,8 @@ describe('PredictActionButtons', () => {
 
       renderWithProvider(<PredictActionButtons {...props} />);
 
-      expect(screen.getByText('YES · 72¢')).toBeOnTheScreen();
-      expect(screen.getByText('NO · 28¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES · 73¢')).toBeOnTheScreen();
+      expect(screen.getByText('NO · 29¢')).toBeOnTheScreen();
     });
 
     it('falls back to static prices when live prices unavailable', () => {
@@ -397,7 +397,7 @@ describe('PredictActionButtons', () => {
 
       renderWithProvider(<PredictActionButtons {...props} />);
 
-      expect(screen.getByText('YES · 80¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES · 81¢')).toBeOnTheScreen();
       expect(screen.getByText('NO · 35¢')).toBeOnTheScreen();
     });
 
@@ -459,8 +459,8 @@ describe('PredictActionButtons', () => {
 
       renderWithProvider(<PredictActionButtons {...props} />);
 
-      expect(screen.getByText('SEA · 55¢')).toBeOnTheScreen();
-      expect(screen.getByText('DEN · 45¢')).toBeOnTheScreen();
+      expect(screen.getByText('SEA · 56¢')).toBeOnTheScreen();
+      expect(screen.getByText('DEN · 46¢')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.tsx
@@ -40,8 +40,8 @@ const PredictActionButtons: React.FC<PredictActionButtonsProps> = ({
     const yesLivePrice = getPrice(yesToken.id);
     const noLivePrice = getPrice(noToken.id);
 
-    const yesPrice = yesLivePrice?.price ?? yesToken.price;
-    const noPrice = noLivePrice?.price ?? noToken.price;
+    const yesPrice = yesLivePrice?.bestAsk ?? yesToken.price;
+    const noPrice = noLivePrice?.bestAsk ?? noToken.price;
 
     if (isGameMarket && market.game) {
       const { awayTeam, homeTeam } = market.game;

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -139,7 +139,7 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
         const lastPoint = existingData[existingData.length - 1];
 
         const newValue = priceUpdate
-          ? Number((priceUpdate.price * 100).toFixed(2))
+          ? Number((priceUpdate.bestAsk * 100).toFixed(2))
           : (lastPoint?.value ?? 50);
 
         const newPoint: GameChartDataPoint = {

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
@@ -385,8 +385,24 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const pricesMap = new Map([
-        ['token-a', { tokenId: 'token-a', price: 0.55, timestamp: Date.now() }],
-        ['token-b', { tokenId: 'token-b', price: 0.45, timestamp: Date.now() }],
+        [
+          'token-a',
+          {
+            tokenId: 'token-a',
+            price: 0.55,
+            bestAsk: 0.55,
+            timestamp: Date.now(),
+          },
+        ],
+        [
+          'token-b',
+          {
+            tokenId: 'token-b',
+            price: 0.45,
+            bestAsk: 0.45,
+            timestamp: Date.now(),
+          },
+        ],
       ]);
 
       mockUseLiveMarketPrices.mockReturnValue({
@@ -469,8 +485,24 @@ describe('PredictGameChart Wrapper', () => {
       jest.setSystemTime(new Date(nextMinute));
 
       const pricesMap = new Map([
-        ['token-a', { tokenId: 'token-a', price: 0.55, timestamp: nextMinute }],
-        ['token-b', { tokenId: 'token-b', price: 0.45, timestamp: nextMinute }],
+        [
+          'token-a',
+          {
+            tokenId: 'token-a',
+            price: 0.55,
+            bestAsk: 0.55,
+            timestamp: nextMinute,
+          },
+        ],
+        [
+          'token-b',
+          {
+            tokenId: 'token-b',
+            price: 0.45,
+            bestAsk: 0.45,
+            timestamp: nextMinute,
+          },
+        ],
       ]);
 
       mockUseLiveMarketPrices.mockReturnValue({
@@ -561,6 +593,7 @@ describe('PredictGameChart Wrapper', () => {
           {
             tokenId: 'token-a',
             price: 0.55,
+            bestAsk: 0.55,
             timestamp: baseTimestamp + 120000,
           },
         ],
@@ -609,7 +642,12 @@ describe('PredictGameChart Wrapper', () => {
       const pricesMap = new Map([
         [
           'token-a',
-          { tokenId: 'token-a', price: 0.65, timestamp: baseTimestamp + 30000 },
+          {
+            tokenId: 'token-a',
+            price: 0.65,
+            bestAsk: 0.65,
+            timestamp: baseTimestamp + 30000,
+          },
         ],
       ]);
 
@@ -656,11 +694,21 @@ describe('PredictGameChart Wrapper', () => {
       const pricesMap = new Map([
         [
           'token-a',
-          { tokenId: 'token-a', price: 0.7, timestamp: baseTimestamp + 30000 },
+          {
+            tokenId: 'token-a',
+            price: 0.7,
+            bestAsk: 0.7,
+            timestamp: baseTimestamp + 30000,
+          },
         ],
         [
           'token-b',
-          { tokenId: 'token-b', price: 0.3, timestamp: baseTimestamp + 30000 },
+          {
+            tokenId: 'token-b',
+            price: 0.3,
+            bestAsk: 0.3,
+            timestamp: baseTimestamp + 30000,
+          },
         ],
       ]);
 
@@ -894,7 +942,15 @@ describe('PredictGameChart Wrapper', () => {
 
       // Only provide price for token-a
       const pricesMap = new Map([
-        ['token-a', { tokenId: 'token-a', price: 0.55, timestamp: Date.now() }],
+        [
+          'token-a',
+          {
+            tokenId: 'token-a',
+            price: 0.55,
+            bestAsk: 0.55,
+            timestamp: Date.now(),
+          },
+        ],
       ]);
 
       mockUseLiveMarketPrices.mockReturnValue({

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
@@ -389,8 +389,8 @@ describe('PredictGameChart Wrapper', () => {
           'token-a',
           {
             tokenId: 'token-a',
-            price: 0.55,
-            bestAsk: 0.55,
+            price: 0.54,
+            bestAsk: 0.56,
             timestamp: Date.now(),
           },
         ],
@@ -398,8 +398,8 @@ describe('PredictGameChart Wrapper', () => {
           'token-b',
           {
             tokenId: 'token-b',
-            price: 0.45,
-            bestAsk: 0.45,
+            price: 0.44,
+            bestAsk: 0.46,
             timestamp: Date.now(),
           },
         ],
@@ -440,10 +440,8 @@ describe('PredictGameChart Wrapper', () => {
         const dataText = getByTestId('content-data').children[0];
         const data = JSON.parse(String(dataText));
 
-        // Should still have 1 data point (updated, not added)
         expect(data[0].data).toHaveLength(1);
-        // Value should be updated to new price
-        expect(data[0].data[0].value).toBe(55);
+        expect(data[0].data[0].value).toBe(56);
       });
     });
 
@@ -489,8 +487,8 @@ describe('PredictGameChart Wrapper', () => {
           'token-a',
           {
             tokenId: 'token-a',
-            price: 0.55,
-            bestAsk: 0.55,
+            price: 0.54,
+            bestAsk: 0.56,
             timestamp: nextMinute,
           },
         ],
@@ -498,8 +496,8 @@ describe('PredictGameChart Wrapper', () => {
           'token-b',
           {
             tokenId: 'token-b',
-            price: 0.45,
-            bestAsk: 0.45,
+            price: 0.44,
+            bestAsk: 0.46,
             timestamp: nextMinute,
           },
         ],
@@ -592,8 +590,8 @@ describe('PredictGameChart Wrapper', () => {
           'token-a',
           {
             tokenId: 'token-a',
-            price: 0.55,
-            bestAsk: 0.55,
+            price: 0.54,
+            bestAsk: 0.56,
             timestamp: baseTimestamp + 120000,
           },
         ],
@@ -644,8 +642,8 @@ describe('PredictGameChart Wrapper', () => {
           'token-a',
           {
             tokenId: 'token-a',
-            price: 0.65,
-            bestAsk: 0.65,
+            price: 0.64,
+            bestAsk: 0.66,
             timestamp: baseTimestamp + 30000,
           },
         ],
@@ -670,7 +668,7 @@ describe('PredictGameChart Wrapper', () => {
         const dataText = getByTestId('content-data').children[0];
         const data = JSON.parse(String(dataText));
 
-        expect(data[0].data[0].value).toBe(65);
+        expect(data[0].data[0].value).toBe(66);
         expect(data[1].data[0].value).toBe(40);
       });
     });
@@ -696,8 +694,8 @@ describe('PredictGameChart Wrapper', () => {
           'token-a',
           {
             tokenId: 'token-a',
-            price: 0.7,
-            bestAsk: 0.7,
+            price: 0.69,
+            bestAsk: 0.71,
             timestamp: baseTimestamp + 30000,
           },
         ],
@@ -705,8 +703,8 @@ describe('PredictGameChart Wrapper', () => {
           'token-b',
           {
             tokenId: 'token-b',
-            price: 0.3,
-            bestAsk: 0.3,
+            price: 0.29,
+            bestAsk: 0.31,
             timestamp: baseTimestamp + 30000,
           },
         ],
@@ -730,7 +728,7 @@ describe('PredictGameChart Wrapper', () => {
       await waitFor(() => {
         const dataText = getByTestId('content-data').children[0];
         const data = JSON.parse(String(dataText));
-        expect(data[0].data[0].value).toBe(70);
+        expect(data[0].data[0].value).toBe(71);
       });
 
       const refetchedHistories = [
@@ -757,8 +755,8 @@ describe('PredictGameChart Wrapper', () => {
         const dataText = getByTestId('content-data').children[0];
         const data = JSON.parse(String(dataText));
 
-        expect(data[0].data[0].value).toBe(70);
-        expect(data[1].data[0].value).toBe(30);
+        expect(data[0].data[0].value).toBe(71);
+        expect(data[1].data[0].value).toBe(31);
       });
     });
   });
@@ -946,8 +944,8 @@ describe('PredictGameChart Wrapper', () => {
           'token-a',
           {
             tokenId: 'token-a',
-            price: 0.55,
-            bestAsk: 0.55,
+            price: 0.54,
+            bestAsk: 0.56,
             timestamp: Date.now(),
           },
         ],


### PR DESCRIPTION
## **Description**

Updates unit tests for `PredictActionButtons` and `PredictGameChart` components to accommodate the logic change from using `price` to `bestAsk` for live price updates.

1. **Reason for change**: The components were updated to use `bestAsk` (the ask price) instead of `price` from live price updates for more accurate pricing display.
2. **Solution**: Updated test expectations and mock data to reflect the new `bestAsk` usage.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/PRED-491

## **Manual testing steps**

```gherkin
Feature: Unit tests for Predict components

  Scenario: Tests pass with bestAsk price logic
    Given the test suite is run

    When running yarn jest PredictActionButtons.test.tsx PredictGameChart.wrapper.test.tsx
    Then all tests pass successfully
```

## **Screenshots/Recordings**

N/A - Test-only changes

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Uses ask-side live prices for display and charting.
> 
> - `PredictActionButtons.tsx`: replace `price` with `bestAsk` for `yes/no` button prices; unit tests updated to expect new cent values and live price mocks include bid/ask fields
> - `PredictGameChart.tsx`: live update logic now reads `bestAsk` for chart points; wrapper tests updated (mocks now include `bestAsk`, expectations adjusted)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61ce4a31ee7d590e89cd84b7ebb10449813c915e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->