### PR TITLE
fix: MultichainNetworkControllerState undefined error

### DIFF
--- a/app/components/UI/ManageNetworks/ManageNetworks.tsx
+++ b/app/components/UI/ManageNetworks/ManageNetworks.tsx
@@ -13,16 +13,13 @@ import {
 } from '../../../selectors/networkInfos';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../constants/navigation/Routes';
-import getDecimalChainId from '../../../util/networks/getDecimalChainId';
 import { useMetrics } from '../../../components/hooks/useMetrics';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { ConnectedAccountsSelectorsIDs } from '../../Views/AccountConnect/ConnectedAccountModal.testIds';
 import AppConstants from '../../../core/AppConstants';
 import styles from './ManageNetworks.styles';
-import { selectChainId } from '../../../selectors/networkController';
 
 export default function ManageNetworksComponent() {
-  const chainId = useSelector(selectChainId);
   const navigation = useNavigation();
   const { trackEvent, createEventBuilder } = useMetrics();
 
@@ -35,13 +32,9 @@ export default function ManageNetworksComponent() {
     });
 
     trackEvent(
-      createEventBuilder(MetaMetricsEvents.NETWORK_SELECTOR_PRESSED)
-        .addProperties({
-          chain_id: getDecimalChainId(chainId),
-        })
-        .build(),
+      createEventBuilder(MetaMetricsEvents.NETWORK_SELECTOR_PRESSED).build(),
     );
-  }, [navigation, trackEvent, chainId, createEventBuilder]);
+  }, [navigation, trackEvent, createEventBuilder]);
 
   const openPrivacyPolicyLink = useCallback(() => {
     Linking.openURL(AppConstants.URLS.PRIVACY_POLICY_2024);

--- a/app/selectors/multichainNetworkController/index.test.ts
+++ b/app/selectors/multichainNetworkController/index.test.ts
@@ -54,7 +54,9 @@ describe('Multichain Network Controller Selectors', () => {
       const result = selectMultichainNetworkControllerState(
         stateWithUndefinedController,
       );
-      expect(result).toStrictEqual(getDefaultMultichainNetworkControllerState());
+      expect(result).toStrictEqual(
+        getDefaultMultichainNetworkControllerState(),
+      );
     });
 
     it('returns default state when backgroundState is undefined', () => {
@@ -67,7 +69,9 @@ describe('Multichain Network Controller Selectors', () => {
       const result = selectMultichainNetworkControllerState(
         stateWithUndefinedBackgroundState,
       );
-      expect(result).toStrictEqual(getDefaultMultichainNetworkControllerState());
+      expect(result).toStrictEqual(
+        getDefaultMultichainNetworkControllerState(),
+      );
     });
   });
 

--- a/app/selectors/multichainNetworkController/index.test.ts
+++ b/app/selectors/multichainNetworkController/index.test.ts
@@ -1,5 +1,6 @@
 import { CaipChainId } from '@metamask/utils';
 import { BtcScope, EthScope, SolScope, TrxScope } from '@metamask/keyring-api';
+import { getDefaultMultichainNetworkControllerState } from '@metamask/multichain-network-controller';
 import {
   selectMultichainNetworkControllerState,
   selectIsEvmNetworkSelected,
@@ -34,30 +35,86 @@ describe('Multichain Network Controller Selectors', () => {
   } as unknown as RootState;
 
   describe('selectMultichainNetworkControllerState', () => {
-    it('should return the multichain network controller state', () => {
+    it('returns the multichain network controller state', () => {
       const result = selectMultichainNetworkControllerState(mockState);
       expect(result).toBe(
         mockState.engine.backgroundState.MultichainNetworkController,
       );
     });
+
+    it('returns default state when MultichainNetworkController is undefined', () => {
+      const stateWithUndefinedController = {
+        engine: {
+          backgroundState: {
+            MultichainNetworkController: undefined,
+          },
+        },
+      } as unknown as RootState;
+
+      const result = selectMultichainNetworkControllerState(
+        stateWithUndefinedController,
+      );
+      expect(result).toStrictEqual(getDefaultMultichainNetworkControllerState());
+    });
+
+    it('returns default state when backgroundState is undefined', () => {
+      const stateWithUndefinedBackgroundState = {
+        engine: {
+          backgroundState: undefined,
+        },
+      } as unknown as RootState;
+
+      const result = selectMultichainNetworkControllerState(
+        stateWithUndefinedBackgroundState,
+      );
+      expect(result).toStrictEqual(getDefaultMultichainNetworkControllerState());
+    });
   });
 
   describe('selectIsEvmNetworkSelected', () => {
-    it('should return isEvmSelected value', () => {
+    it('returns isEvmSelected value', () => {
       const result = selectIsEvmNetworkSelected(mockState);
       expect(result).toBe(true);
+    });
+
+    it('does not crash when MultichainNetworkController state is undefined', () => {
+      const stateWithUndefinedController = {
+        engine: {
+          backgroundState: {
+            MultichainNetworkController: undefined,
+          },
+        },
+      } as unknown as RootState;
+
+      expect(() =>
+        selectIsEvmNetworkSelected(stateWithUndefinedController),
+      ).not.toThrow();
     });
   });
 
   describe('selectSelectedNonEvmNetworkChainId', () => {
-    it('should return the selected non-EVM network chain ID', () => {
+    it('returns the selected non-EVM network chain ID', () => {
       const result = selectSelectedNonEvmNetworkChainId(mockState);
       expect(result).toBe('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp');
+    });
+
+    it('does not crash when MultichainNetworkController state is undefined', () => {
+      const stateWithUndefinedController = {
+        engine: {
+          backgroundState: {
+            MultichainNetworkController: undefined,
+          },
+        },
+      } as unknown as RootState;
+
+      expect(() =>
+        selectSelectedNonEvmNetworkChainId(stateWithUndefinedController),
+      ).not.toThrow();
     });
   });
 
   describe('selectNonEvmNetworkConfigurationsByChainId', () => {
-    it('should return the non-EVM network configurations', () => {
+    it('returns the non-EVM network configurations', () => {
       const result = selectNonEvmNetworkConfigurationsByChainId(mockState);
       expect(result).toEqual(
         mockState.engine.backgroundState.MultichainNetworkController
@@ -67,12 +124,12 @@ describe('Multichain Network Controller Selectors', () => {
   });
 
   describe('selectSelectedNonEvmNetworkName', () => {
-    it('should return the selected network name', () => {
+    it('returns the selected network name', () => {
       const result = selectSelectedNonEvmNetworkName(mockState);
       expect(result).toBe('Solana Mainnet');
     });
 
-    it('should return undefined when network is not found', () => {
+    it('returns undefined when network is not found', () => {
       const modifiedState = {
         ...mockState,
         engine: {
@@ -90,12 +147,12 @@ describe('Multichain Network Controller Selectors', () => {
   });
 
   describe('selectSelectedNonEvmNativeCurrency', () => {
-    it('should return the selected network native currency', () => {
+    it('returns the selected network native currency', () => {
       const result = selectSelectedNonEvmNativeCurrency(mockState);
       expect(result).toBe('solana:sol/token:sol');
     });
 
-    it('should return undefined when network is not found', () => {
+    it('returns undefined when network is not found', () => {
       const modifiedState = {
         ...mockState,
         engine: {
@@ -113,12 +170,12 @@ describe('Multichain Network Controller Selectors', () => {
   });
 
   describe('selectSelectedNonEvmNetworkSymbol', () => {
-    it('should return the selected network symbol', () => {
+    it('returns the selected network symbol', () => {
       const result = selectSelectedNonEvmNetworkSymbol(mockState);
       expect(result).toBe('SOL');
     });
 
-    it('should return undefined when network symbol is not found', () => {
+    it('returns undefined when network symbol is not found', () => {
       const modifiedState = {
         ...mockState,
         engine: {
@@ -166,7 +223,7 @@ describe('getActiveNetworksByScopes', () => {
     },
   } as unknown as RootState;
 
-  it('should return EVM networks with activity for an EOA account', () => {
+  it('returns EVM networks with activity for an EOA account', () => {
     const account = {
       address: MOCK_ETH_ACCOUNT,
       scopes: [EthScope.Eoa],
@@ -182,7 +239,7 @@ describe('getActiveNetworksByScopes', () => {
     ]);
   });
 
-  it('should return Solana network for a Solana account', () => {
+  it('returns Solana network for a Solana account', () => {
     const account = {
       address: MOCK_SOL_ACCOUNT,
       scopes: [SolScope.Mainnet],
@@ -196,7 +253,7 @@ describe('getActiveNetworksByScopes', () => {
   });
 
   it.each(Object.values(BtcScope))(
-    'should return correct network for Bitcoin: %s',
+    'returns correct network for Bitcoin: %s',
     (scope: BtcScope) => {
       const account = {
         address: MOCK_BTC_ACCOUNT,
@@ -212,7 +269,7 @@ describe('getActiveNetworksByScopes', () => {
   );
 
   it.each(Object.values(TrxScope))(
-    'should return correct network for Tron: %s',
+    'returns correct network for Tron: %s',
     (scope: TrxScope) => {
       const account = {
         address: MOCK_TRON_ACCOUNT,
@@ -227,7 +284,7 @@ describe('getActiveNetworksByScopes', () => {
     },
   );
 
-  it('should return an empty array if account has no scopes', () => {
+  it('returns an empty array if account has no scopes', () => {
     const account = {
       address: MOCK_ETH_ACCOUNT,
       scopes: [] as CaipChainId[],
@@ -236,7 +293,7 @@ describe('getActiveNetworksByScopes', () => {
     expect(result).toEqual([]);
   });
 
-  it('should return an empty array if account is undefined', () => {
+  it('returns an empty array if account is undefined', () => {
     const result = getActiveNetworksByScopes(
       baseState,
       undefined as unknown as { address: string; scopes: CaipChainId[] },
@@ -244,7 +301,7 @@ describe('getActiveNetworksByScopes', () => {
     expect(result).toEqual([]);
   });
 
-  it('should return an empty array if no activity for EVM account', () => {
+  it('returns an empty array if no activity for EVM account', () => {
     const account = {
       address: MOCK_ETH_ACCOUNT_NO_ACTIVITY,
       scopes: [EthScope.Eoa],

--- a/app/selectors/multichainNetworkController/index.ts
+++ b/app/selectors/multichainNetworkController/index.ts
@@ -5,6 +5,7 @@ import {
   MULTICHAIN_NETWORK_TICKER,
   MultichainNetworkControllerState,
   type MultichainNetworkConfiguration,
+  getDefaultMultichainNetworkControllerState,
 } from '@metamask/multichain-network-controller';
 import { toHex } from '@metamask/controller-utils';
 import { CaipChainId, Json } from '@metamask/utils';
@@ -25,7 +26,8 @@ import { selectIsBitcoinTestnetEnabled } from '../featureFlagController/bitcoinT
 ///: END:ONLY_INCLUDE_IF
 
 export const selectMultichainNetworkControllerState = (state: RootState) =>
-  state.engine.backgroundState?.MultichainNetworkController;
+  state.engine.backgroundState?.MultichainNetworkController ??
+  getDefaultMultichainNetworkControllerState();
 
 export const selectIsEvmNetworkSelected = createSelector(
   selectMultichainNetworkControllerState,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix `selectMultichainNetworkControllerState` to prevent `TypeError` during app onboarding by providing a default state fallback.

Also cleaned up the underlying analytics event that uses the selector (it is not useful information since we should now handle multiple networks selected)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: network selector startup crash

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/24870 https://consensyssoftware.atlassian.net/browse/ASSETS-2462

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<a href="https://cursor.com/background-agent?bcId=bc-b5583b64-c7f6-4e2c-a780-835eec49cf86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5583b64-c7f6-4e2c-a780-835eec49cf86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents crashes when `MultichainNetworkController` is undefined by defaulting `selectMultichainNetworkControllerState` to `getDefaultMultichainNetworkControllerState()`.
> 
> - Simplifies `ManageNetworks.tsx` analytics by removing `chain_id` property from `NETWORK_SELECTOR_PRESSED` and related dependencies
> - Adds/updates selector tests to validate fallback behavior and robustness when controller/background state is undefined
> - Tests `getActiveNetworksByScopes` across EVM, Solana, Bitcoin, and Tron scopes, including empty/undefined account cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6f996f280f555b32b8896f3bc422d290f36bb95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->