### PR TITLE
feat(predict): cp-7.63.0 add Predict Superbowl sport card to wallet Carousel

### DIFF
--- a/app/components/UI/Carousel/fetchCarouselSlidesFromContentful.ts
+++ b/app/components/UI/Carousel/fetchCarouselSlidesFromContentful.ts
@@ -157,6 +157,7 @@ function mapContentfulEntriesToSlides(
       variableName,
       mobileMinimumVersionNumber,
       mobileMaximumVersionNumber,
+      metadata,
     } = entry.fields;
 
     const slide: CarouselSlide = {
@@ -176,6 +177,7 @@ function mapContentfulEntriesToSlides(
       endDate,
       cardPlacement,
       variableName,
+      metadata,
     };
 
     if (!isValidMinimumVersion(mobileMinimumVersionNumber)) {

--- a/app/components/UI/Carousel/index.test.tsx
+++ b/app/components/UI/Carousel/index.test.tsx
@@ -98,15 +98,22 @@ jest.mock('./fetchCarouselSlidesFromContentful', () => ({
 }));
 
 jest.mock('../Predict/components/PredictMarketSportCard', () => {
+  const { useEffect } = jest.requireActual('react');
   const { View, Text } = jest.requireActual('react-native');
   return {
     PredictMarketSportCardWrapper: function MockPredictMarketSportCardWrapper({
       marketId,
       testID,
+      onLoad,
     }: {
       marketId: string;
       testID?: string;
+      onLoad?: () => void;
     }) {
+      useEffect(() => {
+        onLoad?.();
+      }, [onLoad]);
+
       return (
         <View testID={testID ?? 'predict-sport-card-wrapper'}>
           <Text testID="predict-sport-card-market-id">{marketId}</Text>

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -310,6 +310,22 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
     ///: END:ONLY_INCLUDE_IF
   ]);
 
+  const predictSuperbowlSlide = useMemo(
+    () =>
+      visibleSlides.find(
+        (slide) => slide.variableName === PREDICT_SUPERBOWL_VARIABLE_NAME,
+      ),
+    [visibleSlides],
+  );
+
+  const predictSuperbowlMarketId = useMemo(() => {
+    if (!predictSuperbowlSlide) return null;
+    const metadata = predictSuperbowlSlide.metadata as
+      | PredictCarouselMetadata
+      | undefined;
+    return metadata?.marketId ?? null;
+  }, [predictSuperbowlSlide]);
+
   // Ensure activeSlideIndex is within bounds after filtering
   const safeActiveSlideIndex = Math.min(
     activeSlideIndex,
@@ -563,31 +579,6 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
         );
       }
 
-      if (slide.variableName === PREDICT_SUPERBOWL_VARIABLE_NAME) {
-        const metadata = slide.metadata as PredictCarouselMetadata | undefined;
-        const marketId = metadata?.marketId;
-
-        if (!marketId) {
-          return null;
-        }
-
-        return (
-          <PredictMarketSportCardWrapper
-            marketId={marketId}
-            testID={slide.testID}
-            entryPoint={PredictEventValues.ENTRY_POINT.CAROUSEL}
-            isCurrentCard={isCurrentCard}
-            currentCardOpacity={currentCardOpacity}
-            currentCardScale={currentCardScale}
-            currentCardTranslateY={currentCardTranslateY}
-            nextCardOpacity={nextCardOpacity}
-            nextCardScale={nextCardScale}
-            nextCardTranslateY={nextCardTranslateY}
-            width={BANNER_WIDTH}
-          />
-        );
-      }
-
       return (
         <StackCard
           slide={slide}
@@ -651,6 +642,21 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
     (visibleSlides.length === 0 && !isAnimating.current)
   ) {
     return null;
+  }
+
+  if (predictSuperbowlMarketId) {
+    return (
+      <Box
+        style={tw.style('mx-4')}
+        testID={WalletViewSelectorsIDs.CAROUSEL_CONTAINER}
+      >
+        <PredictMarketSportCardWrapper
+          marketId={predictSuperbowlMarketId}
+          testID={predictSuperbowlSlide?.testID}
+          entryPoint={PredictEventValues.ENTRY_POINT.CAROUSEL}
+        />
+      </Box>
+    );
   }
 
   return (

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -649,9 +649,8 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
     }
   }, [currentSlide, trackEvent, createEventBuilder]);
 
-  // Track predict-superbowl slide display (filtered out of visibleSlides but rendered separately)
-  useEffect(() => {
-    if (predictSuperbowlSlide && predictSuperbowlMarketId) {
+  const handlePredictSuperbowlLoad = useCallback(() => {
+    if (predictSuperbowlSlide) {
       trackEvent(
         createEventBuilder({
           category: 'Banner Display',
@@ -662,12 +661,7 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
         }).build(),
       );
     }
-  }, [
-    predictSuperbowlSlide,
-    predictSuperbowlMarketId,
-    trackEvent,
-    createEventBuilder,
-  ]);
+  }, [predictSuperbowlSlide, trackEvent, createEventBuilder]);
 
   if (predictSuperbowlMarketId) {
     return (
@@ -676,6 +670,7 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
         testID={predictSuperbowlSlide?.testID}
         entryPoint={PredictEventValues.ENTRY_POINT.CAROUSEL}
         onDismiss={handleSportCardDismiss}
+        onLoad={handlePredictSuperbowlLoad}
       />
     );
   }

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -45,6 +45,10 @@ import { subscribeToContentPreviewToken } from '../../../actions/notification/he
 import SharedDeeplinkManager from '../../../core/DeeplinkManager/DeeplinkManager';
 import { isInternalDeepLink } from '../../../core/DeeplinkManager/util/deeplinks';
 import AppConstants from '../../../core/AppConstants';
+import { PredictMarketSportCardWrapper } from '../Predict/components/PredictMarketSportCard';
+import { PredictEventValues } from '../Predict/constants/eventNames';
+import { PREDICT_SUPERBOWL_VARIABLE_NAME } from '../Predict/constants/carousel';
+import { PredictCarouselMetadata } from '../Predict/types';
 
 const MAX_CAROUSEL_SLIDES = 8;
 
@@ -559,6 +563,31 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
         );
       }
 
+      if (slide.variableName === PREDICT_SUPERBOWL_VARIABLE_NAME) {
+        const metadata = slide.metadata as PredictCarouselMetadata | undefined;
+        const marketId = metadata?.marketId;
+
+        if (!marketId) {
+          return null;
+        }
+
+        return (
+          <PredictMarketSportCardWrapper
+            marketId={marketId}
+            testID={slide.testID}
+            entryPoint={PredictEventValues.ENTRY_POINT.CAROUSEL}
+            isCurrentCard={isCurrentCard}
+            currentCardOpacity={currentCardOpacity}
+            currentCardScale={currentCardScale}
+            currentCardTranslateY={currentCardTranslateY}
+            nextCardOpacity={nextCardOpacity}
+            nextCardScale={nextCardScale}
+            nextCardTranslateY={nextCardTranslateY}
+            width={BANNER_WIDTH}
+          />
+        );
+      }
+
       return (
         <StackCard
           slide={slide}
@@ -584,8 +613,8 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
       nextCardTranslateY,
       nextCardBgOpacity,
       handleSlideClick,
-      handleTransitionToNextCard,
       handleTransitionToEmpty,
+      handleTransitionToNextCard,
     ],
   );
 

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -649,6 +649,26 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
     }
   }, [currentSlide, trackEvent, createEventBuilder]);
 
+  // Track predict-superbowl slide display (filtered out of visibleSlides but rendered separately)
+  useEffect(() => {
+    if (predictSuperbowlSlide && predictSuperbowlMarketId) {
+      trackEvent(
+        createEventBuilder({
+          category: 'Banner Display',
+          properties: {
+            name:
+              predictSuperbowlSlide.variableName ?? predictSuperbowlSlide.id,
+          },
+        }).build(),
+      );
+    }
+  }, [
+    predictSuperbowlSlide,
+    predictSuperbowlMarketId,
+    trackEvent,
+    createEventBuilder,
+  ]);
+
   if (predictSuperbowlMarketId) {
     return (
       <Box

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -671,17 +671,12 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
 
   if (predictSuperbowlMarketId) {
     return (
-      <Box
-        style={tw.style('mx-4')}
-        testID={WalletViewSelectorsIDs.CAROUSEL_CONTAINER}
-      >
-        <PredictMarketSportCardWrapper
-          marketId={predictSuperbowlMarketId}
-          testID={predictSuperbowlSlide?.testID}
-          entryPoint={PredictEventValues.ENTRY_POINT.CAROUSEL}
-          onDismiss={handleSportCardDismiss}
-        />
-      </Box>
+      <PredictMarketSportCardWrapper
+        marketId={predictSuperbowlMarketId}
+        testID={predictSuperbowlSlide?.testID}
+        entryPoint={PredictEventValues.ENTRY_POINT.CAROUSEL}
+        onDismiss={handleSportCardDismiss}
+      />
     );
   }
 

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -279,9 +279,11 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
   const predictSuperbowlSlide = useMemo(
     () =>
       slidesConfig.find(
-        (slide) => slide.variableName === PREDICT_SUPERBOWL_VARIABLE_NAME,
+        (slide) =>
+          slide.variableName === PREDICT_SUPERBOWL_VARIABLE_NAME &&
+          !dismissedBanners.includes(slide.id),
       ),
-    [slidesConfig],
+    [slidesConfig, dismissedBanners],
   );
 
   const predictSuperbowlMarketId = useMemo(() => {
@@ -647,13 +649,6 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
     }
   }, [currentSlide, trackEvent, createEventBuilder]);
 
-  if (
-    !isCarouselVisible ||
-    (visibleSlides.length === 0 && !isAnimating.current)
-  ) {
-    return null;
-  }
-
   if (predictSuperbowlMarketId) {
     return (
       <Box
@@ -668,6 +663,13 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
         />
       </Box>
     );
+  }
+
+  if (
+    !isCarouselVisible ||
+    (visibleSlides.length === 0 && !isAnimating.current)
+  ) {
+    return null;
   }
 
   return (

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -276,6 +276,22 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
     dismissedBanners,
   ]);
 
+  const predictSuperbowlSlide = useMemo(
+    () =>
+      slidesConfig.find(
+        (slide) => slide.variableName === PREDICT_SUPERBOWL_VARIABLE_NAME,
+      ),
+    [slidesConfig],
+  );
+
+  const predictSuperbowlMarketId = useMemo(() => {
+    if (!predictSuperbowlSlide) return null;
+    const metadata = predictSuperbowlSlide.metadata as
+      | PredictCarouselMetadata
+      | undefined;
+    return metadata?.marketId ?? null;
+  }, [predictSuperbowlSlide]);
+
   const visibleSlides = useMemo(() => {
     const filtered = slidesConfig.filter((slide: CarouselSlide) => {
       const active = isActive(slide);
@@ -289,6 +305,11 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
         return false;
       }
       ///: END:ONLY_INCLUDE_IF
+
+      // We dont want to show the predict superbowl slide in the carousel
+      if (slide.variableName === PREDICT_SUPERBOWL_VARIABLE_NAME) {
+        return false;
+      }
 
       return !dismissedBanners.includes(slide.id);
     });
@@ -309,22 +330,6 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
     selectedAccount,
     ///: END:ONLY_INCLUDE_IF
   ]);
-
-  const predictSuperbowlSlide = useMemo(
-    () =>
-      visibleSlides.find(
-        (slide) => slide.variableName === PREDICT_SUPERBOWL_VARIABLE_NAME,
-      ),
-    [visibleSlides],
-  );
-
-  const predictSuperbowlMarketId = useMemo(() => {
-    if (!predictSuperbowlSlide) return null;
-    const metadata = predictSuperbowlSlide.metadata as
-      | PredictCarouselMetadata
-      | undefined;
-    return metadata?.marketId ?? null;
-  }, [predictSuperbowlSlide]);
 
   // Ensure activeSlideIndex is within bounds after filtering
   const safeActiveSlideIndex = Math.min(
@@ -557,6 +562,11 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
     }
   }, [transitionToEmpty, onEmptyState]);
 
+  const handleSportCardDismiss = useCallback(() => {
+    if (!predictSuperbowlSlide) return;
+    dispatch(dismissBanner(predictSuperbowlSlide.id));
+  }, [predictSuperbowlSlide, dispatch]);
+
   const renderCard = useCallback(
     (slide: CarouselSlide, isCurrentCard: boolean) => {
       const isEmptyCard = slide.variableName === 'empty';
@@ -654,6 +664,7 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
           marketId={predictSuperbowlMarketId}
           testID={predictSuperbowlSlide?.testID}
           entryPoint={PredictEventValues.ENTRY_POINT.CAROUSEL}
+          onDismiss={handleSportCardDismiss}
         />
       </Box>
     );

--- a/app/components/UI/Carousel/types.ts
+++ b/app/components/UI/Carousel/types.ts
@@ -57,6 +57,7 @@ export interface CarouselSlide {
   testID?: string;
   testIDTitle?: string;
   testIDCloseButton?: string;
+  metadata?: unknown;
 }
 
 export interface CarouselProps {

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
@@ -424,4 +424,64 @@ describe('PredictMarketSportCard', () => {
       );
     });
   });
+
+  describe('onDismiss', () => {
+    it('does not render close button when onDismiss is not provided', () => {
+      const { queryByTestId } = renderWithProvider(
+        <PredictMarketSportCard market={mockMarket} testID="sport-card" />,
+        { state: initialState },
+      );
+
+      expect(queryByTestId('sport-card-close-button')).toBeNull();
+    });
+
+    it('renders close button when onDismiss is provided', () => {
+      const mockOnDismiss = jest.fn();
+
+      const { getByTestId } = renderWithProvider(
+        <PredictMarketSportCard
+          market={mockMarket}
+          testID="sport-card"
+          onDismiss={mockOnDismiss}
+        />,
+        { state: initialState },
+      );
+
+      expect(getByTestId('sport-card-close-button')).toBeOnTheScreen();
+    });
+
+    it('calls onDismiss when close button is pressed', () => {
+      const mockOnDismiss = jest.fn();
+
+      const { getByTestId } = renderWithProvider(
+        <PredictMarketSportCard
+          market={mockMarket}
+          testID="sport-card"
+          onDismiss={mockOnDismiss}
+        />,
+        { state: initialState },
+      );
+
+      fireEvent.press(getByTestId('sport-card-close-button'));
+
+      expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not navigate when close button is pressed', () => {
+      const mockOnDismiss = jest.fn();
+
+      const { getByTestId } = renderWithProvider(
+        <PredictMarketSportCard
+          market={mockMarket}
+          testID="sport-card"
+          onDismiss={mockOnDismiss}
+        />,
+        { state: initialState },
+      );
+
+      fireEvent.press(getByTestId('sport-card-close-button'));
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
@@ -483,5 +483,79 @@ describe('PredictMarketSportCard', () => {
 
       expect(mockNavigate).not.toHaveBeenCalled();
     });
+
+    it('renders close button without testID when onDismiss is provided but testID is not', () => {
+      const mockOnDismiss = jest.fn();
+
+      const { getByText } = renderWithProvider(
+        <PredictMarketSportCard
+          market={mockMarket}
+          onDismiss={mockOnDismiss}
+        />,
+        { state: initialState },
+      );
+
+      expect(getByText('Super Bowl LX (2026)')).toBeOnTheScreen();
+    });
+  });
+
+  describe('team color fallbacks', () => {
+    const mockGame = mockMarket.game;
+
+    it('uses fallback colors when game team colors are undefined', () => {
+      if (!mockGame) {
+        throw new Error('mockGame is required for this test');
+      }
+
+      const marketWithoutColors: PredictMarketType = {
+        ...mockMarket,
+        game: {
+          ...mockGame,
+          awayTeam: {
+            ...mockGame.awayTeam,
+            color: undefined as unknown as string,
+          },
+          homeTeam: {
+            ...mockGame.homeTeam,
+            color: undefined as unknown as string,
+          },
+        },
+      };
+
+      const { getByText } = renderWithProvider(
+        <PredictMarketSportCard market={marketWithoutColors} />,
+        { state: initialState },
+      );
+
+      expect(getByText('Super Bowl LX (2026)')).toBeOnTheScreen();
+    });
+
+    it('uses fallback colors when game team colors are null', () => {
+      if (!mockGame) {
+        throw new Error('mockGame is required for this test');
+      }
+
+      const marketWithNullColors: PredictMarketType = {
+        ...mockMarket,
+        game: {
+          ...mockGame,
+          awayTeam: {
+            ...mockGame.awayTeam,
+            color: null as unknown as string,
+          },
+          homeTeam: {
+            ...mockGame.homeTeam,
+            color: null as unknown as string,
+          },
+        },
+      };
+
+      const { getByText } = renderWithProvider(
+        <PredictMarketSportCard market={marketWithNullColors} />,
+        { state: initialState },
+      );
+
+      expect(getByText('Super Bowl LX (2026)')).toBeOnTheScreen();
+    });
   });
 });

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -3,6 +3,10 @@ import {
   Text,
   TextColor,
   TextVariant,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+  IconColor,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
@@ -24,12 +28,14 @@ interface PredictMarketSportCardProps {
   market: PredictMarketType;
   testID?: string;
   entryPoint?: PredictEntryPoint;
+  onDismiss?: () => void;
 }
 
 const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
   market,
   testID,
   entryPoint = PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+  onDismiss,
 }) => {
   const resolvedEntryPoint = TrendingFeedSessionManager.getInstance()
     .isFromTrending
@@ -63,6 +69,18 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
         borderRadius={16}
         style={tw.style('w-full my-[8px]')}
       >
+        {onDismiss && (
+          <Box twClassName="absolute top-2 right-2 z-10">
+            <ButtonIcon
+              iconName={IconName.Close}
+              size={ButtonIconSize.Sm}
+              iconProps={{ color: IconColor.IconDefault }}
+              onPress={onDismiss}
+              testID={testID ? `${testID}-close-button` : undefined}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            />
+          </Box>
+        )}
         <Box twClassName="p-4">
           <Text
             variant={TextVariant.HeadingSm}

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PredictMarketSportCardWrapper from './PredictMarketSportCardWrapper';
@@ -256,6 +257,50 @@ describe('PredictMarketSportCardWrapper', () => {
 
       const tree = toJSON();
       expect(tree).not.toBeNull();
+    });
+
+    it('renders close button when onDismiss is provided', () => {
+      const mockOnDismiss = jest.fn();
+
+      const { getByTestId } = renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          testID="wrapper-card"
+          onDismiss={mockOnDismiss}
+        />,
+        { state: initialState },
+      );
+
+      expect(getByTestId('wrapper-card-close-button')).toBeOnTheScreen();
+    });
+
+    it('calls onDismiss when close button is pressed', () => {
+      const mockOnDismiss = jest.fn();
+
+      const { getByTestId } = renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          testID="wrapper-card"
+          onDismiss={mockOnDismiss}
+        />,
+        { state: initialState },
+      );
+
+      fireEvent.press(getByTestId('wrapper-card-close-button'));
+
+      expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render close button when onDismiss is not provided', () => {
+      const { queryByTestId } = renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          testID="wrapper-card"
+        />,
+        { state: initialState },
+      );
+
+      expect(queryByTestId('wrapper-card-close-button')).toBeNull();
     });
   });
 

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
@@ -328,4 +328,102 @@ describe('PredictMarketSportCardWrapper', () => {
       });
     });
   });
+
+  describe('onLoad callback', () => {
+    it('calls onLoad when market data is available', () => {
+      const mockOnLoad = jest.fn();
+      mockUsePredictMarket.mockReturnValue({
+        market: mockMarket,
+        isFetching: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          onLoad={mockOnLoad}
+        />,
+        { state: initialState },
+      );
+
+      expect(mockOnLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onLoad when fetching', () => {
+      const mockOnLoad = jest.fn();
+      mockUsePredictMarket.mockReturnValue({
+        market: null,
+        isFetching: true,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          onLoad={mockOnLoad}
+        />,
+        { state: initialState },
+      );
+
+      expect(mockOnLoad).not.toHaveBeenCalled();
+    });
+
+    it('does not call onLoad when error occurs', () => {
+      const mockOnLoad = jest.fn();
+      mockUsePredictMarket.mockReturnValue({
+        market: null,
+        isFetching: false,
+        error: 'Failed to fetch',
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          onLoad={mockOnLoad}
+        />,
+        { state: initialState },
+      );
+
+      expect(mockOnLoad).not.toHaveBeenCalled();
+    });
+
+    it('does not call onLoad when market is null', () => {
+      const mockOnLoad = jest.fn();
+      mockUsePredictMarket.mockReturnValue({
+        market: null,
+        isFetching: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          onLoad={mockOnLoad}
+        />,
+        { state: initialState },
+      );
+
+      expect(mockOnLoad).not.toHaveBeenCalled();
+    });
+
+    it('does not call onLoad when onLoad is not provided', () => {
+      mockUsePredictMarket.mockReturnValue({
+        market: mockMarket,
+        isFetching: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider(
+        <PredictMarketSportCardWrapper marketId="test-market-id" />,
+        { state: initialState },
+      );
+
+      expect(mockUsePredictMarket).toHaveBeenCalled();
+    });
+  });
 });

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
@@ -1,0 +1,363 @@
+import React from 'react';
+import { Animated } from 'react-native';
+import { backgroundState } from '../../../../../util/test/initial-root-state';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import PredictMarketSportCardWrapper from './PredictMarketSportCardWrapper';
+import { PredictEventValues } from '../../constants/eventNames';
+import { usePredictMarket } from '../../hooks/usePredictMarket';
+import { Recurrence, PredictMarket as PredictMarketType } from '../../types';
+
+jest.mock('../../hooks/usePredictMarket');
+const mockUsePredictMarket = jest.mocked(usePredictMarket);
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+jest.mock('../../../Trending/services/TrendingFeedSessionManager', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      get isFromTrending() {
+        return false;
+      },
+    }),
+  },
+}));
+
+jest.mock('../PredictSportScoreboard/PredictSportScoreboard', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: function MockPredictSportScoreboard({
+      testID,
+    }: {
+      testID?: string;
+    }) {
+      return (
+        <View testID={testID ?? 'mock-scoreboard'}>
+          <Text>Mock Scoreboard</Text>
+        </View>
+      );
+    },
+  };
+});
+
+jest.mock('../PredictSportCardFooter', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    PredictSportCardFooter: function MockPredictSportCardFooter({
+      testID,
+    }: {
+      testID?: string;
+    }) {
+      return (
+        <View testID={testID ?? 'mock-footer'}>
+          <Text>Mock Footer</Text>
+        </View>
+      );
+    },
+  };
+});
+
+const mockMarket: PredictMarketType = {
+  id: 'test-market-id',
+  providerId: 'test-provider',
+  slug: 'super-bowl-lix',
+  title: 'Super Bowl LIX',
+  description: 'Who will win Super Bowl LIX?',
+  image: 'https://example.com/superbowl.png',
+  status: 'open',
+  recurrence: Recurrence.NONE,
+  category: 'sports',
+  tags: ['NFL', 'Super Bowl'],
+  outcomes: [
+    {
+      id: 'outcome-1',
+      providerId: 'test-provider',
+      marketId: 'test-market-id',
+      title: 'Team A',
+      description: 'Team A wins',
+      image: '',
+      status: 'open',
+      tokens: [{ id: 'token-1', title: 'Yes', price: 0.55 }],
+      volume: 1000000,
+      groupItemTitle: 'Team A',
+    },
+  ],
+  liquidity: 5000000,
+  volume: 10000000,
+  game: {
+    id: 'game-1',
+    startTime: '2025-02-09T23:30:00Z',
+    status: 'scheduled',
+    league: 'nfl',
+    elapsed: null,
+    period: null,
+    score: null,
+    awayTeam: {
+      id: 'team-a',
+      name: 'Team A',
+      logo: '',
+      abbreviation: 'TA',
+      color: '#FF0000',
+      alias: 'Team A',
+    },
+    homeTeam: {
+      id: 'team-b',
+      name: 'Team B',
+      logo: '',
+      abbreviation: 'TB',
+      color: '#0000FF',
+      alias: 'Team B',
+    },
+  },
+};
+
+const createAnimatedValue = (value: number) => new Animated.Value(value);
+
+const defaultAnimationProps = {
+  isCurrentCard: true,
+  currentCardOpacity: createAnimatedValue(1),
+  currentCardScale: createAnimatedValue(1),
+  currentCardTranslateY: createAnimatedValue(0),
+  nextCardOpacity: createAnimatedValue(0.7),
+  nextCardScale: createAnimatedValue(0.96),
+  nextCardTranslateY: createAnimatedValue(8),
+  width: 350,
+};
+
+const initialState = {
+  engine: {
+    backgroundState,
+  },
+};
+
+describe('PredictMarketSportCardWrapper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePredictMarket.mockReturnValue({
+      market: null,
+      isFetching: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('loading state', () => {
+    it('returns null when fetching market data', () => {
+      mockUsePredictMarket.mockReturnValue({
+        market: null,
+        isFetching: true,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      const { toJSON } = renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          {...defaultAnimationProps}
+        />,
+        { state: initialState },
+      );
+
+      expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe('error state', () => {
+    it('returns null when error occurs', () => {
+      mockUsePredictMarket.mockReturnValue({
+        market: null,
+        isFetching: false,
+        error: 'Failed to fetch market',
+        refetch: jest.fn(),
+      });
+
+      const { toJSON } = renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          {...defaultAnimationProps}
+        />,
+        { state: initialState },
+      );
+
+      expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe('no market data', () => {
+    it('returns null when market is null', () => {
+      mockUsePredictMarket.mockReturnValue({
+        market: null,
+        isFetching: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      const { toJSON } = renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          {...defaultAnimationProps}
+        />,
+        { state: initialState },
+      );
+
+      expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe('successful render', () => {
+    beforeEach(() => {
+      mockUsePredictMarket.mockReturnValue({
+        market: mockMarket,
+        isFetching: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+    });
+
+    it('renders PredictMarketSportCard when market data is available', () => {
+      const { getByText } = renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          {...defaultAnimationProps}
+        />,
+        { state: initialState },
+      );
+
+      expect(getByText('Super Bowl LIX')).toBeOnTheScreen();
+    });
+
+    it('calls usePredictMarket with correct marketId', () => {
+      renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="custom-market-id"
+          {...defaultAnimationProps}
+        />,
+        { state: initialState },
+      );
+
+      expect(mockUsePredictMarket).toHaveBeenCalledWith({
+        id: 'custom-market-id',
+        enabled: true,
+      });
+    });
+
+    it('passes testID to PredictMarketSportCard', () => {
+      const { getByTestId } = renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          testID="wrapper-test-id"
+          {...defaultAnimationProps}
+        />,
+        { state: initialState },
+      );
+
+      expect(getByTestId('wrapper-test-id')).toBeOnTheScreen();
+    });
+
+    it('passes entryPoint to PredictMarketSportCard', () => {
+      const { getByTestId } = renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          testID="wrapper-test-id"
+          entryPoint={PredictEventValues.ENTRY_POINT.CAROUSEL}
+          {...defaultAnimationProps}
+        />,
+        { state: initialState },
+      );
+
+      expect(getByTestId('wrapper-test-id')).toBeOnTheScreen();
+    });
+  });
+
+  describe('animation props', () => {
+    beforeEach(() => {
+      mockUsePredictMarket.mockReturnValue({
+        market: mockMarket,
+        isFetching: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+    });
+
+    it('renders with current card animation styles when isCurrentCard is true', () => {
+      const { toJSON } = renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          isCurrentCard
+          currentCardOpacity={createAnimatedValue(1)}
+          currentCardScale={createAnimatedValue(1)}
+          currentCardTranslateY={createAnimatedValue(0)}
+          nextCardOpacity={createAnimatedValue(0.7)}
+          nextCardScale={createAnimatedValue(0.96)}
+          nextCardTranslateY={createAnimatedValue(8)}
+          width={350}
+        />,
+        { state: initialState },
+      );
+
+      expect(toJSON()).not.toBeNull();
+    });
+
+    it('renders with next card animation styles when isCurrentCard is false', () => {
+      const { toJSON } = renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="test-market-id"
+          isCurrentCard={false}
+          currentCardOpacity={createAnimatedValue(1)}
+          currentCardScale={createAnimatedValue(1)}
+          currentCardTranslateY={createAnimatedValue(0)}
+          nextCardOpacity={createAnimatedValue(0.7)}
+          nextCardScale={createAnimatedValue(0.96)}
+          nextCardTranslateY={createAnimatedValue(8)}
+          width={350}
+        />,
+        { state: initialState },
+      );
+
+      expect(toJSON()).not.toBeNull();
+    });
+  });
+
+  describe('hook enabled state', () => {
+    it('disables hook when marketId is empty string', () => {
+      renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId=""
+          {...defaultAnimationProps}
+        />,
+        { state: initialState },
+      );
+
+      expect(mockUsePredictMarket).toHaveBeenCalledWith({
+        id: '',
+        enabled: false,
+      });
+    });
+
+    it('enables hook when marketId is provided', () => {
+      renderWithProvider(
+        <PredictMarketSportCardWrapper
+          marketId="valid-market-id"
+          {...defaultAnimationProps}
+        />,
+        { state: initialState },
+      );
+
+      expect(mockUsePredictMarket).toHaveBeenCalledWith({
+        id: 'valid-market-id',
+        enabled: true,
+      });
+    });
+  });
+});

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Animated } from 'react-native';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PredictMarketSportCardWrapper from './PredictMarketSportCardWrapper';
@@ -118,19 +117,6 @@ const mockMarket: PredictMarketType = {
   },
 };
 
-const createAnimatedValue = (value: number) => new Animated.Value(value);
-
-const defaultAnimationProps = {
-  isCurrentCard: true,
-  currentCardOpacity: createAnimatedValue(1),
-  currentCardScale: createAnimatedValue(1),
-  currentCardTranslateY: createAnimatedValue(0),
-  nextCardOpacity: createAnimatedValue(0.7),
-  nextCardScale: createAnimatedValue(0.96),
-  nextCardTranslateY: createAnimatedValue(8),
-  width: 350,
-};
-
 const initialState = {
   engine: {
     backgroundState,
@@ -162,10 +148,7 @@ describe('PredictMarketSportCardWrapper', () => {
       });
 
       const { toJSON } = renderWithProvider(
-        <PredictMarketSportCardWrapper
-          marketId="test-market-id"
-          {...defaultAnimationProps}
-        />,
+        <PredictMarketSportCardWrapper marketId="test-market-id" />,
         { state: initialState },
       );
 
@@ -183,10 +166,7 @@ describe('PredictMarketSportCardWrapper', () => {
       });
 
       const { toJSON } = renderWithProvider(
-        <PredictMarketSportCardWrapper
-          marketId="test-market-id"
-          {...defaultAnimationProps}
-        />,
+        <PredictMarketSportCardWrapper marketId="test-market-id" />,
         { state: initialState },
       );
 
@@ -204,10 +184,7 @@ describe('PredictMarketSportCardWrapper', () => {
       });
 
       const { toJSON } = renderWithProvider(
-        <PredictMarketSportCardWrapper
-          marketId="test-market-id"
-          {...defaultAnimationProps}
-        />,
+        <PredictMarketSportCardWrapper marketId="test-market-id" />,
         { state: initialState },
       );
 
@@ -227,10 +204,7 @@ describe('PredictMarketSportCardWrapper', () => {
 
     it('renders PredictMarketSportCard when market data is available', () => {
       const { getByText } = renderWithProvider(
-        <PredictMarketSportCardWrapper
-          marketId="test-market-id"
-          {...defaultAnimationProps}
-        />,
+        <PredictMarketSportCardWrapper marketId="test-market-id" />,
         { state: initialState },
       );
 
@@ -239,10 +213,7 @@ describe('PredictMarketSportCardWrapper', () => {
 
     it('calls usePredictMarket with correct marketId', () => {
       renderWithProvider(
-        <PredictMarketSportCardWrapper
-          marketId="custom-market-id"
-          {...defaultAnimationProps}
-        />,
+        <PredictMarketSportCardWrapper marketId="custom-market-id" />,
         { state: initialState },
       );
 
@@ -257,7 +228,6 @@ describe('PredictMarketSportCardWrapper', () => {
         <PredictMarketSportCardWrapper
           marketId="test-market-id"
           testID="wrapper-test-id"
-          {...defaultAnimationProps}
         />,
         { state: initialState },
       );
@@ -271,73 +241,29 @@ describe('PredictMarketSportCardWrapper', () => {
           marketId="test-market-id"
           testID="wrapper-test-id"
           entryPoint={PredictEventValues.ENTRY_POINT.CAROUSEL}
-          {...defaultAnimationProps}
         />,
         { state: initialState },
       );
 
       expect(getByTestId('wrapper-test-id')).toBeOnTheScreen();
     });
-  });
 
-  describe('animation props', () => {
-    beforeEach(() => {
-      mockUsePredictMarket.mockReturnValue({
-        market: mockMarket,
-        isFetching: false,
-        error: null,
-        refetch: jest.fn(),
-      });
-    });
-
-    it('renders with current card animation styles when isCurrentCard is true', () => {
+    it('renders without Animated.View wrapper', () => {
       const { toJSON } = renderWithProvider(
-        <PredictMarketSportCardWrapper
-          marketId="test-market-id"
-          isCurrentCard
-          currentCardOpacity={createAnimatedValue(1)}
-          currentCardScale={createAnimatedValue(1)}
-          currentCardTranslateY={createAnimatedValue(0)}
-          nextCardOpacity={createAnimatedValue(0.7)}
-          nextCardScale={createAnimatedValue(0.96)}
-          nextCardTranslateY={createAnimatedValue(8)}
-          width={350}
-        />,
+        <PredictMarketSportCardWrapper marketId="test-market-id" />,
         { state: initialState },
       );
 
-      expect(toJSON()).not.toBeNull();
-    });
-
-    it('renders with next card animation styles when isCurrentCard is false', () => {
-      const { toJSON } = renderWithProvider(
-        <PredictMarketSportCardWrapper
-          marketId="test-market-id"
-          isCurrentCard={false}
-          currentCardOpacity={createAnimatedValue(1)}
-          currentCardScale={createAnimatedValue(1)}
-          currentCardTranslateY={createAnimatedValue(0)}
-          nextCardOpacity={createAnimatedValue(0.7)}
-          nextCardScale={createAnimatedValue(0.96)}
-          nextCardTranslateY={createAnimatedValue(8)}
-          width={350}
-        />,
-        { state: initialState },
-      );
-
-      expect(toJSON()).not.toBeNull();
+      const tree = toJSON();
+      expect(tree).not.toBeNull();
     });
   });
 
   describe('hook enabled state', () => {
     it('disables hook when marketId is empty string', () => {
-      renderWithProvider(
-        <PredictMarketSportCardWrapper
-          marketId=""
-          {...defaultAnimationProps}
-        />,
-        { state: initialState },
-      );
+      renderWithProvider(<PredictMarketSportCardWrapper marketId="" />, {
+        state: initialState,
+      });
 
       expect(mockUsePredictMarket).toHaveBeenCalledWith({
         id: '',
@@ -347,10 +273,7 @@ describe('PredictMarketSportCardWrapper', () => {
 
     it('enables hook when marketId is provided', () => {
       renderWithProvider(
-        <PredictMarketSportCardWrapper
-          marketId="valid-market-id"
-          {...defaultAnimationProps}
-        />,
+        <PredictMarketSportCardWrapper marketId="valid-market-id" />,
         { state: initialState },
       );
 

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Animated } from 'react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import PredictMarketSportCard from './PredictMarketSportCard';
+import { usePredictMarket } from '../../hooks/usePredictMarket';
+import { PredictEntryPoint } from '../../types/navigation';
+
+interface PredictMarketSportCardWrapperProps {
+  marketId: string;
+  testID?: string;
+  entryPoint?: PredictEntryPoint;
+  isCurrentCard: boolean;
+  currentCardOpacity: Animated.Value;
+  currentCardScale: Animated.Value;
+  currentCardTranslateY: Animated.Value;
+  nextCardOpacity: Animated.Value;
+  nextCardScale: Animated.Value;
+  nextCardTranslateY: Animated.Value;
+  width: number;
+}
+
+const PredictMarketSportCardWrapper: React.FC<
+  PredictMarketSportCardWrapperProps
+> = ({
+  marketId,
+  testID,
+  entryPoint,
+  isCurrentCard,
+  currentCardOpacity,
+  currentCardScale,
+  currentCardTranslateY,
+  nextCardOpacity,
+  nextCardScale,
+  nextCardTranslateY,
+  width,
+}) => {
+  const tw = useTailwind();
+  const { market, isFetching, error } = usePredictMarket({
+    id: marketId,
+    enabled: Boolean(marketId),
+  });
+
+  if (isFetching || error || !market) {
+    return null;
+  }
+
+  return (
+    <Animated.View
+      style={tw.style('absolute', {
+        opacity: isCurrentCard ? currentCardOpacity : nextCardOpacity,
+        transform: [
+          { scale: isCurrentCard ? currentCardScale : nextCardScale },
+          {
+            translateY: isCurrentCard
+              ? currentCardTranslateY
+              : nextCardTranslateY,
+          },
+        ],
+        zIndex: isCurrentCard ? 10 : 5,
+        width,
+      })}
+    >
+      <PredictMarketSportCard
+        market={market}
+        testID={testID}
+        entryPoint={entryPoint}
+      />
+    </Animated.View>
+  );
+};
+
+export default PredictMarketSportCardWrapper;

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PredictMarketSportCard from './PredictMarketSportCard';
 import { usePredictMarket } from '../../hooks/usePredictMarket';
 import { PredictEntryPoint } from '../../types/navigation';
+import { Box } from '@metamask/design-system-react-native';
 
 interface PredictMarketSportCardWrapperProps {
   marketId: string;
@@ -23,12 +24,14 @@ const PredictMarketSportCardWrapper: React.FC<
   }
 
   return (
-    <PredictMarketSportCard
-      market={market}
-      testID={testID}
-      entryPoint={entryPoint}
-      onDismiss={onDismiss}
-    />
+    <Box twClassName="mx-4">
+      <PredictMarketSportCard
+        market={market}
+        testID={testID}
+        entryPoint={entryPoint}
+        onDismiss={onDismiss}
+      />
+    </Box>
   );
 };
 

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { Animated } from 'react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import PredictMarketSportCard from './PredictMarketSportCard';
 import { usePredictMarket } from '../../hooks/usePredictMarket';
 import { PredictEntryPoint } from '../../types/navigation';
@@ -9,32 +7,11 @@ interface PredictMarketSportCardWrapperProps {
   marketId: string;
   testID?: string;
   entryPoint?: PredictEntryPoint;
-  isCurrentCard: boolean;
-  currentCardOpacity: Animated.Value;
-  currentCardScale: Animated.Value;
-  currentCardTranslateY: Animated.Value;
-  nextCardOpacity: Animated.Value;
-  nextCardScale: Animated.Value;
-  nextCardTranslateY: Animated.Value;
-  width: number;
 }
 
 const PredictMarketSportCardWrapper: React.FC<
   PredictMarketSportCardWrapperProps
-> = ({
-  marketId,
-  testID,
-  entryPoint,
-  isCurrentCard,
-  currentCardOpacity,
-  currentCardScale,
-  currentCardTranslateY,
-  nextCardOpacity,
-  nextCardScale,
-  nextCardTranslateY,
-  width,
-}) => {
-  const tw = useTailwind();
+> = ({ marketId, testID, entryPoint }) => {
   const { market, isFetching, error } = usePredictMarket({
     id: marketId,
     enabled: Boolean(marketId),
@@ -45,27 +22,11 @@ const PredictMarketSportCardWrapper: React.FC<
   }
 
   return (
-    <Animated.View
-      style={tw.style('absolute', {
-        opacity: isCurrentCard ? currentCardOpacity : nextCardOpacity,
-        transform: [
-          { scale: isCurrentCard ? currentCardScale : nextCardScale },
-          {
-            translateY: isCurrentCard
-              ? currentCardTranslateY
-              : nextCardTranslateY,
-          },
-        ],
-        zIndex: isCurrentCard ? 10 : 5,
-        width,
-      })}
-    >
-      <PredictMarketSportCard
-        market={market}
-        testID={testID}
-        entryPoint={entryPoint}
-      />
-    </Animated.View>
+    <PredictMarketSportCard
+      market={market}
+      testID={testID}
+      entryPoint={entryPoint}
+    />
   );
 };
 

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
@@ -7,11 +7,12 @@ interface PredictMarketSportCardWrapperProps {
   marketId: string;
   testID?: string;
   entryPoint?: PredictEntryPoint;
+  onDismiss?: () => void;
 }
 
 const PredictMarketSportCardWrapper: React.FC<
   PredictMarketSportCardWrapperProps
-> = ({ marketId, testID, entryPoint }) => {
+> = ({ marketId, testID, entryPoint, onDismiss }) => {
   const { market, isFetching, error } = usePredictMarket({
     id: marketId,
     enabled: Boolean(marketId),
@@ -26,6 +27,7 @@ const PredictMarketSportCardWrapper: React.FC<
       market={market}
       testID={testID}
       entryPoint={entryPoint}
+      onDismiss={onDismiss}
     />
   );
 };

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PredictMarketSportCard from './PredictMarketSportCard';
 import { usePredictMarket } from '../../hooks/usePredictMarket';
 import { PredictEntryPoint } from '../../types/navigation';
@@ -9,15 +9,24 @@ interface PredictMarketSportCardWrapperProps {
   testID?: string;
   entryPoint?: PredictEntryPoint;
   onDismiss?: () => void;
+  onLoad?: () => void;
 }
 
 const PredictMarketSportCardWrapper: React.FC<
   PredictMarketSportCardWrapperProps
-> = ({ marketId, testID, entryPoint, onDismiss }) => {
+> = ({ marketId, testID, entryPoint, onDismiss, onLoad }) => {
   const { market, isFetching, error } = usePredictMarket({
     id: marketId,
     enabled: Boolean(marketId),
   });
+  const hasCalledOnLoad = useRef(false);
+
+  useEffect(() => {
+    if (!isFetching && !error && market && onLoad && !hasCalledOnLoad.current) {
+      hasCalledOnLoad.current = true;
+      onLoad();
+    }
+  }, [isFetching, error, market, onLoad]);
 
   if (isFetching || error || !market) {
     return null;

--- a/app/components/UI/Predict/components/PredictMarketSportCard/index.ts
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/index.ts
@@ -1,1 +1,2 @@
 export { default } from './PredictMarketSportCard';
+export { default as PredictMarketSportCardWrapper } from './PredictMarketSportCardWrapper';

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
@@ -585,6 +585,34 @@ describe('PredictSportCardFooter', () => {
         );
       });
     });
+
+    it('navigates through PREDICT.ROOT when entry point is CAROUSEL', async () => {
+      mockIsFromTrending.mockReturnValue(false);
+      const market = createMockMarket();
+      setupPositionsMock();
+      mockExecuteGuardedAction.mockImplementation((callback) => callback());
+
+      render(
+        <PredictSportCardFooter
+          market={market}
+          entryPoint={PredictEventValues.ENTRY_POINT.CAROUSEL}
+          testID="footer"
+        />,
+      );
+      fireEvent.press(screen.getByTestId('footer-action-buttons-bet-yes'));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+          screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
+          params: {
+            market,
+            outcome: market.outcomes[0],
+            outcomeToken: market.outcomes[0].tokens[0],
+            entryPoint: PredictEventValues.ENTRY_POINT.CAROUSEL,
+          },
+        });
+      });
+    });
   });
 
   describe('handleClaimPress', () => {

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
@@ -699,5 +699,31 @@ describe('PredictSportCardFooter', () => {
 
       expect(screen.getByTestId('mock-action-buttons')).toBeOnTheScreen();
     });
+
+    it('renders picks without testID when testID prop is not provided', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.OPEN });
+      const positions = [createMockPosition({ claimable: false })];
+      setupPositionsMock({ activePositions: positions });
+
+      render(<PredictSportCardFooter market={market} />);
+
+      expect(screen.getByTestId('mock-picks-for-card')).toBeOnTheScreen();
+    });
+
+    it('renders claim button without testID when testID prop is not provided', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
+      const claimablePositions = [
+        createMockPosition({ claimable: true, currentValue: 50 }),
+      ];
+      setupPositionsMock({
+        activePositions: claimablePositions,
+        claimablePositions,
+      });
+
+      render(<PredictSportCardFooter market={market} />);
+
+      expect(screen.getByTestId('mock-action-buttons')).toBeOnTheScreen();
+      expect(screen.getByText('Claim $50')).toBeOnTheScreen();
+    });
   });
 });

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
@@ -69,12 +69,26 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
     (token: PredictOutcomeToken) => {
       executeGuardedAction(
         () => {
-          navigation.navigate(Routes.PREDICT.MODALS.BUY_PREVIEW, {
-            market,
-            outcome,
-            outcomeToken: token,
-            entryPoint: resolvedEntryPoint,
-          });
+          // When accessed from Carousel, we're outside the Predict navigator,
+          // so we need to navigate through the ROOT first
+          if (resolvedEntryPoint === PredictEventValues.ENTRY_POINT.CAROUSEL) {
+            navigation.navigate(Routes.PREDICT.ROOT, {
+              screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
+              params: {
+                market,
+                outcome,
+                outcomeToken: token,
+                entryPoint: resolvedEntryPoint,
+              },
+            });
+          } else {
+            navigation.navigate(Routes.PREDICT.MODALS.BUY_PREVIEW, {
+              market,
+              outcome,
+              outcomeToken: token,
+              entryPoint: resolvedEntryPoint,
+            });
+          }
         },
         {
           checkBalance: true,

--- a/app/components/UI/Predict/constants/carousel.ts
+++ b/app/components/UI/Predict/constants/carousel.ts
@@ -1,0 +1,1 @@
+export const PREDICT_SUPERBOWL_VARIABLE_NAME = 'predict-superbowl';

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -403,3 +403,7 @@ export type PredictWithdraw = {
 export type PredictAccountMeta = {
   isOnboarded: boolean;
 };
+
+export interface PredictCarouselMetadata {
+  marketId: string;
+}

--- a/app/components/UI/Predict/types/navigation.ts
+++ b/app/components/UI/Predict/types/navigation.ts
@@ -9,6 +9,7 @@ import {
 import { PredictEventValues } from '../constants/eventNames';
 
 export type PredictEntryPoint =
+  | typeof PredictEventValues.ENTRY_POINT.CAROUSEL
   | typeof PredictEventValues.ENTRY_POINT.PREDICT_FEED
   | typeof PredictEventValues.ENTRY_POINT.PREDICT_MARKET_DETAILS
   | typeof PredictEventValues.ENTRY_POINT.SEARCH


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR integrates the Predict Superbowl sport card into the wallet home Carousel component. When a `predict-superbowl` slide is configured in Contentful with a valid `marketId`, the Carousel renders a `PredictMarketSportCardWrapper` instead of the standard carousel cards.

**Key changes:**
- Added `PredictMarketSportCardWrapper` component that fetches market data and renders `PredictMarketSportCard`
- Added `metadata` field to `CarouselSlide` type to support passing `marketId`
- Added `CAROUSEL` entry point for Predict navigation tracking
- Modified `PredictSportCardFooter` to navigate through `PREDICT.ROOT` when accessed from Carousel
- Added close button functionality to `PredictMarketSportCard` for dismissing the banner
- Added comprehensive unit tests for all new components and integration

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?

AI agent: Be specific about what you changed and why. Include context about the fix/feature, not generic descriptions.
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)

AI agent: Use format `CHANGELOG entry: [fix/feat/chore]: [User-facing description in past tense]`.
Examples: `fix: resolved token name display issue`, `feat: added dark mode toggle`, `chore: updated dependencies`.
For non-user-facing changes, use `CHANGELOG entry: null`.
-->

CHANGELOG entry: null

## **Related issues**

<!--
AI agent: Replace with `Fixes: #[ISSUE_NUMBER]` using the actual issue number you're implementing.
-->

Fixes:

## **Manual testing steps**

<!--
AI agent: Write specific, contextual Gherkin steps based on what you actually implemented.
Do NOT use generic placeholders like "my feature name". Be concrete about the feature, scenario, and steps.
-->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

https://www.loom.com/share/232ede925eef4c75ab9e322573d03363

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
AI agent: Check ALL boxes in this section (mark all as [x]).
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

<!--
AI agent: Leave ALL boxes unchecked ([ ]) - these are for reviewers to check, not the author.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates Predict Super Bowl content into the wallet carousel based on Contentful configuration.
> 
> - Adds `metadata` to `CarouselSlide` and maps it from Contentful to extract `marketId`
> - In `Carousel`, detects `predict-superbowl` slides, hides them from regular cards, and renders `PredictMarketSportCardWrapper` directly with `entryPoint = CAROUSEL`; supports dismiss via Redux and tracks "Banner Display" on load
> - Introduces `PredictMarketSportCardWrapper` to fetch market data and call optional `onLoad`; `PredictMarketSportCard` now supports an optional close button
> - Updates `PredictSportCardFooter` to navigate through `Routes.PREDICT.ROOT` when `entryPoint` is `CAROUSEL`
> - Adds `PREDICT_SUPERBOWL_VARIABLE_NAME`, `PredictCarouselMetadata`, and extends `PredictEntryPoint` with `CAROUSEL`
> - Comprehensive unit tests added for carousel integration, card wrapper, card close button, and footer navigation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ebd8779394d20ff08ff105b7d11b9f4096e3198. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->