### PR TITLE
fix: insufficient balance alert when using max in metamask pay

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -1,6 +1,7 @@
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { useInsufficientPayTokenBalanceAlert } from './useInsufficientPayTokenBalanceAlert';
 import {
+  useTransactionPayIsMaxAmount,
   useTransactionPayRequiredTokens,
   useTransactionPayTotals,
 } from '../pay/useTransactionPayData';
@@ -67,6 +68,9 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
   const useTransactionPayTotalsMock = jest.mocked(useTransactionPayTotals);
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const useTokenWithBalanceMock = jest.mocked(useTokenWithBalance);
+  const useTransactionPayIsMaxAmountMock = jest.mocked(
+    useTransactionPayIsMaxAmount,
+  );
 
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
@@ -78,6 +82,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
     useTransactionPayRequiredTokensMock.mockReturnValue([REQUIRED_TOKEN_MOCK]);
     useTransactionPayTotalsMock.mockReturnValue(TOTALS_MOCK);
     useTokenWithBalanceMock.mockReturnValue(NATIVE_TOKEN_MOCK);
+    useTransactionPayIsMaxAmountMock.mockReturnValue(false);
 
     useTransactionPayTokenMock.mockReturnValue({
       payToken: PAY_TOKEN_MOCK,
@@ -130,6 +135,21 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
         },
         setPayToken: jest.fn(),
       });
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([]);
+    });
+
+    it('returns no alert when isMax is true regardless of required token amount', () => {
+      useTransactionPayIsMaxAmountMock.mockReturnValue(true);
+
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          ...REQUIRED_TOKEN_MOCK,
+          amountUsd: '100.00',
+        },
+      ]);
 
       const { result } = runHook();
 

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -7,6 +7,7 @@ import { strings } from '../../../../../../locales/i18n';
 import { BigNumber } from 'bignumber.js';
 import {
   useIsTransactionPayLoading,
+  useTransactionPayIsMaxAmount,
   useTransactionPayRequiredTokens,
   useTransactionPayTotals,
 } from '../pay/useTransactionPayData';
@@ -27,6 +28,7 @@ export function useInsufficientPayTokenBalanceAlert({
   const isLoading = useIsTransactionPayLoading();
   const isSourceGasFeeToken = totals?.fees.isSourceGasFeeToken ?? false;
   const isPendingAlert = Boolean(pendingAmountUsd !== undefined);
+  const isMax = useTransactionPayIsMaxAmount();
 
   const sourceChainId = payToken?.chainId ?? '0x0';
 
@@ -47,15 +49,17 @@ export function useInsufficientPayTokenBalanceAlert({
 
   const totalAmountUsd = useMemo(
     () =>
-      pendingAmountUsd
-        ? new BigNumber(pendingAmountUsd)
-        : requiredTokens
-            .filter((t) => !t.skipIfBalance)
-            .reduce(
-              (acc, t) => acc.plus(new BigNumber(t.amountUsd)),
-              new BigNumber(0),
-            ),
-    [pendingAmountUsd, requiredTokens],
+      isMax
+        ? new BigNumber(balanceUsd ?? '0')
+        : pendingAmountUsd
+          ? new BigNumber(pendingAmountUsd)
+          : requiredTokens
+              .filter((t) => !t.skipIfBalance)
+              .reduce(
+                (acc, t) => acc.plus(new BigNumber(t.amountUsd)),
+                new BigNumber(0),
+              ),
+    [balanceUsd, isMax, pendingAmountUsd, requiredTokens],
   );
 
   const totalSourceAmountRaw = useMemo(() => {


### PR DESCRIPTION
## **Description**

When using the "max" button in MetaMask Pay, the insufficient balance alert was incorrectly triggering due to minor rounding divergence between the token balance and equivalent USD amount from the transaction data.

## **Changelog**

CHANGELOG entry: Fixed insufficient balance alert incorrectly showing when using max amount in MetaMask Pay

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts insufficient balance detection for MetaMask Pay when using Max.
> 
> - In `useInsufficientPayTokenBalanceAlert`, use `useTransactionPayIsMaxAmount` and set `totalAmountUsd` to `balanceUsd` when `isMax` is true, preventing rounding-related false alerts
> - Adds test coverage: mocks `useTransactionPayIsMaxAmount` and asserts no alert is shown when `isMax` is true
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a74d82545c0b73e66b0a539df0247e9feab6123. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->