### PR TITLE
Nft import alert banner

### DIFF
--- a/app/components/Views/AddAsset/AddAsset.styles.ts
+++ b/app/components/Views/AddAsset/AddAsset.styles.ts
@@ -25,9 +25,12 @@ const styleSheet = (params: { theme: Theme }) => {
       backgroundColor: colors.background.default,
     },
     infoWrapper: {
-      alignItems: 'center',
       paddingTop: 16,
-      paddingHorizontal: 16,
+    },
+    infoBanner: {
+      alignSelf: 'stretch',
+      marginHorizontal: 16,
+      borderRadius: 4,
     },
     tabContainer: {
       flex: 1,

--- a/app/components/Views/AddAsset/AddAsset.tsx
+++ b/app/components/Views/AddAsset/AddAsset.tsx
@@ -127,6 +127,7 @@ const AddAsset = () => {
       {assetType !== 'token' && (
         <View style={styles.infoWrapper} testID="add-asset-nft-banner">
           <Banner
+            style={styles.infoBanner}
             variant={BannerVariant.Alert}
             description={
               !displayNftMedia ? (

--- a/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
+++ b/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
@@ -13,8 +13,6 @@ exports[`AddAsset component renders collectible view correctly 1`] = `
   <View
     style={
       {
-        "alignItems": "center",
-        "paddingHorizontal": 16,
         "paddingTop": 16,
       }
     }
@@ -23,11 +21,13 @@ exports[`AddAsset component renders collectible view correctly 1`] = `
     <View
       style={
         {
+          "alignSelf": "stretch",
           "backgroundColor": "#9a63001a",
           "borderColor": "#9a6300",
           "borderLeftWidth": 4,
           "borderRadius": 4,
           "flexDirection": "row",
+          "marginHorizontal": 16,
           "padding": 12,
           "paddingLeft": 8,
         }


### PR DESCRIPTION
Add horizontal margin and border radius to the Import NFT alert banner.

This prevents the banner from touching the viewport edges, improving its visual presentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc9115f5-201f-422a-aab1-15bc38e74c21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc9115f5-201f-422a-aab1-15bc38e74c21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

