### PR TITLE
feat: create deeplink for explore

### DIFF
--- a/app/constants/deeplinks.ts
+++ b/app/constants/deeplinks.ts
@@ -42,6 +42,7 @@ export enum ACTIONS {
   REWARDS = 'rewards',
   PREDICT = 'predict',
   ONBOARDING = 'onboarding',
+  TRENDING = 'trending',
 }
 
 export const PREFIXES = {
@@ -71,5 +72,6 @@ export const PREFIXES = {
   [ACTIONS.ENABLE_CARD_BUTTON]: '',
   [ACTIONS.CARD_ONBOARDING]: '',
   [ACTIONS.CARD_HOME]: '',
+  [ACTIONS.TRENDING]: '',
   METAMASK: 'metamask://',
 };

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
@@ -39,6 +39,7 @@ jest.mock('../handleRewardsUrl');
 jest.mock('../handlePredictUrl');
 jest.mock('../handleFastOnboarding');
 jest.mock('../handleEnableCardButton');
+jest.mock('../handleTrendingUrl');
 jest.mock('react-native-quick-crypto', () => ({
   webcrypto: {
     subtle: {
@@ -625,6 +626,59 @@ describe('handleUniversalLink', () => {
       });
 
       expect(handled).toHaveBeenCalled();
+    });
+  });
+
+  describe('ACTIONS.TRENDING', () => {
+    it('calls _handleTrending when action is TRENDING', async () => {
+      const trendingUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_UNIVERSAL_LINK_HOST}/${ACTIONS.TRENDING}`;
+      const trendingUrlObj = {
+        ...urlObj,
+        hostname: AppConstants.MM_UNIVERSAL_LINK_HOST,
+        href: trendingUrl,
+        pathname: `/${ACTIONS.TRENDING}`,
+      };
+
+      await handleUniversalLink({
+        instance,
+        handled,
+        urlObj: trendingUrlObj,
+        browserCallBack: mockBrowserCallBack,
+        url: trendingUrl,
+        source: 'test-source',
+      });
+
+      expect(handled).toHaveBeenCalled();
+    });
+
+    it('calls _handleTrending with different deeplink domains', async () => {
+      const testCases = [
+        AppConstants.MM_UNIVERSAL_LINK_HOST,
+        AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+        AppConstants.MM_IO_UNIVERSAL_LINK_TEST_HOST,
+      ];
+
+      for (const domain of testCases) {
+        jest.clearAllMocks();
+        const trendingUrl = `${PROTOCOLS.HTTPS}://${domain}/${ACTIONS.TRENDING}`;
+        const trendingUrlObj = {
+          ...urlObj,
+          hostname: domain,
+          href: trendingUrl,
+          pathname: `/${ACTIONS.TRENDING}`,
+        };
+
+        await handleUniversalLink({
+          instance,
+          handled,
+          urlObj: trendingUrlObj,
+          browserCallBack: mockBrowserCallBack,
+          url: trendingUrl,
+          source: 'test-source',
+        });
+
+        expect(handled).toHaveBeenCalled();
+      }
     });
   });
 

--- a/app/core/DeeplinkManager/handlers/legacy/handleTrendingUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleTrendingUrl.ts
@@ -1,0 +1,6 @@
+import NavigationService from '../../../NavigationService';
+import Routes from '../../../../constants/navigation/Routes';
+
+export function handleTrendingUrl() {
+  NavigationService.navigation.navigate(Routes.TRENDING_VIEW);
+}

--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -27,6 +27,7 @@ import handleFastOnboarding from './handleFastOnboarding';
 import { handleEnableCardButton } from './handleEnableCardButton';
 import { handleCardOnboarding } from './handleCardOnboarding';
 import { handleCardHome } from './handleCardHome';
+import { handleTrendingUrl } from './handleTrendingUrl';
 import { RampType } from '../../../../reducers/fiatOrders/types';
 
 const {
@@ -56,6 +57,7 @@ enum SUPPORTED_ACTIONS {
   ENABLE_CARD_BUTTON = ACTIONS.ENABLE_CARD_BUTTON,
   CARD_ONBOARDING = ACTIONS.CARD_ONBOARDING,
   CARD_HOME = ACTIONS.CARD_HOME,
+  TRENDING = ACTIONS.TRENDING,
   // MetaMask SDK specific actions
   ANDROID_SDK = ACTIONS.ANDROID_SDK,
   CONNECT = ACTIONS.CONNECT,
@@ -362,6 +364,10 @@ async function handleUniversalLink({
     }
     case SUPPORTED_ACTIONS.CARD_HOME: {
       handleCardHome();
+      break;
+    }
+    case SUPPORTED_ACTIONS.TRENDING: {
+      handleTrendingUrl();
       break;
     }
   }


### PR DESCRIPTION
## **Description**

This PR adds support for a `trending` deeplink that navigates users directly to the TrendingView (Explore Feed) screen.

**Changes:**
1. Added `TRENDING = 'trending'` action to the deeplinks constants
2. Created `handleTrendingUrl.ts` handler to navigate to `Routes.TRENDING_VIEW`
3. Added `TRENDING` to `SUPPORTED_ACTIONS` enum and switch case in `handleUniversalLink.ts`

## **Changelog**

CHANGELOG entry: Added deeplink support to navigate directly to the Trending/Explore screen

## **Related issues**

Fixes:

## **Manual testing steps**

Feature: Trending deeplink navigation

Scenario: User opens trending deeplink on iOS simulator
- Given the MetaMask app is installed and running on an iOS simulator
- And the user is logged into the wallet
- When user runs: `xcrun simctl openurl booted https://link.metamask.io/trending`
- Then the app navigates to the Trending/Explore screen
- And the trending feed content is displayed

Scenario: User opens trending deeplink on Android emulator
- Given the MetaMask app is installed and running on an Android emulator
- And the user is logged into the wallet
- When user runs: `adb shell am start -a android.intent.action.VIEW -d "https://link.metamask.io/trending"`
- Then the app navigates to the Trending/Explore screen
- And the trending feed content is displayed

### Quick test commands:

**iOS Simulator:**
`xcrun simctl openurl booted https://link.metamask.io/trending`

**Android Emulator:**
`adb shell am start -a android.intent.action.VIEW -d "https://link.metamask.io/trending"`

## **Screenshots/Recordings**

### **Before**

N/A - New feature

### **After**

<!-- Add screenshot/recording of the Trending screen after deeplink navigation -->


https://github.com/user-attachments/assets/bcc45ba8-0059-4b80-a857-715c5a3a0bba


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables direct navigation to the Explore (Trending) feed via universal links.
> 
> - Adds `ACTIONS.TRENDING` with empty prefix in `constants/deeplinks.ts`
> - Implements `handleTrendingUrl` to navigate to `Routes.TRENDING_VIEW`
> - Registers `TRENDING` in `SUPPORTED_ACTIONS` and handles it in `handleUniversalLink`
> - Extends `handleUniversalLink.test.ts` to cover `TRENDING` action, including multiple deeplink domains
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d9c732c7791f9816fc5668f6220597cd1829826. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->