### PR TITLE
fix: explore sites icons sizes and padding issues

### DIFF
--- a/app/components/UI/Sites/components/SiteRowItem/SiteRowItem.test.tsx
+++ b/app/components/UI/Sites/components/SiteRowItem/SiteRowItem.test.tsx
@@ -135,5 +135,19 @@ describe('SiteRowItem', () => {
         getByText('metamask.io/portfolio?utm_source=mobile'),
       ).toBeOnTheScreen();
     });
+
+    it('renders site logo with logoNeedsPadding flag', () => {
+      const site = createSite({
+        logoUrl: 'https://example.com/logo.png',
+        logoNeedsPadding: true,
+      });
+
+      const { getByTestId } = render(
+        <SiteRowItem site={site} onPress={mockOnPress} />,
+      );
+
+      const image = getByTestId('site-logo-image');
+      expect(image).toBeOnTheScreen();
+    });
   });
 });

--- a/app/components/UI/Sites/components/SiteRowItem/SiteRowItem.tsx
+++ b/app/components/UI/Sites/components/SiteRowItem/SiteRowItem.tsx
@@ -17,6 +17,11 @@ export interface SiteData {
   displayUrl: string;
   logoUrl?: string;
   featured?: boolean;
+  /**
+   * When true, applies additional padding around the logo image.
+   * Useful for logos that extend to the edges (like the MetaMask fox).
+   */
+  logoNeedsPadding?: boolean;
 }
 
 interface SiteRowItemProps {
@@ -42,7 +47,9 @@ const SiteRowItem = ({ site, onPress }: SiteRowItemProps) => {
       {/* Logo */}
       <Box twClassName="flex-row items-center flex-1">
         {site.logoUrl && !imageError ? (
-          <Box twClassName="w-10 h-10 rounded-full bg-white border border-muted mr-4 overflow-hidden items-center justify-center p-0.1">
+          <Box
+            twClassName={`w-10 h-10 rounded-full bg-white border border-muted mr-4 overflow-hidden items-center justify-center ${site.logoNeedsPadding ? 'p-1' : 'p-0.1'}`}
+          >
             <Image
               testID="site-logo-image"
               source={{ uri: site.logoUrl }}

--- a/app/components/UI/Sites/hooks/useSiteData/useSitesData.test.ts
+++ b/app/components/UI/Sites/hooks/useSiteData/useSitesData.test.ts
@@ -18,6 +18,7 @@ const EXPECTED_PORTFOLIO_SITE = {
   logoUrl:
     'https://raw.githubusercontent.com/MetaMask/metamask-mobile/main/logo.png',
   featured: true,
+  logoNeedsPadding: true,
 };
 
 describe('useSitesData', () => {

--- a/app/components/UI/Sites/hooks/useSiteData/useSitesData.ts
+++ b/app/components/UI/Sites/hooks/useSiteData/useSitesData.ts
@@ -43,6 +43,7 @@ const PORTFOLIO_SITE: SiteData = {
   logoUrl:
     'https://raw.githubusercontent.com/MetaMask/metamask-mobile/main/logo.png',
   featured: true,
+  logoNeedsPadding: true,
 };
 
 /**

--- a/app/components/Views/SitesFullView/SitesFullView.tsx
+++ b/app/components/Views/SitesFullView/SitesFullView.tsx
@@ -90,7 +90,7 @@ const SitesFullView: React.FC = () => {
   }, [isSearchActive, searchQuery]);
 
   return (
-    <SafeAreaView style={styles.safeArea} edges={['left', 'right', 'bottom']}>
+    <SafeAreaView style={styles.safeArea} edges={['left', 'right']}>
       <View
         style={[
           styles.headerContainer,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add conditional padding to site logos to prevent clipping, specifically for the MetaMask Portfolio logo.

The MetaMask Portfolio logo extends to the edges of its image asset, causing it to appear clipped within the circular display container. This PR introduces a `logoNeedsPadding` flag to `SiteData` and applies additional padding (`p-1`) when this flag is set, ensuring the logo is properly displayed.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: explore sites icons sizes and padding issues

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/24607 https://consensyssoftware.atlassian.net/browse/ASSETS-2307

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See issue

### **After**

<img width="990" height="927" alt="Screenshot 2026-01-19 at 13 14 36" src="https://github.com/user-attachments/assets/5dd7f814-9765-4fd2-8403-74fe1564e9cd" />
<img width="943" height="958" alt="Screenshot 2026-01-19 at 13 12 38" src="https://github.com/user-attachments/assets/f7fac422-7d21-4347-a0e7-b3181b9253cb" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<a href="https://cursor.com/background-agent?bcId=bc-9cc45ff9-a0c8-4a3e-95dd-02c9414080a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9cc45ff9-a0c8-4a3e-95dd-02c9414080a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces conditional logo padding to prevent logo clipping and adjusts Sites view layout.
> 
> - Adds `logoNeedsPadding` to `SiteData` and applies `p-1` vs `p-0.1` padding in `SiteRowItem` when set
> - Updates `PORTFOLIO_SITE` in `useSitesData` to include `logoNeedsPadding: true`
> - Extends tests: new case for `logoNeedsPadding` in `SiteRowItem.test.tsx` and expected Portfolio object updated in `useSitesData.test.ts`
> - Tweaks `SitesFullView` by removing bottom safe-area edge (`SafeAreaView` `edges` now `['left', 'right']`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d62c9184c050e54fc448870cebc2d85a0af1480. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->