### PR TITLE
fix: redesign perps bottomSheet filter

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
@@ -420,7 +420,10 @@ jest.mock('../../../../Views/confirmations/hooks/useConfirmNavigation', () => ({
 jest.mock('../../selectors/perpsController', () => ({
   selectPerpsEligibility: jest.fn(() => true),
   selectPerpsWatchlistMarkets: jest.fn(() => []),
-  selectPerpsMarketFilterPreferences: jest.fn(() => 'volume'),
+  selectPerpsMarketFilterPreferences: jest.fn(() => ({
+    optionId: 'volume',
+    direction: 'desc',
+  })),
 }));
 
 jest.mock('../../utils/formatUtils', () => ({

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
@@ -238,10 +238,9 @@ jest.mock('./components/PerpsMarketFiltersBar', () => {
     const getSortLabel = (optionId: string) => {
       const translations: Record<string, string> = {
         volume: 'Volume',
-        'priceChange-desc': 'Price Change (High to Low)',
-        'priceChange-asc': 'Price Change (Low to High)',
-        fundingRate: 'Funding Rate',
-        openInterest: 'Open Interest',
+        priceChange: 'Price change',
+        fundingRate: 'Funding rate',
+        openInterest: 'Open interest',
       };
       return translations[optionId] || optionId;
     };

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -114,7 +114,7 @@ const PerpsMarketListView = ({
   } = searchState;
 
   // Destructure sort state for easier access
-  const { selectedOptionId, sortBy, handleOptionChange } = sortState;
+  const { selectedOptionId, sortBy, direction, handleOptionChange } = sortState;
 
   // Destructure favorites state for easier access
   const { showFavoritesOnly } = favoritesState;
@@ -575,6 +575,7 @@ const PerpsMarketListView = ({
         isVisible={isSortFieldSheetVisible}
         onClose={() => setIsSortFieldSheetVisible(false)}
         selectedOptionId={selectedOptionId}
+        sortDirection={direction}
         onOptionSelect={handleOptionChange}
         testID={`${PerpsMarketListViewSelectorsIDs.SORT_FILTERS}-field-sheet`}
       />

--- a/app/components/UI/Perps/__mocks__/serviceMocks.ts
+++ b/app/components/UI/Perps/__mocks__/serviceMocks.ts
@@ -128,7 +128,10 @@ export const createMockPerpsControllerState = (
     testnet: {},
     mainnet: {},
   },
-  marketFilterPreferences: 'volume',
+  marketFilterPreferences: {
+    optionId: 'volume',
+    direction: 'desc',
+  },
   lastError: null,
   lastUpdateTimestamp: Date.now(),
   hip3ConfigVersion: 0,

--- a/app/components/UI/Perps/components/PerpsMarketSortDropdowns/PerpsMarketSortDropdowns.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortDropdowns/PerpsMarketSortDropdowns.test.tsx
@@ -121,10 +121,10 @@ describe('PerpsMarketSortDropdowns', () => {
       ).toBeOnTheScreen();
     });
 
-    it('displays price change label when selectedOptionId is priceChange-desc', () => {
+    it('displays price change label when selectedOptionId is priceChange', () => {
       render(
         <PerpsMarketSortDropdowns
-          selectedOptionId="priceChange-desc"
+          selectedOptionId="priceChange"
           onSortPress={mockOnSortPress}
         />,
       );
@@ -195,7 +195,7 @@ describe('PerpsMarketSortDropdowns', () => {
 
       rerender(
         <PerpsMarketSortDropdowns
-          selectedOptionId="priceChange-desc"
+          selectedOptionId="priceChange"
           onSortPress={newOnSortPress}
         />,
       );
@@ -216,7 +216,7 @@ describe('PerpsMarketSortDropdowns', () => {
     it('handles all sort option values', () => {
       const sortOptions: SortOptionId[] = [
         'volume',
-        'priceChange-desc',
+        'priceChange',
         'fundingRate',
       ];
 
@@ -261,7 +261,7 @@ describe('PerpsMarketSortDropdowns', () => {
 
       rerender(
         <PerpsMarketSortDropdowns
-          selectedOptionId="priceChange-desc"
+          selectedOptionId="priceChange"
           onSortPress={mockOnSortPress}
         />,
       );

--- a/app/components/UI/Perps/components/PerpsMarketSortDropdowns/PerpsMarketSortDropdowns.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortDropdowns/PerpsMarketSortDropdowns.test.tsx
@@ -46,10 +46,9 @@ jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const translations: Record<string, string> = {
       'perps.sort.volume': 'Volume',
-      'perps.sort.price_change_high_to_low': 'Price Change (High to Low)',
-      'perps.sort.price_change_low_to_high': 'Price Change (Low to High)',
-      'perps.sort.funding_rate': 'Funding Rate',
-      'perps.sort.open_interest': 'Open Interest',
+      'perps.sort.price_change': 'Price change',
+      'perps.sort.funding_rate': 'Funding rate',
+      'perps.sort.open_interest': 'Open interest',
     };
     return translations[key] || key;
   },
@@ -129,7 +128,7 @@ describe('PerpsMarketSortDropdowns', () => {
         />,
       );
 
-      expect(screen.getByText('Price Change (High to Low)')).toBeOnTheScreen();
+      expect(screen.getByText('Price change')).toBeOnTheScreen();
     });
 
     it('displays funding rate label when selectedOptionId is fundingRate', () => {
@@ -140,7 +139,7 @@ describe('PerpsMarketSortDropdowns', () => {
         />,
       );
 
-      expect(screen.getByText('Funding Rate')).toBeOnTheScreen();
+      expect(screen.getByText('Funding rate')).toBeOnTheScreen();
     });
   });
 
@@ -200,7 +199,7 @@ describe('PerpsMarketSortDropdowns', () => {
         />,
       );
 
-      expect(screen.getByText('Price Change (High to Low)')).toBeOnTheScreen();
+      expect(screen.getByText('Price change')).toBeOnTheScreen();
 
       const sortButton = screen.getByTestId(
         'perps-market-sort-dropdowns-sort-field',

--- a/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.styles.ts
+++ b/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.styles.ts
@@ -19,5 +19,32 @@ export const styleSheet = (params: { theme: Theme }) => {
     optionRowSelected: {
       backgroundColor: theme.colors.background.muted,
     },
+    arrowContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+    },
+    applyButton: {
+      height: 48,
+      paddingVertical: 4,
+      paddingHorizontal: 16,
+      justifyContent: 'center',
+      alignItems: 'center',
+      flexShrink: 0,
+      alignSelf: 'stretch',
+      borderRadius: 12,
+      backgroundColor: theme.colors.icon.default,
+      marginHorizontal: 16,
+      marginTop: 16,
+      marginBottom: 32,
+    },
+    applyButtonText: {
+      color: theme.colors.icon.inverse,
+      textAlign: 'center',
+      fontSize: 16,
+      fontStyle: 'normal',
+      fontWeight: '500',
+      lineHeight: undefined, // normal
+    },
   });
 };

--- a/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.test.tsx
@@ -6,19 +6,22 @@ import PerpsMarketSortFieldBottomSheet from './PerpsMarketSortFieldBottomSheet';
 jest.mock('../../../../../component-library/hooks', () => ({
   useStyles: () => ({
     styles: {
-      filterList: {},
-      filterRow: {},
-      filterRowActive: {},
-      filterRowContent: {},
-      toggleContainer: {},
+      optionsList: {},
+      optionRow: {},
+      optionRowSelected: {},
+      arrowContainer: {},
+      applyButton: {},
+      applyButtonText: {},
     },
     theme: {
       colors: {
         background: {
           alternative: '#E5E5E5',
+          muted: '#F0F0F0',
         },
         icon: {
           default: '#000000',
+          inverse: '#FFFFFF',
         },
         border: {
           muted: '#D6D6D6',
@@ -46,13 +49,15 @@ jest.mock(
           },
           ref: React.Ref<{
             onOpenBottomSheet: () => void;
-            onCloseBottomSheet: () => void;
+            onCloseBottomSheet: (callback?: () => void) => void;
           }>,
         ) => {
           // Expose mock ref methods
           MockReact.useImperativeHandle(ref, () => ({
             onOpenBottomSheet: jest.fn(),
-            onCloseBottomSheet: jest.fn(),
+            onCloseBottomSheet: (callback?: () => void) => {
+              callback?.();
+            },
           }));
 
           return <View testID={testID}>{children}</View>;
@@ -77,50 +82,38 @@ jest.mock(
 );
 
 jest.mock(
-  '../../../../../component-library/components-temp/SegmentedControl',
+  '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase',
   () => {
-    const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
-    return function MockSegmentedControl({
-      options,
-      selectedValue,
-      onValueChange,
+    const { TouchableOpacity, View } = jest.requireActual('react-native');
+    return ({
+      label,
+      onPress,
+      style,
       testID,
     }: {
-      options: { value: string; label: string }[];
-      selectedValue: string;
-      onValueChange: (value: string) => void;
+      label?: React.ReactNode;
+      onPress?: () => void;
+      style?: unknown;
       testID?: string;
-    }) {
-      return (
-        <View testID={testID}>
-          {options.map((option) => (
-            <TouchableOpacity
-              key={option.value}
-              testID={`${testID}-option-${option.value}`}
-              onPress={() => onValueChange(option.value)}
-            >
-              <Text>
-                {option.label}{' '}
-                {selectedValue === option.value ? '(selected)' : ''}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </View>
-      );
-    };
+    }) => (
+      <TouchableOpacity onPress={onPress} style={style} testID={testID}>
+        <View>{label}</View>
+      </TouchableOpacity>
+    );
   },
 );
 
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
     const translations: Record<string, string> = {
-      'perps.sort.sort_by': 'Sort By',
+      'perps.sort.sort_by': 'Sort by',
       'perps.sort.volume': 'Volume',
-      'perps.sort.price_change': '24h Change',
-      'perps.sort.funding_rate': 'Funding Rate',
-      'perps.sort.open_interest': 'Open Interest',
-      'perps.sort.high': 'High',
-      'perps.sort.low': 'Low',
+      'perps.sort.price_change': 'Price change',
+      'perps.sort.funding_rate': 'Funding rate',
+      'perps.sort.open_interest': 'Open interest',
+      'perps.sort.high_to_low': 'High to low',
+      'perps.sort.low_to_high': 'Low to high',
+      'perps.sort.apply': 'Apply',
     };
     return translations[key] || key;
   }),
@@ -134,16 +127,13 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
     jest.clearAllMocks();
   });
 
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
-
   describe('Visibility', () => {
     it('returns null when isVisible is false', () => {
       const { toJSON } = render(
         <PerpsMarketSortFieldBottomSheet
           isVisible={false}
           selectedOptionId="volume"
+          sortDirection="desc"
           onClose={mockOnClose}
           onOptionSelect={mockOnOptionSelect}
         />,
@@ -157,6 +147,7 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
         <PerpsMarketSortFieldBottomSheet
           isVisible
           selectedOptionId="volume"
+          sortDirection="desc"
           onClose={mockOnClose}
           onOptionSelect={mockOnOptionSelect}
         />,
@@ -172,6 +163,7 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
         <PerpsMarketSortFieldBottomSheet
           isVisible
           selectedOptionId="volume"
+          sortDirection="desc"
           onClose={mockOnClose}
           onOptionSelect={mockOnOptionSelect}
           testID="sort-field-sheet"
@@ -182,10 +174,7 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
         screen.getByTestId('sort-field-sheet-option-volume'),
       ).toBeOnTheScreen();
       expect(
-        screen.getByTestId('sort-field-sheet-option-priceChange-desc'),
-      ).toBeOnTheScreen();
-      expect(
-        screen.getByTestId('sort-field-sheet-option-priceChange-asc'),
+        screen.getByTestId('sort-field-sheet-option-priceChange'),
       ).toBeOnTheScreen();
       expect(
         screen.getByTestId('sort-field-sheet-option-openInterest'),
@@ -195,11 +184,56 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
       ).toBeOnTheScreen();
     });
 
-    it('shows checkmark on selected option', () => {
+    it('shows direction indicator only on priceChange option when selected', () => {
       render(
         <PerpsMarketSortFieldBottomSheet
           isVisible
-          selectedOptionId="priceChange-desc"
+          selectedOptionId="priceChange"
+          sortDirection="desc"
+          onClose={mockOnClose}
+          onOptionSelect={mockOnOptionSelect}
+          testID="sort-field-sheet"
+        />,
+      );
+
+      // Check that direction indicator is present for priceChange
+      expect(
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('sort-field-sheet-direction-text'),
+      ).toBeOnTheScreen();
+    });
+
+    it('shows checkmark for non-priceChange options when selected', () => {
+      render(
+        <PerpsMarketSortFieldBottomSheet
+          isVisible
+          selectedOptionId="volume"
+          sortDirection="desc"
+          onClose={mockOnClose}
+          onOptionSelect={mockOnOptionSelect}
+          testID="sort-field-sheet"
+        />,
+      );
+
+      // Should show checkmark for volume
+      expect(
+        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+      ).toBeOnTheScreen();
+
+      // Should not show direction indicator
+      expect(
+        screen.queryByTestId('sort-field-sheet-direction-indicator'),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('renders apply button', () => {
+      render(
+        <PerpsMarketSortFieldBottomSheet
+          isVisible
+          selectedOptionId="volume"
+          sortDirection="desc"
           onClose={mockOnClose}
           onOptionSelect={mockOnOptionSelect}
           testID="sort-field-sheet"
@@ -207,74 +241,253 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
       );
 
       expect(
-        screen.getByTestId('sort-field-sheet-checkmark-priceChange-desc'),
+        screen.getByTestId('sort-field-sheet-apply-button'),
       ).toBeOnTheScreen();
     });
   });
 
   describe('Option Selection', () => {
-    it('calls onOptionSelect with option ID, field, and direction', () => {
+    it('selects a different option when pressed', () => {
       render(
         <PerpsMarketSortFieldBottomSheet
           isVisible
           selectedOptionId="volume"
+          sortDirection="desc"
           onClose={mockOnClose}
           onOptionSelect={mockOnOptionSelect}
           testID="sort-field-sheet"
         />,
       );
 
+      // Initially volume is selected (has checkmark)
+      expect(
+        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+      ).toBeOnTheScreen();
+
+      // Press priceChange option
       fireEvent.press(
-        screen.getByTestId('sort-field-sheet-option-priceChange-desc'),
+        screen.getByTestId('sort-field-sheet-option-priceChange'),
       );
 
+      // Now priceChange should have direction indicator
+      expect(
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
+      ).toBeOnTheScreen();
+
+      // onOptionSelect should NOT be called until Apply is pressed
+      expect(mockOnOptionSelect).not.toHaveBeenCalled();
+    });
+
+    it('toggles direction when pressing the same priceChange option', () => {
+      render(
+        <PerpsMarketSortFieldBottomSheet
+          isVisible
+          selectedOptionId="priceChange"
+          sortDirection="desc"
+          onClose={mockOnClose}
+          onOptionSelect={mockOnOptionSelect}
+          testID="sort-field-sheet"
+        />,
+      );
+
+      // Direction indicator should be visible initially
+      expect(
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
+      ).toBeOnTheScreen();
+
+      // Press priceChange again to toggle direction
+      fireEvent.press(
+        screen.getByTestId('sort-field-sheet-option-priceChange'),
+      );
+
+      // Direction indicator should still be visible (direction toggled internally)
+      expect(
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
+      ).toBeOnTheScreen();
+
+      // onOptionSelect should NOT be called until Apply is pressed
+      expect(mockOnOptionSelect).not.toHaveBeenCalled();
+    });
+
+    it('does not toggle direction for non-priceChange options when pressed again', () => {
+      render(
+        <PerpsMarketSortFieldBottomSheet
+          isVisible
+          selectedOptionId="volume"
+          sortDirection="desc"
+          onClose={mockOnClose}
+          onOptionSelect={mockOnOptionSelect}
+          testID="sort-field-sheet"
+        />,
+      );
+
+      // Volume should have checkmark
+      expect(
+        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+      ).toBeOnTheScreen();
+
+      // Press volume again (same option)
+      fireEvent.press(screen.getByTestId('sort-field-sheet-option-volume'));
+
+      // Should still show checkmark, not direction indicator
+      expect(
+        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId('sort-field-sheet-direction-indicator'),
+      ).not.toBeOnTheScreen();
+
+      // onOptionSelect should NOT be called until Apply is pressed
+      expect(mockOnOptionSelect).not.toHaveBeenCalled();
+    });
+
+    it('calls onOptionSelect and closes when Apply button is pressed', () => {
+      render(
+        <PerpsMarketSortFieldBottomSheet
+          isVisible
+          selectedOptionId="volume"
+          sortDirection="desc"
+          onClose={mockOnClose}
+          onOptionSelect={mockOnOptionSelect}
+          testID="sort-field-sheet"
+        />,
+      );
+
+      // Select priceChange option
+      fireEvent.press(
+        screen.getByTestId('sort-field-sheet-option-priceChange'),
+      );
+
+      // Press Apply button
+      fireEvent.press(screen.getByTestId('sort-field-sheet-apply-button'));
+
+      // Should call onOptionSelect with correct parameters
       expect(mockOnOptionSelect).toHaveBeenCalledTimes(1);
       expect(mockOnOptionSelect).toHaveBeenCalledWith(
-        'priceChange-desc',
         'priceChange',
+        'priceChange',
+        'desc',
+      );
+
+      // Should call onClose
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onOptionSelect with toggled direction when Apply is pressed for priceChange', () => {
+      render(
+        <PerpsMarketSortFieldBottomSheet
+          isVisible
+          selectedOptionId="priceChange"
+          sortDirection="desc"
+          onClose={mockOnClose}
+          onOptionSelect={mockOnOptionSelect}
+          testID="sort-field-sheet"
+        />,
+      );
+
+      // Toggle direction
+      fireEvent.press(
+        screen.getByTestId('sort-field-sheet-option-priceChange'),
+      );
+
+      // Press Apply
+      fireEvent.press(screen.getByTestId('sort-field-sheet-apply-button'));
+
+      // Should call with ascending direction (toggled from desc to asc)
+      expect(mockOnOptionSelect).toHaveBeenCalledWith(
+        'priceChange',
+        'priceChange',
+        'asc',
+      );
+    });
+
+    it('calls onOptionSelect with desc direction for non-priceChange options', () => {
+      render(
+        <PerpsMarketSortFieldBottomSheet
+          isVisible
+          selectedOptionId="priceChange"
+          sortDirection="asc"
+          onClose={mockOnClose}
+          onOptionSelect={mockOnOptionSelect}
+          testID="sort-field-sheet"
+        />,
+      );
+
+      // Select volume option
+      fireEvent.press(screen.getByTestId('sort-field-sheet-option-volume'));
+
+      // Press Apply
+      fireEvent.press(screen.getByTestId('sort-field-sheet-apply-button'));
+
+      // Should call with desc direction (default for new selection)
+      expect(mockOnOptionSelect).toHaveBeenCalledWith(
+        'volume',
+        'volume',
         'desc',
       );
     });
 
-    it('auto-closes when option is selected', () => {
+    it('does not auto-close when option is selected (waits for Apply)', () => {
       render(
         <PerpsMarketSortFieldBottomSheet
           isVisible
           selectedOptionId="volume"
+          sortDirection="desc"
           onClose={mockOnClose}
           onOptionSelect={mockOnOptionSelect}
           testID="sort-field-sheet"
         />,
       );
 
+      // Select an option
       fireEvent.press(
-        screen.getByTestId('sort-field-sheet-option-priceChange-desc'),
+        screen.getByTestId('sort-field-sheet-option-priceChange'),
       );
 
-      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      // Should NOT close yet
+      expect(mockOnClose).not.toHaveBeenCalled();
+      expect(mockOnOptionSelect).not.toHaveBeenCalled();
     });
+  });
 
-    it('calls onOptionSelect for ascending price change option', () => {
-      render(
+  describe('State Synchronization', () => {
+    it('syncs local state when props change', () => {
+      const { rerender } = render(
         <PerpsMarketSortFieldBottomSheet
           isVisible
           selectedOptionId="volume"
+          sortDirection="desc"
           onClose={mockOnClose}
           onOptionSelect={mockOnOptionSelect}
           testID="sort-field-sheet"
         />,
       );
 
-      fireEvent.press(
-        screen.getByTestId('sort-field-sheet-option-priceChange-asc'),
+      // Initially volume is selected
+      expect(
+        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+      ).toBeOnTheScreen();
+
+      // Change props to priceChange with asc direction
+      rerender(
+        <PerpsMarketSortFieldBottomSheet
+          isVisible
+          selectedOptionId="priceChange"
+          sortDirection="asc"
+          onClose={mockOnClose}
+          onOptionSelect={mockOnOptionSelect}
+          testID="sort-field-sheet"
+        />,
       );
 
-      expect(mockOnOptionSelect).toHaveBeenCalledTimes(1);
-      expect(mockOnOptionSelect).toHaveBeenCalledWith(
-        'priceChange-asc',
-        'priceChange',
-        'asc',
-      );
+      // Now priceChange should have direction indicator
+      expect(
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
+      ).toBeOnTheScreen();
+      // Volume checkmark should be gone
+      expect(
+        screen.queryByTestId('sort-field-sheet-checkmark-volume'),
+      ).not.toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.test.tsx
@@ -489,5 +489,65 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
         screen.queryByTestId('sort-field-sheet-checkmark-volume'),
       ).not.toBeOnTheScreen();
     });
+
+    it('resets uncommitted changes when reopening the sheet', () => {
+      const { rerender } = render(
+        <PerpsMarketSortFieldBottomSheet
+          isVisible
+          selectedOptionId="volume"
+          sortDirection="desc"
+          onClose={mockOnClose}
+          onOptionSelect={mockOnOptionSelect}
+          testID="sort-field-sheet"
+        />,
+      );
+
+      // Initially volume is selected
+      expect(
+        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+      ).toBeOnTheScreen();
+
+      // User makes changes without applying - select priceChange
+      fireEvent.press(
+        screen.getByTestId('sort-field-sheet-option-priceChange'),
+      );
+
+      // Now priceChange should be selected locally
+      expect(
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
+      ).toBeOnTheScreen();
+
+      // User closes the sheet without applying
+      rerender(
+        <PerpsMarketSortFieldBottomSheet
+          isVisible={false}
+          selectedOptionId="volume"
+          sortDirection="desc"
+          onClose={mockOnClose}
+          onOptionSelect={mockOnOptionSelect}
+          testID="sort-field-sheet"
+        />,
+      );
+
+      // User reopens the sheet - props haven't changed (still volume)
+      rerender(
+        <PerpsMarketSortFieldBottomSheet
+          isVisible
+          selectedOptionId="volume"
+          sortDirection="desc"
+          onClose={mockOnClose}
+          onOptionSelect={mockOnOptionSelect}
+          testID="sort-field-sheet"
+        />,
+      );
+
+      // Local state should be reset to volume (uncommitted changes discarded)
+      expect(
+        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId('sort-field-sheet-direction-indicator'),
+      ).not.toBeOnTheScreen();
+    });
   });
 });

--- a/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.tsx
@@ -1,49 +1,72 @@
-import React, { useRef, useEffect } from 'react';
-import { TouchableOpacity } from 'react-native';
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import { TouchableOpacity, View } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import Text, {
   TextVariant,
+  TextColor,
 } from '../../../../../component-library/components/Texts/Text';
 import Icon, {
   IconName,
   IconSize,
+  IconColor,
 } from '../../../../../component-library/components/Icons/Icon';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import { Box } from '@metamask/design-system-react-native';
+import ButtonBase from '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase';
 import { strings } from '../../../../../../locales/i18n';
 import { styleSheet } from './PerpsMarketSortFieldBottomSheet.styles';
 import type { PerpsMarketSortFieldBottomSheetProps } from './PerpsMarketSortFieldBottomSheet.types';
 import { MARKET_SORTING_CONFIG } from '../../constants/perpsConfig';
+import type { SortDirection } from '../../utils/sortMarkets';
 
 /**
  * PerpsMarketSortFieldBottomSheet Component
  *
- * Simple list-based bottom sheet for selecting market sort options.
- * Each option combines field + direction into a single selectable item.
+ * Bottom sheet for selecting market sort options with apply button.
+ * Similar to trending tokens sort pattern.
  *
  * Features:
  * - Flat list of sort options
- * - Checkmark icon on selected option
- * - Auto-closes on selection
+ * - Direction toggle for price change only (tap to toggle high-to-low / low-to-high)
+ * - Other options (volume, open interest, funding rate) show checkmark when selected
+ * - Apply button to confirm selection
  *
  * @example
  * ```tsx
  * <PerpsMarketSortFieldBottomSheet
  *   isVisible={showSortSheet}
  *   onClose={() => setShowSortSheet(false)}
- *   selectedOptionId="priceChange-desc"
+ *   selectedOptionId="priceChange"
+ *   sortDirection="desc"
  *   onOptionSelect={handleSortChange}
  * />
  * ```
  */
 const PerpsMarketSortFieldBottomSheet: React.FC<
   PerpsMarketSortFieldBottomSheetProps
-> = ({ isVisible, onClose, selectedOptionId, onOptionSelect, testID }) => {
+> = ({
+  isVisible,
+  onClose,
+  selectedOptionId: initialSelectedOptionId,
+  sortDirection: initialSortDirection,
+  onOptionSelect,
+  testID,
+}) => {
   const { styles } = useStyles(styleSheet, {});
   const bottomSheetRef = useRef<BottomSheetRef>(null);
+
+  // Local state for selection (not applied until Apply button is pressed)
+  const [selectedOption, setSelectedOption] = useState(initialSelectedOptionId);
+  const [sortDirection, setSortDirection] =
+    useState<SortDirection>(initialSortDirection);
+
+  // Sync local state when props change
+  useEffect(() => {
+    setSelectedOption(initialSelectedOptionId);
+    setSortDirection(initialSortDirection);
+  }, [initialSelectedOptionId, initialSortDirection]);
 
   useEffect(() => {
     if (isVisible) {
@@ -52,17 +75,37 @@ const PerpsMarketSortFieldBottomSheet: React.FC<
   }, [isVisible]);
 
   /**
-   * Handle option selection - selects the option and closes the sheet
+   * Handle option press - either select new option or toggle direction (only for priceChange)
    */
-  const handleOptionSelect = (optionId: string) => {
+  const handleOptionPress = useCallback(
+    (optionId: string) => {
+      // If clicking the same option AND it's priceChange, toggle sort direction
+      if (selectedOption === optionId && optionId === 'priceChange') {
+        const newDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+        setSortDirection(newDirection);
+      } else {
+        // If clicking a different option, select it with descending direction
+        setSelectedOption(optionId);
+        setSortDirection('desc');
+      }
+    },
+    [selectedOption, sortDirection],
+  );
+
+  /**
+   * Handle apply button - applies selection and closes sheet
+   */
+  const handleApply = useCallback(() => {
     const option = MARKET_SORTING_CONFIG.SORT_OPTIONS.find(
-      (opt) => opt.id === optionId,
+      (opt) => opt.id === selectedOption,
     );
     if (option) {
-      onOptionSelect(option.id, option.field, option.direction);
-      onClose();
+      onOptionSelect(option.id, option.field, sortDirection);
     }
-  };
+    bottomSheetRef.current?.onCloseBottomSheet(() => {
+      onClose();
+    });
+  }, [selectedOption, sortDirection, onOptionSelect, onClose]);
 
   if (!isVisible) return null;
 
@@ -79,21 +122,47 @@ const PerpsMarketSortFieldBottomSheet: React.FC<
           {strings('perps.sort.sort_by')}
         </Text>
       </BottomSheetHeader>
-      <Box style={styles.optionsList}>
+      <View style={styles.optionsList}>
         {/* Render sort options */}
         {MARKET_SORTING_CONFIG.SORT_OPTIONS.map((option) => {
-          const isSelected = selectedOptionId === option.id;
+          const isSelected = selectedOption === option.id;
           return (
             <TouchableOpacity
               key={option.id}
               style={[styles.optionRow, isSelected && styles.optionRowSelected]}
-              onPress={() => handleOptionSelect(option.id)}
+              activeOpacity={1}
+              onPress={() => handleOptionPress(option.id)}
               testID={testID ? `${testID}-option-${option.id}` : undefined}
             >
               <Text variant={TextVariant.BodyMD}>
                 {strings(option.labelKey)}
               </Text>
-              {isSelected && (
+              {isSelected && option.id === 'priceChange' && (
+                <View
+                  style={styles.arrowContainer}
+                  testID={testID ? `${testID}-direction-indicator` : undefined}
+                >
+                  <Text
+                    variant={TextVariant.BodyMDMedium}
+                    color={TextColor.Alternative}
+                    testID={testID ? `${testID}-direction-text` : undefined}
+                  >
+                    {sortDirection === 'asc'
+                      ? strings('perps.sort.low_to_high')
+                      : strings('perps.sort.high_to_low')}
+                  </Text>
+                  <Icon
+                    name={
+                      sortDirection === 'asc'
+                        ? IconName.Arrow2Up
+                        : IconName.Arrow2Down
+                    }
+                    size={IconSize.Md}
+                    color={IconColor.Alternative}
+                  />
+                </View>
+              )}
+              {isSelected && option.id !== 'priceChange' && (
                 <Icon
                   name={IconName.Check}
                   size={IconSize.Md}
@@ -105,7 +174,17 @@ const PerpsMarketSortFieldBottomSheet: React.FC<
             </TouchableOpacity>
           );
         })}
-      </Box>
+      </View>
+      <ButtonBase
+        label={
+          <Text style={styles.applyButtonText}>
+            {strings('perps.sort.apply')}
+          </Text>
+        }
+        onPress={handleApply}
+        style={styles.applyButton}
+        testID={testID ? `${testID}-apply-button` : undefined}
+      />
     </BottomSheet>
   );
 };

--- a/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.tsx
@@ -18,7 +18,10 @@ import ButtonBase from '../../../../../component-library/components/Buttons/Butt
 import { strings } from '../../../../../../locales/i18n';
 import { styleSheet } from './PerpsMarketSortFieldBottomSheet.styles';
 import type { PerpsMarketSortFieldBottomSheetProps } from './PerpsMarketSortFieldBottomSheet.types';
-import { MARKET_SORTING_CONFIG } from '../../constants/perpsConfig';
+import {
+  MARKET_SORTING_CONFIG,
+  type SortOptionId,
+} from '../../constants/perpsConfig';
 import type { SortDirection } from '../../utils/sortMarkets';
 
 /**
@@ -78,7 +81,7 @@ const PerpsMarketSortFieldBottomSheet: React.FC<
    * Handle option press - either select new option or toggle direction (only for priceChange)
    */
   const handleOptionPress = useCallback(
-    (optionId: string) => {
+    (optionId: SortOptionId) => {
       // If clicking the same option AND it's priceChange, toggle sort direction
       if (selectedOption === optionId && optionId === 'priceChange') {
         const newDirection = sortDirection === 'asc' ? 'desc' : 'asc';

--- a/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.tsx
@@ -65,11 +65,14 @@ const PerpsMarketSortFieldBottomSheet: React.FC<
   const [sortDirection, setSortDirection] =
     useState<SortDirection>(initialSortDirection);
 
-  // Sync local state when props change
+  // Sync local state when props change or when sheet opens
+  // This ensures uncommitted changes are reset when reopening the sheet
   useEffect(() => {
-    setSelectedOption(initialSelectedOptionId);
-    setSortDirection(initialSortDirection);
-  }, [initialSelectedOptionId, initialSortDirection]);
+    if (isVisible) {
+      setSelectedOption(initialSelectedOptionId);
+      setSortDirection(initialSortDirection);
+    }
+  }, [initialSelectedOptionId, initialSortDirection, isVisible]);
 
   useEffect(() => {
     if (isVisible) {

--- a/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.types.ts
+++ b/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.types.ts
@@ -18,6 +18,10 @@ export interface PerpsMarketSortFieldBottomSheetProps {
    */
   selectedOptionId: SortOptionId;
   /**
+   * Current sort direction (used for price change toggle and default for other options)
+   */
+  sortDirection: SortDirection;
+  /**
    * Callback when an option is selected
    * @param optionId - The ID of the selected option
    * @param field - The sort field

--- a/app/components/UI/Perps/constants/perpsConfig.ts
+++ b/app/components/UI/Perps/constants/perpsConfig.ts
@@ -413,8 +413,8 @@ export const MARKET_SORTING_CONFIG = {
   ] as const,
 
   // Sort options for the bottom sheet
-  // Each option combines field + direction into a single selectable item
-  // Only Price Change has both directions as separate options
+  // Only Price Change can be toggled for direction (similar to trending tokens pattern)
+  // Other options (volume, open interest, funding rate) use descending sort only
   SORT_OPTIONS: [
     {
       id: 'volume',
@@ -423,16 +423,10 @@ export const MARKET_SORTING_CONFIG = {
       direction: 'desc',
     },
     {
-      id: 'priceChange-desc',
-      labelKey: 'perps.sort.price_change_high_to_low',
+      id: 'priceChange',
+      labelKey: 'perps.sort.price_change',
       field: 'priceChange',
       direction: 'desc',
-    },
-    {
-      id: 'priceChange-asc',
-      labelKey: 'perps.sort.price_change_low_to_high',
-      field: 'priceChange',
-      direction: 'asc',
     },
     {
       id: 'openInterest',
@@ -452,7 +446,7 @@ export const MARKET_SORTING_CONFIG = {
 /**
  * Type for valid sort option IDs
  * Derived from SORT_OPTIONS to ensure type safety
- * Valid values: 'volume' | 'priceChange-desc' | 'priceChange-asc' | 'openInterest' | 'fundingRate'
+ * Valid values: 'volume' | 'priceChange' | 'openInterest' | 'fundingRate'
  */
 export type SortOptionId =
   (typeof MARKET_SORTING_CONFIG.SORT_OPTIONS)[number]['id'];

--- a/app/components/UI/Perps/controllers/PerpsController.test.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.test.ts
@@ -2910,11 +2910,25 @@ describe('PerpsController', () => {
 
   describe('market filter preferences', () => {
     it('saves and retrieves filter preference', () => {
-      controller.saveMarketFilterPreferences('openInterest');
+      controller.saveMarketFilterPreferences('openInterest', 'desc');
 
       const result = controller.getMarketFilterPreferences();
 
-      expect(result).toBe('openInterest');
+      expect(result).toEqual({
+        optionId: 'openInterest',
+        direction: 'desc',
+      });
+    });
+
+    it('saves and retrieves price change with ascending direction', () => {
+      controller.saveMarketFilterPreferences('priceChange', 'asc');
+
+      const result = controller.getMarketFilterPreferences();
+
+      expect(result).toEqual({
+        optionId: 'priceChange',
+        direction: 'asc',
+      });
     });
   });
 

--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -35,6 +35,7 @@ import {
   MARKET_SORTING_CONFIG,
   type SortOptionId,
 } from '../constants/perpsConfig';
+import type { SortDirection } from '../utils/sortMarkets';
 import { PERPS_ERROR_CODES } from './perpsErrorCodes';
 import { HyperLiquidProvider } from './providers/HyperLiquidProvider';
 import { MarketDataService } from './services/MarketDataService';
@@ -263,7 +264,10 @@ export type PerpsControllerState = {
   };
 
   // Market filter preferences (network-independent) - includes both sorting and filtering options
-  marketFilterPreferences: SortOptionId;
+  marketFilterPreferences: {
+    optionId: SortOptionId;
+    direction: SortDirection;
+  };
 
   // Error handling
   lastError: string | null;
@@ -316,7 +320,10 @@ export const getDefaultPerpsControllerState = (): PerpsControllerState => ({
     testnet: {},
     mainnet: {},
   },
-  marketFilterPreferences: MARKET_SORTING_CONFIG.DEFAULT_SORT_OPTION_ID,
+  marketFilterPreferences: {
+    optionId: MARKET_SORTING_CONFIG.DEFAULT_SORT_OPTION_ID,
+    direction: MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
+  },
   hip3ConfigVersion: 0,
 });
 
@@ -2622,26 +2629,65 @@ export class PerpsController extends BaseController<
 
   /**
    * Get saved market filter preferences
+   * Handles backward compatibility with legacy string format
    */
-  getMarketFilterPreferences(): SortOptionId {
+  getMarketFilterPreferences(): {
+    optionId: SortOptionId;
+    direction: SortDirection;
+  } {
+    const pref = this.state.marketFilterPreferences;
+
+    // Handle legacy string format (backward compatibility)
+    if (typeof pref === 'string') {
+      // Map legacy compound IDs to new format
+      // Old format: 'priceChange-desc' or 'priceChange-asc'
+      // New format: { optionId: 'priceChange', direction: 'desc'/'asc' }
+      if (pref === 'priceChange-desc') {
+        return {
+          optionId: 'priceChange',
+          direction: 'desc',
+        };
+      }
+      if (pref === 'priceChange-asc') {
+        return {
+          optionId: 'priceChange',
+          direction: 'asc',
+        };
+      }
+
+      // Handle other simple legacy strings (e.g., 'volume', 'openInterest', etc.)
+      return {
+        optionId: pref as SortOptionId,
+        direction: MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
+      };
+    }
+
+    // Return new object format or default
     return (
-      this.state.marketFilterPreferences ??
-      MARKET_SORTING_CONFIG.DEFAULT_SORT_OPTION_ID
+      pref ?? {
+        optionId: MARKET_SORTING_CONFIG.DEFAULT_SORT_OPTION_ID,
+        direction: MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
+      }
     );
   }
 
   /**
    * Save market filter preferences
    * @param optionId - Sort/filter option ID
+   * @param direction - Sort direction ('asc' or 'desc')
    */
-  saveMarketFilterPreferences(optionId: SortOptionId): void {
+  saveMarketFilterPreferences(
+    optionId: SortOptionId,
+    direction: SortDirection,
+  ): void {
     this.debugLog('PerpsController: Saving market filter preferences', {
       optionId,
+      direction,
       timestamp: new Date().toISOString(),
     });
 
     this.update((state) => {
-      state.marketFilterPreferences = optionId;
+      state.marketFilterPreferences = { optionId, direction };
     });
   }
 

--- a/app/components/UI/Perps/controllers/selectors.test.ts
+++ b/app/components/UI/Perps/controllers/selectors.test.ts
@@ -234,20 +234,81 @@ describe('PerpsController selectors', () => {
   describe('selectMarketFilterPreferences', () => {
     it('returns saved filter preferences when defined', () => {
       const state = {
-        marketFilterPreferences: 'price',
+        marketFilterPreferences: {
+          optionId: 'priceChange',
+          direction: 'asc',
+        },
       } as unknown as PerpsControllerState;
 
       const result = selectMarketFilterPreferences(state);
 
-      expect(result).toBe('price');
+      expect(result).toEqual({
+        optionId: 'priceChange',
+        direction: 'asc',
+      });
     });
 
-    it('returns default volume when preference is undefined', () => {
+    it('returns default preferences when preference is undefined', () => {
       const state = {} as unknown as PerpsControllerState;
 
       const result = selectMarketFilterPreferences(state);
 
-      expect(result).toBe(MARKET_SORTING_CONFIG.DEFAULT_SORT_OPTION_ID);
+      expect(result).toEqual({
+        optionId: MARKET_SORTING_CONFIG.DEFAULT_SORT_OPTION_ID,
+        direction: MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
+      });
+    });
+
+    it('handles legacy string format (backward compatibility)', () => {
+      const state = {
+        marketFilterPreferences: 'priceChange',
+      } as unknown as PerpsControllerState;
+
+      const result = selectMarketFilterPreferences(state);
+
+      expect(result).toEqual({
+        optionId: 'priceChange',
+        direction: MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
+      });
+    });
+
+    it('handles legacy compound ID priceChange-desc (backward compatibility)', () => {
+      const state = {
+        marketFilterPreferences: 'priceChange-desc',
+      } as unknown as PerpsControllerState;
+
+      const result = selectMarketFilterPreferences(state);
+
+      expect(result).toEqual({
+        optionId: 'priceChange',
+        direction: 'desc',
+      });
+    });
+
+    it('handles legacy compound ID priceChange-asc (backward compatibility)', () => {
+      const state = {
+        marketFilterPreferences: 'priceChange-asc',
+      } as unknown as PerpsControllerState;
+
+      const result = selectMarketFilterPreferences(state);
+
+      expect(result).toEqual({
+        optionId: 'priceChange',
+        direction: 'asc',
+      });
+    });
+
+    it('handles other legacy simple strings (backward compatibility)', () => {
+      const state = {
+        marketFilterPreferences: 'volume',
+      } as unknown as PerpsControllerState;
+
+      const result = selectMarketFilterPreferences(state);
+
+      expect(result).toEqual({
+        optionId: 'volume',
+        direction: MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
+      });
     });
   });
 

--- a/app/components/UI/Perps/controllers/selectors.ts
+++ b/app/components/UI/Perps/controllers/selectors.ts
@@ -4,6 +4,7 @@ import {
   MARKET_SORTING_CONFIG,
   type SortOptionId,
 } from '../constants/perpsConfig';
+import type { SortDirection } from '../utils/sortMarkets';
 
 /**
  * Select whether the user is a first-time perps user
@@ -139,13 +140,46 @@ export const selectPendingTradeConfiguration = createSelector(
 /**
  * Select market filter preferences (network-independent)
  * @param state - PerpsController state
- * @returns Sort/filter option ID
+ * @returns Sort/filter preferences object with optionId and direction
  */
 export const selectMarketFilterPreferences = (
   state: PerpsControllerState,
-): SortOptionId =>
-  state?.marketFilterPreferences ??
-  MARKET_SORTING_CONFIG.DEFAULT_SORT_OPTION_ID;
+): { optionId: SortOptionId; direction: SortDirection } => {
+  const pref = state?.marketFilterPreferences;
+
+  // Handle legacy string format (backward compatibility)
+  if (typeof pref === 'string') {
+    // Map legacy compound IDs to new format
+    // Old format: 'priceChange-desc' or 'priceChange-asc'
+    // New format: { optionId: 'priceChange', direction: 'desc'/'asc' }
+    if (pref === 'priceChange-desc') {
+      return {
+        optionId: 'priceChange',
+        direction: 'desc',
+      };
+    }
+    if (pref === 'priceChange-asc') {
+      return {
+        optionId: 'priceChange',
+        direction: 'asc',
+      };
+    }
+
+    // Handle other simple legacy strings (e.g., 'volume', 'openInterest', etc.)
+    return {
+      optionId: pref as SortOptionId,
+      direction: MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
+    };
+  }
+
+  // Return new object format or default
+  return (
+    pref ?? {
+      optionId: MARKET_SORTING_CONFIG.DEFAULT_SORT_OPTION_ID,
+      direction: MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
+    }
+  );
+};
 
 /**
  * Select order book grouping for a specific market on the current network

--- a/app/components/UI/Perps/hooks/usePerpsHomeData.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeData.test.ts
@@ -303,7 +303,10 @@ describe('usePerpsHomeData', () => {
 
     // Set default return values for the selectors
     mockSelectPerpsWatchlistMarkets.mockReturnValue(['BTC', 'ETH']);
-    mockSelectPerpsMarketFilterPreferences.mockReturnValue('volume');
+    mockSelectPerpsMarketFilterPreferences.mockReturnValue({
+      optionId: 'volume',
+      direction: 'desc',
+    });
   });
 
   describe('Initial state and data loading', () => {
@@ -502,9 +505,10 @@ describe('usePerpsHomeData', () => {
     });
 
     it('uses default direction when sort option not found', () => {
-      mockSelectPerpsMarketFilterPreferences.mockReturnValue(
-        'unknown-sort-option' as never,
-      );
+      mockSelectPerpsMarketFilterPreferences.mockReturnValue({
+        optionId: 'unknown-sort-option' as never,
+        direction: 'desc',
+      });
 
       renderHook(() => usePerpsHomeData());
 

--- a/app/components/UI/Perps/hooks/usePerpsHomeData.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeData.ts
@@ -165,16 +165,15 @@ export const usePerpsHomeData = ({
     [allMarkets, watchlistSymbols],
   );
 
-  // Derive sort field and direction from saved preference
+  // Derive sort field from saved preference
   const { sortBy, direction } = useMemo(() => {
     const sortOption = MARKET_SORTING_CONFIG.SORT_OPTIONS.find(
-      (opt) => opt.id === savedSortPreference,
+      (opt) => opt.id === savedSortPreference.optionId,
     );
 
     return {
       sortBy: sortOption?.field ?? MARKET_SORTING_CONFIG.SORT_FIELDS.VOLUME,
-      direction:
-        sortOption?.direction ?? MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
+      direction: savedSortPreference.direction,
     };
   }, [savedSortPreference]);
 

--- a/app/components/UI/Perps/hooks/usePerpsMarketListView.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketListView.test.ts
@@ -304,13 +304,13 @@ describe('usePerpsMarketListView', () => {
           return ['BTC'];
         }
         // Even calls are sort preference
-        return 'priceChange-desc';
+        return 'priceChange';
       });
 
       renderHook(() => usePerpsMarketListView());
 
       expect(mockUsePerpsSorting).toHaveBeenCalledWith({
-        initialOptionId: 'priceChange-desc',
+        initialOptionId: 'priceChange',
       });
     });
 

--- a/app/components/UI/Perps/hooks/usePerpsMarketListView.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketListView.test.ts
@@ -330,7 +330,7 @@ describe('usePerpsMarketListView', () => {
 
       // Call handleOptionChange
       result.current.sortState.handleOptionChange(
-        'priceChange-desc',
+        'priceChange',
         'priceChange' as SortField,
         'desc' as SortDirection,
       );
@@ -338,7 +338,7 @@ describe('usePerpsMarketListView', () => {
       // Should have called Engine's saveMarketFilterPreferences
       expect(
         Engine.context.PerpsController.saveMarketFilterPreferences,
-      ).toHaveBeenCalledWith('priceChange-desc');
+      ).toHaveBeenCalledWith('priceChange');
     });
 
     it('applies sorting to filtered markets', () => {
@@ -482,7 +482,7 @@ describe('usePerpsMarketListView', () => {
       );
 
       mockUsePerpsSorting.mockReturnValue({
-        selectedOptionId: 'priceChange-asc',
+        selectedOptionId: 'priceChange',
         sortBy: 'priceChange' as SortField,
         direction: 'asc' as SortDirection,
         handleOptionChange: jest.fn(),

--- a/app/components/UI/Perps/hooks/usePerpsMarketListView.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketListView.test.ts
@@ -115,7 +115,7 @@ describe('usePerpsMarketListView', () => {
         return ['BTC', 'ETH'];
       }
       // Even calls are sort preference (second, fourth, sixth, etc.)
-      return 'volume';
+      return { optionId: 'volume', direction: 'desc' };
     });
   });
 
@@ -304,13 +304,14 @@ describe('usePerpsMarketListView', () => {
           return ['BTC'];
         }
         // Even calls are sort preference
-        return 'priceChange';
+        return { optionId: 'priceChange', direction: 'asc' };
       });
 
       renderHook(() => usePerpsMarketListView());
 
       expect(mockUsePerpsSorting).toHaveBeenCalledWith({
         initialOptionId: 'priceChange',
+        initialDirection: 'asc',
       });
     });
 
@@ -328,17 +329,17 @@ describe('usePerpsMarketListView', () => {
     it('saves sort preference to PerpsController when changed', () => {
       const { result } = renderHook(() => usePerpsMarketListView());
 
-      // Call handleOptionChange
+      // Call handleOptionChange with 'asc' direction
       result.current.sortState.handleOptionChange(
         'priceChange',
         'priceChange' as SortField,
-        'desc' as SortDirection,
+        'asc' as SortDirection,
       );
 
-      // Should have called Engine's saveMarketFilterPreferences
+      // Should have called Engine's saveMarketFilterPreferences with both optionId and direction
       expect(
         Engine.context.PerpsController.saveMarketFilterPreferences,
-      ).toHaveBeenCalledWith('priceChange');
+      ).toHaveBeenCalledWith('priceChange', 'asc');
     });
 
     it('applies sorting to filtered markets', () => {
@@ -373,7 +374,7 @@ describe('usePerpsMarketListView', () => {
         if (selectorCallCount % 2 === 1) {
           return ['BTC', 'ETH'];
         }
-        return 'volume';
+        return { optionId: 'volume', direction: 'desc' };
       });
 
       const { result } = renderHook(() =>
@@ -434,7 +435,7 @@ describe('usePerpsMarketListView', () => {
         if (selectorCallCount % 2 === 1) {
           return ['BTC', 'ETH'];
         }
-        return 'volume';
+        return { optionId: 'volume', direction: 'desc' };
       });
 
       // Mock search to return only BTC
@@ -464,7 +465,7 @@ describe('usePerpsMarketListView', () => {
         if (selectorCallCount % 2 === 1) {
           return ['ETH'];
         }
-        return 'volume';
+        return { optionId: 'volume', direction: 'desc' };
       });
 
       mockUsePerpsSearch.mockReturnValue({

--- a/app/components/UI/Perps/hooks/usePerpsMarketListView.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketListView.ts
@@ -206,14 +206,18 @@ export const usePerpsMarketListView = ({
 
   // Use sorting hook for sort state and sorting logic
   const sortingHook = usePerpsSorting({
-    initialOptionId: savedSortPreference,
+    initialOptionId: savedSortPreference.optionId,
+    initialDirection: savedSortPreference.direction,
   });
 
   // Wrap handleOptionChange to save preference to PerpsController
   const handleOptionChange = useCallback(
     (optionId: SortOptionId, field: SortField, direction: SortDirection) => {
       // Save preference to controller
-      Engine.context.PerpsController.saveMarketFilterPreferences(optionId);
+      Engine.context.PerpsController.saveMarketFilterPreferences(
+        optionId,
+        direction,
+      );
       // Update local state
       sortingHook.handleOptionChange(optionId, field, direction);
     },

--- a/app/components/UI/Perps/hooks/usePerpsSorting.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsSorting.test.ts
@@ -54,12 +54,12 @@ describe('usePerpsSorting', () => {
 
     it('initializes with custom sort option', () => {
       const { result } = renderHook(() =>
-        usePerpsSorting({ initialOptionId: 'priceChange-asc' }),
+        usePerpsSorting({ initialOptionId: 'priceChange' }),
       );
 
-      expect(result.current.selectedOptionId).toBe('priceChange-asc');
+      expect(result.current.selectedOptionId).toBe('priceChange');
       expect(result.current.sortBy).toBe('priceChange');
-      expect(result.current.direction).toBe('asc');
+      expect(result.current.direction).toBe('desc');
     });
   });
 
@@ -80,14 +80,10 @@ describe('usePerpsSorting', () => {
       const { result } = renderHook(() => usePerpsSorting());
 
       act(() => {
-        result.current.handleOptionChange(
-          'priceChange-asc',
-          'priceChange',
-          'asc',
-        );
+        result.current.handleOptionChange('priceChange', 'priceChange', 'asc');
       });
 
-      expect(result.current.selectedOptionId).toBe('priceChange-asc');
+      expect(result.current.selectedOptionId).toBe('priceChange');
       expect(result.current.sortBy).toBe('priceChange');
       expect(result.current.direction).toBe('asc');
     });
@@ -96,14 +92,10 @@ describe('usePerpsSorting', () => {
       const { result } = renderHook(() => usePerpsSorting());
 
       act(() => {
-        result.current.handleOptionChange(
-          'priceChange-desc',
-          'priceChange',
-          'desc',
-        );
+        result.current.handleOptionChange('priceChange', 'priceChange', 'desc');
       });
 
-      expect(result.current.selectedOptionId).toBe('priceChange-desc');
+      expect(result.current.selectedOptionId).toBe('priceChange');
       expect(result.current.sortBy).toBe('priceChange');
       expect(result.current.direction).toBe('desc');
     });
@@ -155,11 +147,7 @@ describe('usePerpsSorting', () => {
       const { result } = renderHook(() => usePerpsSorting());
 
       act(() => {
-        result.current.handleOptionChange(
-          'priceChange-asc',
-          'priceChange',
-          'asc',
-        );
+        result.current.handleOptionChange('priceChange', 'priceChange', 'asc');
       });
 
       act(() => {
@@ -247,11 +235,7 @@ describe('usePerpsSorting', () => {
       expect(result.current.sortBy).toBe('fundingRate');
 
       act(() => {
-        result.current.handleOptionChange(
-          'priceChange-asc',
-          'priceChange',
-          'asc',
-        );
+        result.current.handleOptionChange('priceChange', 'priceChange', 'asc');
       });
 
       expect(result.current.sortBy).toBe('priceChange');

--- a/app/components/UI/Perps/hooks/usePerpsSorting.ts
+++ b/app/components/UI/Perps/hooks/usePerpsSorting.ts
@@ -12,6 +12,7 @@ import {
 
 interface UsePerpsSortingParams {
   initialOptionId?: SortOptionId;
+  initialDirection?: SortDirection;
 }
 
 interface UsePerpsSortingReturn {
@@ -33,14 +34,13 @@ interface UsePerpsSortingReturn {
  */
 export const usePerpsSorting = ({
   initialOptionId = MARKET_SORTING_CONFIG.DEFAULT_SORT_OPTION_ID,
+  initialDirection = MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
 }: UsePerpsSortingParams = {}): UsePerpsSortingReturn => {
   const [selectedOptionId, setSelectedOptionId] =
     useState<SortOptionId>(initialOptionId);
 
   // Maintain direction as separate state to allow toggling
-  const [direction, setDirection] = useState<SortDirection>(
-    MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
-  );
+  const [direction, setDirection] = useState<SortDirection>(initialDirection);
 
   // Derive sortBy from selectedOptionId
   const sortBy = useMemo(() => {

--- a/app/components/UI/Perps/hooks/usePerpsSorting.ts
+++ b/app/components/UI/Perps/hooks/usePerpsSorting.ts
@@ -28,7 +28,8 @@ interface UsePerpsSortingReturn {
 
 /**
  * Hook for managing market sorting state
- * Uses combined option IDs (e.g., 'volume', 'priceChange-desc') for simplified selection
+ * Maintains sort field and direction as separate state
+ * Direction can be toggled independently (used for price change option in UI)
  */
 export const usePerpsSorting = ({
   initialOptionId = MARKET_SORTING_CONFIG.DEFAULT_SORT_OPTION_ID,
@@ -36,20 +37,27 @@ export const usePerpsSorting = ({
   const [selectedOptionId, setSelectedOptionId] =
     useState<SortOptionId>(initialOptionId);
 
-  // Derive sortBy and direction from selectedOptionId
-  const { sortBy, direction } = useMemo(() => {
+  // Maintain direction as separate state to allow toggling
+  const [direction, setDirection] = useState<SortDirection>(
+    MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
+  );
+
+  // Derive sortBy from selectedOptionId
+  const sortBy = useMemo(() => {
     const option = MARKET_SORTING_CONFIG.SORT_OPTIONS.find(
       (opt) => opt.id === selectedOptionId,
     );
-    return {
-      sortBy: option?.field ?? MARKET_SORTING_CONFIG.SORT_FIELDS.VOLUME,
-      direction: option?.direction ?? MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
-    };
+    return option?.field ?? MARKET_SORTING_CONFIG.SORT_FIELDS.VOLUME;
   }, [selectedOptionId]);
 
   const handleOptionChange = useCallback(
-    (optionId: SortOptionId, _field: SortField, _direction: SortDirection) => {
+    (
+      optionId: SortOptionId,
+      _field: SortField,
+      newDirection: SortDirection,
+    ) => {
       setSelectedOptionId(optionId);
+      setDirection(newDirection);
     },
     [],
   );

--- a/app/core/Engine/controllers/perps-controller/index.test.ts
+++ b/app/core/Engine/controllers/perps-controller/index.test.ts
@@ -104,7 +104,10 @@ describe('perps controller init', () => {
         testnet: {},
         mainnet: {},
       },
-      marketFilterPreferences: MARKET_SORTING_CONFIG.DEFAULT_SORT_OPTION_ID,
+      marketFilterPreferences: {
+        optionId: MARKET_SORTING_CONFIG.DEFAULT_SORT_OPTION_ID,
+        direction: MARKET_SORTING_CONFIG.DEFAULT_DIRECTION,
+      },
       hip3ConfigVersion: 0,
       withdrawInProgress: false,
       lastWithdrawResult: null,

--- a/app/util/logs/__snapshots__/index.test.ts.snap
+++ b/app/util/logs/__snapshots__/index.test.ts.snap
@@ -514,7 +514,10 @@ exports[`logs :: generateStateLogs Sanitized SeedlessOnboardingController State 
         "lastError": null,
         "lastUpdateTimestamp": 0,
         "lastWithdrawResult": null,
-        "marketFilterPreferences": "volume",
+        "marketFilterPreferences": {
+          "direction": "desc",
+          "optionId": "volume",
+        },
         "perpsBalances": {},
         "tradeConfigurations": {
           "mainnet": {},
@@ -1313,7 +1316,10 @@ exports[`logs :: generateStateLogs generates a valid json export 1`] = `
         "lastError": null,
         "lastUpdateTimestamp": 0,
         "lastWithdrawResult": null,
-        "marketFilterPreferences": "volume",
+        "marketFilterPreferences": {
+          "direction": "desc",
+          "optionId": "volume",
+        },
         "perpsBalances": {},
         "tradeConfigurations": {
           "mainnet": {},

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -513,7 +513,10 @@
       "mainnet": {},
       "testnet": {}
     },
-    "marketFilterPreferences": "volume",
+    "marketFilterPreferences": {
+      "optionId": "volume",
+      "direction": "desc"
+    },
     "hip3ConfigVersion": 0,
     "perpsBalances": {}
   },

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1814,7 +1814,8 @@
       "price_change_low_to_high": "Price change: low to high",
       "past_hour": "Past hour",
       "past_24_hours": "Past 24 hours",
-      "time": "Time"
+      "time": "Time",
+      "apply": "Apply"
     },
     "perps_markets": "Perps markets",
     "volume": "Volume",


### PR DESCRIPTION
## **Description**

Re-design perps sortBy bottom sheet to be aligned with trending bottom sheet.

## **Changelog**

CHANGELOG entry: Updated design of perps SortBy bottomSheet

## **Related issues**

(Eventually we decided to keep trending filter as is but align perps filter)

Fixes: https://github.com/MetaMask/metamask-mobile/issues/24391

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/72766335-592d-491c-9556-5e96e666da00


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/86ca3a02-89a7-4c63-9dfd-4e4310eb9472


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Perps sorting UX with trending tokens and updates persistence model.
> 
> - UI: Replaces sort selection with `PerpsMarketSortFieldBottomSheet` featuring an Apply button, checkmarks for non-price options, and a direction indicator/toggle for `priceChange`; adds new styles and i18n strings (e.g., "Apply").
> - Hooks: Refactors `usePerpsSorting` to manage `direction` separately and accept `initialDirection`; updates `usePerpsMarketListView` and `usePerpsHomeData` to read `{ optionId, direction }` and pass `sortDirection` to the sheet.
> - State/Controller: Changes `marketFilterPreferences` from a string to `{ optionId, direction }`; updates `saveMarketFilterPreferences(optionId, direction)` and `getMarketFilterPreferences()` with legacy string compatibility; selectors mirror this and handle old values.
> - Config: Simplifies sort options to single `priceChange` id (direction toggled in UI); removes `priceChange-asc/desc` ids.
> - Wiring/Tests: Updates `PerpsMarketListView` to pass and handle direction; broad test/mocks updates across components, selectors, controller, and logs snapshots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 805780ff70a5a9cd980ac64063860eb95d42d8c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->