### PR TITLE
fix(predict): cp-7.62.0 display user positions in sport market cards

### DIFF
--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
@@ -87,6 +87,30 @@ jest.mock('../PredictSportScoreboard/PredictSportScoreboard', () => {
   };
 });
 
+jest.mock('../PredictPicks', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    PredictPicksForCard: function MockPredictPicksForCard({
+      marketId,
+      showSeparator,
+      testID,
+    }: {
+      marketId: string;
+      showSeparator?: boolean;
+      testID?: string;
+    }) {
+      return (
+        <View testID={testID ?? 'mock-picks-for-card'}>
+          <Text testID="mock-picks-market-id">{marketId}</Text>
+          <Text testID="mock-picks-show-separator">
+            {showSeparator ? 'true' : 'false'}
+          </Text>
+        </View>
+      );
+    },
+  };
+});
+
 const mockMarket: PredictMarketType = {
   id: 'test-market-sport-1',
   providerId: 'test-provider',
@@ -430,5 +454,63 @@ describe('PredictMarketSportCard', () => {
 
     // Should render without crashing
     expect(getByTestId('sport-market-card')).toBeOnTheScreen();
+  });
+
+  describe('positions display', () => {
+    it('renders PredictPicksForCard with correct marketId', () => {
+      const { getByTestId } = renderWithProvider(
+        <PredictMarketSportCard market={mockMarket} testID="sport-card" />,
+        { state: initialState },
+      );
+
+      expect(getByTestId('mock-picks-market-id').props.children).toBe(
+        'test-market-sport-1',
+      );
+    });
+
+    it('renders PredictPicksForCard with showSeparator enabled', () => {
+      const { getByTestId } = renderWithProvider(
+        <PredictMarketSportCard market={mockMarket} testID="sport-card" />,
+        { state: initialState },
+      );
+
+      expect(getByTestId('mock-picks-show-separator').props.children).toBe(
+        'true',
+      );
+    });
+
+    it('renders PredictPicksForCard with correct testID', () => {
+      const { getByTestId } = renderWithProvider(
+        <PredictMarketSportCard market={mockMarket} testID="sport-card" />,
+        { state: initialState },
+      );
+
+      expect(getByTestId('sport-card-picks')).toBeOnTheScreen();
+    });
+
+    it('renders PredictPicksForCard with default testID when no testID provided', () => {
+      const { getByTestId } = renderWithProvider(
+        <PredictMarketSportCard market={mockMarket} />,
+        { state: initialState },
+      );
+
+      expect(getByTestId('mock-picks-for-card')).toBeOnTheScreen();
+    });
+
+    it('renders PredictPicksForCard when game has ended', () => {
+      const endedMarket: PredictMarketType = {
+        ...mockMarket,
+        game: mockMarket.game
+          ? { ...mockMarket.game, status: 'ended' }
+          : undefined,
+      };
+
+      const { getByTestId } = renderWithProvider(
+        <PredictMarketSportCard market={endedMarket} testID="sport-card" />,
+        { state: initialState },
+      );
+
+      expect(getByTestId('sport-card-picks')).toBeOnTheScreen();
+    });
   });
 });

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -6,12 +6,9 @@ import {
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { TouchableOpacity } from 'react-native';
-import {
-  PredictMarket as PredictMarketType,
-  PredictOutcomeToken,
-} from '../../types';
+import { PredictMarket as PredictMarketType } from '../../types';
 import {
   PredictNavigationParamList,
   PredictEntryPoint,
@@ -21,9 +18,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import TrendingFeedSessionManager from '../../../Trending/services/TrendingFeedSessionManager';
 import PredictSportTeamGradient from '../PredictSportTeamGradient/PredictSportTeamGradient';
 import PredictSportScoreboard from '../PredictSportScoreboard/PredictSportScoreboard';
-import { PredictActionButtons } from '../PredictActionButtons';
-import { PredictPicksForCard } from '../PredictPicks';
-import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
+import { PredictSportCardFooter } from '../PredictSportCardFooter';
 
 interface PredictMarketSportCardProps {
   market: PredictMarketType;
@@ -45,34 +40,7 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const tw = useTailwind();
 
-  const { executeGuardedAction } = usePredictActionGuard({
-    providerId: market.providerId,
-    navigation,
-  });
-
-  const outcome = market.outcomes?.[0];
   const game = market.game;
-  const isEnded = game?.status === 'ended';
-
-  const handleBetPress = useCallback(
-    (token: PredictOutcomeToken) => {
-      executeGuardedAction(
-        () => {
-          navigation.navigate(Routes.PREDICT.MODALS.BUY_PREVIEW, {
-            market,
-            outcome,
-            outcomeToken: token,
-            entryPoint: resolvedEntryPoint,
-          });
-        },
-        {
-          checkBalance: true,
-          attemptedAction: PredictEventValues.ATTEMPTED_ACTION.PREDICT,
-        },
-      );
-    },
-    [executeGuardedAction, navigation, market, outcome, resolvedEntryPoint],
-  );
 
   return (
     <TouchableOpacity
@@ -111,20 +79,11 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
             />
           )}
 
-          <PredictPicksForCard
-            marketId={market.id}
-            showSeparator
-            testID={testID ? `${testID}-picks` : undefined}
+          <PredictSportCardFooter
+            market={market}
+            entryPoint={resolvedEntryPoint}
+            testID={testID ? `${testID}-footer` : undefined}
           />
-
-          {outcome && !isEnded && (
-            <PredictActionButtons
-              market={market}
-              outcome={outcome}
-              onBetPress={handleBetPress}
-              testID={testID ? `${testID}-action-buttons` : undefined}
-            />
-          )}
         </Box>
       </PredictSportTeamGradient>
     </TouchableOpacity>

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -22,6 +22,7 @@ import TrendingFeedSessionManager from '../../../Trending/services/TrendingFeedS
 import PredictSportTeamGradient from '../PredictSportTeamGradient/PredictSportTeamGradient';
 import PredictSportScoreboard from '../PredictSportScoreboard/PredictSportScoreboard';
 import { PredictActionButtons } from '../PredictActionButtons';
+import { PredictPicksForCard } from '../PredictPicks';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 
 interface PredictMarketSportCardProps {
@@ -109,6 +110,12 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
               testID={testID ? `${testID}-scoreboard` : undefined}
             />
           )}
+
+          <PredictPicksForCard
+            marketId={market.id}
+            showSeparator
+            testID={testID ? `${testID}-picks` : undefined}
+          />
 
           {outcome && !isEnded && (
             <PredictActionButtons

--- a/app/components/UI/Predict/components/PredictPicks/PredictPicksForCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPicksForCard.test.tsx
@@ -65,9 +65,9 @@ describe('PredictPicksForCard', () => {
   });
 
   describe('rendering', () => {
-    it('renders container with default testID', () => {
+    it('renders container with default testID when positions exist', () => {
       mockUsePredictPositions.mockReturnValue({
-        positions: [],
+        positions: [createMockPosition()],
         isLoading: false,
         isRefreshing: false,
         error: null,
@@ -81,9 +81,9 @@ describe('PredictPicksForCard', () => {
       ).toBeGreaterThan(0);
     });
 
-    it('renders container with custom testID', () => {
+    it('renders container with custom testID when positions exist', () => {
       mockUsePredictPositions.mockReturnValue({
-        positions: [],
+        positions: [createMockPosition()],
         isLoading: false,
         isRefreshing: false,
         error: null,
@@ -97,6 +97,20 @@ describe('PredictPicksForCard', () => {
       expect(screen.getAllByTestId('custom-card-picks').length).toBeGreaterThan(
         0,
       );
+    });
+
+    it('returns null when no positions', () => {
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictPicksForCard marketId="market-1" />);
+
+      expect(screen.queryByTestId('predict-picks-for-card')).toBeNull();
     });
   });
 
@@ -238,9 +252,9 @@ describe('PredictPicksForCard', () => {
       );
     });
 
-    it('displays position amount', () => {
+    it('displays position currentValue', () => {
       mockUsePredictPositions.mockReturnValue({
-        positions: [createMockPosition({ amount: 75.25 })],
+        positions: [createMockPosition({ currentValue: 75.25 })],
         isLoading: false,
         isRefreshing: false,
         error: null,
@@ -331,20 +345,6 @@ describe('PredictPicksForCard', () => {
   });
 
   describe('edge cases', () => {
-    it('renders empty when no positions', () => {
-      mockUsePredictPositions.mockReturnValue({
-        positions: [],
-        isLoading: false,
-        isRefreshing: false,
-        error: null,
-        loadPositions: mockLoadPositions,
-      });
-
-      render(<PredictPicksForCard marketId="market-1" />);
-
-      expect(screen.queryByText(/to win/)).toBeNull();
-    });
-
     it('displays position with different outcome text', () => {
       mockUsePredictPositions.mockReturnValue({
         positions: [createMockPosition({ outcome: 'Maybe' })],
@@ -357,6 +357,76 @@ describe('PredictPicksForCard', () => {
       render(<PredictPicksForCard marketId="market-1" />);
 
       expect(screen.getByText(/Maybe to win/)).toBeOnTheScreen();
+    });
+  });
+
+  describe('separator', () => {
+    it('renders separator when showSeparator is true and positions exist', () => {
+      mockUsePredictPositions.mockReturnValue({
+        positions: [createMockPosition()],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictPicksForCard marketId="market-1" showSeparator />);
+
+      expect(
+        screen.getByTestId('predict-picks-for-card-separator'),
+      ).toBeOnTheScreen();
+    });
+
+    it('does not render separator when showSeparator is false', () => {
+      mockUsePredictPositions.mockReturnValue({
+        positions: [createMockPosition()],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictPicksForCard marketId="market-1" showSeparator={false} />);
+
+      expect(
+        screen.queryByTestId('predict-picks-for-card-separator'),
+      ).toBeNull();
+    });
+
+    it('does not render separator when showSeparator is true but no positions', () => {
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictPicksForCard marketId="market-1" showSeparator />);
+
+      expect(
+        screen.queryByTestId('predict-picks-for-card-separator'),
+      ).toBeNull();
+    });
+
+    it('renders separator with custom testID', () => {
+      mockUsePredictPositions.mockReturnValue({
+        positions: [createMockPosition()],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(
+        <PredictPicksForCard
+          marketId="market-1"
+          testID="custom-picks"
+          showSeparator
+        />,
+      );
+
+      expect(screen.getByTestId('custom-picks-separator')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictPicks/PredictPicksForCard.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPicksForCard.tsx
@@ -9,6 +9,7 @@ import {
 import { usePredictPositions } from '../../hooks/usePredictPositions';
 import { formatPrice } from '../../utils/format';
 import { strings } from '../../../../../../locales/i18n';
+import type { PredictPosition } from '../../types';
 
 interface PredictPicksForCardProps {
   marketId: string;
@@ -18,16 +19,26 @@ interface PredictPicksForCardProps {
    * Only renders if there are positions to display
    */
   showSeparator?: boolean;
+  /**
+   * Optional positions array. When provided, skips internal fetching
+   * and uses these positions directly.
+   */
+  positions?: PredictPosition[];
 }
 const PredictPicksForCard: React.FC<PredictPicksForCardProps> = ({
   marketId,
   testID = 'predict-picks-for-card',
   showSeparator = false,
+  positions: positionsProp,
 }) => {
-  const { positions } = usePredictPositions({
+  const { positions: fetchedPositions } = usePredictPositions({
     marketId,
-    autoRefreshTimeout: 10000,
+    autoRefreshTimeout: positionsProp ? undefined : 10000,
+    loadOnMount: !positionsProp,
+    refreshOnFocus: !positionsProp,
   });
+
+  const positions = positionsProp ?? fetchedPositions;
 
   if (positions.length === 0) {
     return null;

--- a/app/components/UI/Predict/components/PredictPicks/PredictPicksForCard.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPicksForCard.tsx
@@ -13,18 +13,34 @@ import { strings } from '../../../../../../locales/i18n';
 interface PredictPicksForCardProps {
   marketId: string;
   testID?: string;
+  /**
+   * When true, renders a separator line above the positions list
+   * Only renders if there are positions to display
+   */
+  showSeparator?: boolean;
 }
 const PredictPicksForCard: React.FC<PredictPicksForCardProps> = ({
   marketId,
   testID = 'predict-picks-for-card',
+  showSeparator = false,
 }) => {
   const { positions } = usePredictPositions({
     marketId,
     autoRefreshTimeout: 10000,
   });
 
+  if (positions.length === 0) {
+    return null;
+  }
+
   return (
     <Box testID={testID} twClassName="flex-col gap-2">
+      {showSeparator && (
+        <Box
+          testID={`${testID}-separator`}
+          twClassName="h-px bg-border-muted my-2"
+        />
+      )}
       {positions.map((position) => (
         <Box
           testID={testID}
@@ -52,7 +68,7 @@ const PredictPicksForCard: React.FC<PredictPicksForCardProps> = ({
               {formatPrice(position.cashPnl, { maximumDecimals: 2 })}
             </Text>
             <Text color={TextColor.TextDefault}>
-              {formatPrice(position.amount, { maximumDecimals: 2 })}
+              {formatPrice(position.currentValue, { maximumDecimals: 2 })}
             </Text>
           </Box>
         </Box>

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
@@ -1,0 +1,708 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react-native';
+import PredictSportCardFooter from './PredictSportCardFooter';
+import { usePredictPositions } from '../../hooks/usePredictPositions';
+import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
+import { usePredictClaim } from '../../hooks/usePredictClaim';
+import {
+  PredictMarket,
+  PredictMarketStatus,
+  PredictPosition,
+  PredictPositionStatus,
+  Recurrence,
+} from '../../types';
+import { PredictEventValues } from '../../constants/eventNames';
+import Routes from '../../../../../constants/navigation/Routes';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+jest.mock('../../hooks/usePredictPositions');
+jest.mock('../../hooks/usePredictActionGuard');
+jest.mock('../../hooks/usePredictClaim');
+
+const mockUsePredictPositions = usePredictPositions as jest.MockedFunction<
+  typeof usePredictPositions
+>;
+const mockUsePredictActionGuard = usePredictActionGuard as jest.MockedFunction<
+  typeof usePredictActionGuard
+>;
+const mockUsePredictClaim = usePredictClaim as jest.MockedFunction<
+  typeof usePredictClaim
+>;
+
+const mockIsFromTrending = jest.fn();
+jest.mock('../../../Trending/services/TrendingFeedSessionManager', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      get isFromTrending() {
+        return mockIsFromTrending();
+      },
+    }),
+  },
+}));
+
+jest.mock('../PredictActionButtons', () => {
+  const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
+  return {
+    PredictActionButtons: function MockPredictActionButtons({
+      market,
+      outcome,
+      onBetPress,
+      onClaimPress,
+      claimableAmount,
+      testID,
+    }: {
+      market: { id: string };
+      outcome: { id: string; tokens: { id: string; title: string }[] };
+      onBetPress?: (token: { id: string; title: string }) => void;
+      onClaimPress?: () => void;
+      claimableAmount?: number;
+      testID?: string;
+    }) {
+      const showClaimButton =
+        claimableAmount && claimableAmount > 0 && onClaimPress;
+      const showBetButtons = !showClaimButton && onBetPress && outcome?.tokens;
+
+      return (
+        <View testID={testID ?? 'mock-action-buttons'}>
+          <Text testID={`${testID}-market-id`}>{market.id}</Text>
+          <Text testID={`${testID}-outcome-id`}>{outcome?.id}</Text>
+          {showClaimButton && (
+            <TouchableOpacity testID={`${testID}-claim`} onPress={onClaimPress}>
+              <Text>Claim ${claimableAmount}</Text>
+            </TouchableOpacity>
+          )}
+          {showBetButtons && (
+            <>
+              <TouchableOpacity
+                testID={`${testID}-bet-yes`}
+                onPress={() => onBetPress(outcome.tokens[0])}
+              >
+                <Text>Bet Yes</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                testID={`${testID}-bet-no`}
+                onPress={() => onBetPress(outcome.tokens[1])}
+              >
+                <Text>Bet No</Text>
+              </TouchableOpacity>
+            </>
+          )}
+        </View>
+      );
+    },
+  };
+});
+
+jest.mock('../PredictPicks', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    PredictPicksForCard: function MockPredictPicksForCard({
+      marketId,
+      positions,
+      showSeparator,
+      testID,
+    }: {
+      marketId: string;
+      positions?: { id: string }[];
+      showSeparator?: boolean;
+      testID?: string;
+    }) {
+      return (
+        <View testID={testID ?? 'mock-picks-for-card'}>
+          <Text testID={`${testID}-market-id`}>{marketId}</Text>
+          <Text testID={`${testID}-positions-count`}>
+            {positions?.length ?? 0}
+          </Text>
+          <Text testID={`${testID}-show-separator`}>
+            {showSeparator ? 'true' : 'false'}
+          </Text>
+        </View>
+      );
+    },
+  };
+});
+
+const createMockPosition = (
+  overrides: Partial<PredictPosition> = {},
+): PredictPosition => ({
+  id: 'position-1',
+  providerId: 'polymarket',
+  marketId: 'market-1',
+  outcomeId: 'outcome-1',
+  outcomeTokenId: '0',
+  icon: 'https://example.com/icon.png',
+  title: 'Test Market',
+  outcome: 'Yes',
+  outcomeIndex: 0,
+  amount: 25,
+  price: 0.67,
+  status: PredictPositionStatus.OPEN,
+  size: 50,
+  cashPnl: 15.5,
+  percentPnl: 5.25,
+  initialValue: 100,
+  currentValue: 115.5,
+  avgPrice: 0.5,
+  claimable: false,
+  endDate: '2025-12-31T00:00:00Z',
+  ...overrides,
+});
+
+const createMockMarket = (
+  overrides: Partial<PredictMarket> = {},
+): PredictMarket => ({
+  id: 'market-1',
+  providerId: 'polymarket',
+  slug: 'test-market',
+  title: 'Test Market',
+  description: 'Test description',
+  image: 'https://example.com/image.png',
+  status: PredictMarketStatus.OPEN,
+  recurrence: Recurrence.NONE,
+  category: 'sports',
+  tags: ['test'],
+  outcomes: [
+    {
+      id: 'outcome-1',
+      providerId: 'polymarket',
+      marketId: 'market-1',
+      title: 'Will it happen?',
+      description: 'Test outcome',
+      image: 'https://example.com/outcome.png',
+      status: 'open',
+      tokens: [
+        { id: 'token-yes', title: 'Yes', price: 0.65 },
+        { id: 'token-no', title: 'No', price: 0.35 },
+      ],
+      volume: 1000000,
+      groupItemTitle: 'Test Group',
+    },
+  ],
+  liquidity: 500000,
+  volume: 1000000,
+  ...overrides,
+});
+
+describe('PredictSportCardFooter', () => {
+  const mockExecuteGuardedAction = jest.fn();
+  const mockClaim = jest.fn();
+  const mockLoadPositions = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsFromTrending.mockReturnValue(false);
+
+    mockUsePredictPositions.mockReturnValue({
+      positions: [],
+      isLoading: false,
+      isRefreshing: false,
+      error: null,
+      loadPositions: mockLoadPositions,
+    });
+
+    mockUsePredictActionGuard.mockReturnValue({
+      executeGuardedAction: mockExecuteGuardedAction,
+      isEligible: true,
+      hasNoBalance: false,
+    });
+
+    mockUsePredictClaim.mockReturnValue({
+      claim: mockClaim,
+    });
+
+    mockExecuteGuardedAction.mockImplementation((callback) => callback());
+  });
+
+  describe('hook configuration', () => {
+    it('calls usePredictPositions with correct marketId', () => {
+      const market = createMockMarket({ id: 'specific-market-123' });
+
+      render(<PredictSportCardFooter market={market} />);
+
+      expect(mockUsePredictPositions).toHaveBeenCalledWith({
+        marketId: 'specific-market-123',
+        autoRefreshTimeout: 10000,
+      });
+    });
+
+    it('calls usePredictActionGuard with correct providerId', () => {
+      const market = createMockMarket({ providerId: 'test-provider' });
+
+      render(<PredictSportCardFooter market={market} />);
+
+      expect(mockUsePredictActionGuard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerId: 'test-provider',
+        }),
+      );
+    });
+
+    it('calls usePredictClaim with correct providerId', () => {
+      const market = createMockMarket({ providerId: 'claim-provider' });
+
+      render(<PredictSportCardFooter market={market} />);
+
+      expect(mockUsePredictClaim).toHaveBeenCalledWith({
+        providerId: 'claim-provider',
+      });
+    });
+  });
+
+  describe('no positions - open market', () => {
+    it('renders bet buttons when market is open and no positions', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.OPEN });
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.getByTestId('footer-action-buttons')).toBeOnTheScreen();
+      expect(screen.getByText('Bet Yes')).toBeOnTheScreen();
+      expect(screen.getByText('Bet No')).toBeOnTheScreen();
+    });
+
+    it('does not render picks when no positions', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.OPEN });
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.queryByTestId('footer-picks')).toBeNull();
+    });
+  });
+
+  describe('open positions - open market', () => {
+    it('renders positions when user has open positions', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.OPEN });
+      const positions = [createMockPosition({ claimable: false })];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.getByTestId('footer-picks')).toBeOnTheScreen();
+    });
+
+    it('does not render bet buttons when user has open positions', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.OPEN });
+      const positions = [createMockPosition({ claimable: false })];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.queryByText('Bet Yes')).toBeNull();
+      expect(screen.queryByText('Bet No')).toBeNull();
+    });
+
+    it('passes positions to PredictPicksForCard', () => {
+      const market = createMockMarket();
+      const positions = [
+        createMockPosition({ id: 'pos-1' }),
+        createMockPosition({ id: 'pos-2' }),
+      ];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(
+        screen.getByTestId('footer-picks-positions-count').props.children,
+      ).toBe(2);
+    });
+
+    it('passes showSeparator=true to PredictPicksForCard', () => {
+      const market = createMockMarket();
+      const positions = [createMockPosition()];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(
+        screen.getByTestId('footer-picks-show-separator').props.children,
+      ).toBe('true');
+    });
+  });
+
+  describe('claimable positions - resolved market', () => {
+    it('renders claim button when positions are claimable', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
+      const positions = [
+        createMockPosition({ claimable: true, currentValue: 50 }),
+      ];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.getByText('Claim $50')).toBeOnTheScreen();
+    });
+
+    it('renders positions with claim button when claimable', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
+      const positions = [
+        createMockPosition({ claimable: true, currentValue: 50 }),
+      ];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.getByTestId('footer-picks')).toBeOnTheScreen();
+      expect(screen.getByTestId('footer-action-buttons')).toBeOnTheScreen();
+    });
+
+    it('calculates total claimable amount from multiple positions', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
+      const positions = [
+        createMockPosition({ id: 'pos-1', claimable: true, currentValue: 30 }),
+        createMockPosition({ id: 'pos-2', claimable: true, currentValue: 20 }),
+        createMockPosition({
+          id: 'pos-3',
+          claimable: false,
+          currentValue: 100,
+        }),
+      ];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.getByText('Claim $50')).toBeOnTheScreen();
+    });
+
+    it('does not render bet buttons when market is resolved', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
+      const positions = [
+        createMockPosition({ claimable: true, currentValue: 50 }),
+      ];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.queryByText('Bet Yes')).toBeNull();
+      expect(screen.queryByText('Bet No')).toBeNull();
+    });
+  });
+
+  describe('closed market', () => {
+    it('renders nothing when market is closed and no positions', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.CLOSED });
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.queryByTestId('footer-picks')).toBeNull();
+      expect(screen.queryByTestId('footer-action-buttons')).toBeNull();
+    });
+
+    it('renders positions when market is closed but has non-claimable positions', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.CLOSED });
+      const positions = [createMockPosition({ claimable: false })];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.getByTestId('footer-picks')).toBeOnTheScreen();
+      expect(screen.queryByText(/Claim/)).toBeNull();
+    });
+  });
+
+  describe('handleBetPress', () => {
+    it('navigates to buy preview when bet button is pressed', async () => {
+      const market = createMockMarket();
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+      fireEvent.press(screen.getByTestId('footer-action-buttons-bet-yes'));
+
+      await waitFor(() => {
+        expect(mockExecuteGuardedAction).toHaveBeenCalledWith(
+          expect.any(Function),
+          {
+            checkBalance: true,
+            attemptedAction: PredictEventValues.ATTEMPTED_ACTION.PREDICT,
+          },
+        );
+      });
+    });
+
+    it('calls navigate with correct params when guarded action succeeds', async () => {
+      const market = createMockMarket();
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+      mockExecuteGuardedAction.mockImplementation((callback) => callback());
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+      fireEvent.press(screen.getByTestId('footer-action-buttons-bet-yes'));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          Routes.PREDICT.MODALS.BUY_PREVIEW,
+          {
+            market,
+            outcome: market.outcomes[0],
+            outcomeToken: market.outcomes[0].tokens[0],
+            entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+          },
+        );
+      });
+    });
+
+    it('uses trending entry point when from trending feed', async () => {
+      mockIsFromTrending.mockReturnValue(true);
+      const market = createMockMarket();
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(
+        <PredictSportCardFooter
+          market={market}
+          entryPoint={PredictEventValues.ENTRY_POINT.PREDICT_FEED}
+          testID="footer"
+        />,
+      );
+      fireEvent.press(screen.getByTestId('footer-action-buttons-bet-yes'));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          Routes.PREDICT.MODALS.BUY_PREVIEW,
+          expect.objectContaining({
+            entryPoint: PredictEventValues.ENTRY_POINT.TRENDING,
+          }),
+        );
+      });
+    });
+
+    it('uses custom entry point when not from trending', async () => {
+      mockIsFromTrending.mockReturnValue(false);
+      const market = createMockMarket();
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(
+        <PredictSportCardFooter
+          market={market}
+          entryPoint={PredictEventValues.ENTRY_POINT.HOMEPAGE_POSITIONS}
+          testID="footer"
+        />,
+      );
+      fireEvent.press(screen.getByTestId('footer-action-buttons-bet-yes'));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          Routes.PREDICT.MODALS.BUY_PREVIEW,
+          expect.objectContaining({
+            entryPoint: PredictEventValues.ENTRY_POINT.HOMEPAGE_POSITIONS,
+          }),
+        );
+      });
+    });
+  });
+
+  describe('handleClaimPress', () => {
+    it('calls claim function when claim button is pressed', async () => {
+      const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
+      const positions = [
+        createMockPosition({ claimable: true, currentValue: 50 }),
+      ];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+      mockExecuteGuardedAction.mockImplementation(async (callback) => {
+        await callback();
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+      fireEvent.press(screen.getByTestId('footer-action-buttons-claim'));
+
+      await waitFor(() => {
+        expect(mockExecuteGuardedAction).toHaveBeenCalledWith(
+          expect.any(Function),
+          { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CLAIM },
+        );
+      });
+    });
+
+    it('executes claim through guarded action', async () => {
+      const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
+      const positions = [
+        createMockPosition({ claimable: true, currentValue: 50 }),
+      ];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+      mockExecuteGuardedAction.mockImplementation(async (callback) => {
+        await callback();
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+      fireEvent.press(screen.getByTestId('footer-action-buttons-claim'));
+
+      await waitFor(() => {
+        expect(mockClaim).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('renders nothing when market has no outcomes', () => {
+      const market = createMockMarket({ outcomes: [] });
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.queryByTestId('footer-action-buttons')).toBeNull();
+    });
+
+    it('handles positions with null currentValue', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
+      const positions = [
+        createMockPosition({
+          claimable: true,
+          currentValue: undefined as unknown as number,
+        }),
+        createMockPosition({ id: 'pos-2', claimable: true, currentValue: 30 }),
+      ];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.getByText('Claim $30')).toBeOnTheScreen();
+    });
+
+    it('renders with default testID when not provided', () => {
+      const market = createMockMarket();
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} />);
+
+      expect(screen.getByTestId('mock-action-buttons')).toBeOnTheScreen();
+    });
+  });
+});

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
@@ -226,6 +226,72 @@ describe('PredictSportCardFooter', () => {
     mockExecuteGuardedAction.mockImplementation((callback) => callback());
   });
 
+  describe('loading state', () => {
+    it('renders skeleton when positions are loading', () => {
+      const market = createMockMarket();
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: true,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.getByTestId('footer-skeleton')).toBeOnTheScreen();
+      expect(screen.getByTestId('footer-skeleton-1')).toBeOnTheScreen();
+      expect(screen.getByTestId('footer-skeleton-2')).toBeOnTheScreen();
+    });
+
+    it('does not render bet buttons when loading', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.OPEN });
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: true,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.queryByText('Bet Yes')).toBeNull();
+      expect(screen.queryByText('Bet No')).toBeNull();
+    });
+
+    it('does not render picks when loading', () => {
+      const market = createMockMarket();
+      const positions = [createMockPosition()];
+      mockUsePredictPositions.mockReturnValue({
+        positions,
+        isLoading: true,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.queryByTestId('footer-picks')).toBeNull();
+    });
+
+    it('renders with default testID when no testID provided', () => {
+      const market = createMockMarket();
+      mockUsePredictPositions.mockReturnValue({
+        positions: [],
+        isLoading: true,
+        isRefreshing: false,
+        error: null,
+        loadPositions: mockLoadPositions,
+      });
+
+      render(<PredictSportCardFooter market={market} />);
+
+      expect(screen.getByTestId('footer-skeleton')).toBeOnTheScreen();
+    });
+  });
+
   describe('hook configuration', () => {
     it('calls usePredictPositions with correct marketId', () => {
       const market = createMockMarket({ id: 'specific-market-123' });

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
@@ -1,0 +1,136 @@
+import React, { useCallback, useMemo } from 'react';
+import { NavigationProp, useNavigation } from '@react-navigation/native';
+import {
+  PredictMarket as PredictMarketType,
+  PredictMarketStatus,
+  PredictOutcomeToken,
+} from '../../types';
+import {
+  PredictNavigationParamList,
+  PredictEntryPoint,
+} from '../../types/navigation';
+import { PredictEventValues } from '../../constants/eventNames';
+import Routes from '../../../../../constants/navigation/Routes';
+import TrendingFeedSessionManager from '../../../Trending/services/TrendingFeedSessionManager';
+import { PredictActionButtons } from '../PredictActionButtons';
+import { PredictPicksForCard } from '../PredictPicks';
+import { usePredictPositions } from '../../hooks/usePredictPositions';
+import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
+import { usePredictClaim } from '../../hooks/usePredictClaim';
+
+interface PredictSportCardFooterProps {
+  market: PredictMarketType;
+  testID?: string;
+  entryPoint?: PredictEntryPoint;
+}
+
+const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
+  market,
+  testID,
+  entryPoint = PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+}) => {
+  const navigation =
+    useNavigation<NavigationProp<PredictNavigationParamList>>();
+
+  const resolvedEntryPoint = TrendingFeedSessionManager.getInstance()
+    .isFromTrending
+    ? PredictEventValues.ENTRY_POINT.TRENDING
+    : entryPoint;
+
+  const { positions } = usePredictPositions({
+    marketId: market.id,
+    autoRefreshTimeout: 10000,
+  });
+
+  const { executeGuardedAction } = usePredictActionGuard({
+    providerId: market.providerId,
+    navigation,
+  });
+
+  const { claim } = usePredictClaim({
+    providerId: market.providerId,
+  });
+
+  const outcome = market.outcomes?.[0];
+  const isMarketOpen = market.status === PredictMarketStatus.OPEN;
+
+  const { hasPositions, hasClaimablePositions, claimableAmount } =
+    useMemo(() => {
+      const claimablePositions = positions.filter((p) => p.claimable);
+      return {
+        hasPositions: positions.length > 0,
+        hasClaimablePositions: claimablePositions.length > 0,
+        claimableAmount: claimablePositions.reduce(
+          (sum, p) => sum + (p.currentValue ?? 0),
+          0,
+        ),
+      };
+    }, [positions]);
+
+  const handleBetPress = useCallback(
+    (token: PredictOutcomeToken) => {
+      executeGuardedAction(
+        () => {
+          navigation.navigate(Routes.PREDICT.MODALS.BUY_PREVIEW, {
+            market,
+            outcome,
+            outcomeToken: token,
+            entryPoint: resolvedEntryPoint,
+          });
+        },
+        {
+          checkBalance: true,
+          attemptedAction: PredictEventValues.ATTEMPTED_ACTION.PREDICT,
+        },
+      );
+    },
+    [executeGuardedAction, navigation, market, outcome, resolvedEntryPoint],
+  );
+
+  const handleClaimPress = useCallback(async () => {
+    await executeGuardedAction(
+      async () => {
+        await claim();
+      },
+      { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CLAIM },
+    );
+  }, [executeGuardedAction, claim]);
+
+  const showBetButtons = isMarketOpen && !hasPositions && outcome;
+  const showClaimButton = hasClaimablePositions && outcome;
+
+  return (
+    <>
+      {hasPositions && (
+        <PredictPicksForCard
+          marketId={market.id}
+          positions={positions}
+          showSeparator
+          testID={testID ? `${testID}-picks` : undefined}
+        />
+      )}
+
+      {showClaimButton && (
+        <PredictActionButtons
+          market={market}
+          outcome={outcome}
+          onBetPress={handleBetPress}
+          onClaimPress={handleClaimPress}
+          claimableAmount={claimableAmount}
+          testID={testID ? `${testID}-action-buttons` : undefined}
+        />
+      )}
+
+      {showBetButtons && !showClaimButton && (
+        <PredictActionButtons
+          market={market}
+          outcome={outcome}
+          onBetPress={handleBetPress}
+          testID={testID ? `${testID}-action-buttons` : undefined}
+        />
+      )}
+    </>
+  );
+};
+
+export default PredictSportCardFooter;

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
+import { Box, BoxFlexDirection } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   PredictMarket as PredictMarketType,
   PredictMarketStatus,
@@ -12,6 +14,7 @@ import {
 import { PredictEventValues } from '../../constants/eventNames';
 import Routes from '../../../../../constants/navigation/Routes';
 import TrendingFeedSessionManager from '../../../Trending/services/TrendingFeedSessionManager';
+import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
 import { PredictActionButtons } from '../PredictActionButtons';
 import { PredictPicksForCard } from '../PredictPicks';
 import { usePredictPositions } from '../../hooks/usePredictPositions';
@@ -29,6 +32,7 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
   testID,
   entryPoint = PredictEventValues.ENTRY_POINT.PREDICT_FEED,
 }) => {
+  const tw = useTailwind();
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
 
@@ -37,7 +41,7 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
     ? PredictEventValues.ENTRY_POINT.TRENDING
     : entryPoint;
 
-  const { positions } = usePredictPositions({
+  const { positions, isLoading } = usePredictPositions({
     marketId: market.id,
     autoRefreshTimeout: 10000,
   });
@@ -98,6 +102,33 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
 
   const showBetButtons = isMarketOpen && !hasPositions && outcome;
   const showClaimButton = hasClaimablePositions && outcome;
+
+  if (isLoading) {
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        twClassName="w-full gap-3"
+        testID={testID ? `${testID}-skeleton` : 'footer-skeleton'}
+      >
+        <Box twClassName="flex-1">
+          <Skeleton
+            width="100%"
+            height={48}
+            style={tw.style('rounded-md')}
+            testID={testID ? `${testID}-skeleton-1` : 'footer-skeleton-1'}
+          />
+        </Box>
+        <Box twClassName="flex-1">
+          <Skeleton
+            width="100%"
+            height={48}
+            style={tw.style('rounded-md')}
+            testID={testID ? `${testID}-skeleton-2` : 'footer-skeleton-2'}
+          />
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <>

--- a/app/components/UI/Predict/components/PredictSportCardFooter/index.ts
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/index.ts
@@ -1,0 +1,1 @@
+export { default as PredictSportCardFooter } from './PredictSportCardFooter';


### PR DESCRIPTION
## **Description**

This PR integrates user positions into `PredictMarketSportCard` with conditional rendering of action buttons based on position state.

**Problem**: Sport market cards always showed bet buttons regardless of whether the user had open positions.

**Solution**: Created a new `PredictSportCardFooter` component that:
- Fetches positions via `usePredictPositions`
- Shows skeleton loader while positions are loading (prevents flash of bet buttons → picks)
- Conditionally renders UI based on market status and positions:

| Market Status | Positions | Rendered UI |
|---------------|-----------|-------------|
| `open` | None | Bet buttons |
| `open` | Has open positions | Positions only (no buttons) |
| `closed` | Any | Positions only (if any) |
| `resolved` | Has claimable positions | Positions + Claim button |

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-492

## **Manual testing steps**

```gherkin
Feature: Sport Market Card Position Display

  Scenario: user sees bet buttons when no positions exist
    Given user has no positions on a sport market
    When user views the sport market card
    Then user sees Yes/No bet buttons

  Scenario: user sees positions when they have open positions
    Given user has open positions on a sport market
    When user views the sport market card
    Then user sees their positions displayed
    And user does not see bet buttons

  Scenario: user sees claim button when positions are claimable
    Given user has claimable positions on a resolved sport market
    When user views the sport market card
    Then user sees their positions displayed
    And user sees a Claim button with the claimable amount

  Scenario: user sees skeleton while positions load
    Given user opens the predict feed
    When sport market cards are loading
    Then user sees skeleton placeholders in card footers
    And user does not see a flash of bet buttons
```

## **Screenshots/Recordings**

### **Before**

<!-- Cards always showed bet buttons, then flashed to positions when loaded -->

### **After**

<!-- Cards show skeleton → then positions (or buttons if no positions) -->
<img width="382" height="805" alt="Screenshot 2026-01-16 at 10 17 34 PM" src="https://github.com/user-attachments/assets/4732657b-ccf5-4272-ae75-53dd9822d330" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a footer that owns positions and actions, and refactors the sport market card to delegate UI there.
> 
> - New `PredictSportCardFooter` fetches positions (`usePredictPositions`), shows a loading skeleton, and conditionally renders: user picks, bet buttons (only when market is `open` and no positions), and a claim button with aggregated amount when positions are claimable; respects resolved entry point (Trending override) and wires guarded bet/claim flows.
> - `PredictMarketSportCard` simplified: removes inline action logic and renders `PredictSportCardFooter`; still navigates to market details with resolved `entryPoint`.
> - `PredictPicksForCard` enhancements: accepts optional `positions` prop (disables internal fetching when provided), optional `showSeparator`, returns null when empty, and shows `currentValue` instead of `amount`.
> - Extensive tests added/updated for footer states, navigation/guards, entry point resolution, and new `PredictPicksForCard` behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc11640025a66321b61e8fe863544d17a003c60e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->