### PR TITLE
feat(predict): cp-7.62.0 improve PredictGameChart with market prop and smart timeframe defaults

### DIFF
--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -5,7 +5,7 @@ import React, {
   useCallback,
   useRef,
 } from 'react';
-import { PredictPriceHistoryInterval } from '../../types';
+import { PredictGameStatus, PredictPriceHistoryInterval } from '../../types';
 import { usePredictPriceHistory } from '../../hooks/usePredictPriceHistory';
 import { useLiveMarketPrices } from '../../hooks/useLiveMarketPrices';
 import PredictGameChartContent from './PredictGameChartContent';
@@ -14,13 +14,14 @@ import {
   GameChartSeries,
   GameChartDataPoint,
   ChartTimeframe,
+  GameChartSeriesConfig,
 } from './PredictGameChart.types';
 
 const TIMEFRAME_TO_INTERVAL: Record<
-  ChartTimeframe,
+  Exclude<ChartTimeframe, 'live'>,
   PredictPriceHistoryInterval
 > = {
-  live: PredictPriceHistoryInterval.ONE_HOUR,
+  '1h': PredictPriceHistoryInterval.ONE_HOUR,
   '6h': PredictPriceHistoryInterval.SIX_HOUR,
   '1d': PredictPriceHistoryInterval.ONE_DAY,
   max: PredictPriceHistoryInterval.MAX,
@@ -28,40 +29,96 @@ const TIMEFRAME_TO_INTERVAL: Record<
 
 const FIDELITY_BY_TIMEFRAME: Record<ChartTimeframe, number> = {
   live: 1,
+  '1h': 1,
   '6h': 5,
   '1d': 15,
   max: 60,
 };
 
+const ENDED_GAME_FIDELITY = 2;
+
 const getMinuteTimestamp = (timestamp: number): number =>
   Math.floor(timestamp / 60000) * 60000;
 
-/**
- * Converts a timestamp to milliseconds.
- * Detects if timestamp is in seconds (10 digits) or milliseconds (13 digits).
- * Unix timestamps in seconds are typically < 10 billion (until year 2286).
- */
 const toMilliseconds = (timestamp: number): number =>
   timestamp < 10_000_000_000 ? timestamp * 1000 : timestamp;
 
+const toUnixSeconds = (isoString: string): number =>
+  Math.floor(new Date(isoString).getTime() / 1000);
+
+const getDefaultTimeframe = (
+  gameStatus: PredictGameStatus | undefined,
+): ChartTimeframe => {
+  switch (gameStatus) {
+    case 'ongoing':
+      return 'live';
+    case 'scheduled':
+      return '6h';
+    case 'ended':
+      return 'max';
+    default:
+      return '6h';
+  }
+};
+
 const PredictGameChart: React.FC<PredictGameChartProps> = ({
-  tokenIds,
-  seriesConfig,
+  market,
   providerId = 'polymarket',
   testID,
 }) => {
-  const [timeframe, setTimeframe] = useState<ChartTimeframe>('live');
+  const game = market.game;
+  const gameStatus = game?.status;
+  const isGameEnded = gameStatus === 'ended';
+  const isGameOngoing = gameStatus === 'ongoing';
+
+  const tokenIds = useMemo(() => {
+    const tokens = market.outcomes[0]?.tokens ?? [];
+    return tokens.map((t) => t.id);
+  }, [market.outcomes]);
+
+  const seriesConfig: [GameChartSeriesConfig, GameChartSeriesConfig] | null =
+    useMemo(() => {
+      if (!game) return null;
+      return [
+        { label: game.awayTeam.abbreviation, color: game.awayTeam.color },
+        { label: game.homeTeam.abbreviation, color: game.homeTeam.color },
+      ];
+    }, [game]);
+
+  const [timeframe, setTimeframe] = useState<ChartTimeframe>(() =>
+    getDefaultTimeframe(gameStatus),
+  );
   const [liveChartData, setLiveChartData] = useState<GameChartSeries[]>([]);
   const initialDataLoadedRef = useRef<boolean>(false);
 
-  const isLive = timeframe === 'live';
-  const interval = TIMEFRAME_TO_INTERVAL[timeframe];
-  const fidelity = FIDELITY_BY_TIMEFRAME[timeframe];
+  const isLive = timeframe === 'live' && isGameOngoing;
+  const disabledTimeframeSelector = isGameEnded;
+
+  const { startTs, endTs } = useMemo(() => {
+    if (!isGameEnded || !game?.startTime) {
+      return { startTs: undefined, endTs: undefined };
+    }
+    const start = toUnixSeconds(game.startTime);
+    const end = game.endTime ? toUnixSeconds(game.endTime) : undefined;
+    return { startTs: start, endTs: end };
+  }, [isGameEnded, game?.startTime, game?.endTime]);
+
+  const interval = useMemo(() => {
+    if (isGameEnded) return undefined;
+    if (timeframe === 'live') return PredictPriceHistoryInterval.ONE_HOUR;
+    return TIMEFRAME_TO_INTERVAL[timeframe];
+  }, [isGameEnded, timeframe]);
+
+  const fidelity = isGameEnded
+    ? ENDED_GAME_FIDELITY
+    : FIDELITY_BY_TIMEFRAME[timeframe];
 
   const { priceHistories, isFetching, errors, refetch } =
     usePredictPriceHistory({
       marketIds: tokenIds,
       interval,
+      startTs,
+      endTs,
       fidelity,
       providerId,
       enabled: tokenIds.length === 2,
@@ -72,7 +129,7 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
   });
 
   const historicalChartData: GameChartSeries[] = useMemo(() => {
-    if (priceHistories.length < 2) return [];
+    if (priceHistories.length < 2 || !seriesConfig) return [];
 
     return tokenIds.map((_tokenId, index) => {
       const history = priceHistories[index] ?? [];
@@ -189,6 +246,10 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
     ? (errors.find((error) => error !== null) ?? null)
     : null;
 
+  if (!game || !seriesConfig) {
+    return null;
+  }
+
   return (
     <PredictGameChartContent
       data={chartData}
@@ -197,6 +258,7 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
       onRetry={handleRetry}
       timeframe={timeframe}
       onTimeframeChange={handleTimeframeChange}
+      disabledTimeframeSelector={disabledTimeframeSelector}
       testID={testID}
     />
   );

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.types.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.types.ts
@@ -1,24 +1,17 @@
-/**
- * Data point for game chart series
- */
+import { PredictMarket } from '../../types';
+
 export interface GameChartDataPoint {
   timestamp: number;
   value: number;
 }
 
-/**
- * Series configuration for game chart
- */
 export interface GameChartSeries {
   label: string;
   color: string;
   data: GameChartDataPoint[];
 }
 
-/**
- * Available chart timeframes
- */
-export type ChartTimeframe = 'live' | '6h' | '1d' | 'max';
+export type ChartTimeframe = 'live' | '1h' | '6h' | '1d' | 'max';
 
 export interface GameChartSeriesConfig {
   label: string;
@@ -32,12 +25,12 @@ export interface PredictGameChartContentProps {
   onRetry?: () => void;
   timeframe?: ChartTimeframe;
   onTimeframeChange?: (timeframe: ChartTimeframe) => void;
+  disabledTimeframeSelector?: boolean;
   testID?: string;
 }
 
 export interface PredictGameChartProps {
-  tokenIds: [string, string];
-  seriesConfig: [GameChartSeriesConfig, GameChartSeriesConfig];
+  market: PredictMarket;
   providerId?: string;
   testID?: string;
 }

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
@@ -3,7 +3,12 @@ import { render, act, waitFor } from '@testing-library/react-native';
 import PredictGameChart from './PredictGameChart';
 import { usePredictPriceHistory } from '../../hooks/usePredictPriceHistory';
 import { useLiveMarketPrices } from '../../hooks/useLiveMarketPrices';
-import { PredictPriceHistoryInterval } from '../../types';
+import {
+  PredictMarket,
+  PredictMarketStatus,
+  PredictPriceHistoryInterval,
+  PredictGameStatus,
+} from '../../types';
 
 // Mock the hooks
 jest.mock('../../hooks/usePredictPriceHistory');
@@ -17,12 +22,14 @@ jest.mock('./PredictGameChartContent', () => {
     isLoading,
     timeframe,
     onTimeframeChange,
+    disabledTimeframeSelector,
     testID,
   }: {
     data: unknown[];
     isLoading: boolean;
     timeframe: string;
-    onTimeframeChange: (tf: string) => void;
+    onTimeframeChange?: (tf: string) => void;
+    disabledTimeframeSelector?: boolean;
     testID?: string;
   }) {
     return (
@@ -30,10 +37,15 @@ jest.mock('./PredictGameChartContent', () => {
         <Text testID="content-data">{JSON.stringify(data)}</Text>
         <Text testID="content-loading">{String(isLoading)}</Text>
         <Text testID="content-timeframe">{timeframe}</Text>
-        <View
-          testID="timeframe-trigger"
-          onTouchEnd={() => onTimeframeChange('6h')}
-        />
+        <Text testID="content-disabled-selector">
+          {String(disabledTimeframeSelector)}
+        </Text>
+        {onTimeframeChange && !disabledTimeframeSelector && (
+          <View
+            testID="timeframe-trigger"
+            onTouchEnd={() => onTimeframeChange('6h')}
+          />
+        )}
       </View>
     );
   };
@@ -52,15 +64,65 @@ const createMockPriceHistory = (
     price: basePrice + (tokenIndex === 0 ? 0.01 : -0.01) * i,
   }));
 
-const defaultSeriesConfig: [
-  { label: string; color: string },
-  { label: string; color: string },
-] = [
-  { label: 'Team A', color: '#FF0000' },
-  { label: 'Team B', color: '#0000FF' },
-];
+const mockBaseGame = {
+  id: 'game-123',
+  homeTeam: {
+    id: 'team-home',
+    name: 'Team B',
+    abbreviation: 'TB',
+    color: '#0000FF',
+    alias: 'Team B',
+    logo: 'https://example.com/logo-b.png',
+  },
+  awayTeam: {
+    id: 'team-away',
+    name: 'Team A',
+    abbreviation: 'TA',
+    color: '#FF0000',
+    alias: 'Team A',
+    logo: 'https://example.com/logo-a.png',
+  },
+  startTime: '2024-01-15T10:00:00Z',
+  status: 'ongoing' as PredictGameStatus,
+  league: 'nfl' as const,
+  elapsed: null,
+  period: null,
+  score: null,
+};
+
+const createMockMarket = (
+  overrides: Partial<PredictMarket> = {},
+): PredictMarket =>
+  ({
+    id: 'test-market-id',
+    title: 'Test Game Market',
+    description: 'Test description',
+    image: 'https://example.com/image.png',
+    providerId: 'polymarket',
+    status: PredictMarketStatus.OPEN,
+    category: 'sports',
+    tags: ['NFL'],
+    outcomes: [
+      {
+        id: 'outcome-1',
+        marketId: 'test-market-id',
+        title: 'Game Outcome',
+        groupItemTitle: 'Game Outcome',
+        status: 'open',
+        volume: 1000,
+        tokens: [
+          { id: 'token-a', title: 'Team A', price: 0.65 },
+          { id: 'token-b', title: 'Team B', price: 0.35 },
+        ],
+      },
+    ],
+    endDate: '2024-12-31T23:59:59Z',
+    game: mockBaseGame,
+    ...overrides,
+  }) as PredictMarket;
 
 const defaultTokenIds: [string, string] = ['token-a', 'token-b'];
+const defaultMarket = createMockMarket();
 
 describe('PredictGameChart Wrapper', () => {
   beforeEach(() => {
@@ -90,13 +152,7 @@ describe('PredictGameChart Wrapper', () => {
 
   describe('Hook Configuration', () => {
     it('calls usePredictPriceHistory with correct interval for live timeframe', () => {
-      render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
-      );
+      render(<PredictGameChart market={defaultMarket} testID="chart" />);
 
       expect(mockUsePredictPriceHistory).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -110,12 +166,7 @@ describe('PredictGameChart Wrapper', () => {
     });
 
     it('calls useLiveMarketPrices with enabled true for live timeframe', () => {
-      render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-        />,
-      );
+      render(<PredictGameChart market={defaultMarket} />);
 
       expect(mockUseLiveMarketPrices).toHaveBeenCalledWith(defaultTokenIds, {
         enabled: true,
@@ -123,10 +174,13 @@ describe('PredictGameChart Wrapper', () => {
     });
 
     it('passes custom providerId to usePredictPriceHistory', () => {
+      const marketWithCustomProvider = createMockMarket({
+        providerId: 'custom-provider',
+      });
+
       render(
         <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
+          market={marketWithCustomProvider}
           providerId="custom-provider"
         />,
       );
@@ -138,13 +192,12 @@ describe('PredictGameChart Wrapper', () => {
       );
     });
 
-    it('disables hooks when tokenIds length is not 2', () => {
-      render(
-        <PredictGameChart
-          tokenIds={['single-token'] as unknown as [string, string]}
-          seriesConfig={defaultSeriesConfig}
-        />,
-      );
+    it('disables hooks when market has no tokens', () => {
+      const marketNoTokens = createMockMarket({
+        outcomes: [],
+      });
+
+      render(<PredictGameChart market={marketNoTokens} />);
 
       expect(mockUsePredictPriceHistory).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -176,11 +229,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       await waitFor(() => {
@@ -188,7 +237,7 @@ describe('PredictGameChart Wrapper', () => {
         const data = JSON.parse(String(dataText));
 
         expect(data).toHaveLength(2);
-        expect(data[0].label).toBe('Team A');
+        expect(data[0].label).toBe('TA');
         expect(data[0].color).toBe('#FF0000');
         expect(data[0].data).toHaveLength(3);
         expect(data[0].data[0].value).toBe(60);
@@ -209,11 +258,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       await waitFor(() => {
@@ -239,11 +284,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       await waitFor(() => {
@@ -265,11 +306,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       expect(getByTestId('content-loading').children[0]).toBe('true');
@@ -284,11 +321,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       // No data yet, should show loading
@@ -309,11 +342,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       await waitFor(() => {
@@ -332,11 +361,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId, rerender } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       expect(getByTestId('content-loading').children[0]).toBe('true');
@@ -353,13 +378,7 @@ describe('PredictGameChart Wrapper', () => {
         refetch: jest.fn(),
       });
 
-      rerender(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
-      );
+      rerender(<PredictGameChart market={defaultMarket} testID="chart" />);
 
       await waitFor(() => {
         expect(getByTestId('content-loading').children[0]).toBe('false');
@@ -397,11 +416,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId, rerender } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       // Wait for initial data to load
@@ -412,13 +427,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       // Trigger re-render with updated prices
-      rerender(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
-      );
+      rerender(<PredictGameChart market={defaultMarket} testID="chart" />);
 
       await waitFor(() => {
         const dataText = getByTestId('content-data').children[0];
@@ -450,11 +459,7 @@ describe('PredictGameChart Wrapper', () => {
       jest.setSystemTime(new Date(baseTimestamp));
 
       const { getByTestId, rerender } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       // Wait for initial data
@@ -480,13 +485,7 @@ describe('PredictGameChart Wrapper', () => {
         lastUpdateTime: nextMinute,
       });
 
-      rerender(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
-      );
+      rerender(<PredictGameChart market={defaultMarket} testID="chart" />);
 
       await waitFor(() => {
         const dataText = getByTestId('content-data').children[0];
@@ -517,11 +516,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       await waitFor(() => {
@@ -574,11 +569,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       await waitFor(() => {
@@ -621,11 +612,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       await waitFor(() => {
@@ -672,11 +659,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId, rerender } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       await waitFor(() => {
@@ -697,13 +680,7 @@ describe('PredictGameChart Wrapper', () => {
         refetch: jest.fn(),
       });
 
-      rerender(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
-      );
+      rerender(<PredictGameChart market={defaultMarket} testID="chart" />);
 
       await waitFor(() => {
         const dataText = getByTestId('content-data').children[0];
@@ -730,11 +707,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       // Wait for initial render
@@ -771,11 +744,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       // Change to 6h timeframe
@@ -807,11 +776,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       // Wait for initial data load
@@ -843,11 +808,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       const dataText = getByTestId('content-data').children[0];
@@ -865,11 +826,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       const dataText = getByTestId('content-data').children[0];
@@ -905,11 +862,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       await waitFor(() => {
@@ -923,11 +876,7 @@ describe('PredictGameChart Wrapper', () => {
 
     it('passes testID to content component', () => {
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="my-chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="my-chart" />,
       );
 
       expect(getByTestId('my-chart')).toBeTruthy();
@@ -944,11 +893,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       const errorText = JSON.parse(
@@ -968,11 +913,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       const mockContent = getByTestId('chart');
@@ -988,11 +929,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       expect(getByTestId('chart')).toBeTruthy();
@@ -1012,11 +949,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-          testID="chart"
-        />,
+        <PredictGameChart market={defaultMarket} testID="chart" />,
       );
 
       await waitFor(() => {
@@ -1029,12 +962,7 @@ describe('PredictGameChart Wrapper', () => {
 
   describe('Fidelity Configuration', () => {
     it('uses fidelity 1 for live timeframe', () => {
-      render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-        />,
-      );
+      render(<PredictGameChart market={defaultMarket} />);
 
       expect(mockUsePredictPriceHistory).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1057,10 +985,7 @@ describe('PredictGameChart Wrapper', () => {
       });
 
       const { getByTestId } = render(
-        <PredictGameChart
-          tokenIds={defaultTokenIds}
-          seriesConfig={defaultSeriesConfig}
-        />,
+        <PredictGameChart market={defaultMarket} />,
       );
 
       await act(async () => {
@@ -1074,6 +999,117 @@ describe('PredictGameChart Wrapper', () => {
           ];
         expect(lastCall[0].fidelity).toBe(5);
       });
+    });
+  });
+
+  describe('Game Status Timeframe Defaults', () => {
+    it('defaults to live timeframe for ongoing games', () => {
+      const { getByTestId } = render(
+        <PredictGameChart market={defaultMarket} testID="chart" />,
+      );
+
+      expect(getByTestId('content-timeframe').children[0]).toBe('live');
+      expect(getByTestId('content-disabled-selector').children[0]).toBe(
+        'false',
+      );
+    });
+
+    it('defaults to 6h timeframe for scheduled games', () => {
+      const scheduledMarket = createMockMarket({
+        game: {
+          ...mockBaseGame,
+          status: 'scheduled' as PredictGameStatus,
+        },
+      });
+
+      const { getByTestId } = render(
+        <PredictGameChart market={scheduledMarket} testID="chart" />,
+      );
+
+      expect(getByTestId('content-timeframe').children[0]).toBe('6h');
+      expect(getByTestId('content-disabled-selector').children[0]).toBe(
+        'false',
+      );
+    });
+
+    it('defaults to max timeframe for ended games and disables selector', () => {
+      const endedMarket = createMockMarket({
+        game: {
+          ...mockBaseGame,
+          status: 'ended' as PredictGameStatus,
+          startTime: '2024-01-15T10:00:00Z',
+          endTime: '2024-01-15T13:00:00Z',
+        },
+      });
+
+      const { getByTestId, queryByTestId } = render(
+        <PredictGameChart market={endedMarket} testID="chart" />,
+      );
+
+      expect(getByTestId('content-timeframe').children[0]).toBe('max');
+      expect(getByTestId('content-disabled-selector').children[0]).toBe('true');
+      expect(queryByTestId('timeframe-trigger')).toBeNull();
+    });
+
+    it('uses startTs/endTs for ended games instead of interval', () => {
+      const endedMarket = createMockMarket({
+        game: {
+          ...mockBaseGame,
+          status: 'ended' as PredictGameStatus,
+          startTime: '2024-01-15T10:00:00Z',
+          endTime: '2024-01-15T13:00:00Z',
+        },
+      });
+
+      render(<PredictGameChart market={endedMarket} testID="chart" />);
+
+      expect(mockUsePredictPriceHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startTs: Math.floor(
+            new Date('2024-01-15T10:00:00Z').getTime() / 1000,
+          ),
+          endTs: Math.floor(new Date('2024-01-15T13:00:00Z').getTime() / 1000),
+          interval: undefined,
+          fidelity: 2,
+        }),
+      );
+    });
+
+    it('uses 2-minute fidelity for ended games', () => {
+      const endedMarket = createMockMarket({
+        game: {
+          ...mockBaseGame,
+          status: 'ended' as PredictGameStatus,
+          startTime: '2024-01-15T10:00:00Z',
+          endTime: '2024-01-15T13:00:00Z',
+        },
+      });
+
+      render(<PredictGameChart market={endedMarket} testID="chart" />);
+
+      expect(mockUsePredictPriceHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fidelity: 2,
+        }),
+      );
+    });
+
+    it('disables live market prices for non-ongoing games', () => {
+      const scheduledMarket = createMockMarket({
+        game: {
+          ...mockBaseGame,
+          status: 'scheduled' as PredictGameStatus,
+        },
+      });
+
+      render(<PredictGameChart market={scheduledMarket} testID="chart" />);
+
+      expect(mockUseLiveMarketPrices).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          enabled: false,
+        }),
+      );
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx
@@ -32,6 +32,7 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
   onRetry,
   timeframe = 'live',
   onTimeframeChange,
+  disabledTimeframeSelector = false,
   testID,
 }) => {
   const tw = useTailwind();
@@ -147,7 +148,7 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
           <TimeframeSelector
             selected={timeframe}
             onSelect={onTimeframeChange}
-            disabled
+            disabled={disabledTimeframeSelector || isLoading}
           />
         )}
       </Box>
@@ -185,6 +186,7 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
           <TimeframeSelector
             selected={timeframe}
             onSelect={onTimeframeChange}
+            disabled={disabledTimeframeSelector}
           />
         )}
       </Box>
@@ -203,6 +205,7 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
           <TimeframeSelector
             selected={timeframe}
             onSelect={onTimeframeChange}
+            disabled={disabledTimeframeSelector}
           />
         )}
       </Box>
@@ -332,7 +335,11 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
       </View>
 
       {onTimeframeChange && (
-        <TimeframeSelector selected={timeframe} onSelect={onTimeframeChange} />
+        <TimeframeSelector
+          selected={timeframe}
+          onSelect={onTimeframeChange}
+          disabled={disabledTimeframeSelector}
+        />
       )}
     </Box>
   );

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
@@ -131,15 +131,15 @@ jest.mock('../PredictGameChart', () => {
   const { View } = jest.requireActual('react-native');
   return function MockPredictGameChart({
     testID,
-    tokenIds,
+    market,
   }: {
     testID?: string;
-    tokenIds?: string[];
+    market?: { id: string };
   }) {
     return (
       <View
         testID={testID}
-        accessibilityHint={`tokens:${tokenIds?.join(',') ?? 'none'}`}
+        accessibilityHint={`marketId:${market?.id ?? 'undefined'}`}
       />
     );
   };
@@ -601,7 +601,7 @@ describe('PredictGameDetailsContent', () => {
   });
 
   describe('Chart Integration', () => {
-    it('renders chart with token IDs when two tokens exist', () => {
+    it('renders chart with market', () => {
       const market = createMockMarket();
 
       const { getByTestId } = render(
@@ -617,38 +617,7 @@ describe('PredictGameDetailsContent', () => {
       const chart = getByTestId('game-chart');
 
       expect(chart).toBeOnTheScreen();
-      expect(chart.props.accessibilityHint).toBe('tokens:token-1,token-2');
-    });
-
-    it('does not render chart when fewer than two tokens exist', () => {
-      const market = createMockMarket({
-        outcomes: [
-          {
-            id: 'outcome-1',
-            marketId: 'test-market-id',
-            title: 'Team A',
-            groupItemTitle: 'Team A',
-            status: 'open',
-            volume: 1000,
-            providerId: 'polymarket',
-            description: '',
-            image: '',
-            tokens: [{ id: 'token-1', title: 'Team A', price: 0.65 }],
-          },
-        ],
-      });
-
-      const { queryByTestId } = render(
-        <PredictGameDetailsContent
-          market={market}
-          onBack={mockOnBack}
-          onRefresh={mockOnRefresh}
-          onBetPress={mockOnBetPress}
-          refreshing={false}
-        />,
-      );
-
-      expect(queryByTestId('game-chart')).toBeNull();
+      expect(chart.props.accessibilityHint).toBe('marketId:test-market-id');
     });
   });
 

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
@@ -55,10 +55,6 @@ const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
 
   const outcome = useMemo(() => market.outcomes[0], [market.outcomes]);
   const game = market.game;
-  const tokenIds = useMemo(
-    () => (outcome?.tokens ?? []).map((t) => t.id),
-    [outcome?.tokens],
-  );
 
   if (!outcome || !game) {
     return null;
@@ -122,24 +118,9 @@ const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
             <PredictSportScoreboard game={game} testID="game-scoreboard" />
           </Box>
 
-          {tokenIds.length === 2 && (
-            <Box twClassName="mt-4">
-              <PredictGameChart
-                tokenIds={tokenIds as [string, string]}
-                seriesConfig={[
-                  {
-                    label: game.awayTeam.abbreviation,
-                    color: game.awayTeam.color,
-                  },
-                  {
-                    label: game.homeTeam.abbreviation,
-                    color: game.homeTeam.color,
-                  },
-                ]}
-                testID="game-chart"
-              />
-            </Box>
-          )}
+          <Box twClassName="mt-4">
+            <PredictGameChart market={market} testID="game-chart" />
+          </Box>
 
           <Box twClassName="px-4 py-2">
             <PredictPicks market={market} testID="game-picks" />

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/__snapshots__/PredictGameDetailsContent.test.tsx.snap
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/__snapshots__/PredictGameDetailsContent.test.tsx.snap
@@ -196,7 +196,7 @@ exports[`PredictGameDetailsContent matches snapshot 1`] = `
           }
         >
           <View
-            accessibilityHint="tokens:token-1,token-2"
+            accessibilityHint="marketId:test-market-id"
             testID="game-chart"
           />
         </View>

--- a/app/components/UI/Predict/hooks/usePredictPriceHistory.tsx
+++ b/app/components/UI/Predict/hooks/usePredictPriceHistory.tsx
@@ -12,6 +12,8 @@ import {
 export interface UsePredictPriceHistoryOptions {
   marketIds: string[];
   interval?: PredictPriceHistoryInterval;
+  startTs?: number;
+  endTs?: number;
   fidelity?: number;
   providerId?: string;
   enabled?: boolean;
@@ -34,6 +36,8 @@ export const usePredictPriceHistory = (
     marketIds = [],
     fidelity,
     interval = PredictPriceHistoryInterval.ONE_DAY,
+    startTs,
+    endTs,
     providerId,
     enabled = true,
   } = options;
@@ -99,6 +103,8 @@ export const usePredictPriceHistory = (
             marketId,
             fidelity,
             interval,
+            startTs,
+            endTs,
             providerId,
           });
           return { index, data: history ?? [], error: null };
@@ -127,6 +133,8 @@ export const usePredictPriceHistory = (
                 marketId,
                 providerId,
                 interval,
+                startTs,
+                endTs,
                 fidelity,
               },
             },
@@ -171,6 +179,8 @@ export const usePredictPriceHistory = (
             marketCount: marketIds.length,
             providerId,
             interval,
+            startTs,
+            endTs,
             fidelity,
           },
         },
@@ -187,7 +197,7 @@ export const usePredictPriceHistory = (
     }
     // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, marketIdsKey, fidelity, interval, providerId]);
+  }, [enabled, marketIdsKey, fidelity, interval, startTs, endTs, providerId]);
 
   useEffect(() => {
     fetchPriceHistories();

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -344,6 +344,8 @@ export class PolymarketProvider implements PredictProvider {
     marketId,
     fidelity,
     interval,
+    startTs,
+    endTs,
   }: GetPriceHistoryParams): Promise<PredictPriceHistoryPoint[]> {
     if (!marketId) {
       throw new Error('marketId parameter is required');
@@ -357,7 +359,10 @@ export class PolymarketProvider implements PredictProvider {
         searchParams.set('fidelity', String(fidelity));
       }
 
-      if (interval) {
+      if (startTs !== undefined && endTs !== undefined) {
+        searchParams.set('startTs', String(startTs));
+        searchParams.set('endTs', String(endTs));
+      } else if (interval) {
         searchParams.set('interval', interval);
       }
 
@@ -392,13 +397,14 @@ export class PolymarketProvider implements PredictProvider {
     } catch (error) {
       DevLogger.log('Error getting price history via Polymarket API:', error);
 
-      // Log to Sentry - this error is swallowed (returns []) so controller won't see it
       Logger.error(
         error instanceof Error ? error : new Error(String(error)),
         this.getErrorContext('getPriceHistory', {
           marketId,
           fidelity,
           interval,
+          startTs,
+          endTs,
         }),
       );
 

--- a/app/components/UI/Predict/providers/polymarket/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/types.ts
@@ -181,6 +181,7 @@ export interface PolymarketApiEvent {
   sortBy?: 'price' | 'ascending' | 'descending';
   gameId?: string;
   startTime?: string;
+  finishedTimestamp?: string;
   score?: string;
   elapsed?: string;
   period?: PredictGamePeriod;
@@ -362,6 +363,7 @@ export interface PolymarketApiTeam {
 export interface PolymarketApiGameEvent {
   gameId?: string;
   startTime?: string;
+  finishedTimestamp?: string;
   score?: string;
   elapsed?: string;
   period?: PredictGamePeriod;

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -278,6 +278,8 @@ export interface GetPriceHistoryParams {
   providerId?: string;
   fidelity?: number;
   interval?: PredictPriceHistoryInterval;
+  startTs?: number;
+  endTs?: number;
 }
 
 /**

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -152,6 +152,7 @@ export type PredictGamePeriod =
 export interface PredictMarketGame {
   id: string;
   startTime: string;
+  endTime?: string; // ISO date when game ended, available for ended games
   status: PredictGameStatus;
   league: PredictSportsLeague;
   elapsed: string | null; // Game clock, null if not available

--- a/app/components/UI/Predict/utils/gameParser.ts
+++ b/app/components/UI/Predict/utils/gameParser.ts
@@ -176,6 +176,7 @@ export function buildGameData(
     id: event.gameId,
     startTime:
       event.startTime ?? event.endDate ?? `${parsedSlug.dateString}T00:00:00Z`,
+    endTime: event.finishedTimestamp,
     status: getGameStatus(event),
     league,
     elapsed: event.elapsed || null,


### PR DESCRIPTION
## **Description**

This PR improves the PredictGameChart component for live NFL games by:

1. **Refactoring to accept a `market` prop** - Instead of requiring `tokenIds` and `seriesConfig` to be passed separately, the component now derives these internally from the market object, simplifying the API.

2. **Adding smart timeframe defaults based on game status**:
   - `ongoing` games → Default to `'live'` timeframe with live price updates
   - `scheduled` games → Default to `'6h'` timeframe (no live updates)
   - `ended` games → Default to `'max'` timeframe with disabled selector, using timestamp-based queries

3. **Supporting time-range price history queries** - For ended games, the chart now queries price history using `startTs`/`endTs` (game start/end timestamps) instead of interval-based queries, with 2-minute fidelity for detailed game period visualization.

4. **Showing disabled timeframe selector for ended games** - Instead of hiding the selector entirely, it's now shown but disabled with "Max" selected, providing better UX feedback.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (internal improvement)

## **Manual testing steps**

```gherkin
Feature: PredictGameChart smart timeframe defaults

  Scenario: User views chart for ongoing game
    Given user is on a game details page for an ongoing NFL game
    When the page loads
    Then the chart defaults to "Live" timeframe
    And the timeframe selector buttons are enabled

  Scenario: User views chart for scheduled game
    Given user is on a game details page for a scheduled NFL game
    When the page loads
    Then the chart defaults to "6H" timeframe
    And the timeframe selector buttons are enabled

  Scenario: User views chart for ended game
    Given user is on a game details page for a completed NFL game
    When the page loads
    Then the chart defaults to "Max" timeframe
    And the timeframe selector buttons are visible but disabled
    And the chart shows the full game period with detailed price history
```

## **Screenshots/Recordings**

### **Before**

N/A - Internal refactor

### **After**

N/A - Internal refactor

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Refactor API**: `PredictGameChart` now takes a `market` prop and derives `tokenIds`/series labels/colors internally; `PredictGameDetailsContent` updated to pass `market`.
> - **Smart timeframe defaults**: Defaults to `live` for `ongoing`, `6h` for `scheduled`, and `max` for `ended`; disables timeframe selector for ended games and during loading as needed.
> - **Ended games support**: Price history fetched via `startTs`/`endTs` (from `game.startTime`/`game.endTime`) with 2-minute fidelity; live updates only for ongoing games.
> - **Hook/Provider updates**: `usePredictPriceHistory` adds `startTs`/`endTs` options and dependencies; Polymarket `getPriceHistory` forwards `startTs`/`endTs` or `interval` accordingly.
> - **Types/parsing**: Adds `game.endTime`, `finishedTimestamp` to provider types; `gameParser` sets `endTime`. `ChartTimeframe` adds `1h`; content supports `disabledTimeframeSelector`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4b4bbf2232a61eaecb25938236a752c9972974e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->