### PR TITLE
fix: MUSD-236 fixed mUSD education screen heading breaking works on smaller devices

### DIFF
--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.styles.ts
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.styles.ts
@@ -26,7 +26,6 @@ export const styleSheet = (_params: { theme: Theme }) =>
       lineHeight: 40,
       paddingVertical: 16,
       textAlign: 'center',
-      textOverflow: 'ellipsis',
     },
     bodyText: {
       textAlign: 'center',

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
@@ -180,7 +180,7 @@ const EarnMusdConversionEducationView = () => {
     // Do not remove the top edge as this screen does not have a navbar set in the route options.
     <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
       <View style={styles.content}>
-        <Text style={styles.heading} numberOfLines={3} adjustsFontSizeToFit>
+        <Text style={styles.heading} numberOfLines={2} adjustsFontSizeToFit>
           {strings('earn.musd_conversion.education.heading', {
             percentage: MUSD_CONVERSION_APY,
           })}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5729,7 +5729,7 @@
         "failed": "mUSD conversion failed"
       },
       "education": {
-        "heading": "GET {{percentage}}% ON STABLECOINS",
+        "heading": "GET {{percentage}}% ON\nSTABLECOINS",
         "description": "Convert your stablecoins to mUSD, MetaMask’s US dollar-backed stablecoin, and receive up to a {{percentage}}% bonus. Terms apply.",
         "primary_button": "Get Started",
         "secondary_button": "Not now"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixed "Get 3% Stablecoins" heading being rendered on 3 lines.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?

AI agent: Be specific about what you changed and why. Include context about the fix/feature, not generic descriptions.
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)

AI agent: Use format `CHANGELOG entry: [fix/feat/chore]: [User-facing description in past tense]`.
Examples: `fix: resolved token name display issue`, `feat: added dark mode toggle`, `chore: updated dependencies`.
For non-user-facing changes, use `CHANGELOG entry: null`.
-->

CHANGELOG entry: fixed "Get 3% Stablecoins" heading being rendered on 3 lines.

## **Related issues**

<!--
AI agent: Replace with `Fixes: #[ISSUE_NUMBER]` using the actual issue number you're implementing.
-->

Fixes: [MUSD-236: Conversion education screen heading rendered incorrectly on smaller devices](https://consensyssoftware.atlassian.net/browse/MUSD-236)

## **Manual testing steps**

<!--
AI agent: Write specific, contextual Gherkin steps based on what you actually implemented.
Do NOT use generic placeholders like "my feature name". Be concrete about the feature, scenario, and steps.
-->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="333" height="720" alt="image" src="https://github.com/user-attachments/assets/b61c1124-8095-4cb2-bd6d-c18b047faf19" />


### **After**

<!-- [screenshots/recordings] -->
<img width="332" height="719" alt="image" src="https://github.com/user-attachments/assets/26de142b-d8d9-46bb-b9fa-d1eff6fd967f" />

## **Pre-merge author checklist**

<!--
AI agent: Check ALL boxes in this section (mark all as [x]).
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

<!--
AI agent: Leave ALL boxes unchecked ([ ]) - these are for reviewers to check, not the author.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves heading layout on the mUSD conversion education screen to avoid awkward 3-line wrapping on smaller devices.
> 
> - Updates `locales/languages/en.json` `earn.musd_conversion.education.heading` to include an explicit line break
> - Sets heading `numberOfLines` to `2` in `EarnMusdConversionEducationView`
> - Removes `textOverflow: 'ellipsis'` from `styles.heading` to prevent truncation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6343ce94a634b60d0055c55c6b93b20793247094. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->