### PR TITLE
perf: Disable fence linting outside of production builds

### DIFF
--- a/metro.transform.js
+++ b/metro.transform.js
@@ -109,6 +109,9 @@ module.exports.transform = async ({ src, filename, options }) => {
     return svgTransformer.transform({ src, filename, options });
   }
 
+  const environment = process.env.METAMASK_ENVIRONMENT ?? 'production';
+  const shouldLintFencedFiles = environment === 'production';
+
   /**
    * Params based on builds we're code splitting
    * i.e: flavorDimensions "version" productFlavors from android/app/build.gradle
@@ -122,7 +125,7 @@ module.exports.transform = async ({ src, filename, options }) => {
       active: getBuildTypeFeatures(),
     });
 
-    if (didModify) {
+    if (shouldLintFencedFiles && didModify) {
       await lintTransformedFile(getESLintInstance(), filename, processedSource);
     }
     return defaultTransformer.transform({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Mirror extension behavior when building using code fences by disabling linting outside of production builds. This should speed up development and E2E test builds. **This change assumes that keep building a production build in CI to warn developers if the fencing they've introduced causes invalid syntax or other linting mistakes.**

Comparing with a random build on main, repack is now significantly faster:
```
Main, Android repack: 9m 39s
Main, iOS repack: 6m 3s

This PR, Android repack: 6m 43s
This PR, iOS repack: 3m 47s
```

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits linting of code-fence–processed files to production builds to speed up dev/test builds.
> 
> - Adds `METAMASK_ENVIRONMENT` check in `metro.transform.js` and only runs `lintTransformedFile` when `environment === 'production'`
> - Defaults environment to `production`; non-production builds skip fence-linting after `removeFencedCode` while keeping existing transform flow intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d2a781b3afa454dabf11e688a56abdf8ea94951. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->