### PR TITLE
feat: add useAnalytics hook

### DIFF
--- a/app/components/hooks/useAnalytics/index.ts
+++ b/app/components/hooks/useAnalytics/index.ts
@@ -1,9 +1,0 @@
-import { MetaMetricsEvents } from '../../../core/Analytics';
-import type { IUseAnalyticsHook } from './useAnalytics.types';
-import withAnalyticsAwareness from './withAnalyticsAwareness';
-
-export { default as useAnalytics } from './useAnalytics';
-
-export { MetaMetricsEvents, withAnalyticsAwareness };
-
-export type { IUseAnalyticsHook };

--- a/app/components/hooks/useAnalytics/index.ts
+++ b/app/components/hooks/useAnalytics/index.ts
@@ -1,0 +1,9 @@
+import { MetaMetricsEvents } from '../../../core/Analytics';
+import type { IUseAnalyticsHook } from './useAnalytics.types';
+import withAnalyticsAwareness from './withAnalyticsAwareness';
+
+export { default as useAnalytics } from './useAnalytics';
+
+export { MetaMetricsEvents, withAnalyticsAwareness };
+
+export type { IUseAnalyticsHook };

--- a/app/components/hooks/useAnalytics/useAnalytics.test.tsx
+++ b/app/components/hooks/useAnalytics/useAnalytics.test.tsx
@@ -11,7 +11,7 @@ import type {
 import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
 import type { AnalyticsTrackingEvent } from '../../../util/analytics/AnalyticsEventBuilder';
 import { analytics } from '../../../util/analytics/analytics';
-import useAnalytics from './useAnalytics';
+import { useAnalytics } from './useAnalytics';
 import type { IUseAnalyticsHook } from './useAnalytics.types';
 
 jest.mock('../../../core/Analytics/MetaMetrics');

--- a/app/components/hooks/useAnalytics/useAnalytics.test.tsx
+++ b/app/components/hooks/useAnalytics/useAnalytics.test.tsx
@@ -1,0 +1,253 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { DataDeleteResponseStatus, DataDeleteStatus } from '../../../core/Analytics';
+import MetaMetrics from '../../../core/Analytics/MetaMetrics';
+import type {
+  DataDeleteDate,
+  IDeleteRegulationResponse,
+  IDeleteRegulationStatus,
+  IMetaMetrics,
+  ITrackingEvent,
+} from '../../../core/Analytics/MetaMetrics.types';
+import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
+import type { AnalyticsTrackingEvent } from '../../../util/analytics/AnalyticsEventBuilder';
+import { analytics } from '../../../util/analytics/analytics';
+import useAnalytics from './useAnalytics';
+import type { IUseAnalyticsHook } from './useAnalytics.types';
+
+jest.mock('../../../core/Analytics/MetaMetrics');
+jest.mock('../../../util/analytics/analytics', () => ({
+  analytics: {
+    trackEvent: jest.fn(),
+    optIn: jest.fn(() => Promise.resolve()),
+    optOut: jest.fn(() => Promise.resolve()),
+    identify: jest.fn(() => Promise.resolve()),
+    getAnalyticsId: jest.fn(() =>
+      Promise.resolve('4d657461-4d61-436b-8e73-46756e212121'),
+    ),
+    isEnabled: jest.fn(() => true),
+  },
+}));
+
+const expectedDataDeletionTaskResponse = {
+  status: DataDeleteResponseStatus.ok,
+};
+
+const expectedDataDeleteStatus = {
+  deletionRequestDate: undefined,
+  dataDeletionRequestStatus: DataDeleteStatus.unknown,
+  hasCollectedDataSinceDeletionRequest: false,
+};
+
+const expectedDate = '20/04/2024';
+
+const expectedDataDeleteRegulationId = 'TWV0YU1hc2t1c2Vzbm9wb2ludCE';
+
+const buildAnalyticsEvent = (
+  saveDataRecording: boolean,
+): AnalyticsTrackingEvent => ({
+  name: 'test-event',
+  properties: {},
+  sensitiveProperties: {},
+  saveDataRecording,
+  get isAnonymous() {
+    return false;
+  },
+  get hasProperties() {
+    return false;
+  },
+});
+
+const createMockEventBuilder = (
+  analyticsEvent: AnalyticsTrackingEvent,
+): ReturnType<typeof AnalyticsEventBuilder.createEventBuilder> => ({
+  addProperties: jest.fn().mockReturnThis(),
+  addSensitiveProperties: jest.fn().mockReturnThis(),
+  removeProperties: jest.fn().mockReturnThis(),
+  removeSensitiveProperties: jest.fn().mockReturnThis(),
+  setSaveDataRecording: jest.fn().mockReturnThis(),
+  build: jest.fn(() => analyticsEvent),
+});
+
+type MetaMetricsMocks = Pick<
+  IMetaMetrics,
+  | 'createDataDeletionTask'
+  | 'checkDataDeleteStatus'
+  | 'getDeleteRegulationCreationDate'
+  | 'getDeleteRegulationId'
+  | 'isDataRecorded'
+  | 'updateDataRecordingFlag'
+>;
+
+describe('useAnalytics', () => {
+  const mockMetaMetrics: jest.Mocked<MetaMetricsMocks> = {
+    createDataDeletionTask: jest.fn(() =>
+      Promise.resolve(expectedDataDeletionTaskResponse),
+    ),
+    checkDataDeleteStatus: jest.fn(() =>
+      Promise.resolve(expectedDataDeleteStatus),
+    ),
+    getDeleteRegulationCreationDate: jest.fn(() => expectedDate),
+    getDeleteRegulationId: jest.fn(() => expectedDataDeleteRegulationId),
+    isDataRecorded: jest.fn(() => true),
+    updateDataRecordingFlag: jest.fn(),
+  };
+
+  let mockEventBuilder: ReturnType<
+    typeof AnalyticsEventBuilder.createEventBuilder
+  >;
+  let mockAnalyticsEvent: AnalyticsTrackingEvent;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const mockGetInstance = MetaMetrics.getInstance as jest.MockedFunction<
+      typeof MetaMetrics.getInstance
+    >;
+    mockGetInstance.mockReturnValue(mockMetaMetrics as IMetaMetrics);
+
+    mockAnalyticsEvent = buildAnalyticsEvent(false);
+    mockEventBuilder = createMockEventBuilder(mockAnalyticsEvent);
+
+    jest
+      .spyOn(AnalyticsEventBuilder, 'createEventBuilder')
+      .mockReturnValue(mockEventBuilder);
+  });
+
+  it('exposes analytics event builder', () => {
+    const { result } = renderHook(() => useAnalytics());
+
+    const createEventBuilder = result.current.createEventBuilder;
+
+    expect(createEventBuilder).toBe(AnalyticsEventBuilder.createEventBuilder);
+  });
+
+  it('tracks events through analytics and updates data recording flag', () => {
+    const event: ITrackingEvent = {
+      name: 'test-event',
+      properties: {},
+      sensitiveProperties: {},
+      saveDataRecording: true,
+      get isAnonymous() {
+        return false;
+      },
+      get hasProperties() {
+        return false;
+      },
+    };
+    const { result } = renderHook(() => useAnalytics());
+
+    act(() => {
+      result.current.trackEvent(event, false);
+    });
+
+    expect(AnalyticsEventBuilder.createEventBuilder).toHaveBeenCalledWith(event);
+    expect(mockEventBuilder.setSaveDataRecording).toHaveBeenCalledWith(false);
+    expect(analytics.trackEvent).toHaveBeenCalledWith(mockAnalyticsEvent);
+    expect(mockMetaMetrics.updateDataRecordingFlag).toHaveBeenCalledWith(false);
+  });
+
+  it('calls analytics optIn when enable is true', async () => {
+    const { result } = renderHook(() => useAnalytics());
+
+    await act(async () => {
+      await result.current.enable(true);
+    });
+
+    expect(analytics.optIn).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls analytics optOut when enable is false', async () => {
+    const { result } = renderHook(() => useAnalytics());
+
+    await act(async () => {
+      await result.current.enable(false);
+    });
+
+    expect(analytics.optOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls analytics identify with traits', async () => {
+    const userTraits = { test: 'value' };
+    const { result } = renderHook(() => useAnalytics());
+
+    await act(async () => {
+      await result.current.addTraitsToUser(userTraits);
+    });
+
+    expect(analytics.identify).toHaveBeenCalledWith(userTraits);
+  });
+
+  it('delegates data deletion methods to MetaMetrics', async () => {
+    const { result } = renderHook(() => useAnalytics());
+
+    let deletionTask: IDeleteRegulationResponse | undefined;
+    let dataDeleteStatus: IDeleteRegulationStatus | undefined;
+    let deletionDate: DataDeleteDate | undefined;
+    let regulationId: string | undefined;
+    let isDataRecordedValue: boolean | undefined;
+
+    await act(async () => {
+      deletionTask = await result.current.createDataDeletionTask();
+      dataDeleteStatus = await result.current.checkDataDeleteStatus();
+      deletionDate = result.current.getDeleteRegulationCreationDate();
+      regulationId = result.current.getDeleteRegulationId();
+      isDataRecordedValue = result.current.isDataRecorded();
+    });
+
+    expect(mockMetaMetrics.createDataDeletionTask).toHaveBeenCalledTimes(1);
+    expect(deletionTask).toEqual(expectedDataDeletionTaskResponse);
+    expect(mockMetaMetrics.checkDataDeleteStatus).toHaveBeenCalledTimes(1);
+    expect(dataDeleteStatus).toEqual(expectedDataDeleteStatus);
+    expect(mockMetaMetrics.getDeleteRegulationCreationDate).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(deletionDate).toEqual(expectedDate);
+    expect(mockMetaMetrics.getDeleteRegulationId).toHaveBeenCalledTimes(1);
+    expect(regulationId).toEqual(expectedDataDeleteRegulationId);
+    expect(mockMetaMetrics.isDataRecorded).toHaveBeenCalledTimes(1);
+    expect(isDataRecordedValue).toBe(true);
+  });
+
+  it('returns analytics enabled state', () => {
+    const { result } = renderHook(() => useAnalytics());
+
+    const enabled = result.current.isEnabled();
+
+    expect(analytics.isEnabled).toHaveBeenCalledTimes(1);
+    expect(enabled).toBe(true);
+  });
+
+  it('returns analytics id from analytics helper', async () => {
+    const { result } = renderHook(() => useAnalytics());
+
+    let analyticsId;
+    await act(async () => {
+      analyticsId = await result.current.getMetaMetricsId();
+    });
+
+    expect(analytics.getAnalyticsId).toHaveBeenCalledTimes(1);
+    expect(analyticsId).toBe('4d657461-4d61-436b-8e73-46756e212121');
+  });
+
+  it('keeps method references across rerenders', () => {
+    const { result, rerender } = renderHook(() => useAnalytics());
+    const firstResult = result.current;
+
+    rerender();
+    const secondResult = result.current;
+
+    (Object.keys(firstResult) as (keyof IUseAnalyticsHook)[]).forEach((key) => {
+      expect(firstResult[key]).toBe(secondResult[key]);
+    });
+  });
+
+  it('keeps hook object reference across rerenders', () => {
+    const { result, rerender } = renderHook(() => useAnalytics());
+    const firstRender = result.current;
+
+    rerender();
+    const secondRender = result.current;
+
+    expect(secondRender).toBe(firstRender);
+  });
+});

--- a/app/components/hooks/useAnalytics/useAnalytics.ts
+++ b/app/components/hooks/useAnalytics/useAnalytics.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import type { IUseAnalyticsHook } from './useAnalytics.types';
+import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
+import { analytics } from '../../../util/analytics/analytics';
+import { MetaMetrics } from '../../../core/Analytics';
+import type { ITrackingEvent } from '../../../core/Analytics/MetaMetrics.types';
+import type { AnalyticsTrackingEvent } from '../../../util/analytics/AnalyticsEventBuilder';
+import type { UserTraits } from '@segment/analytics-react-native';
+import type { AnalyticsUserTraits } from '@metamask/analytics-controller';
+
+/**
+ * Provides analytics utilities backed by the analytics helper to keep the
+ * existing hook API while migrating off MetaMetrics internals.
+ */
+const useAnalytics = (): IUseAnalyticsHook =>
+  useMemo(
+    () => ({
+      trackEvent: (
+        event: ITrackingEvent | AnalyticsTrackingEvent,
+        saveDataRecording?: boolean,
+      ): void => {
+        const analyticsEvent = AnalyticsEventBuilder.createEventBuilder(event)
+          .setSaveDataRecording(saveDataRecording ?? true)
+          .build();
+        analytics.trackEvent(analyticsEvent);
+
+        // Preserve data deletion behavior until MetaMetrics is fully removed.
+        MetaMetrics.getInstance().updateDataRecordingFlag(
+          analyticsEvent.saveDataRecording,
+        );
+      },
+      enable: async (enable?: boolean): Promise<void> => {
+        if (enable === false) {
+          await analytics.optOut();
+        } else {
+          await analytics.optIn();
+        }
+      },
+      addTraitsToUser: async (userTraits: UserTraits): Promise<void> => {
+        analytics.identify(userTraits as unknown as AnalyticsUserTraits);
+      },
+      createDataDeletionTask: MetaMetrics.getInstance().createDataDeletionTask,
+      checkDataDeleteStatus: MetaMetrics.getInstance().checkDataDeleteStatus,
+      getDeleteRegulationCreationDate:
+        MetaMetrics.getInstance().getDeleteRegulationCreationDate,
+      getDeleteRegulationId: MetaMetrics.getInstance().getDeleteRegulationId,
+      isDataRecorded: MetaMetrics.getInstance().isDataRecorded,
+      isEnabled: (): boolean => analytics.isEnabled(),
+      getMetaMetricsId: async (): Promise<string | undefined> => {
+        const id = await analytics.getAnalyticsId();
+        return id;
+      },
+      createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+    }),
+    [],
+  );
+
+export default useAnalytics;

--- a/app/components/hooks/useAnalytics/useAnalytics.ts
+++ b/app/components/hooks/useAnalytics/useAnalytics.ts
@@ -12,7 +12,7 @@ import type { AnalyticsUserTraits } from '@metamask/analytics-controller';
  * Provides analytics utilities backed by the analytics helper to keep the
  * existing hook API while migrating off MetaMetrics internals.
  */
-const useAnalytics = (): IUseAnalyticsHook =>
+export const useAnalytics = (): IUseAnalyticsHook =>
   useMemo(
     () => ({
       trackEvent: (
@@ -54,5 +54,3 @@ const useAnalytics = (): IUseAnalyticsHook =>
     }),
     [],
   );
-
-export default useAnalytics;

--- a/app/components/hooks/useAnalytics/useAnalytics.types.ts
+++ b/app/components/hooks/useAnalytics/useAnalytics.types.ts
@@ -1,0 +1,35 @@
+import type { UserTraits } from '@segment/analytics-react-native';
+import {
+  DataDeleteDate,
+  IDeleteRegulationResponse,
+  IDeleteRegulationStatus,
+  IMetaMetricsEvent,
+  ITrackingEvent,
+} from '../../../core/Analytics/MetaMetrics.types';
+import {
+  AnalyticsEventBuilder,
+  type AnalyticsTrackingEvent,
+} from '../../../util/analytics/AnalyticsEventBuilder';
+
+type AnalyticsEventBuilderType = ReturnType<
+  typeof AnalyticsEventBuilder.createEventBuilder
+>;
+
+export interface IUseAnalyticsHook {
+  isEnabled(): boolean;
+  enable(enable?: boolean): Promise<void>;
+  addTraitsToUser(userTraits: UserTraits): Promise<void>;
+  trackEvent(
+    event: ITrackingEvent | AnalyticsTrackingEvent,
+    saveDataRecording?: boolean,
+  ): void;
+  createDataDeletionTask(): Promise<IDeleteRegulationResponse>;
+  checkDataDeleteStatus(): Promise<IDeleteRegulationStatus>;
+  getDeleteRegulationCreationDate(): DataDeleteDate;
+  getDeleteRegulationId(): string | undefined;
+  isDataRecorded(): boolean;
+  getMetaMetricsId(): Promise<string | undefined>;
+  createEventBuilder(
+    event: IMetaMetricsEvent | ITrackingEvent,
+  ): AnalyticsEventBuilderType;
+}

--- a/app/components/hooks/useAnalytics/withAnalyticsAwareness.test.tsx
+++ b/app/components/hooks/useAnalytics/withAnalyticsAwareness.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { View } from 'react-native';
+import withAnalyticsAwareness from './withAnalyticsAwareness';
+import useAnalytics from './useAnalytics';
+import type { IUseAnalyticsHook } from './useAnalytics.types';
+import type { IWithAnalyticsAwarenessProps } from './withAnalyticsAwareness.types';
+
+jest.mock('./useAnalytics');
+
+describe('withAnalyticsAwareness', () => {
+  it('injects metrics prop from useAnalytics', () => {
+    const mockAnalytics = { someProp: 'someValue' } as unknown as IUseAnalyticsHook;
+    const renderSpy = jest.fn();
+    const mockUseAnalytics = useAnalytics as jest.MockedFunction<
+      typeof useAnalytics
+    >;
+    const MockComponent = ({ metrics }: IWithAnalyticsAwarenessProps) => {
+      renderSpy(metrics);
+      return <View />;
+    };
+
+    mockUseAnalytics.mockReturnValue(mockAnalytics);
+
+    const MockComponentWithAnalytics = withAnalyticsAwareness(MockComponent);
+
+    render(<MockComponentWithAnalytics />);
+
+    expect(renderSpy).toHaveBeenCalledWith(mockAnalytics);
+  });
+});

--- a/app/components/hooks/useAnalytics/withAnalyticsAwareness.test.tsx
+++ b/app/components/hooks/useAnalytics/withAnalyticsAwareness.test.tsx
@@ -1,16 +1,20 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { View } from 'react-native';
-import withAnalyticsAwareness from './withAnalyticsAwareness';
-import useAnalytics from './useAnalytics';
+import { withAnalyticsAwareness } from './withAnalyticsAwareness';
+import { useAnalytics } from './useAnalytics';
 import type { IUseAnalyticsHook } from './useAnalytics.types';
 import type { IWithAnalyticsAwarenessProps } from './withAnalyticsAwareness.types';
 
-jest.mock('./useAnalytics');
+jest.mock('./useAnalytics', () => ({
+  useAnalytics: jest.fn(),
+}));
 
 describe('withAnalyticsAwareness', () => {
   it('injects metrics prop from useAnalytics', () => {
-    const mockAnalytics = { someProp: 'someValue' } as unknown as IUseAnalyticsHook;
+    const mockAnalytics = {
+      someProp: 'someValue',
+    } as unknown as IUseAnalyticsHook;
     const renderSpy = jest.fn();
     const mockUseAnalytics = useAnalytics as jest.MockedFunction<
       typeof useAnalytics

--- a/app/components/hooks/useAnalytics/withAnalyticsAwareness.tsx
+++ b/app/components/hooks/useAnalytics/withAnalyticsAwareness.tsx
@@ -1,8 +1,8 @@
 import React, { ComponentType } from 'react';
-import useAnalytics from './useAnalytics';
+import { useAnalytics } from './useAnalytics';
 import { IWithAnalyticsAwarenessProps } from './withAnalyticsAwareness.types';
 
-const withAnalyticsAwareness = <P extends IWithAnalyticsAwarenessProps>(
+export const withAnalyticsAwareness = <P extends IWithAnalyticsAwarenessProps>(
   Child: ComponentType<P>,
 ) => {
   const ComponentWithAnalytics = (
@@ -11,5 +11,3 @@ const withAnalyticsAwareness = <P extends IWithAnalyticsAwarenessProps>(
 
   return ComponentWithAnalytics;
 };
-
-export default withAnalyticsAwareness;

--- a/app/components/hooks/useAnalytics/withAnalyticsAwareness.tsx
+++ b/app/components/hooks/useAnalytics/withAnalyticsAwareness.tsx
@@ -1,0 +1,15 @@
+import React, { ComponentType } from 'react';
+import useAnalytics from './useAnalytics';
+import { IWithAnalyticsAwarenessProps } from './withAnalyticsAwareness.types';
+
+const withAnalyticsAwareness = <P extends IWithAnalyticsAwarenessProps>(
+  Child: ComponentType<P>,
+) => {
+  const ComponentWithAnalytics = (
+    props: Omit<P, keyof IWithAnalyticsAwarenessProps>,
+  ) => <Child {...(props as P)} metrics={useAnalytics()} />;
+
+  return ComponentWithAnalytics;
+};
+
+export default withAnalyticsAwareness;

--- a/app/components/hooks/useAnalytics/withAnalyticsAwareness.types.ts
+++ b/app/components/hooks/useAnalytics/withAnalyticsAwareness.types.ts
@@ -1,0 +1,5 @@
+import type { IUseAnalyticsHook } from './useAnalytics.types';
+
+export interface IWithAnalyticsAwarenessProps {
+  metrics: IUseAnalyticsHook;
+}

--- a/app/components/hooks/useMetrics/index.ts
+++ b/app/components/hooks/useMetrics/index.ts
@@ -3,14 +3,16 @@ import { IUseMetricsHook } from './useMetrics.types';
 import withMetricsAwareness from './withMetricsAwareness';
 
 /**
- * @deprecated Use useAnalytics from app/components/hooks/useAnalytics.
+ * @deprecated Use useAnalytics from
+ * app/components/hooks/useAnalytics/useAnalytics.
  */
 export { default as useMetrics } from './useMetrics';
 
 export { MetaMetricsEvents };
 
 /**
- * @deprecated Use withAnalyticsAwareness from app/components/hooks/useAnalytics.
+ * @deprecated Use withAnalyticsAwareness from
+ * app/components/hooks/useAnalytics/withAnalyticsAwareness.
  */
 export { withMetricsAwareness };
 

--- a/app/components/hooks/useMetrics/index.ts
+++ b/app/components/hooks/useMetrics/index.ts
@@ -2,8 +2,16 @@ import { MetaMetricsEvents } from '../../../core/Analytics';
 import { IUseMetricsHook } from './useMetrics.types';
 import withMetricsAwareness from './withMetricsAwareness';
 
+/**
+ * @deprecated Use useAnalytics from app/components/hooks/useAnalytics.
+ */
 export { default as useMetrics } from './useMetrics';
 
-export { MetaMetricsEvents, withMetricsAwareness };
+export { MetaMetricsEvents };
+
+/**
+ * @deprecated Use withAnalyticsAwareness from app/components/hooks/useAnalytics.
+ */
+export { withMetricsAwareness };
 
 export type { IUseMetricsHook };

--- a/app/components/hooks/useMetrics/useMetrics.ts
+++ b/app/components/hooks/useMetrics/useMetrics.ts
@@ -23,6 +23,8 @@ import type { AnalyticsUserTraits } from '@metamask/analytics-controller';
  * - The anonymous event includes sensitive properties so you can know **what** but not **who**
  * - The non-anonymous event has either no properties or not sensitive one so you can know **who** but not **what**
  *
+ * @deprecated Use useAnalytics from app/components/hooks/useAnalytics to migrate
+ * away from MetaMetrics.
  * @returns Analytics functions
  *
  * @example basic non-anonymous tracking with no properties:

--- a/app/components/hooks/useMetrics/useMetrics.ts
+++ b/app/components/hooks/useMetrics/useMetrics.ts
@@ -23,7 +23,8 @@ import type { AnalyticsUserTraits } from '@metamask/analytics-controller';
  * - The anonymous event includes sensitive properties so you can know **what** but not **who**
  * - The non-anonymous event has either no properties or not sensitive one so you can know **who** but not **what**
  *
- * @deprecated Use useAnalytics from app/components/hooks/useAnalytics to migrate
+ * @deprecated Use useAnalytics from
+ * app/components/hooks/useAnalytics/useAnalytics to migrate
  * away from MetaMetrics.
  * @returns Analytics functions
  *

--- a/app/components/hooks/useMetrics/withMetricsAwareness.tsx
+++ b/app/components/hooks/useMetrics/withMetricsAwareness.tsx
@@ -2,6 +2,10 @@ import React, { ComponentType } from 'react';
 import useMetrics from './useMetrics';
 import { IWithMetricsAwarenessProps } from './withMetricsAwareness.types';
 
+/**
+ * @deprecated Use withAnalyticsAwareness from app/components/hooks/useAnalytics
+ * to stop new MetaMetrics usage.
+ */
 const withMetricsAwareness =
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/components/hooks/useMetrics/withMetricsAwareness.tsx
+++ b/app/components/hooks/useMetrics/withMetricsAwareness.tsx
@@ -3,7 +3,8 @@ import useMetrics from './useMetrics';
 import { IWithMetricsAwarenessProps } from './withMetricsAwareness.types';
 
 /**
- * @deprecated Use withAnalyticsAwareness from app/components/hooks/useAnalytics
+ * @deprecated Use withAnalyticsAwareness from
+ * app/components/hooks/useAnalytics/withAnalyticsAwareness
  * to stop new MetaMetrics usage.
  */
 const withMetricsAwareness =

--- a/app/util/test/testSetup.js
+++ b/app/util/test/testSetup.js
@@ -229,8 +229,11 @@ const mockUseAnalytics = {
   getMetaMetricsId: jest.fn().mockResolvedValue('mock-analytics-id'),
 };
 
-jest.mock('../../components/hooks/useAnalytics', () => ({
+jest.mock('../../components/hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: jest.fn(() => mockUseAnalytics),
+}));
+
+jest.mock('../../components/hooks/useAnalytics/withAnalyticsAwareness', () => ({
   withAnalyticsAwareness: jest.fn((Component) => Component),
 }));
 

--- a/app/util/test/testSetup.js
+++ b/app/util/test/testSetup.js
@@ -209,6 +209,31 @@ jest.mock('../../core/NotificationManager', () => ({
   showSimpleNotification: jest.fn(),
 }));
 
+const createMockAnalyticsEventBuilder = () => ({
+  addProperties: jest.fn().mockReturnThis(),
+  addSensitiveProperties: jest.fn().mockReturnThis(),
+  build: jest.fn(() => ({})),
+});
+
+const mockUseAnalytics = {
+  trackEvent: jest.fn(),
+  createEventBuilder: jest.fn(() => createMockAnalyticsEventBuilder()),
+  isEnabled: jest.fn().mockReturnValue(true),
+  enable: jest.fn().mockResolvedValue(undefined),
+  addTraitsToUser: jest.fn().mockResolvedValue(undefined),
+  createDataDeletionTask: jest.fn().mockResolvedValue({ regulationId: 'mock-id' }),
+  checkDataDeleteStatus: jest.fn().mockResolvedValue({ status: 'pending' }),
+  getDeleteRegulationCreationDate: jest.fn().mockReturnValue(new Date()),
+  getDeleteRegulationId: jest.fn().mockReturnValue('mock-regulation-id'),
+  isDataRecorded: jest.fn().mockReturnValue(true),
+  getMetaMetricsId: jest.fn().mockResolvedValue('mock-analytics-id'),
+};
+
+jest.mock('../../components/hooks/useAnalytics', () => ({
+  useAnalytics: jest.fn(() => mockUseAnalytics),
+  withAnalyticsAwareness: jest.fn((Component) => Component),
+}));
+
 let mockState = {};
 
 jest.mock('../../store', () => ({


### PR DESCRIPTION
## **Description**

- Add useAnalytics hook and withAnalyticsAwareness HOC backed by the analytics helper to replace MetaMetrics usage.
- Deprecate useMetrics and withMetricsAwareness with migration notes.
- Add tests and a global mock for the new hook.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #25036

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.