### PR TITLE
feat: MUSD-231 added mUSD developer options section with button to reset education screen seen state

### DIFF
--- a/app/components/UI/Earn/components/MusdDeveloperOptionsSection.test.tsx
+++ b/app/components/UI/Earn/components/MusdDeveloperOptionsSection.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { fireEvent, act } from '@testing-library/react-native';
+import { useDispatch } from 'react-redux';
+
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import { MusdDeveloperOptionsSection } from './MusdDeveloperOptionsSection';
+import {
+  setMusdConversionEducationSeen,
+  UserActionType,
+} from '../../../../actions/user';
+
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../../../../actions/user', () => ({
+  setMusdConversionEducationSeen: jest.fn(),
+  UserActionType: {
+    SET_MUSD_CONVERSION_EDUCATION_SEEN: 'SET_MUSD_CONVERSION_EDUCATION_SEEN',
+  },
+}));
+
+jest.mock('../../../../util/theme', () => ({
+  useTheme: jest.fn().mockReturnValue({
+    colors: {
+      background: { default: '#FFFFFF' },
+      text: { default: '#000000' },
+    },
+    themeAppearance: 'light',
+    typography: {},
+    shadows: {},
+    brandColors: {},
+  }),
+}));
+
+describe('MusdDeveloperOptionsSection', () => {
+  const mockUseDispatch = jest.mocked(useDispatch);
+  const mockSetMusdConversionEducationSeen = jest.mocked(
+    setMusdConversionEducationSeen,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDispatch.mockReturnValue(mockDispatch);
+
+    mockSetMusdConversionEducationSeen.mockImplementation((seen: boolean) => ({
+      type: UserActionType.SET_MUSD_CONVERSION_EDUCATION_SEEN,
+      payload: { seen },
+    }));
+  });
+
+  it('renders the status label from redux state', () => {
+    const { getByText } = renderWithProvider(<MusdDeveloperOptionsSection />, {
+      state: { user: { musdConversionEducationSeen: true } },
+    });
+
+    expect(getByText('Education screen seen: true')).toBeOnTheScreen();
+  });
+
+  it('dispatches reset action when reset button pressed', async () => {
+    const { getByText } = renderWithProvider(<MusdDeveloperOptionsSection />, {
+      state: { user: { musdConversionEducationSeen: true } },
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText('Reset education screen'));
+    });
+
+    expect(mockSetMusdConversionEducationSeen).toHaveBeenCalledWith(false);
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: UserActionType.SET_MUSD_CONVERSION_EDUCATION_SEEN,
+      payload: { seen: false },
+    });
+  });
+});

--- a/app/components/UI/Earn/components/MusdDeveloperOptionsSection.tsx
+++ b/app/components/UI/Earn/components/MusdDeveloperOptionsSection.tsx
@@ -1,0 +1,58 @@
+import React, { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useTheme } from '../../../../util/theme';
+import { setMusdConversionEducationSeen } from '../../../../actions/user';
+import { selectMusdConversionEducationSeen } from '../../../../reducers/user';
+import { useStyles } from '../../../../component-library/hooks';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../component-library/components/Texts/Text';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../component-library/components/Buttons/Button';
+import styleSheet from '../../../Views/Settings/DeveloperOptions/DeveloperOptions.styles';
+
+export const MusdDeveloperOptionsSection = () => {
+  const dispatch = useDispatch();
+  const theme = useTheme();
+  const { styles } = useStyles(styleSheet, { theme });
+
+  const hasSeenConversionEducationScreen = useSelector(
+    selectMusdConversionEducationSeen,
+  );
+
+  const handleResetEducationSeenState = useCallback(() => {
+    dispatch(setMusdConversionEducationSeen(false));
+  }, [dispatch]);
+
+  return (
+    <>
+      <Text
+        color={TextColor.Default}
+        variant={TextVariant.HeadingLG}
+        style={styles.heading}
+      >
+        {'mUSD'}
+      </Text>
+      <Text
+        color={TextColor.Alternative}
+        variant={TextVariant.BodyMD}
+        style={styles.desc}
+      >
+        {`Education screen seen: ${String(hasSeenConversionEducationScreen)}`}
+      </Text>
+      <Button
+        variant={ButtonVariants.Secondary}
+        size={ButtonSize.Lg}
+        label={'Reset education screen'}
+        onPress={handleResetEducationSeenState}
+        width={ButtonWidthTypes.Full}
+        style={styles.accessory}
+      />
+    </>
+  );
+};

--- a/app/components/Views/Settings/DeveloperOptions/DeveloperOptions.styles.ts
+++ b/app/components/Views/Settings/DeveloperOptions/DeveloperOptions.styles.ts
@@ -10,6 +10,7 @@ const styleSheet = (params: { theme: Theme }) => {
       flex: 1,
       padding: 24,
       paddingBottom: 48,
+      marginBottom: 32,
     },
     heading: {
       marginTop: 16,

--- a/app/components/Views/Settings/DeveloperOptions/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/DeveloperOptions/__snapshots__/index.test.tsx.snap
@@ -428,6 +428,7 @@ exports[`DeveloperOptions renders correctly 1`] = `
                         {
                           "backgroundColor": "#ffffff",
                           "flex": 1,
+                          "marginBottom": 32,
                           "padding": 24,
                           "paddingBottom": 48,
                         }

--- a/app/components/Views/Settings/DeveloperOptions/index.test.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/index.test.tsx
@@ -3,13 +3,22 @@ import DeveloperOptions from './';
 import { renderScreen } from '../../../../util/test/renderWithProvider';
 
 const mockSelectPerpsEnabledFlag = jest.fn();
+const mockSelectIsMusdConversionFlowEnabledFlag = jest.fn();
 
 jest.mock('../../../UI/Perps/selectors/featureFlags', () => ({
   selectPerpsEnabledFlag: () => mockSelectPerpsEnabledFlag(),
 }));
 
+jest.mock('../../../UI/Earn/selectors/featureFlags', () => {
+  const actual = jest.requireActual('../../../UI/Earn/selectors/featureFlags');
+  return {
+    ...actual,
+    selectIsMusdConversionFlowEnabledFlag: () =>
+      mockSelectIsMusdConversionFlowEnabledFlag(),
+  };
+});
+
 const initialState = {
-  DeveloperOptions: {},
   engine: {
     backgroundState,
   },
@@ -19,6 +28,7 @@ describe('DeveloperOptions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSelectPerpsEnabledFlag.mockReturnValue(true);
+    mockSelectIsMusdConversionFlowEnabledFlag.mockReturnValue(false);
   });
 
   it('renders correctly', () => {

--- a/app/components/Views/Settings/DeveloperOptions/index.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/index.tsx
@@ -16,6 +16,8 @@ import { PerpsDeveloperOptionsSection } from '../../../UI/Perps/components/Perps
 import { useSelector } from 'react-redux';
 import { selectPerpsEnabledFlag } from '../../../UI/Perps';
 import { ConfirmationsDeveloperOptions } from '../../confirmations/components/developer/confirmations-developer-options';
+import { selectIsMusdConversionFlowEnabledFlag } from '../../../UI/Earn/selectors/featureFlags';
+import { MusdDeveloperOptionsSection } from '../../../UI/Earn/components/MusdDeveloperOptionsSection';
 
 const DeveloperOptions = () => {
   const navigation = useNavigation();
@@ -27,6 +29,9 @@ const DeveloperOptions = () => {
   const { styles } = useStyles(styleSheet, { theme });
 
   const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
+  const isMusdConversionEnabled = useSelector(
+    selectIsMusdConversionFlowEnabledFlag,
+  );
 
   useEffect(() => {
     navigation.setOptions(
@@ -52,6 +57,7 @@ const DeveloperOptions = () => {
       }
       {isPerpsEnabled && <PerpsDeveloperOptionsSection />}
       <ConfirmationsDeveloperOptions />
+      {isMusdConversionEnabled && <MusdDeveloperOptionsSection />}
     </ScrollView>
   );
 };


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Added mUSD developer options section with button to reset education screen seen state

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added mUSD developer options section with button to reset education screen seen state

## **Related issues**

Fixes: [MUSD-231: Add reset education screen seen button to developer options](https://consensyssoftware.atlassian.net/browse/MUSD-231)

## **Manual testing steps**

```gherkin
Feature: Reset mUSD conversion education screen in Developer Options

  Scenario: user resets mUSD education screen seen state
    Given Developer Options is available in Settings
    And mUSD conversion feature is enabled
    And user has previously seen the mUSD conversion education screen

    When user opens Developer Options
    And user taps "Reset education screen" in the "mUSD" section
    Then the status label shows "Education screen seen: false"
    And the mUSD conversion education screen can be shown again on the next mUSD conversion attempt

  Scenario: user does not see mUSD developer controls when mUSD conversion is disabled
    Given Developer Options is available in Settings
    And mUSD conversion feature is disabled

    When user opens Developer Options
    Then the "mUSD" section is not displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an mUSD developer controls section in Developer Options, gated by the `selectIsMusdConversionFlowEnabledFlag` feature flag.
> 
> - Adds `MusdDeveloperOptionsSection` showing `Education screen seen` from `selectMusdConversionEducationSeen` and a reset button that dispatches `setMusdConversionEducationSeen(false)`
> - Integrates into `DeveloperOptions` only when `selectIsMusdConversionFlowEnabledFlag` returns true
> - Tweaks `DeveloperOptions.styles` wrapper with `marginBottom: 32`
> - Adds tests: component behavior (`MusdDeveloperOptionsSection.test.tsx`) and feature-flag gating in `DeveloperOptions` (plus snapshot update)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 975ccf172e70fc6944eb247a144c47d9e6605108. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->