### PR TITLE
fix: rm network confirmation modal on trending

### DIFF
--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -194,24 +194,18 @@ const Tokens = memo(({ isFullView = false }: TokensProps) => {
     return isHomepageRedesignV1Enabled ? 10 : undefined;
   }, [isFullView, isHomepageRedesignV1Enabled]);
 
-  return (
-    <Box
-      twClassName={
-        isHomepageRedesignV1Enabled && !isFullView
-          ? 'bg-default'
-          : 'flex-1 bg-default'
-      }
-      testID={WalletViewSelectorsIDs.TOKENS_CONTAINER}
-    >
-      <TokenListControlBar
-        goToAddToken={goToAddToken}
-        style={isFullView ? tw`px-4 pb-4` : undefined}
-      />
-      {!hasInitialLoad ? (
+  // Determine which content to render based on loading and token state
+  const tokenContent = useMemo(() => {
+    if (!hasInitialLoad) {
+      return (
         <Box twClassName={isFullView ? 'px-4' : undefined}>
           <TokenListSkeleton />
         </Box>
-      ) : sortedTokenKeys.length > 0 ? (
+      );
+    }
+
+    if (sortedTokenKeys.length > 0) {
+      return (
         <>
           {isMusdConversionFlowEnabled && (
             <View style={isFullView ? tw`px-4` : undefined}>
@@ -228,11 +222,41 @@ const Tokens = memo(({ isFullView = false }: TokensProps) => {
             isFullView={isFullView}
           />
         </>
-      ) : (
-        <Box twClassName={isFullView ? 'px-4 items-center' : 'items-center'}>
-          <TokensEmptyState />
-        </Box>
-      )}
+      );
+    }
+
+    return (
+      <Box twClassName={isFullView ? 'px-4 items-center' : 'items-center'}>
+        <TokensEmptyState />
+      </Box>
+    );
+  }, [
+    hasInitialLoad,
+    isFullView,
+    sortedTokenKeys,
+    isMusdConversionFlowEnabled,
+    tw,
+    refreshing,
+    onRefresh,
+    showRemoveMenu,
+    handleScamWarningModal,
+    maxItems,
+  ]);
+
+  return (
+    <Box
+      twClassName={
+        isHomepageRedesignV1Enabled && !isFullView
+          ? 'bg-default'
+          : 'flex-1 bg-default'
+      }
+      testID={WalletViewSelectorsIDs.TOKENS_CONTAINER}
+    >
+      <TokenListControlBar
+        goToAddToken={goToAddToken}
+        style={isFullView ? tw`px-4 pb-4` : undefined}
+      />
+      {tokenContent}
       <ScamWarningModal
         showScamWarningModal={showScamWarningModal}
         setShowScamWarningModal={setShowScamWarningModal}

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -18,7 +18,7 @@ import {
   removeNonEvmToken,
   goToAddEvmToken,
 } from './util';
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Box } from '@metamask/design-system-react-native';
 import { TokenListControlBar } from './TokenListControlBar/TokenListControlBar';
@@ -90,6 +90,17 @@ const Tokens = memo(({ isFullView = false }: TokensProps) => {
 
   // Memoize selector computation for better performance
   const sortedTokenKeys = useSelector(selectSortedAssetsBySelectedAccountGroup);
+
+  const [, forceUpdate] = useState(0);
+
+  // Force re-render when coming back into focus to ensure the component
+  // picks up any network changes that happened while navigated away
+  // (e.g., when returning from trending flow after network switch)
+  useFocusEffect(
+    useCallback(() => {
+      forceUpdate((n) => n + 1);
+    }, []),
+  );
 
   // Mark as loaded once we have data (even if empty)
   useEffect(() => {

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
@@ -913,8 +913,6 @@ describe('TrendingTokenRowItem', () => {
     });
 
     it('adds network directly when network is not added and navigates to asset', async () => {
-      jest.useFakeTimers();
-
       const token = createMockToken({
         assetId: 'eip155:8453/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
         symbol: 'USDC',
@@ -972,15 +970,10 @@ describe('TrendingTokenRowItem', () => {
         );
       });
 
-      // Advance timers past the 100ms setTimeout delay and flush promises
-      jest.advanceTimersByTime(100);
-
-      // Wait for the async navigation call after timer delay
+      // Wait for the async navigation call
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('Asset', expect.any(Object));
       });
-
-      jest.useRealTimers();
     });
 
     it('does not navigate when network addition fails', async () => {

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react-native';
+import { fireEvent, waitFor } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import TrendingTokenRowItem from './TrendingTokenRowItem';
 import type { TrendingAsset } from '@metamask/assets-controllers';
@@ -960,16 +960,15 @@ describe('TrendingTokenRowItem', () => {
       );
       await fireEvent.press(tokenRow);
 
-      // Wait for async operation
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // Verify addPopularNetwork was called with Base network
-      expect(mockAddPopularNetwork).toHaveBeenCalledWith(
-        expect.objectContaining({
-          chainId: '0x2105',
-          nickname: 'Base',
-        }),
-      );
+      // Wait for async operation to complete
+      await waitFor(() => {
+        expect(mockAddPopularNetwork).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chainId: '0x2105',
+            nickname: 'Base',
+          }),
+        );
+      });
 
       // Navigation should be called after network is added
       expect(mockNavigate).toHaveBeenCalledWith('Asset', expect.any(Object));
@@ -1024,11 +1023,10 @@ describe('TrendingTokenRowItem', () => {
       );
       await fireEvent.press(tokenRow);
 
-      // Wait for async operation
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // Verify addPopularNetwork was called
-      expect(mockAddPopularNetwork).toHaveBeenCalled();
+      // Wait for async operation to complete
+      await waitFor(() => {
+        expect(mockAddPopularNetwork).toHaveBeenCalled();
+      });
 
       // Navigation should NOT be called when network addition fails
       expect(mockNavigate).not.toHaveBeenCalled();

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
@@ -913,6 +913,8 @@ describe('TrendingTokenRowItem', () => {
     });
 
     it('adds network directly when network is not added and navigates to asset', async () => {
+      jest.useFakeTimers();
+
       const token = createMockToken({
         assetId: 'eip155:8453/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
         symbol: 'USDC',
@@ -958,9 +960,9 @@ describe('TrendingTokenRowItem', () => {
       const tokenRow = getByTestId(
         'trending-token-row-item-eip155:8453/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
       );
-      await fireEvent.press(tokenRow);
+      fireEvent.press(tokenRow);
 
-      // Wait for async operation to complete
+      // Wait for addPopularNetwork to be called
       await waitFor(() => {
         expect(mockAddPopularNetwork).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -970,8 +972,15 @@ describe('TrendingTokenRowItem', () => {
         );
       });
 
-      // Navigation should be called after network is added
-      expect(mockNavigate).toHaveBeenCalledWith('Asset', expect.any(Object));
+      // Advance timers past the 100ms setTimeout delay and flush promises
+      jest.advanceTimersByTime(100);
+
+      // Wait for the async navigation call after timer delay
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('Asset', expect.any(Object));
+      });
+
+      jest.useRealTimers();
     });
 
     it('does not navigate when network addition fails', async () => {

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -111,6 +111,17 @@ const getPriceChangeColor = (priceChange: number): TextColor => {
 };
 
 /**
+ * Gets the prefix symbol for price percentage change
+ */
+const getPriceChangePrefix = (
+  priceChange: number,
+  isPositive: boolean,
+): string => {
+  if (priceChange === 0) return '';
+  return isPositive ? '+' : '-';
+};
+
+/**
  * Maps TimeOption to the corresponding priceChangePct field key
  */
 export const getPriceChangeFieldKey = (
@@ -296,7 +307,7 @@ const TrendingTokenRowItem = ({
               variant={TextVariant.BodySM}
               color={getPriceChangeColor(pricePercentChange)}
             >
-              {pricePercentChange === 0 ? '' : isPositiveChange ? '+' : '-'}
+              {getPriceChangePrefix(pricePercentChange, isPositiveChange)}
               {Math.abs(pricePercentChange).toFixed(2)}%
             </Text>
           )

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -220,13 +220,6 @@ const TrendingTokenRowItem = ({
         // and switching to it (shouldSwitchNetwork defaults to true)
         try {
           await addPopularNetwork(popularNetwork);
-          
-          // Brief delay to ensure Redux state updates and React re-renders
-          // have propagated before navigation. This ensures the home page
-          // shows the newly switched network when the user navigates back.
-          await new Promise((resolve) => {
-            setTimeout(resolve, 100);
-          });
         } catch (error) {
           // If network addition fails, don't navigate
           console.error('Failed to add network:', error);

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -216,8 +216,17 @@ const TrendingTokenRowItem = ({
 
       if (popularNetwork) {
         // Add the network directly without showing confirmation modal
+        // addPopularNetwork handles both enabling the network in the filter
+        // and switching to it (shouldSwitchNetwork defaults to true)
         try {
           await addPopularNetwork(popularNetwork);
+          
+          // Brief delay to ensure Redux state updates and React re-renders
+          // have propagated before navigation. This ensures the home page
+          // shows the newly switched network when the user navigates back.
+          await new Promise((resolve) => {
+            setTimeout(resolve, 100);
+          });
         } catch (error) {
           // If network addition fails, don't navigate
           console.error('Failed to add network:', error);

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -270,7 +270,7 @@ const TrendingTokenRowItem = ({
             numberOfLines={1}
             ellipsizeMode="tail"
           >
-            {token.name}
+            {token?.name ?? token?.symbol}
           </Text>
         </View>
         <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { ImageSourcePropType, TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
@@ -38,10 +38,9 @@ import { AvatarSize } from '../../../../../component-library/components/Avatars/
 import { formatMarketStats } from './utils';
 import { formatPriceWithSubscriptNotation } from '../../../Predict/utils/format';
 import { TimeOption } from '../TrendingTokensBottomSheet';
-import NetworkModals from '../../../NetworkModal';
 import { selectNetworkConfigurationsByCaipChainId } from '../../../../../selectors/networkController';
-import type { Network } from '../../../../Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
 import { getTrendingTokenImageUrl } from '../../utils/getTrendingTokenImageUrl';
+import { useAddPopularNetwork } from '../../../../hooks/useAddPopularNetwork';
 
 /**
  * Extracts CAIP chain ID from asset ID
@@ -176,8 +175,7 @@ const TrendingTokenRowItem = ({
   const networkConfigurations = useSelector(
     selectNetworkConfigurationsByCaipChainId,
   );
-  const [isNetworkModalVisible, setIsNetworkModalVisible] = useState(false);
-  const [selectedNetwork, setSelectedNetwork] = useState<Network | null>(null);
+  const { addPopularNetwork } = useAddPopularNetwork();
 
   // Memoize derived values
   const caipChainId = useMemo(
@@ -206,7 +204,7 @@ const TrendingTokenRowItem = ({
     pricePercentChange !== undefined && !isNaN(pricePercentChange);
   const isPositiveChange = hasPercentageChange && pricePercentChange > 0;
 
-  const handlePress = useCallback(() => {
+  const handlePress = useCallback(async () => {
     if (!assetParams) return;
 
     const isNetworkAdded = Boolean(networkConfigurations[caipChainId]);
@@ -217,117 +215,92 @@ const TrendingTokenRowItem = ({
       );
 
       if (popularNetwork) {
-        setSelectedNetwork(popularNetwork);
-        setIsNetworkModalVisible(true);
-        return;
+        // Add the network directly without showing confirmation modal
+        try {
+          await addPopularNetwork(popularNetwork);
+        } catch (error) {
+          // If network addition fails, don't navigate
+          console.error('Failed to add network:', error);
+          return;
+        }
       }
     }
 
     navigation.navigate('Asset', assetParams);
-  }, [assetParams, caipChainId, navigation, networkConfigurations]);
-
-  const closeNetworkModal = useCallback(() => {
-    setIsNetworkModalVisible(false);
-    setSelectedNetwork(null);
-  }, []);
-
-  const handleNetworkModalAccept = useCallback(() => {
-    if (assetParams) {
-      navigation.navigate('Asset', assetParams);
-    }
-    closeNetworkModal();
-  }, [assetParams, navigation, closeNetworkModal]);
+  }, [
+    assetParams,
+    caipChainId,
+    navigation,
+    networkConfigurations,
+    addPopularNetwork,
+  ]);
 
   return (
-    <>
-      {isNetworkModalVisible && selectedNetwork && (
-        <NetworkModals
-          showPopularNetworkModal
-          isVisible={isNetworkModalVisible}
-          onClose={closeNetworkModal}
-          networkConfiguration={{
-            chainId: selectedNetwork.chainId,
-            nickname: selectedNetwork.nickname,
-            ticker: selectedNetwork.ticker,
-            rpcUrl: selectedNetwork.rpcUrl,
-            failoverRpcUrls: selectedNetwork.failoverRpcUrls,
-            formattedRpcUrl: selectedNetwork.rpcUrl,
-            rpcPrefs: {
-              blockExplorerUrl: selectedNetwork.rpcPrefs.blockExplorerUrl,
-              imageUrl: selectedNetwork.rpcPrefs.imageUrl,
-            },
-          }}
-          allowNetworkSwitch={false}
-          skipEnableNetwork
-          onAccept={handleNetworkModalAccept}
-        />
-      )}
-      <TouchableOpacity
-        style={styles.container}
-        onPress={handlePress}
-        testID={`trending-token-row-item-${token.assetId}`}
-      >
-        <View>
-          <BadgeWrapper
-            style={styles.badge}
-            badgePosition={BadgePosition.BottomRight}
-            badgeElement={
-              <Badge
-                size={AvatarSize.Xs}
-                variant={BadgeVariant.Network}
-                imageSource={networkBadgeImageSource}
-                isScaled={false}
-              />
-            }
-          >
-            <TrendingTokenLogo
-              assetId={token.assetId}
-              symbol={token.symbol}
-              size={40}
-              recyclingKey={token.assetId}
+    <TouchableOpacity
+      style={styles.container}
+      onPress={handlePress}
+      testID={`trending-token-row-item-${token.assetId}`}
+    >
+      <View>
+        <BadgeWrapper
+          style={styles.badge}
+          badgePosition={BadgePosition.BottomRight}
+          badgeElement={
+            <Badge
+              size={AvatarSize.Xs}
+              variant={BadgeVariant.Network}
+              imageSource={networkBadgeImageSource}
+              isScaled={false}
             />
-          </BadgeWrapper>
-        </View>
-        <View style={styles.leftContainer}>
-          <View style={styles.tokenHeaderRow}>
-            <Text
-              variant={TextVariant.BodyMDMedium}
-              color={TextColor.Default}
-              numberOfLines={1}
-              ellipsizeMode="tail"
-            >
-              {token.name}
-            </Text>
-          </View>
-          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
-            {formatMarketStats(
-              token.marketCap ?? 0,
-              token.aggregatedUsdVolume ?? 0,
-            )}
+          }
+        >
+          <TrendingTokenLogo
+            assetId={token.assetId}
+            symbol={token.symbol}
+            size={40}
+            recyclingKey={token.assetId}
+          />
+        </BadgeWrapper>
+      </View>
+      <View style={styles.leftContainer}>
+        <View style={styles.tokenHeaderRow}>
+          <Text
+            variant={TextVariant.BodyMDMedium}
+            color={TextColor.Default}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          >
+            {token.name}
           </Text>
         </View>
-        <View style={styles.rightContainer}>
-          <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
-            {formatPriceWithSubscriptNotation(token.price)}
-          </Text>
-          {parseFloat(token.price) === 0 ? (
-            <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
-              —
-            </Text>
-          ) : (
-            hasPercentageChange && (
-              <Text
-                variant={TextVariant.BodySM}
-                color={getPriceChangeColor(pricePercentChange)}
-              >
-                {pricePercentChange === 0 ? '' : isPositiveChange ? '+' : '-'}
-                {Math.abs(pricePercentChange).toFixed(2)}%
-              </Text>
-            )
+        <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          {formatMarketStats(
+            token.marketCap ?? 0,
+            token.aggregatedUsdVolume ?? 0,
           )}
-        </View>
-      </TouchableOpacity>
-    </>
+        </Text>
+      </View>
+      <View style={styles.rightContainer}>
+        <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+          {formatPriceWithSubscriptNotation(token.price)}
+        </Text>
+        {parseFloat(token.price) === 0 ? (
+          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+            —
+          </Text>
+        ) : (
+          hasPercentageChange && (
+            <Text
+              variant={TextVariant.BodySM}
+              color={getPriceChangeColor(pricePercentChange)}
+            >
+              {pricePercentChange === 0 ? '' : isPositiveChange ? '+' : '-'}
+              {Math.abs(pricePercentChange).toFixed(2)}%
+            </Text>
+          )
+        )}
+      </View>
+    </TouchableOpacity>
   );
 };
 


### PR DESCRIPTION
## **Description**

PR to remove network confirmation modal on trending flow

## **Changelog**

CHANGELOG entry: Remove the network confirmation modal on trending flow

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/8d864583-faab-4aa1-afc9-682f4d3e478a


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/5fe9d992-db31-407d-aaba-3f7ff94c5c11

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes confirmation UI from trending flow and streamlines navigation; minor Tokens screen lifecycle tweak.
> 
> - **Trending**: Replace `NetworkModal` flow with direct add via `useAddPopularNetwork` when a network isn't added; then navigate to `Asset`. On add failure, do not navigate. Simplifies component state and markup. Tests updated to mock `useAddPopularNetwork`, await async flows, and cover failure cases.
> - **Tokens**: Use `useFocusEffect` to force a re-render on screen focus to pick up network changes; refactor conditional rendering into memoized `tokenContent` for clearer loading/empty/list states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a210d1c16af67e344587c6f5fa847bdf101303b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->