### PR TITLE
feat(ramps): adds analytics tracking for level 2 KYC

### DIFF
--- a/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.test.ts
+++ b/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.test.ts
@@ -707,7 +707,7 @@ describe('useDepositRouting', () => {
       ).rejects.toThrow('KYC forms fetch failed');
     });
 
-    it('should throw error when KYC requirements are missing', async () => {
+    it('throws error when KYC requirements are missing', async () => {
       const mockQuote = { quoteId: 'test-quote-id' } as BuyQuote;
 
       mockGetKycRequirement = jest.fn().mockResolvedValue(null);
@@ -719,7 +719,7 @@ describe('useDepositRouting', () => {
       ).rejects.toThrow('Missing KYC requirements');
     });
 
-    it('should throw error when KYC requirements are undefined', async () => {
+    it('throws error when KYC requirements are undefined', async () => {
       const mockQuote = { quoteId: 'test-quote-id' } as BuyQuote;
 
       mockGetKycRequirement = jest.fn().mockResolvedValue(undefined);

--- a/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.test.ts
+++ b/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.test.ts
@@ -707,6 +707,30 @@ describe('useDepositRouting', () => {
       ).rejects.toThrow('KYC forms fetch failed');
     });
 
+    it('should throw error when KYC requirements are missing', async () => {
+      const mockQuote = { quoteId: 'test-quote-id' } as BuyQuote;
+
+      mockGetKycRequirement = jest.fn().mockResolvedValue(null);
+
+      const { result } = renderHook(() => useDepositRouting());
+
+      await expect(
+        result.current.routeAfterAuthentication(mockQuote),
+      ).rejects.toThrow('Missing KYC requirements');
+    });
+
+    it('should throw error when KYC requirements are undefined', async () => {
+      const mockQuote = { quoteId: 'test-quote-id' } as BuyQuote;
+
+      mockGetKycRequirement = jest.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useDepositRouting());
+
+      await expect(
+        result.current.routeAfterAuthentication(mockQuote),
+      ).rejects.toThrow('Missing KYC requirements');
+    });
+
     it('should throw error when payment URL generation fails', async () => {
       const mockQuote = { quoteId: 'test-quote-id' } as BuyQuote;
 

--- a/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.test.ts
+++ b/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.test.ts
@@ -159,7 +159,10 @@ jest.mock('./useDepositSdkMethod', () => ({
 }));
 
 const mockLogoutFromProvider = jest.fn();
-let mockSelectedRegion = { isoCode: 'US', currency: 'USD' };
+let mockSelectedRegion: DepositRegion | null = {
+  isoCode: 'US',
+  currency: 'USD',
+} as DepositRegion;
 let mockSelectedPaymentMethod = {
   isManualBankTransfer: false,
   id: 'credit_debit_card',
@@ -223,7 +226,7 @@ describe('useDepositRouting', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockSelectedRegion = { isoCode: 'US', currency: 'USD' };
+    mockSelectedRegion = { isoCode: 'US', currency: 'USD' } as DepositRegion;
     mockSelectedPaymentMethod = {
       isManualBankTransfer: false,
       id: 'credit_debit_card',
@@ -1241,7 +1244,7 @@ describe('useDepositRouting', () => {
 
       mockSelectedRegion = {
         currency: 'USD',
-      } as Partial<DepositRegion> as DepositRegion | null;
+      } as unknown as DepositRegion;
 
       mockGetKycRequirement = jest.fn().mockResolvedValue({
         status: 'ADDITIONAL_FORMS_REQUIRED',

--- a/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.test.ts
+++ b/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.test.ts
@@ -1122,6 +1122,38 @@ describe('useDepositRouting', () => {
       });
     });
 
+    it('tracks RAMPS_KYC_STARTED event with kyc_type STANDARD when Level 2 KYC (IDPROOF) is required', async () => {
+      const mockQuote = { quoteId: 'test-quote-id' } as BuyQuote;
+
+      mockGetKycRequirement = jest.fn().mockResolvedValue({
+        status: 'ADDITIONAL_FORMS_REQUIRED',
+      });
+
+      mockGetAdditionalRequirements = jest.fn().mockResolvedValue({
+        formsRequired: [
+          {
+            type: 'IDPROOF',
+            metadata: {
+              kycUrl: 'test-kyc-url',
+              workFlowRunId: 'test-workflow-run-id',
+            },
+          },
+        ],
+      });
+
+      const { result } = renderHook(() => useDepositRouting());
+
+      await expect(
+        result.current.routeAfterAuthentication(mockQuote),
+      ).resolves.not.toThrow();
+
+      expect(mockTrackEvent).toHaveBeenCalledWith('RAMPS_KYC_STARTED', {
+        ramp_type: 'DEPOSIT',
+        kyc_type: 'STANDARD',
+        region: 'US',
+      });
+    });
+
     it('does not track analytics event when no KYC forms are required', async () => {
       const mockQuote = { quoteId: 'test-quote-id' } as BuyQuote;
 

--- a/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.ts
+++ b/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.ts
@@ -539,6 +539,12 @@ export const useDepositRouting = (config?: UseDepositRoutingConfig) => {
                 throw new Error('Missing ID proof metadata');
               }
 
+              trackEvent('RAMPS_KYC_STARTED', {
+                ramp_type: 'DEPOSIT',
+                kyc_type: 'STANDARD',
+                region: selectedRegion?.isoCode || '',
+              });
+
               navigateToAdditionalVerificationCallback({
                 quote,
                 kycUrl: metadata.kycUrl,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds tracking for Level 2 KYC start to measure the Onfido widget funnel.

**Changes:**
- Track `RAMPS_KYC_STARTED` with `kyc_type: 'STANDARD'` when navigating to Additional Verification (IDPROOF form detected)
- Enables funnel analysis for Level 2 KYC separately from Level 1
- Covers both users starting fresh with STANDARD KYC and users being "promoted" from SIMPLE to STANDARD

**Files Modified:**
- `metamask-mobile/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.ts`
- `metamask-mobile/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.test.ts`

This tracks when users begin Level 2 KYC (Onfido verification), enabling conversion rate analysis for the Onfido widget flow.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:
https://consensyssoftware.atlassian.net/browse/TRAM-2772

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Level 2 KYC analytics and strengthens routing/test coverage.
> 
> - Tracks `RAMPS_KYC_STARTED` with `kyc_type: 'STANDARD'` and `region: selectedRegion?.isoCode || ''` when `IDPROOF` is required in `useDepositRouting.ts`
> - Expands tests in `useDepositRouting.test.ts`:
>   - Validates tracking for `STANDARD` path and empty-region fallback (no `selectedRegion` or missing `isoCode`)
>   - Asserts errors for missing/undefined KYC requirements and payment URL failures
>   - Updates mocks to allow `selectedRegion: DepositRegion | null`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d2cd615e8448edb964de506877798c7ce2f39a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->