### PR TITLE
chore: Add a script for using preview builds more easily

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -37,6 +37,8 @@ ignores:
   - 'esbuild-register'
   # xml2js is used in .github/scripts/ for E2E test report processing
   - 'xml2js'
+  # @types/yargs is used in scripts/use-preview-build.mjs
+  - '@types/yargs'
 
   # Used in scripts/repack for CI optimization
   - '@expo/repack-app'

--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
     "gen-bundle:ios": "NODE_OPTIONS='--max-old-space-size=8192' yarn react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle",
     "gen-bundle:android": "yarn react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/main.jsbundle",
     "circular:deps": "dpdm ./app/* --circular --exit-code circular:1 --warning=false",
-    "generate-icons": "yarn ts-node app/component-library/components/Icons/Icon/scripts/generate-assets.ts"
+    "generate-icons": "yarn ts-node app/component-library/components/Icons/Icon/scripts/generate-assets.ts",
+    "use-preview-build": "./scripts/use-preview-build.mjs"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
@@ -557,10 +558,12 @@
     "@types/serve-handler": "^6.1.4",
     "@types/url-parse": "^1.4.8",
     "@types/valid-url": "^1.0.4",
+    "@types/yargs": "^17.0.35",
     "@typescript-eslint/eslint-plugin": "^7.10.0",
     "@typescript-eslint/parser": "^7.10.0",
     "@walletconnect/types": "^2.19.2",
     "@welldone-software/why-did-you-render": "^8.0.1",
+    "@yarnpkg/core": "^4.5.0",
     "appium": "^2.12.1",
     "appium-uiautomator2-driver": "4.2.7",
     "appium-xcuitest-driver": "5.16.1",
@@ -635,7 +638,8 @@
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4",
     "xhr2": "^0.2.1",
-    "xml2js": "^0.5.0"
+    "xml2js": "^0.5.0",
+    "yargs": "^17.7.2"
   },
   "config": {
     "react-native-storybook-loader": {

--- a/scripts/use-preview-build.mjs
+++ b/scripts/use-preview-build.mjs
@@ -1,0 +1,615 @@
+#!/usr/bin/env node
+
+// This script is copied between Extension and Mobile,
+// and it needs to stay relatively the same between the two.
+/* eslint-disable import/no-nodejs-modules,import/no-namespace,no-console */
+
+import { structUtils } from '@yarnpkg/core';
+import { ESLint } from 'eslint';
+import { execa } from 'execa';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import * as semver from 'semver';
+import yargs from 'yargs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * The scope that all MetaMask packages are published under.
+ */
+const METAMASK_NPM_SCOPE = 'metamask';
+
+/**
+ * Valid values for the `--type` option.
+ * @typedef {'breaking' | 'non-breaking'} ChangeType
+ */
+
+/**
+ * Captures the arguments passed to this script.
+ * @typedef {Object} CommandLineArguments
+ * @property {string} packageName
+ * @property {string} previewNpmScope
+ * @property {string} previewVersion
+ * @property {ChangeType} type
+ */
+
+/**
+ * The contents of a package's `package.json`.
+ * @typedef {Object} Manifest
+ * @property {string} name
+ * @property {Record<string, string>} [dependencies]
+ * @property {Record<string, string>} [devDependencies]
+ * @property {Record<string, string>} [resolutions]
+ */
+
+/**
+ * The shape of each line returned by `yarn why --json`.
+ * @typedef {Object} YarnWhyEntry
+ * @property {string} value
+ * @property {Record<string, { locator: string; descriptor: string }>} children
+ */
+
+/**
+ * Different interpretations of a SemVer-compatible version range,
+ * e.g. `^1.2.3`.
+ * @typedef {Object} ParsedVersionRange
+ * @property {semver.Range} semverRange
+ * @property {semver.SemVer} primarySemver
+ * @property {number} majorVersion
+ * @property {string} string
+ */
+
+/**
+ * Parses command line arguments using yargs.
+ *
+ * @returns {Promise<CommandLineArguments>} The parsed command line arguments.
+ */
+async function parseArgs() {
+  const argv = await yargs(process.argv.slice(2))
+    .usage(
+      'Usage: $0 <package-name> <preview-version> --type <breaking|non-breaking> [options]',
+    )
+    .positional('package-name', {
+      describe: 'The name of the package',
+      type: 'string',
+    })
+    .option('preview-npm-scope', {
+      describe: 'NPM organization for preview builds',
+      type: 'string',
+      default: 'metamask-previews',
+    })
+    .positional('preview-version', {
+      describe: 'The preview version string (e.g., "1.1.4-preview-e2df9b4")',
+      type: 'string',
+    })
+    .option('type', {
+      alias: 't',
+      describe: 'Type of change',
+      choices: ['breaking', 'non-breaking'],
+      demandOption: true,
+    })
+    .example(
+      '$0 @metamask/controller-utils 1.1.4-preview-e2df9b4 --type non-breaking',
+      'Add resolutions for non-breaking changes',
+    )
+    .example(
+      '$0 @metamask/network-controller 12.4.9-preview-e2df9b4 --type breaking',
+      'Add resolution for breaking changes',
+    )
+    .check((args) => {
+      const positionals = args._;
+      if (positionals.length < 2) {
+        throw new Error(
+          'Both <package-name> and <preview-version> are required',
+        );
+      }
+      return true;
+    })
+    .string('_')
+    .help().argv;
+
+  const [uncorrectedPackageName, previewVersion] = argv._;
+
+  const packageName = uncorrectedPackageName.startsWith(
+    `@${METAMASK_NPM_SCOPE}/`,
+  )
+    ? uncorrectedPackageName
+    : `@${METAMASK_NPM_SCOPE}/${uncorrectedPackageName}`;
+  const previewNpmScope = argv.previewNpmScope.startsWith('@')
+    ? argv.previewNpmScope.slice(1)
+    : argv.previewNpmScope;
+
+  return {
+    packageName,
+    previewNpmScope,
+    previewVersion,
+    type: argv.type,
+  };
+}
+
+/**
+ * Reads and parses a `package.json` file.
+ *
+ * @param {string} manifestPath - Path to the `package.json` file.
+ * @returns {Promise<Manifest>} The parsed `package.json` contents.
+ */
+async function readManifest(manifestPath) {
+  const content = await fs.promises.readFile(manifestPath, 'utf-8');
+  return JSON.parse(content);
+}
+
+/**
+ * Writes a `package.json` file.
+ *
+ * @param {string} manifestPath - Path to the `package.json` file.
+ * @param {Manifest} contents - The package.json contents to write.
+ * @returns {Promise<void>}
+ */
+async function writeManifest(manifestPath, contents) {
+  await fs.promises.writeFile(
+    manifestPath,
+    `${JSON.stringify(contents, null, 2)}\n`,
+    'utf-8',
+  );
+}
+
+/**
+ * Formats a `package.json` file.
+ *
+ * @param {string} manifestPath - Path to the `package.json` file.
+ * @returns {Promise<void>}
+ */
+async function formatManifest(manifestPath) {
+  const eslint = new ESLint({
+    // This is necessary in order to run this script outside of this project,
+    // e.g., for testing purposes.
+    cwd: path.resolve(__dirname, '..'),
+    ignore: false,
+    fix: true,
+  });
+  console.log('Formatting package.json...');
+  const results = await eslint.lintFiles(manifestPath);
+  await ESLint.outputFixes(results);
+}
+
+/**
+ * Saves a formatted version of the given `package.json` with the given
+ * resolutions updated.
+ *
+ * @param {string} manifestPath - The path to `package.json`.
+ * @param {Record<string, string>} resolutions - The new resolutions to load into `package.json`.
+ * @returns {Promise<void>}
+ */
+async function updateResolutionsInManifest(manifestPath, resolutions) {
+  console.log('Adding resolutions:');
+  const manifest = await readManifest(manifestPath);
+  for (const [key, value] of Object.entries(resolutions)) {
+    console.log(`  "${key}": "${value}"`);
+  }
+
+  await writeManifest(manifestPath, {
+    ...manifest,
+    resolutions: {
+      ...manifest.resolutions,
+      ...resolutions,
+    },
+  });
+  // await formatManifest(manifestPath);
+  await installDependencies();
+}
+
+/**
+ * Verifies that the the given version range is SemVer-compatible and that it is
+ * a version range that we can handle, and then parses the major version from
+ * the version range.
+ *
+ * Currently, this is the list of supported version ranges:
+ *
+ * - "18.0.0"
+ * - "=18.0.0"
+ * - ">=18.0.0,<19.0.0"
+ * - "^18.0.0"
+ *
+ * @param {string} versionRange - The version range.
+ * @returns {ParsedVersionRange} A semver.Range that represents the version range.
+ * @throws {Error} If the version range is not supported.
+ */
+function parseVersionRange(versionRange) {
+  const semverRange = new semver.Range(versionRange);
+
+  if (
+    !(
+      semverRange.set.length === 1 &&
+      semverRange.set[0] !== undefined &&
+      ((semverRange.set[0].length === 2 &&
+        semverRange.set[0][0] !== undefined &&
+        semverRange.set[0][1] !== undefined &&
+        semverRange.set[0][0].operator === '>=' &&
+        semverRange.set[0][1].operator === '<' &&
+        semverRange.set[0][1].semver.major ===
+          semverRange.set[0][0].semver.major + 1) ||
+        (semverRange.set[0].length === 1 &&
+          semverRange.set[0][0] !== undefined &&
+          (semverRange.set[0][0].operator === '' ||
+            semverRange.set[0][0].operator === '=')))
+    )
+  ) {
+    throw new Error(`Unsupported version range: ${versionRange}`);
+  }
+
+  const primarySemver = semverRange.set[0][0].semver;
+  const { major } = primarySemver;
+
+  return {
+    semverRange,
+    primarySemver,
+    majorVersion: major,
+    string: versionRange,
+  };
+}
+
+/**
+ * Compare two SemVer-compatible, supported version ranges, for use in sorting.
+ *
+ * @param {ParsedVersionRange} a - The first version range as parsed via `parseVersionRange`.
+ * @param {ParsedVersionRange} b - The second version range as parsed via `parseVersionRange`.
+ * @returns {number} 1, 0, or -1 depending on whether the first version range should be
+ * placed before or after the second, or whether no swapping should occur.
+ */
+function compareParsedVersionRanges(a, b) {
+  return semver.compare(a.primarySemver, b.primarySemver);
+}
+
+/**
+ * Sorts the given set of parsed version ranges.
+ *
+ * @param {ParsedVersionRange[]} parsedVersionRanges - The list of parsed version ranges to sort.
+ * @returns {ParsedVersionRange[]} The sorted list of version ranges.
+ */
+function sortParsedVersionRanges(parsedVersionRanges) {
+  return [...parsedVersionRanges].sort((a, b) =>
+    compareParsedVersionRanges(a, b),
+  );
+}
+
+/**
+ * Check whether the given descriptor of a package (as would come from
+ * `dependencies`) represents a patch. As we do not support adding preview
+ * builds for patches at this time, throw an error.
+ *
+ * @param {string | Descriptor} descriptor - The right-hand side of an entry in `dependencies`, either
+ * unparsed or parsed via Yarn's `parseDescriptor` function.
+ * @param {string} name - The name of the dependency.
+ * @returns {void}
+ * @throws {Error} If the descriptor of the dependency starts with `patch:`.
+ */
+function validateNonPatchDescriptor(descriptor, name) {
+  const isPatched =
+    typeof descriptor === 'string'
+      ? descriptor.startsWith('patch:')
+      : descriptor.name === 'patch:';
+
+  if (isPatched) {
+    throw new Error(
+      `It looks like ${name} is patched. You'll need to configure a preview build for this dependency yourself. Please see the documentation on how to do this here: https://github.com/MetaMask/core/tree/main/docs/processes/preview-builds.md`,
+    );
+  }
+}
+
+/**
+ * Parses the given string as if it were the right-hand side of a dependency
+ * entry (e.g. `npm:@metamask/transaction-controller@^12.3.4`) and extracts the
+ * version range specified within it.
+ *
+ * Currently does not support patched dependencies.
+ *
+ * @param {string} rawDescriptor - The string to parse.
+ * @param {string} dependencyName - The name of the dependency that `rawDescriptor`
+ * represents.
+ * @returns {ParsedVersionRange} A parsed representation of the version range within `rawDescriptor`.
+ * @throws {Error} If `rawDescriptor` represents a patched dependency.
+ */
+function getParsedVersionRangeForDescriptor(rawDescriptor, dependencyName) {
+  validateNonPatchDescriptor(rawDescriptor, dependencyName);
+
+  const range = structUtils.parseRange(rawDescriptor);
+  // TODO - Support patches
+  // if (range.protocol === 'patch:' && range.source !== null) {
+  //   const descriptor = structUtils.parseDescriptor(range.source);
+  //   const innerRange = structUtils.parseRange(descriptor.range);
+  //   return parseVersionRange(innerRange.selector);
+  // }
+  return parseVersionRange(range.selector);
+}
+
+/**
+ * Gets the version range for a dependency in `dependencies`.
+ *
+ * @param {Manifest} manifest - The contents of `package.json`.
+ * @param {string} packageName - The name of the package.
+ * @returns {ParsedVersionRange} The version range.
+ */
+function getVersionRangeForDependency(manifest, packageName) {
+  const rawDescriptor = manifest.dependencies?.[packageName];
+  if (!rawDescriptor) {
+    throw new Error(`Could not find ${packageName} in dependencies`);
+  }
+  return getParsedVersionRangeForDescriptor(rawDescriptor, packageName);
+}
+
+/**
+ * Looks up the given package name in `dependencies` and checks that it is not
+ * patched. As we do not support adding preview builds for patches at this time,
+ * throw an error.
+ *
+ * @param {string} packageName - The name of the packege.
+ * @param {string} manifestPath - The path to `package.json`
+ * @returns {Promise<void>}
+ * @throws {Error} If there is no entry in `dependencies` for the package.
+ * @throws {Error} If the version range starts with `patch:`.
+ */
+async function validateDependencyNotPatched(packageName, manifestPath) {
+  const manifest = await readManifest(manifestPath);
+  const rawDescriptor = manifest.dependencies?.[packageName];
+  if (!rawDescriptor) {
+    throw new Error(`Could not find ${packageName} in dependencies`);
+  }
+  validateNonPatchDescriptor(rawDescriptor, packageName);
+}
+
+/**
+ * Updates `package.json` to remove resolutions for preview builds that match
+ * the given package name.
+ *
+ * @param {string} packageName - The name of a package.
+ * @param {string} previewNpmScope - The NPM scope of the preview build.
+ * @param {string} manifestPath - The path to `package.json`.
+ * @returns {Promise<void>}
+ */
+async function removeExistingPreviewBuildResolutions(
+  packageName,
+  previewNpmScope,
+  manifestPath,
+) {
+  const manifest = await readManifest(manifestPath);
+  const { resolutions } = manifest;
+  const packageNameWithoutScope = packageName.replace(
+    `@${METAMASK_NPM_SCOPE}/`,
+    '',
+  );
+
+  const resolutionsToRemove = Object.entries(resolutions ?? {}).reduce(
+    (obj, [resolutionName, resolutionValue]) => {
+      const range = structUtils.parseRange(resolutionValue);
+      if (range.protocol === 'npm:') {
+        const descriptor = structUtils.parseDescriptor(range.selector);
+        if (
+          descriptor.scope === previewNpmScope &&
+          descriptor.name === packageNameWithoutScope
+        ) {
+          return { ...obj, [resolutionName]: resolutionValue };
+        }
+      }
+      return obj;
+    },
+    {},
+  );
+
+  if (
+    Object.keys(resolutionsToRemove).length === 0 ||
+    resolutions === undefined
+  ) {
+    return;
+  }
+
+  console.log('Removing resolutions for existing preview builds:');
+  for (const [key, value] of Object.entries(resolutionsToRemove)) {
+    console.log(`  "${key}": "${value}"`);
+  }
+
+  const newResolutions = Object.keys(resolutionsToRemove).reduce(
+    (workingResolutions, resolutionName) => {
+      if (resolutionName in workingResolutions) {
+        const clone = { ...workingResolutions };
+        delete clone[resolutionName];
+        return clone;
+      }
+      return workingResolutions;
+    },
+    resolutions,
+  );
+  await writeManifest(manifestPath, {
+    ...manifest,
+    resolutions: newResolutions,
+  });
+  // await formatManifest(manifestPath);
+  await installDependencies();
+
+  console.log('');
+}
+
+/**
+ * Uses `yarn why` to get all version ranges of the given package that are being
+ * used across the dependency tree and which are compatible with the given major
+ * version.
+ *
+ * @param {string} packageName - The name of a package.
+ * @param {number} majorVersion - A major version of the package.
+ * @returns {Promise<Set<ParsedVersionRange>>} An array of unique version ranges.
+ */
+async function getAllCompatibleVersionRangesAcrossDependencyTree(
+  packageName,
+  majorVersion,
+) {
+  const { stdout } = await execa('yarn', ['why', packageName, '--json']);
+
+  const parsedVersionRanges = new Set();
+  const lines = stdout.trim().split('\n');
+
+  for (const line of lines) {
+    /** @type {YarnWhyEntry} */
+    const entry = JSON.parse(line);
+
+    const parentLocator = structUtils.parseLocator(entry.value);
+    if (parentLocator.reference === 'workspace:.') {
+      // Skip dependencies or resolutions defined directly in the project's
+      // `package.json`, as we already know what they are
+      continue;
+    }
+
+    for (const child of Object.values(entry.children)) {
+      const devirtualizedDescriptor = structUtils.ensureDevirtualizedDescriptor(
+        structUtils.parseDescriptor(child.descriptor),
+      );
+
+      const parsedVersionRange = getParsedVersionRangeForDescriptor(
+        structUtils.stringifyDescriptor(devirtualizedDescriptor),
+        packageName,
+      );
+
+      if (majorVersion === parsedVersionRange.majorVersion) {
+        parsedVersionRanges.add(parsedVersionRange);
+      }
+    }
+  }
+
+  return parsedVersionRanges;
+}
+
+/**
+ * Computes resolutions necessary to add a preview build which is expected to
+ * have breaking changes.
+ *
+ * In this case, there will be one resolution which overrides the given
+ * package name ONLY at the root package level.
+ *
+ * @param {Object} args - The arguments.
+ * @param {string} args.packageName - The name of the package to add resolutions for.
+ * @param {string} args.previewNpmScope - The NPM scope of the preview build.
+ * @param {string} args.previewVersion - The preview build version to use.
+ * @param {string} args.manifestPath - Path to the package.json file.
+ * @returns {Promise<Record<string, string>>} The resulting resolutions.
+ */
+async function getResolutionsForBreakingPreviewBuilds({
+  packageName,
+  previewNpmScope,
+  previewVersion,
+  manifestPath,
+}) {
+  const manifest = await readManifest(manifestPath);
+  const rootPackageName = manifest.name;
+  const parsedVersionRange = getVersionRangeForDependency(
+    manifest,
+    packageName,
+  );
+
+  const resolutionKey = `${rootPackageName}@workspace:./${packageName}@${parsedVersionRange.string}`;
+  const resolutionValue = `npm:${packageName.replace(`@${METAMASK_NPM_SCOPE}/`, `@${previewNpmScope}/`)}@${previewVersion}`;
+  return {
+    [resolutionKey]: resolutionValue,
+  };
+}
+
+/**
+ * Computes resolutions necessary to add a preview build which is expected to
+ * have non-breaking changes.
+ *
+ * In this case, there may be multiple resolutions, one for each version of the
+ * package in the dependency tree that is compatible with the version range
+ * specified in `dependencies`.
+ *
+ * @param {Object} args - The arguments.
+ * @param {string} args.packageName - The name of the package to add resolutions for.
+ * @param {string} args.previewNpmScope - The NPM scope of the preview build.
+ * @param {string} args.previewVersion - The preview build version to use.
+ * @param {string} args.manifestPath - Path to the package.json file.
+ * @returns {Promise<Record<string, string>>} The resulting resolutions.
+ */
+async function getResolutionsForNonBreakingPreviewBuilds({
+  packageName,
+  previewNpmScope,
+  previewVersion,
+  manifestPath,
+}) {
+  const manifest = await readManifest(manifestPath);
+  const parsedVersionRange = getVersionRangeForDependency(
+    manifest,
+    packageName,
+  );
+
+  const compatibleVersionRanges =
+    await getAllCompatibleVersionRangesAcrossDependencyTree(
+      packageName,
+      parsedVersionRange.majorVersion,
+    );
+  const parsedVersionRangesToAdd = new Set([
+    ...compatibleVersionRanges,
+    parsedVersionRange,
+  ]);
+  const sortedParsedVersionRangesToAdd = sortParsedVersionRanges([
+    ...parsedVersionRangesToAdd,
+  ]);
+
+  return sortedParsedVersionRangesToAdd.reduce(
+    (obj, parsedVersionRangeToAdd) => {
+      const resolutionKey = `${packageName}@${parsedVersionRangeToAdd.string}`;
+      const resolutionValue = `npm:${packageName.replace(`@${METAMASK_NPM_SCOPE}/`, `@${previewNpmScope}/`)}@${previewVersion}`;
+      return { ...obj, [resolutionKey]: resolutionValue };
+    },
+    {},
+  );
+}
+
+/**
+ * Installs the resolutions just added.
+ * @returns {Promise<void>}
+ */
+async function installDependencies() {
+  console.log('Running `yarn install`...');
+  await execa('yarn', ['install']);
+}
+
+/**
+ * Main entry point for the script.
+ * @returns {Promise<void>}
+ */
+async function main() {
+  const { packageName, previewNpmScope, previewVersion, type } =
+    await parseArgs();
+
+  const manifestPath = path.join(process.cwd(), 'package.json');
+
+  await validateDependencyNotPatched(packageName, manifestPath);
+
+  await removeExistingPreviewBuildResolutions(
+    packageName,
+    previewNpmScope,
+    manifestPath,
+  );
+
+  const newResolutions =
+    type === 'breaking'
+      ? await getResolutionsForBreakingPreviewBuilds({
+          packageName,
+          previewVersion,
+          previewNpmScope,
+          manifestPath,
+        })
+      : await getResolutionsForNonBreakingPreviewBuilds({
+          packageName,
+          previewVersion,
+          previewNpmScope,
+          manifestPath,
+        });
+  await updateResolutionsInManifest(manifestPath, newResolutions);
+
+  console.log('\nDone!');
+}
+
+// Run this script.
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,7 +64,8 @@
     "node_modules/expect-webdriverio",
     "node_modules/expect-webdriverio/jest",
     "e2e/**/*",
-    "appwright/**/*"
+    "appwright/**/*",
+    "scripts/use-preview-build.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,6 +319,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@arcanis/slice-ansi@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@arcanis/slice-ansi@npm:1.1.1"
+  dependencies:
+    grapheme-splitter: "npm:^1.0.4"
+  checksum: 10/14ed60cb45750d386c64229ac7bab20e10eedc193503fa4decff764162d329d6d3363ed2cd3debec833186ee54affe4f824f6e8eff531295117fd1ebda200270
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:7.10.4, @babel/code-frame@npm:~7.10.4":
   version: 7.10.4
   resolution: "@babel/code-frame@npm:7.10.4"
@@ -12758,6 +12767,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sindresorhus/is@npm:^4.0.0":
+  version: 4.6.0
+  resolution: "@sindresorhus/is@npm:4.6.0"
+  checksum: 10/e7f36ed72abfcd5e0355f7423a72918b9748bb1ef370a59f3e5ad8d40b728b85d63b272f65f63eec1faf417cda89dcb0aeebe94015647b6054659c1442fe5ce0
+  languageName: node
+  linkType: hard
+
 "@sindresorhus/is@npm:^5.2.0":
   version: 5.6.0
   resolution: "@sindresorhus/is@npm:5.6.0"
@@ -16640,6 +16656,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@szmarczak/http-timer@npm:^4.0.5":
+  version: 4.0.6
+  resolution: "@szmarczak/http-timer@npm:4.0.6"
+  dependencies:
+    defer-to-connect: "npm:^2.0.0"
+  checksum: 10/c29df3bcec6fc3bdec2b17981d89d9c9fc9bd7d0c9bcfe92821dc533f4440bc890ccde79971838b4ceed1921d456973c4180d7175ee1d0023ad0562240a58d95
+  languageName: node
+  linkType: hard
+
 "@szmarczak/http-timer@npm:^5.0.1":
   version: 5.0.1
   resolution: "@szmarczak/http-timer@npm:5.0.1"
@@ -17481,6 +17506,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cacheable-request@npm:^6.0.1":
+  version: 6.0.3
+  resolution: "@types/cacheable-request@npm:6.0.3"
+  dependencies:
+    "@types/http-cache-semantics": "npm:*"
+    "@types/keyv": "npm:^3.1.4"
+    "@types/node": "npm:*"
+    "@types/responselike": "npm:^1.0.0"
+  checksum: 10/159f9fdb2a1b7175eef453ae2ced5ea04c0d2b9610cc9ccd9f9abb066d36dacb1f37acd879ace10ad7cbb649490723feb396fb7307004c9670be29636304b988
+  languageName: node
+  linkType: hard
+
 "@types/cheerio@npm:*":
   version: 0.22.30
   resolution: "@types/cheerio@npm:0.22.30"
@@ -17588,6 +17625,13 @@ __metadata:
   version: 0.0.3
   resolution: "@types/doctrine@npm:0.0.3"
   checksum: 10/398c30efc903a750c71166c7385d763c98605723dfae23f0134d6de4d365a8f0a5585a0fe6f959569ff33646e7f43fa83bacb5f2a4d5929cd0f6163d06e4f6b3
+  languageName: node
+  linkType: hard
+
+"@types/emscripten@npm:^1.39.6":
+  version: 1.41.5
+  resolution: "@types/emscripten@npm:1.41.5"
+  checksum: 10/60dfcced39b2d0c94f31907c5cf5d97fe06ed35ed6cb134650a1a96bae861302722d4a6f459b484ea09588cde70cbcc034974454a746be3ce9688b52398d2953
   languageName: node
   linkType: hard
 
@@ -17751,7 +17795,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/http-cache-semantics@npm:^4.0.2":
+"@types/http-cache-semantics@npm:*, @types/http-cache-semantics@npm:^4.0.2":
   version: 4.0.4
   resolution: "@types/http-cache-semantics@npm:4.0.4"
   checksum: 10/a59566cff646025a5de396d6b3f44a39ab6a74f2ed8150692e0f31cc52f3661a68b04afe3166ebe0d566bd3259cb18522f46e949576d5204781cd6452b7fe0c5
@@ -17862,6 +17906,15 @@ __metadata:
   version: 1.0.6
   resolution: "@types/keygrip@npm:1.0.6"
   checksum: 10/d157f60bf920492347791d2b26d530d5069ce05796549fbacd4c24d66ffbebbcb0ab67b21e7a1b80a593b9fd4b67dc4843dec04c12bbc2e0fddfb8577a826c41
+  languageName: node
+  linkType: hard
+
+"@types/keyv@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "@types/keyv@npm:3.1.4"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/e009a2bfb50e90ca9b7c6e8f648f8464067271fd99116f881073fa6fa76dc8d0133181dd65e6614d5fb1220d671d67b0124aef7d97dc02d7e342ab143a47779d
   languageName: node
   linkType: hard
 
@@ -18236,6 +18289,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/responselike@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@types/responselike@npm:1.0.3"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/6ac4b35723429b11b117e813c7acc42c3af8b5554caaf1fc750404c1ae59f9b7376bc69b9e9e194a5a97357a597c2228b7173d317320f0360d617b6425212f58
+  languageName: node
+  linkType: hard
+
 "@types/secp256k1@npm:^4.0.1":
   version: 4.0.3
   resolution: "@types/secp256k1@npm:4.0.3"
@@ -18259,7 +18321,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7, @types/semver@npm:^7.3.12, @types/semver@npm:^7.3.4":
+"@types/semver@npm:^7, @types/semver@npm:^7.1.0, @types/semver@npm:^7.3.12, @types/semver@npm:^7.3.4":
   version: 7.7.1
   resolution: "@types/semver@npm:7.7.1"
   checksum: 10/8f09e7e6ca3ded67d78ba7a8f7535c8d9cf8ced83c52e7f3ac3c281fe8c689c3fe475d199d94390dc04fc681d51f2358b430bb7b2e21c62de24f2bee2c719068
@@ -18338,6 +18400,13 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/fa5f00ce7f03d7514710003435cca64c7e4f24e4076e577cd5030a5214f78cc10cb318da820aa2dc4cb0c98e8386e22a45241261d39b2ef81b1f681803f765f3
+  languageName: node
+  linkType: hard
+
+"@types/treeify@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@types/treeify@npm:1.0.3"
+  checksum: 10/777e579b30a916a781e7cbad2b7a76bc5473ff7bfe7167dd6de47f80f4386df5bf3d0dc34170afb75d52e75f6ed61cc109abf2324e093c1f9ecd4e79fec58d0c
   languageName: node
   linkType: hard
 
@@ -18482,12 +18551,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yargs@npm:^17.0.8":
-  version: 17.0.13
-  resolution: "@types/yargs@npm:17.0.13"
+"@types/yargs@npm:^17.0.35, @types/yargs@npm:^17.0.8":
+  version: 17.0.35
+  resolution: "@types/yargs@npm:17.0.35"
   dependencies:
     "@types/yargs-parser": "npm:*"
-  checksum: 10/cf54305c8607393a5d3a5763d46f7ce0e89276c3083dcca23afb8417c9c362287860b48d554e9a5db9627c809747c04ebfd051d1a3f868eb029af3eb6c670ea0
+  checksum: 10/47bcd4476a4194ea11617ea71cba8a1eddf5505fc39c44336c1a08d452a0de4486aedbc13f47a017c8efbcb5a8aa358d976880663732ebcbc6dbcbbecadb0581
   languageName: node
   linkType: hard
 
@@ -19941,6 +20010,62 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@yarnpkg/core@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "@yarnpkg/core@npm:4.5.0"
+  dependencies:
+    "@arcanis/slice-ansi": "npm:^1.1.1"
+    "@types/semver": "npm:^7.1.0"
+    "@types/treeify": "npm:^1.0.0"
+    "@yarnpkg/fslib": "npm:^3.1.4"
+    "@yarnpkg/libzip": "npm:^3.2.2"
+    "@yarnpkg/parsers": "npm:^3.0.3"
+    "@yarnpkg/shell": "npm:^4.1.3"
+    camelcase: "npm:^5.3.1"
+    chalk: "npm:^4.1.2"
+    ci-info: "npm:^4.0.0"
+    clipanion: "npm:^4.0.0-rc.2"
+    cross-spawn: "npm:^7.0.3"
+    diff: "npm:^5.1.0"
+    dotenv: "npm:^16.3.1"
+    es-toolkit: "npm:^1.39.7"
+    fast-glob: "npm:^3.2.2"
+    got: "npm:^11.7.0"
+    hpagent: "npm:^1.2.0"
+    micromatch: "npm:^4.0.2"
+    p-limit: "npm:^2.2.0"
+    semver: "npm:^7.1.2"
+    strip-ansi: "npm:^6.0.0"
+    tar: "npm:^6.0.5"
+    tinylogic: "npm:^2.0.0"
+    treeify: "npm:^1.1.0"
+    tslib: "npm:^2.4.0"
+  checksum: 10/438e0d0e73f22454696575436ee11f27e765df7fa6b6f9bf63e3d5f79f2b7ceb382dd7df1efbb27ca674a974a2c444a5bf346aac3875ffa6a555b26517309b71
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/fslib@npm:^3.1.2, @yarnpkg/fslib@npm:^3.1.3, @yarnpkg/fslib@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "@yarnpkg/fslib@npm:3.1.4"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/9587a154768e61fbcf71ae745b1bf84e4ce0cbaa94163137ec88bd5005000a5b893dacbccbed7ac5f7643f957781c4f481d11ab3baf421ccafffbf43c275073d
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/libzip@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@yarnpkg/libzip@npm:3.2.2"
+  dependencies:
+    "@types/emscripten": "npm:^1.39.6"
+    "@yarnpkg/fslib": "npm:^3.1.3"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    "@yarnpkg/fslib": ^3.1.3
+  checksum: 10/b6548be0a421e2390b74fd767d5f90e6da34a84af3ca28389b86d7f9e7602663f01347b5081cb93f8821877cae3ed48d2cb1cb8c35a4a4f7fc3d00109c85af0f
+  languageName: node
+  linkType: hard
+
 "@yarnpkg/lockfile@npm:^1.1.0":
   version: 1.1.0
   resolution: "@yarnpkg/lockfile@npm:1.1.0"
@@ -19948,13 +20073,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/parsers@npm:^3.0.0-rc.48.1":
-  version: 3.0.2
-  resolution: "@yarnpkg/parsers@npm:3.0.2"
+"@yarnpkg/parsers@npm:^3.0.0-rc.48.1, @yarnpkg/parsers@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@yarnpkg/parsers@npm:3.0.3"
   dependencies:
     js-yaml: "npm:^3.10.0"
     tslib: "npm:^2.4.0"
-  checksum: 10/87506f140d6c401bdd89ff22073c3dd3ec7b6858e7f576e63ec1aea1b0b8a8ec241eb46ca5582dc2071098a86d6a55c3b0628da5eeff91d33afb4fa7cac0cf65
+  checksum: 10/379f7ff8fc1b37d3818dfeba4e18a72f8e9817bb41aab9332b50bbc843e45c9bf135563a7a06882ffb50e4cdd29c8da33c8e4f3739201de2fbcd38ecb59e3a8e
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/shell@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "@yarnpkg/shell@npm:4.1.3"
+  dependencies:
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/parsers": "npm:^3.0.3"
+    chalk: "npm:^4.1.2"
+    clipanion: "npm:^4.0.0-rc.2"
+    cross-spawn: "npm:^7.0.3"
+    fast-glob: "npm:^3.2.2"
+    micromatch: "npm:^4.0.2"
+    tslib: "npm:^2.4.0"
+  bin:
+    shell: ./lib/cli.js
+  checksum: 10/5994f92adf960071ac938653c5ad09746285d3fdc452fc6fdd30c3a832b612cc208e8d2274731e35957b457b168d6be524f5ce30ceb18542532d9326b422421b
   languageName: node
   linkType: hard
 
@@ -22919,6 +23062,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cacheable-lookup@npm:^5.0.3":
+  version: 5.0.4
+  resolution: "cacheable-lookup@npm:5.0.4"
+  checksum: 10/618a8b3eea314060e74cb3285a6154e8343c244a34235acf91cfe626ee0705c24e3cd11e4b1a7b3900bd749ee203ae65afe13adf610c8ab173e99d4a208faf75
+  languageName: node
+  linkType: hard
+
 "cacheable-lookup@npm:^6.0.0":
   version: 6.1.0
   resolution: "cacheable-lookup@npm:6.1.0"
@@ -22945,6 +23095,21 @@ __metadata:
     normalize-url: "npm:^8.0.0"
     responselike: "npm:^3.0.0"
   checksum: 10/102f454ac68eb66f99a709c5cf65e90ed89f1b9269752578d5a08590b3986c3ea47a5d9dff208fe7b65855a29da129a2f23321b88490106898e0ba70b807c912
+  languageName: node
+  linkType: hard
+
+"cacheable-request@npm:^7.0.2":
+  version: 7.0.4
+  resolution: "cacheable-request@npm:7.0.4"
+  dependencies:
+    clone-response: "npm:^1.0.2"
+    get-stream: "npm:^5.1.0"
+    http-cache-semantics: "npm:^4.0.0"
+    keyv: "npm:^4.0.0"
+    lowercase-keys: "npm:^2.0.0"
+    normalize-url: "npm:^6.0.1"
+    responselike: "npm:^2.0.0"
+  checksum: 10/0f4f2001260ecca78b9f64fc8245e6b5a5dcde24ea53006daab71f5e0e1338095aa1512ec099c4f9895a9e5acfac9da423cb7c079e131485891e9214aca46c41
   languageName: node
   linkType: hard
 
@@ -23346,6 +23511,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ci-info@npm:^4.0.0":
+  version: 4.3.1
+  resolution: "ci-info@npm:4.3.1"
+  checksum: 10/9dc952bef67e665ccde2e7a552d42d5d095529d21829ece060a00925ede2dfa136160c70ef2471ea6ed6c9b133218b47c007f56955c0f1734a2e57f240aa7445
+  languageName: node
+  linkType: hard
+
 "cids@npm:^0.7.1":
   version: 0.7.5
   resolution: "cids@npm:0.7.5"
@@ -23480,6 +23652,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clipanion@npm:^4.0.0-rc.2":
+  version: 4.0.0-rc.4
+  resolution: "clipanion@npm:4.0.0-rc.4"
+  dependencies:
+    typanion: "npm:^3.8.0"
+  peerDependencies:
+    typanion: "*"
+  checksum: 10/c3a94783318d91e6b35380a8aa4a6f166964082a51ff2df21a339266223aaab98f5986dd2c37ca7fd640ad1d233b3cd5b24aad64c51537b54ccc9c66ec070eeb
+  languageName: node
+  linkType: hard
+
 "clipboardy@npm:^3.0.0":
   version: 3.0.0
   resolution: "clipboardy@npm:3.0.0"
@@ -23544,6 +23727,15 @@ __metadata:
     kind-of: "npm:^6.0.2"
     shallow-clone: "npm:^3.0.0"
   checksum: 10/770f912fe4e6f21873c8e8fbb1e99134db3b93da32df271d00589ea4a29dbe83a9808a322c93f3bcaf8584b8b4fa6fc269fc8032efbaa6728e0c9886c74467d2
+  languageName: node
+  linkType: hard
+
+"clone-response@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "clone-response@npm:1.0.3"
+  dependencies:
+    mimic-response: "npm:^1.0.0"
+  checksum: 10/4e671cac39b11c60aa8ba0a450657194a5d6504df51bca3fac5b3bd0145c4f8e8464898f87c8406b83232e3bc5cca555f51c1f9c8ac023969ebfbf7f6bdabb2e
   languageName: node
   linkType: hard
 
@@ -24972,7 +25164,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"defer-to-connect@npm:^2.0.1":
+"defer-to-connect@npm:^2.0.0, defer-to-connect@npm:^2.0.1":
   version: 2.0.1
   resolution: "defer-to-connect@npm:2.0.1"
   checksum: 10/8a9b50d2f25446c0bfefb55a48e90afd58f85b21bcf78e9207cd7b804354f6409032a1705c2491686e202e64fc05f147aa5aa45f9aa82627563f045937f5791b
@@ -25365,10 +25557,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:^5.0.0":
-  version: 5.1.0
-  resolution: "diff@npm:5.1.0"
-  checksum: 10/f4557032a98b2967fe27b1a91dfcf8ebb6b9a24b1afe616b5c2312465100b861e9b8d4da374be535f2d6b967ce2f53826d7f6edc2a0d32b2ab55abc96acc2f9d
+"diff@npm:^5.0.0, diff@npm:^5.1.0":
+  version: 5.2.0
+  resolution: "diff@npm:5.2.0"
+  checksum: 10/01b7b440f83a997350a988e9d2f558366c0f90f15be19f4aa7f1bb3109a4e153dfc3b9fbf78e14ea725717017407eeaa2271e3896374a0181e8f52445740846d
   languageName: node
   linkType: hard
 
@@ -25570,7 +25762,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.0, dotenv@npm:^16.0.3, dotenv@npm:^16.4.5, dotenv@npm:^16.5.0":
+"dotenv@npm:^16.0.0, dotenv@npm:^16.0.3, dotenv@npm:^16.3.1, dotenv@npm:^16.4.5, dotenv@npm:^16.5.0":
   version: 16.6.1
   resolution: "dotenv@npm:16.6.1"
   checksum: 10/1d1897144344447ffe62aa1a6d664f4cd2e0784e0aff787eeeec1940ded32f8e4b5b506d665134fc87157baa086fce07ec6383970a2b6d2e7985beaed6a4cc14
@@ -26398,6 +26590,18 @@ __metadata:
     prettier-plugin-sort-re-exports@0.0.1:
       unplugged: true
   checksum: 10/db613d885c407dc3b84b3939b8b0c9976f658bfb03fa0f9cd3a3fe8383a60a75e1e4f34584e86c3fbf00def50ea0ca5f1a5264a1014018286dedbed08426b5f0
+  languageName: node
+  linkType: hard
+
+"es-toolkit@npm:^1.39.7":
+  version: 1.44.0
+  resolution: "es-toolkit@npm:1.44.0"
+  dependenciesMeta:
+    "@trivago/prettier-plugin-sort-imports@4.3.0":
+      unplugged: true
+    prettier-plugin-sort-re-exports@0.0.1:
+      unplugged: true
+  checksum: 10/72a74c8688dec99743b3170e1e78822b983519b795643c2f04c4a8e6b49e2d6f554013e2266850de7929718b4113768912e9b8394eb6e3d6c9e28a38fb8f5317
   languageName: node
   linkType: hard
 
@@ -28214,7 +28418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.5, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2":
+"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.2, fast-glob@npm:^3.2.5, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -29743,6 +29947,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"got@npm:^11.7.0":
+  version: 11.8.6
+  resolution: "got@npm:11.8.6"
+  dependencies:
+    "@sindresorhus/is": "npm:^4.0.0"
+    "@szmarczak/http-timer": "npm:^4.0.5"
+    "@types/cacheable-request": "npm:^6.0.1"
+    "@types/responselike": "npm:^1.0.0"
+    cacheable-lookup: "npm:^5.0.3"
+    cacheable-request: "npm:^7.0.2"
+    decompress-response: "npm:^6.0.0"
+    http2-wrapper: "npm:^1.0.0-beta.5.2"
+    lowercase-keys: "npm:^2.0.0"
+    p-cancelable: "npm:^2.0.0"
+    responselike: "npm:^2.0.0"
+  checksum: 10/a30c74029d81bd5fe50dea1a0c970595d792c568e188ff8be254b5bc11e6158d1b014570772d4a30d0a97723e7dd34e7c8cc1a2f23018f60aece3070a7a5c2a5
+  languageName: node
+  linkType: hard
+
 "got@npm:^12.6.1":
   version: 12.6.1
   resolution: "got@npm:12.6.1"
@@ -30152,6 +30375,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hpagent@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "hpagent@npm:1.2.0"
+  checksum: 10/bad186449da7e3456788a8cbae459fc6c0a855d5872a7f460c48ce4a613020d8d914839dad10047297099299c4f9e6c65a0eec3f5886af196c0a516e4ad8a845
+  languageName: node
+  linkType: hard
+
 "html-element-map@npm:^1.0.0":
   version: 1.3.1
   resolution: "html-element-map@npm:1.3.1"
@@ -30271,10 +30501,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-cache-semantics@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "http-cache-semantics@npm:4.1.1"
-  checksum: 10/362d5ed66b12ceb9c0a328fb31200b590ab1b02f4a254a697dc796850cc4385603e75f53ec59f768b2dad3bfa1464bd229f7de278d2899a0e3beffc634b6683f
+"http-cache-semantics@npm:^4.0.0, http-cache-semantics@npm:^4.1.1":
+  version: 4.2.0
+  resolution: "http-cache-semantics@npm:4.2.0"
+  checksum: 10/4efd2dfcfeea9d5e88c84af450b9980be8a43c2c8179508b1c57c7b4421c855f3e8efe92fa53e0b3f4a43c85824ada930eabbc306d1b3beab750b6dcc5187693
   languageName: node
   linkType: hard
 
@@ -30375,6 +30605,16 @@ __metadata:
   version: 2.3.0
   resolution: "http-status-codes@npm:2.3.0"
   checksum: 10/1b8a01940b5e14d3c5b2f842313f4531469b41ce4fa40ca3aae5c82a3101828db2cc9406bfb2d50a46e6d521d106577b6656c2b065c76125b99ee54b2cbbac09
+  languageName: node
+  linkType: hard
+
+"http2-wrapper@npm:^1.0.0-beta.5.2":
+  version: 1.0.3
+  resolution: "http2-wrapper@npm:1.0.3"
+  dependencies:
+    quick-lru: "npm:^5.1.1"
+    resolve-alpn: "npm:^1.0.0"
+  checksum: 10/8097ee2699440c2e64bda52124990cc5b0fb347401c7797b1a0c1efd5a0f79a4ebaa68e8a6ac3e2dde5f09460c1602764da6da2412bad628ed0a3b0ae35e72d4
   languageName: node
   linkType: hard
 
@@ -32767,7 +33007,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyv@npm:^4.5.3":
+"keyv@npm:^4.0.0, keyv@npm:^4.5.3":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
   dependencies:
@@ -33707,6 +33947,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lowercase-keys@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "lowercase-keys@npm:2.0.0"
+  checksum: 10/1c233d2da35056e8c49fae8097ee061b8c799b2f02e33c2bf32f9913c7de8fb481ab04dab7df35e94156c800f5f34e99acbf32b21781d87c3aa43ef7b748b79e
+  languageName: node
+  linkType: hard
+
 "lowercase-keys@npm:^3.0.0":
   version: 3.0.0
   resolution: "lowercase-keys@npm:3.0.0"
@@ -34251,6 +34498,7 @@ __metadata:
     "@types/serve-handler": "npm:^6.1.4"
     "@types/url-parse": "npm:^1.4.8"
     "@types/valid-url": "npm:^1.0.4"
+    "@types/yargs": "npm:^17.0.35"
     "@typescript-eslint/eslint-plugin": "npm:^7.10.0"
     "@typescript-eslint/parser": "npm:^7.10.0"
     "@viem/anvil": "npm:^0.0.10"
@@ -34261,6 +34509,7 @@ __metadata:
     "@walletconnect/utils": "npm:^2.19.2"
     "@welldone-software/why-did-you-render": "npm:^8.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
+    "@yarnpkg/core": "npm:^4.5.0"
     appium: "npm:^2.12.1"
     appium-uiautomator2-driver: "npm:4.2.7"
     appium-xcuitest-driver: "npm:5.16.1"
@@ -34484,6 +34733,7 @@ __metadata:
     webpack-cli: "npm:^5.1.4"
     xhr2: "npm:^0.2.1"
     xml2js: "npm:^0.5.0"
+    yargs: "npm:^17.7.2"
     zxcvbn: "npm:4.4.2"
   dependenciesMeta:
     "@img/sharp-darwin-arm64":
@@ -34930,6 +35180,13 @@ __metadata:
   version: 4.0.0
   resolution: "mimic-fn@npm:4.0.0"
   checksum: 10/995dcece15ee29aa16e188de6633d43a3db4611bcf93620e7e62109ec41c79c0f34277165b8ce5e361205049766e371851264c21ac64ca35499acb5421c2ba56
+  languageName: node
+  linkType: hard
+
+"mimic-response@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "mimic-response@npm:1.0.1"
+  checksum: 10/034c78753b0e622bc03c983663b1cdf66d03861050e0c8606563d149bc2b02d63f62ce4d32be4ab50d0553ae0ffe647fc34d1f5281184c6e1e8cf4d85e8d9823
   languageName: node
   linkType: hard
 
@@ -36011,6 +36268,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"normalize-url@npm:^6.0.1":
+  version: 6.1.0
+  resolution: "normalize-url@npm:6.1.0"
+  checksum: 10/5ae699402c9d5ffa330adc348fcd6fc6e6a155ab7c811b96e30b7ecab60ceef821d8f86443869671dda71bbc47f4b9625739c82ad247e883e9aefe875bfb8659
+  languageName: node
+  linkType: hard
+
 "normalize-url@npm:^8.0.0":
   version: 8.1.0
   resolution: "normalize-url@npm:8.1.0"
@@ -36674,6 +36938,13 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/a3c967e5b30792d89e7ecbdf976c00c625738e96263e1f0a95ad43c27b57ac18f21357eb7a651ce3c0ff0dc54b3ed071516c9804bc48fa2134262a5066b62fcc
+  languageName: node
+  linkType: hard
+
+"p-cancelable@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "p-cancelable@npm:2.1.1"
+  checksum: 10/7f1b64db17fc54acf359167d62898115dcf2a64bf6b3b038e4faf36fc059e5ed762fb9624df8ed04b25bee8de3ab8d72dea9879a2a960cd12e23c420a4aca6ed
   languageName: node
   linkType: hard
 
@@ -40254,7 +40525,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve-alpn@npm:^1.2.0":
+"resolve-alpn@npm:^1.0.0, resolve-alpn@npm:^1.2.0":
   version: 1.2.1
   resolution: "resolve-alpn@npm:1.2.1"
   checksum: 10/744e87888f0b6fa0b256ab454ca0b9c0b80808715e2ef1f3672773665c92a941f6181194e30ccae4a8cd0adbe0d955d3f133102636d2ee0cca0119fec0bc9aec
@@ -40415,6 +40686,15 @@ __metadata:
   dependencies:
     path-parse: "npm:^1.0.5"
   checksum: 10/3bfc4ed0768c158d320bdd1076875e2c783cba03985d6052cd5142ed971e413eb8f8a81753fc4f12f3051723356898bf9c5a24d6c988dfb9de9587f710ca692d
+  languageName: node
+  linkType: hard
+
+"responselike@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "responselike@npm:2.0.1"
+  dependencies:
+    lowercase-keys: "npm:^2.0.0"
+  checksum: 10/b122535466e9c97b55e69c7f18e2be0ce3823c5d47ee8de0d9c0b114aa55741c6db8bfbfce3766a94d1272e61bfb1ebf0a15e9310ac5629fbb7446a861b4fd3a
   languageName: node
   linkType: hard
 
@@ -41012,7 +41292,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.1.3, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.2, semver@npm:^7.6.3, semver@npm:^7.7.2, semver@npm:^7.7.3":
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.1.3, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.2, semver@npm:^7.6.3, semver@npm:^7.7.2, semver@npm:^7.7.3":
   version: 7.7.3
   resolution: "semver@npm:7.7.3"
   bin:
@@ -42733,7 +43013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:6.2.1, tar@npm:^6.1.11, tar@npm:^6.1.2, tar@npm:^6.2.1":
+"tar@npm:6.2.1, tar@npm:^6.0.5, tar@npm:^6.1.11, tar@npm:^6.1.2, tar@npm:^6.2.1":
   version: 6.2.1
   resolution: "tar@npm:6.2.1"
   dependencies:
@@ -43129,6 +43409,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinylogic@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "tinylogic@npm:2.0.0"
+  checksum: 10/6467b1ed9b602dae035726ee3faf2682bddffb5389b42fdb4daf13878037420ed9981a572ca7db467bd26c4ab00fb4eefe654f24e35984ec017fb5e83081db97
+  languageName: node
+  linkType: hard
+
 "tmp@npm:^0.0.33":
   version: 0.0.33
   resolution: "tmp@npm:0.0.33"
@@ -43206,6 +43493,13 @@ __metadata:
   version: 0.3.9
   resolution: "traverse@npm:0.3.9"
   checksum: 10/ffbb8460a934f271b7b7ae654e676f740d81037d6c20ab9fd05781cfdf644929f494399b5cb3aa3db4ab69cbfef06ff8f885560d523ca49b7da33763f6c4c9f1
+  languageName: node
+  linkType: hard
+
+"treeify@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "treeify@npm:1.1.0"
+  checksum: 10/5241976a751168fb9894a12d031299f1f6337b7f2cbd3eff22ee86e6777620352a69a1cab0d4709251317ff307eeda0dc45918850974fc44f4c7fc50e623b990
   languageName: node
   linkType: hard
 
@@ -43440,6 +43734,13 @@ __metadata:
   peerDependencies:
     react-native: ">=0.62.2"
   checksum: 10/425c1f6c67e9c3d545c38271f3b10d6f11e62a18367802dd562b37a737646193c0329779ffb9ae14c1d90f7c14ce012c966bcb02f60450a8dc4b72c1b09e4650
+  languageName: node
+  linkType: hard
+
+"typanion@npm:^3.8.0":
+  version: 3.14.0
+  resolution: "typanion@npm:3.14.0"
+  checksum: 10/5e88d9e6121ff0ec543f572152fdd1b70e9cca35406d79013ec8e08defa8ef96de5fec9e98da3afbd1eb4426b9e8e8fe423163d0b482e34a40103cab1ef29abd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Some MetaMask repos (e.g. `core`) allow upcoming package changes to be tested in Extension and/or Mobile prior to release by publishing "preview builds".

However, using a preview build can be complicated, and specific steps must be followed depending on whether the upcoming changes are breaking or non-breaking.

To make following this workflow easier, this commit adds a package script which can be run to use a preview build. The general usage for this script is:

    yarn use-preview-build <package-name> <preview-version> --type <breaking | non-breaking>

This will automatically update the `resolutions` sections in `package.json` with the appropriate entries given what already exists for the package in `dependencies` and your choice of `type`.

Examples:

- You want to use a preview build for the package `@metamask/permission-controller`; the preview build version is `13.0.2-preview-940c934`; and you anticipate making non-breaking changes. You would say:

      yarn use-preview-build @metamask/permission-controller 13.0.2-preview-940c934 --type breaking

  This would add resolutions which repoint `@metamask/permission-controller` 13.x across the dependency tree to `@metamask-previews/permission-controller@13.0.2-preview-a4747b2b`.

- You want to use a preview build for the package `@metamask/network-controller`; the preview build version is `29.0.0-preview-a4747b2b`; and you anticipate making breaking changes. You would say:

      yarn use-preview-build @metamask/network-controller 29.0.0-preview-a4747b2b --type non-breaking

  This would add a resolution which repoints `@metamask/network-controller` to `@metamask-previews/network-controller@29.0.0-preview-a4747b2b` for whichever version is being used at the root level (it would not apply this resolution across the dependency tree).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-199

## **Manual testing steps**

- Run `yarn use-preview-build @metamask/permission-controller 12.2.0-preview-a4747b2b --type non-breaking`. The script should succeed, and should add 4 resolutions.
- Run `yarn use-preview-build @metamask/permission-controller 12.2.0-preview-a4747b2b --type breaking`. The script should succeed, removing the previously added resolutions, and adding only 1 new resolution.

## **Screenshots/Recordings**

(N/A)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a helper to apply preview NPM builds via Yarn resolutions.
> 
> - Adds `scripts/use-preview-build.mjs` to update `package.json` `resolutions` for a given MetaMask package and preview version, handling both breaking and non-breaking cases; installs deps after changes
> - Wires script as `yarn use-preview-build` in `package.json`; includes script in `tsconfig.json`
> - Adds required deps (`@yarnpkg/core`, `yargs`, `@types/yargs`) and updates `yarn.lock`; ignores `@types/yargs` in `.depcheckrc.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d527a8dcccbf4edc98e6995945af5f911ee52d20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->