### PR TITLE
Import NFT screen layout

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Image, StyleSheet, Keyboard, Platform } from 'react-native';
 import { createStackNavigator } from '@react-navigation/stack';
+import { useNavigationState } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import Browser from '../../Views/Browser';
@@ -512,6 +513,11 @@ const HomeTabs = () => {
   const isAssetsTrendingTokensEnabled = useSelector(
     selectAssetsTrendingTokensEnabled,
   );
+  const rootState = useNavigationState((state) => state);
+  const currentRootRoute = rootState?.routes?.[rootState.index];
+  const isImportNftScreen =
+    currentRootRoute?.name === 'AddAsset' &&
+    currentRootRoute?.params?.assetType === 'collectible';
 
   const chainId = useSelector((state) => {
     const providerConfig = selectProviderConfig(state);
@@ -626,6 +632,10 @@ const HomeTabs = () => {
 
   const renderTabBar = ({ state, descriptors, navigation }) => {
     const currentRoute = state.routes[state.index];
+
+    if (isImportNftScreen) {
+      return null;
+    }
 
     // Hide tab bar for rewards onboarding splash screen
     if (currentRoute.name?.startsWith('Rewards') && !rewardsSubscription) {

--- a/app/components/UI/AddCustomCollectible/index.test.tsx
+++ b/app/components/UI/AddCustomCollectible/index.test.tsx
@@ -9,6 +9,7 @@ import { act, fireEvent, waitFor } from '@testing-library/react-native';
 import Engine from '../../../core/Engine';
 // eslint-disable-next-line import/no-namespace
 import * as utilsTransactions from '../../../util/transactions';
+import { toSentenceCase } from '../../../util/string';
 
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 jest.mock('../../../core/Engine', () => ({
@@ -551,7 +552,7 @@ describe('AddCustomCollectible', () => {
       );
 
       const cancelButton = getByText(
-        'add_asset.collectibles.cancel_add_collectible',
+        toSentenceCase('add_asset.collectibles.cancel_add_collectible'),
       );
       fireEvent.press(cancelButton);
 

--- a/app/components/UI/AddCustomCollectible/index.tsx
+++ b/app/components/UI/AddCustomCollectible/index.tsx
@@ -7,6 +7,7 @@ import {
   StyleSheet,
   TouchableOpacity,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   ToastContext,
   ToastVariants,
@@ -34,6 +35,7 @@ import {
 import { useMetrics } from '../../../components/hooks/useMetrics';
 import Logger from '../../../util/Logger';
 import { TraceName, endTrace, trace } from '../../../util/trace';
+import { toSentenceCase } from '../../../util/string';
 import {
   IconColor,
   IconName,
@@ -140,9 +142,13 @@ const AddCustomCollectible = ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const assetTokenIdInput = React.createRef() as any;
   const { colors, themeAppearance } = useTheme();
+  const { bottom: bottomInset } = useSafeAreaInsets();
   const { trackEvent, createEventBuilder } = useMetrics();
   const { toastRef } = useContext(ToastContext);
   const styles = createStyles(colors);
+  const buttonContainerStyle = {
+    paddingBottom: Math.max(bottomInset, 16),
+  };
 
   const selectedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
@@ -314,13 +320,18 @@ const AddCustomCollectible = ({
   return (
     <View style={styles.wrapper} testID={NFTImportScreenSelectorsIDs.CONTAINER}>
       <ActionView
-        cancelText={strings('add_asset.collectibles.cancel_add_collectible')}
-        confirmText={strings('add_asset.collectibles.add_collectible')}
+        cancelText={toSentenceCase(
+          strings('add_asset.collectibles.cancel_add_collectible'),
+        )}
+        confirmText={toSentenceCase(
+          strings('add_asset.collectibles.add_collectible'),
+        )}
         onCancelPress={cancelAddCollectible}
         onConfirmPress={addNft}
         confirmDisabled={!address || !tokenId || !selectedNetwork}
         loading={loading}
         confirmTestID={'add-collectible-button'}
+        buttonContainerStyle={buttonContainerStyle}
       >
         <View>
           <View style={styles.rowWrapper}>


### PR DESCRIPTION
Reworks the Import NFT screen layout to match design specs by removing the bottom tab bar, pinning footer buttons, and updating button label casing.

---
<a href="https://cursor.com/background-agent?bcId=bc-3097ae14-26f7-43bd-b8b7-273c3577e0ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3097ae14-26f7-43bd-b8b7-273c3577e0ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

