### PR TITLE
fix: show custom chart msg with a single price point

### DIFF
--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.test.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import PriceChart from './PriceChart';
+import { TokenPrice } from '../../../hooks/useTokenHistoricalPrices';
+
+// Mock the strings function
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: (key: string) => {
+    const translations: Record<string, string> = {
+      'asset_overview.no_chart_data.title': 'No chart data',
+      'asset_overview.no_chart_data.description':
+        'We could not fetch any data for this token',
+      'asset_overview.no_chart_data.insufficient_data':
+        'Data is not available for this time period',
+    };
+    return translations[key] || key;
+  },
+}));
+
+describe('PriceChart', () => {
+  const mockOnChartIndexChange = jest.fn();
+
+  const defaultProps = {
+    prices: [] as TokenPrice[],
+    priceDiff: 0,
+    isLoading: false,
+    onChartIndexChange: mockOnChartIndexChange,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('NoDataOverlay', () => {
+    it('shows full overlay with icon and description when there are no data points', () => {
+      const { getByText, getByTestId } = render(
+        <PriceChart {...defaultProps} prices={[]} />,
+      );
+
+      // Should show title
+      expect(getByText('No chart data')).toBeTruthy();
+
+      // Should show description
+      expect(
+        getByText('We could not fetch any data for this token'),
+      ).toBeTruthy();
+
+      // Should render no data overlay with icon
+      expect(getByTestId('price-chart-no-data')).toBeTruthy();
+      expect(getByTestId('price-chart-no-data-icon')).toBeTruthy();
+    });
+
+    it('shows simplified message when there is only 1 data point', () => {
+      const singleDataPoint: TokenPrice[] = [['1736761237983', 100]];
+
+      const { getByText, queryByText, getByTestId } = render(
+        <PriceChart {...defaultProps} prices={singleDataPoint} />,
+      );
+
+      // Should show insufficient data overlay
+      expect(getByTestId('price-chart-insufficient-data')).toBeTruthy();
+
+      // Should show insufficient data message
+      expect(
+        getByText('Data is not available for this time period'),
+      ).toBeTruthy();
+
+      // Should NOT show full description
+      expect(
+        queryByText('We could not fetch any data for this token'),
+      ).toBeFalsy();
+
+      // Should NOT show title as a Title component
+      expect(queryByText('No chart data')).toBeFalsy();
+    });
+
+    it('does not show overlay when there are 2 data points', () => {
+      const validDataPoints: TokenPrice[] = [
+        ['1736761237983', 100],
+        ['1736761237986', 105],
+      ];
+
+      const { queryByText } = render(
+        <PriceChart {...defaultProps} prices={validDataPoints} />,
+      );
+
+      // Should NOT show any overlay messages
+      expect(queryByText('No chart data')).toBeFalsy();
+      expect(
+        queryByText('We could not fetch any data for this token'),
+      ).toBeFalsy();
+      expect(
+        queryByText('Data is not available for this time period'),
+      ).toBeFalsy();
+    });
+
+    it('does not show overlay when there are multiple data points', () => {
+      const multipleDataPoints: TokenPrice[] = [
+        ['1736761237983', 100],
+        ['1736761237986', 105],
+        ['1736761237989', 110],
+        ['1736761237992', 108],
+      ];
+
+      const { queryByText } = render(
+        <PriceChart {...defaultProps} prices={multipleDataPoints} />,
+      );
+
+      // Should NOT show any overlay messages
+      expect(queryByText('No chart data')).toBeFalsy();
+      expect(
+        queryByText('We could not fetch any data for this token'),
+      ).toBeFalsy();
+      expect(
+        queryByText('Data is not available for this time period'),
+      ).toBeFalsy();
+    });
+  });
+
+  describe('Loading state', () => {
+    it('shows loading overlay when isLoading is true', () => {
+      const { getByTestId } = render(
+        <PriceChart {...defaultProps} isLoading />,
+      );
+
+      // Should render loading overlay
+      expect(getByTestId('price-chart-loading')).toBeTruthy();
+    });
+
+    it('does not show no data overlay when loading', () => {
+      const { queryByText } = render(
+        <PriceChart {...defaultProps} prices={[]} isLoading />,
+      );
+
+      // Should NOT show no data messages when loading
+      expect(queryByText('No chart data')).toBeFalsy();
+      expect(
+        queryByText('We could not fetch any data for this token'),
+      ).toBeFalsy();
+    });
+  });
+
+  describe('Chart rendering', () => {
+    it('renders chart with positive price difference', () => {
+      const prices: TokenPrice[] = [
+        ['1736761237983', 100],
+        ['1736761237986', 105],
+      ];
+
+      const { getByTestId } = render(
+        <PriceChart {...defaultProps} prices={prices} priceDiff={5} />,
+      );
+
+      // Should render AreaChart
+      expect(getByTestId('price-chart-area')).toBeTruthy();
+    });
+
+    it('renders chart with negative price difference', () => {
+      const prices: TokenPrice[] = [
+        ['1736761237983', 105],
+        ['1736761237986', 100],
+      ];
+
+      const { getByTestId } = render(
+        <PriceChart {...defaultProps} prices={prices} priceDiff={-5} />,
+      );
+
+      // Should render AreaChart
+      expect(getByTestId('price-chart-area')).toBeTruthy();
+    });
+  });
+});

--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.test.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.test.tsx
@@ -38,16 +38,16 @@ describe('PriceChart', () => {
       );
 
       // Should show title
-      expect(getByText('No chart data')).toBeTruthy();
+      expect(getByText('No chart data')).toBeOnTheScreen();
 
       // Should show description
       expect(
         getByText('We could not fetch any data for this token'),
-      ).toBeTruthy();
+      ).toBeOnTheScreen();
 
       // Should render no data overlay with icon
-      expect(getByTestId('price-chart-no-data')).toBeTruthy();
-      expect(getByTestId('price-chart-no-data-icon')).toBeTruthy();
+      expect(getByTestId('price-chart-no-data')).toBeOnTheScreen();
+      expect(getByTestId('price-chart-no-data-icon')).toBeOnTheScreen();
     });
 
     it('shows simplified message when there is only 1 data point', () => {
@@ -58,20 +58,20 @@ describe('PriceChart', () => {
       );
 
       // Should show insufficient data overlay
-      expect(getByTestId('price-chart-insufficient-data')).toBeTruthy();
+      expect(getByTestId('price-chart-insufficient-data')).toBeOnTheScreen();
 
       // Should show insufficient data message
       expect(
         getByText('Data is not available for this time period'),
-      ).toBeTruthy();
+      ).toBeOnTheScreen();
 
       // Should NOT show full description
       expect(
         queryByText('We could not fetch any data for this token'),
-      ).toBeFalsy();
+      ).not.toBeOnTheScreen();
 
       // Should NOT show title as a Title component
-      expect(queryByText('No chart data')).toBeFalsy();
+      expect(queryByText('No chart data')).not.toBeOnTheScreen();
     });
 
     it('does not show overlay when there are 2 data points', () => {
@@ -85,13 +85,13 @@ describe('PriceChart', () => {
       );
 
       // Should NOT show any overlay messages
-      expect(queryByText('No chart data')).toBeFalsy();
+      expect(queryByText('No chart data')).not.toBeOnTheScreen();
       expect(
         queryByText('We could not fetch any data for this token'),
-      ).toBeFalsy();
+      ).not.toBeOnTheScreen();
       expect(
         queryByText('Data is not available for this time period'),
-      ).toBeFalsy();
+      ).not.toBeOnTheScreen();
     });
 
     it('does not show overlay when there are multiple data points', () => {
@@ -107,13 +107,13 @@ describe('PriceChart', () => {
       );
 
       // Should NOT show any overlay messages
-      expect(queryByText('No chart data')).toBeFalsy();
+      expect(queryByText('No chart data')).not.toBeOnTheScreen();
       expect(
         queryByText('We could not fetch any data for this token'),
-      ).toBeFalsy();
+      ).not.toBeOnTheScreen();
       expect(
         queryByText('Data is not available for this time period'),
-      ).toBeFalsy();
+      ).not.toBeOnTheScreen();
     });
   });
 
@@ -124,7 +124,7 @@ describe('PriceChart', () => {
       );
 
       // Should render loading overlay
-      expect(getByTestId('price-chart-loading')).toBeTruthy();
+      expect(getByTestId('price-chart-loading')).toBeOnTheScreen();
     });
 
     it('does not show no data overlay when loading', () => {
@@ -133,10 +133,10 @@ describe('PriceChart', () => {
       );
 
       // Should NOT show no data messages when loading
-      expect(queryByText('No chart data')).toBeFalsy();
+      expect(queryByText('No chart data')).not.toBeOnTheScreen();
       expect(
         queryByText('We could not fetch any data for this token'),
-      ).toBeFalsy();
+      ).not.toBeOnTheScreen();
     });
   });
 
@@ -152,7 +152,7 @@ describe('PriceChart', () => {
       );
 
       // Should render AreaChart
-      expect(getByTestId('price-chart-area')).toBeTruthy();
+      expect(getByTestId('price-chart-area')).toBeOnTheScreen();
     });
 
     it('renders chart with negative price difference', () => {
@@ -166,7 +166,7 @@ describe('PriceChart', () => {
       );
 
       // Should render AreaChart
-      expect(getByTestId('price-chart-area')).toBeTruthy();
+      expect(getByTestId('price-chart-area')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.tsx
@@ -260,7 +260,10 @@ const PriceChart = ({
     if (hasInsufficientData) {
       // Show simplified message for 1 data point
       return (
-        <View style={styles.noDataOverlay}>
+        <View
+          style={styles.noDataOverlay}
+          testID="price-chart-insufficient-data"
+        >
           <Text
             variant={TextVariant.BodyLGMedium}
             style={styles.noDataOverlayText}
@@ -273,12 +276,13 @@ const PriceChart = ({
 
     // Show full overlay for no data
     return (
-      <View style={styles.noDataOverlay}>
+      <View style={styles.noDataOverlay} testID="price-chart-no-data">
         <Text>
           <Icon
             name={IconName.Warning}
             color={IconColor.Muted}
             size={IconSize.Xl}
+            testID="price-chart-no-data-icon"
           />
         </Text>
         <Title style={styles.noDataOverlayTitle}>
@@ -326,7 +330,7 @@ const PriceChart = ({
    * @see https://github.com/MetaMask/metamask-mobile/issues/20854
    */
   const LoadingOverlay = () => (
-    <View style={styles.noDataOverlay}>
+    <View style={styles.noDataOverlay} testID="price-chart-loading">
       <SkeletonPlaceholder
         backgroundColor={theme.colors.background.section}
         highlightColor={theme.colors.background.subsection}
@@ -344,7 +348,11 @@ const PriceChart = ({
 
   return (
     <View style={styles.chart}>
-      <View style={styles.chartArea} {...panResponder.current.panHandlers}>
+      <View
+        style={styles.chartArea}
+        testID={chartHasData ? 'price-chart-area' : undefined}
+        {...panResponder.current.panHandlers}
+      >
         {isLoading ? <LoadingOverlay /> : !chartHasData && <NoDataOverlay />}
         {/* Chart is always rendered to avoid Android rendering bug; visible elements are conditionally hidden during loading. See: https://github.com/MetaMask/metamask-mobile/issues/20854 */}
         <AreaChart

--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.tsx
@@ -254,23 +254,45 @@ const PriceChart = ({
     );
   };
 
-  const NoDataOverlay = () => (
-    <View style={styles.noDataOverlay}>
-      <Text>
-        <Icon
-          name={IconName.Warning}
-          color={IconColor.Muted}
-          size={IconSize.Xl}
-        />
-      </Text>
-      <Title style={styles.noDataOverlayTitle}>
-        {strings('asset_overview.no_chart_data.title')}
-      </Title>
-      <Text variant={TextVariant.BodyLGMedium} style={styles.noDataOverlayText}>
-        {strings('asset_overview.no_chart_data.description')}
-      </Text>
-    </View>
-  );
+  const NoDataOverlay = () => {
+    const hasInsufficientData = priceList.length > 0 && priceList.length <= 1;
+
+    if (hasInsufficientData) {
+      // Show simplified message for 1 data point
+      return (
+        <View style={styles.noDataOverlay}>
+          <Text
+            variant={TextVariant.BodyLGMedium}
+            style={styles.noDataOverlayText}
+          >
+            {strings('asset_overview.no_chart_data.insufficient_data')}
+          </Text>
+        </View>
+      );
+    }
+
+    // Show full overlay for no data
+    return (
+      <View style={styles.noDataOverlay}>
+        <Text>
+          <Icon
+            name={IconName.Warning}
+            color={IconColor.Muted}
+            size={IconSize.Xl}
+          />
+        </Text>
+        <Title style={styles.noDataOverlayTitle}>
+          {strings('asset_overview.no_chart_data.title')}
+        </Title>
+        <Text
+          variant={TextVariant.BodyLGMedium}
+          style={styles.noDataOverlayText}
+        >
+          {strings('asset_overview.no_chart_data.description')}
+        </Text>
+      </View>
+    );
+  };
 
   const Tooltip = ({ x, y }: Partial<TooltipProps>) => {
     if (positionX < 0) {
@@ -318,7 +340,7 @@ const PriceChart = ({
     </View>
   );
 
-  const chartHasData = priceList.length > 0;
+  const chartHasData = priceList.length > 1;
 
   return (
     <View style={styles.chart}>

--- a/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
+++ b/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
@@ -131,6 +131,7 @@ exports[`AssetOverview should render native balances when non evm network is sel
             "flex": 1,
           }
         }
+        testID="price-chart-area"
       >
         <View
           style={

--- a/app/components/Views/Asset/__snapshots__/index.test.js.snap
+++ b/app/components/Views/Asset/__snapshots__/index.test.js.snap
@@ -2193,6 +2193,7 @@ exports[`Asset Multichain Functionality renders empty state when no multichain t
                                             "flex": 1,
                                           }
                                         }
+                                        testID="price-chart-area"
                                       >
                                         <View
                                           style={
@@ -3649,6 +3650,7 @@ exports[`Asset Multichain Functionality returns empty list for unknown SPL token
                                             "flex": 1,
                                           }
                                         }
+                                        testID="price-chart-area"
                                       >
                                         <View
                                           style={
@@ -5174,6 +5176,7 @@ exports[`Asset Multichain Functionality should exclude mixed token/SOL transacti
                                             "flex": 1,
                                           }
                                         }
+                                        testID="price-chart-area"
                                       >
                                         <View
                                           style={
@@ -6630,6 +6633,7 @@ exports[`Asset Multichain Functionality should exclude transactions with empty a
                                             "flex": 1,
                                           }
                                         }
+                                        testID="price-chart-area"
                                       >
                                         <View
                                           style={
@@ -8086,6 +8090,7 @@ exports[`Asset Multichain Functionality should filter SPL token transactions cor
                                             "flex": 1,
                                           }
                                         }
+                                        testID="price-chart-area"
                                       >
                                         <View
                                           style={
@@ -9611,6 +9616,7 @@ exports[`Asset Multichain Functionality should filter native SOL transactions co
                                             "flex": 1,
                                           }
                                         }
+                                        testID="price-chart-area"
                                       >
                                         <View
                                           style={
@@ -11633,6 +11639,7 @@ exports[`Asset Multichain Functionality should render non-EVM assets with Multic
                                             "flex": 1,
                                           }
                                         }
+                                        testID="price-chart-area"
                                       >
                                         <View
                                           style={
@@ -13089,6 +13096,7 @@ exports[`Asset Multichain Functionality should sort filtered transactions by tim
                                             "flex": 1,
                                           }
                                         }
+                                        testID="price-chart-area"
                                       >
                                         <View
                                           style={

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3333,7 +3333,8 @@
     },
     "no_chart_data": {
       "title": "No chart data",
-      "description": "We could not fetch any data for this token"
+      "description": "We could not fetch any data for this token",
+      "insufficient_data": "Data is not available for this time period"
     },
     "your_balance": "Your balance",
     "perps_position": "Perps position",


### PR DESCRIPTION

## **Description**

Show msg "data is not available for this time period" when there is a single data point for price chart.
Keep the default empty chart display when there is zero data points.

## **Changelog**


CHANGELOG entry: Display custom msg for chart data when there is a single data point

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/24611

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
With a single data point

<img width="366" height="790" alt="Screenshot 2026-01-20 at 01 51 18" src="https://github.com/user-attachments/assets/c1f5361b-0ecd-4fe0-87c9-428d3e1dcc6b" />


With zero data points we keep the old display

<img width="398" height="875" alt="Screenshot 2026-01-20 at 01 52 05" src="https://github.com/user-attachments/assets/9e10bd9c-8b3d-4706-8f1f-6c247cb9200f" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces distinct empty states in `PriceChart` and tightens the data threshold for rendering.
> 
> - `PriceChart`: show simplified `asset_overview.no_chart_data.insufficient_data` message when `prices.length === 1`; keep full no-data overlay (icon, title, description) for `0` points; set `chartHasData` to `prices.length > 1`; add `testID`s (`price-chart-insufficient-data`, `price-chart-no-data`, `price-chart-no-data-icon`, `price-chart-loading`, conditionally `price-chart-area`).
> - Tests: new `PriceChart.test.tsx` covering no data/one point/multi-point, loading overlay, and chart rendering.
> - i18n: add `asset_overview.no_chart_data.insufficient_data` string; snapshots updated to reflect new `testID`s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67d50c1d08d5cef4057b1218a78bfaaabe9696d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->