### PR TITLE
fix: render native tokens as source when navigate from asset details cp-7.62.0

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -292,6 +292,14 @@ jest.mock('../Ramp/hooks/useRampsUnifiedV1Enabled', () => ({
   default: () => mockUseRampsUnifiedV1Enabled(),
 }));
 
+jest.mock('@metamask/bridge-controller', () => ({
+  ...jest.requireActual('@metamask/bridge-controller'),
+  isNativeAddress: jest.fn(
+    (address: string) =>
+      address === '0x0000000000000000000000000000000000000000',
+  ),
+}));
+
 const asset = {
   balance: '400',
   balanceFiat: '1500',
@@ -1891,7 +1899,7 @@ describe('getSwapTokens', () => {
     });
   });
 
-  it('returns native gas token as sourceToken when asset is native gas token', () => {
+  it('returns native gas token as sourceToken when asset is native gas token from home page', () => {
     const nativeGasToken = {
       ...asset,
       address: '0x0000000000000000000000000000000000000000',
@@ -1912,5 +1920,23 @@ describe('getSwapTokens', () => {
     });
     // destToken is undefined (will be determined by swap UI)
     expect(result.destToken).toBeUndefined();
+  });
+
+  it('returns native gas token as destToken when asset is native gas token from trending', () => {
+    const trendingNativeGasToken = {
+      ...asset,
+      address: '0x0000000000000000000000000000000000000000',
+      isETH: true,
+      isFromTrending: true,
+    };
+
+    const result = getSwapTokens(trendingNativeGasToken);
+
+    // When coming from trending with native token, user wants to BUY it (dest position)
+    expect(result.destToken).toBeDefined();
+    expect(result.destToken?.address).toBe(
+      '0x0000000000000000000000000000000000000000',
+    );
+    expect(result.destToken?.symbol).toBe(trendingNativeGasToken.symbol);
   });
 });

--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -292,14 +292,6 @@ jest.mock('../Ramp/hooks/useRampsUnifiedV1Enabled', () => ({
   default: () => mockUseRampsUnifiedV1Enabled(),
 }));
 
-jest.mock('@metamask/bridge-controller', () => ({
-  ...jest.requireActual('@metamask/bridge-controller'),
-  isNativeAddress: jest.fn(
-    (address: string) =>
-      address === '0x0000000000000000000000000000000000000000',
-  ),
-}));
-
 const asset = {
   balance: '400',
   balanceFiat: '1500',

--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -1891,7 +1891,7 @@ describe('getSwapTokens', () => {
     });
   });
 
-  it('returns default pair token as sourceToken and native gas token as destToken when asset is native gas token', () => {
+  it('returns native gas token as sourceToken when asset is native gas token', () => {
     const nativeGasToken = {
       ...asset,
       address: '0x0000000000000000000000000000000000000000',
@@ -1900,18 +1900,8 @@ describe('getSwapTokens', () => {
 
     const result = getSwapTokens(nativeGasToken);
 
-    // sourceToken is the default pair token for mainnet (mUSD)
+    // sourceToken is the native gas token (user wants to swap FROM it)
     expect(result.sourceToken).toEqual({
-      symbol: 'mUSD',
-      name: 'MetaMask USD',
-      address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
-      decimals: 6,
-      image:
-        'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xaca92e438df0b2401ff60da7e4337b687a2435da.png',
-      chainId: MOCK_CHAIN_ID,
-    });
-    // destToken is the native gas token
-    expect(result.destToken).toEqual({
       ...nativeGasToken,
       address: '0x0000000000000000000000000000000000000000',
       chainId: MOCK_CHAIN_ID,
@@ -1920,5 +1910,7 @@ describe('getSwapTokens', () => {
       name: nativeGasToken.name,
       image: nativeGasToken.image,
     });
+    // destToken is undefined (will be determined by swap UI)
+    expect(result.destToken).toBeUndefined();
   });
 });

--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -78,10 +78,7 @@ import {
   isAssetFromTrending,
 } from '../Bridge/hooks/useSwapBridgeNavigation';
 import { NATIVE_SWAPS_TOKEN_ADDRESS } from '../../../constants/bridge';
-import {
-  getNativeSourceToken,
-  getDefaultDestToken,
-} from '../Bridge/utils/tokenUtils';
+import { getNativeSourceToken } from '../Bridge/utils/tokenUtils';
 import { TraceName, endTrace } from '../../../util/trace';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { selectMultichainAssetsRates } from '../../../selectors/multichain';
@@ -89,10 +86,7 @@ import { isEvmAccountType, KeyringAccountType } from '@metamask/keyring-api';
 import { useSendNonEvmAsset } from '../../hooks/useSendNonEvmAsset';
 ///: END:ONLY_INCLUDE_IF
 import { calculateAssetPrice } from './utils/calculateAssetPrice';
-import {
-  formatChainIdToCaip,
-  isNativeAddress,
-} from '@metamask/bridge-controller';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { InitSendLocation } from '../../Views/confirmations/constants/send';
 import { useSendNavigation } from '../../Views/confirmations/hooks/useSendNavigation';
 import { selectMultichainAccountsState2Enabled } from '../../../selectors/featureFlagController/multichainAccounts';
@@ -126,10 +120,6 @@ import { BridgeToken } from '../Bridge/types';
 /**
  * Determines the source and destination tokens for swap/bridge navigation.
  *
- * When the asset is a native gas token (e.g., ETH), we set sourceToken to the default
- * pair token for that chain (e.g., mUSD on mainnet) and destToken to the native token,
- * allowing the user to swap INTO the native token.
- *
  * When coming from the trending tokens list, the user likely wants to BUY the token,
  * so we configure the swap with the native token as source and the asset as destination.
  *
@@ -156,15 +146,6 @@ export const getSwapTokens = (
     name: asset.name,
     image: asset.image,
   };
-
-  // If the asset is a native gas token, set source to the default pair token for that chain
-  // and dest to the native token, allowing the user to swap INTO the native token
-  if (isNativeAddress(asset.address)) {
-    return {
-      sourceToken: getDefaultDestToken(bridgeToken.chainId),
-      destToken: bridgeToken,
-    };
-  }
 
   if (wantsToBuyToken) {
     return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Scenario 1: Home page → Token details → Swap (SELL) 
Example: BNB details → BNB (source) → USDT (dest chosen in UI)

Scenario 2: Explore/Trending → Token details → Swap (BUY) 
Example: Trending BNB → USDT (source) → BNB (dest)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: render native token as source when navigating to swaps from asset overview page.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/24865 , https://consensyssoftware.atlassian.net/browse/SWAPS-3797

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/55071760-eb5c-4540-8c1d-972dba8be1b9



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x]  I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines swap token preselection to reflect entry context and native-token specifics.
> 
> - Updates `getSwapTokens` in `AssetOverview.tsx`:
>   - From trending (BUY): sets asset as `destToken`; uses default pair as `sourceToken` for native assets, otherwise uses the chain’s native token as source
>   - From asset details/home (SELL): sets asset as `sourceToken` and leaves `destToken` undefined
> - Adjusts tests in `AssetOverview.test.tsx` to validate new behavior, including native gas tokens from home (source) and trending (dest), and cross-chain cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3f29a5d7743c2d843d1ee16c2b5d6e39c38b786. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->