### PR TITLE
fix: biometric on create srp wallet (#24695)

### DIFF
--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -589,12 +589,12 @@ describe('Authentication', () => {
     expect(result.currentAuthType).toEqual(AUTHENTICATION_TYPE.BIOMETRIC);
   });
 
-  it('returns PASSCODE type for components when no previous auth choice exists (new user choosing biometrics)', async () => {
+  it('returns BIOMETRIC type for components when no previous auth choice exists (new user choosing biometrics)', async () => {
     SecureKeychain.getSupportedBiometryType = jest
       .fn()
       .mockReturnValue(Keychain.BIOMETRY_TYPE.FINGERPRINT);
     // No storage flags set - represents new user or first-time choice
-    // With new logic, this defaults to PASSCODE when biometryChoice is true
+    // With new logic, this defaults to BIOMETRIC when biometryChoice is true
 
     // Mock Redux store to return allowLoginWithRememberMe: false
     jest.spyOn(ReduxService, 'store', 'get').mockReturnValue({
@@ -606,7 +606,7 @@ describe('Authentication', () => {
       false,
     );
     expect(result.availableBiometryType).toEqual('Fingerprint');
-    expect(result.currentAuthType).toEqual(AUTHENTICATION_TYPE.PASSCODE);
+    expect(result.currentAuthType).toEqual(AUTHENTICATION_TYPE.BIOMETRIC);
   });
 
   it('returns PASSWORD type when biometryChoice is false', async () => {

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -555,19 +555,14 @@ class AuthenticationService {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const availableBiometryType: any =
       await SecureKeychain.getSupportedBiometryType();
-    const passcodePreviouslyDisabled =
-      await StorageWrapper.getItem(PASSCODE_DISABLED);
+
+    const passcodeDisabled = await StorageWrapper.getItem(PASSCODE_DISABLED);
+
+    const biometryDisabled = await StorageWrapper.getItem(
+      BIOMETRY_CHOICE_DISABLED,
+    );
 
     if (
-      availableBiometryType &&
-      biometryChoice &&
-      passcodePreviouslyDisabled === TRUE
-    ) {
-      return {
-        currentAuthType: AUTHENTICATION_TYPE.BIOMETRIC,
-        availableBiometryType,
-      };
-    } else if (
       rememberMe &&
       ReduxService.store.getState().security.allowLoginWithRememberMe
     ) {
@@ -576,15 +571,37 @@ class AuthenticationService {
         availableBiometryType,
       };
     } else if (
-      availableBiometryType &&
       biometryChoice &&
-      !(passcodePreviouslyDisabled && passcodePreviouslyDisabled === TRUE)
+      availableBiometryType &&
+      biometryDisabled === TRUE &&
+      passcodeDisabled === TRUE
     ) {
+      // this case is where user disable both passcode and biometric
+      // by right we should not show the login switch for this case, hence we should return PASSWORD type
+      // however for the current behaviour, we are showing the login switch with BIOMETRIC type
+      // return biometric type for now to prevent unexpected behaviour
+      return {
+        currentAuthType: AUTHENTICATION_TYPE.BIOMETRIC,
+        availableBiometryType,
+      };
+    } else if (
+      biometryChoice &&
+      availableBiometryType &&
+      biometryDisabled === TRUE
+    ) {
+      // return passcode since biometric is disabled
       return {
         currentAuthType: AUTHENTICATION_TYPE.PASSCODE,
         availableBiometryType,
       };
+    } else if (biometryChoice && availableBiometryType) {
+      return {
+        currentAuthType: AUTHENTICATION_TYPE.BIOMETRIC,
+        availableBiometryType,
+      };
     }
+
+    // if biometricChoice or availableBiometryType is false, return PASSWORD
     return {
       currentAuthType: AUTHENTICATION_TYPE.PASSWORD,
       availableBiometryType,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->

## **Description**
Recent added check against the passcodePreviouslyDisable for the biometric in #23917 is causing new user not being prompted biometric when they create new wallet after fresh install metamask

This pr update the function componentAuthenticationType in Authentication.js to
Changes
it priotize REMEMBER_ME if both biometric choise and remember_me are both true.
if biometric choise is true and biometric is available It will fallback to PassCode if bioemetric is disabled. else it will return Biometric
if biometric choise or biometric is not available
it will return Password

This PR scope down
https://github.com/MetaMask/metamask-mobile/pull/24480 fixes to the `componentAuthenticationType` only
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution? -->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs` `CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Biometric choice logic update

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/24553

## **Manual testing steps**

```gherkin
Feature: prompt biometric on create new srp wallet

  Scenario: uninstall MM and then reinstall new app
    Given user create new srp wallet
    When user successful create wallet
    Then user should be prompted biometric
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates authentication selection logic for components.
> 
> - **Auth precedence changes**: Return `REMEMBER_ME` when enabled; if `biometryChoice` is true and biometrics available, return `BIOMETRIC` unless `BIOMETRY_CHOICE_DISABLED` is `TRUE` (then `PASSCODE`), with a temporary case returning `BIOMETRIC` when both biometric and passcode are disabled; otherwise default to `PASSWORD`.
> - **Storage flags**: Now reads `PASSCODE_DISABLED` and `BIOMETRY_CHOICE_DISABLED` (replacing prior `passcodePreviouslyDisabled`).
> - **Tests**: Adjusts expectations/comments to return `BIOMETRIC` for new users selecting biometrics and aligns unit tests with the new logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6941ad1a9375c24551c240ce869793bce9626b79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
