### PR TITLE
refactor: update useTrendingSearch hook to accept options object

### DIFF
--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
@@ -113,7 +113,7 @@ describe('useTrendingSearch', () => {
     });
 
     const { result } = renderHookWithProvider(() =>
-      useTrendingSearch('ETH', 'h24_trending'),
+      useTrendingSearch({ searchQuery: 'ETH', sortBy: 'h24_trending' }),
     );
 
     jest.advanceTimersByTime(200);
@@ -150,7 +150,7 @@ describe('useTrendingSearch', () => {
     });
 
     const { result } = renderHookWithProvider(() =>
-      useTrendingSearch('ETH', 'h24_trending'),
+      useTrendingSearch({ searchQuery: 'ETH', sortBy: 'h24_trending' }),
     );
 
     jest.advanceTimersByTime(200);
@@ -194,7 +194,7 @@ describe('useTrendingSearch', () => {
     });
 
     const { result } = renderHookWithProvider(() =>
-      useTrendingSearch('ETH', 'h24_trending'),
+      useTrendingSearch({ searchQuery: 'ETH', sortBy: 'h24_trending' }),
     );
 
     jest.advanceTimersByTime(200);
@@ -208,10 +208,10 @@ describe('useTrendingSearch', () => {
       mockSortTrendingTokens.mockReturnValue(sortedResults);
 
       const { result: result1 } = renderHookWithProvider(() =>
-        useTrendingSearch(''),
+        useTrendingSearch({ searchQuery: '' }),
       );
       const { result: result2 } = renderHookWithProvider(() =>
-        useTrendingSearch('   '),
+        useTrendingSearch({ searchQuery: '   ' }),
       );
 
       await waitFor(() => {
@@ -221,7 +221,9 @@ describe('useTrendingSearch', () => {
     });
 
     it('filters trending results by symbol case-insensitively', async () => {
-      const { result } = renderHookWithProvider(() => useTrendingSearch('eth'));
+      const { result } = renderHookWithProvider(() =>
+        useTrendingSearch({ searchQuery: 'eth' }),
+      );
 
       jest.advanceTimersByTime(200);
 
@@ -233,7 +235,7 @@ describe('useTrendingSearch', () => {
 
     it('filters trending results by name case-insensitively', async () => {
       const { result } = renderHookWithProvider(() =>
-        useTrendingSearch('ethereum'),
+        useTrendingSearch({ searchQuery: 'ethereum' }),
       );
 
       jest.advanceTimersByTime(200);
@@ -245,7 +247,9 @@ describe('useTrendingSearch', () => {
     });
 
     it('filters trending results by partial matches', async () => {
-      const { result } = renderHookWithProvider(() => useTrendingSearch('dai'));
+      const { result } = renderHookWithProvider(() =>
+        useTrendingSearch({ searchQuery: 'dai' }),
+      );
 
       jest.advanceTimersByTime(200);
 
@@ -257,7 +261,7 @@ describe('useTrendingSearch', () => {
 
     it('returns empty array when no trending results match query', async () => {
       const { result } = renderHookWithProvider(() =>
-        useTrendingSearch('NonExistent'),
+        useTrendingSearch({ searchQuery: 'NonExistent' }),
       );
 
       jest.advanceTimersByTime(200);
@@ -269,7 +273,7 @@ describe('useTrendingSearch', () => {
 
     it('trims whitespace from query before filtering', async () => {
       const { result } = renderHookWithProvider(() =>
-        useTrendingSearch('  ETH  '),
+        useTrendingSearch({ searchQuery: '  ETH  ' }),
       );
 
       jest.advanceTimersByTime(200);
@@ -290,7 +294,12 @@ describe('useTrendingSearch', () => {
     });
 
     const { result } = renderHookWithProvider(() =>
-      useTrendingSearch('USDC', 'h24_trending', null, false),
+      useTrendingSearch({
+        searchQuery: 'USDC',
+        sortBy: 'h24_trending',
+        chainIds: null,
+        enableDebounce: false,
+      }),
     );
 
     expect(mockUseSearchRequest).toHaveBeenCalledWith(

--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
@@ -5,6 +5,19 @@ import { useSearchRequest } from '../useSearchRequest/useSearchRequest';
 import { useTrendingRequest } from '../useTrendingRequest/useTrendingRequest';
 import { sortTrendingTokens } from '../../utils/sortTrendingTokens';
 import { PriceChangeOption } from '../../components/TrendingTokensBottomSheet';
+import { isEqual } from 'lodash';
+
+const useStableReference = <T>(value: T) => {
+  const [stableValue, setStableValue] = useState(value);
+
+  useEffect(() => {
+    if (!isEqual(stableValue, value)) {
+      setStableValue(value);
+    }
+  }, [value, stableValue]);
+
+  return stableValue;
+};
 
 /**
  * Hook for trending tokens search with optional debouncing.
@@ -15,12 +28,19 @@ import { PriceChangeOption } from '../../components/TrendingTokensBottomSheet';
  * @param enableDebounce - Whether to debounce (default: true)
  * @returns Trending/search results, loading state, and refetch function
  */
-export const useTrendingSearch = (
-  searchQuery?: string,
-  sortBy?: SortTrendingBy,
-  chainIds?: CaipChainId[] | null,
-  enableDebounce = true,
-) => {
+export const useTrendingSearch = (opts?: {
+  searchQuery?: string;
+  sortBy?: SortTrendingBy;
+  chainIds?: CaipChainId[] | null;
+  enableDebounce?: boolean;
+}) => {
+  const {
+    searchQuery,
+    sortBy,
+    chainIds,
+    enableDebounce = true,
+  } = useStableReference(opts ?? {});
+
   const [debouncedQuery, setDebouncedQuery] = useState(searchQuery);
 
   // Debounce the search query

--- a/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.test.tsx
+++ b/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, waitFor, act } from '@testing-library/react-native';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import TrendingTokensFullView from './TrendingTokensFullView';
 import type { TrendingAsset } from '@metamask/assets-controllers';
+import { useTrendingSearch } from '../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -29,20 +30,8 @@ jest.mock(
   }),
 );
 
-const mockUseTrendingSearch = jest.fn();
-
-jest.mock(
-  '../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch',
-  () => ({
-    useTrendingSearch: (
-      searchQuery?: string,
-      sortBy?: unknown,
-      chainIds?: unknown,
-      enableDebounce?: boolean,
-    ) =>
-      mockUseTrendingSearch({ searchQuery, sortBy, chainIds, enableDebounce }),
-  }),
-);
+jest.mock('../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch');
+const mockUseTrendingSearch = jest.mocked(useTrendingSearch);
 
 // Mock sections.config to avoid complex Perps dependencies
 jest.mock('../../TrendingView/sections.config', () => ({

--- a/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.tsx
+++ b/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.tsx
@@ -204,7 +204,11 @@ const TrendingTokensFullView = () => {
     data: searchResults,
     isLoading,
     refetch: refetchTokensSection,
-  } = useTrendingSearch(searchQuery || undefined, sortBy, selectedNetwork);
+  } = useTrendingSearch({
+    searchQuery: searchQuery || undefined,
+    sortBy,
+    chainIds: selectedNetwork,
+  });
 
   // Sort and display tokens based on selected option and direction
   const trendingTokens = useMemo(() => {

--- a/app/components/Views/TrendingView/sections.config.tsx
+++ b/app/components/Views/TrendingView/sections.config.tsx
@@ -137,12 +137,10 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
     Skeleton: TrendingTokensSkeleton,
     Section: SectionCard,
     useSectionData: (searchQuery) => {
-      const { data, isLoading, refetch } = useTrendingSearch(
+      const { data, isLoading, refetch } = useTrendingSearch({
         searchQuery,
-        undefined,
-        undefined,
-        false, // Disable debouncing here because useExploreSearch already handles it
-      );
+        enableDebounce: false, // Disable debouncing here because useExploreSearch already handles it
+      });
       const filteredData = useMemo(
         () =>
           fuseSearch(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Refactored `useTrendingSearch` to accept a single options object instead of multiple parameters, improving readability and flexibility.
- Updated all related tests and components to utilize the new options structure, ensuring consistent usage across the application.
- Enhanced the test cases to validate the new implementation, including case-insensitive filtering and whitespace trimming for search queries.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: refactor: cleanup useTrendingSearch hook

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A - this is an internal code change

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors trending tokens search to use a single options object and aligns all consumers/tests with the new API.
> 
> - Migrates `useTrendingSearch(searchQuery, sortBy, chainIds, enableDebounce)` to `useTrendingSearch({ searchQuery, sortBy, chainIds, enableDebounce })`
> - Introduces `useStableReference` (using `lodash/isEqual`) to stabilize options and avoid unnecessary updates; preserves debounced search behavior with `enableDebounce`
> - Updates `TrendingTokensFullView` and `sections.config` to pass options object and explicitly disable debounce where higher-level search already handles it
> - Adjusts mocks/tests to new signature and validates combined search+trending results, deduplication, case-insensitive/trimmed filtering, and immediate search when debounce is disabled
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9369f30a433b8471acec1f1508e7f20418d58529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->