### PR TITLE
chore: Use the best Claude model in workflows

### DIFF
--- a/.github/actions/cursor-background-agent/action.yml
+++ b/.github/actions/cursor-background-agent/action.yml
@@ -19,9 +19,9 @@ inputs:
     description: 'Git ref (branch/tag) to use as base'
     required: true
   model:
-    description: 'Model to use (e.g., claude-4.5-opus-thinking, claude-4-sonnet-thinking)'
+    description: 'Model to use (e.g., claude-4.5-opus-high-thinking, claude-4-sonnet-thinking)'
     required: false
-    default: 'claude-4.5-opus-thinking'
+    default: 'claude-4.5-opus-high-thinking'
   branch-name:
     description: 'Branch name for changes (optional, for implementation tasks)'
     required: false

--- a/.github/workflows/cursor-issue-analysis.yml
+++ b/.github/workflows/cursor-issue-analysis.yml
@@ -79,7 +79,7 @@ jobs:
           prompt: ${{ steps.prompt.outputs.prompt }}
           repository: https://github.com/${{ github.repository }}
           ref: ${{ github.event.repository.default_branch }}
-          model: claude-4.5-opus-thinking
+          model: claude-4.5-opus-high-thinking
           timeout-minutes: '10'
 
       - name: Post analysis comment

--- a/.github/workflows/cursorbot.yml
+++ b/.github/workflows/cursorbot.yml
@@ -90,7 +90,7 @@ jobs:
           prompt: ${{ steps.prompt.outputs.prompt }}
           repository: https://github.com/${{ github.repository }}
           ref: ${{ github.event.repository.default_branch }}
-          model: claude-4.5-opus-thinking
+          model: claude-4.5-opus-high-thinking
           branch-name: cursorbot/issue-${{ github.event.issue.number }}
           auto-create-pr: 'true'
           timeout-minutes: '15'


### PR DESCRIPTION
## **Description**
Uses the best Claude model in workflows.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Cursor automation to the higher-tier Claude model.
> 
> - Updates `model` example and sets default to `claude-4.5-opus-high-thinking` in `./.github/actions/cursor-background-agent/action.yml`
> - Updates `cursor-issue-analysis.yml` and `cursorbot.yml` to use `claude-4.5-opus-high-thinking` for agent runs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f28d3f9e617ebc5a00ab9311c5db9f690424b797. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->