### PR TITLE
feat(rewards): add Bitcoin account support 

### DIFF
--- a/app/core/Engine/controllers/rewards-controller/index.ts
+++ b/app/core/Engine/controllers/rewards-controller/index.ts
@@ -5,6 +5,7 @@ import {
   RewardsControllerMessenger,
   defaultRewardsControllerState,
 } from './RewardsController';
+import { getFeatureFlagValue } from '../../../../selectors/featureFlagController/env';
 
 /**
  * Initialize the RewardsController.
@@ -26,6 +27,23 @@ export const rewardsControllerInit: ControllerInitFunction<
     isDisabled: () => {
       const isEnabled = selectBasicFunctionalityEnabled(getState());
       return !isEnabled;
+    },
+    isBtcEnabled: () => {
+      try {
+        const remoteValue =
+          controllerMessenger.call('RemoteFeatureFlagController:getState')
+            ?.remoteFeatureFlags?.['rewards-bitcoin-enabled'] ?? false;
+        return getFeatureFlagValue(
+          process.env.MM_REWARDS_BITCOIN_ENABLED,
+          Boolean(remoteValue),
+        );
+      } catch {
+        // If RemoteFeatureFlagController is not available, fall back to env variable
+        return getFeatureFlagValue(
+          process.env.MM_REWARDS_BITCOIN_ENABLED,
+          false,
+        );
+      }
     },
   });
 

--- a/app/core/Engine/controllers/rewards-controller/utils/bitcoin-snap.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/utils/bitcoin-snap.test.ts
@@ -1,0 +1,163 @@
+import { HandlerType } from '@metamask/snaps-utils';
+import { signBitcoinRewardsMessage } from './bitcoin-snap';
+import { handleSnapRequest } from '../../../../Snaps/utils';
+import { BITCOIN_WALLET_SNAP_ID } from '../../../../SnapKeyring/BitcoinWalletSnap';
+import Engine from '../../../../Engine';
+import Logger from '../../../../../util/Logger';
+
+jest.mock('../../../../Snaps/utils', () => ({
+  handleSnapRequest: jest.fn(),
+}));
+
+jest.mock('../../../../Engine', () => ({
+  controllerMessenger: {},
+}));
+
+jest.mock('../../../../../util/Logger', () => ({
+  log: jest.fn(),
+}));
+
+describe('bitcoin-snap', () => {
+  const mockAccountId = 'bitcoin-account-id';
+  const mockMessage = 'base64-encoded-message';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('signBitcoinRewardsMessage', () => {
+    it('should successfully sign a Bitcoin rewards message', async () => {
+      const mockResult = {
+        signature: '0xabcdef123456',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await signBitcoinRewardsMessage(
+        mockAccountId,
+        mockMessage,
+      );
+
+      expect(handleSnapRequest).toHaveBeenCalledWith(
+        Engine.controllerMessenger,
+        {
+          origin: 'metamask',
+          snapId: BITCOIN_WALLET_SNAP_ID,
+          handler: HandlerType.OnClientRequest,
+          request: {
+            jsonrpc: '2.0',
+            id: expect.any(Number),
+            method: 'signRewardsMessage',
+            params: {
+              accountId: mockAccountId,
+              message: mockMessage,
+            },
+          },
+        },
+      );
+
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should handle errors when signing fails', async () => {
+      const mockError = new Error('Signing failed');
+      (handleSnapRequest as jest.Mock).mockRejectedValue(mockError);
+
+      await expect(
+        signBitcoinRewardsMessage(mockAccountId, mockMessage),
+      ).rejects.toThrow('Signing failed');
+
+      expect(Logger.log).toHaveBeenCalledWith(
+        'Error signing Bitcoin rewards message:',
+        mockError,
+      );
+    });
+
+    it('should handle errors from handleSnapRequest', async () => {
+      const mockError = new Error('Snap request failed');
+      (handleSnapRequest as jest.Mock).mockRejectedValue(mockError);
+
+      await expect(
+        signBitcoinRewardsMessage(mockAccountId, mockMessage),
+      ).rejects.toThrow('Snap request failed');
+
+      expect(Logger.log).toHaveBeenCalledWith(
+        'Error signing Bitcoin rewards message:',
+        mockError,
+      );
+    });
+
+    it('should use correct snap ID', async () => {
+      const mockResult = {
+        signature: '0x123',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      await signBitcoinRewardsMessage(mockAccountId, mockMessage);
+
+      expect(handleSnapRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          snapId: BITCOIN_WALLET_SNAP_ID,
+        }),
+      );
+    });
+
+    it('should pass correct accountId and message', async () => {
+      const mockResult = {
+        signature: '0x123',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      await signBitcoinRewardsMessage(mockAccountId, mockMessage);
+
+      expect(handleSnapRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          request: expect.objectContaining({
+            params: {
+              accountId: mockAccountId,
+              message: mockMessage,
+            },
+          }),
+        }),
+      );
+    });
+
+    it('should handle empty accountId', async () => {
+      const mockResult = {
+        signature: '0x123',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await signBitcoinRewardsMessage('', mockMessage);
+
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should handle empty message', async () => {
+      const mockResult = {
+        signature: '0x123',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await signBitcoinRewardsMessage(mockAccountId, '');
+
+      expect(result).toEqual(mockResult);
+    });
+  });
+});

--- a/app/core/Engine/controllers/rewards-controller/utils/bitcoin-snap.ts
+++ b/app/core/Engine/controllers/rewards-controller/utils/bitcoin-snap.ts
@@ -1,0 +1,38 @@
+import { handleSnapRequest } from '../../../../Snaps/utils';
+import Engine from '../../../../Engine';
+import { BITCOIN_WALLET_SNAP_ID } from '../../../../SnapKeyring/BitcoinWalletSnap';
+import { HandlerType } from '@metamask/snaps-utils';
+import Logger from '../../../../../util/Logger';
+
+export interface SignRewardsMessageResult {
+  signature: string;
+  signedMessage: string;
+  signatureType: 'ecdsa';
+}
+
+export async function signBitcoinRewardsMessage(
+  accountId: string,
+  message: string,
+): Promise<SignRewardsMessageResult> {
+  try {
+    const result = await handleSnapRequest(Engine.controllerMessenger, {
+      origin: 'metamask',
+      snapId: BITCOIN_WALLET_SNAP_ID,
+      handler: HandlerType.OnClientRequest,
+      request: {
+        jsonrpc: '2.0',
+        id: Date.now(),
+        method: 'signRewardsMessage',
+        params: {
+          accountId,
+          message,
+        },
+      },
+    });
+
+    return result as SignRewardsMessageResult;
+  } catch (error) {
+    Logger.log('Error signing Bitcoin rewards message:', error);
+    throw error;
+  }
+}

--- a/app/core/Engine/messengers/rewards-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/rewards-controller-messenger/index.ts
@@ -34,6 +34,7 @@ import {
   AccountsControllerGetSelectedMultichainAccountAction,
   AccountsControllerListMultichainAccountsAction,
 } from '@metamask/accounts-controller';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import {
   RewardsDataServiceGetOptInStatusAction,
   RewardsDataServiceGetPointsEventsAction,
@@ -55,6 +56,7 @@ type AllowedActions =
   | AccountsControllerListMultichainAccountsAction
   | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
   | KeyringControllerSignPersonalMessageAction
+  | RemoteFeatureFlagControllerGetStateAction
   | RewardsDataServiceLoginAction
   | RewardsDataServiceGetPointsEventsAction
   | RewardsDataServiceGetPointsEventsLastUpdatedAction
@@ -107,6 +109,7 @@ export function getRewardsControllerMessenger(
       'AccountTreeController:getAccountsFromSelectedAccountGroup',
       'AccountsController:listMultichainAccounts',
       'KeyringController:signPersonalMessage',
+      'RemoteFeatureFlagController:getState',
       'RewardsDataService:login',
       'RewardsDataService:getPointsEvents',
       'RewardsDataService:getPointsEventsLastUpdated',


### PR DESCRIPTION
## **Description**

Add bitcoin account support

## **Changelog**

CHANGELOG entry: add bitcoin account support for rewards

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables rewards for Bitcoin accounts alongside EVM and Solana, with gating via remote/env feature flag.
> 
> - Adds BTC handling in `RewardsController` for signing (`signBitcoinRewardsMessage`) and opt-in checks (`isBtcAccount`, `#isBtcEnabled`)
> - Introduces `utils/bitcoin-snap` to sign rewards messages via Bitcoin Wallet Snap; includes unit tests
> - Wires `isBtcEnabled` in controller init using `RemoteFeatureFlagController:getState` and `MM_REWARDS_BITCOIN_ENABLED`
> - Extends messenger to allow `RemoteFeatureFlagController:getState`
> - Expands tests to cover BTC signing paths, 0x prefix handling, disabled flag behavior, and opt-in support across account types
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b20d2d5600a830edcbdab7cdbdc3333c9010d5ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->