### PR TITLE
feat(predict): add NBA support to sports predictions

### DIFF
--- a/app/components/UI/Predict/components/PredictMarket/PredictMarket.tsx
+++ b/app/components/UI/Predict/components/PredictMarket/PredictMarket.tsx
@@ -19,7 +19,7 @@ const PredictMarket: React.FC<PredictMarketProps> = ({
   entryPoint = PredictEventValues.ENTRY_POINT.PREDICT_FEED,
   isCarousel = false,
 }) => {
-  if (market.game?.league === 'nfl') {
+  if (market.game) {
     return (
       <PredictMarketSportCard
         market={market}

--- a/app/components/UI/Predict/constants/sports.ts
+++ b/app/components/UI/Predict/constants/sports.ts
@@ -9,7 +9,7 @@ import { PredictSportsLeague } from '../types';
  * 3. Add the league to this array
  * 4. Add tests for the new league's slug parsing
  */
-export const SUPPORTED_SPORTS_LEAGUES: PredictSportsLeague[] = ['nfl'];
+export const SUPPORTED_SPORTS_LEAGUES: PredictSportsLeague[] = ['nfl', 'nba'];
 
 export const filterSupportedLeagues = (
   leagues: string[],

--- a/app/components/UI/Predict/providers/polymarket/TeamsCache.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/TeamsCache.test.ts
@@ -276,32 +276,6 @@ describe('TeamsCache', () => {
     });
   });
 
-  describe('getNflTeam', () => {
-    beforeEach(async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockNflTeams,
-      });
-      await TeamsCache.getInstance().ensureLeagueLoaded('nfl');
-    });
-
-    it('returns NFL team by abbreviation', () => {
-      const cache = TeamsCache.getInstance();
-
-      const team = cache.getNflTeam('den');
-
-      expect(team?.name).toBe('Denver Broncos');
-    });
-
-    it('returns undefined for unknown NFL team', () => {
-      const cache = TeamsCache.getInstance();
-
-      const team = cache.getNflTeam('unknown');
-
-      expect(team).toBeUndefined();
-    });
-  });
-
   describe('isLeagueLoaded', () => {
     it('returns false for unloaded league', () => {
       const cache = TeamsCache.getInstance();

--- a/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
+++ b/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
@@ -60,10 +60,6 @@ export class TeamsCache {
     return leagueCache.get(abbreviation.toLowerCase());
   }
 
-  getNflTeam(abbreviation: string): PolymarketApiTeam | undefined {
-    return this.getTeam('nfl', abbreviation);
-  }
-
   isLeagueLoaded(league: PredictSportsLeague): boolean {
     return this.cache.has(league);
   }

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -113,7 +113,7 @@ export type PredictCategory =
   | 'politics';
 
 // Sports league types
-export type PredictSportsLeague = 'nfl';
+export type PredictSportsLeague = 'nfl' | 'nba';
 
 // Game status
 export type PredictGameStatus = 'scheduled' | 'ongoing' | 'ended';

--- a/app/components/UI/Predict/utils/gameParser.ts
+++ b/app/components/UI/Predict/utils/gameParser.ts
@@ -11,9 +11,11 @@ import {
 } from '../providers/polymarket/types';
 
 const NFL_SLUG_PATTERN = /^nfl-([a-z]+)-([a-z]+)-(\d{4}-\d{2}-\d{2})$/;
+const NBA_SLUG_PATTERN = /^nba-([a-z]+)-([a-z]+)-(\d{4}-\d{2}-\d{2})$/;
 
 const LEAGUE_SLUG_PATTERNS: Record<PredictSportsLeague, RegExp> = {
   nfl: NFL_SLUG_PATTERN,
+  nba: NBA_SLUG_PATTERN,
 };
 
 export type TeamLookup = (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
- Add 'nba' to PredictSportsLeague type union
- Add NBA slug pattern for game parsing (nba-{away}-{home}-{date})
- Include 'nba' in SUPPORTED_SPORTS_LEAGUES constant
- Generalize PredictMarket to render sport cards for any game with a league
- Remove NFL-specific getNflTeam method in favor of generic getTeam
- Update TeamsCache tests to reflect removed method

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands sports support and simplifies league-specific logic.
> 
> - Adds `nba` to `PredictSportsLeague` and `SUPPORTED_SPORTS_LEAGUES`; introduces `NBA_SLUG_PATTERN` and updates `LEAGUE_SLUG_PATTERNS` in `utils/gameParser.ts`
> - Generalizes `PredictMarket` to render `PredictMarketSportCard` for any `market.game` (not just `nfl`)
> - Removes `getNflTeam` from `TeamsCache` in favor of generic `getTeam`; updates `TeamsCache.test.ts` accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f465aa4f5bd31511580a7f57a546ca855506e92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->