### PR TITLE
fix: Update secondary mUSD conversion CTA copy

### DIFF
--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.test.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.test.tsx
@@ -549,7 +549,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       );
 
       expect(getByText('+2.50%')).toBeOnTheScreen();
-      expect(queryByText('Get 3% mUSD Bonus')).toBeNull();
+      expect(queryByText('Get 3% mUSD bonus')).toBeNull();
     });
 
     it('displays percentage change when asset is not a convertible stablecoin', () => {
@@ -576,7 +576,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       );
 
       expect(getByText('+3.20%')).toBeOnTheScreen();
-      expect(queryByText('Get 3% mUSD Bonus')).toBeNull();
+      expect(queryByText('Get 3% mUSD bonus')).toBeNull();
     });
 
     it('calls initiateConversion with correct parameters when secondary balance is pressed', async () => {

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.test.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.test.tsx
@@ -113,6 +113,7 @@ jest.mock('../../../Stake/hooks/useStakingChain', () => ({
 }));
 
 import { selectIsMusdConversionFlowEnabledFlag } from '../../../Earn/selectors/featureFlags';
+import { MUSD_CONVERSION_APY } from '../../../Earn/constants/musd';
 
 jest.mock('../../../Earn/selectors/featureFlags', () => ({
   selectPooledStakingEnabledFlag: jest.fn(() => true),
@@ -511,7 +512,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       jest.clearAllMocks();
     });
 
-    it('displays "Convert to mUSD" CTA when asset is convertible stablecoin with positive balance', () => {
+    it('displays "Get 3% mUSD bonus" CTA when asset is convertible stablecoin with positive balance', () => {
       prepareMocks({
         asset: usdcAsset,
         isMusdConversionEnabled: true,
@@ -527,7 +528,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
         />,
       );
 
-      expect(getByText('Convert to mUSD')).toBeOnTheScreen();
+      expect(getByText('Get 3% mUSD bonus')).toBeOnTheScreen();
     });
 
     it('displays percentage change when mUSD conversion flag is disabled', () => {
@@ -548,7 +549,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       );
 
       expect(getByText('+2.50%')).toBeOnTheScreen();
-      expect(queryByText('Convert to mUSD')).toBeNull();
+      expect(queryByText('Get 3% mUSD Bonus')).toBeNull();
     });
 
     it('displays percentage change when asset is not a convertible stablecoin', () => {
@@ -575,7 +576,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       );
 
       expect(getByText('+3.20%')).toBeOnTheScreen();
-      expect(queryByText('Convert to mUSD')).toBeNull();
+      expect(queryByText('Get 3% mUSD Bonus')).toBeNull();
     });
 
     it('calls initiateConversion with correct parameters when secondary balance is pressed', async () => {
@@ -610,7 +611,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       });
     });
 
-    it('tracks mUSD conversion CTA clicked event when Convert to mUSD is pressed and education screen has not been seen', async () => {
+    it('tracks mUSD conversion CTA clicked event when pressed and education screen has not been seen', async () => {
       // Arrange
       mockHasSeenConversionEducationScreen = false;
       prepareMocks({
@@ -658,7 +659,9 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
         location: 'token_list_item',
         redirects_to: 'conversion_education_screen',
         cta_type: 'musd_conversion_secondary_cta',
-        cta_text: strings('earn.musd_conversion.convert_to_musd'),
+        cta_text: strings('earn.musd_conversion.get_a_percentage_musd_bonus', {
+          percentage: MUSD_CONVERSION_APY,
+        }),
         network_chain_id: usdcAsset.chainId,
         network_name: 'Ethereum Mainnet',
         asset_symbol: usdcAsset.symbol,
@@ -668,7 +671,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'mock-built-event' });
     });
 
-    it('tracks mUSD conversion CTA clicked event when Convert to mUSD is pressed and education screen has been seen', async () => {
+    it('tracks mUSD conversion CTA clicked event pressed and education screen has been seen', async () => {
       // Arrange
       mockHasSeenConversionEducationScreen = true;
       prepareMocks({
@@ -716,7 +719,9 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
         location: 'token_list_item',
         redirects_to: 'custom_amount_screen',
         cta_type: 'musd_conversion_secondary_cta',
-        cta_text: strings('earn.musd_conversion.convert_to_musd'),
+        cta_text: strings('earn.musd_conversion.get_a_percentage_musd_bonus', {
+          percentage: MUSD_CONVERSION_APY,
+        }),
         network_chain_id: usdcAsset.chainId,
         network_name: 'Ethereum Mainnet',
         asset_symbol: usdcAsset.symbol,

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
@@ -47,6 +47,7 @@ import Logger from '../../../../../util/Logger';
 import { useMusdCtaVisibility } from '../../../Earn/hooks/useMusdCtaVisibility';
 import { useNetworkName } from '../../../../Views/confirmations/hooks/useNetworkName';
 import { MUSD_EVENTS_CONSTANTS } from '../../../Earn/constants/events';
+import { MUSD_CONVERSION_APY } from '../../../Earn/constants/musd';
 
 export const ACCOUNT_TYPE_LABEL_TEST_ID = 'account-type-label';
 
@@ -145,7 +146,12 @@ export const TokenListItem = React.memo(
               location: EVENT_LOCATIONS.TOKEN_LIST_ITEM,
               redirects_to: getRedirectLocation(),
               cta_type: MUSD_CTA_TYPES.SECONDARY,
-              cta_text: strings('earn.musd_conversion.convert_to_musd'),
+              cta_text: strings(
+                'earn.musd_conversion.get_a_percentage_musd_bonus',
+                {
+                  percentage: MUSD_CONVERSION_APY,
+                },
+              ),
               network_chain_id: chainId,
               network_name: networkName,
               asset_symbol: asset?.symbol,
@@ -201,7 +207,9 @@ export const TokenListItem = React.memo(
     const secondaryBalanceDisplay = useMemo(() => {
       if (shouldShowConvertToMusdCta) {
         return {
-          text: strings('earn.musd_conversion.convert_to_musd'),
+          text: strings('earn.musd_conversion.get_a_percentage_musd_bonus', {
+            percentage: MUSD_CONVERSION_APY,
+          }),
           color: TextColor.Primary,
           onPress: handleConvertToMUSD,
         };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5710,6 +5710,7 @@
     },
     "musd_conversion": {
       "convert_to_musd": "Convert to mUSD",
+      "get_a_percentage_musd_bonus": "Get {{percentage}}% mUSD bonus",
       "convert": "Convert",
       "toasts": {
         "converting": "Converting {{token}} → mUSD",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updated secondary mUSD conversion CTA text from `"Convert to mUSD"` to `"Get 3% mUSD bonus"`.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated secondary mUSD conversion CTA text to get 3% mUSD bonus

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: mUSD conversion secondary CTA copy

  Scenario: user sees mUSD bonus copy on eligible stablecoin
    Given user has a convertible stablecoin balance on a supported network
    And the mUSD conversion feature is enabled

    When user views the token in the token list
    Then the secondary CTA displays "Get {percentage}% mUSD bonus"

  Scenario: user does not see mUSD bonus copy when not eligible
    Given user is viewing a token that is not eligible for mUSD conversion or the feature is disabled

    When user views the token in the token list
    Then the secondary CTA "Get {percentage}% mUSD bonus" is not displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="478" height="994" alt="image" src="https://github.com/user-attachments/assets/717fbe63-e9aa-48cd-9a5b-03e2ed9563a5" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates secondary mUSD conversion CTA to display a dynamic bonus percentage and aligns analytics tracking.
> 
> - Changes TokenListItem secondary balance CTA text to `strings('earn.musd_conversion.get_a_percentage_musd_bonus', { percentage: MUSD_CONVERSION_APY })`
> - Updates metrics `cta_text` for `MUSD_CONVERSION_CTA_CLICKED` to the new localized, percentage-based string
> - Adds `get_a_percentage_musd_bonus` key to `en.json`; imports `MUSD_CONVERSION_APY`
> - Adjusts unit tests to expect the new CTA text and updated tracking properties
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61c06d2fd76c92662151630ddc5d9739c64a5153. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->