### PR TITLE
feat: MegaETH add infura RPC and blockscout URL

### DIFF
--- a/app/store/migrations/113.test.ts
+++ b/app/store/migrations/113.test.ts
@@ -1,0 +1,451 @@
+import { captureException } from '@sentry/react-native';
+import { cloneDeep } from 'lodash';
+
+import { ensureValidState } from './util';
+import migrate, { migrationVersion, MEGAETH_MAINNET_CHAIN_ID } from './113';
+import { Hex } from '@metamask/utils';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+jest.mock('uuid', () => ({ v4: () => 'mock-uuid' }));
+
+const mockedCaptureException = jest.mocked(captureException);
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+
+const mainnetConfiguration = {
+  '0x1': {
+    chainId: '0x1',
+    name: 'Ethereum',
+    nativeCurrency: 'ETH',
+    blockExplorerUrls: ['https://explorer.com'],
+    defaultRpcEndpointIndex: 0,
+    defaultBlockExplorerUrlIndex: 0,
+    rpcEndpoints: [
+      {
+        networkClientId: 'mainnet',
+        type: 'custom',
+        url: 'https://mainnet.com',
+      },
+    ],
+  },
+};
+
+const megaEthMainnetInitialConfiguration = {
+  [MEGAETH_MAINNET_CHAIN_ID]: {
+    chainId: MEGAETH_MAINNET_CHAIN_ID,
+    name: 'MegaETH Mainnet',
+    nativeCurrency: 'ETH',
+    blockExplorerUrls: ['https://explorer.com'],
+    defaultRpcEndpointIndex: 0,
+    defaultBlockExplorerUrlIndex: 0,
+    rpcEndpoints: [
+      {
+        networkClientId: 'megaeth-mainnet',
+        type: 'custom',
+        url: 'https://rpc.com',
+      },
+    ],
+  },
+};
+
+interface RpcEndpoint {
+  failoverUrls?: string[];
+  name?: string;
+  networkClientId: string;
+  url: string;
+  type: string;
+}
+
+interface NetworkConfiguration {
+  blockExplorerUrls: string[];
+  chainId: Hex;
+  defaultBlockExplorerUrlIndex?: number;
+  defaultRpcEndpointIndex: number;
+  name: string;
+  nativeCurrency: string;
+  rpcEndpoints: RpcEndpoint[];
+}
+
+const unitTestInfuraId = 'unitTestInfuraId';
+
+export const MEGAETH_MAINNET_CLEAN_CONFIG: NetworkConfiguration = {
+  chainId: MEGAETH_MAINNET_CHAIN_ID,
+  name: 'MegaETH Mainnet',
+  nativeCurrency: 'ETH',
+  blockExplorerUrls: ['https://megaeth.blockscout.com/'],
+  defaultRpcEndpointIndex: 0,
+  defaultBlockExplorerUrlIndex: 0,
+  rpcEndpoints: [
+    {
+      failoverUrls: [],
+      networkClientId: 'megaeth-mainnet',
+      type: 'custom',
+      url: `https://megaeth-mainnet.infura.io/v3/${unitTestInfuraId}`,
+    },
+  ],
+};
+
+describe(`migration #${migrationVersion}`, () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+
+    originalEnv = { ...process.env };
+    process.env.MM_INFURA_PROJECT_ID = unitTestInfuraId;
+  });
+
+  afterEach(() => {
+    for (const key of new Set([
+      ...Object.keys(originalEnv),
+      ...Object.keys(process.env),
+    ])) {
+      if (originalEnv[key]) {
+        process.env[key] = originalEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it('returns state unchanged if ensureValidState fails', () => {
+    const state = { some: 'state' };
+    mockedEnsureValidState.mockReturnValue(false);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toStrictEqual({ some: 'state' });
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  const invalidStates = [
+    {
+      state: {
+        engine: {},
+      },
+      scenario: 'empty engine state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {},
+        },
+      },
+      scenario: 'empty backgroundState',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: 'invalid',
+          },
+        },
+      },
+      scenario: 'invalid NetworkController state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {},
+          },
+        },
+      },
+      scenario: 'missing networkConfigurationsByChainId property',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {
+              networkConfigurationsByChainId: 'invalid',
+            },
+          },
+        },
+      },
+      scenario: 'invalid networkConfigurationsByChainId state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {
+              networkConfigurationsByChainId: {
+                [MEGAETH_MAINNET_CHAIN_ID]: {
+                  chainId: MEGAETH_MAINNET_CHAIN_ID,
+                  name: 'MegaETH mainnet',
+                  nativeCurrency: 'MegaETH',
+                  blockExplorerUrls: ['https://explorer.com'],
+                  defaultRpcEndpointIndex: 0,
+                  defaultBlockExplorerUrlIndex: 0,
+                  rpcEndpoints: [
+                    {
+                      networkClientId: 'megaeth-mainnet',
+                      type: 'custom',
+                      url: 'https://rpc.com',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+      scenario: 'selectedNetworkClientId is missing',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {
+              selectedNetworkClientId: {},
+              networkConfigurationsByChainId: {
+                [MEGAETH_MAINNET_CHAIN_ID]: {
+                  chainId: MEGAETH_MAINNET_CHAIN_ID,
+                  name: 'MegaETH Mainnet',
+                  nativeCurrency: 'MegaETH',
+                  blockExplorerUrls: ['https://explorer.com'],
+                  defaultRpcEndpointIndex: 0,
+                  defaultBlockExplorerUrlIndex: 0,
+                  rpcEndpoints: [
+                    {
+                      networkClientId: 'megaeth-mainnet',
+                      type: 'custom',
+                      url: 'https://rpc.com',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+      scenario: 'selectedNetworkClientId is not a string',
+    },
+  ];
+
+  it.each(invalidStates)('captures exception if $scenario', ({ state }) => {
+    const orgState = cloneDeep(state);
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = migrate(state);
+
+    // State should be unchanged
+    expect(migratedState).toStrictEqual(orgState);
+    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('keeps config as is without error, if already clean', async () => {
+    const orgState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'mainnet',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              [MEGAETH_MAINNET_CHAIN_ID]: MEGAETH_MAINNET_CLEAN_CONFIG,
+            },
+          },
+        },
+      },
+    };
+
+    const expectedState = cloneDeep(orgState);
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(orgState);
+
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+
+    expect(migratedState).toStrictEqual(expectedState);
+  });
+
+  it('merges the existing megaeth mainnet network configuration if there is one', async () => {
+    const orgState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              ...megaEthMainnetInitialConfiguration,
+            },
+          },
+        },
+      },
+    };
+
+    const expectedState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              [MEGAETH_MAINNET_CHAIN_ID]: {
+                ...MEGAETH_MAINNET_CLEAN_CONFIG,
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'megaeth-mainnet',
+                    url: 'https://rpc.com',
+                    type: 'custom',
+                  },
+                  {
+                    ...MEGAETH_MAINNET_CLEAN_CONFIG.rpcEndpoints[0],
+                    networkClientId: 'mock-uuid',
+                  },
+                ],
+                defaultRpcEndpointIndex: 1,
+                defaultBlockExplorerUrlIndex: 1,
+                blockExplorerUrls: [
+                  'https://explorer.com',
+                  'https://megaeth.blockscout.com', // No backslash, since was not already present
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(orgState);
+
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+
+    expect(migratedState).toStrictEqual(expectedState);
+  });
+
+  it('keeps original RPC if no infura key is found', async () => {
+    delete process.env.MM_INFURA_PROJECT_ID;
+
+    const orgState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              ...megaEthMainnetInitialConfiguration,
+              [MEGAETH_MAINNET_CHAIN_ID]: {
+                ...MEGAETH_MAINNET_CLEAN_CONFIG,
+                name: 'MegaETH Mainnet',
+                nativeCurrency: 'ETH',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'megaeth-mainnet',
+                    url: 'https://rpc.com',
+                    type: 'custom',
+                  },
+                ],
+                defaultRpcEndpointIndex: 0,
+                defaultBlockExplorerUrlIndex: 0,
+                blockExplorerUrls: ['https://explorer.com'],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const expectedState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              [MEGAETH_MAINNET_CHAIN_ID]: {
+                ...MEGAETH_MAINNET_CLEAN_CONFIG,
+                rpcEndpoints:
+                  megaEthMainnetInitialConfiguration[MEGAETH_MAINNET_CHAIN_ID]
+                    .rpcEndpoints,
+                defaultRpcEndpointIndex: 0,
+                defaultBlockExplorerUrlIndex: 1,
+                blockExplorerUrls: [
+                  'https://explorer.com',
+                  'https://megaeth.blockscout.com', // No backslash, since was not already present
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(orgState);
+
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Infura project ID is not set, skip the MegaETH RPC part of the migration',
+        ),
+      }),
+    );
+
+    expect(migratedState).toStrictEqual(expectedState);
+  });
+
+  it('returns the original state if the megaeth mainnet network configuration exists but is invalid', async () => {
+    const orgState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              [MEGAETH_MAINNET_CHAIN_ID]: {
+                ...MEGAETH_MAINNET_CLEAN_CONFIG,
+                name: 'MegaETH Mainnet',
+                nativeCurrency: 'ETH',
+                rpcEndpoints: 'invalid',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const expectedState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              [MEGAETH_MAINNET_CHAIN_ID]: {
+                ...MEGAETH_MAINNET_CLEAN_CONFIG,
+                name: 'MegaETH Mainnet',
+                nativeCurrency: 'ETH',
+                rpcEndpoints: 'invalid',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(orgState);
+
+    expect(migratedState).toStrictEqual(expectedState);
+  });
+});

--- a/app/store/migrations/113.ts
+++ b/app/store/migrations/113.ts
@@ -1,0 +1,267 @@
+import { captureException } from '@sentry/react-native';
+import {
+  getErrorMessage,
+  hasProperty,
+  Hex,
+  isHexString,
+  isObject,
+} from '@metamask/utils';
+import { v4 as uuidV4 } from 'uuid';
+
+import { ensureValidState, ValidState } from './util';
+import { cloneDeep } from 'lodash';
+
+/**
+ * A Copy of the RpcEndpoint type from the network controller,
+ * This is used to avoid the dependency on the network controller.
+ */
+interface RpcEndpoint {
+  failoverUrls?: string[];
+  name?: string;
+  networkClientId: string;
+  url: string;
+  type: string;
+}
+
+/**
+ * A Copy of the NetworkConfiguration type from the network controller,
+ * This is used to avoid the dependency on the network controller.
+ */
+interface NetworkConfiguration {
+  blockExplorerUrls: string[];
+  chainId: Hex;
+  defaultBlockExplorerUrlIndex?: number;
+  defaultRpcEndpointIndex: number;
+  name: string;
+  nativeCurrency: string;
+  rpcEndpoints: RpcEndpoint[];
+}
+
+export const migrationVersion = 113;
+
+// Export for tests
+export const MEGAETH_MAINNET_CHAIN_ID = '0x10e6';
+
+/**
+ * This migration does:
+ * - Adds Infura RPC to MegaETH and set as default if not already present. Otherwise leaves untouched.
+ * - Adds Blockscout Explorer URL to list of explorers if not already present.
+ *
+ * @param versionedState - MetaMask state, exactly
+ * what we persist to disk.
+ * @returns Updated MetaMask state.
+ */
+export default function migrate(versionedState: unknown) {
+  // Putting env-fetching here for easier testing.
+  // Ideally all "infuraProjectId" logic should use a getter.
+  const INFURA_KEY = process.env.MM_INFURA_PROJECT_ID;
+  const infuraProjectId = INFURA_KEY === 'null' ? '' : INFURA_KEY;
+
+  const state = cloneDeep(versionedState);
+  try {
+    if (!ensureValidState(state, migrationVersion)) {
+      return state;
+    }
+
+    const networkState = validateNetworkController(state);
+    // No Migration should be performed if the NetworkController state is invalid.
+    if (networkState === undefined) {
+      console.warn(
+        `Migration ${migrationVersion}: Missing or invalid NetworkController state, skip the migration`,
+      );
+      return state;
+    }
+
+    const { networkConfigurationsByChainId } = networkState;
+
+    // Migrate NetworkController:
+    // - Merge the MegaETH Mainnet network configuration if user already has it.
+    if (hasProperty(networkConfigurationsByChainId, MEGAETH_MAINNET_CHAIN_ID)) {
+      const megaethMainnetConfiguration =
+        networkConfigurationsByChainId[MEGAETH_MAINNET_CHAIN_ID];
+      if (!isValidNetworkConfiguration(megaethMainnetConfiguration)) {
+        console.warn(
+          `Migration ${migrationVersion}: Invalid MegaETH Mainnet network configuration, skip the migration`,
+        );
+        return state;
+      }
+
+      if (infuraProjectId) {
+        const newInfuraURL = `https://megaeth-mainnet.infura.io/v3/${infuraProjectId}`;
+        const isInfuraRpcPresent =
+          megaethMainnetConfiguration.rpcEndpoints.find(
+            (rpc) => rpc.url === newInfuraURL,
+          );
+        // Avoid RPC duplication if Infura is already present.
+        if (!isInfuraRpcPresent) {
+          // Add Infura RPC
+          megaethMainnetConfiguration.rpcEndpoints.push({
+            failoverUrls: [],
+            networkClientId: uuidV4(),
+            type: 'custom',
+            url: newInfuraURL,
+          });
+          // Set newly added Infura RPC as default RPC.
+          megaethMainnetConfiguration.defaultRpcEndpointIndex =
+            megaethMainnetConfiguration.rpcEndpoints.length - 1;
+        }
+      } else {
+        captureException(
+          new Error(
+            `Migration ${migrationVersion}: Infura project ID is not set, skip the MegaETH RPC part of the migration`,
+          ),
+        );
+      }
+
+      const newBlockExplorerUrl = 'https://megaeth.blockscout.com';
+      const isBlockExplorerUrlExist =
+        megaethMainnetConfiguration.blockExplorerUrls.find(
+          (url) => url.includes(newBlockExplorerUrl), // In case of trailing slash
+        );
+      // Avoid Explorer duplication
+      if (!isBlockExplorerUrlExist) {
+        // Add Blockscout as default Explorer URL if it was not already present.
+        megaethMainnetConfiguration.blockExplorerUrls.push(newBlockExplorerUrl);
+        megaethMainnetConfiguration.defaultBlockExplorerUrlIndex =
+          megaethMainnetConfiguration.blockExplorerUrls.length - 1;
+      }
+    }
+
+    return state;
+  } catch (error) {
+    console.error(error);
+    captureException(
+      new Error(`Migration ${migrationVersion}: ${getErrorMessage(error)}`),
+    );
+
+    // Return the original state if migration fails to avoid breaking the app
+    return versionedState;
+  }
+}
+
+function validateNetworkController(state: ValidState):
+  | {
+      networkConfigurationsByChainId: Record<Hex, unknown>;
+      selectedNetworkClientId: string;
+    }
+  | undefined {
+  if (!hasProperty(state.engine.backgroundState, 'NetworkController')) {
+    // We catch the exception here, as we don't expect the NetworkController state is missing.
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: missing NetworkController`,
+      ),
+    );
+    return undefined;
+  }
+
+  const networkState = state.engine.backgroundState.NetworkController;
+
+  // To narrow the type of the networkState to the expected type.
+  if (!isValidNetworkControllerState(networkState)) {
+    return undefined;
+  }
+
+  return networkState;
+}
+
+function isValidNetworkControllerState(value: unknown): value is {
+  networkConfigurationsByChainId: Record<Hex, unknown>;
+  selectedNetworkClientId: string;
+} {
+  if (!isObject(value)) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: NetworkController state is not an object: '${typeof value}'`,
+      ),
+    );
+    return false;
+  }
+
+  if (!hasProperty(value, 'networkConfigurationsByChainId')) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: missing networkConfigurationsByChainId property`,
+      ),
+    );
+    return false;
+  }
+
+  if (
+    !isValidNetworkConfigurationsByChainId(value.networkConfigurationsByChainId)
+  ) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: networkConfigurationsByChainId is not a valid Record<Hex, unknown>`,
+      ),
+    );
+    return false;
+  }
+
+  if (!hasProperty(value, 'selectedNetworkClientId')) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: missing selectedNetworkClientId property`,
+      ),
+    );
+    return false;
+  }
+
+  if (typeof value.selectedNetworkClientId !== 'string') {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: selectedNetworkClientId is not a string: '${typeof value.selectedNetworkClientId}'`,
+      ),
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function isValidNetworkConfigurationsByChainId(
+  value: unknown,
+): value is Record<Hex, unknown> {
+  return (
+    isObject(value) &&
+    Object.entries(value).every(
+      ([chainId]) => typeof chainId === 'string' && isHexString(chainId),
+    )
+  );
+}
+
+function isValidNetworkConfiguration(
+  object: unknown,
+): object is NetworkConfiguration {
+  return (
+    isObject(object) &&
+    hasProperty(object, 'chainId') &&
+    typeof object.chainId === 'string' &&
+    isHexString(object.chainId) &&
+    hasProperty(object, 'rpcEndpoints') &&
+    Array.isArray(object.rpcEndpoints) &&
+    object.rpcEndpoints.every(isValidRpcEndpoint) &&
+    hasProperty(object, 'name') &&
+    typeof object.name === 'string' &&
+    hasProperty(object, 'nativeCurrency') &&
+    typeof object.nativeCurrency === 'string' &&
+    hasProperty(object, 'blockExplorerUrls') &&
+    Array.isArray(object.blockExplorerUrls) &&
+    object.blockExplorerUrls.every((url) => typeof url === 'string') &&
+    hasProperty(object, 'defaultRpcEndpointIndex') &&
+    typeof object.defaultRpcEndpointIndex === 'number' &&
+    (!hasProperty(object, 'defaultBlockExplorerUrlIndex') ||
+      (hasProperty(object, 'defaultBlockExplorerUrlIndex') &&
+        typeof object.defaultBlockExplorerUrlIndex === 'number'))
+  );
+}
+
+function isValidRpcEndpoint(object: unknown): boolean {
+  return (
+    isObject(object) &&
+    hasProperty(object, 'networkClientId') &&
+    typeof object.networkClientId === 'string' &&
+    hasProperty(object, 'url') &&
+    typeof object.url === 'string'
+  );
+}

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -113,6 +113,7 @@ import migration109 from './109';
 import migration110 from './110';
 import migration111 from './111';
 import migration112 from './112';
+import migration113 from './113';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -245,6 +246,7 @@ export const migrationList: MigrationsList = {
   110: migration110,
   111: migration111,
   112: migration112,
+  113: migration113,
 };
 
 // Enable both synchronous and asynchronous migrations

--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -184,7 +184,7 @@ export const PopularList = [
     ticker: 'ETH',
     warning: true,
     rpcPrefs: {
-      blockExplorerUrl: 'https://megaeth.blockscout.com',
+      blockExplorerUrl: 'https://megaeth.blockscout.com/',
       imageUrl: 'MEGAETH',
       imageSource: require('../../images/megaeth-mainnet-logo.png'),
     },

--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -179,12 +179,12 @@ export const PopularList = [
   {
     chainId: toHex('4326'),
     nickname: 'MegaEth',
-    rpcUrl: `https://mainnet.megaeth.com/rpc`,
+    rpcUrl: `https://megaeth-mainnet.infura.io/v3/${infuraProjectId}`,
     failoverRpcUrls: [],
     ticker: 'ETH',
     warning: true,
     rpcPrefs: {
-      blockExplorerUrl: 'https://explorer.megaeth.com',
+      blockExplorerUrl: 'https://megaeth.blockscout.com',
       imageUrl: 'MEGAETH',
       imageSource: require('../../images/megaeth-mainnet-logo.png'),
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Infura to support MegaETH.
- Blockscout to become the preferred block explorer for MegaETH.
--> This PR updates the RPC and block explorer URL of MegaETH.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update MegaETH RPC (Infura) and explorer (Blockscout) URLs
CHANGELOG entry: add migration (113) for MegaETH RPC (Infura) and explorer (Blockscout) URLs

## **Related issues**

[Fixes: https://consensyssoftware.atlassian.net/browse/NEB-71?atlOrigin=eyJpIjoiYWU1OGI2NzEyOWEwNDc3ZmI0MDhhMDQyODFmN2JhNGMiLCJwIjoiaiJ9](https://consensyssoftware.atlassian.net/browse/NEB-71?atlOrigin=eyJpIjoiYWU1OGI2NzEyOWEwNDc3ZmI0MDhhMDQyODFmN2JhNGMiLCJwIjoiaiJ9)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="200" alt="image" src="https://github.com/user-attachments/assets/a983dc49-b4ba-4d5c-a556-4c6557bdfd51" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns MegaETH defaults with Infura RPC and Blockscout explorer, and migrates existing user configs safely.
> 
> - Adds `migration 113` to: add Infura RPC to `MegaETH Mainnet` and set it default if not present; add Blockscout explorer and set it default if not present; skip safely on invalid state, already-clean configs, or when the Infura key is missing (logs to Sentry)
> - Introduces strict validation helpers for `NetworkController` state and MegaETH config; captures exceptions via Sentry
> - Registers migration in `migrations/index.ts` and adds thorough unit tests covering success, invalid states, missing Infura key, and no-op cases
> - Updates `customNetworks.tsx` MegaEth entry to Infura RPC URL and Blockscout explorer URL
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2e93a4878b0154fd05cd289897387ab336db2d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->