### PR TITLE
fix(predict): cp-7.62.0 show correct action buttons when NFL game ends

### DIFF
--- a/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.tsx
@@ -37,7 +37,8 @@ const PredictGameDetailsFooter: React.FC<PredictGameDetailsFooterProps> = ({
     [market.volume],
   );
 
-  const isMarketClosed = market.status !== 'open';
+  const isMarketClosed =
+    market.status !== 'open' || market.game?.status === 'ended';
   const hasClaimableWinnings = claimableAmount > 0;
   const showClaimButton = hasClaimableWinnings && onClaimPress;
 

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { Box, BoxFlexDirection } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -46,6 +46,11 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
     autoRefreshTimeout: 10000,
   });
 
+  const { positions: claimablePositions } = usePredictPositions({
+    marketId: market.id,
+    claimable: true,
+  });
+
   const { executeGuardedAction } = usePredictActionGuard({
     providerId: market.providerId,
     navigation,
@@ -56,20 +61,9 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
   });
 
   const outcome = market.outcomes?.[0];
-  const isMarketOpen = market.status === PredictMarketStatus.OPEN;
-
-  const { hasPositions, hasClaimablePositions, claimableAmount } =
-    useMemo(() => {
-      const claimablePositions = positions.filter((p) => p.claimable);
-      return {
-        hasPositions: positions.length > 0,
-        hasClaimablePositions: claimablePositions.length > 0,
-        claimableAmount: claimablePositions.reduce(
-          (sum, p) => sum + (p.currentValue ?? 0),
-          0,
-        ),
-      };
-    }, [positions]);
+  const isMarketOpen =
+    market.status === PredictMarketStatus.OPEN &&
+    market.game?.status !== 'ended';
 
   const handleBetPress = useCallback(
     (token: PredictOutcomeToken) => {
@@ -99,6 +93,13 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
       { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CLAIM },
     );
   }, [executeGuardedAction, claim]);
+
+  const hasPositions = positions.length > 0;
+  const hasClaimablePositions = claimablePositions.length > 0;
+  const claimableAmount = claimablePositions.reduce(
+    (sum, p) => sum + (p.currentValue ?? 0),
+    0,
+  );
 
   const showBetButtons = isMarketOpen && !hasPositions && outcome;
   const showClaimButton = hasClaimablePositions && outcome;


### PR DESCRIPTION
## **Description**

**Problem**: When an NFL game ended and the market was closed, the feed card was still showing bet buttons instead of the "Claim winnings" button. However, the game details screen correctly showed the claim button.

**Root Cause**: 
1. `PredictSportCardFooter` only fetched active positions via `usePredictPositions({ marketId })` and tried to filter them locally for claimable positions
2. The game details screen (`PredictMarketDetails`) correctly fetched claimable positions separately using `usePredictPositions({ marketId, claimable: true })` which retrieves them from the Redux selector
3. Additionally, when `market.status` hadn't synced yet but `game.status` was already "ended", bet buttons could still appear

**Solution**:
1. Added a separate `usePredictPositions({ claimable: true })` call in `PredictSportCardFooter` to properly fetch claimable positions (matching the details screen approach)
2. Added `market.game?.status === 'ended'` check to both `PredictSportCardFooter` and `PredictGameDetailsFooter` to handle cases where game status updates before market status

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (found during manual testing)

## **Manual testing steps**

```gherkin
Feature: Predict NFL game action buttons

  Scenario: user sees claim button after game ends
    Given user has placed a bet on an NFL game
    And the game has ended with a winner

    When user views the game card in the Predict feed
    Then the card displays "Claim winnings" button (not bet buttons)

    When user taps on the game card to view details
    Then the details screen footer also shows "Claim winnings" button
```

## **Screenshots/Recordings**

### **Before**

Feed card showed "HOU · 0¢" and "NE · 100¢" bet buttons after game ended

### **After**

Feed card shows "Claim winnings" button matching the details screen behavior

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 3dfc31cc0253a6c2e72a94a684e9865e2ef527bf. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->