### PR TITLE
feat(earn): add geo-blocking for mUSD conversion feature (#24501)

### DIFF
--- a/app/components/UI/OptinMetrics/index.tsx
+++ b/app/components/UI/OptinMetrics/index.tsx
@@ -16,9 +16,8 @@ import { strings } from '../../../../locales/i18n';
 import { useDispatch, useSelector } from 'react-redux';
 import { clearOnboardingEvents } from '../../../actions/onboarding';
 import { setDataCollectionForMarketing } from '../../../actions/security';
-import { OPTIN_META_METRICS_UI_SEEN, TRUE } from '../../../constants/storage';
 import { MetaMetricsEvents, useMetrics } from '../../hooks/useMetrics';
-import StorageWrapper from '../../../store/storage-wrapper';
+import { markMetricsOptInUISeen } from '../../../util/metrics/metricsOptInUIUtils';
 import { useTheme } from '../../../util/theme';
 import { MetaMetricsOptInSelectorsIDs } from './MetaMetricsOptIn.testIds';
 import Checkbox from '../../../component-library/components/Checkbox';
@@ -126,7 +125,7 @@ const OptinMetrics = () => {
    * Action to be triggered when pressing any button
    */
   const continueNavigation = useCallback(async () => {
-    await StorageWrapper.setItem(OPTIN_META_METRICS_UI_SEEN, TRUE);
+    await markMetricsOptInUISeen();
 
     const onContinue = route?.params?.onContinue as (() => void) | undefined;
     if (onContinue) {

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -41,6 +41,10 @@ import { getVaultFromBackup } from '../../../core/BackupVault';
 import Logger from '../../../util/Logger';
 import FilesystemStorage from 'redux-persist-filesystem-storage';
 import { MIGRATION_ERROR_HAPPENED } from '../../../constants/storage';
+import {
+  markMetricsOptInUISeen,
+  resetMetricsOptInUISeen,
+} from '../../../util/metrics/metricsOptInUIUtils';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import { isE2E } from '../../../util/test/utils';
 import { OnboardingSelectorIDs } from './Onboarding.testIds';
@@ -326,6 +330,10 @@ const Onboarding = () => {
     if (SEEDLESS_ONBOARDING_ENABLED) {
       OAuthLoginService.resetOauthState();
     }
+    // Reset metrics opt-in UI flag so the user sees the consent screen again.
+    // This ensures users starting a new wallet flow are prompted to make a fresh choice.
+    await resetMetricsOptInUISeen();
+
     await metrics.enable(false);
     // need to call hasMetricConset to update the cached consent state
     await hasMetricsConsent();
@@ -355,6 +363,10 @@ const Onboarding = () => {
     if (SEEDLESS_ONBOARDING_ENABLED) {
       OAuthLoginService.resetOauthState();
     }
+    // Reset metrics opt-in UI flag so the user sees the consent screen again.
+    // This ensures users starting a new wallet flow are prompted to make a fresh choice.
+    await resetMetricsOptInUISeen();
+
     await metrics.enable(false);
     await hasMetricsConsent();
 
@@ -670,6 +682,10 @@ const Onboarding = () => {
             createWallet,
             provider,
           );
+
+          // Mark metrics opt-in UI as seen since OAuth users auto-consent to metrics.
+          // Set AFTER OAuth succeeds to avoid marking as seen if the flow fails.
+          await markMetricsOptInUISeen();
 
           // delay unset loading to avoid flash of loading state
           setTimeout(() => {

--- a/app/util/metrics/metricsOptInUIUtils.ts
+++ b/app/util/metrics/metricsOptInUIUtils.ts
@@ -1,0 +1,43 @@
+import StorageWrapper from '../../store/storage-wrapper';
+import Logger from '../Logger';
+import { OPTIN_META_METRICS_UI_SEEN, TRUE } from '../../constants/storage';
+
+/**
+ * Marks the metrics opt-in UI as seen.
+ * This flag indicates the user has been presented with (or bypassed) the metrics consent screen.
+ *
+ * Used by:
+ * - OptinMetrics: After user makes an explicit choice on the consent screen
+ * - Onboarding (OAuth): When user authenticates via social login (auto-consents to metrics)
+ *
+ * @returns Promise<boolean> - true if successful, false if storage operation failed
+ */
+export async function markMetricsOptInUISeen(): Promise<boolean> {
+  try {
+    await StorageWrapper.setItem(OPTIN_META_METRICS_UI_SEEN, TRUE);
+    return true;
+  } catch (error) {
+    Logger.error(error as Error, 'Failed to mark metrics opt-in UI as seen');
+    return false;
+  }
+}
+
+/**
+ * Resets the metrics opt-in UI seen flag.
+ * This ensures the user will see the consent screen again when starting a new wallet flow.
+ *
+ * Used by:
+ * - Onboarding: When user starts "Create Wallet" or "Import Wallet" flow
+ * to ensure they make a fresh metrics consent choice
+ *
+ * @returns Promise<boolean> - true if successful, false if storage operation failed
+ */
+export async function resetMetricsOptInUISeen(): Promise<boolean> {
+  try {
+    await StorageWrapper.removeItem(OPTIN_META_METRICS_UI_SEEN);
+    return true;
+  } catch (error) {
+    Logger.error(error as Error, 'Failed to reset metrics opt-in UI seen flag');
+    return false;
+  }
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been
completely filled out, and PR status checks have passed at least once.
-->

## **Description**

# What is the reason for the change?
As MetaMask Legal, we need to geofence the mUSD conversion feature so it
is not available in countries where it is not compliant. This ensures
regulatory compliance by restricting access to the convert feature in
specific regions.

# What is the improvement/solution?
This PR implements geo-blocking for the mUSD conversion feature using a
two-tier approach:
- LaunchDarkly (Primary): Remote feature flag
earnMusdConversionGeoBlockedCountries with { blockedCountries: ["GB",
...] } structure
- Environment Variable (Fallback):
MM_MUSD_CONVERSION_GEO_BLOCKED_COUNTRIES as comma-separated country
codes (e.g., "GB,US")
The implementation leverages the existing RampsController geolocation
data and integrates geo-blocking checks everywhere the mUSD conversion
flow is enabled.
Key changes:
- New selectMusdConversionBlockedCountries selector with LD + env var
fallback
- New useMusdConversionEligibility hook combining geolocation with
blocked countries
- Geo-blocking integrated into: useMusdCtaVisibility, EarnBalance,
EarnLendingBalance, TokenListItem, and useCustomAmount

<!--
Write a short description of the changes included in this pull request,
also include relevant motivation and context. Have in mind the following
questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the
CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing
description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and
accurately)
-->

CHANGELOG entry: Added geo-blocking for mUSD conversion feature to
restrict access in non-compliant countries

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-194

## **Manual testing steps**

```gherkin
Feature: mUSD Conversion Geo-blocking

  Scenario: UK user cannot see mUSD conversion CTA
    Given user is located in the UK (GB)
    And user has a convertible stablecoin (USDC, DAI, USDT)
    And MM_MUSD_CONVERSION_GEO_BLOCKED_COUNTRIES="GB" or LD flag blocks GB

    When user views their token list
    Then user does not see "Convert to mUSD" CTA
    And user cannot access the mUSD conversion flow

  Scenario: US user can see mUSD conversion CTA
    Given user is located in the US
    And user has a convertible stablecoin (USDC, DAI, USDT)
    And GB is the only blocked country

    When user views their token list
    Then user sees "Convert to mUSD" CTA
    And user can initiate the mUSD conversion flow

  Scenario: Fallback to env var when LaunchDarkly unavailable
    Given LaunchDarkly flag earnMusdConversionGeoBlockedCountries is not configured
    And MM_MUSD_CONVERSION_GEO_BLOCKED_COUNTRIES="GB" is set

    When selector evaluates blocked countries
    Then GB is returned as a blocked country
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the
before and after of your change. -->

### **Before**
n/a
<!-- [screenshots/recordings] -->

### **After**
n/a
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor
Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile
Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format
if applicable
- [x] I’ve applied the right labels on the PR (see [labeling
guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the
app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described
in the ticket it closes and includes the necessary testing evidence such
as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a utility to manage the `OPTIN_META_METRICS_UI_SEEN` flag and integrates it into onboarding and consent flows.
> 
> - **New** `util/metrics/metricsOptInUIUtils.ts` with `markMetricsOptInUISeen()` and `resetMetricsOptInUISeen()` (safe storage ops with logging)
> - **Onboarding**: calls `resetMetricsOptInUISeen()` on "Create Wallet" and "Import Wallet" to re-prompt consent; calls `markMetricsOptInUISeen()` after successful OAuth login (post-success only)
> - **OptinMetrics**: replaces direct storage write with `markMetricsOptInUISeen()` before navigation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6926bd956286c8fbe569a71f8d3425b7e490cccb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
