### PR TITLE
fix: Predict empty search screen items

### DIFF
--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -455,7 +455,7 @@ describe('PredictFeed', () => {
       // After clearing search, the clear button should no longer be visible
       // (only shows when searchQuery.length > 0)
       expect(queryByTestId('clear-button')).not.toBeOnTheScreen();
-      // Trending results should still be visible (new behavior - show trending when search is empty)
+      // Trending results visible when no search query is empty
       expect(getByTestId('predict-search-result-0')).toBeOnTheScreen();
     });
   });

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -452,7 +452,11 @@ describe('PredictFeed', () => {
       fireEvent.changeText(searchInput, 'test query');
       fireEvent.press(getByTestId('clear-button'));
 
-      expect(queryByTestId('predict-search-result-0')).toBeNull();
+      // After clearing search, the clear button should no longer be visible
+      // (only shows when searchQuery.length > 0)
+      expect(queryByTestId('clear-button')).toBeNull();
+      // Trending results should still be visible (new behavior - show trending when search is empty)
+      expect(getByTestId('predict-search-result-0')).toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -454,7 +454,7 @@ describe('PredictFeed', () => {
 
       // After clearing search, the clear button should no longer be visible
       // (only shows when searchQuery.length > 0)
-      expect(queryByTestId('clear-button')).toBeNull();
+      expect(queryByTestId('clear-button')).not.toBeOnTheScreen();
       // Trending results should still be visible (new behavior - show trending when search is empty)
       expect(getByTestId('predict-search-result-0')).toBeOnTheScreen();
     });

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -615,36 +615,34 @@ const PredictSearchOverlay: React.FC<PredictSearchOverlayProps> = ({
         </Pressable>
       </Box>
 
-      {searchQuery.length > 0 && (
-        <Box twClassName="flex-1">
-          {isSearchLoading ? (
-            <Box twClassName="px-4 pt-4">
-              <PredictMarketSkeleton testID="search-skeleton-1" />
-              <PredictMarketSkeleton testID="search-skeleton-2" />
-              <PredictMarketSkeleton testID="search-skeleton-3" />
-            </Box>
-          ) : error ? (
-            <PredictOffline onRetry={refetch} />
-          ) : !marketData || marketData.length === 0 ? (
-            <Box twClassName="flex-1 justify-center items-center p-8">
-              <Text
-                variant={TextVariant.BodyMd}
-                color={TextColor.PrimaryAlternative}
-              >
-                {strings('predict.search_no_markets_found', { q: searchQuery })}
-              </Text>
-            </Box>
-          ) : (
-            <FlashList<PredictMarketType>
-              data={marketData}
-              renderItem={renderItem}
-              keyExtractor={keyExtractor}
-              contentContainerStyle={tw.style('px-4 pt-4 pb-4')}
-              showsVerticalScrollIndicator={false}
-            />
-          )}
-        </Box>
-      )}
+      <Box twClassName="flex-1">
+        {isSearchLoading ? (
+          <Box twClassName="px-4 pt-4">
+            <PredictMarketSkeleton testID="search-skeleton-1" />
+            <PredictMarketSkeleton testID="search-skeleton-2" />
+            <PredictMarketSkeleton testID="search-skeleton-3" />
+          </Box>
+        ) : error ? (
+          <PredictOffline onRetry={refetch} />
+        ) : !marketData || marketData.length === 0 ? (
+          <Box twClassName="flex-1 justify-center items-center p-8">
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.PrimaryAlternative}
+            >
+              {strings('predict.search_no_markets_found', { q: searchQuery })}
+            </Text>
+          </Box>
+        ) : (
+          <FlashList<PredictMarketType>
+            data={marketData}
+            renderItem={renderItem}
+            keyExtractor={keyExtractor}
+            contentContainerStyle={tw.style('px-4 pt-4 pb-4')}
+            showsVerticalScrollIndicator={false}
+          />
+        )}
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Remove conditional rendering in `PredictSearchOverlay` to always display trending results when the search query is empty.

Previously, the search overlay would show a blank screen when opened without an active search query. This change ensures that the default trending markets are visible, aligning with the behavior of other search sections.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: Predict empty search screen items

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/24401 https://consensyssoftware.atlassian.net/browse/ASSETS-2264

## **Manual testing steps**

1. Go to predict
2. Click search
3. EXPECTED - see some initial predict items even when the search query is empty.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://www.loom.com/share/953e045a02a84103afde9191efedc796

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<a href="https://cursor.com/background-agent?bcId=bc-fdbffcea-e1fc-4117-9d2b-3adfcd5a1b1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fdbffcea-e1fc-4117-9d2b-3adfcd5a1b1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the Predict search overlay displays default trending markets when no query is entered.
> 
> - In `PredictFeed.tsx`, removes conditional gating around the search results area so it always renders, showing trending results for empty `searchQuery`
> - Updates tests in `PredictFeed.test.tsx` to expect the clear button to disappear after clearing and trending results to be visible with an empty query
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d51774ff8faecbfb8b50ea6be27bad5cdc64c8b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->