### PR TITLE
fix(predict): Optimize MAX chart performance via dynamic API fidelity

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/types.ts
@@ -171,6 +171,7 @@ export interface PolymarketApiEvent {
   title: string;
   description: string;
   icon: string;
+  startDate?: string;
   endDate?: string;
   closed: boolean;
   series: PolymarketApiSeries[];

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -666,6 +666,7 @@ export const parsePolymarketEvents = (
           ? PredictMarketStatus.CLOSED
           : PredictMarketStatus.OPEN,
         recurrence: getRecurrence(event.series),
+        startDate: event.startDate,
         endDate: event.endDate,
         category,
         tags: tags.map((t) => t.label),

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -89,6 +89,7 @@ export type PredictMarket = {
   slug: string;
   title: string;
   description: string;
+  startDate?: string;
   endDate?: string;
   image: string;
   status: 'open' | 'closed' | 'resolved';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes chart rendering performance issues on low-end devices (e.g., Galaxy A32) when the MAX timeframe is selected with large datasets (e.g., longer running markets). Implements server-side data limiting via dynamic fidelity calculation in the price history hook.

### Changes

- Add `startDate` field to `PredictMarket` type
- Map `startDate` from Polymarket API response in `parsePolymarketEvents`
- Add `marketStartDate` option to `usePredictPriceHistory` hook
- Calculate dynamic fidelity for `MAX` timeframe based on market age
  - Targets ~100 data points regardless of market age
  - Falls back to 1-year range when `startDate` unavailable
- Remove `MAX` fidelity from `DEFAULT_FIDELITY_BY_INTERVAL` (now calculated dynamically)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)

AI agent: Use format `CHANGELOG entry: [fix/feat/chore]: [User-facing description in past tense]`.
Examples: `fix: resolved token name display issue`, `feat: added dark mode toggle`, `chore: updated dependencies`.
For non-user-facing changes, use `CHANGELOG entry: null`.
-->

CHANGELOG entry: null

## **Related issues**

<!--
AI agent: Replace with `Fixes: #[ISSUE_NUMBER]` using the actual issue number you're implementing.
-->

Fixes: [24523](https://github.com/MetaMask/metamask-mobile/issues/24523)

## **Manual testing steps**

<!--
AI agent: Write specific, contextual Gherkin steps based on what you actually implemented.
Do NOT use generic placeholders like "my feature name". Be concrete about the feature, scenario, and steps.
-->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="720" height="1600" alt="image" src="https://github.com/user-attachments/assets/b79fc3ba-5db5-4556-8255-ce71c105a3c2" />

## **Pre-merge author checklist**

<!--
AI agent: Check ALL boxes in this section (mark all as [x]).
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

<!--
AI agent: Leave ALL boxes unchecked ([ ]) - these are for reviewers to check, not the author.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves chart performance for `MAX` timeframe by limiting API data via dynamic fidelity.
> 
> - Adds `startDate` to `PredictMarket` and maps `PolymarketApiEvent.startDate` in `parsePolymarketEvents`
> - Extends `usePredictPriceHistory` with `marketStartDate` and dynamic fidelity calculation for `PredictPriceHistoryInterval.MAX` (targets ~100 samples; 1-year fallback; override respected)
> - Removes static `MAX` fidelity from `DEFAULT_FIDELITY_BY_INTERVAL` and deletes prior client-side adaptive fidelity logic in `PredictMarketDetails`; now passes `market.startDate` to the hook
> - Updates tests: new MAX dynamic fidelity cases, hook argument expectations (including `startTs/endTs`), and view tests to assert `marketStartDate` propagation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68157133cbc224811e2701aed4919922fccccc05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->