### PR TITLE
feat: MUSD-227: update mUSD conversion education screen screen copy

### DIFF
--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.test.tsx
@@ -13,6 +13,7 @@ import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { strings } from '../../../../../../locales/i18n';
 import { useMusdConversion } from '../../hooks/useMusdConversion';
 import { useParams } from '../../../../../util/navigation/navUtils';
+import { MUSD_CONVERSION_APY } from '../../constants/musd';
 
 const FIXED_NOW_MS = 1730000000000;
 const mockTrackEvent = jest.fn();
@@ -160,10 +161,18 @@ describe('EarnMusdConversionEducationView', () => {
       );
 
       expect(
-        getByText(strings('earn.musd_conversion.education.heading')),
+        getByText(
+          strings('earn.musd_conversion.education.heading', {
+            percentage: MUSD_CONVERSION_APY,
+          }),
+        ),
       ).toBeOnTheScreen();
       expect(
-        getByText(strings('earn.musd_conversion.education.description')),
+        getByText(
+          strings('earn.musd_conversion.education.description', {
+            percentage: MUSD_CONVERSION_APY,
+          }),
+        ),
       ).toBeOnTheScreen();
       expect(
         getByText(strings('earn.musd_conversion.education.primary_button')),

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
@@ -27,6 +27,7 @@ import {
 import { strings } from '../../../../../../locales/i18n';
 import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
 import { MUSD_EVENTS_CONSTANTS } from '../../constants/events';
+import { MUSD_CONVERSION_APY } from '../../constants/musd';
 interface EarnMusdConversionEducationViewRouteParams {
   /**
    * The payment token to preselect in the confirmation screen
@@ -180,10 +181,14 @@ const EarnMusdConversionEducationView = () => {
     <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
       <View style={styles.content}>
         <Text style={styles.heading} numberOfLines={3} adjustsFontSizeToFit>
-          {strings('earn.musd_conversion.education.heading')}
+          {strings('earn.musd_conversion.education.heading', {
+            percentage: MUSD_CONVERSION_APY,
+          })}
         </Text>
         <Text variant={TextVariant.BodyMD} style={styles.bodyText}>
-          {strings('earn.musd_conversion.education.description')}
+          {strings('earn.musd_conversion.education.description', {
+            percentage: MUSD_CONVERSION_APY,
+          })}
         </Text>
       </View>
       <View style={styles.imageContainer}>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5718,9 +5718,9 @@
         "failed": "mUSD conversion failed"
       },
       "education": {
-        "heading": "Boost Earnings with mUSD",
-        "description": "Get an automatic mUSD bonus when you convert your stablecoins to mUSD, MetaMask’s dollar-backed stable.",
-        "primary_button": "Convert to mUSD",
+        "heading": "GET {{percentage}}% ON STABLECOINS",
+        "description": "Convert your stablecoins to mUSD, MetaMask’s US dollar-backed stablecoin, and receive up to a {{percentage}}% bonus. Terms apply.",
+        "primary_button": "Get Started",
         "secondary_button": "Not now"
       },
       "buy_musd": "Buy mUSD",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updates copy for the mUSD conversion education screen.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated copy for the mUSD conversion education screen.


## **Related issues**

Fixes: [MUSD-227: Update splash page](https://consensyssoftware.atlassian.net/browse/MUSD-227)

## **Manual testing steps**

```gherkin
Feature: mUSD conversion education messaging

  Scenario: user views mUSD conversion education screen
    Given user opens the mUSD conversion education screen

    When the education content is displayed
    Then the heading shows the current mUSD conversion APY percentage
    And the description mentions the bonus percentage
    And the primary call to action says "Get Started"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="478" height="994" alt="image" src="https://github.com/user-attachments/assets/97c83b9f-8105-4b57-8429-0cf40ec3709c" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes mUSD conversion education content and wires in dynamic APY.
> 
> - Injects `MUSD_CONVERSION_APY` into `heading` and `description` in `EarnMusdConversionEducationView`
> - Updates i18n strings (heading, description, primary_button) in `en.json` and changes CTA to "Get Started"
> - Aligns tests to expect interpolated strings and new CTA
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f34b1d9fc0edcaa02a4e99190e50b068ec4c5ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->