### PR TITLE
feat: add close button to EarnTokenList BottomSheet

### DIFF
--- a/app/components/UI/Earn/components/EarnTokenList/EarnTokenList.test.tsx
+++ b/app/components/UI/Earn/components/EarnTokenList/EarnTokenList.test.tsx
@@ -835,10 +835,14 @@ describe('EarnTokenList', () => {
 
     expect(closeButton).toBeDefined();
 
-    // Press the close button - this should trigger the handleClose callback
+    // Press the close button - this triggers:
+    // 1. handleClose callback
+    // 2. bottomSheetRef.current?.onCloseBottomSheet()
+    // 3. BottomSheet animates closed and calls onCloseCB
+    // 4. onCloseCB calls navigation.goBack() (when shouldNavigateBack is true)
     fireEvent.press(closeButton);
 
-    // Verify that navigation.goBack() was called to close the bottom sheet
+    // Verify that navigation.goBack() was called, confirming the bottom sheet close flow executed
     expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
 

--- a/app/components/UI/Earn/components/EarnTokenList/EarnTokenList.test.tsx
+++ b/app/components/UI/Earn/components/EarnTokenList/EarnTokenList.test.tsx
@@ -84,6 +84,7 @@ jest.mock(
 );
 
 const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -91,7 +92,7 @@ jest.mock('@react-navigation/native', () => {
     ...actualNav,
     useNavigation: () => ({
       navigate: mockNavigate,
-      goBack: jest.fn(),
+      goBack: mockGoBack,
     }),
     useRoute: () => ({
       params: {
@@ -834,12 +835,11 @@ describe('EarnTokenList', () => {
 
     expect(closeButton).toBeDefined();
 
-    // Press the close button - this exercises the handleClose callback
-    // and calls bottomSheetRef.current?.onCloseBottomSheet()
+    // Press the close button - this should trigger the handleClose callback
     fireEvent.press(closeButton);
 
-    // If we get here without throwing, the close handler executed successfully
-    expect(closeButton).toBeDefined();
+    // Verify that navigation.goBack() was called to close the bottom sheet
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
 
   describe('Tron tokens', () => {

--- a/app/components/UI/Earn/components/EarnTokenList/EarnTokenList.test.tsx
+++ b/app/components/UI/Earn/components/EarnTokenList/EarnTokenList.test.tsx
@@ -820,6 +820,28 @@ describe('EarnTokenList', () => {
     });
   });
 
+  it('closes the bottom sheet when close button is pressed', () => {
+    const { getByTestId } = renderWithProvider(
+      <SafeAreaProvider initialMetrics={initialMetrics}>
+        <EarnTokenList />
+      </SafeAreaProvider>,
+      {
+        state: initialState,
+      },
+    );
+
+    const closeButton = getByTestId('earn-token-list-close-button');
+
+    expect(closeButton).toBeDefined();
+
+    // Press the close button - this exercises the handleClose callback
+    // and calls bottomSheetRef.current?.onCloseBottomSheet()
+    fireEvent.press(closeButton);
+
+    // If we get here without throwing, the close handler executed successfully
+    expect(closeButton).toBeDefined();
+  });
+
   describe('Tron tokens', () => {
     beforeEach(() => {
       mockIsTronChainId.mockReturnValue(false);

--- a/app/components/UI/Earn/components/EarnTokenList/__snapshots__/EarnTokenList.test.tsx.snap
+++ b/app/components/UI/Earn/components/EarnTokenList/__snapshots__/EarnTokenList.test.tsx.snap
@@ -201,6 +201,7 @@ exports[`EarnTokenList render matches snapshot 1`] = `
                     "width": 32,
                   }
                 }
+                testID="earn-token-list-close-button"
               >
                 <SvgMock
                   color="#121314"

--- a/app/components/UI/Earn/components/EarnTokenList/__snapshots__/EarnTokenList.test.tsx.snap
+++ b/app/components/UI/Earn/components/EarnTokenList/__snapshots__/EarnTokenList.test.tsx.snap
@@ -146,6 +146,11 @@ exports[`EarnTokenList render matches snapshot 1`] = `
           }
           testID="header"
         >
+          <View>
+            <View
+              onLayout={[Function]}
+            />
+          </View>
           <View
             style={
               [
@@ -174,6 +179,44 @@ exports[`EarnTokenList render matches snapshot 1`] = `
             >
               Select a token to deposit
             </Text>
+          </View>
+          <View>
+            <View
+              onLayout={[Function]}
+            >
+              <TouchableOpacity
+                accessible={true}
+                activeOpacity={1}
+                disabled={false}
+                onPress={[Function]}
+                onPressIn={[Function]}
+                onPressOut={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "borderRadius": 8,
+                    "height": 32,
+                    "justifyContent": "center",
+                    "opacity": 1,
+                    "width": 32,
+                  }
+                }
+              >
+                <SvgMock
+                  color="#121314"
+                  fill="currentColor"
+                  height={24}
+                  name="Close"
+                  style={
+                    {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                  width={24}
+                />
+              </TouchableOpacity>
+            </View>
           </View>
         </View>
         <View

--- a/app/components/UI/Earn/components/EarnTokenList/index.tsx
+++ b/app/components/UI/Earn/components/EarnTokenList/index.tsx
@@ -22,7 +22,8 @@ import { FlatList } from 'react-native-gesture-handler';
 import { Hex } from '@metamask/utils';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
-import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../core/Analytics/MetaMetrics.events';
 import {
   EVENT_LOCATIONS,
   EVENT_PROVIDERS,
@@ -102,7 +103,7 @@ const EarnTokenList = () => {
 
   // Temp: Used as workaround for BadgeNetwork not properly anchoring to its parent BadgeWrapper.
   const [, forceUpdate] = useReducer((x) => x + 1, 0);
-  const { createEventBuilder, trackEvent } = useMetrics();
+  const { createEventBuilder, trackEvent } = useAnalytics();
   const { styles } = useStyles(styleSheet, {});
   const { navigate } = useNavigation();
   const { params } = useRoute<EarnTokenListProps['route']>();

--- a/app/components/UI/Earn/components/EarnTokenList/index.tsx
+++ b/app/components/UI/Earn/components/EarnTokenList/index.tsx
@@ -23,7 +23,7 @@ import { Hex } from '@metamask/utils';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../../../core/Analytics/MetaMetrics.events';
+import { EVENT_NAME } from '../../../../../core/Analytics/MetaMetrics.events';
 import {
   EVENT_LOCATIONS,
   EVENT_PROVIDERS,
@@ -210,7 +210,7 @@ const EarnTokenList = () => {
     }
 
     trackEvent(
-      createEventBuilder(MetaMetricsEvents.EARN_TOKEN_LIST_ITEM_CLICKED)
+      createEventBuilder(EVENT_NAME.EARN_TOKEN_LIST_ITEM_CLICKED)
         .addProperties({
           provider: EVENT_PROVIDERS.CONSENSYS,
           location: EVENT_LOCATIONS.WALLET_ACTIONS_BOTTOM_SHEET,

--- a/app/components/UI/Earn/components/EarnTokenList/index.tsx
+++ b/app/components/UI/Earn/components/EarnTokenList/index.tsx
@@ -376,9 +376,13 @@ const EarnTokenList = () => {
     return <EarnTokenListSkeletonPlaceholder />;
   }, [earnTokens?.length]);
 
+  const handleClose = useCallback(() => {
+    bottomSheetRef.current?.onCloseBottomSheet();
+  }, []);
+
   return (
     <BottomSheet ref={bottomSheetRef}>
-      <BottomSheetHeader>
+      <BottomSheetHeader onClose={handleClose}>
         <Text variant={TextVariant.HeadingSM}>
           {params?.onItemPressScreen === EARN_INPUT_VIEW_ACTIONS.WITHDRAW
             ? strings('stake.select_a_token_to_withdraw')

--- a/app/components/UI/Earn/components/EarnTokenList/index.tsx
+++ b/app/components/UI/Earn/components/EarnTokenList/index.tsx
@@ -382,7 +382,10 @@ const EarnTokenList = () => {
 
   return (
     <BottomSheet ref={bottomSheetRef}>
-      <BottomSheetHeader onClose={handleClose}>
+      <BottomSheetHeader
+        onClose={handleClose}
+        closeButtonProps={{ testID: 'earn-token-list-close-button' }}
+      >
         <Text variant={TextVariant.HeadingSM}>
           {params?.onItemPressScreen === EARN_INPUT_VIEW_ACTIONS.WITHDRAW
             ? strings('stake.select_a_token_to_withdraw')


### PR DESCRIPTION
## **Description**

This PR adds a close button to the EarnTokenList BottomSheet header to improve user experience and provide a consistent way to dismiss the modal.

**Reason for change:**
The EarnTokenList BottomSheet was missing a close button in its header, making it inconsistent with other BottomSheet modals in the app and potentially confusing for users who expect a standard way to close modals.

**Improvement/Solution:**
Added a close button to the BottomSheetHeader by implementing a handleClose callback that calls the BottomSheet's onCloseBottomSheet method, following the same pattern used in other modals throughout the codebase.

## **Changelog**

CHANGELOG entry: Added close button to token selection modal in Earn feature

## **Related issues**

Part of: https://consensyssoftware.atlassian.net/browse/MDP-343

## **Manual testing steps**

```gherkin
Feature: Earn token list modal

  Scenario: user closes the token selection modal
    Given the user has opened the Earn token selection modal (deposit or withdraw)
    When user taps the close button in the header
    Then the modal should close and navigate back
```

## **Screenshots/Recordings**

### **Before**

The BottomSheet header only showed the title without a close button.

https://github.com/user-attachments/assets/d8d66e1f-0ff0-4234-991a-deaa1b19df57

### **After**

The BottomSheet header now includes a close button (X icon) in the top right corner.

https://github.com/user-attachments/assets/aa0fc0eb-9b75-4893-9743-cdf3bb09d75f

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a dismiss control to the Earn token selection modal and updates analytics wiring.
> 
> - Bottom sheet header now includes a close button (`onClose` via `handleClose`), with `testID` `earn-token-list-close-button`
> - Pressing close triggers `onCloseBottomSheet()`; flow verified by new test asserting `navigation.goBack()` is called
> - Snapshot updated to include the close button UI
> - Migrates metrics: replaces `useMetrics`/`MetaMetricsEvents` with `useAnalytics`/`EVENT_NAME` for `EARN_TOKEN_LIST_ITEM_CLICKED` tracking
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9efec6248f519c0a5a3c8f688d05a9a1172905e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->