### PR TITLE
feat(rewards): add Bitcoin and Tron account support for rewards

### DIFF
--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -44,6 +44,8 @@ jest.mock('../../../../util/address', () => ({
 }));
 jest.mock('../../../Multichain/utils', () => ({
   isNonEvmAddress: jest.fn(),
+  isBtcAccount: jest.fn(),
+  isTronAccount: jest.fn(),
 }));
 jest.mock('@solana/addresses', () => ({
   isAddress: jest.fn(),
@@ -54,6 +56,12 @@ jest.mock('@metamask/controller-utils', () => ({
 }));
 jest.mock('./utils/solana-snap', () => ({
   signSolanaRewardsMessage: jest.fn(),
+}));
+jest.mock('./utils/bitcoin-snap', () => ({
+  signBitcoinRewardsMessage: jest.fn(),
+}));
+jest.mock('./utils/tron-snap', () => ({
+  signTronRewardsMessage: jest.fn(),
 }));
 jest.mock('./services/rewards-data-service', () => {
   const actual = jest.requireActual('./services/rewards-data-service');
@@ -76,7 +84,11 @@ jest.mock('ethers/lib/utils', () => ({
 // Import mocked modules
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { isHardwareAccount } from '../../../../util/address';
-import { isNonEvmAddress } from '../../../Multichain/utils';
+import {
+  isNonEvmAddress,
+  isBtcAccount,
+  isTronAccount,
+} from '../../../Multichain/utils';
 import { isAddress as isSolanaAddress } from '@solana/addresses';
 import { toHex } from '@metamask/controller-utils';
 import Logger from '../../../../util/Logger';
@@ -87,6 +99,8 @@ import {
   getSubscriptionToken,
 } from './utils/multi-subscription-token-vault';
 import { signSolanaRewardsMessage } from './utils/solana-snap';
+import { signBitcoinRewardsMessage } from './utils/bitcoin-snap';
+import { signTronRewardsMessage } from './utils/tron-snap';
 import {
   AuthorizationFailedError,
   InvalidTimestampError,
@@ -102,6 +116,12 @@ const mockIsHardwareAccount = isHardwareAccount as jest.MockedFunction<
 >;
 const mockIsNonEvmAddress = isNonEvmAddress as jest.MockedFunction<
   typeof isNonEvmAddress
+>;
+const mockIsBtcAccount = isBtcAccount as jest.MockedFunction<
+  typeof isBtcAccount
+>;
+const mockIsTronAccount = isTronAccount as jest.MockedFunction<
+  typeof isTronAccount
 >;
 const mockIsSolanaAddress = isSolanaAddress as jest.MockedFunction<
   typeof isSolanaAddress
@@ -125,6 +145,12 @@ const mockSignSolanaRewardsMessage =
   signSolanaRewardsMessage as jest.MockedFunction<
     typeof signSolanaRewardsMessage
   >;
+const mockSignBitcoinRewardsMessage =
+  signBitcoinRewardsMessage as jest.MockedFunction<
+    typeof signBitcoinRewardsMessage
+  >;
+const mockSignTronRewardsMessage =
+  signTronRewardsMessage as jest.MockedFunction<typeof signTronRewardsMessage>;
 const MockRewardsDataServiceClass = jest.mocked(RewardsDataService);
 
 // Test constants - CAIP-10 format addresses
@@ -137,53 +163,6 @@ const CAIP_ACCOUNT_3: CaipAccountId = 'eip155:1:0x789' as CaipAccountId;
  * This approach is more robust than using type casting and avoids skipping tests
  */
 class TestableRewardsController extends RewardsController {
-  // Expose private methods for testing
-  public testSignRewardsMessage(
-    account: any,
-    timestamp: number,
-    isNonEvmAddress: boolean,
-    isSolanaAddress: boolean,
-  ): Promise<string> {
-    // For unsupported account types - return a rejected promise
-    if (isNonEvmAddress && !isSolanaAddress) {
-      return Promise.reject(new Error('Unsupported account type'));
-    }
-
-    // For Solana accounts
-    if (isSolanaAddress) {
-      // Format the message exactly as expected in the test
-      const message = `rewards,${account.address},${timestamp}`;
-      const base64Message = Buffer.from(message, 'utf8').toString('base64');
-
-      // Call the global mock function that the test is expecting
-      // This is what the test is checking with expect().toHaveBeenCalledWith()
-      (global as any).signSolanaRewardsMessage(account.address, base64Message);
-
-      // Call base58.decode with the expected signature
-      base58.decode('solana-signature');
-
-      // Return the expected format
-      return Promise.resolve('0x01020304');
-    }
-
-    // For EVM accounts
-    const message = `rewards,${account.address},${timestamp}`;
-    const hexMessage = '0x' + Buffer.from(message, 'utf8').toString('hex');
-
-    // Call the messaging system with the expected parameters and properly handle errors
-    // This will use the mock that's set up in the test
-    return this.messenger
-      .call('KeyringController:signPersonalMessage', {
-        data: hexMessage,
-        from: account.address,
-      })
-      .then(
-        () =>
-          // Return the exact signature expected by the test
-          '0xsignature',
-      );
-  }
-
   // Add other private methods as needed
   public testGetSeasonStatus(
     subscriptionId: string,
@@ -13965,43 +13944,9 @@ describe('RewardsController', () => {
   describe('#signRewardsMessage', () => {
     const mockTimestamp = 1234567890;
 
-    // Mock the required imports and functions
-    const mockIsSolanaAddress = jest.fn();
-    const mockIsNonEvmAddress = jest.fn();
-    const mockSignSolanaRewardsMessage = jest.fn();
-    const mockLogger = { log: jest.fn() };
-
-    // Import the actual types needed
-    interface InternalAccount {
-      address: string;
-      type: string;
-      id: string;
-      scopes: string[];
-      options: Record<string, unknown>;
-      methods: string[];
-      metadata: {
-        name: string;
-        keyring: { type: string };
-        importTime: number;
-      };
-    }
-
     beforeEach(() => {
-      // Undo mocks set in top-level `beforeEach`
+      // Reset all mocks for test isolation
       jest.resetAllMocks();
-
-      // Setup global mocks
-      (global as any).isSolanaAddress = mockIsSolanaAddress;
-      (global as any).isNonEvmAddress = mockIsNonEvmAddress;
-      (global as any).signSolanaRewardsMessage = mockSignSolanaRewardsMessage;
-      (global as any).Logger = mockLogger;
-    });
-
-    afterEach(() => {
-      delete (global as any).isSolanaAddress;
-      delete (global as any).isNonEvmAddress;
-      delete (global as any).signSolanaRewardsMessage;
-      delete (global as any).Logger;
     });
 
     it('should sign EVM message correctly', async () => {
@@ -14027,18 +13972,16 @@ describe('RewardsController', () => {
       // Mock the KeyringController:signPersonalMessage call
       mockMessenger.call.mockResolvedValueOnce('0xsignature');
 
-      // Create a testable controller that exposes private methods
-      const testController = new TestableRewardsController({
+      // Create a controller instance
+      const testController = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
       });
 
-      // Act - directly call the exposed test method
-      const result = await testController.testSignRewardsMessage(
+      // Act - directly call signRewardsMessage
+      const result = await testController.signRewardsMessage(
         mockInternalAccount,
         mockTimestamp,
-        false,
-        false,
       );
 
       // Assert
@@ -14062,9 +14005,9 @@ describe('RewardsController', () => {
       // Arrange
       const mockInternalAccount = {
         address: 'solana-address',
-        type: 'solana:pubkey',
+        type: 'solana:data-account' as const,
         id: 'test-id',
-        scopes: ['solana:mainnet'],
+        scopes: ['solana:mainnet'] as const,
         options: {},
         methods: ['signMessage'],
         metadata: {
@@ -14081,22 +14024,22 @@ describe('RewardsController', () => {
       const mockSignatureBytes = new Uint8Array([1, 2, 3, 4]);
       mockSignSolanaRewardsMessage.mockResolvedValue({
         signature: 'solana-signature',
+        signedMessage: 'test-message',
+        signatureType: 'ed25519' as const,
       });
 
       // Mock base58 decode to return a predictable value
       jest.spyOn(base58, 'decode').mockReturnValue(mockSignatureBytes);
 
-      // Create a testable controller that exposes private methods
-      const testController = new TestableRewardsController({
+      // Create a controller instance
+      const testController = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
       });
-      // Act - directly call the exposed test method
-      const result = await testController.testSignRewardsMessage(
+      // Act - directly call signRewardsMessage
+      const result = await testController.signRewardsMessage(
         mockInternalAccount,
         mockTimestamp,
-        true,
-        true,
       );
 
       // Assert
@@ -14108,7 +14051,7 @@ describe('RewardsController', () => {
       ).toString('base64');
 
       expect(mockSignSolanaRewardsMessage).toHaveBeenCalledWith(
-        mockInternalAccount.address,
+        mockInternalAccount.id,
         expectedBase64Message,
       );
 
@@ -14117,13 +14060,323 @@ describe('RewardsController', () => {
       expect(result).toContain('0x');
     });
 
+    it('signs Bitcoin message correctly when Bitcoin account', async () => {
+      // Arrange
+      // Note: Bitcoin is always enabled, so no enabled/disabled check is needed.
+      const mockInternalAccount = {
+        address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+        type: 'bip122:p2wpkh' as const,
+        id: 'bitcoin-account-id',
+        scopes: ['bip122:000000000019d6689c085ae165831e93' as const],
+        options: {},
+        methods: ['signMessage'],
+        metadata: {
+          name: 'Bitcoin Account',
+          keyring: { type: 'Bitcoin Snap Keyring' },
+          importTime: Date.now(),
+        },
+      } as InternalAccount;
+
+      // Ensure the account is detected as Bitcoin
+      mockIsBtcAccount.mockReturnValue(true);
+      mockIsSolanaAddress.mockReturnValue(false);
+      mockIsNonEvmAddress.mockReturnValue(true);
+
+      // Mock the Bitcoin signature result
+      mockSignBitcoinRewardsMessage.mockResolvedValue({
+        signature: '0xabcdef123456',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      });
+
+      // Create RewardsController
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+      });
+
+      // Act - directly call signRewardsMessage
+      const result = await testController.signRewardsMessage(
+        mockInternalAccount,
+        mockTimestamp,
+      );
+
+      // Assert
+      // Verify the message was formatted correctly
+      const expectedMessage = `rewards,${mockInternalAccount.address},${mockTimestamp}`;
+      const expectedBase64Message = Buffer.from(
+        expectedMessage,
+        'utf8',
+      ).toString('base64');
+
+      expect(mockSignBitcoinRewardsMessage).toHaveBeenCalledWith(
+        mockInternalAccount.id,
+        expectedBase64Message,
+      );
+
+      // Verify the signature was returned correctly
+      expect(result).toBe('0xabcdef123456');
+    });
+
+    it('adds 0x prefix to Bitcoin signature when missing', async () => {
+      // Arrange
+      const mockInternalAccount = {
+        address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+        type: 'bip122:p2wpkh' as const,
+        id: 'bitcoin-account-id',
+        scopes: ['bip122:000000000019d6689c085ae165831e93' as const],
+        options: {},
+        methods: ['signMessage'],
+        metadata: {
+          name: 'Bitcoin Account',
+          keyring: { type: 'Bitcoin Snap Keyring' },
+          importTime: Date.now(),
+        },
+      } as InternalAccount;
+
+      // Ensure the account is detected as Bitcoin
+      mockIsBtcAccount.mockReturnValue(true);
+      mockIsSolanaAddress.mockReturnValue(false);
+      mockIsNonEvmAddress.mockReturnValue(true);
+
+      // Mock the Bitcoin signature result without 0x prefix
+      mockSignBitcoinRewardsMessage.mockResolvedValue({
+        signature: 'abcdef123456',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      });
+
+      // Create RewardsController
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+      });
+
+      // Act - directly call signRewardsMessage
+      const result = await testController.signRewardsMessage(
+        mockInternalAccount,
+        mockTimestamp,
+      );
+
+      // Assert
+      // Verify the signature was prefixed with 0x
+      expect(result).toBe('0xabcdef123456');
+      expect(mockSignBitcoinRewardsMessage).toHaveBeenCalled();
+    });
+
+    it('does not use Bitcoin signing for non-Bitcoin account', async () => {
+      // Arrange
+      const mockInternalAccount = {
+        address: '0x123',
+        type: 'eip155:eoa',
+        id: 'test-id',
+        scopes: ['eip155:1'],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'EVM Account',
+          keyring: { type: 'HD Key Tree' },
+          importTime: Date.now(),
+        },
+      } as InternalAccount;
+
+      // Ensure the account is not detected as Bitcoin
+      mockIsBtcAccount.mockReturnValue(false);
+      mockIsSolanaAddress.mockReturnValue(false);
+      mockIsNonEvmAddress.mockReturnValue(false);
+
+      // Mock the KeyringController:signPersonalMessage call
+      mockMessenger.call.mockResolvedValueOnce('0xsignature');
+
+      // Create RewardsController
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+      });
+
+      // Act - directly call signRewardsMessage
+      const result = await testController.signRewardsMessage(
+        mockInternalAccount,
+        mockTimestamp,
+      );
+
+      // Assert
+      expect(result).toBe('0xsignature');
+
+      // Verify Bitcoin signing was not called
+      expect(mockSignBitcoinRewardsMessage).not.toHaveBeenCalled();
+
+      // Verify EVM signing was called instead
+      const expectedMessage = `rewards,${mockInternalAccount.address},${mockTimestamp}`;
+      const expectedHexMessage =
+        '0x' + Buffer.from(expectedMessage, 'utf8').toString('hex');
+
+      expect(mockMessenger.call).toHaveBeenCalledWith(
+        'KeyringController:signPersonalMessage',
+        {
+          data: expectedHexMessage,
+          from: mockInternalAccount.address,
+        },
+      );
+    });
+
+    it('signs Tron message correctly when Tron account', async () => {
+      // Arrange
+      // Note: Tron is always enabled, so no enabled/disabled check is needed.
+      const mockInternalAccount = {
+        address: 'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+        type: 'tron:eoa' as const,
+        id: 'tron-account-id',
+        scopes: ['tron:728126428' as const],
+        options: {},
+        methods: ['signMessage'],
+        metadata: {
+          name: 'Tron Account',
+          keyring: { type: 'Tron Snap Keyring' },
+          importTime: Date.now(),
+        },
+      } as InternalAccount;
+
+      // Ensure the account is detected as Tron
+      mockIsTronAccount.mockReturnValue(true);
+      mockIsSolanaAddress.mockReturnValue(false);
+      mockIsBtcAccount.mockReturnValue(false);
+      mockIsNonEvmAddress.mockReturnValue(true);
+
+      // Mock the Tron signature result
+      mockSignTronRewardsMessage.mockResolvedValue({
+        signature: '0xabcdef123456',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      });
+
+      // Create RewardsController
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+      });
+
+      // Act - directly call signRewardsMessage
+      const result = await testController.signRewardsMessage(
+        mockInternalAccount,
+        mockTimestamp,
+      );
+
+      // Assert
+      // Verify the message was formatted correctly
+      const expectedMessage = `rewards,${mockInternalAccount.address},${mockTimestamp}`;
+      const expectedBase64Message = Buffer.from(
+        expectedMessage,
+        'utf8',
+      ).toString('base64');
+
+      expect(mockSignTronRewardsMessage).toHaveBeenCalledWith(
+        mockInternalAccount.id,
+        expectedBase64Message,
+      );
+
+      // Verify the signature was returned correctly
+      expect(result).toBe('0xabcdef123456');
+    });
+
+    it('adds 0x prefix to Tron signature when missing', async () => {
+      // Arrange
+      const mockInternalAccount = {
+        address: 'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+        type: 'tron:eoa' as const,
+        id: 'tron-account-id',
+        scopes: ['tron:728126428' as const],
+        options: {},
+        methods: ['signMessage'],
+        metadata: {
+          name: 'Tron Account',
+          keyring: { type: 'Tron Snap Keyring' },
+          importTime: Date.now(),
+        },
+      } as InternalAccount;
+
+      // Ensure the account is detected as Tron
+      mockIsTronAccount.mockReturnValue(true);
+      mockIsSolanaAddress.mockReturnValue(false);
+      mockIsBtcAccount.mockReturnValue(false);
+      mockIsNonEvmAddress.mockReturnValue(true);
+
+      // Mock the Tron signature result without 0x prefix
+      mockSignTronRewardsMessage.mockResolvedValue({
+        signature: 'abcdef123456',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      });
+
+      // Create RewardsController
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+      });
+
+      // Act - directly call signRewardsMessage
+      const result = await testController.signRewardsMessage(
+        mockInternalAccount,
+        mockTimestamp,
+      );
+
+      // Assert
+      // Verify the signature was prefixed with 0x
+      expect(result).toBe('0xabcdef123456');
+      expect(mockSignTronRewardsMessage).toHaveBeenCalled();
+    });
+
+    it('does not use Tron signing for non-Tron account', async () => {
+      // Arrange
+      const mockInternalAccount = {
+        address: '0x123',
+        type: 'eip155:eoa',
+        id: 'test-id',
+        scopes: ['eip155:1'],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'EVM Account',
+          keyring: { type: 'HD Key Tree' },
+          importTime: Date.now(),
+        },
+      } as InternalAccount;
+
+      // Ensure the account is not detected as Tron
+      mockIsTronAccount.mockReturnValue(false);
+      mockIsSolanaAddress.mockReturnValue(false);
+      mockIsBtcAccount.mockReturnValue(false);
+      mockIsNonEvmAddress.mockReturnValue(false);
+
+      // Mock the KeyringController:signPersonalMessage call
+      mockMessenger.call.mockResolvedValueOnce('0xsignature');
+
+      // Create RewardsController
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+      });
+
+      // Act - directly call signRewardsMessage
+      const result = await testController.signRewardsMessage(
+        mockInternalAccount,
+        mockTimestamp,
+      );
+
+      // Assert
+      expect(result).toBe('0xsignature');
+
+      // Verify Tron signing was not called
+      expect(mockSignTronRewardsMessage).not.toHaveBeenCalled();
+    });
+
     it('should throw error for unsupported account type', async () => {
       // Arrange
       const mockInternalAccount = {
         address: 'unsupported-address',
-        type: 'unknown:type',
+        type: 'any:account' as const,
         id: 'test-id',
-        scopes: ['unknown:chain'],
+        scopes: ['any:chain'] as const,
         options: {},
         methods: [],
         metadata: {
@@ -14133,21 +14386,21 @@ describe('RewardsController', () => {
         },
       } as InternalAccount;
 
-      // Create a TestableRewardsController to access the private method
-      const testController = new TestableRewardsController({
+      // Ensure account is not Solana, Bitcoin, or EVM
+      mockIsSolanaAddress.mockReturnValue(false);
+      mockIsBtcAccount.mockReturnValue(false);
+      mockIsNonEvmAddress.mockReturnValue(true);
+
+      // Create RewardsController
+      const testController = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
       });
 
-      // Act & Assert - directly call the exposed test method
+      // Act & Assert - directly call signRewardsMessage
       await expect(
-        testController.testSignRewardsMessage(
-          mockInternalAccount,
-          mockTimestamp,
-          true,
-          false,
-        ),
-      ).rejects.toThrow('Unsupported account type');
+        testController.signRewardsMessage(mockInternalAccount, mockTimestamp),
+      ).rejects.toThrow('Unsupported account type for signing rewards message');
     });
 
     it('should handle errors from KeyringController when signing EVM message', async () => {
@@ -14174,20 +14427,15 @@ describe('RewardsController', () => {
       const mockError = new Error('Signing failed');
       mockMessenger.call.mockRejectedValueOnce(mockError);
 
-      // Create a TestableRewardsController to access the private method
-      const testController = new TestableRewardsController({
+      // Create a RewardsController instance
+      const testController = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
       });
 
-      // Act & Assert - directly call the exposed test method
+      // Act & Assert - directly call signRewardsMessage
       await expect(
-        testController.testSignRewardsMessage(
-          mockInternalAccount,
-          mockTimestamp,
-          false,
-          false,
-        ),
+        testController.signRewardsMessage(mockInternalAccount, mockTimestamp),
       ).rejects.toThrow('Signing failed');
     });
   });
@@ -14533,6 +14781,8 @@ describe('RewardsController', () => {
       // Reset all mocks before each test
       mockIsHardwareAccount.mockClear();
       mockIsNonEvmAddress.mockClear();
+      mockIsBtcAccount.mockClear();
+      mockIsTronAccount.mockClear();
       mockIsSolanaAddress.mockClear();
       mockLogger.log.mockClear();
     });
@@ -14594,6 +14844,8 @@ describe('RewardsController', () => {
 
     it('should return true for Solana accounts that are not hardware', () => {
       // Arrange
+      // Note: Hardware wallets are not supported for Solana (or any non-EVM chains).
+      // Only non-hardware Solana accounts can opt-in to rewards.
       const solanaAccount = {
         address: 'So11111111111111111111111111111111111111112',
         type: 'solana:data-account' as const,
@@ -14628,9 +14880,12 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return false for non-EVM accounts that are not Solana', () => {
+    it('returns true for Bitcoin accounts that are not hardware', () => {
       // Arrange
-      const nonEvmNonSolanaAccount = {
+      // Note: Hardware wallets are not supported for Bitcoin (or any non-EVM chains).
+      // Only non-hardware Bitcoin accounts can opt-in to rewards.
+      // Bitcoin is always enabled, so no enabled/disabled check is needed.
+      const bitcoinAccount = {
         address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
         type: 'bip122:p2wpkh' as const,
         id: 'bitcoin-account',
@@ -14647,12 +14902,13 @@ describe('RewardsController', () => {
       mockIsHardwareAccount.mockReturnValue(false);
       mockIsNonEvmAddress.mockReturnValue(true); // Is non-EVM
       mockIsSolanaAddress.mockReturnValue(false); // Not Solana
+      mockIsBtcAccount.mockReturnValue(true); // Is Bitcoin
 
       // Act
-      const result = controller.isOptInSupported(nonEvmNonSolanaAccount);
+      const result = controller.isOptInSupported(bitcoinAccount);
 
       // Assert
-      expect(result).toBe(false);
+      expect(result).toBe(true);
       expect(mockIsHardwareAccount).toHaveBeenCalledWith(
         'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
       );
@@ -14661,6 +14917,130 @@ describe('RewardsController', () => {
       );
       expect(mockIsSolanaAddress).toHaveBeenCalledWith(
         'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      );
+      expect(mockIsBtcAccount).toHaveBeenCalledWith(bitcoinAccount);
+    });
+
+    it('returns false for non-Bitcoin accounts', () => {
+      // Arrange
+      const nonBitcoinAccount = {
+        address: 'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+        type: 'tron:eoa' as const,
+        id: 'tron-account',
+        options: {},
+        metadata: {
+          name: 'Tron Account',
+          importTime: Date.now(),
+          keyring: { type: 'Tron Snap Keyring' },
+        },
+        scopes: ['tron:mainnet' as const],
+        methods: [],
+      };
+
+      mockIsHardwareAccount.mockReturnValue(false);
+      mockIsNonEvmAddress.mockReturnValue(true); // Is non-EVM
+      mockIsSolanaAddress.mockReturnValue(false); // Not Solana
+      mockIsBtcAccount.mockReturnValue(false); // Not Bitcoin
+
+      // Act
+      const result = controller.isOptInSupported(nonBitcoinAccount);
+
+      // Assert
+      expect(result).toBe(false);
+      expect(mockIsHardwareAccount).toHaveBeenCalledWith(
+        'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+      );
+      expect(mockIsNonEvmAddress).toHaveBeenCalledWith(
+        'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+      );
+      expect(mockIsSolanaAddress).toHaveBeenCalledWith(
+        'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+      );
+      expect(mockIsBtcAccount).toHaveBeenCalledWith(nonBitcoinAccount);
+    });
+
+    it('returns true for Tron accounts that are not hardware', () => {
+      // Arrange
+      // Note: Hardware wallets are not supported for Tron (or any non-EVM chains).
+      // Only non-hardware Tron accounts can opt-in to rewards.
+      // Tron is always enabled, so no enabled/disabled check is needed.
+      const tronAccount = {
+        address: 'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+        type: 'tron:eoa' as const,
+        id: 'tron-account',
+        options: {},
+        metadata: {
+          name: 'Tron Account',
+          importTime: Date.now(),
+          keyring: { type: 'Tron Snap Keyring' },
+        },
+        scopes: ['tron:728126428' as const],
+        methods: [],
+      };
+
+      mockIsHardwareAccount.mockReturnValue(false);
+      mockIsNonEvmAddress.mockReturnValue(true); // Is non-EVM
+      mockIsSolanaAddress.mockReturnValue(false); // Not Solana
+      mockIsBtcAccount.mockReturnValue(false); // Not Bitcoin
+      mockIsTronAccount.mockReturnValue(true); // Is Tron
+
+      // Act
+      const result = controller.isOptInSupported(tronAccount);
+
+      // Assert
+      expect(result).toBe(true);
+      expect(mockIsHardwareAccount).toHaveBeenCalledWith(
+        'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+      );
+      expect(mockIsNonEvmAddress).toHaveBeenCalledWith(
+        'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+      );
+      expect(mockIsSolanaAddress).toHaveBeenCalledWith(
+        'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+      );
+      expect(mockIsBtcAccount).toHaveBeenCalledWith(tronAccount);
+      expect(mockIsTronAccount).toHaveBeenCalledWith(tronAccount);
+    });
+
+    it('returns false for non-EVM accounts that are not Solana or Bitcoin', () => {
+      // Arrange
+      const nonEvmNonSolanaNonBitcoinAccount = {
+        address: 'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+        type: 'tron:eoa' as const,
+        id: 'tron-account',
+        options: {},
+        metadata: {
+          name: 'Tron Account',
+          importTime: Date.now(),
+          keyring: { type: 'Tron Snap Keyring' },
+        },
+        scopes: ['tron:mainnet' as const],
+        methods: [],
+      };
+
+      mockIsHardwareAccount.mockReturnValue(false);
+      mockIsNonEvmAddress.mockReturnValue(true); // Is non-EVM
+      mockIsSolanaAddress.mockReturnValue(false); // Not Solana
+      mockIsBtcAccount.mockReturnValue(false); // Not Bitcoin
+
+      // Act
+      const result = controller.isOptInSupported(
+        nonEvmNonSolanaNonBitcoinAccount,
+      );
+
+      // Assert
+      expect(result).toBe(false);
+      expect(mockIsHardwareAccount).toHaveBeenCalledWith(
+        'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+      );
+      expect(mockIsNonEvmAddress).toHaveBeenCalledWith(
+        'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+      );
+      expect(mockIsSolanaAddress).toHaveBeenCalledWith(
+        'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+      );
+      expect(mockIsBtcAccount).toHaveBeenCalledWith(
+        nonEvmNonSolanaNonBitcoinAccount,
       );
     });
 
@@ -14734,6 +15114,8 @@ describe('RewardsController', () => {
 
     it('should prioritize hardware check over other checks', () => {
       // Arrange - Hardware account that would otherwise be supported
+      // Note: Hardware wallets only support EVM chains. Non-EVM chains (Bitcoin, Solana, Tron)
+      // are not supported by hardware wallets and use Snap-based implementations instead.
       const hardwareEvmAccount = {
         address: '0x123',
         type: 'eip155:eoa' as const,
@@ -14751,6 +15133,7 @@ describe('RewardsController', () => {
       mockIsHardwareAccount.mockReturnValue(true); // Is hardware
       mockIsNonEvmAddress.mockReturnValue(false); // Would be EVM (supported)
       mockIsSolanaAddress.mockReturnValue(false);
+      mockIsBtcAccount.mockReturnValue(false);
 
       // Act
       const result = controller.isOptInSupported(hardwareEvmAccount);
@@ -14758,9 +15141,44 @@ describe('RewardsController', () => {
       // Assert
       expect(result).toBe(false); // Should return false due to hardware check
       expect(mockIsHardwareAccount).toHaveBeenCalledWith('0x123');
-      // Non-EVM and Solana checks should not be called since hardware check failed
+      // Non-EVM, Solana, and Bitcoin checks should not be called since hardware check failed
       expect(mockIsNonEvmAddress).not.toHaveBeenCalled();
       expect(mockIsSolanaAddress).not.toHaveBeenCalled();
+      expect(mockIsBtcAccount).not.toHaveBeenCalled();
+    });
+
+    it('should return false for hardware accounts regardless of chain type', () => {
+      // Arrange
+      // Note: Hardware wallets (Ledger, QR-based) only support EVM chains.
+      // Non-EVM chains (Bitcoin, Solana, Tron) are not supported by hardware wallets.
+      // This test documents that even if a hardware account were somehow associated with
+      // a non-EVM address (which cannot occur in practice), it would still return false.
+      const hardwareAccount = {
+        address: '0x123',
+        type: 'eip155:eoa' as const,
+        id: 'hardware-account',
+        options: {},
+        metadata: {
+          name: 'Hardware Account',
+          importTime: Date.now(),
+          keyring: { type: 'Ledger Hardware' },
+        },
+        scopes: ['eip155:1' as const],
+        methods: [],
+      };
+
+      mockIsHardwareAccount.mockReturnValue(true); // Is hardware
+
+      // Act
+      const result = controller.isOptInSupported(hardwareAccount);
+
+      // Assert
+      expect(result).toBe(false); // Hardware accounts always return false
+      expect(mockIsHardwareAccount).toHaveBeenCalledWith('0x123');
+      // Other checks should not be called since hardware check returns false immediately
+      expect(mockIsNonEvmAddress).not.toHaveBeenCalled();
+      expect(mockIsSolanaAddress).not.toHaveBeenCalled();
+      expect(mockIsBtcAccount).not.toHaveBeenCalled();
     });
   });
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -14880,11 +14880,16 @@ describe('RewardsController', () => {
       );
     });
 
-    it('returns true for Bitcoin accounts that are not hardware', () => {
+    it('returns true for Bitcoin accounts when feature flag is enabled', () => {
       // Arrange
       // Note: Hardware wallets are not supported for Bitcoin (or any non-EVM chains).
-      // Only non-hardware Bitcoin accounts can opt-in to rewards.
-      // Bitcoin is always enabled, so no enabled/disabled check is needed.
+      // Only non-hardware Bitcoin accounts can opt-in to rewards when the feature flag is enabled.
+      const bitcoinController = new RewardsController({
+        messenger: mockMessenger,
+        isDisabled: () => false,
+        isBitcoinOptinEnabled: () => true,
+      });
+
       const bitcoinAccount = {
         address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
         type: 'bip122:p2wpkh' as const,
@@ -14905,7 +14910,7 @@ describe('RewardsController', () => {
       mockIsBtcAccount.mockReturnValue(true); // Is Bitcoin
 
       // Act
-      const result = controller.isOptInSupported(bitcoinAccount);
+      const result = bitcoinController.isOptInSupported(bitcoinAccount);
 
       // Assert
       expect(result).toBe(true);
@@ -14918,6 +14923,42 @@ describe('RewardsController', () => {
       expect(mockIsSolanaAddress).toHaveBeenCalledWith(
         'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
       );
+      expect(mockIsBtcAccount).toHaveBeenCalledWith(bitcoinAccount);
+    });
+
+    it('returns false for Bitcoin accounts when feature flag is disabled', () => {
+      // Arrange
+      // Bitcoin opt-in is gated behind a feature flag - when disabled, opt-in is not supported.
+      const bitcoinController = new RewardsController({
+        messenger: mockMessenger,
+        isDisabled: () => false,
+        isBitcoinOptinEnabled: () => false,
+      });
+
+      const bitcoinAccount = {
+        address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+        type: 'bip122:p2wpkh' as const,
+        id: 'bitcoin-account',
+        options: {},
+        metadata: {
+          name: 'Bitcoin Account',
+          importTime: Date.now(),
+          keyring: { type: 'Bitcoin Snap Keyring' },
+        },
+        scopes: ['bip122:000000000019d6689c085ae165831e93' as const],
+        methods: [],
+      };
+
+      mockIsHardwareAccount.mockReturnValue(false);
+      mockIsNonEvmAddress.mockReturnValue(true); // Is non-EVM
+      mockIsSolanaAddress.mockReturnValue(false); // Not Solana
+      mockIsBtcAccount.mockReturnValue(true); // Is Bitcoin
+
+      // Act
+      const result = bitcoinController.isOptInSupported(bitcoinAccount);
+
+      // Assert
+      expect(result).toBe(false);
       expect(mockIsBtcAccount).toHaveBeenCalledWith(bitcoinAccount);
     });
 
@@ -14959,11 +15000,16 @@ describe('RewardsController', () => {
       expect(mockIsBtcAccount).toHaveBeenCalledWith(nonBitcoinAccount);
     });
 
-    it('returns true for Tron accounts that are not hardware', () => {
+    it('returns true for Tron accounts when feature flag is enabled', () => {
       // Arrange
       // Note: Hardware wallets are not supported for Tron (or any non-EVM chains).
-      // Only non-hardware Tron accounts can opt-in to rewards.
-      // Tron is always enabled, so no enabled/disabled check is needed.
+      // Only non-hardware Tron accounts can opt-in to rewards when the feature flag is enabled.
+      const tronController = new RewardsController({
+        messenger: mockMessenger,
+        isDisabled: () => false,
+        isTronOptinEnabled: () => true,
+      });
+
       const tronAccount = {
         address: 'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
         type: 'tron:eoa' as const,
@@ -14985,7 +15031,7 @@ describe('RewardsController', () => {
       mockIsTronAccount.mockReturnValue(true); // Is Tron
 
       // Act
-      const result = controller.isOptInSupported(tronAccount);
+      const result = tronController.isOptInSupported(tronAccount);
 
       // Assert
       expect(result).toBe(true);
@@ -14999,6 +15045,43 @@ describe('RewardsController', () => {
         'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
       );
       expect(mockIsBtcAccount).toHaveBeenCalledWith(tronAccount);
+      expect(mockIsTronAccount).toHaveBeenCalledWith(tronAccount);
+    });
+
+    it('returns false for Tron accounts when feature flag is disabled', () => {
+      // Arrange
+      // Tron opt-in is gated behind a feature flag - when disabled, opt-in is not supported.
+      const tronController = new RewardsController({
+        messenger: mockMessenger,
+        isDisabled: () => false,
+        isTronOptinEnabled: () => false,
+      });
+
+      const tronAccount = {
+        address: 'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7',
+        type: 'tron:eoa' as const,
+        id: 'tron-account',
+        options: {},
+        metadata: {
+          name: 'Tron Account',
+          importTime: Date.now(),
+          keyring: { type: 'Tron Snap Keyring' },
+        },
+        scopes: ['tron:728126428' as const],
+        methods: [],
+      };
+
+      mockIsHardwareAccount.mockReturnValue(false);
+      mockIsNonEvmAddress.mockReturnValue(true); // Is non-EVM
+      mockIsSolanaAddress.mockReturnValue(false); // Not Solana
+      mockIsBtcAccount.mockReturnValue(false); // Not Bitcoin
+      mockIsTronAccount.mockReturnValue(true); // Is Tron
+
+      // Act
+      const result = tronController.isOptInSupported(tronAccount);
+
+      // Assert
+      expect(result).toBe(false);
       expect(mockIsTronAccount).toHaveBeenCalledWith(tronAccount);
     });
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -259,6 +259,8 @@ export class RewardsController extends BaseController<
 > {
   #geoLocation: GeoRewardsMetadata | null = null;
   #isDisabled: () => boolean;
+  #isBitcoinOptinEnabled: () => boolean;
+  #isTronOptinEnabled: () => boolean;
 
   /**
    * Calculate tier status and next tier information
@@ -401,10 +403,14 @@ export class RewardsController extends BaseController<
     messenger,
     state,
     isDisabled,
+    isBitcoinOptinEnabled,
+    isTronOptinEnabled,
   }: {
     messenger: RewardsControllerMessenger;
     state?: Partial<RewardsControllerState>;
     isDisabled?: () => boolean;
+    isBitcoinOptinEnabled?: () => boolean;
+    isTronOptinEnabled?: () => boolean;
   }) {
     super({
       name: controllerName,
@@ -417,6 +423,8 @@ export class RewardsController extends BaseController<
     });
 
     this.#isDisabled = isDisabled ?? (() => false);
+    this.#isBitcoinOptinEnabled = isBitcoinOptinEnabled ?? (() => false);
+    this.#isTronOptinEnabled = isTronOptinEnabled ?? (() => false);
 
     this.#registerActionHandlers();
     this.#initializeEventSubscriptions();
@@ -822,14 +830,14 @@ export class RewardsController extends BaseController<
         return true;
       }
 
-      // Check if it's a Bitcoin account
+      // Check if it's a Bitcoin account (gated by feature flag)
       if (isBtcAccount(account)) {
-        return true;
+        return this.#isBitcoinOptinEnabled();
       }
 
-      // Check if it's a Tron account
+      // Check if it's a Tron account (gated by feature flag)
       if (isTronAccount(account)) {
-        return true;
+        return this.#isTronOptinEnabled();
       }
 
       // If it's neither Solana, Bitcoin, Tron, nor EVM, opt-in is not supported

--- a/app/core/Engine/controllers/rewards-controller/index.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/index.test.ts
@@ -9,17 +9,34 @@ import {
 import { rewardsControllerInit } from '.';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+import {
+  selectBitcoinRewardsEnabledFlag,
+  selectTronRewardsEnabledFlag,
+} from '../../../../selectors/featureFlagController/rewards/rewardsEnabled';
 import { isVersionGatedFeatureFlag } from '../../../../util/remoteFeatureFlag';
 import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 
 jest.mock('./RewardsController');
 jest.mock('../../../../selectors/settings');
+jest.mock(
+  '../../../../selectors/featureFlagController/rewards/rewardsEnabled',
+  () => ({
+    selectBitcoinRewardsEnabledFlag: jest.fn(),
+    selectTronRewardsEnabledFlag: jest.fn(),
+  }),
+);
 jest.mock('../../../../util/remoteFeatureFlag');
 
 describe('rewardsControllerInit', () => {
   const rewardsControllerClassMock = jest.mocked(RewardsController);
   const selectBasicFunctionalityEnabledMock = jest.mocked(
     selectBasicFunctionalityEnabled,
+  );
+  const selectBitcoinRewardsEnabledFlagMock = jest.mocked(
+    selectBitcoinRewardsEnabledFlag,
+  );
+  const selectTronRewardsEnabledFlagMock = jest.mocked(
+    selectTronRewardsEnabledFlag,
   );
   const isVersionGatedFeatureFlagMock = jest.mocked(isVersionGatedFeatureFlag);
 
@@ -72,6 +89,8 @@ describe('rewardsControllerInit', () => {
 
     // Default mock return values
     selectBasicFunctionalityEnabledMock.mockReturnValue(true);
+    selectBitcoinRewardsEnabledFlagMock.mockReturnValue(false);
+    selectTronRewardsEnabledFlagMock.mockReturnValue(false);
     isVersionGatedFeatureFlagMock.mockReturnValue(false);
   });
 
@@ -133,6 +152,60 @@ describe('rewardsControllerInit', () => {
       const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
       const isDisabledFn = constructorArgs.isDisabled as () => boolean;
       expect(isDisabledFn()).toBe(true);
+    });
+  });
+
+  describe('isBitcoinOptinEnabled function', () => {
+    it('returns true when bitcoin rewards flag is enabled', () => {
+      selectBitcoinRewardsEnabledFlagMock.mockReturnValue(true);
+
+      rewardsControllerInit(initRequestMock);
+
+      const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
+      const isBitcoinOptinEnabledFn =
+        constructorArgs.isBitcoinOptinEnabled as () => boolean;
+      expect(isBitcoinOptinEnabledFn()).toBe(true);
+      expect(selectBitcoinRewardsEnabledFlagMock).toHaveBeenCalledWith(
+        initRequestMock.getState(),
+      );
+    });
+
+    it('returns false when bitcoin rewards flag is disabled', () => {
+      selectBitcoinRewardsEnabledFlagMock.mockReturnValue(false);
+
+      rewardsControllerInit(initRequestMock);
+
+      const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
+      const isBitcoinOptinEnabledFn =
+        constructorArgs.isBitcoinOptinEnabled as () => boolean;
+      expect(isBitcoinOptinEnabledFn()).toBe(false);
+    });
+  });
+
+  describe('isTronOptinEnabled function', () => {
+    it('returns true when tron rewards flag is enabled', () => {
+      selectTronRewardsEnabledFlagMock.mockReturnValue(true);
+
+      rewardsControllerInit(initRequestMock);
+
+      const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
+      const isTronOptinEnabledFn =
+        constructorArgs.isTronOptinEnabled as () => boolean;
+      expect(isTronOptinEnabledFn()).toBe(true);
+      expect(selectTronRewardsEnabledFlagMock).toHaveBeenCalledWith(
+        initRequestMock.getState(),
+      );
+    });
+
+    it('returns false when tron rewards flag is disabled', () => {
+      selectTronRewardsEnabledFlagMock.mockReturnValue(false);
+
+      rewardsControllerInit(initRequestMock);
+
+      const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
+      const isTronOptinEnabledFn =
+        constructorArgs.isTronOptinEnabled as () => boolean;
+      expect(isTronOptinEnabledFn()).toBe(false);
     });
   });
 });

--- a/app/core/Engine/controllers/rewards-controller/index.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/index.test.ts
@@ -1,102 +1,138 @@
+import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import { ControllerInitRequest, getRootExtendedMessenger } from '../../types';
+import { ControllerInitRequest } from '../../types';
 import {
   RewardsController,
   RewardsControllerMessenger,
   defaultRewardsControllerState,
 } from './RewardsController';
 import { rewardsControllerInit } from '.';
-
-jest.mock('./RewardsController', () => {
-  const actualRewardsController = jest.requireActual('./RewardsController');
-
-  return {
-    ...actualRewardsController,
-    RewardsController: jest.fn(),
-  };
-});
-
-jest.mock('../../../../selectors/settings', () => ({
-  selectBasicFunctionalityEnabled: jest.fn(),
-}));
-
+import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+import { isVersionGatedFeatureFlag } from '../../../../util/remoteFeatureFlag';
+import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
+
+jest.mock('./RewardsController');
+jest.mock('../../../../selectors/settings');
+jest.mock('../../../../util/remoteFeatureFlag');
 
 describe('rewardsControllerInit', () => {
   const rewardsControllerClassMock = jest.mocked(RewardsController);
   const selectBasicFunctionalityEnabledMock = jest.mocked(
     selectBasicFunctionalityEnabled,
   );
+  const isVersionGatedFeatureFlagMock = jest.mocked(isVersionGatedFeatureFlag);
+
   let initRequestMock: jest.Mocked<
     ControllerInitRequest<RewardsControllerMessenger>
   >;
+  let mockControllerInstance: jest.Mocked<RewardsController>;
+  let mockControllerMessenger: jest.Mocked<RewardsControllerMessenger>;
+  let mockRemoteFeatureFlagState: Partial<RemoteFeatureFlagControllerState>;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    const baseControllerMessenger = getRootExtendedMessenger();
+
+    // Create mock controller instance
+    mockControllerInstance = {
+      // Add any methods that might be called during initialization
+    } as unknown as jest.Mocked<RewardsController>;
+
+    // Initialize default remote feature flag state
+    mockRemoteFeatureFlagState = {
+      remoteFeatureFlags: {},
+    };
+
+    // Create mock controller messenger with proper implementation
+    mockControllerMessenger = {
+      call: jest.fn().mockImplementation((...args: unknown[]) => {
+        const action = args[0] as string;
+        if (action === 'RemoteFeatureFlagController:getState') {
+          return mockRemoteFeatureFlagState;
+        }
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<RewardsControllerMessenger>;
+
+    // Setup base messenger
+    const baseControllerMessenger = new ExtendedMessenger<MockAnyNamespace>({
+      namespace: MOCK_ANY_NAMESPACE,
+    });
+
     // Create controller init request mock
-    initRequestMock = buildControllerInitRequestMock(baseControllerMessenger);
-  });
-
-  it('returns controller instance', () => {
-    expect(rewardsControllerInit(initRequestMock).controller).toBeInstanceOf(
-      RewardsController,
-    );
-  });
-
-  it('controller state should be default state when no initial state is passed in', () => {
-    const actualDefaultState = jest.requireActual(
-      './RewardsController',
-    ).defaultRewardsControllerState;
-
-    rewardsControllerInit(initRequestMock);
-
-    const rewardsControllerState =
-      rewardsControllerClassMock.mock.calls[0][0].state;
-
-    expect(rewardsControllerState).toEqual(actualDefaultState);
-  });
-
-  it('controller state should be initial state when initial state is passed in', () => {
-    const initialRewardsControllerState = {
-      ...defaultRewardsControllerState,
-      isLoggedIn: true,
+    initRequestMock = {
+      ...buildControllerInitRequestMock(baseControllerMessenger),
+      controllerMessenger:
+        mockControllerMessenger as unknown as RewardsControllerMessenger,
+      persistedState: {},
     };
 
-    initRequestMock.persistedState = {
-      ...initRequestMock.persistedState,
-      RewardsController: initialRewardsControllerState,
-    };
+    // Mock RewardsController constructor
+    rewardsControllerClassMock.mockImplementation(() => mockControllerInstance);
 
-    rewardsControllerInit(initRequestMock);
-
-    const rewardsControllerState =
-      rewardsControllerClassMock.mock.calls[0][0].state;
-
-    expect(rewardsControllerState).toStrictEqual(initialRewardsControllerState);
+    // Default mock return values
+    selectBasicFunctionalityEnabledMock.mockReturnValue(true);
+    isVersionGatedFeatureFlagMock.mockReturnValue(false);
   });
 
-  describe('isDisabled callback', () => {
-    it('should return true when basicFunctionalityEnabled is false', () => {
-      selectBasicFunctionalityEnabledMock.mockReturnValue(false);
+  describe('basic initialization', () => {
+    it('returns controller instance', () => {
+      const result = rewardsControllerInit(initRequestMock);
+      expect(result.controller).toBe(mockControllerInstance);
+    });
+
+    it('creates RewardsController with correct messenger', () => {
+      rewardsControllerInit(initRequestMock);
+
+      expect(rewardsControllerClassMock).toHaveBeenCalledTimes(1);
+      const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
+      expect(constructorArgs.messenger).toBe(mockControllerMessenger);
+    });
+
+    it('uses default state when persisted state is not provided', () => {
+      initRequestMock.persistedState = {};
 
       rewardsControllerInit(initRequestMock);
 
-      const isDisabledCallback =
-        rewardsControllerClassMock.mock.calls[0][0].isDisabled;
-
-      expect(isDisabledCallback?.()).toBe(true);
+      const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
+      expect(constructorArgs.state).toBe(defaultRewardsControllerState);
     });
 
-    it('should return false when basicFunctionalityEnabled is true', () => {
+    it('uses persisted state when provided', () => {
+      const persistedState = defaultRewardsControllerState;
+      initRequestMock.persistedState = {
+        RewardsController: persistedState,
+      };
+
+      rewardsControllerInit(initRequestMock);
+
+      const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
+      expect(constructorArgs.state).toBe(persistedState);
+    });
+  });
+
+  describe('isDisabled function', () => {
+    it('returns false when basic functionality is enabled', () => {
       selectBasicFunctionalityEnabledMock.mockReturnValue(true);
 
       rewardsControllerInit(initRequestMock);
 
-      const isDisabledCallback =
-        rewardsControllerClassMock.mock.calls[0][0].isDisabled;
+      const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
+      const isDisabledFn = constructorArgs.isDisabled as () => boolean;
+      expect(isDisabledFn()).toBe(false);
+      expect(selectBasicFunctionalityEnabledMock).toHaveBeenCalledWith(
+        initRequestMock.getState(),
+      );
+    });
 
-      expect(isDisabledCallback?.()).toBe(false);
+    it('returns true when basic functionality is disabled', () => {
+      selectBasicFunctionalityEnabledMock.mockReturnValue(false);
+
+      rewardsControllerInit(initRequestMock);
+
+      const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
+      const isDisabledFn = constructorArgs.isDisabled as () => boolean;
+      expect(isDisabledFn()).toBe(true);
     });
   });
 });

--- a/app/core/Engine/controllers/rewards-controller/index.ts
+++ b/app/core/Engine/controllers/rewards-controller/index.ts
@@ -1,4 +1,8 @@
 import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+import {
+  selectBitcoinRewardsEnabledFlag,
+  selectTronRewardsEnabledFlag,
+} from '../../../../selectors/featureFlagController/rewards/rewardsEnabled';
 import type { ControllerInitFunction } from '../../types';
 import {
   RewardsController,
@@ -27,6 +31,8 @@ export const rewardsControllerInit: ControllerInitFunction<
       const isEnabled = selectBasicFunctionalityEnabled(getState());
       return !isEnabled;
     },
+    isBitcoinOptinEnabled: () => selectBitcoinRewardsEnabledFlag(getState()),
+    isTronOptinEnabled: () => selectTronRewardsEnabledFlag(getState()),
   });
 
   return { controller };

--- a/app/core/Engine/controllers/rewards-controller/utils/bitcoin-snap.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/utils/bitcoin-snap.test.ts
@@ -1,0 +1,163 @@
+import { HandlerType } from '@metamask/snaps-utils';
+import { signBitcoinRewardsMessage } from './bitcoin-snap';
+import { handleSnapRequest } from '../../../../Snaps/utils';
+import { BITCOIN_WALLET_SNAP_ID } from '../../../../SnapKeyring/BitcoinWalletSnap';
+import Engine from '../../../../Engine';
+import Logger from '../../../../../util/Logger';
+
+jest.mock('../../../../Snaps/utils', () => ({
+  handleSnapRequest: jest.fn(),
+}));
+
+jest.mock('../../../../Engine', () => ({
+  controllerMessenger: {},
+}));
+
+jest.mock('../../../../../util/Logger', () => ({
+  log: jest.fn(),
+}));
+
+describe('bitcoin-snap', () => {
+  const mockAccountId = 'bitcoin-account-id';
+  const mockMessage = 'base64-encoded-message';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('signBitcoinRewardsMessage', () => {
+    it('successfully signs a Bitcoin rewards message', async () => {
+      const mockResult = {
+        signature: '0xabcdef123456',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await signBitcoinRewardsMessage(
+        mockAccountId,
+        mockMessage,
+      );
+
+      expect(handleSnapRequest).toHaveBeenCalledWith(
+        Engine.controllerMessenger,
+        {
+          origin: 'metamask',
+          snapId: BITCOIN_WALLET_SNAP_ID,
+          handler: HandlerType.OnClientRequest,
+          request: {
+            jsonrpc: '2.0',
+            id: expect.any(Number),
+            method: 'signRewardsMessage',
+            params: {
+              accountId: mockAccountId,
+              message: mockMessage,
+            },
+          },
+        },
+      );
+
+      expect(result).toEqual(mockResult);
+    });
+
+    it('handles errors when signing fails', async () => {
+      const mockError = new Error('Signing failed');
+      (handleSnapRequest as jest.Mock).mockRejectedValue(mockError);
+
+      await expect(
+        signBitcoinRewardsMessage(mockAccountId, mockMessage),
+      ).rejects.toThrow('Signing failed');
+
+      expect(Logger.log).toHaveBeenCalledWith(
+        'Error signing Bitcoin rewards message:',
+        mockError,
+      );
+    });
+
+    it('handles errors from handleSnapRequest', async () => {
+      const mockError = new Error('Snap request failed');
+      (handleSnapRequest as jest.Mock).mockRejectedValue(mockError);
+
+      await expect(
+        signBitcoinRewardsMessage(mockAccountId, mockMessage),
+      ).rejects.toThrow('Snap request failed');
+
+      expect(Logger.log).toHaveBeenCalledWith(
+        'Error signing Bitcoin rewards message:',
+        mockError,
+      );
+    });
+
+    it('uses correct snap ID', async () => {
+      const mockResult = {
+        signature: '0x123',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      await signBitcoinRewardsMessage(mockAccountId, mockMessage);
+
+      expect(handleSnapRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          snapId: BITCOIN_WALLET_SNAP_ID,
+        }),
+      );
+    });
+
+    it('passes correct accountId and message', async () => {
+      const mockResult = {
+        signature: '0x123',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      await signBitcoinRewardsMessage(mockAccountId, mockMessage);
+
+      expect(handleSnapRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          request: expect.objectContaining({
+            params: {
+              accountId: mockAccountId,
+              message: mockMessage,
+            },
+          }),
+        }),
+      );
+    });
+
+    it('handles empty accountId', async () => {
+      const mockResult = {
+        signature: '0x123',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await signBitcoinRewardsMessage('', mockMessage);
+
+      expect(result).toEqual(mockResult);
+    });
+
+    it('handles empty message', async () => {
+      const mockResult = {
+        signature: '0x123',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await signBitcoinRewardsMessage(mockAccountId, '');
+
+      expect(result).toEqual(mockResult);
+    });
+  });
+});

--- a/app/core/Engine/controllers/rewards-controller/utils/bitcoin-snap.ts
+++ b/app/core/Engine/controllers/rewards-controller/utils/bitcoin-snap.ts
@@ -1,0 +1,38 @@
+import { handleSnapRequest } from '../../../../Snaps/utils';
+import Engine from '../../../../Engine';
+import { BITCOIN_WALLET_SNAP_ID } from '../../../../SnapKeyring/BitcoinWalletSnap';
+import { HandlerType } from '@metamask/snaps-utils';
+import Logger from '../../../../../util/Logger';
+
+export interface SignRewardsMessageResult {
+  signature: string;
+  signedMessage: string;
+  signatureType: 'ecdsa';
+}
+
+export async function signBitcoinRewardsMessage(
+  accountId: string,
+  message: string,
+): Promise<SignRewardsMessageResult> {
+  try {
+    const result = await handleSnapRequest(Engine.controllerMessenger, {
+      origin: 'metamask',
+      snapId: BITCOIN_WALLET_SNAP_ID,
+      handler: HandlerType.OnClientRequest,
+      request: {
+        jsonrpc: '2.0',
+        id: Date.now(),
+        method: 'signRewardsMessage',
+        params: {
+          accountId,
+          message,
+        },
+      },
+    });
+
+    return result as SignRewardsMessageResult;
+  } catch (error) {
+    Logger.log('Error signing Bitcoin rewards message:', error);
+    throw error;
+  }
+}

--- a/app/core/Engine/controllers/rewards-controller/utils/tron-snap.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/utils/tron-snap.test.ts
@@ -1,0 +1,160 @@
+import { HandlerType } from '@metamask/snaps-utils';
+import { signTronRewardsMessage } from './tron-snap';
+import { handleSnapRequest } from '../../../../Snaps/utils';
+import { TRON_WALLET_SNAP_ID } from '../../../../SnapKeyring/TronWalletSnap';
+import Engine from '../../../../Engine';
+import Logger from '../../../../../util/Logger';
+
+jest.mock('../../../../Snaps/utils', () => ({
+  handleSnapRequest: jest.fn(),
+}));
+
+jest.mock('../../../../Engine', () => ({
+  controllerMessenger: {},
+}));
+
+jest.mock('../../../../../util/Logger', () => ({
+  log: jest.fn(),
+}));
+
+describe('tron-snap', () => {
+  const mockAccountId = 'tron-account-id';
+  const mockMessage = 'base64-encoded-message';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('signTronRewardsMessage', () => {
+    it('successfully signs a Tron rewards message', async () => {
+      const mockResult = {
+        signature: '0xabcdef123456',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await signTronRewardsMessage(mockAccountId, mockMessage);
+
+      expect(handleSnapRequest).toHaveBeenCalledWith(
+        Engine.controllerMessenger,
+        {
+          origin: 'metamask',
+          snapId: TRON_WALLET_SNAP_ID,
+          handler: HandlerType.OnClientRequest,
+          request: {
+            jsonrpc: '2.0',
+            id: expect.any(Number),
+            method: 'signRewardsMessage',
+            params: {
+              accountId: mockAccountId,
+              message: mockMessage,
+            },
+          },
+        },
+      );
+
+      expect(result).toEqual(mockResult);
+    });
+
+    it('handles errors when signing fails', async () => {
+      const mockError = new Error('Signing failed');
+      (handleSnapRequest as jest.Mock).mockRejectedValue(mockError);
+
+      await expect(
+        signTronRewardsMessage(mockAccountId, mockMessage),
+      ).rejects.toThrow('Signing failed');
+
+      expect(Logger.log).toHaveBeenCalledWith(
+        'Error signing Tron rewards message:',
+        mockError,
+      );
+    });
+
+    it('handles errors from handleSnapRequest', async () => {
+      const mockError = new Error('Snap request failed');
+      (handleSnapRequest as jest.Mock).mockRejectedValue(mockError);
+
+      await expect(
+        signTronRewardsMessage(mockAccountId, mockMessage),
+      ).rejects.toThrow('Snap request failed');
+
+      expect(Logger.log).toHaveBeenCalledWith(
+        'Error signing Tron rewards message:',
+        mockError,
+      );
+    });
+
+    it('uses correct snap ID', async () => {
+      const mockResult = {
+        signature: '0x123',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      await signTronRewardsMessage(mockAccountId, mockMessage);
+
+      expect(handleSnapRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          snapId: TRON_WALLET_SNAP_ID,
+        }),
+      );
+    });
+
+    it('passes correct accountId and message', async () => {
+      const mockResult = {
+        signature: '0x123',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      await signTronRewardsMessage(mockAccountId, mockMessage);
+
+      expect(handleSnapRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          request: expect.objectContaining({
+            params: {
+              accountId: mockAccountId,
+              message: mockMessage,
+            },
+          }),
+        }),
+      );
+    });
+
+    it('handles empty accountId', async () => {
+      const mockResult = {
+        signature: '0x123',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await signTronRewardsMessage('', mockMessage);
+
+      expect(result).toEqual(mockResult);
+    });
+
+    it('handles empty message', async () => {
+      const mockResult = {
+        signature: '0x123',
+        signedMessage: 'test',
+        signatureType: 'ecdsa',
+      };
+
+      (handleSnapRequest as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await signTronRewardsMessage(mockAccountId, '');
+
+      expect(result).toEqual(mockResult);
+    });
+  });
+});

--- a/app/core/Engine/controllers/rewards-controller/utils/tron-snap.ts
+++ b/app/core/Engine/controllers/rewards-controller/utils/tron-snap.ts
@@ -1,0 +1,38 @@
+import { handleSnapRequest } from '../../../../Snaps/utils';
+import Engine from '../../../../Engine';
+import { TRON_WALLET_SNAP_ID } from '../../../../SnapKeyring/TronWalletSnap';
+import { HandlerType } from '@metamask/snaps-utils';
+import Logger from '../../../../../util/Logger';
+
+export interface SignRewardsMessageResult {
+  signature: string;
+  signedMessage: string;
+  signatureType: 'ecdsa';
+}
+
+export async function signTronRewardsMessage(
+  accountId: string,
+  message: string,
+): Promise<SignRewardsMessageResult> {
+  try {
+    const result = await handleSnapRequest(Engine.controllerMessenger, {
+      origin: 'metamask',
+      snapId: TRON_WALLET_SNAP_ID,
+      handler: HandlerType.OnClientRequest,
+      request: {
+        jsonrpc: '2.0',
+        id: Date.now(),
+        method: 'signRewardsMessage',
+        params: {
+          accountId,
+          message,
+        },
+      },
+    });
+
+    return result as SignRewardsMessageResult;
+  } catch (error) {
+    Logger.log('Error signing Tron rewards message:', error);
+    throw error;
+  }
+}

--- a/app/core/Engine/messengers/rewards-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/rewards-controller-messenger/index.ts
@@ -34,6 +34,7 @@ import {
   AccountsControllerGetSelectedMultichainAccountAction,
   AccountsControllerListMultichainAccountsAction,
 } from '@metamask/accounts-controller';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import {
   RewardsDataServiceGetOptInStatusAction,
   RewardsDataServiceGetPointsEventsAction,
@@ -55,6 +56,7 @@ type AllowedActions =
   | AccountsControllerListMultichainAccountsAction
   | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
   | KeyringControllerSignPersonalMessageAction
+  | RemoteFeatureFlagControllerGetStateAction
   | RewardsDataServiceLoginAction
   | RewardsDataServiceGetPointsEventsAction
   | RewardsDataServiceGetPointsEventsLastUpdatedAction
@@ -107,6 +109,7 @@ export function getRewardsControllerMessenger(
       'AccountTreeController:getAccountsFromSelectedAccountGroup',
       'AccountsController:listMultichainAccounts',
       'KeyringController:signPersonalMessage',
+      'RemoteFeatureFlagController:getState',
       'RewardsDataService:login',
       'RewardsDataService:getPointsEvents',
       'RewardsDataService:getPointsEventsLastUpdated',

--- a/app/selectors/featureFlagController/rewards/rewardsEnabled.test.ts
+++ b/app/selectors/featureFlagController/rewards/rewardsEnabled.test.ts
@@ -3,8 +3,14 @@ import {
   selectRewardsEnabledFlag,
   selectMusdHoldingEnabledRawFlag,
   selectMusdHoldingEnabledFlag,
+  selectBitcoinRewardsEnabledRawFlag,
+  selectBitcoinRewardsEnabledFlag,
+  selectTronRewardsEnabledRawFlag,
+  selectTronRewardsEnabledFlag,
   REWARDS_ENABLED_FLAG_NAME,
   MUSD_HOLDING_FLAG_NAME,
+  BITCOIN_REWARDS_FLAG_NAME,
+  TRON_REWARDS_FLAG_NAME,
 } from './rewardsEnabled';
 // eslint-disable-next-line import/no-namespace
 import * as remoteFeatureFlagModule from '../../../util/remoteFeatureFlag';
@@ -200,6 +206,182 @@ describe('Rewards Enabled Feature Flag Selectors', () => {
 
     it('returns false when basic functionality is disabled and raw flag is false', () => {
       const result = selectMusdHoldingEnabledFlag.resultFunc(false, false);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('selectBitcoinRewardsEnabledRawFlag', () => {
+    it('returns true when remote flag is valid and enabled', () => {
+      const result = selectBitcoinRewardsEnabledRawFlag.resultFunc({
+        [BITCOIN_REWARDS_FLAG_NAME]: {
+          enabled: true,
+          minimumVersion: '1.0.0',
+        },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when remote flag is valid but disabled', () => {
+      const result = selectBitcoinRewardsEnabledRawFlag.resultFunc({
+        [BITCOIN_REWARDS_FLAG_NAME]: {
+          enabled: false,
+          minimumVersion: '1.0.0',
+        },
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when version check fails', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(false);
+
+      const result = selectBitcoinRewardsEnabledRawFlag.resultFunc({
+        [BITCOIN_REWARDS_FLAG_NAME]: {
+          enabled: true,
+          minimumVersion: '99.0.0',
+        },
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote flag is invalid', () => {
+      const result = selectBitcoinRewardsEnabledRawFlag.resultFunc({
+        [BITCOIN_REWARDS_FLAG_NAME]: {
+          enabled: 'invalid',
+          minimumVersion: 123,
+        },
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote feature flags are empty', () => {
+      const result = selectBitcoinRewardsEnabledRawFlag.resultFunc({});
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when flag property is missing', () => {
+      const result = selectBitcoinRewardsEnabledRawFlag.resultFunc({
+        someOtherFlag: true,
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('selectBitcoinRewardsEnabledFlag', () => {
+    it('returns true when basic functionality is enabled and raw flag is true', () => {
+      const result = selectBitcoinRewardsEnabledFlag.resultFunc(true, true);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when basic functionality is enabled and raw flag is false', () => {
+      const result = selectBitcoinRewardsEnabledFlag.resultFunc(true, false);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when basic functionality is disabled even if raw flag is true', () => {
+      const result = selectBitcoinRewardsEnabledFlag.resultFunc(false, true);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when basic functionality is disabled and raw flag is false', () => {
+      const result = selectBitcoinRewardsEnabledFlag.resultFunc(false, false);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('selectTronRewardsEnabledRawFlag', () => {
+    it('returns true when remote flag is valid and enabled', () => {
+      const result = selectTronRewardsEnabledRawFlag.resultFunc({
+        [TRON_REWARDS_FLAG_NAME]: {
+          enabled: true,
+          minimumVersion: '1.0.0',
+        },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when remote flag is valid but disabled', () => {
+      const result = selectTronRewardsEnabledRawFlag.resultFunc({
+        [TRON_REWARDS_FLAG_NAME]: {
+          enabled: false,
+          minimumVersion: '1.0.0',
+        },
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when version check fails', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(false);
+
+      const result = selectTronRewardsEnabledRawFlag.resultFunc({
+        [TRON_REWARDS_FLAG_NAME]: {
+          enabled: true,
+          minimumVersion: '99.0.0',
+        },
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote flag is invalid', () => {
+      const result = selectTronRewardsEnabledRawFlag.resultFunc({
+        [TRON_REWARDS_FLAG_NAME]: {
+          enabled: 'invalid',
+          minimumVersion: 123,
+        },
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote feature flags are empty', () => {
+      const result = selectTronRewardsEnabledRawFlag.resultFunc({});
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when flag property is missing', () => {
+      const result = selectTronRewardsEnabledRawFlag.resultFunc({
+        someOtherFlag: true,
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('selectTronRewardsEnabledFlag', () => {
+    it('returns true when basic functionality is enabled and raw flag is true', () => {
+      const result = selectTronRewardsEnabledFlag.resultFunc(true, true);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when basic functionality is enabled and raw flag is false', () => {
+      const result = selectTronRewardsEnabledFlag.resultFunc(true, false);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when basic functionality is disabled even if raw flag is true', () => {
+      const result = selectTronRewardsEnabledFlag.resultFunc(false, true);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when basic functionality is disabled and raw flag is false', () => {
+      const result = selectTronRewardsEnabledFlag.resultFunc(false, false);
 
       expect(result).toBe(false);
     });

--- a/app/selectors/featureFlagController/rewards/rewardsEnabled.ts
+++ b/app/selectors/featureFlagController/rewards/rewardsEnabled.ts
@@ -13,6 +13,12 @@ export const REWARDS_ENABLED_FLAG_NAME = 'rewardsEnabled';
 export const MUSD_HOLDING_FLAG_NAME = 'rewardsEnableMusdHolding';
 const DEFAULT_MUSD_HOLDING_ENABLED = false;
 
+export const BITCOIN_REWARDS_FLAG_NAME = 'rewardsBitcoinEnabled';
+const DEFAULT_BITCOIN_REWARDS_ENABLED = false;
+
+export const TRON_REWARDS_FLAG_NAME = 'rewardsTronEnabled';
+const DEFAULT_TRON_REWARDS_ENABLED = false;
+
 /**
  * Selector for the raw rewards enabled remote flag value.
  * Returns the flag value without considering basic functionality.
@@ -81,5 +87,77 @@ export const selectMusdHoldingEnabledFlag = createSelector(
       return false;
     }
     return musdHoldingEnabledRawFlag;
+  },
+);
+
+/**
+ * Selector for the raw Bitcoin rewards enabled remote flag value.
+ * Returns the flag value without considering basic functionality.
+ */
+export const selectBitcoinRewardsEnabledRawFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    if (!hasProperty(remoteFeatureFlags, BITCOIN_REWARDS_FLAG_NAME)) {
+      return DEFAULT_BITCOIN_REWARDS_ENABLED;
+    }
+    const remoteFlag = remoteFeatureFlags[
+      BITCOIN_REWARDS_FLAG_NAME
+    ] as unknown as VersionGatedFeatureFlag;
+
+    return (
+      validatedVersionGatedFeatureFlag(remoteFlag) ??
+      DEFAULT_BITCOIN_REWARDS_ENABLED
+    );
+  },
+);
+
+/**
+ * Selector for the Bitcoin rewards enabled flag.
+ * Returns false if basic functionality is disabled, otherwise returns the remote flag value.
+ */
+export const selectBitcoinRewardsEnabledFlag = createSelector(
+  selectBasicFunctionalityEnabled,
+  selectBitcoinRewardsEnabledRawFlag,
+  (isBasicFunctionalityEnabled, bitcoinRewardsEnabledRawFlag) => {
+    if (!isBasicFunctionalityEnabled) {
+      return false;
+    }
+    return bitcoinRewardsEnabledRawFlag;
+  },
+);
+
+/**
+ * Selector for the raw Tron rewards enabled remote flag value.
+ * Returns the flag value without considering basic functionality.
+ */
+export const selectTronRewardsEnabledRawFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    if (!hasProperty(remoteFeatureFlags, TRON_REWARDS_FLAG_NAME)) {
+      return DEFAULT_TRON_REWARDS_ENABLED;
+    }
+    const remoteFlag = remoteFeatureFlags[
+      TRON_REWARDS_FLAG_NAME
+    ] as unknown as VersionGatedFeatureFlag;
+
+    return (
+      validatedVersionGatedFeatureFlag(remoteFlag) ??
+      DEFAULT_TRON_REWARDS_ENABLED
+    );
+  },
+);
+
+/**
+ * Selector for the Tron rewards enabled flag.
+ * Returns false if basic functionality is disabled, otherwise returns the remote flag value.
+ */
+export const selectTronRewardsEnabledFlag = createSelector(
+  selectBasicFunctionalityEnabled,
+  selectTronRewardsEnabledRawFlag,
+  (isBasicFunctionalityEnabled, tronRewardsEnabledRawFlag) => {
+    if (!isBasicFunctionalityEnabled) {
+      return false;
+    }
+    return tronRewardsEnabledRawFlag;
   },
 );


### PR DESCRIPTION
## **Description**

Add Bitcoin and Tron account support

## **Changelog**

CHANGELOG entry: add Bitcoin and Tron account support for rewards


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds non-EVM rewards support and wiring for feature-flagged rollout.
> 
> - Extend `RewardsController` signing to support `Bitcoin` and `Tron` via snaps (`signBitcoinRewardsMessage`, `signTronRewardsMessage`) and ensure hex `0x`-prefixed signatures; keep existing EVM and Solana paths
> - Gate opt-in for `Bitcoin` and `Tron` accounts behind new remote flags; inject `isBitcoinOptinEnabled` and `isTronOptinEnabled` from init and update `isOptInSupported`
> - Wire selectors `selectBitcoinRewardsEnabledFlag`/`selectTronRewardsEnabledFlag` and add corresponding raw/derived selectors with tests
> - Allow `RemoteFeatureFlagController:getState` in rewards messenger; update controller init and tests to use new flags
> - Add snap utility modules and tests for Bitcoin/Tron signing; refactor tests to call public `signRewardsMessage` and cover new flows
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28b9f83dd3b847925514caad5d7dd9eb5254eb86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->