### PR TITLE
refactor: update Explore navigation stacks

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -314,53 +314,6 @@ const ExploreHome = () => (
       component={ExploreFeed}
       options={{ headerShown: false }}
     />
-    <Stack.Screen
-      name={Routes.EXPLORE_SEARCH}
-      component={ExploreSearchScreen}
-      options={{
-        headerShown: false,
-        animationEnabled: true,
-        cardStyleInterpolator: ({ current, layouts }) => ({
-          cardStyle: {
-            transform: [
-              {
-                translateX: current.progress.interpolate({
-                  inputRange: [0, 1],
-                  outputRange: [layouts.screen.width, 0],
-                }),
-              },
-            ],
-          },
-        }),
-      }}
-    />
-    <Stack.Screen
-      name={Routes.SITES_FULL_VIEW}
-      component={SitesFullView}
-      options={{
-        headerShown: false,
-        animationEnabled: true,
-        cardStyleInterpolator: ({ current, layouts }) => ({
-          cardStyle: {
-            transform: [
-              {
-                translateX: current.progress.interpolate({
-                  inputRange: [0, 1],
-                  outputRange: [layouts.screen.width, 0],
-                }),
-              },
-            ],
-          },
-        }),
-      }}
-    />
-
-    {/* Trending Browser Stack (uses existing browser flow) */}
-    <Stack.Screen
-      name={Routes.BROWSER.HOME}
-      component={BrowserFlow}
-      options={{ headerShown: false }}
-    />
   </Stack.Navigator>
 );
 
@@ -921,6 +874,10 @@ const MainNavigator = () => {
     () => predictEnabledFlag,
     [predictEnabledFlag],
   );
+  // Get feature flag state for conditional Trending Tokens screen registration
+  const isAssetsTrendingTokensEnabled = useSelector(
+    selectAssetsTrendingTokensEnabled,
+  );
 
   return (
     <Stack.Navigator
@@ -1233,6 +1190,70 @@ const MainNavigator = () => {
             name={Routes.PREDICT.MODALS.ROOT}
             component={PredictModalStack}
             options={clearStackNavigatorOptions}
+          />
+        </>
+      )}
+      {isAssetsTrendingTokensEnabled && (
+        <>
+          <Stack.Screen
+            name={Routes.EXPLORE_SEARCH}
+            component={ExploreSearchScreen}
+            options={{
+              headerShown: false,
+              animationEnabled: true,
+              cardStyleInterpolator: ({ current, layouts }) => ({
+                cardStyle: {
+                  transform: [
+                    {
+                      translateX: current.progress.interpolate({
+                        inputRange: [0, 1],
+                        outputRange: [layouts.screen.width, 0],
+                      }),
+                    },
+                  ],
+                },
+              }),
+            }}
+          />
+          <Stack.Screen
+            name={Routes.SITES_FULL_VIEW}
+            component={SitesFullView}
+            options={{
+              headerShown: false,
+              animationEnabled: true,
+              cardStyleInterpolator: ({ current, layouts }) => ({
+                cardStyle: {
+                  transform: [
+                    {
+                      translateX: current.progress.interpolate({
+                        inputRange: [0, 1],
+                        outputRange: [layouts.screen.width, 0],
+                      }),
+                    },
+                  ],
+                },
+              }),
+            }}
+          />
+          <Stack.Screen
+            name={Routes.BROWSER.HOME}
+            component={BrowserFlow}
+            options={{
+              headerShown: false,
+              animationEnabled: true,
+              cardStyleInterpolator: ({ current, layouts }) => ({
+                cardStyle: {
+                  transform: [
+                    {
+                      translateX: current.progress.interpolate({
+                        inputRange: [0, 1],
+                        outputRange: [layouts.screen.width, 0],
+                      }),
+                    },
+                  ],
+                },
+              }),
+            }}
           />
         </>
       )}

--- a/app/components/Views/TrendingView/components/ExploreSearchBar/ExploreSearchBar.tsx
+++ b/app/components/Views/TrendingView/components/ExploreSearchBar/ExploreSearchBar.tsx
@@ -88,7 +88,7 @@ const ExploreSearchBar: React.FC<ExploreSearchBarProps> = (props) => {
             onChangeText={props.onSearchChange}
             placeholder={placeholder}
             placeholderTextColor={colors.text.alternative}
-            style={tw.style('flex-1 text-base text-default py-2.5')}
+            style={tw.style('flex-1 text-body-md leading-0 text-default')}
             testID="explore-view-search-input"
             autoFocus={props.type === 'interactive'}
             autoCapitalize="none"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Removed hardcoded Trending Tokens screens from MainNavigator.
- Added conditional rendering for ExploreSearchScreen, SitesFullView, and BrowserFlow based on the `isAssetsTrendingTokensEnabled` feature flag.
- Updated ExploreSearchBar styles for improved text appearance.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: refactor: update Explore navigation stacks

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/24342 https://github.com/MetaMask/metamask-mobile/issues/24393 https://consensyssoftware.atlassian.net/browse/ASSETS-2238 https://consensyssoftware.atlassian.net/browse/ASSETS-2253

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before + After**

https://www.loom.com/share/1556ba489e1c495cbcbd0933c5708e53

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts Explore-related screen registration and guards it with a feature flag for clearer, conditional navigation.
> 
> - Removes `EXPLORE_SEARCH`, `SITES_FULL_VIEW`, and `BROWSER.HOME` from `ExploreHome` stack
> - Conditionally registers `ExploreSearchScreen`, `SitesFullView`, and `BrowserFlow` in `MainNavigator` when `isAssetsTrendingTokensEnabled` is true (adds `selectAssetsTrendingTokensEnabled` selector usage)
> - Updates `ExploreSearchBar` `TextInput` styles to `text-body-md` with tighter leading and removes extra padding
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d486fedc7bcfe9759ce04686bd6595b243206d4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->