### PR TITLE
chore: Enable Cursor Issue Analysis again

### DIFF
--- a/.github/workflows/cursor-issue-analysis.yml
+++ b/.github/workflows/cursor-issue-analysis.yml
@@ -12,11 +12,9 @@ permissions:
 jobs:
   analyze-issue:
     runs-on: ubuntu-latest
-    # TEMPORARILY DISABLED - Re-enable after holidays by removing the 'false &&' below
     # Check if issue has team-confirmations AND (Sev1-high OR Sev2-normal) AND NOT external-contributor
     # Note: Only maintainers can add labels, providing first line of defense
     if: |
-      false &&
       contains(github.event.issue.labels.*.name, 'team-confirmations') &&
       (contains(github.event.issue.labels.*.name, 'Sev1-high') || contains(github.event.issue.labels.*.name, 'Sev2-normal')) &&
       !contains(github.event.issue.labels.*.name, 'external-contributor')


### PR DESCRIPTION
## **Description**
Enables Cursor Issue Analysis again.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Reactivates** the `Cursor Issue Analysis` workflow by removing the temporary `false &&` guard in the job `if` condition.
> 
> - Workflow now executes again on `issues` (opened/labeled) when labels include `team-confirmations` and (`Sev1-high` or `Sev2-normal`) and exclude `external-contributor`
> - No other logic in the workflow changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f0138d32503251e394fff19e2dda239d383c614. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->