### PR TITLE
fix: MUSD-225 Update "Get mUSD" CTA to respect network filter when creating mUSD conversion tx

### DIFF
--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.test.tsx
@@ -298,7 +298,7 @@ describe('MusdConversionAssetListCta', () => {
       });
     });
 
-    it('Get mUSD respects selected chain filter and uses correct payment token', async () => {
+    it('uses payment token from selected chain when available', async () => {
       (
         useMusdCtaVisibility as jest.MockedFunction<typeof useMusdCtaVisibility>
       ).mockReturnValue({

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
@@ -108,7 +108,7 @@ const MusdConversionAssetListCta = () => {
       const rampIntent: RampIntent = {
         assetId:
           MUSD_TOKEN_ASSET_ID_BY_CHAIN[
-          selectedChainId || MUSD_CONVERSION_DEFAULT_CHAIN_ID
+            selectedChainId || MUSD_CONVERSION_DEFAULT_CHAIN_ID
           ],
       };
       goToBuy(rampIntent);

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
@@ -108,7 +108,7 @@ const MusdConversionAssetListCta = () => {
       const rampIntent: RampIntent = {
         assetId:
           MUSD_TOKEN_ASSET_ID_BY_CHAIN[
-            selectedChainId || MUSD_CONVERSION_DEFAULT_CHAIN_ID
+          selectedChainId || MUSD_CONVERSION_DEFAULT_CHAIN_ID
           ],
       };
       goToBuy(rampIntent);
@@ -126,12 +126,10 @@ const MusdConversionAssetListCta = () => {
       throw new Error('[mUSD Conversion] payment token chainID missing');
     }
 
-    const paymentTokenAddress = toChecksumAddress(paymentToken.address);
-
     try {
       await initiateConversion({
         preferredPaymentToken: {
-          address: paymentTokenAddress,
+          address: toChecksumAddress(paymentToken.address),
           chainId: toHex(paymentToken.chainId),
         },
         outputChainId: getMusdOutputChainId(paymentToken.chainId),

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
@@ -115,21 +115,26 @@ const MusdConversionAssetListCta = () => {
       return;
     }
 
-    const { address, chainId: paymentTokenChainId } = tokens[0];
+    // Respect network filter if specific chain selected.
+    const preferredTokenOnSelectedChain = selectedChainId
+      ? tokens.find((token) => token.chainId === selectedChainId)
+      : undefined;
 
-    if (!paymentTokenChainId) {
+    const paymentToken = preferredTokenOnSelectedChain ?? tokens[0];
+
+    if (!paymentToken.chainId) {
       throw new Error('[mUSD Conversion] payment token chainID missing');
     }
 
-    const paymentTokenAddress = toChecksumAddress(address);
+    const paymentTokenAddress = toChecksumAddress(paymentToken.address);
 
     try {
       await initiateConversion({
         preferredPaymentToken: {
           address: paymentTokenAddress,
-          chainId: toHex(paymentTokenChainId),
+          chainId: toHex(paymentToken.chainId),
         },
-        outputChainId: getMusdOutputChainId(paymentTokenChainId),
+        outputChainId: getMusdOutputChainId(paymentToken.chainId),
       });
     } catch (error) {
       Logger.error(


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updated "Get mUSD" CTA to respect network filter when creating mUSD conversion tx. If no supported asset exists on the selected network, we fallback to the first available.

Previously, we ignored the network filter and always selected the first eligible token even if it was on another network.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated get mUSD cta to respect network filter when creating mUSD conversion tx

## **Related issues**

Fixes: [MUSD-225: Buy/Get CTA doesn't take selected chain into account when pre-selecting output chain and payment token](https://consensyssoftware.atlassian.net/browse/MUSD-225)

## **Manual testing steps**

```gherkin
Feature: mUSD conversion respects selected network filter

  Scenario: user initiates mUSD conversion with a selected network filter
    Given the user has eligible conversion tokens on multiple networks
    And the user has filtered their asset list to a specific network

    When the user taps "Get mUSD"
    Then the app uses a payment token on the selected network when one is available
    And the conversion output network matches the chosen payment token network

  Scenario: user initiates mUSD conversion when selected network has no eligible token
    Given the user has eligible conversion tokens
    And the user has filtered their asset list to a network with no eligible token

    When the user taps "Get mUSD"
    Then the app falls back to the first available eligible token
    And the conversion output network matches the fallback token network
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
First eligible token on any chain was selected

### **After**
First eligible token on selected network selected. Falls back to first eligible on any network if user's selected network doesn't have eligible tokens.
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns mUSD conversion to the selected network when available, improving token/chain preselection.
> 
> - Updates `MusdConversionAssetListCta` to pick `preferredPaymentToken` from `selectedChainId` (falls back to `tokens[0]`) and sets `outputChainId` via `getMusdOutputChainId(paymentToken.chainId)`
> - Normalizes addresses and chain IDs using `toChecksumAddress` and `toHex`
> - Adds tests covering selected-network token usage, fallback behavior, and preserves existing CTA/telemetry behaviors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f188ad36b4c34997383de5ca7f914c4554cb4ae9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->