### PR TITLE
fix(EarnBalance): only show stake button for native TRX

### DIFF
--- a/app/components/UI/Earn/components/EarnBalance/index.tsx
+++ b/app/components/UI/Earn/components/EarnBalance/index.tsx
@@ -42,6 +42,8 @@ const EarnBalance = ({ asset }: EarnBalanceProps) => {
   const isTrxStakingEnabled = useSelector(selectTrxStakingEnabled);
 
   const isTron = asset?.chainId?.startsWith('tron:');
+  const isNativeTrx =
+    isTron && (asset?.ticker === 'TRX' || asset?.symbol === 'TRX');
   const isStakedTrxAsset =
     isTron && (asset?.ticker === 'sTRX' || asset?.symbol === 'sTRX');
 
@@ -61,7 +63,7 @@ const EarnBalance = ({ asset }: EarnBalanceProps) => {
       );
     }
 
-    if (!hasStakedTrxPositions && !isStakedTrxAsset) {
+    if (!hasStakedTrxPositions && isNativeTrx) {
       // TRX native row: show CTA + single Stake button
       return (
         <TronStakingButtons


### PR DESCRIPTION
## **Description**

On the Tron network, we are missing a check to avoid showing the "Stake" button for TRC20 assets

## **Changelog**

CHANGELOG entry: Fixed `Stake` button showing for assets in the Tron network that were not native TRX

## **Related issues**

n/a

## **Manual testing steps**

<!--
AI agent: Write specific, contextual Gherkin steps based on what you actually implemented.
Do NOT use generic placeholders like "my feature name". Be concrete about the feature, scenario, and steps.
-->

```gherkin
Feature: Tron Staking Banner Visibility

  Scenario: User views USDT token details on Tron network
    Given user has a Tron account with USDT tokens
    And user has no staked TRX positions

    When user navigates to the USDT token details screen
    Then the TRX staking banner should NOT be displayed
    And no "Stake" button should appear

  Scenario: User views native TRX token details on Tron network
    Given user has a Tron account with TRX tokens
    And user has no staked TRX positions

    When user navigates to the TRX token details screen
    Then the TRX staking banner should be displayed
    And the "Stake" button should appear with APY information

  Scenario: User views sTRX token details with staked positions
    Given user has a Tron account with staked TRX (sTRX)
    And user has active staked TRX positions

    When user navigates to the sTRX token details screen
    Then the "Unstake" and "Stake More" buttons should be displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="731" height="989" alt="image" src="https://github.com/user-attachments/assets/45e926e0-1925-4401-b454-5a22c34bbda7" />

### **After**

<img width="335" height="111" alt="Screenshot 2026-01-22 at 15 29 51" src="https://github.com/user-attachments/assets/66c604a4-2409-4dba-97ee-4e797b0d2b5e" />

<img width="338" height="107" alt="Screenshot 2026-01-22 at 15 30 46" src="https://github.com/user-attachments/assets/6fb5539e-b154-4397-9dcf-c01379786b2e" />

## **Pre-merge author checklist**

<!--
AI agent: Check ALL boxes in this section (mark all as [x]).
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

<!--
AI agent: Leave ALL boxes unchecked ([ ]) - these are for reviewers to check, not the author.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts Tron staking UI to native TRX.
> 
> - Introduces `isNativeTrx` and updates rendering to show `TronStakingButtons` only when on Tron, staking is enabled, there are no staked positions, and the asset is native `TRX`
> - Keeps existing `sTRX` path (show Unstake + Stake more when positions exist); returns `null` for other Tron assets (e.g., TRC20)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cfe03e019d6c09e0ca20ce10a273211a89fcd98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->