### PR TITLE
fix: Add expected parameter to `createUnsupportedMethodMiddleware`

### DIFF
--- a/app/core/RPCMethods/createUnsupportedMethodMiddleware/index.ts
+++ b/app/core/RPCMethods/createUnsupportedMethodMiddleware/index.ts
@@ -5,15 +5,17 @@ import { UNSUPPORTED_RPC_METHODS } from '../utils';
 import { Json, JsonRpcParams } from '@metamask/utils';
 
 /**
- * Creates a middleware that rejects explicitly unsupported RPC methods with the
+ * Create a middleware that rejects explicitly unsupported RPC methods with the
  * appropriate error.
+ *
+ * @param unsupportedMethods - The unsupported methods set.
+ * @returns The middleware.
  */
-const createUnsupportedMethodMiddleware = (): JsonRpcMiddleware<
-  JsonRpcParams,
-  Json
-> =>
+const createUnsupportedMethodMiddleware = (
+  unsupportedMethods: Set<string> = UNSUPPORTED_RPC_METHODS,
+): JsonRpcMiddleware<JsonRpcParams, Json> =>
   async function unsupportedMethodMiddleware(req, _res, next, end) {
-    if ((UNSUPPORTED_RPC_METHODS as Set<string>).has(req.method)) {
+    if (unsupportedMethods.has(req.method)) {
       return end(rpcErrors.methodNotSupported());
     }
     return next();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add `unsupportedMethods` parameter to `createUnsupportedMethodMiddleware` which is expected by the following usage: https://github.com/MetaMask/metamask-mobile/blob/2a9d9ea588bbea6a57c16a4328cdb276c1059ab3/app/core/BackgroundBridge/BackgroundBridge.js#L775-L783

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Ensure proper responses when requesting invalid RPC methods using the multichain API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables configurable unsupported RPC methods for the middleware.
> 
> - `createUnsupportedMethodMiddleware` now accepts `unsupportedMethods: Set<string>` (defaults to `UNSUPPORTED_RPC_METHODS`)
> - Middleware checks the provided set to return `rpcErrors.methodNotSupported()`
> - Minor JSDoc wording and annotations updated
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebe25e294bd271c10a56e0bd3bdc8c218bd66e3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->