### PR TITLE
fix: Swaps metrics provider not set

### DIFF
--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -503,6 +503,7 @@ class TransactionElement extends PureComponent {
       bridgeTxHistoryData: { bridgeTxHistoryItem, isBridgeComplete },
     } = this.props;
     const isBridgeTransaction = type === TransactionType.bridge;
+    const isUnifiedSwap = type === TransactionType.swap && bridgeTxHistoryItem;
     const { colors, typography } = this.context || mockTheme;
     const styles = createStyles(colors, typography);
     const { value, fiatValue = false, actionKey } = transactionElement;
@@ -525,7 +526,7 @@ class TransactionElement extends PureComponent {
     const renderLedgerActions =
       transactionStatus === 'approved' && isLedgerAccount;
     let title = actionKey;
-    if (isBridgeTransaction && bridgeTxHistoryItem) {
+    if ((isBridgeTransaction || isUnifiedSwap) && bridgeTxHistoryItem) {
       title = getSwapBridgeTxActivityTitle(bridgeTxHistoryItem) ?? title;
     }
 
@@ -539,8 +540,12 @@ class TransactionElement extends PureComponent {
             {this.renderTxElementIcon(transactionElement, tx)}
           </ListItem.Icon>
           <ListItem.Body>
-            <ListItem.Title numberOfLines={1} style={styles.listItemTitle}>
-              {title}
+            <ListItem.Title numberOfLines={2} style={styles.listItemTitle}>
+              {title} (id: {tx.id?.slice(0, 4)}...{tx.id?.slice(-4)}
+              {tx.actionId
+                ? `, actionId: ${tx.actionId?.slice(0, 4)}...${tx.actionId?.slice(-4)}`
+                : ''}
+              )
             </ListItem.Title>
             {!FINAL_NON_CONFIRMED_STATUSES.includes(transactionStatus) &&
             isBridgeTransaction &&

--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -540,12 +540,8 @@ class TransactionElement extends PureComponent {
             {this.renderTxElementIcon(transactionElement, tx)}
           </ListItem.Icon>
           <ListItem.Body>
-            <ListItem.Title numberOfLines={2} style={styles.listItemTitle}>
-              {title} (id: {tx.id?.slice(0, 4)}...{tx.id?.slice(-4)}
-              {tx.actionId
-                ? `, actionId: ${tx.actionId?.slice(0, 4)}...${tx.actionId?.slice(-4)}`
-                : ''}
-              )
+            <ListItem.Title numberOfLines={1} style={styles.listItemTitle}>
+              {title}
             </ListItem.Title>
             {!FINAL_NON_CONFIRMED_STATUSES.includes(transactionStatus) &&
             isBridgeTransaction &&

--- a/app/util/activity/index.ts
+++ b/app/util/activity/index.ts
@@ -228,6 +228,7 @@ function isFilteredByMetaMaskPay(
       (item) =>
         item.status.destChain?.txHash?.toLowerCase() ===
           tx.hash?.toLowerCase() &&
+        item.txMetaId &&
         requiredTransactionIds.includes(item.txMetaId),
     );
 

--- a/app/util/bridge/hooks/useBridgeTxHistoryData.ts
+++ b/app/util/bridge/hooks/useBridgeTxHistoryData.ts
@@ -38,6 +38,11 @@ export function useBridgeTxHistoryData({
     const srcTxMetaId = evmTxMeta?.id;
     bridgeHistoryItem = srcTxMetaId ? bridgeHistory[srcTxMetaId] : undefined;
 
+    // If not found, try to find by actionId (history items can be keyed by actionId)
+    if (!bridgeHistoryItem && evmTxMeta.actionId) {
+      bridgeHistoryItem = bridgeHistory[evmTxMeta.actionId];
+    }
+
     // If not found, try to find by originalTransactionId for intent transactions
     if (!bridgeHistoryItem && srcTxMetaId) {
       const matchingEntry = Object.entries(bridgeHistory).find(

--- a/app/util/bridge/hooks/useBridgeTxHistoryData/useBridgeTxHistoryData.test.ts
+++ b/app/util/bridge/hooks/useBridgeTxHistoryData/useBridgeTxHistoryData.test.ts
@@ -233,4 +233,121 @@ describe('useBridgeTxHistoryData', () => {
       });
     });
   });
+
+  it('should find bridge history item by actionId when not found by transaction ID', async () => {
+    const mockActionId = 'test-action-id';
+    const stateWithActionIdHistory = {
+      ...initialState,
+      engine: {
+        ...initialState.engine,
+        backgroundState: {
+          ...initialState.engine.backgroundState,
+          BridgeStatusController: {
+            txHistory: {
+              [mockActionId]: {
+                txMetaId: mockActionId,
+                account: evmAccountAddress,
+                quote: {
+                  requestId: 'action-request-id',
+                  srcChainId: 1,
+                  srcAsset: {
+                    chainId: 1,
+                    address: '0xabc',
+                    decimals: 18,
+                    symbol: 'SRC',
+                    name: 'Source Token',
+                  },
+                  destChainId: 137,
+                  destAsset: {
+                    chainId: 137,
+                    address: '0xdef',
+                    decimals: 18,
+                    symbol: 'DST',
+                    name: 'Dest Token',
+                  },
+                  srcTokenAmount: '500000000000000000',
+                  destTokenAmount: '1000000000000000000',
+                },
+                status: {
+                  status: StatusTypes.COMPLETE,
+                  srcChain: {
+                    txHash: '0xsrchash',
+                  },
+                  destChain: {
+                    txHash: '0xdesthash',
+                  },
+                },
+                startTime: Date.now(),
+                estimatedProcessingTimeInSeconds: 180,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const tx: TransactionMeta = {
+      id: 'different-tx-id', // Different from the key in txHistory
+      actionId: mockActionId, // Matches the key in txHistory
+      status: TransactionStatus.confirmed,
+      chainId: mockChainId,
+      networkClientId: 'mainnet',
+      time: Date.now(),
+      txParams: {
+        to: '0x123',
+        from: '0x456',
+        value: '0x0',
+        data: '0x',
+      },
+    };
+
+    const { result } = renderHookWithProvider(
+      () => useBridgeTxHistoryData({ evmTxMeta: tx }),
+      {
+        state: stateWithActionIdHistory,
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        bridgeTxHistoryItem: {
+          txMetaId: mockActionId,
+          account: evmAccountAddress,
+          quote: {
+            requestId: 'action-request-id',
+            srcChainId: 1,
+            srcAsset: {
+              chainId: 1,
+              address: '0xabc',
+              decimals: 18,
+              symbol: 'SRC',
+              name: 'Source Token',
+            },
+            destChainId: 137,
+            destAsset: {
+              chainId: 137,
+              address: '0xdef',
+              decimals: 18,
+              symbol: 'DST',
+              name: 'Dest Token',
+            },
+            srcTokenAmount: '500000000000000000',
+            destTokenAmount: '1000000000000000000',
+          },
+          status: {
+            status: StatusTypes.COMPLETE,
+            srcChain: {
+              txHash: '0xsrchash',
+            },
+            destChain: {
+              txHash: '0xdesthash',
+            },
+          },
+          startTime: expect.any(Number),
+          estimatedProcessingTimeInSeconds: 180,
+        },
+        isBridgeComplete: true,
+      });
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "@metamask/base-controller": "^9.0.0",
     "@metamask/bitcoin-wallet-snap": "^1.9.0",
     "@metamask/bridge-controller": "^64.8.0",
-    "@metamask/bridge-status-controller": "^64.4.1",
+    "@metamask/bridge-status-controller": "^64.4.5",
     "@metamask/chain-agnostic-permission": "^1.3.0",
     "@metamask/connectivity-controller": "^0.1.0",
     "@metamask/controller-utils": "^11.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7602,9 +7602,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^64.8.0, @metamask/bridge-controller@npm:^64.8.1":
-  version: 64.8.1
-  resolution: "@metamask/bridge-controller@npm:64.8.1"
+"@metamask/bridge-controller@npm:^64.8.0, @metamask/bridge-controller@npm:^64.8.1, @metamask/bridge-controller@npm:^64.8.2":
+  version: 64.8.2
+  resolution: "@metamask/bridge-controller@npm:64.8.2"
   dependencies:
     "@ethersproject/address": "npm:^5.7.0"
     "@ethersproject/bignumber": "npm:^5.7.0"
@@ -7612,7 +7612,7 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/accounts-controller": "npm:^35.0.2"
-    "@metamask/assets-controllers": "npm:^96.0.0"
+    "@metamask/assets-controllers": "npm:^97.0.0"
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/controller-utils": "npm:^11.18.0"
     "@metamask/gas-fee-controller": "npm:^26.0.2"
@@ -7629,17 +7629,17 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/c1e73b783666eeb1480ca78ace999e80cb06270666e05965059416d156b60dafbe631ca7a6519538cd7f7e4999371f5e992a5e8440035472b1f80e88ba58423c
+  checksum: 10/d909662a42e24bae9c1489cf719460c455905e25e3a61ba3f69f67e74a3c93d9ffe50fe5eff6e8959464902432875bfc874cf4f95329c4f6bec8c6d06561c3e2
   languageName: node
   linkType: hard
 
-"@metamask/bridge-status-controller@npm:^64.4.1, @metamask/bridge-status-controller@npm:^64.4.4":
-  version: 64.4.4
-  resolution: "@metamask/bridge-status-controller@npm:64.4.4"
+"@metamask/bridge-status-controller@npm:^64.4.4, @metamask/bridge-status-controller@npm:^64.4.5":
+  version: 64.4.5
+  resolution: "@metamask/bridge-status-controller@npm:64.4.5"
   dependencies:
     "@metamask/accounts-controller": "npm:^35.0.2"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/bridge-controller": "npm:^64.8.1"
+    "@metamask/bridge-controller": "npm:^64.8.2"
     "@metamask/controller-utils": "npm:^11.18.0"
     "@metamask/gas-fee-controller": "npm:^26.0.2"
     "@metamask/network-controller": "npm:^29.0.0"
@@ -7650,7 +7650,7 @@ __metadata:
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     uuid: "npm:^8.3.2"
-  checksum: 10/92d41e1c7441884c82fe6108011d8e33180998f470bb6b5610a15660741f543d07932223b0d56fc7c0c5c98fcad33a54d0ecf1d6b8a104e0ce595c3c6b4aa86e
+  checksum: 10/20ab3e69e3ea9c46ca06dfef793710610133f301897a6d0915422a13319a87facd53b8e4f23b7f99acdc2f868954e947529d4e963171ebf6dff31d1558e47cb6
   languageName: node
   linkType: hard
 
@@ -34520,7 +34520,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^1.9.0"
     "@metamask/bridge-controller": "npm:^64.8.0"
-    "@metamask/bridge-status-controller": "npm:^64.4.1"
+    "@metamask/bridge-status-controller": "npm:^64.4.5"
     "@metamask/browser-passworder": "npm:^5.0.0"
     "@metamask/build-utils": "npm:^3.0.0"
     "@metamask/chain-agnostic-permission": "npm:^1.3.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR attempts to look up historyItems by `actionId` where possible in order to set the `provider` field properly in analytics on failed txs.

It also fixes an issue where swaps were not being picked up properly on the tx activity list. Also if you notice, there is no more flash of `Swaps Transaction` anymore before turning into `Swap X to Y`, this is because we now always have the `historyItem` data for non-STX txs.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3591

Related to https://github.com/MetaMask/core/pull/7696/

## **Manual testing steps**

```gherkin
Feature: fix for provider not being set on failed txs

  Scenario: user is trying to swap
    Given user is using a smart account on Polygon and trying to swap an ERC20 that needs an approval

    When user swaps
    Then the swap tx fails
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

#### Polygon, Smart Account, ERC20 Source token

https://github.com/user-attachments/assets/c95d838c-f688-403c-abf2-58f3ca74228b

<img width="1436" height="816" alt="Screenshot 2026-01-22 at 1 23 19 PM" src="https://github.com/user-attachments/assets/576add03-9312-4cc5-9ff5-1661bc138237" />

### OP, Non smart account, non STX, ERC20 source token

Notice how the tx history is immediately populated with the swap details

https://github.com/user-attachments/assets/6de11569-736c-4d15-923d-9512df695b8a

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves history association and activity rendering for swaps/bridges.
> 
> - `useBridgeTxHistoryData`: adds lookup by `actionId` (in addition to tx id and `originalTransactionId`); new tests cover actionId matching and existing paths
> - `TransactionElement`: treats swaps with a matching history item as unified, uses `getSwapBridgeTxActivityTitle` for titles, and routes clicks through unified handler (eliminates transient "Swaps Transaction" label)
> - `activity/index.ts`: tightens MetaMask Pay filtering for bridge receives by ensuring `txMetaId` exists before matching required ids
> - Bumps deps: `@metamask/bridge-status-controller` to `^64.4.5` and `@metamask/bridge-controller` to `^64.8.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 408e3309cb47bf20a706acbe4b88b1f5a4d40715. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->