### PR TITLE
feat: fetch tx status in transactions screen from BridgeStatusController

### DIFF
--- a/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.tsx
+++ b/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import { Transaction } from '@metamask/keyring-api';
 import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
+import { StatusTypes } from '@metamask/bridge-controller';
 import { useTheme } from '../../../util/theme';
 import ListItem from '../../Base/ListItem';
 import StatusText from '../../Base/StatusText';
@@ -29,6 +30,8 @@ import Badge, {
 } from '../../../component-library/components/Badges/Badge';
 import { getNetworkImageSource } from '../../../util/networks';
 import { parseCaipAssetType } from '@metamask/utils';
+import { getEffectiveTransactionStatus } from '../../../util/transactions/statusMapping';
+import { TransactionStatus } from '@metamask/transaction-controller';
 
 const MultichainBridgeTransactionListItem = ({
   transaction,
@@ -58,8 +61,16 @@ const MultichainBridgeTransactionListItem = ({
     });
   };
 
+  // Get effective status prioritizing BridgeStatusController when available
+  const transactionStatus = getEffectiveTransactionStatus(
+    transaction,
+    bridgeHistoryItem,
+  );
+  const bridgeStatus = bridgeHistoryItem?.status?.status;
+
   const renderTxElementIcon = () => {
-    const isFailedTransaction = transaction.status === 'failed';
+    const isFailedTransaction =
+      bridgeStatus === StatusTypes.FAILED || transactionStatus === 'failed';
     const icon = getTransactionIcon(
       isSwap ? 'swap' : 'bridge',
       isFailedTransaction,
@@ -131,13 +142,13 @@ const MultichainBridgeTransactionListItem = ({
               {!isBridgeComplete && !isSwap && (
                 <BridgeActivityItemTxSegments
                   bridgeTxHistoryItem={bridgeHistoryItem}
-                  transactionStatus={transaction.status}
+                  transactionStatus={transactionStatus as TransactionStatus}
                 />
               )}
               {(isBridgeComplete || isSwap) && (
                 <StatusText
                   testID={`transaction-status-${transaction.id}`}
-                  status={transaction.status}
+                  status={transactionStatus}
                   style={style.listItemStatus as TextStyle}
                   context="transaction"
                 />

--- a/app/util/transactions/statusMapping.test.ts
+++ b/app/util/transactions/statusMapping.test.ts
@@ -1,0 +1,288 @@
+import { StatusTypes } from '@metamask/bridge-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+  TransactionStatus,
+} from '@metamask/transaction-controller';
+import { Transaction } from '@metamask/keyring-api';
+import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
+import {
+  mapIntentStatusToTransactionStatus,
+  mapBridgeStatusToTransactionStatus,
+  getEffectiveTransactionStatus,
+} from './statusMapping';
+
+describe('statusMapping', () => {
+  describe('mapIntentStatusToTransactionStatus', () => {
+    it('returns submitted for PENDING status', () => {
+      const result = mapIntentStatusToTransactionStatus(StatusTypes.PENDING);
+
+      expect(result).toBe('submitted');
+    });
+
+    it('returns confirmed for COMPLETE status', () => {
+      const result = mapIntentStatusToTransactionStatus(StatusTypes.COMPLETE);
+
+      expect(result).toBe('confirmed');
+    });
+
+    it('returns failed for FAILED status', () => {
+      const result = mapIntentStatusToTransactionStatus(StatusTypes.FAILED);
+
+      expect(result).toBe('failed');
+    });
+
+    it('returns submitted for SUBMITTED status', () => {
+      const result = mapIntentStatusToTransactionStatus(StatusTypes.SUBMITTED);
+
+      expect(result).toBe('submitted');
+    });
+
+    it('returns failed for UNKNOWN status', () => {
+      const result = mapIntentStatusToTransactionStatus(StatusTypes.UNKNOWN);
+
+      expect(result).toBe('failed');
+    });
+  });
+
+  describe('mapBridgeStatusToTransactionStatus', () => {
+    it('returns confirmed for COMPLETE status', () => {
+      const result = mapBridgeStatusToTransactionStatus(StatusTypes.COMPLETE);
+
+      expect(result).toBe('confirmed');
+    });
+
+    it('returns submitted for PENDING status', () => {
+      const result = mapBridgeStatusToTransactionStatus(StatusTypes.PENDING);
+
+      expect(result).toBe('submitted');
+    });
+
+    it('returns submitted for SUBMITTED status', () => {
+      const result = mapBridgeStatusToTransactionStatus(StatusTypes.SUBMITTED);
+
+      expect(result).toBe('submitted');
+    });
+
+    it('returns failed for FAILED status', () => {
+      const result = mapBridgeStatusToTransactionStatus(StatusTypes.FAILED);
+
+      expect(result).toBe('failed');
+    });
+
+    it('returns failed for UNKNOWN status', () => {
+      const result = mapBridgeStatusToTransactionStatus(StatusTypes.UNKNOWN);
+
+      expect(result).toBe('failed');
+    });
+  });
+
+  describe('getEffectiveTransactionStatus', () => {
+    const createMockEvmTransaction = (
+      overrides?: Partial<TransactionMeta>,
+    ): TransactionMeta =>
+      ({
+        id: 'test-tx-id',
+        status: TransactionStatus.submitted,
+        type: TransactionType.swap,
+        chainId: '0xa4b1',
+        ...overrides,
+      }) as TransactionMeta;
+
+    const createMockNonEvmTransaction = (
+      overrides?: Partial<Transaction>,
+    ): Transaction =>
+      ({
+        id: 'test-tx-id',
+        status: 'submitted',
+        chain: 'solana:mainnet',
+        ...overrides,
+      }) as Transaction;
+
+    const createMockBridgeHistoryItem = (
+      overrides?: Partial<BridgeHistoryItem>,
+    ): BridgeHistoryItem =>
+      ({
+        quote: {
+          srcChainId: 42161,
+          destChainId: 42161,
+          intent: undefined,
+        },
+        status: {
+          status: StatusTypes.PENDING,
+          srcChain: {
+            chainId: 42161,
+            txHash: '0x123',
+          },
+        },
+        ...overrides,
+      }) as BridgeHistoryItem;
+
+    it('returns transaction status for non-bridge/swap transactions', () => {
+      const tx = createMockEvmTransaction({
+        type: TransactionType.contractInteraction,
+        status: TransactionStatus.confirmed,
+      });
+
+      const result = getEffectiveTransactionStatus(tx, undefined);
+
+      expect(result).toBe(TransactionStatus.confirmed);
+    });
+
+    it('returns transaction status when no bridge history item exists', () => {
+      const tx = createMockEvmTransaction({
+        type: TransactionType.swap,
+        status: TransactionStatus.confirmed,
+      });
+
+      const result = getEffectiveTransactionStatus(tx, undefined);
+
+      expect(result).toBe(TransactionStatus.confirmed);
+    });
+
+    it('returns transaction status for confirmed same-chain swap', () => {
+      const tx = createMockEvmTransaction({
+        type: TransactionType.swap,
+        status: TransactionStatus.confirmed,
+      });
+      const bridgeHistoryItem = createMockBridgeHistoryItem({
+        status: {
+          status: StatusTypes.PENDING, // Bridge status not updated yet
+          srcChain: {
+            chainId: 42161,
+            txHash: '0x123',
+          },
+        },
+      });
+
+      const result = getEffectiveTransactionStatus(tx, bridgeHistoryItem);
+
+      expect(result).toBe(TransactionStatus.confirmed);
+    });
+
+    it('returns bridge status for pending same-chain swap', () => {
+      const tx = createMockEvmTransaction({
+        type: TransactionType.swap,
+        status: TransactionStatus.submitted,
+      });
+      const bridgeHistoryItem = createMockBridgeHistoryItem({
+        status: {
+          status: StatusTypes.PENDING,
+          srcChain: {
+            chainId: 42161,
+            txHash: '0x123',
+          },
+        },
+      });
+
+      const result = getEffectiveTransactionStatus(tx, bridgeHistoryItem);
+
+      expect(result).toBe('submitted');
+    });
+
+    it('returns mapped bridge status for cross-chain bridge', () => {
+      const tx = createMockEvmTransaction({
+        type: TransactionType.bridge,
+        status: TransactionStatus.submitted,
+      });
+      const bridgeHistoryItem = createMockBridgeHistoryItem({
+        quote: {
+          srcChainId: 1,
+          destChainId: 10, // Different chains = bridge
+        } as BridgeHistoryItem['quote'],
+        status: {
+          status: StatusTypes.COMPLETE,
+          srcChain: {
+            chainId: 1,
+            txHash: '0x123',
+          },
+        },
+      });
+
+      const result = getEffectiveTransactionStatus(tx, bridgeHistoryItem);
+
+      expect(result).toBe('confirmed');
+    });
+
+    it('returns mapped intent status for intent-based swap', () => {
+      const tx = createMockEvmTransaction({
+        type: TransactionType.swap,
+        status: TransactionStatus.submitted,
+      });
+      const bridgeHistoryItem = createMockBridgeHistoryItem({
+        quote: {
+          intent: {} as BridgeHistoryItem['quote']['intent'], // Intent-based
+        } as BridgeHistoryItem['quote'],
+        status: {
+          status: StatusTypes.COMPLETE,
+          srcChain: {
+            chainId: 42161,
+            txHash: '0x123',
+          },
+        },
+      });
+
+      const result = getEffectiveTransactionStatus(tx, bridgeHistoryItem);
+
+      expect(result).toBe('confirmed');
+    });
+
+    it('returns failed for intent transaction with FAILED status', () => {
+      const tx = createMockEvmTransaction({
+        type: TransactionType.swap,
+        status: TransactionStatus.submitted,
+      });
+      const bridgeHistoryItem = createMockBridgeHistoryItem({
+        quote: {
+          intent: {} as BridgeHistoryItem['quote']['intent'],
+        } as BridgeHistoryItem['quote'],
+        status: {
+          status: StatusTypes.FAILED,
+          srcChain: {
+            chainId: 42161,
+            txHash: '0x123',
+          },
+        },
+      });
+
+      const result = getEffectiveTransactionStatus(tx, bridgeHistoryItem);
+
+      expect(result).toBe('failed');
+    });
+
+    it('handles non-EVM transactions correctly', () => {
+      const tx = createMockNonEvmTransaction({
+        status: 'confirmed',
+      });
+      const bridgeHistoryItem = createMockBridgeHistoryItem();
+
+      const result = getEffectiveTransactionStatus(tx, bridgeHistoryItem);
+
+      expect(result).toBe('confirmed');
+    });
+
+    it('returns failed for UNKNOWN bridge status on non-intent transaction', () => {
+      const tx = createMockEvmTransaction({
+        type: TransactionType.bridge,
+        status: TransactionStatus.submitted,
+      });
+      const bridgeHistoryItem = createMockBridgeHistoryItem({
+        quote: {
+          srcChainId: 1,
+          destChainId: 10,
+        } as BridgeHistoryItem['quote'],
+        status: {
+          status: StatusTypes.UNKNOWN,
+          srcChain: {
+            chainId: 1,
+            txHash: '0x123',
+          },
+        },
+      });
+
+      const result = getEffectiveTransactionStatus(tx, bridgeHistoryItem);
+
+      expect(result).toBe('failed');
+    });
+  });
+});

--- a/app/util/transactions/statusMapping.ts
+++ b/app/util/transactions/statusMapping.ts
@@ -1,0 +1,123 @@
+import { StatusTypes } from '@metamask/bridge-controller';
+import {
+  TransactionMeta,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { Transaction } from '@metamask/keyring-api';
+import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
+
+/**
+ * Maps intent status to transaction status for intent-based bridge/swap transactions.
+ * Intent-based transactions use a different status lifecycle than regular transactions.
+ *
+ * @param intentStatus - Status from BridgeStatusController for intent quotes
+ * @returns Status string compatible with StatusText component
+ */
+export const mapIntentStatusToTransactionStatus = (
+  intentStatus: StatusTypes,
+): 'confirmed' | 'submitted' | 'failed' | 'pending' => {
+  switch (intentStatus) {
+    case StatusTypes.COMPLETE:
+      return 'confirmed';
+    case StatusTypes.FAILED:
+      return 'failed';
+    case StatusTypes.PENDING:
+    case StatusTypes.SUBMITTED:
+      return 'submitted';
+    case StatusTypes.UNKNOWN:
+    default:
+      return 'failed';
+  }
+};
+
+/**
+ * Maps BridgeStatusController StatusTypes to transaction status for non-intent transactions.
+ * This provides the standard mapping for regular bridge/swap transactions.
+ *
+ * @param bridgeStatus - Status from BridgeStatusController
+ * @returns Status string compatible with StatusText component
+ */
+export const mapBridgeStatusToTransactionStatus = (
+  bridgeStatus: StatusTypes,
+): 'confirmed' | 'submitted' | 'failed' => {
+  switch (bridgeStatus) {
+    case StatusTypes.COMPLETE:
+      return 'confirmed';
+    case StatusTypes.PENDING:
+    case StatusTypes.SUBMITTED:
+      return 'submitted';
+    case StatusTypes.FAILED:
+      return 'failed';
+    case StatusTypes.UNKNOWN:
+    default:
+      return 'failed';
+  }
+};
+
+/**
+ * Gets the effective transaction status, prioritizing BridgeStatusController when available.
+ * For same-chain swaps, prioritizes the transaction confirmation over bridge status since
+ * TransactionController gets blockchain confirmation immediately while BridgeStatusController
+ * polls every 10 seconds.
+ *
+ * Decision hierarchy:
+ * 1. For non-bridge/swap transactions → use transaction.status directly
+ * 2. For same-chain swaps that are confirmed → use transaction.status (immediate)
+ * 3. For intent-based transactions → use intent status mapping from BridgeStatusController
+ * 4. For bridge/swap transactions → use bridge status mapping from BridgeStatusController
+ * 5. Fallback → use transaction.status if no bridge history available
+ *
+ * @param transaction - Transaction object (can be TransactionMeta or Transaction)
+ * @param bridgeHistoryItem - Bridge transaction history item from BridgeStatusController
+ * @returns Effective transaction status string
+ */
+export const getEffectiveTransactionStatus = (
+  transaction: TransactionMeta | Transaction,
+  bridgeHistoryItem: BridgeHistoryItem | undefined,
+):
+  | TransactionStatus
+  | 'submitted'
+  | 'failed'
+  | 'unconfirmed'
+  | 'confirmed'
+  | 'pending' => {
+  const { status, type } = transaction;
+
+  // Check if it's a bridge or swap transaction
+  // TransactionType.bridge = "bridge" and TransactionType.swap = "swap"
+  const isBridgeOrSwap =
+    type === TransactionType.bridge || type === TransactionType.swap;
+
+  // If not a bridge/swap transaction, use transaction status directly
+  if (!isBridgeOrSwap) {
+    return status;
+  }
+
+  // If no bridge history item, fall back to transaction status
+  if (!bridgeHistoryItem?.status) {
+    return status;
+  }
+
+  // Determine if it's a same-chain swap
+  const isSwap =
+    bridgeHistoryItem.quote?.srcChainId ===
+    bridgeHistoryItem.quote?.destChainId;
+  const bridgeStatus = bridgeHistoryItem.status.status;
+
+  // For same-chain swaps, if the source transaction is confirmed,
+  // use that status instead of waiting for bridge status to update.
+  // TransactionController gets blockchain confirmation immediately,
+  // while BridgeStatusController polls every 10 seconds.
+  if (isSwap && status === TransactionStatus.confirmed) {
+    return status;
+  }
+
+  // For intent-based transactions, use intent status mapping
+  if (bridgeHistoryItem.quote?.intent) {
+    return mapIntentStatusToTransactionStatus(bridgeStatus);
+  }
+
+  // For non-intent bridge/swap transactions, use bridge status mapping
+  return mapBridgeStatusToTransactionStatus(bridgeStatus);
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Update logic of transaction status to use bridge status controller on swaps/bridges/intents. Extracted the status logic into a separate utility.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update logic of transaction status to use bridge status controller

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-2974

## **Manual testing steps**

```gherkin
Ensure that transaction statuses are working as expected, no regressions were introduced.
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies transaction status handling and prioritizes `BridgeStatusController` for swaps/bridges/intents, with special-casing for same-chain swaps.
> 
> - Adds `util/transactions/statusMapping.ts` with `mapIntentStatusToTransactionStatus`, `mapBridgeStatusToTransactionStatus`, and `getEffectiveTransactionStatus`
> - Updates `TransactionElement` and `MultichainBridgeTransactionListItem` to consume `getEffectiveTransactionStatus` for icons, `StatusText`, and `BridgeActivityItemTxSegments`
> - Removes local status constants/mapping in `TransactionElement`; failure detection now based on effective status
> - Adds comprehensive tests in `statusMapping.test.ts` covering intent, bridge, same-chain swaps, non-EVM, and UNKNOWN cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcd7c03bd19aa24d8e26aaa329467be53a5ce181. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->