### PR TITLE
fix: fix account list in the reveal SRP flow

### DIFF
--- a/app/components/UI/SRPListItem/SRPListItem.styles.ts
+++ b/app/components/UI/SRPListItem/SRPListItem.styles.ts
@@ -53,6 +53,7 @@ const styleSheet = (params: { theme: Theme }) => {
       display: 'flex',
       width: '100%',
       flexShrink: 1,
+      maxHeight: 200,
     },
     accountsListContentContainer: {
       display: 'flex',

--- a/app/components/UI/SRPListItem/SRPListItem.test.tsx
+++ b/app/components/UI/SRPListItem/SRPListItem.test.tsx
@@ -139,6 +139,7 @@ describe('SRPList', () => {
         onActionComplete={mockOnKeyringSelect}
       />,
       {
+        // @ts-expect-error - initialState is not typed entirely correct
         state: initialState,
       },
     );
@@ -169,6 +170,7 @@ describe('SRPList', () => {
         onActionComplete={mockOnKeyringSelect}
       />,
       {
+        // @ts-expect-error - initialState is not typed entirely correct
         state: initialState,
       },
     );
@@ -193,6 +195,7 @@ describe('SRPList', () => {
         onActionComplete={mockOnKeyringSelect}
       />,
       {
+        // @ts-expect-error - initialState is not typed entirely correct
         state: initialState,
       },
     );
@@ -225,6 +228,7 @@ describe('SRPList', () => {
         onActionComplete={mockOnKeyringSelect}
       />,
       {
+        // @ts-expect-error - initialState is not typed entirely correct
         state: initialState,
       },
     );
@@ -256,6 +260,7 @@ describe('SRPList', () => {
         onActionComplete={mockOnKeyringSelect}
       />,
       {
+        // @ts-expect-error - initialState is not typed entirely correct
         state: initialState,
       },
     );
@@ -273,6 +278,8 @@ describe('SRPList', () => {
         onActionComplete={mockOnKeyringSelect}
       />,
       {
+        // @ts-expect-error - initialState is not typed entirely correct
+
         state: initialState,
       },
     );

--- a/app/components/UI/SRPListItem/SRPListItem.test.tsx
+++ b/app/components/UI/SRPListItem/SRPListItem.test.tsx
@@ -156,7 +156,7 @@ describe('SRPList', () => {
           mockKeyring1.metadata.id,
         ),
       ),
-    ).toBeDefined();
+    ).toBeOnTheScreen();
     expect(
       getByTestId(
         getTestId(
@@ -164,7 +164,7 @@ describe('SRPList', () => {
           mockKeyring1.metadata.id,
         ),
       ),
-    ).toBeDefined();
+    ).toBeOnTheScreen();
   });
 
   it('calls onActionComplete when the item is clicked', () => {
@@ -251,7 +251,7 @@ describe('SRPList', () => {
           mockKeyring1.metadata.id,
         ),
       ),
-    ).toBeDefined();
+    ).toBeOnTheScreen();
   });
 
   it('displays correct account group count instead of individual accounts', () => {
@@ -268,7 +268,7 @@ describe('SRPList', () => {
 
     // The button label shows 2 account groups (multichain accounts)
     // instead of showing individual chain accounts (EVM, Solana, etc.)
-    expect(getByText(/2 accounts/i)).toBeDefined();
+    expect(getByText(/2 accounts/i)).toBeOnTheScreen();
   });
 
   it('displays account group names when expanded', () => {
@@ -293,7 +293,7 @@ describe('SRPList', () => {
     fireEvent.press(toggle);
 
     // Account group names are displayed (multichain account names)
-    expect(getByText('Account 1')).toBeDefined();
-    expect(getByText('Account 2')).toBeDefined();
+    expect(getByText('Account 1')).toBeOnTheScreen();
+    expect(getByText('Account 2')).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/SRPListItem/SRPListItem.test.tsx
+++ b/app/components/UI/SRPListItem/SRPListItem.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
+import { AccountTreeControllerState } from '@metamask/account-tree-controller';
 
-import renderWithProvider from '../../../util/test/renderWithProvider';
-
+import renderWithProvider, {
+  DeepPartial,
+} from '../../../util/test/renderWithProvider';
 import { SRPListItemSelectorsIDs } from './SRPListItem.testIds';
 import { backgroundState } from '../../../util/test/initial-root-state';
 import {
@@ -11,12 +15,10 @@ import {
 } from '../../../util/test/accountsControllerTestUtils';
 
 import SRPListItem from './SRPListItem';
-import { fireEvent } from '@testing-library/react-native';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 import { MetaMetricsEvents } from '../../../core/Analytics/MetaMetrics.events';
 import { MetricsEventBuilder } from '../../../core/Analytics/MetricsEventBuilder';
 import useMetrics from '../../hooks/useMetrics/useMetrics';
-import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
 
 const mockTrackEvent = jest.fn();
 jest.mock('../../hooks/useMetrics/useMetrics', () => ({
@@ -59,9 +61,12 @@ const mockKeyring2 = {
 };
 
 // Account groups representing multichain accounts
+const mockAccountGroupId1 = `entropy:${mockKeyringId1}/0` as const;
+const mockAccountGroupId2 = `entropy:${mockKeyringId1}/1` as const;
+
 const mockAccountGroup1 = {
-  id: `entropy:${mockKeyringId1}/0`,
-  type: AccountGroupType.MultichainAccount,
+  id: mockAccountGroupId1,
+  type: AccountGroupType.MultichainAccount as const,
   accounts: [internalAccount1.id],
   metadata: {
     name: 'Account 1',
@@ -72,8 +77,8 @@ const mockAccountGroup1 = {
 };
 
 const mockAccountGroup2 = {
-  id: `entropy:${mockKeyringId1}/1`,
-  type: AccountGroupType.MultichainAccount,
+  id: mockAccountGroupId2,
+  type: AccountGroupType.MultichainAccount as const,
   accounts: [internalAccount2.id],
   metadata: {
     name: 'Account 2',
@@ -83,25 +88,26 @@ const mockAccountGroup2 = {
   },
 };
 
-const mockAccountTreeControllerState = {
-  accountTree: {
-    wallets: {
-      [`entropy:${mockKeyringId1}`]: {
-        id: `entropy:${mockKeyringId1}`,
-        type: AccountWalletType.Entropy,
-        metadata: {
-          name: 'Wallet 1',
-          entropy: { id: mockKeyringId1 },
-        },
-        groups: {
-          [mockAccountGroup1.id]: mockAccountGroup1,
-          [mockAccountGroup2.id]: mockAccountGroup2,
+const mockAccountTreeControllerState: DeepPartial<AccountTreeControllerState> =
+  {
+    accountTree: {
+      wallets: {
+        [`entropy:${mockKeyringId1}`]: {
+          id: `entropy:${mockKeyringId1}`,
+          type: AccountWalletType.Entropy,
+          metadata: {
+            name: 'Wallet 1',
+            entropy: { id: mockKeyringId1 },
+          },
+          groups: {
+            [mockAccountGroupId1]: mockAccountGroup1,
+            [mockAccountGroupId2]: mockAccountGroup2,
+          },
         },
       },
+      selectedAccountGroup: mockAccountGroupId1,
     },
-    selectedAccountGroup: mockAccountGroup1.id,
-  },
-};
+  };
 
 const initialState = {
   swaps: { '0x1': { isLive: true }, hasOnboarded: false, isLive: true },
@@ -139,7 +145,6 @@ describe('SRPList', () => {
         onActionComplete={mockOnKeyringSelect}
       />,
       {
-        // @ts-expect-error - initialState is not typed entirely correct
         state: initialState,
       },
     );
@@ -170,7 +175,6 @@ describe('SRPList', () => {
         onActionComplete={mockOnKeyringSelect}
       />,
       {
-        // @ts-expect-error - initialState is not typed entirely correct
         state: initialState,
       },
     );
@@ -195,7 +199,6 @@ describe('SRPList', () => {
         onActionComplete={mockOnKeyringSelect}
       />,
       {
-        // @ts-expect-error - initialState is not typed entirely correct
         state: initialState,
       },
     );
@@ -228,7 +231,6 @@ describe('SRPList', () => {
         onActionComplete={mockOnKeyringSelect}
       />,
       {
-        // @ts-expect-error - initialState is not typed entirely correct
         state: initialState,
       },
     );
@@ -260,7 +262,6 @@ describe('SRPList', () => {
         onActionComplete={mockOnKeyringSelect}
       />,
       {
-        // @ts-expect-error - initialState is not typed entirely correct
         state: initialState,
       },
     );
@@ -278,8 +279,6 @@ describe('SRPList', () => {
         onActionComplete={mockOnKeyringSelect}
       />,
       {
-        // @ts-expect-error - initialState is not typed entirely correct
-
         state: initialState,
       },
     );

--- a/app/components/UI/SRPListItem/SRPListItem.tsx
+++ b/app/components/UI/SRPListItem/SRPListItem.tsx
@@ -30,9 +30,6 @@ import { RootState } from '../../../reducers';
 import { selectIconSeedAddressByAccountGroupId } from '../../../selectors/multichainAccounts/accounts';
 import { AccountGroupWithInternalAccounts } from '../../../selectors/multichainAccounts/accounts.type';
 
-/**
- * Component to render an account group item with its avatar and name
- */
 const AccountGroupItem = ({
   accountGroup,
   accountAvatarType,
@@ -74,12 +71,10 @@ const SRPListItem = ({
   const [showAccounts, setShowAccounts] = useState(false);
   const accountAvatarType = useSelector(selectAvatarAccountType);
 
-  // Get account groups (multichain accounts) for this keyring instead of individual accounts
   const accountGroups = useSelector((state: RootState) =>
     selectAccountGroupsByKeyringId(state, keyring.metadata.id),
   );
 
-  // Number of multichain accounts (account groups) to display
   const accountCount = accountGroups.length;
 
   const handleSRPSelection = () => {

--- a/app/components/UI/SRPListItem/SRPListItem.tsx
+++ b/app/components/UI/SRPListItem/SRPListItem.tsx
@@ -41,18 +41,18 @@ const AccountGroupItem = ({
   accountAvatarType: ReturnType<typeof selectAvatarAccountType>;
 }) => {
   const { styles } = useStyles(styleSheet, {});
-  const selectEvmAddress = useMemo(
+  const selectSeedAddress = useMemo(
     () => selectIconSeedAddressByAccountGroupId(accountGroup.id),
     [accountGroup.id],
   );
-  const evmAddress = useSelector(selectEvmAddress);
+  const seedAddress = useSelector(selectSeedAddress);
 
   return (
     <View style={styles.accountItem}>
       <Avatar
         variant={AvatarVariant.Account}
         type={accountAvatarType}
-        accountAddress={evmAddress}
+        accountAddress={seedAddress}
         size={AvatarSize.Sm}
       />
       <Text variant={TextVariant.BodySM} color={TextColor.Default}>

--- a/app/components/Views/AddNewAccount/AddNewAccount.test.tsx
+++ b/app/components/Views/AddNewAccount/AddNewAccount.test.tsx
@@ -20,6 +20,7 @@ import { KeyringTypes } from '@metamask/keyring-controller';
 import { AddNewAccountIds } from './AddHdAccount.testIds';
 import Logger from '../../../util/Logger';
 import { SolAccountType, TrxScope } from '@metamask/keyring-api';
+import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
 
 const mockAddNewHdAccount = jest.fn().mockResolvedValue(null);
 const mockNavigate = jest.fn();
@@ -459,6 +460,54 @@ describe('AddNewAccount', () => {
         accounts: [solanaAccount.address],
         type: KeyringTypes.snap,
       };
+
+      // Create account groups for the accounts
+      const mockAccountGroup1 = {
+        id: `entropy:${mockKeyring1.metadata.id}/0`,
+        type: AccountGroupType.MultichainAccount,
+        accounts: [mockAccount1.id],
+        metadata: {
+          name: 'Account 1',
+          pinned: false,
+          hidden: false,
+          entropy: { groupIndex: 0 },
+        },
+      };
+
+      const mockAccountGroup2 = {
+        id: `entropy:${mockKeyring1.metadata.id}/1`,
+        type: AccountGroupType.MultichainAccount,
+        accounts: [solanaAccount.id],
+        metadata: {
+          name: 'Solana Account 1',
+          pinned: false,
+          hidden: false,
+          entropy: { groupIndex: 1 },
+        },
+      };
+
+      const mockAccountTreeControllerState = {
+        accountTree: {
+          wallets: {
+            [`entropy:${mockKeyring1.metadata.id}`]: {
+              id: `entropy:${mockKeyring1.metadata.id}`,
+              type: AccountWalletType.Entropy,
+              metadata: {
+                name: 'Wallet 1',
+                entropy: { id: mockKeyring1.metadata.id },
+              },
+              groups: {
+                [mockAccountGroup1.id]: mockAccountGroup1,
+                [mockAccountGroup2.id]: mockAccountGroup2,
+              },
+            },
+          },
+          selectedAccountGroup: mockAccountGroup1.id,
+        },
+        hasAccountTreeSyncingSyncedAtLeastOnce: false,
+        isAccountTreeSyncingInProgress: false,
+      };
+
       const stateWithSnapAccount = {
         engine: {
           backgroundState: {
@@ -476,6 +525,7 @@ describe('AddNewAccount', () => {
             KeyringController: {
               keyrings: [mockKeyring1, mockKeyring2, snapKeyring],
             },
+            AccountTreeController: mockAccountTreeControllerState,
           },
         },
       } as unknown as RootState;

--- a/app/selectors/multichainAccounts/accounts.test.ts
+++ b/app/selectors/multichainAccounts/accounts.test.ts
@@ -1671,7 +1671,7 @@ describe('accounts selectors', () => {
       expect(result).toBe(polygonEvmAccount.address);
     });
 
-    it('throws when group has no accounts', () => {
+    it('returns empty string when group has no accounts', () => {
       const emptyGroupId = 'entropy:empty/0' as AccountGroupId;
       const state = createMockState(
         {
@@ -1694,9 +1694,8 @@ describe('accounts selectors', () => {
       );
 
       const selector = selectIconSeedAddressByAccountGroupId(emptyGroupId);
-      expect(() => selector(state)).toThrow(
-        `Error in selectIconSeedAddressByAccountGroupId: No accounts found in the specified group ${emptyGroupId}`,
-      );
+      const result = selector(state);
+      expect(result).toBe('');
     });
 
     it('throws when no internal accounts resolve', () => {
@@ -1725,9 +1724,8 @@ describe('accounts selectors', () => {
       );
 
       const selector = selectIconSeedAddressByAccountGroupId(unresolvedGroupId);
-      expect(() => selector(state)).toThrow(
-        `Error in selectIconSeedAddressByAccountGroupId: No accounts found in the specified group ${unresolvedGroupId}`,
-      );
+      const result = selector(state);
+      expect(result).toBe('');
     });
   });
 

--- a/app/selectors/multichainAccounts/accounts.ts
+++ b/app/selectors/multichainAccounts/accounts.ts
@@ -371,9 +371,8 @@ export const selectIconSeedAddressByAccountGroupId = (
         return accountsInGroup[0].address;
       }
 
-      throw new Error(
-        `Error in selectIconSeedAddressByAccountGroupId: No accounts found in the specified group ${groupId}`,
-      );
+      // Fallback to empty string
+      return '';
     },
   );
 

--- a/app/selectors/multisrp/index.test.ts
+++ b/app/selectors/multisrp/index.test.ts
@@ -1,3 +1,7 @@
+import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
+
 import {
   selectHdKeyringIndexByIdOrDefault,
   getSnapAccountsByKeyringId,
@@ -5,10 +9,7 @@ import {
 } from './index';
 import { RootState } from '../../reducers';
 import { createMockInternalAccount } from '../../util/test/accountsControllerTestUtils';
-import { KeyringTypes } from '@metamask/keyring-controller';
-import { InternalAccount } from '@metamask/keyring-internal-api';
 import { SOLANA_WALLET_SNAP_ID } from '../../core/SnapKeyring/SolanaWalletSnap';
-import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
 
 const MOCK_ADDRESS_1 = '0x67B2fAf7959fB61eb9746571041476Bbd0672569';
 const MOCK_ADDRESS_2 = '0xeE94464eFCa6F3fb77AC3A77Ca995234c0c1f7fC';
@@ -273,7 +274,6 @@ describe('multisrp selectors', () => {
     });
 
     it('returns empty array when no account groups exist for keyring', () => {
-      // Use the simple keyring ID which has no account groups
       const result = selectAccountGroupsByKeyringId(
         mockState(),
         mockSimpleKeyring.metadata.id,

--- a/app/selectors/multisrp/index.test.ts
+++ b/app/selectors/multisrp/index.test.ts
@@ -1,12 +1,14 @@
 import {
   selectHdKeyringIndexByIdOrDefault,
   getSnapAccountsByKeyringId,
+  selectAccountGroupsByKeyringId,
 } from './index';
 import { RootState } from '../../reducers';
 import { createMockInternalAccount } from '../../util/test/accountsControllerTestUtils';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { SOLANA_WALLET_SNAP_ID } from '../../core/SnapKeyring/SolanaWalletSnap';
+import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
 
 const MOCK_ADDRESS_1 = '0x67B2fAf7959fB61eb9746571041476Bbd0672569';
 const MOCK_ADDRESS_2 = '0xeE94464eFCa6F3fb77AC3A77Ca995234c0c1f7fC';
@@ -96,6 +98,74 @@ const mockSnapKeyring = {
   },
 };
 
+// Account groups representing multichain accounts
+const mockAccountGroup1 = {
+  id: `entropy:${mockHDKeyring.metadata.id}/0`,
+  type: AccountGroupType.MultichainAccount,
+  accounts: [mockAccount1.id],
+  metadata: {
+    name: 'Account 1',
+    pinned: false,
+    hidden: false,
+    entropy: { groupIndex: 0 },
+  },
+};
+
+const mockAccountGroup2 = {
+  id: `entropy:${mockHDKeyring.metadata.id}/1`,
+  type: AccountGroupType.MultichainAccount,
+  accounts: [mockAccount2.id],
+  metadata: {
+    name: 'Account 2',
+    pinned: false,
+    hidden: false,
+    entropy: { groupIndex: 1 },
+  },
+};
+
+const mockAccountGroup3 = {
+  id: `entropy:${mockHDKeyring2.metadata.id}/0`,
+  type: AccountGroupType.MultichainAccount,
+  accounts: [mockAccount3.id],
+  metadata: {
+    name: 'Account 3',
+    pinned: false,
+    hidden: false,
+    entropy: { groupIndex: 0 },
+  },
+};
+
+const mockAccountTreeControllerState = {
+  accountTree: {
+    wallets: {
+      [`entropy:${mockHDKeyring.metadata.id}`]: {
+        id: `entropy:${mockHDKeyring.metadata.id}`,
+        type: AccountWalletType.Entropy,
+        metadata: {
+          name: 'Wallet 1',
+          entropy: { id: mockHDKeyring.metadata.id },
+        },
+        groups: {
+          [mockAccountGroup1.id]: mockAccountGroup1,
+          [mockAccountGroup2.id]: mockAccountGroup2,
+        },
+      },
+      [`entropy:${mockHDKeyring2.metadata.id}`]: {
+        id: `entropy:${mockHDKeyring2.metadata.id}`,
+        type: AccountWalletType.Entropy,
+        metadata: {
+          name: 'Wallet 2',
+          entropy: { id: mockHDKeyring2.metadata.id },
+        },
+        groups: {
+          [mockAccountGroup3.id]: mockAccountGroup3,
+        },
+      },
+    },
+    selectedAccountGroup: mockAccountGroup1.id,
+  },
+};
+
 const mockState = (selectedAccount: InternalAccount = mockAccount1) =>
   ({
     engine: {
@@ -121,6 +191,7 @@ const mockState = (selectedAccount: InternalAccount = mockAccount1) =>
             selectedAccount: selectedAccount.id,
           },
         },
+        AccountTreeController: mockAccountTreeControllerState,
       },
     },
   }) as unknown as RootState;
@@ -167,6 +238,58 @@ describe('multisrp selectors', () => {
     it('returns empty array when keyringId is not found', () => {
       const result = getSnapAccountsByKeyringId(mockState(), 'non-existent');
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('selectAccountGroupsByKeyringId', () => {
+    it('returns account groups for a specific keyring', () => {
+      const result = selectAccountGroupsByKeyringId(
+        mockState(),
+        mockHDKeyring.metadata.id,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].metadata.name).toBe('Account 1');
+      expect(result[1].metadata.name).toBe('Account 2');
+    });
+
+    it('returns account groups for a different keyring', () => {
+      const result = selectAccountGroupsByKeyringId(
+        mockState(),
+        mockHDKeyring2.metadata.id,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].metadata.name).toBe('Account 3');
+    });
+
+    it('returns empty array when keyringId is not found', () => {
+      const result = selectAccountGroupsByKeyringId(
+        mockState(),
+        'non-existent-keyring-id',
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when no account groups exist for keyring', () => {
+      // Use the simple keyring ID which has no account groups
+      const result = selectAccountGroupsByKeyringId(
+        mockState(),
+        mockSimpleKeyring.metadata.id,
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns account groups with resolved internal accounts', () => {
+      const result = selectAccountGroupsByKeyringId(
+        mockState(),
+        mockHDKeyring.metadata.id,
+      );
+
+      expect(result[0].accounts).toHaveLength(1);
+      expect(result[0].accounts[0].id).toBe(mockAccount1.id);
     });
   });
 });

--- a/app/selectors/multisrp/index.ts
+++ b/app/selectors/multisrp/index.ts
@@ -54,9 +54,9 @@ export const getSnapAccountsByKeyringId = createDeepEqualSelector(
  * Account groups represent multichain accounts that share the same entropy source.
  * Each account group contains multiple accounts across different chains (EVM, Solana, Bitcoin, etc.)
  *
- * @param {RootState} state - The Redux state
- * @param {string} keyringId - The ID of the keyring to get account groups for
- * @returns {AccountGroupWithInternalAccounts[]} An array of account groups belonging to the keyring
+ * @param state - The Redux state
+ * @param keyringId - The ID of the keyring to get account groups for
+ * @returns An array of account groups belonging to the keyring
  */
 export const selectAccountGroupsByKeyringId = createDeepEqualSelector(
   selectAccountGroupWithInternalAccounts,

--- a/app/selectors/multisrp/index.ts
+++ b/app/selectors/multisrp/index.ts
@@ -4,6 +4,8 @@ import { selectInternalAccounts } from '../accountsController';
 import { selectHDKeyrings } from '../keyringController';
 import { createDeepEqualSelector } from '../util';
 import { KeyringObject } from '@metamask/keyring-controller';
+import { selectAccountGroupWithInternalAccounts } from '../multichainAccounts/accountTreeController';
+import { AccountGroupWithInternalAccounts } from '../multichainAccounts/accounts.type';
 
 /**
  * Selects the index of an HD keyring by its ID, defaulting to 0 if not found
@@ -44,5 +46,26 @@ export const getSnapAccountsByKeyringId = createDeepEqualSelector(
     accounts.filter(
       (account: InternalAccount) =>
         account.options?.entropySource === keyringId,
+    ),
+);
+
+/**
+ * Selector that returns account groups (multichain accounts) for a specific keyring ID.
+ * Account groups represent multichain accounts that share the same entropy source.
+ * Each account group contains multiple accounts across different chains (EVM, Solana, Bitcoin, etc.)
+ *
+ * @param {RootState} state - The Redux state
+ * @param {string} keyringId - The ID of the keyring to get account groups for
+ * @returns {AccountGroupWithInternalAccounts[]} An array of account groups belonging to the keyring
+ */
+export const selectAccountGroupsByKeyringId = createDeepEqualSelector(
+  selectAccountGroupWithInternalAccounts,
+  (_state: RootState, keyringId: string) => keyringId,
+  (
+    accountGroups: readonly AccountGroupWithInternalAccounts[],
+    keyringId: string,
+  ) =>
+    accountGroups.filter((group) =>
+      group.id.startsWith(`entropy:${keyringId}/`),
     ),
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The account list displayed on the SRP reveal flow was outdated by showing the UI pre-BIP44. This PR updates the UI to show the correct multichain account list.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update SRP flow to display multichain accounts

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22950

## **Manual testing steps**

1. Import 2 or more SRPs
2. Create multiple accounts for each SRP (3 or more)
3. Go to the reveal SRP flow
4. Check that the account name and icon is correct when toggling the "Show X accounts" option
5. Check that the revealed SRP is the correct one

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Check https://github.com/MetaMask/metamask-mobile/issues/22950

### **After**

<!-- [screenshots/recordings] -->

<img width="500"  alt="Simulator Screenshot - iPhone 15 Pro - 2026-01-19 at 16 52 06" src="https://github.com/user-attachments/assets/309fa549-e2d2-45ee-9820-1de64d1152f1" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates SRP reveal to reflect multichain account model.
> 
> - Replace per-address list with multichain `accountGroups` in `SRPListItem`; toggle shows group count and expands a `FlatList` of group names with avatars seeded by `selectIconSeedAddressByAccountGroupId`; add `maxHeight` to `accountsList` style
> - Add `selectAccountGroupsByKeyringId` selector and tests; integrate into `SRPListItem`
> - Make `selectIconSeedAddressByAccountGroupId` resilient (returns empty string when no accounts); adjust tests accordingly
> - Refresh tests for `SRPListItem` and `AddNewAccount` to assert group-based counts, rendering, and analytics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 239b576ce87de108c105b55bf18a85f71c8f18bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->