### PR TITLE
feat: MUSD-210 MUSD-223 updated copy for claimable bonus tooltip

### DIFF
--- a/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.test.tsx
@@ -34,7 +34,7 @@ describe('PercentageRow', () => {
   it('renders label, tooltip and APY when not loading', () => {
     const { getByText, getByTestId } = render();
 
-    expect(getByText(strings('earn.bonus'))).toBeOnTheScreen();
+    expect(getByText(strings('earn.claimable_bonus'))).toBeOnTheScreen();
     expect(getByTestId('info-row-tooltip-open-btn')).toBeOnTheScreen();
     expect(getByText(`${MUSD_CONVERSION_APY}%`)).toBeOnTheScreen();
   });

--- a/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.test.tsx
@@ -47,7 +47,7 @@ describe('PercentageRow', () => {
     const { queryByText, queryByTestId } = render();
 
     expect(queryByTestId('percentage-row-skeleton')).toBeNull();
-    expect(queryByText(strings('earn.bonus'))).toBeNull();
+    expect(queryByText(strings('earn.claimable_bonus'))).toBeNull();
     expect(queryByText(`${MUSD_CONVERSION_APY}%`)).toBeNull();
   });
 
@@ -57,7 +57,7 @@ describe('PercentageRow', () => {
     const { queryByText, queryByTestId } = render();
 
     expect(queryByTestId('percentage-row-skeleton')).toBeNull();
-    expect(queryByText(strings('earn.bonus'))).toBeNull();
+    expect(queryByText(strings('earn.claimable_bonus'))).toBeNull();
     expect(queryByText(`${MUSD_CONVERSION_APY}%`)).toBeNull();
   });
 

--- a/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.tsx
+++ b/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.tsx
@@ -17,8 +17,8 @@ function getTxTypeRowConfig(
 ): { label: string; tooltip: string } | undefined {
   if (transactionType === TransactionType.musdConversion) {
     return {
-      label: strings('earn.bonus'),
-      tooltip: strings('earn.bonus_tooltip'),
+      label: strings('earn.claimable_bonus'),
+      tooltip: strings('earn.claimable_bonus_tooltip'),
     };
   }
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5621,9 +5621,9 @@
     "error_description": "Installation of {{snap}} failed."
   },
   "earn": {
-    "bonus_tooltip": "Daily mUSD bonus added to your wallet as a reward for holding mUSD.",
+    "claimable_bonus_tooltip": "An annual bonus claimable daily from your wallet.",
     "earn_a_percentage_bonus": "Earn a {{percentage}}% bonus",
-    "bonus": "Bonus",
+    "claimable_bonus": "Claimable bonus",
     "empty_state_cta": {
       "heading": "Lend {{tokenSymbol}} and earn",
       "body": "Lend your {{tokenSymbol}} with {{protocol}} and earn",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Update the copy for the mUSD conversion claimable bonus tooltip.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated the copy for the mUSD conversion claimable bonus tooltip.

## **Related issues**

Fixes: 
- [MUSD-210: [UX Improvement] Copy of bonus distribution in tooltip is not very clear. ](https://consensyssoftware.atlassian.net/browse/MUSD-210)
- [MUSD-223: [UX Improvement] Update the Bonus copy in the confirmation screen](https://consensyssoftware.atlassian.net/browse/MUSD-223)

## **Manual testing steps**

```gherkin
Feature: Claimable bonus copy for mUSD conversion

  Scenario: user views claimable bonus label and tooltip in mUSD conversion confirmation
    Given user is reviewing a transaction confirmation for converting to mUSD

    When the confirmation screen displays the APY row
    Then the row label is "Claimable bonus"
    And the tooltip copy explains the bonus is annual and claimable daily from the wallet
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines copy for the mUSD conversion APY row.
> 
> - PercentageRow now uses `strings('earn.claimable_bonus')` and `strings('earn.claimable_bonus_tooltip')` for `musdConversion`
> - English i18n updated: replaced `earn.bonus`/`earn.bonus_tooltip` with `earn.claimable_bonus`/`earn.claimable_bonus_tooltip`
> - Unit tests updated to assert new label and tooltip while preserving APY rendering and unsupported/undefined transaction behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 228d786a5f94cd91a6d3d46a08df49e1468bb30e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->