### PR TITLE
feat: implement scrolling to MerklRewards section on navigation

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -23,6 +23,7 @@ import {
 } from '../AssetElement/index.constants';
 import { SolScope, SolAccountType } from '@metamask/keyring-api';
 import { useSendNonEvmAsset } from '../../hooks/useSendNonEvmAsset';
+import { useSendNavigation } from '../../Views/confirmations/hooks/useSendNavigation';
 import {
   ActionButtonType,
   ActionLocation,
@@ -222,6 +223,9 @@ jest.mock('../../../core/Engine', () => ({
     MultichainNetworkController: {
       setActiveNetwork: jest.fn().mockResolvedValue(undefined),
     },
+    SwapsController: {
+      fetchTokenWithCache: jest.fn().mockResolvedValue(undefined),
+    },
   },
 }));
 
@@ -295,6 +299,18 @@ jest.mock('../Ramp/hooks/useRampsUnifiedV1Enabled', () => ({
 const mockUseRampTokens = jest.fn();
 jest.mock('../Ramp/hooks/useRampTokens', () => ({
   useRampTokens: () => mockUseRampTokens(),
+}));
+
+// Only mock the new hook added in this branch: useScrollToMerklRewards
+// This hook uses useRoute/useNavigation which need proper test setup
+jest.mock('./hooks/useScrollToMerklRewards', () => ({
+  useScrollToMerklRewards: jest.fn(() => ({
+    hasScrolledRef: { current: false },
+  })),
+}));
+
+jest.mock('../../Views/confirmations/hooks/useSendNavigation', () => ({
+  useSendNavigation: jest.fn(),
 }));
 
 const asset = {
@@ -377,6 +393,13 @@ describe('AssetOverview', () => {
       topTokens: [],
       isLoading: false,
       error: null,
+    });
+
+    // Setup useSendNavigation mock to call navigate
+    (useSendNavigation as jest.Mock).mockReturnValue({
+      navigateToSendPage: jest.fn((params) => {
+        mockNavigate('Send', params);
+      }),
     });
   });
 

--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
@@ -55,6 +61,7 @@ import Routes from '../../../constants/navigation/Routes';
 import TokenDetails from './TokenDetails';
 import { RootState } from '../../../reducers';
 import { MetaMetricsEvents } from '../../../core/Analytics';
+import { useScrollToMerklRewards } from './hooks/useScrollToMerklRewards';
 import { getDecimalChainId } from '../../../util/networks';
 import { useMetrics } from '../../../components/hooks/useMetrics';
 import {
@@ -223,6 +230,11 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
     selectMerklCampaignClaimingEnabledFlag,
   );
   const { navigateToSendPage } = useSendNavigation();
+  const merklRewardsRef = useRef<View>(null);
+  const merklRewardsYInHeaderRef = useRef<number | null>(null);
+
+  // Scroll to MerklRewards section when navigating from "Claim bonus" CTA
+  useScrollToMerklRewards(merklRewardsYInHeaderRef);
 
   const nativeCurrency = useSelector((state: RootState) =>
     selectNativeCurrencyByChainId(state, asset.chainId as Hex),
@@ -831,7 +843,20 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
             )
             ///: END:ONLY_INCLUDE_IF
           }
-          {isMerklCampaignClaimingEnabled && <MerklRewards asset={asset} />}
+          {isMerklCampaignClaimingEnabled && (
+            <View
+              ref={merklRewardsRef}
+              testID="merkl-rewards-section"
+              onLayout={(event) => {
+                // Store Y position relative to header (which is the scroll offset)
+                // This is more reliable than measureInWindow for FlatList scrolling
+                const { y } = event.nativeEvent.layout;
+                merklRewardsYInHeaderRef.current = y;
+              }}
+            >
+              <MerklRewards asset={asset} />
+            </View>
+          )}
           {isPerpsEnabled && hasPerpsMarket && marketData && (
             <>
               <View style={styles.perpsPositionHeader}>

--- a/app/components/UI/AssetOverview/hooks/scrollToMerklRewardsUtils.ts
+++ b/app/components/UI/AssetOverview/hooks/scrollToMerklRewardsUtils.ts
@@ -1,0 +1,13 @@
+import { DeviceEventEmitter } from 'react-native';
+
+export const SCROLL_PADDING = 350;
+export const MAX_RETRIES = 10;
+export const RETRY_DELAY_MS = 100;
+export const SCROLL_DELAY_MS = 150;
+
+/**
+ * Emits the scroll event to scroll to MerklRewards section
+ */
+export const emitScrollToMerklRewards = (scrollY: number) => {
+  DeviceEventEmitter.emit('scrollToMerklRewards', { y: scrollY });
+};

--- a/app/components/UI/AssetOverview/hooks/useScrollToMerklRewards.test.ts
+++ b/app/components/UI/AssetOverview/hooks/useScrollToMerklRewards.test.ts
@@ -1,0 +1,220 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { DeviceEventEmitter } from 'react-native';
+import { useScrollToMerklRewards } from './useScrollToMerklRewards';
+
+// Mock DeviceEventEmitter
+jest.mock('react-native', () => {
+  const RN = jest.requireActual('react-native');
+  return {
+    ...RN,
+    DeviceEventEmitter: {
+      emit: jest.fn(),
+    },
+    InteractionManager: {
+      runAfterInteractions: jest.fn((callback) => callback()),
+    },
+  };
+});
+
+// Mock React Navigation
+const mockSetParams = jest.fn();
+const mockRoute = {
+  params: {},
+};
+
+const mockUseFocusEffect = jest.fn((callback: () => void | (() => void)) => {
+  // Call the callback immediately for testing
+  const cleanup = callback();
+  return cleanup;
+});
+
+jest.mock('@react-navigation/native', () => ({
+  useRoute: () => mockRoute,
+  useNavigation: () => ({
+    setParams: mockSetParams,
+  }),
+  useFocusEffect: mockUseFocusEffect,
+}));
+
+// Mock requestAnimationFrame
+global.requestAnimationFrame = jest.fn((callback) => {
+  setTimeout(callback, 0);
+  return 0;
+});
+
+// Mock setTimeout/clearTimeout for better control
+jest.useFakeTimers();
+
+describe('useScrollToMerklRewards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRoute.params = {};
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('does not scroll when scrollToMerklRewards param is not present', () => {
+    const merklRewardsYInHeaderRef = { current: 500 };
+    renderHook(() => useScrollToMerklRewards(merklRewardsYInHeaderRef));
+
+    expect(DeviceEventEmitter.emit).not.toHaveBeenCalled();
+    expect(mockSetParams).not.toHaveBeenCalled();
+  });
+
+  it('scrolls when scrollToMerklRewards param is true and Y position is available', async () => {
+    mockRoute.params = { scrollToMerklRewards: true };
+    const merklRewardsYInHeaderRef = { current: 500 };
+
+    renderHook(() => useScrollToMerklRewards(merklRewardsYInHeaderRef));
+
+    // Fast-forward timers
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => {
+      expect(mockSetParams).toHaveBeenCalledWith({
+        scrollToMerklRewards: undefined,
+      });
+    });
+
+    // Wait for requestAnimationFrame and setTimeout
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => {
+      expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(
+        'scrollToMerklRewards',
+        {
+          y: 150, // 500 - 350
+        },
+      );
+    });
+  });
+
+  it('retries scrolling when Y position is not available initially', async () => {
+    mockRoute.params = { scrollToMerklRewards: true };
+    const merklRewardsYInHeaderRef: React.MutableRefObject<number | null> = {
+      current: null,
+    };
+
+    renderHook(() => useScrollToMerklRewards(merklRewardsYInHeaderRef));
+
+    // First retry - still null
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(DeviceEventEmitter.emit).not.toHaveBeenCalled();
+
+    // Set Y position after first retry
+    merklRewardsYInHeaderRef.current = 600;
+
+    // Second retry - should now scroll
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    // Wait for requestAnimationFrame and setTimeout
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => {
+      expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(
+        'scrollToMerklRewards',
+        {
+          y: 250, // 600 - 350
+        },
+      );
+    });
+  });
+
+  it('stops retrying after max retries', async () => {
+    mockRoute.params = { scrollToMerklRewards: true };
+    const merklRewardsYInHeaderRef = { current: null };
+
+    renderHook(() => useScrollToMerklRewards(merklRewardsYInHeaderRef));
+
+    // Fast-forward through all retries (10 retries * 100ms = 1000ms)
+    act(() => {
+      jest.advanceTimersByTime(1100);
+    });
+
+    // Should not have emitted after max retries
+    expect(DeviceEventEmitter.emit).not.toHaveBeenCalled();
+  });
+
+  it('calculates scroll offset correctly with padding', async () => {
+    mockRoute.params = { scrollToMerklRewards: true };
+    const merklRewardsYInHeaderRef = { current: 1000 };
+
+    renderHook(() => useScrollToMerklRewards(merklRewardsYInHeaderRef));
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => {
+      expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(
+        'scrollToMerklRewards',
+        {
+          y: 650, // 1000 - 350
+        },
+      );
+    });
+  });
+
+  it('does not allow negative scroll offset', async () => {
+    mockRoute.params = { scrollToMerklRewards: true };
+    const merklRewardsYInHeaderRef = { current: 200 }; // Less than padding
+
+    renderHook(() => useScrollToMerklRewards(merklRewardsYInHeaderRef));
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => {
+      expect(DeviceEventEmitter.emit).toHaveBeenCalledWith(
+        'scrollToMerklRewards',
+        {
+          y: 0, // Math.max(0, 200 - 350) = 0
+        },
+      );
+    });
+  });
+
+  it('scrolls only once per navigation', async () => {
+    mockRoute.params = { scrollToMerklRewards: true };
+    const merklRewardsYInHeaderRef = { current: 500 };
+
+    const { rerender } = renderHook(() =>
+      useScrollToMerklRewards(merklRewardsYInHeaderRef),
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => {
+      expect(DeviceEventEmitter.emit).toHaveBeenCalledTimes(1);
+    });
+
+    // Clear the mock
+    (DeviceEventEmitter.emit as jest.Mock).mockClear();
+
+    // Rerender with same params - should not scroll again
+    rerender(merklRewardsYInHeaderRef);
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    // Should not emit again
+    expect(DeviceEventEmitter.emit).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/AssetOverview/hooks/useScrollToMerklRewards.ts
+++ b/app/components/UI/AssetOverview/hooks/useScrollToMerklRewards.ts
@@ -82,6 +82,10 @@ export const useScrollToMerklRewards = (
   );
 
   // Scroll to MerklRewards section when navigating from "Claim bonus" CTA
+  // Note: route.params is intentionally NOT in the dependency array.
+  // We read it inside the callback to get the current value, but we don't want
+  // the effect to re-run when params change (especially after we call setParams).
+  // The effect should only run when the screen gains focus.
   useFocusEffect(
     useCallback(() => {
       const scrollToMerklRewards = (
@@ -107,7 +111,8 @@ export const useScrollToMerklRewards = (
         clearAllTimeouts();
         hasScrolledRef.current = false;
       };
-    }, [route.params, navigation, attemptScroll, clearAllTimeouts]),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [navigation, attemptScroll, clearAllTimeouts]),
   );
 
   return {

--- a/app/components/UI/AssetOverview/hooks/useScrollToMerklRewards.ts
+++ b/app/components/UI/AssetOverview/hooks/useScrollToMerklRewards.ts
@@ -1,0 +1,91 @@
+import { useCallback, useRef } from 'react';
+import { InteractionManager, DeviceEventEmitter } from 'react-native';
+import {
+  useRoute,
+  useNavigation,
+  useFocusEffect,
+} from '@react-navigation/native';
+
+const SCROLL_PADDING = 350;
+const MAX_RETRIES = 10;
+const RETRY_DELAY_MS = 100;
+const SCROLL_DELAY_MS = 150;
+
+/**
+ * Hook to handle scrolling to MerklRewards section when navigating from "Claim bonus" CTA
+ *
+ * @param merklRewardsYInHeaderRef - Ref storing the Y position of MerklRewards relative to header
+ * @returns Object with refs and handlers needed by the component
+ */
+export const useScrollToMerklRewards = (
+  merklRewardsYInHeaderRef: React.MutableRefObject<number | null>,
+) => {
+  const route = useRoute();
+  const navigation = useNavigation();
+  const hasScrolledRef = useRef(false);
+
+  /**
+   * Attempts to scroll to MerklRewards section
+   * Retries if layout hasn't been measured yet
+   */
+  const attemptScroll = useCallback(
+    (retryCount = 0) => {
+      // Check if we have the Y position
+      if (merklRewardsYInHeaderRef.current !== null) {
+        // The Y position from onLayout is relative to the header
+        // Since the header is the ListHeaderComponent starting at scroll offset 0,
+        // the Y position should be the scroll offset (with some padding)
+        const scrollY = Math.max(
+          0,
+          merklRewardsYInHeaderRef.current - SCROLL_PADDING,
+        );
+
+        // Use requestAnimationFrame for better timing - waits for next paint
+        requestAnimationFrame(() => {
+          InteractionManager.runAfterInteractions(() => {
+            // Small delay to ensure FlatList is ready
+            setTimeout(() => {
+              DeviceEventEmitter.emit('scrollToMerklRewards', { y: scrollY });
+            }, SCROLL_DELAY_MS);
+          });
+        });
+      } else if (retryCount < MAX_RETRIES) {
+        // Retry if layout hasn't been measured yet
+        setTimeout(() => attemptScroll(retryCount + 1), RETRY_DELAY_MS);
+      }
+    },
+    [merklRewardsYInHeaderRef],
+  );
+
+  // Scroll to MerklRewards section when navigating from "Claim bonus" CTA
+  useFocusEffect(
+    useCallback(() => {
+      const scrollToMerklRewards = (
+        route.params as { scrollToMerklRewards?: boolean }
+      )?.scrollToMerklRewards;
+
+      // Only scroll once per navigation
+      if (scrollToMerklRewards && !hasScrolledRef.current) {
+        hasScrolledRef.current = true;
+
+        // Clear the param immediately to prevent re-triggering
+        navigation.setParams({ scrollToMerklRewards: undefined } as Record<
+          string,
+          unknown
+        >);
+
+        // Start attempting to scroll
+        attemptScroll();
+      }
+
+      // Reset the scroll flag when component loses focus (user navigates away)
+      return () => {
+        hasScrolledRef.current = false;
+      };
+    }, [route.params, navigation, attemptScroll]),
+  );
+
+  return {
+    hasScrolledRef,
+  };
+};

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
@@ -140,6 +140,16 @@ describe('useMerklRewards', () => {
     expect(result.current.claimableReward).toBe(null);
   });
 
+  it('returns null and does not fetch when asset is undefined', async () => {
+    const { result } = renderHook(() => useMerklRewards({ asset: undefined }));
+
+    await waitFor(() => {
+      expect(result.current.claimableReward).toBe(null);
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it('returns null when asset is not eligible', async () => {
     const nonEligibleAsset: TokenI = {
       ...mockAsset,

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.ts
@@ -42,7 +42,7 @@ export const isEligibleForMerklRewards = (
 };
 
 interface UseMerklRewardsOptions {
-  asset: TokenI;
+  asset: TokenI | undefined;
   exchangeRate?: number;
 }
 
@@ -63,6 +63,12 @@ export const useMerklRewards = ({
   );
 
   useEffect(() => {
+    // Guard against undefined asset (can happen during race conditions)
+    if (!asset) {
+      setClaimableReward(null);
+      return;
+    }
+
     const isEligible = isEligibleForMerklRewards(
       asset.chainId as Hex,
       asset.address as Hex | undefined,

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.test.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.test.tsx
@@ -19,7 +19,10 @@ import { strings } from '../../../../../../locales/i18n';
 
 import { useMusdConversionTokens } from '../../../Earn/hooks/useMusdConversionTokens';
 import { useMusdConversionEligibility } from '../../../Earn/hooks/useMusdConversionEligibility';
-import { selectIsMusdConversionFlowEnabledFlag , selectMerklCampaignClaimingEnabledFlag } from '../../../Earn/selectors/featureFlags';
+import {
+  selectIsMusdConversionFlowEnabledFlag,
+  selectMerklCampaignClaimingEnabledFlag,
+} from '../../../Earn/selectors/featureFlags';
 import { MUSD_CONVERSION_APY } from '../../../Earn/constants/musd';
 
 jest.mock('../../../Stake/components/StakeButton', () => ({
@@ -156,7 +159,6 @@ jest.mock('../../../Earn/selectors/featureFlags', () => ({
   selectMusdConversionPaymentTokensAllowlist: jest.fn(() => ({})),
   selectMerklCampaignClaimingEnabledFlag: jest.fn(() => false),
 }));
-
 
 const mockSelectIsMusdConversionFlowEnabledFlag =
   selectIsMusdConversionFlowEnabledFlag as jest.MockedFunction<
@@ -856,6 +858,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       mockIsEligibleForMerklRewards.mockReturnValue(true);
       prepareMocks({
         asset: musdAsset,
+        isMerklCampaignClaimingEnabled: true,
       });
 
       const assetKey: FlashListAssetKey = {
@@ -884,6 +887,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       mockIsEligibleForMerklRewards.mockReturnValue(false);
       prepareMocks({
         asset: musdAsset,
+        isMerklCampaignClaimingEnabled: true,
       });
 
       const assetKey: FlashListAssetKey = {

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.test.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.test.tsx
@@ -19,7 +19,7 @@ import { strings } from '../../../../../../locales/i18n';
 
 import { useMusdConversionTokens } from '../../../Earn/hooks/useMusdConversionTokens';
 import { useMusdConversionEligibility } from '../../../Earn/hooks/useMusdConversionEligibility';
-import { selectIsMusdConversionFlowEnabledFlag } from '../../../Earn/selectors/featureFlags';
+import { selectIsMusdConversionFlowEnabledFlag , selectMerklCampaignClaimingEnabledFlag } from '../../../Earn/selectors/featureFlags';
 import { MUSD_CONVERSION_APY } from '../../../Earn/constants/musd';
 
 jest.mock('../../../Stake/components/StakeButton', () => ({
@@ -154,7 +154,9 @@ jest.mock('../../../Earn/selectors/featureFlags', () => ({
   selectStablecoinLendingEnabledFlag: jest.fn(() => false),
   selectIsMusdConversionFlowEnabledFlag: jest.fn(() => false),
   selectMusdConversionPaymentTokensAllowlist: jest.fn(() => ({})),
+  selectMerklCampaignClaimingEnabledFlag: jest.fn(() => false),
 }));
+
 
 const mockSelectIsMusdConversionFlowEnabledFlag =
   selectIsMusdConversionFlowEnabledFlag as jest.MockedFunction<
@@ -284,6 +286,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
     isMusdConversionEnabled?: boolean;
     isTokenWithCta?: boolean;
     isGeoEligible?: boolean;
+    isMerklCampaignClaimingEnabled?: boolean;
   }
 
   function prepareMocks({
@@ -292,6 +295,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
     isMusdConversionEnabled = false,
     isTokenWithCta = false,
     isGeoEligible = true,
+    isMerklCampaignClaimingEnabled = false,
   }: PrepareMocksOptions = {}) {
     jest.clearAllMocks();
 
@@ -333,6 +337,10 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
 
         if (selector === selectIsMusdConversionFlowEnabledFlag) {
           return isMusdConversionEnabled;
+        }
+
+        if (selector === selectMerklCampaignClaimingEnabledFlag) {
+          return isMerklCampaignClaimingEnabled;
         }
 
         const selectorString = selector.toString();
@@ -819,6 +827,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       mockIsEligibleForMerklRewards.mockReturnValue(true);
       prepareMocks({
         asset: musdAsset,
+        isMerklCampaignClaimingEnabled: true,
       });
 
       const assetKey: FlashListAssetKey = {
@@ -897,12 +906,42 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       expect(queryByText(strings('earn.claim_bonus'))).toBeNull();
     });
 
+    it('does not show "Claim bonus" CTA when feature flag is disabled', () => {
+      // Arrange
+      mockClaimableReward = '100.50';
+      mockIsEligibleForMerklRewards.mockReturnValue(true);
+      prepareMocks({
+        asset: musdAsset,
+        isMerklCampaignClaimingEnabled: false,
+      });
+
+      const assetKey: FlashListAssetKey = {
+        address: musdAsset.address,
+        chainId: musdAsset.chainId,
+        isStaked: false,
+      };
+
+      // Act
+      const { queryByText } = renderWithProvider(
+        <TokenListItem
+          assetKey={assetKey}
+          showRemoveMenu={jest.fn()}
+          setShowScamWarningModal={jest.fn()}
+          privacyMode={false}
+        />,
+      );
+
+      // Assert
+      expect(queryByText(strings('earn.claim_bonus'))).toBeNull();
+    });
+
     it('navigates with scrollToMerklRewards when "Claim bonus" CTA is pressed', async () => {
       // Arrange
       mockClaimableReward = '100.50';
       mockIsEligibleForMerklRewards.mockReturnValue(true);
       prepareMocks({
         asset: musdAsset,
+        isMerklCampaignClaimingEnabled: true,
       });
 
       const assetKey: FlashListAssetKey = {
@@ -939,6 +978,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       prepareMocks({
         asset: musdAsset,
         pricePercentChange1d: 5.67,
+        isMerklCampaignClaimingEnabled: true,
       });
 
       const assetKey: FlashListAssetKey = {

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
@@ -24,7 +24,10 @@ import { TokenI } from '../../types';
 import { ScamWarningIcon } from './ScamWarningIcon/ScamWarningIcon';
 import { FlashListAssetKey } from '../TokenList';
 import useEarnTokens from '../../../Earn/hooks/useEarnTokens';
-import { selectStablecoinLendingEnabledFlag } from '../../../Earn/selectors/featureFlags';
+import {
+  selectStablecoinLendingEnabledFlag,
+  selectMerklCampaignClaimingEnabledFlag,
+} from '../../../Earn/selectors/featureFlags';
 import { useTokenPricePercentageChange } from '../../hooks/useTokenPricePercentageChange';
 import { selectAsset } from '../../../../../selectors/assets/assets-list';
 import Tag from '../../../../../component-library/components/Tags/Tag';
@@ -134,8 +137,11 @@ export const TokenListItem = React.memo(
     );
 
     // Check for claimable Merkl rewards
+    const isMerklCampaignClaimingEnabled = useSelector(
+      selectMerklCampaignClaimingEnabledFlag,
+    );
     const { claimableReward } = useMerklRewards({
-      asset: asset as TokenI,
+      asset,
     });
 
     const isEligibleForMerkl = useMemo(
@@ -149,7 +155,9 @@ export const TokenListItem = React.memo(
       [asset?.chainId, asset?.address],
     );
 
-    const hasClaimableBonus = Boolean(claimableReward && isEligibleForMerkl);
+    const hasClaimableBonus = Boolean(
+      isMerklCampaignClaimingEnabled && claimableReward && isEligibleForMerkl,
+    );
 
     const pricePercentChange1d = useTokenPricePercentageChange(asset);
 

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import {
   ActivityIndicator,
+  DeviceEventEmitter,
   FlatList,
   InteractionManager,
   RefreshControl,
@@ -245,10 +246,52 @@ class Transactions extends PureComponent {
     this.setState({
       isQRHardwareAccount: isHardwareAccount(this.props.selectedAddress),
     });
+
+    // Listen for scroll to MerklRewards event
+    // Use a debounce mechanism to prevent multiple rapid scrolls
+    this.scrollToMerklRewardsListener = DeviceEventEmitter.addListener(
+      'scrollToMerklRewards',
+      ({ y }) => {
+        if (this.flatList?.current && y !== undefined && this.mounted) {
+          // Clear any pending scroll
+          if (this.scrollTimeout) {
+            clearTimeout(this.scrollTimeout);
+          }
+
+          // Debounce scroll to prevent multiple rapid calls
+          this.scrollTimeout = setTimeout(() => {
+            try {
+              // Check if FlatList is still mounted and ready
+              if (this.flatList?.current && this.mounted) {
+                // Ensure we have a valid offset
+                const scrollOffset = Math.max(0, y);
+                this.flatList.current.scrollToOffset({
+                  offset: scrollOffset,
+                  animated: true,
+                });
+              }
+            } catch (error) {
+              // Log error for debugging but don't crash
+              Logger.error(error, 'Failed to scroll to MerklRewards', { y });
+            }
+          }, 100); // Small delay to ensure FlatList is ready
+        }
+      },
+    );
   };
 
   componentWillUnmount() {
     this.mounted = false;
+    // Remove the scroll listener
+    if (this.scrollToMerklRewardsListener) {
+      this.scrollToMerklRewardsListener.remove();
+      this.scrollToMerklRewardsListener = null;
+    }
+    // Clear any pending scroll timeouts
+    if (this.scrollTimeout) {
+      clearTimeout(this.scrollTimeout);
+      this.scrollTimeout = null;
+    }
   }
 
   updateBlockExplorer = () => {

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -2524,7 +2524,7 @@ describe('UnconnectedTransactions Scroll to MerklRewards', () => {
     expect(mockScrollToOffset).not.toHaveBeenCalled();
   });
 
-  it('handles scroll errors gracefully', () => {
+  it('logs error and does not crash when scrollToOffset throws', () => {
     const mockError = new Error('Scroll failed');
     mockScrollToOffset.mockImplementation(() => {
       throw mockError;
@@ -2587,7 +2587,7 @@ describe('UnconnectedTransactions Scroll to MerklRewards', () => {
     });
   });
 
-  it('handles undefined y value', () => {
+  it('does not scroll when y value is undefined', () => {
     instance.componentDidMount();
     const scrollCallback = addListenerSpy.mock.calls.find(
       (call) => call[0] === 'scrollToMerklRewards',
@@ -2618,7 +2618,7 @@ describe('UnconnectedTransactions Scroll to MerklRewards', () => {
     expect(mockScrollToOffset).not.toHaveBeenCalled();
   });
 
-  it('handles componentWillUnmount when no listener exists', () => {
+  it('does not throw on unmount when no listener exists', () => {
     // Don't call componentDidMount, so no listener is created
     instance.scrollToMerklRewardsListener = null;
     instance.scrollTimeout = null;
@@ -2627,7 +2627,7 @@ describe('UnconnectedTransactions Scroll to MerklRewards', () => {
     expect(() => instance.componentWillUnmount()).not.toThrow();
   });
 
-  it('handles componentWillUnmount when no pending timeout exists', () => {
+  it('removes listener on unmount when no pending timeout exists', () => {
     instance.componentDidMount();
 
     // Don't trigger any scroll event, so no timeout is pending

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5633,6 +5633,7 @@
     "claimable_bonus_tooltip": "An annual bonus claimable daily from your wallet.",
     "earn_a_percentage_bonus": "Earn a {{percentage}}% bonus",
     "claimable_bonus": "Claimable bonus",
+    "claim_bonus": "Claim bonus",
     "empty_state_cta": {
       "heading": "Lend {{tokenSymbol}} and earn",
       "body": "Lend your {{tokenSymbol}} with {{protocol}} and earn",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR implements a feature to notify users about claimable mUSD bonuses on eligible tokens (specifically mUSD on Linea). When a user has a claimable bonus, a "Claim bonus" CTA is displayed on the token list item. Clicking this CTA navigates to the asset details page and automatically scrolls to the MerklRewards section where the user can claim their bonus.

**Key changes:**
1. **TokenListItem**: Added logic to detect claimable Merkl rewards and display "Claim bonus" CTA when applicable
2. **AssetOverview**: Implemented scroll-to-section functionality using a custom hook (`useScrollToMerklRewards`) that handles navigation parameters and scroll timing
3. **Transactions**: Added DeviceEventEmitter listener to handle scroll events from the header component
4. **Testing**: Added comprehensive unit tests for all new functionality

**Technical implementation:**
- Extracted scroll logic into a reusable hook (`useScrollToMerklRewards`) for better testability
- Used `onLayout` to measure MerklRewards position relative to the header (which is the FlatList's ListHeaderComponent)
- Implemented retry mechanism to handle cases where layout hasn't been measured yet
- Added debouncing in the scroll listener to prevent multiple rapid scrolls
- Used DeviceEventEmitter for communication between AssetOverview (header) and Transactions (FlatList)

## **Changelog**

CHANGELOG entry: Added "Claim bonus" CTA on token list items for tokens with claimable mUSD bonuses, with automatic scroll to claim section on asset details page

## **Manual testing steps**

```gherkin
Feature: Claim bonus notification on token list

  Scenario: User sees "Claim bonus" CTA for token with claimable bonus
    Given the user has a token with a claimable bonus
    And the user is viewing the token list
    When the token list item is displayed
    Then the "Claim bonus" CTA should be visible in the secondary balance area
    And clicking the CTA should navigate to the asset details page
    And the page should automatically scroll to the MerklRewards section

  Scenario: User does not see "Claim bonus" CTA for token without claimable bonus
    Given the user has a token without a claimable bonus
    And the user is viewing the token list
    When the token list item is displayed
    Then the "Claim bonus" CTA should not be visible
    And the normal secondary balance display (percentage change or mUSD conversion CTA) should be shown instead
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/50dd5eb5-d724-4c69-89e2-2c2049c267e4


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables users to quickly claim Merkl rewards by surfacing a CTA in the token list and auto-scrolling to the rewards section on the asset details page.
> 
> - **TokenListItem**: Displays `earn.claim_bonus` CTA when Merkl rewards are claimable (behind `selectMerklCampaignClaimingEnabledFlag`); pressing navigates to `Asset` with `scrollToMerklRewards` param
> - **AssetOverview**: Wraps `MerklRewards` in a measured `View`, stores header-relative Y, and uses `useScrollToMerklRewards` to emit a scroll event (retry + delay)
> - **Transactions (FlatList host)**: Listens for `scrollToMerklRewards` via `DeviceEventEmitter` and scrolls to the provided offset with debouncing and cleanup
> - **Hooks/Utils**: New `useScrollToMerklRewards` and `scrollToMerklRewardsUtils` (padding, retries, delays); `useMerklRewards` now guards undefined assets
> - **Tests/i18n**: Comprehensive tests for CTA visibility, navigation/scroll behavior, and hook logic; adds `earn.claim_bonus` locale string
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdbd8e4bbf62cdf195fc706215da5bfb4e27ee01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->