### PR TITLE
fix: update HeaderCenter close button size to LG for consistency

### DIFF
--- a/app/component-library/components-temp/HeaderCenter/HeaderCenter.tsx
+++ b/app/component-library/components-temp/HeaderCenter/HeaderCenter.tsx
@@ -11,6 +11,7 @@ import {
   FontWeight,
   IconName,
   ButtonIconProps,
+  ButtonIconSize,
 } from '@metamask/design-system-react-native';
 
 // Internal dependencies.
@@ -76,6 +77,7 @@ const HeaderCenter: React.FC<HeaderCenterProps> = ({
     if (onClose || closeButtonProps) {
       const closeProps: ButtonIconProps = {
         iconName: IconName.Close,
+        size: ButtonIconSize.Lg,
         ...(closeButtonProps || {}),
         onPress: closeButtonProps?.onPress ?? onClose,
       };

--- a/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
@@ -253,10 +253,10 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
                         "alignItems": "center",
                         "backgroundColor": "transparent",
                         "borderRadius": 2,
-                        "height": 32,
+                        "height": 40,
                         "justifyContent": "center",
                         "opacity": 1,
-                        "width": 32,
+                        "width": 40,
                       },
                       undefined,
                     ]
@@ -270,8 +270,8 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
                       [
                         {
                           "color": "#121314",
-                          "height": 20,
-                          "width": 20,
+                          "height": 24,
+                          "width": 24,
                         },
                         undefined,
                       ]

--- a/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
@@ -253,10 +253,10 @@ exports[`SlippageModal renders all UI elements with the proper slippage options 
                         "alignItems": "center",
                         "backgroundColor": "transparent",
                         "borderRadius": 2,
-                        "height": 32,
+                        "height": 40,
                         "justifyContent": "center",
                         "opacity": 1,
-                        "width": 32,
+                        "width": 40,
                       },
                       undefined,
                     ]
@@ -270,8 +270,8 @@ exports[`SlippageModal renders all UI elements with the proper slippage options 
                       [
                         {
                           "color": "#121314",
-                          "height": 20,
-                          "width": 20,
+                          "height": 24,
+                          "width": 24,
                         },
                         undefined,
                       ]

--- a/app/components/UI/Earn/components/EarnTokenList/index.tsx
+++ b/app/components/UI/Earn/components/EarnTokenList/index.tsx
@@ -376,9 +376,13 @@ const EarnTokenList = () => {
     return <EarnTokenListSkeletonPlaceholder />;
   }, [earnTokens?.length]);
 
+  const handleClose = useCallback(() => {
+    bottomSheetRef.current?.onCloseBottomSheet();
+  }, []);
+
   return (
     <BottomSheet ref={bottomSheetRef}>
-      <BottomSheetHeader>
+      <BottomSheetHeader onClose={handleClose}>
         <Text variant={TextVariant.HeadingSM}>
           {params?.onItemPressScreen === EARN_INPUT_VIEW_ACTIONS.WITHDRAW
             ? strings('stake.select_a_token_to_withdraw')

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -762,10 +762,10 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                         "alignItems": "center",
                         "backgroundColor": "transparent",
                         "borderRadius": 2,
-                        "height": 32,
+                        "height": 40,
                         "justifyContent": "center",
                         "opacity": 1,
-                        "width": 32,
+                        "width": 40,
                       },
                       undefined,
                     ]
@@ -779,8 +779,8 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                       [
                         {
                           "color": "#121314",
-                          "height": 20,
-                          "width": 20,
+                          "height": 24,
+                          "width": 24,
                         },
                         undefined,
                       ]
@@ -1215,10 +1215,10 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -1232,8 +1232,8 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -1864,10 +1864,10 @@ exports[`Quotes renders animation on first fetching 1`] = `
                         "alignItems": "center",
                         "backgroundColor": "transparent",
                         "borderRadius": 2,
-                        "height": 32,
+                        "height": 40,
                         "justifyContent": "center",
                         "opacity": 1,
-                        "width": 32,
+                        "width": 40,
                       },
                       undefined,
                     ]
@@ -1881,8 +1881,8 @@ exports[`Quotes renders animation on first fetching 1`] = `
                       [
                         {
                           "color": "#121314",
-                          "height": 20,
-                          "width": 20,
+                          "height": 24,
+                          "width": 24,
                         },
                         undefined,
                       ]
@@ -2992,10 +2992,10 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                         "alignItems": "center",
                         "backgroundColor": "transparent",
                         "borderRadius": 2,
-                        "height": 32,
+                        "height": 40,
                         "justifyContent": "center",
                         "opacity": 1,
-                        "width": 32,
+                        "width": 40,
                       },
                       undefined,
                     ]
@@ -3009,8 +3009,8 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                       [
                         {
                           "color": "#121314",
-                          "height": 20,
-                          "width": 20,
+                          "height": 24,
+                          "width": 24,
                         },
                         undefined,
                       ]
@@ -3426,10 +3426,10 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -3443,8 +3443,8 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -4852,10 +4852,10 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                         "alignItems": "center",
                         "backgroundColor": "transparent",
                         "borderRadius": 2,
-                        "height": 32,
+                        "height": 40,
                         "justifyContent": "center",
                         "opacity": 1,
-                        "width": 32,
+                        "width": 40,
                       },
                       undefined,
                     ]
@@ -4869,8 +4869,8 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                       [
                         {
                           "color": "#121314",
-                          "height": 20,
-                          "width": 20,
+                          "height": 24,
+                          "width": 24,
                         },
                         undefined,
                       ]
@@ -5305,10 +5305,10 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -5322,8 +5322,8 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -6104,10 +6104,10 @@ exports[`Quotes renders correctly after animation without quotes 1`] = `
                         "alignItems": "center",
                         "backgroundColor": "transparent",
                         "borderRadius": 2,
-                        "height": 32,
+                        "height": 40,
                         "justifyContent": "center",
                         "opacity": 1,
-                        "width": 32,
+                        "width": 40,
                       },
                       undefined,
                     ]
@@ -6121,8 +6121,8 @@ exports[`Quotes renders correctly after animation without quotes 1`] = `
                       [
                         {
                           "color": "#121314",
-                          "height": 20,
-                          "width": 20,
+                          "height": 24,
+                          "width": 24,
                         },
                         undefined,
                       ]
@@ -6866,10 +6866,10 @@ exports[`Quotes renders correctly when fetching quotes errors 1`] = `
                         "alignItems": "center",
                         "backgroundColor": "transparent",
                         "borderRadius": 2,
-                        "height": 32,
+                        "height": 40,
                         "justifyContent": "center",
                         "opacity": 1,
-                        "width": 32,
+                        "width": 40,
                       },
                       undefined,
                     ]
@@ -6883,8 +6883,8 @@ exports[`Quotes renders correctly when fetching quotes errors 1`] = `
                       [
                         {
                           "color": "#121314",
-                          "height": 20,
-                          "width": 20,
+                          "height": 24,
+                          "width": 24,
                         },
                         undefined,
                       ]
@@ -7628,10 +7628,10 @@ exports[`Quotes renders correctly with sdkError 1`] = `
                         "alignItems": "center",
                         "backgroundColor": "transparent",
                         "borderRadius": 2,
-                        "height": 32,
+                        "height": 40,
                         "justifyContent": "center",
                         "opacity": 1,
-                        "width": 32,
+                        "width": 40,
                       },
                       undefined,
                     ]
@@ -7645,8 +7645,8 @@ exports[`Quotes renders correctly with sdkError 1`] = `
                       [
                         {
                           "color": "#121314",
-                          "height": 20,
-                          "width": 20,
+                          "height": 24,
+                          "width": 24,
                         },
                         undefined,
                       ]
@@ -8390,10 +8390,10 @@ exports[`Quotes renders quotes expired screen 1`] = `
                         "alignItems": "center",
                         "backgroundColor": "transparent",
                         "borderRadius": 2,
-                        "height": 32,
+                        "height": 40,
                         "justifyContent": "center",
                         "opacity": 1,
-                        "width": 32,
+                        "width": 40,
                       },
                       undefined,
                     ]
@@ -8407,8 +8407,8 @@ exports[`Quotes renders quotes expired screen 1`] = `
                       [
                         {
                           "color": "#121314",
-                          "height": 20,
-                          "width": 20,
+                          "height": 24,
+                          "width": 24,
                         },
                         undefined,
                       ]

--- a/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
@@ -553,10 +553,10 @@ exports[`FiatSelectorModal renders the modal with currency list 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -570,8 +570,8 @@ exports[`FiatSelectorModal renders the modal with currency list 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -1551,10 +1551,10 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -1568,8 +1568,8 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -2549,10 +2549,10 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -2566,8 +2566,8 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -3547,10 +3547,10 @@ exports[`FiatSelectorModal search displays max 20 results 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -3564,8 +3564,8 @@ exports[`FiatSelectorModal search displays max 20 results 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]

--- a/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -553,10 +553,10 @@ exports[`PaymentMethodSelectorModal renders correctly 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -570,8 +570,8 @@ exports[`PaymentMethodSelectorModal renders correctly 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -1762,10 +1762,10 @@ exports[`PaymentMethodSelectorModal renders for sell flow 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -1779,8 +1779,8 @@ exports[`PaymentMethodSelectorModal renders for sell flow 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -2971,10 +2971,10 @@ exports[`PaymentMethodSelectorModal renders without disclaimer when selected pay
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -2988,8 +2988,8 @@ exports[`PaymentMethodSelectorModal renders without disclaimer when selected pay
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]

--- a/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -553,10 +553,10 @@ exports[`RegionSelectorModal clears search when clear button is pressed 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -570,8 +570,8 @@ exports[`RegionSelectorModal clears search when clear button is pressed 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -1475,10 +1475,10 @@ exports[`RegionSelectorModal clears search when clear button is pressed 2`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -1492,8 +1492,8 @@ exports[`RegionSelectorModal clears search when clear button is pressed 2`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -2735,10 +2735,10 @@ exports[`RegionSelectorModal filters regions based on search input 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -2752,8 +2752,8 @@ exports[`RegionSelectorModal filters regions based on search input 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -3657,10 +3657,10 @@ exports[`RegionSelectorModal handles empty regions list gracefully 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -3674,8 +3674,8 @@ exports[`RegionSelectorModal handles empty regions list gracefully 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -4447,10 +4447,10 @@ exports[`RegionSelectorModal handles undefined regions gracefully 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -4464,8 +4464,8 @@ exports[`RegionSelectorModal handles undefined regions gracefully 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -5317,10 +5317,10 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -5334,8 +5334,8 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -6195,10 +6195,10 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -6212,8 +6212,8 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -7455,10 +7455,10 @@ exports[`RegionSelectorModal renders the modal with region list 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -7472,8 +7472,8 @@ exports[`RegionSelectorModal renders the modal with region list 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -8715,10 +8715,10 @@ exports[`RegionSelectorModal renders the modal with selected region in list 1`] 
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -8732,8 +8732,8 @@ exports[`RegionSelectorModal renders the modal with selected region in list 1`] 
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -9991,10 +9991,10 @@ exports[`RegionSelectorModal renders the modal with selected state in list 1`] =
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -10008,8 +10008,8 @@ exports[`RegionSelectorModal renders the modal with selected state in list 1`] =
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -11267,10 +11267,10 @@ exports[`RegionSelectorModal shows empty state when search returns no results 1`
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -11284,8 +11284,8 @@ exports[`RegionSelectorModal shows empty state when search returns no results 1`
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]

--- a/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
@@ -553,10 +553,10 @@ exports[`TokenSelectModal renders the modal with token list 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -570,8 +570,8 @@ exports[`TokenSelectModal renders the modal with token list 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]

--- a/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -553,10 +553,10 @@ exports[`PaymentMethodSelectorModal Component renders correctly and matches snap
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -570,8 +570,8 @@ exports[`PaymentMethodSelectorModal Component renders correctly and matches snap
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]

--- a/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -553,10 +553,10 @@ exports[`RegionSelectorModal Component handles empty regions array from navigati
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -570,8 +570,8 @@ exports[`RegionSelectorModal Component handles empty regions array from navigati
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -1320,10 +1320,10 @@ exports[`RegionSelectorModal Component receives and uses regions from navigation
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -1337,8 +1337,8 @@ exports[`RegionSelectorModal Component receives and uses regions from navigation
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -2283,10 +2283,10 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -2300,8 +2300,8 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -3478,10 +3478,10 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -3495,8 +3495,8 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -4286,10 +4286,10 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -4303,8 +4303,8 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -5182,10 +5182,10 @@ exports[`RegionSelectorModal Component render matches snapshot with allRegionsSe
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -5199,8 +5199,8 @@ exports[`RegionSelectorModal Component render matches snapshot with allRegionsSe
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -6377,10 +6377,10 @@ exports[`RegionSelectorModal Component render matches snapshot with custom selec
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -6394,8 +6394,8 @@ exports[`RegionSelectorModal Component render matches snapshot with custom selec
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -7572,10 +7572,10 @@ exports[`RegionSelectorModal Component sorts recommended regions to the top when
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -7589,8 +7589,8 @@ exports[`RegionSelectorModal Component sorts recommended regions to the top when
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]

--- a/app/components/UI/Ramp/Deposit/Views/Modals/SsnInfoModal/__snapshots__/SsnInfoModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/SsnInfoModal/__snapshots__/SsnInfoModal.test.tsx.snap
@@ -553,10 +553,10 @@ exports[`SsnInfoModal Component renders correctly and matches snapshot 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -570,8 +570,8 @@ exports[`SsnInfoModal Component renders correctly and matches snapshot 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -553,10 +553,10 @@ exports[`TokenSelectorModal Component displays empty state when no tokens match 
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -570,8 +570,8 @@ exports[`TokenSelectorModal Component displays empty state when no tokens match 
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -1569,10 +1569,10 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -1586,8 +1586,8 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -2786,10 +2786,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -2803,8 +2803,8 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]

--- a/app/components/UI/Ramp/Deposit/Views/Modals/WebviewModal/__snapshots__/WebviewModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/WebviewModal/__snapshots__/WebviewModal.test.tsx.snap
@@ -523,10 +523,10 @@ exports[`WebviewModal Component renders correctly and matches snapshot 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -540,8 +540,8 @@ exports[`WebviewModal Component renders correctly and matches snapshot 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]
@@ -1128,10 +1128,10 @@ exports[`WebviewModal Component should display error view when webview HTTP erro
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -1145,8 +1145,8 @@ exports[`WebviewModal Component should display error view when webview HTTP erro
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]

--- a/app/components/UI/SeedphraseModal/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/SeedphraseModal/__snapshots__/index.test.tsx.snap
@@ -135,10 +135,10 @@ exports[`SeedphraseModal renders matches snapshot 1`] = `
                     "alignItems": "center",
                     "backgroundColor": "transparent",
                     "borderRadius": 2,
-                    "height": 32,
+                    "height": 40,
                     "justifyContent": "center",
                     "opacity": 1,
-                    "width": 32,
+                    "width": 40,
                   },
                   undefined,
                 ]
@@ -152,8 +152,8 @@ exports[`SeedphraseModal renders matches snapshot 1`] = `
                   [
                     {
                       "color": "#121314",
-                      "height": 20,
-                      "width": 20,
+                      "height": 24,
+                      "width": 24,
                     },
                     undefined,
                   ]

--- a/app/components/Views/AccountSelector/__snapshots__/AccountSelector.test.tsx.snap
+++ b/app/components/Views/AccountSelector/__snapshots__/AccountSelector.test.tsx.snap
@@ -553,10 +553,10 @@ exports[`AccountSelector should render correctly 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -570,8 +570,8 @@ exports[`AccountSelector should render correctly 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]

--- a/app/components/Views/ShowDisplayMediaNFTSheet/__snapshots__/ShowDisplayNFTMediaSheet.test.tsx.snap
+++ b/app/components/Views/ShowDisplayMediaNFTSheet/__snapshots__/ShowDisplayNFTMediaSheet.test.tsx.snap
@@ -553,10 +553,10 @@ exports[`ShowNftSheet render matches snapshot 1`] = `
                                           "alignItems": "center",
                                           "backgroundColor": "transparent",
                                           "borderRadius": 2,
-                                          "height": 32,
+                                          "height": 40,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 32,
+                                          "width": 40,
                                         },
                                         undefined,
                                       ]
@@ -570,8 +570,8 @@ exports[`ShowNftSheet render matches snapshot 1`] = `
                                         [
                                           {
                                             "color": "#121314",
-                                            "height": 20,
-                                            "width": 20,
+                                            "height": 24,
+                                            "width": 24,
                                           },
                                           undefined,
                                         ]


### PR DESCRIPTION
## **Description**

This PR updates the close button size in `HeaderCenter` component to use `IconSize.Lg` for consistency with the recent change made to `BottomSheetHeader`. 

Previously, we updated the `BottomSheetHeader` close button to use the large (LG) icon size. However, many components in the codebase use `HeaderCenter` for their navigation headers, which also has a close button. To maintain visual consistency across the app, this PR updates the `HeaderCenter` close button to match the same size.

Additionally, this PR updates all snapshot tests for components that use `HeaderCenter` to reflect the icon size change.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (consistency improvement following previous BottomSheetHeader update)

## **Manual testing steps**

\`\`\`gherkin
Feature: HeaderCenter close button size consistency

  Scenario: user views a modal with HeaderCenter
    Given the app is running
    When user opens any modal that uses HeaderCenter (e.g., Token Select Modal, Region Selector Modal, Account Selector)
    Then the close button should be visually consistent with BottomSheetHeader close button size
    And the close button should be large (LG) size
\`\`\`

## **Screenshots/Recordings**

### **Before**

Close button in HeaderCenter was using default/medium size

<img width="422" height="77" alt="Screenshot 2026-01-21 at 11 33 46 AM" src="https://github.com/user-attachments/assets/576883fb-5a99-46a6-93f1-553db0bc8a28" />


### **After**

Close button in HeaderCenter now uses LG size, matching BottomSheetHeader

<img width="440" height="84" alt="Screenshot 2026-01-21 at 11 33 28 AM" src="https://github.com/user-attachments/assets/565ffa34-c1c5-47eb-af5f-d8ff2f7e0817" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.