### PR TITLE
chore: Align spacing in Token Details page

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.styles.ts
+++ b/app/components/UI/AssetOverview/AssetOverview.styles.ts
@@ -89,7 +89,7 @@ const styleSheet = (params: { theme: Theme }) => {
       paddingHorizontal: 16,
     },
     tokenDetailsWrapper: {
-      marginBottom: 20,
+      marginBottom: 12,
       paddingHorizontal: 16,
     },
   });

--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -114,6 +114,8 @@ interface AssetOverviewProps {
   displaySwapsButton?: boolean;
   networkName?: string;
   hidePrice?: boolean;
+  timePeriod?: TimePeriod;
+  onTimePeriodChange?: (timePeriod: TimePeriod) => void;
 }
 
 const AssetOverview: React.FC<AssetOverviewProps> = ({
@@ -122,12 +124,16 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
   displaySwapsButton,
   networkName,
   hidePrice = false,
+  timePeriod: timePeriodProp,
+  onTimePeriodChange,
 }: AssetOverviewProps) => {
   // For non evm assets, the resultChainId is equal to the asset.chainId; while for evm assets; the resultChainId === "eip155:1" !== asset.chainId
   const resultChainId = formatChainIdToCaip(asset.chainId as Hex);
   const isNonEvmAsset = resultChainId === asset.chainId;
   const navigation = useNavigation();
-  const [timePeriod, setTimePeriod] = React.useState<TimePeriod>('1d');
+  const [timePeriodInternal, setTimePeriodInternal] =
+    React.useState<TimePeriod>('1d');
+  const timePeriod = timePeriodProp ?? timePeriodInternal;
   const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
   const selectedInternalAccountAddress = selectedInternalAccount?.address;
   const selectedAccountGroup = useSelector(selectSelectedAccountGroup);
@@ -415,9 +421,16 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
     [isNonEvmAsset],
   );
 
-  const handleSelectTimePeriod = useCallback((_timePeriod: TimePeriod) => {
-    setTimePeriod(_timePeriod);
-  }, []);
+  const handleSelectTimePeriod = useCallback(
+    (_timePeriod: TimePeriod) => {
+      if (onTimePeriodChange) {
+        onTimePeriodChange(_timePeriod);
+      } else {
+        setTimePeriodInternal(_timePeriod);
+      }
+    },
+    [onTimePeriodChange],
+  );
 
   const renderChartNavigationButton = useCallback(
     () =>

--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -48,6 +48,8 @@ import useTokenHistoricalPrices, {
 import Balance from './Balance';
 import ChartNavigationButton from './ChartNavigationButton';
 import Price from './Price';
+import PriceChart from './PriceChart';
+import { distributeDataPoints } from './PriceChart/utils';
 import styleSheet from './AssetOverview.styles';
 import { useStyles } from '../../../component-library/hooks';
 import Routes from '../../../constants/navigation/Routes';
@@ -111,6 +113,7 @@ interface AssetOverviewProps {
   displayBuyButton?: boolean;
   displaySwapsButton?: boolean;
   networkName?: string;
+  hidePrice?: boolean;
 }
 
 const AssetOverview: React.FC<AssetOverviewProps> = ({
@@ -118,6 +121,7 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
   displayBuyButton,
   displaySwapsButton,
   networkName,
+  hidePrice = false,
 }: AssetOverviewProps) => {
   // For non evm assets, the resultChainId is equal to the asset.chainId; while for evm assets; the resultChainId === "eip155:1" !== asset.chainId
   const resultChainId = formatChainIdToCaip(asset.chainId as Hex);
@@ -651,19 +655,35 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
         renderWarning()
       ) : (
         <View>
-          <Price
-            asset={asset}
-            prices={prices}
-            priceDiff={priceDiff}
-            currentCurrency={currentCurrency}
-            currentPrice={currentPrice}
-            comparePrice={comparePrice}
-            isLoading={isLoading}
-            timePeriod={timePeriod}
-          />
-          <View style={styles.chartNavigationWrapper}>
-            {renderChartNavigationButton()}
-          </View>
+          {hidePrice ? (
+            <>
+              <PriceChart
+                prices={distributeDataPoints(prices)}
+                priceDiff={priceDiff}
+                isLoading={isLoading}
+                onChartIndexChange={() => {}}
+              />
+              <View style={styles.chartNavigationWrapper}>
+                {renderChartNavigationButton()}
+              </View>
+            </>
+          ) : (
+            <>
+              <Price
+                asset={asset}
+                prices={prices}
+                priceDiff={priceDiff}
+                currentCurrency={currentCurrency}
+                currentPrice={currentPrice}
+                comparePrice={comparePrice}
+                isLoading={isLoading}
+                timePeriod={timePeriod}
+              />
+              <View style={styles.chartNavigationWrapper}>
+                {renderChartNavigationButton()}
+              </View>
+            </>
+          )}
           <AssetDetailsActions
             displayBuyButton={displayBuyButton}
             displaySwapsButton={displaySwapsButton}

--- a/app/components/UI/AssetOverview/TokenDetails/TokenDetails.styles.tsx
+++ b/app/components/UI/AssetOverview/TokenDetails/TokenDetails.styles.tsx
@@ -10,7 +10,7 @@ const styleSheet = () =>
       paddingVertical: 8,
     } as TextStyle,
     listWrapper: {
-      paddingTop: 8,
+      paddingTop: 4,
       paddingBottom: 8,
     },
     listItem: {

--- a/app/components/UI/AssetOverview/TokenDetails/TokenDetails.styles.tsx
+++ b/app/components/UI/AssetOverview/TokenDetails/TokenDetails.styles.tsx
@@ -4,7 +4,7 @@ const styleSheet = () =>
   StyleSheet.create({
     tokenDetailsContainer: {
       marginTop: 16,
-      gap: 24,
+      gap: 12,
     },
     title: {
       paddingVertical: 8,

--- a/app/components/UI/AssetOverview/TokenDetails/TokenDetailsList/TokenDetailsList.tsx
+++ b/app/components/UI/AssetOverview/TokenDetails/TokenDetailsList/TokenDetailsList.tsx
@@ -65,7 +65,7 @@ const TokenDetailsList: React.FC<TokenDetailsListProps> = ({
               style={tw`flex-row items-center gap-1`}
               onPress={copyAccountToClipboard}
             >
-              <Text variant={TextVariant.BodySM}>
+              <Text variant={TextVariant.BodyMD}>
                 {formatAddress(tokenDetails.contractAddress, 'short')}
               </Text>
               <Icon name={DesignSystemIconName.Copy} size={IconSize.Sm} />

--- a/app/components/UI/AssetOverview/TokenDetails/TokenDetailsListItem.tsx
+++ b/app/components/UI/AssetOverview/TokenDetails/TokenDetailsListItem.tsx
@@ -23,7 +23,7 @@ const TokenDetailsListItem: React.FC<TokenDetailsListItemProps> = ({
       {label}
     </Text>
     {children || (
-      <Text variant={TextVariant.BodySM} color={TextColor.Default}>
+      <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
         {value}
       </Text>
     )}

--- a/app/components/UI/Earn/components/EarnLendingBalance/EarnLendingBalance.styles.ts
+++ b/app/components/UI/Earn/components/EarnLendingBalance/EarnLendingBalance.styles.ts
@@ -16,7 +16,7 @@ const styleSheet = (params: {
       gap: 16,
     },
     buttonsContainer: {
-      marginTop: 4,
+      marginTop: 2,
     },
     button: {
       flex: 1,
@@ -38,7 +38,7 @@ const styleSheet = (params: {
       paddingTop: 16,
     },
     earnings: {
-      paddingTop: 16,
+      paddingTop: 24,
     },
   });
 };

--- a/app/components/UI/Earn/components/EarnLendingBalance/EarnLendingBalance.styles.ts
+++ b/app/components/UI/Earn/components/EarnLendingBalance/EarnLendingBalance.styles.ts
@@ -16,10 +16,7 @@ const styleSheet = (params: {
       gap: 16,
     },
     buttonsContainer: {
-      marginTop: 16,
-      padding: 16,
-      borderRadius: 12,
-      backgroundColor: theme.colors.background.section,
+      marginTop: 4,
     },
     button: {
       flex: 1,
@@ -41,7 +38,6 @@ const styleSheet = (params: {
       paddingTop: 16,
     },
     earnings: {
-      paddingHorizontal: 16,
       paddingTop: 16,
     },
   });

--- a/app/components/UI/Earn/components/Earnings/Earnings.styles.ts
+++ b/app/components/UI/Earn/components/Earnings/Earnings.styles.ts
@@ -21,7 +21,7 @@ const styleSheet = (params: { theme: Theme }) => {
     keyValueRow: {
       flexDirection: 'row',
       justifyContent: 'space-between',
-      paddingVertical: 8,
+      paddingVertical: 4,
     },
     keyValuePrimaryTextWrapper: {
       flexDirection: 'row',

--- a/app/components/UI/Earn/components/Earnings/Earnings.styles.ts
+++ b/app/components/UI/Earn/components/Earnings/Earnings.styles.ts
@@ -13,7 +13,7 @@ const styleSheet = (params: { theme: Theme }) => {
       right: 15,
     },
     earningsContainer: {
-      paddingTop: 16,
+      paddingTop: 0,
     },
     title: {
       paddingBottom: 8,

--- a/app/components/UI/Earn/components/Earnings/EarningsHistoryButton/EarningsHistoryButton.styles.ts
+++ b/app/components/UI/Earn/components/Earnings/EarningsHistoryButton/EarningsHistoryButton.styles.ts
@@ -3,7 +3,7 @@ import { StyleSheet } from 'react-native';
 const styleSheet = () =>
   StyleSheet.create({
     container: {
-      marginTop: 20,
+      marginTop: 16,
     },
   });
 

--- a/app/components/UI/Earn/components/Earnings/EarningsHistoryButton/EarningsHistoryButton.styles.ts
+++ b/app/components/UI/Earn/components/Earnings/EarningsHistoryButton/EarningsHistoryButton.styles.ts
@@ -1,0 +1,10 @@
+import { StyleSheet } from 'react-native';
+
+const styleSheet = () =>
+  StyleSheet.create({
+    container: {
+      marginTop: 20,
+    },
+  });
+
+export default styleSheet;

--- a/app/components/UI/Earn/components/Earnings/EarningsHistoryButton/EarningsHistoryButton.tsx
+++ b/app/components/UI/Earn/components/Earnings/EarningsHistoryButton/EarningsHistoryButton.tsx
@@ -2,7 +2,10 @@ import { useNavigation } from '@react-navigation/native';
 import React from 'react';
 import { View } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
+import { useStyles } from '../../../../../../component-library/hooks';
+import styleSheet from './EarningsHistoryButton.styles';
 import Button, {
+  ButtonSize,
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../../component-library/components/Buttons/Button';
@@ -20,6 +23,7 @@ interface EarningsHistoryButtonProps {
 
 const EarningsHistoryButton = ({ asset }: EarningsHistoryButtonProps) => {
   const { navigate } = useNavigation();
+  const { styles } = useStyles(styleSheet, {});
 
   const { outputToken } = useSelector((state: RootState) =>
     earnSelectors.selectEarnTokenPair(state, asset),
@@ -32,11 +36,12 @@ const EarningsHistoryButton = ({ asset }: EarningsHistoryButtonProps) => {
   };
 
   return (
-    <View>
+    <View style={styles.container}>
       <Button
         testID={WalletViewSelectorsIDs.EARN_EARNINGS_HISTORY_BUTTON}
         width={ButtonWidthTypes.Full}
         variant={ButtonVariants.Secondary}
+        size={ButtonSize.Lg}
         label={
           outputToken?.experience?.type === EARN_EXPERIENCES.STABLECOIN_LENDING
             ? strings('earn.view_earnings_history.lending')

--- a/app/components/UI/Earn/components/Earnings/index.tsx
+++ b/app/components/UI/Earn/components/Earnings/index.tsx
@@ -98,7 +98,7 @@ const EarningsContent = ({ asset }: EarningsProps) => {
           <View style={styles.keyValuePrimaryTextWrapper}>
             <Text
               variant={TextVariant.BodyMDMedium}
-              style={styles.keyValuePrimaryText}
+              color={TextColor.Alternative}
             >
               {strings('stake.annual_rate')}
             </Text>
@@ -138,12 +138,12 @@ const EarningsContent = ({ asset }: EarningsProps) => {
         {experienceType === EARN_EXPERIENCES.POOLED_STAKING && (
           <View style={styles.keyValueRow}>
             <View style={styles.keyValuePrimaryTextWrapperCentered}>
-              <Text
-                variant={TextVariant.BodyMDMedium}
-                style={styles.keyValuePrimaryText}
-              >
-                {strings('stake.lifetime_rewards')}
-              </Text>
+            <Text
+              variant={TextVariant.BodyMDMedium}
+              color={TextColor.Alternative}
+            >
+              {strings('stake.lifetime_rewards')}
+            </Text>
             </View>
             <View style={styles.keyValueSecondaryText}>
               {isLoadingEarningsData ? (
@@ -166,7 +166,7 @@ const EarningsContent = ({ asset }: EarningsProps) => {
                     {lifetimeRewardsFiat}
                   </Text>
                   <Text
-                    variant={TextVariant.BodySMMedium}
+                    variant={TextVariant.BodySM}
                     color={TextColor.Alternative}
                   >
                     {lifetimeRewards}

--- a/app/components/UI/Stake/components/PoolStakingLearnMoreModal/PoolStakingLearnMoreModal.styles.ts
+++ b/app/components/UI/Stake/components/PoolStakingLearnMoreModal/PoolStakingLearnMoreModal.styles.ts
@@ -1,4 +1,4 @@
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 const styleSheet = () =>
   StyleSheet.create({
@@ -10,7 +10,8 @@ const styleSheet = () =>
       fontStyle: 'italic',
     },
     footer: {
-      paddingVertical: 16,
+      paddingTop: 24,
+      paddingBottom: Platform.OS === 'ios' ? 16 : 0,
       paddingHorizontal: 16,
     },
   });

--- a/app/components/UI/Stake/components/PoolStakingLearnMoreModal/index.tsx
+++ b/app/components/UI/Stake/components/PoolStakingLearnMoreModal/index.tsx
@@ -7,7 +7,7 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { ScrollView, View } from 'react-native';
-import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import HeaderCenter from '../../../../../component-library/components-temp/HeaderCenter';
 import BottomSheetFooter, {
   ButtonsAlignment,
 } from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
@@ -190,11 +190,10 @@ const PoolStakingLearnMoreModal = () => {
   return (
     <BottomSheet ref={sheetRef} isInteractable={false}>
       <ScrollView bounces={false}>
-        <BottomSheetHeader onClose={handleClose}>
-          <Text variant={TextVariant.HeadingSM}>
-            {strings('stake.stake_eth_and_earn')}
-          </Text>
-        </BottomSheetHeader>
+        <HeaderCenter
+          title={strings('stake.stake_eth_and_earn')}
+          onClose={handleClose}
+        />
         {Boolean(reversedVaultApys.length) && activeTimespanApyAverage && (
           <InteractiveTimespanChart
             dataPoints={reversedVaultApys}

--- a/app/components/UI/Stake/components/StakingBalance/StakingBalance.styles.ts
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBalance.styles.ts
@@ -19,13 +19,13 @@ const styleSheet = (params: { theme: Theme }) =>
     balances: {
       flex: 1,
       justifyContent: 'center',
-      marginLeft: 16,
+      marginLeft: 20,
       alignSelf: 'center',
     },
     ethLogo: {
-      width: 32,
-      height: 32,
-      borderRadius: 16,
+      width: 40,
+      height: 40,
+      borderRadius: 20,
       overflow: 'hidden',
     },
     bannerStyles: {

--- a/app/components/UI/Stake/components/StakingBalance/StakingBalance.styles.ts
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBalance.styles.ts
@@ -11,7 +11,7 @@ const styleSheet = (params: { theme: Theme }) =>
     },
     stakingEarnings: {
       paddingHorizontal: 16,
-      paddingTop: 16,
+      paddingTop: 24,
     },
     badgeWrapper: {
       alignSelf: 'center',
@@ -32,7 +32,7 @@ const styleSheet = (params: { theme: Theme }) =>
       marginVertical: 8,
     },
     buttonsContainer: {
-      paddingTop: 8,
+      paddingTop: 16,
     },
     stakingCta: {
       paddingBottom: 8,

--- a/app/components/UI/Stake/components/StakingBalance/StakingBalance.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBalance.tsx
@@ -251,7 +251,7 @@ const StakingBalanceContent = ({ asset }: StakingBalanceProps) => {
             />
           </BadgeWrapper>
           <View style={styles.balances}>
-            <Text variant={TextVariant.BodyMD} testID="staked-ethereum-label">
+            <Text variant={TextVariant.BodyMDMedium} testID="staked-ethereum-label">
               {strings('stake.staked_ethereum')}
             </Text>
             <Text>

--- a/app/components/UI/Stake/components/StakingEarnings/StakingEarnings.styles.tsx
+++ b/app/components/UI/Stake/components/StakingEarnings/StakingEarnings.styles.tsx
@@ -7,7 +7,7 @@ const styleSheet = (params: { theme: Theme }) => {
 
   return StyleSheet.create({
     stakingEarningsContainer: {
-      paddingTop: 16,
+      paddingTop: 0,
     },
     title: {
       paddingBottom: 8,

--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -89,8 +89,8 @@ const createStyles = (colors, typography) =>
       paddingHorizontal: 10,
     },
     icon: {
-      width: 32,
-      height: 32,
+      width: 40,
+      height: 40,
     },
     summaryWrapper: {
       padding: 15,
@@ -120,24 +120,29 @@ const createStyles = (colors, typography) =>
       marginTop: 0,
       paddingTop: 0,
     },
+    listItemIcon: {
+      marginRight: 20,
+    },
     listItemTitle: {
-      ...typography.sBodyLGMedium,
-      fontFamily: getFontFamily(TextVariant.BodyLGMedium),
+      ...typography.sBodyMDMedium,
+      fontFamily: getFontFamily(TextVariant.BodyMDMedium),
       marginTop: 0,
     },
     listItemStatus: {
-      ...typography.sBodyMDBold,
-      fontFamily: getFontFamily(TextVariant.BodyMDBold),
+      ...typography.sBodySMMedium,
+      fontFamily: getFontFamily(TextVariant.BodySMMedium),
+      marginTop: 0,
     },
     listItemFiatAmount: {
-      ...typography.sBodyLGMedium,
-      fontFamily: getFontFamily(TextVariant.BodyLGMedium),
+      ...typography.sBodyMDMedium,
+      fontFamily: getFontFamily(TextVariant.BodyMDMedium),
       marginTop: 0,
     },
     listItemAmount: {
-      ...typography.sBodyMD,
-      fontFamily: getFontFamily(TextVariant.BodyMD),
+      ...typography.sBodySMMedium,
+      fontFamily: getFontFamily(TextVariant.BodySMMedium),
       color: colors.text.alternative,
+      marginTop: 0,
     },
   });
 
@@ -489,7 +494,7 @@ class TransactionElement extends PureComponent {
           {this.renderTxTime()}
         </ListItem.Date>
         <ListItem.Content style={styles.listItemContent}>
-          <ListItem.Icon>
+          <ListItem.Icon style={styles.listItemIcon}>
             {this.renderTxElementIcon(transactionElement, tx)}
           </ListItem.Icon>
           <ListItem.Body>

--- a/app/components/UI/Transactions/TransactionsFooter.tsx
+++ b/app/components/UI/Transactions/TransactionsFooter.tsx
@@ -1,49 +1,28 @@
 import React from 'react';
-import { View, StyleSheet, ViewStyle, TextStyle } from 'react-native';
-import type { Theme } from '@metamask/design-tokens';
+import { View, StyleSheet } from 'react-native';
 import { strings } from '../../../../locales/i18n';
-import Button, {
+import {
+  Button,
   ButtonSize,
-  ButtonVariants,
-} from '../../../component-library/components/Buttons/Button';
-import Text, {
-  getFontFamily,
+  ButtonVariant,
+  Text,
   TextVariant,
-} from '../../../component-library/components/Texts/Text';
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { NO_RPC_BLOCK_EXPLORER, RPC } from '../../../constants/network';
 import {
   getBlockExplorerName,
   isMainnetByChainId,
 } from '../../../util/networks';
-import { useTheme } from '../../../util/theme';
 
-interface Styles {
-  viewMoreWrapper: ViewStyle;
-  viewMoreButton: ViewStyle;
-  disclaimerWrapper: ViewStyle;
-  disclaimerText: TextStyle;
-}
-
-const createStyles = (
-  colors: Theme['colors'],
-  typography: Theme['typography'],
-): Styles =>
-  StyleSheet.create({
-    viewMoreWrapper: {
-      padding: 16,
-    },
-    viewMoreButton: {
-      width: '100%',
-    },
-    disclaimerWrapper: {
-      padding: 16,
-    },
-    disclaimerText: {
-      color: colors.text.default,
-      ...typography.sBodySM,
-      fontFamily: getFontFamily(TextVariant.BodySM),
-    } as TextStyle,
-  });
+const styles = StyleSheet.create({
+  viewMoreWrapper: {
+    padding: 16,
+  },
+  disclaimerWrapper: {
+    padding: 16,
+  },
+});
 
 interface TransactionsFooterProps {
   /**
@@ -80,9 +59,6 @@ const TransactionsFooter = ({
   onViewBlockExplorer,
   showDisclaimer = true,
 }: TransactionsFooterProps) => {
-  const { colors, typography } = useTheme();
-  const styles = createStyles(colors, typography);
-
   const getBlockExplorerText = (): string | null => {
     if (isNonEvmChain) {
       if (rpcBlockExplorer && rpcBlockExplorer !== NO_RPC_BLOCK_EXPLORER) {
@@ -113,17 +89,18 @@ const TransactionsFooter = ({
       {blockExplorerText && rpcBlockExplorer && (
         <View style={styles.viewMoreWrapper}>
           <Button
-            variant={ButtonVariants.Link}
+            variant={ButtonVariant.Secondary}
             size={ButtonSize.Lg}
-            label={blockExplorerText}
-            style={styles.viewMoreButton}
             onPress={onViewBlockExplorer}
-          />
+            isFullWidth
+          >
+            {blockExplorerText}
+          </Button>
         </View>
       )}
       {showDisclaimer && (
         <View style={styles.disclaimerWrapper}>
-          <Text style={styles.disclaimerText}>
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
             {strings('asset_overview.disclaimer')}
           </Text>
         </View>

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -77,7 +77,7 @@ const createStyles = (colors) =>
       flex: 1,
     },
     listContentContainer: {
-      paddingBottom: 80,
+      paddingBottom: 16,
     },
     bottomModal: {
       justifyContent: 'flex-end',

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -498,11 +498,9 @@ class Transactions extends PureComponent {
   };
 
   onScroll = (event) => {
-    const { nativeEvent } = event;
-    const { contentOffset } = nativeEvent;
-    // 16 is the top padding of the list
     if (this.props.onScrollThroughContent) {
-      this.props.onScrollThroughContent(contentOffset.y);
+      // Pass the full event for HeaderWithTitleLeftScrollable compatibility
+      this.props.onScrollThroughContent(event);
     }
   };
 
@@ -812,7 +810,7 @@ class Transactions extends PureComponent {
               }
               contentContainerStyle={styles.listContentContainer}
               style={baseStyles.flexGrow}
-              scrollIndicatorInsets={{ right: 1 }}
+              showsVerticalScrollIndicator={false}
               onScroll={this.onScroll}
               scrollEnabled={!isChartBeingTouched}
             />

--- a/app/components/Views/Asset/ActivityHeader.styles.tsx
+++ b/app/components/Views/Asset/ActivityHeader.styles.tsx
@@ -6,7 +6,8 @@ const styleSheet = () =>
       paddingHorizontal: 16,
     },
     title: {
-      paddingVertical: 8,
+      paddingTop: 8,
+      paddingBottom: 4,
     } as TextStyle,
   });
 

--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -157,9 +157,9 @@ const createStyles = (colors) =>
 
 const staticStyles = StyleSheet.create({
   tokenAvatar: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
+    width: 48,
+    height: 48,
+    borderRadius: 24,
   },
 });
 
@@ -224,7 +224,7 @@ const TokenAvatar = ({ asset }) => {
     <AvatarToken
       name={asset.symbol}
       imageSource={{ uri: asset.image }}
-      size={AvatarSize.Lg}
+      size={AvatarSize.Xl}
     />
   );
 };
@@ -301,6 +301,14 @@ class Asset extends PureComponent {
      * Expanded height of the header for content padding
      */
     expandedHeight: PropTypes.number,
+    /**
+     * Current time period for price chart
+     */
+    timePeriod: PropTypes.string,
+    /**
+     * Callback when time period changes
+     */
+    onTimePeriodChange: PropTypes.func,
   };
 
   state = {
@@ -682,6 +690,8 @@ class Asset extends PureComponent {
                     this.props.networkConfigurations[asset.chainId]?.name
                   }
                   hidePrice
+                  timePeriod={this.props.timePeriod}
+                  onTimePeriodChange={this.props.onTimePeriodChange}
                 />
                 <ActivityHeader asset={asset} />
               </View>
@@ -707,6 +717,8 @@ class Asset extends PureComponent {
                     this.props.networkConfigurations[asset.chainId]?.name
                   }
                   hidePrice
+                  timePeriod={this.props.timePeriod}
+                  onTimePeriodChange={this.props.onTimePeriodChange}
                 />
                 <ActivityHeader asset={asset} />
               </View>
@@ -905,6 +917,7 @@ const AssetWithScrollableHeader = (props) => {
   const { colors } = useTheme();
   const asset = route.params;
   const chainId = asset?.chainId;
+  const [timePeriod, setTimePeriod] = React.useState('1d');
 
   // Get network configurations
   const networkConfigurations = useSelector(selectNetworkConfigurations);
@@ -934,7 +947,7 @@ const AssetWithScrollableHeader = (props) => {
     asset,
     address: asset?.address,
     chainId,
-    timePeriod: '1d',
+    timePeriod,
     vsCurrency: currentCurrency,
   });
 
@@ -978,7 +991,7 @@ const AssetWithScrollableHeader = (props) => {
         conversionRateByTicker?.[nativeCurrency]?.conversionRate ?? undefined,
       prices,
       multichainAssetRates: convertedMultichainAssetRates,
-      timePeriod: '1d',
+      timePeriod,
     });
   }, [
     asset,
@@ -989,6 +1002,7 @@ const AssetWithScrollableHeader = (props) => {
     prices,
     convertedMultichainAssetRates,
     tokenResult,
+    timePeriod,
   ]);
 
   const { currentPrice, priceDiff, comparePrice } = priceData;
@@ -1023,6 +1037,10 @@ const AssetWithScrollableHeader = (props) => {
     navigation.pop();
   }, [navigation]);
 
+  const handleTimePeriodChange = useCallback((newTimePeriod) => {
+    setTimePeriod(newTimePeriod);
+  }, []);
+
   // Build header props
   const endButtonIconProps = useMemo(() => {
     if (!shouldShowMoreOptionsInNavBar) return undefined;
@@ -1049,7 +1067,7 @@ const AssetWithScrollableHeader = (props) => {
             diff={priceDiff}
             comparePrice={comparePrice}
             currentCurrency={currentCurrency}
-            date={strings('asset_overview.chart_time_period.1d')}
+            date={strings(`asset_overview.chart_time_period.${timePeriod}`)}
           />
         ) : null,
       endAccessory: asset ? <TokenAvatar asset={asset} /> : null,
@@ -1062,6 +1080,7 @@ const AssetWithScrollableHeader = (props) => {
       priceDiff,
       comparePrice,
       asset,
+      timePeriod,
     ],
   );
 
@@ -1088,6 +1107,8 @@ const AssetWithScrollableHeader = (props) => {
         {...props}
         onScrollEvent={onScroll}
         expandedHeight={expandedHeight}
+        timePeriod={timePeriod}
+        onTimePeriodChange={handleTimePeriodChange}
       />
     </SafeAreaView>
   );

--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -10,12 +10,7 @@ import {
   TextColor as DSTextColor,
   FontWeight,
   IconName,
-  AvatarSize,
 } from '@metamask/design-system-react-native';
-import Text, {
-  TextVariant,
-  TextColor,
-} from '../../../component-library/components/Texts/Text';
 import Routes from '../../../constants/navigation/Routes';
 import {
   TX_CONFIRMED,
@@ -104,6 +99,7 @@ import { addCurrencySymbol } from '../../../util/number';
 import { strings } from '../../../../locales/i18n';
 import NetworkAssetLogo from '../../UI/NetworkAssetLogo';
 import AvatarToken from '../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
+import { AvatarSize } from '../../../component-library/components/Avatars/Avatar/Avatar.types';
 import { selectTokenMarketData } from '../../../selectors/tokenRatesController';
 
 const createStyles = (colors) =>

--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -159,6 +159,14 @@ const createStyles = (colors) =>
     },
   });
 
+const staticStyles = StyleSheet.create({
+  tokenAvatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+  },
+});
+
 /**
  * PriceDiffText component displays the price difference with dynamic colors
  */
@@ -212,7 +220,7 @@ const TokenAvatar = ({ asset }) => {
       <NetworkAssetLogo
         chainId={asset.chainId}
         ticker={asset.ticker ?? asset.symbol}
-        big
+        style={staticStyles.tokenAvatar}
       />
     );
   }
@@ -220,7 +228,7 @@ const TokenAvatar = ({ asset }) => {
     <AvatarToken
       name={asset.symbol}
       imageSource={{ uri: asset.image }}
-      size={AvatarSize.Xl}
+      size={AvatarSize.Lg}
     />
   );
 };
@@ -1067,7 +1075,11 @@ const AssetWithScrollableHeader = (props) => {
     <SafeAreaView style={wrapperStyles.wrapper} edges={['top']}>
       <HeaderWithTitleLeftScrollable
         title={asset?.symbol ?? ''}
-        subtitle={currentNetworkName}
+        subtitle={
+          !isNaN(currentPrice)
+            ? addCurrencySymbol(currentPrice, currentCurrency, true)
+            : ''
+        }
         onBack={handleBack}
         endButtonIconProps={endButtonIconProps}
         titleLeftProps={titleLeftProps}

--- a/app/components/Views/AssetDetails/index.tsx
+++ b/app/components/Views/AssetDetails/index.tsx
@@ -8,16 +8,8 @@ import {
   InteractionManager,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import {
-  ButtonIcon,
-  ButtonIconSize,
-  IconName,
-} from '@metamask/design-system-react-native';
-import Text, {
-  TextVariant,
-  TextColor,
-} from '../../../component-library/components/Texts/Text';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import HeaderCenter from '../../../component-library/components-temp/HeaderCenter';
 import { fontStyles } from '../../../styles/common';
 import ClipboardManager from '../../../core/ClipboardManager';
 import { strings } from '../../../../locales/i18n';
@@ -64,27 +56,6 @@ import { Hex } from '@metamask/utils';
 import { selectLastSelectedEvmAccount } from '../../../selectors/accountsController';
 import { TokenI } from '../../UI/Tokens/types';
 import { areAddressesEqual } from '../../../util/address';
-
-// Inline header styles
-const inlineHeaderStyles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    height: 48,
-    gap: 16,
-  },
-  leftButton: {
-    marginLeft: 16,
-  },
-  titleWrapper: {
-    flex: 1,
-    alignItems: 'center',
-  },
-  rightPlaceholder: {
-    marginRight: 16,
-    width: 24,
-  },
-});
 
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
@@ -207,8 +178,11 @@ const AssetDetails = (props: InnerProps) => {
     return name;
   }, [isAllNetworks, tokenNetworkConfig, providerConfig]);
 
-  const insets = useSafeAreaInsets();
   const networkName = getNetworkName();
+
+  const handleBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
 
   const copyAddressToClipboard = async () => {
     await ClipboardManager.setString(address);
@@ -398,36 +372,12 @@ const AssetDetails = (props: InnerProps) => {
   );
 
   return (
-    <View style={styles.wrapper}>
-      {/* Inline header for instant rendering */}
-      <View
-        style={[
-          inlineHeaderStyles.container,
-          { marginTop: insets.top, backgroundColor: colors.background.default },
-        ]}
-      >
-        <ButtonIcon
-          style={inlineHeaderStyles.leftButton}
-          onPress={() => navigation.goBack()}
-          size={ButtonIconSize.Lg}
-          iconName={IconName.ArrowLeft}
-        />
-        <View style={inlineHeaderStyles.titleWrapper}>
-          <Text variant={TextVariant.HeadingSM} numberOfLines={1}>
-            {strings('asset_details.options.token_details')}
-          </Text>
-          {networkName ? (
-            <Text
-              variant={TextVariant.BodySM}
-              color={TextColor.Alternative}
-              numberOfLines={1}
-            >
-              {networkName}
-            </Text>
-          ) : null}
-        </View>
-        <View style={inlineHeaderStyles.rightPlaceholder} />
-      </View>
+    <SafeAreaView style={styles.wrapper} edges={['top']}>
+      <HeaderCenter
+        title={strings('asset_details.options.token_details')}
+        subtitle={networkName}
+        onBack={handleBack}
+      />
       <ScrollView contentContainerStyle={styles.container}>
         {renderSectionTitle(strings('asset_details.token'), true)}
         {renderTokenSymbol()}
@@ -447,7 +397,7 @@ const AssetDetails = (props: InnerProps) => {
         )}
         {renderHideButton()}
       </ScrollView>
-    </View>
+    </SafeAreaView>
   );
 };
 

--- a/app/components/Views/AssetOptions/AssetOptions.tsx
+++ b/app/components/Views/AssetOptions/AssetOptions.tsx
@@ -3,7 +3,6 @@ import React, { useMemo, useRef } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import {
   Text,
-  TextVariant,
   Icon,
   IconName,
 } from '@metamask/design-system-react-native';
@@ -35,7 +34,7 @@ import useBlockExplorer from '../../hooks/useBlockExplorer';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetHeader from '../../../component-library/components/BottomSheets/BottomSheetHeader';
+import HeaderCenter from '../../../component-library/components-temp/HeaderCenter';
 
 // Wrapped SOL token address on Solana
 const WRAPPED_SOL_ADDRESS = 'So11111111111111111111111111111111111111111';
@@ -333,11 +332,10 @@ const AssetOptions = (props: Props) => {
 
   return (
     <BottomSheet ref={modalRef}>
-      <BottomSheetHeader onClose={() => modalRef.current?.onCloseBottomSheet()}>
-        <Text variant={TextVariant.HeadingMd}>
-          {strings('asset_details.options.title')}
-        </Text>
-      </BottomSheetHeader>
+      <HeaderCenter
+        title={strings('asset_details.options.title')}
+        onClose={() => modalRef.current?.onCloseBottomSheet()}
+      />
       <View>{renderOptions()}</View>
     </BottomSheet>
   );

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -179,6 +179,7 @@ const MultichainTransactionsView = ({
               ListFooterComponent={footer}
               style={baseStyles.flexGrow}
               contentContainerStyle={style.listContentContainer}
+              showsVerticalScrollIndicator={false}
               refreshControl={
                 enableRefresh ? (
                   <RefreshControl


### PR DESCRIPTION
## **Description**

This PR implements a new collapsible header design for the Token Details page. The changes include:

**Header Redesign:**
- Replaced the static inline header (`AssetInlineHeader`) with a new scrollable `HeaderWithTitleLeftScrollable` component that collapses as the user scrolls
- The expanded header now displays the token name, current price, price change (with color-coded positive/negative indicators), and a token avatar
- Price information moves to the header, allowing the main content area to focus on the price chart

**Asset Overview Updates:**
- Added a `hidePrice` prop to `AssetOverview` to prevent duplicate price display when the header shows pricing
- When `hidePrice` is enabled, only the price chart is rendered in the overview section

**TransactionsFooter Migration:**
- Migrated from component-library `Button` to `@metamask/design-system-react-native` `Button`
- Updated styling to use MMDS Text components with proper variants and colors

**Visual Alignment:**
- Reduced spacing in TokenDetails section (gap: 24 → 12, padding adjustments)
- Adjusted Earnings and StakingBalance component spacing for consistent visual rhythm
- Increased staked ETH logo size from 32x32 to 40x40 pixels
- Updated PoolStakingLearnMoreModal to use `HeaderCenter` component

## **Changelog**

CHANGELOG entry: feat: redesigned Token Details page with collapsible header showing price information

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/jira/software/c/projects/MDP/boards/2972?assignee=62afb43d33a882e2be47c36f&quickFilter=3325&selectedIssue=MDP-693

## **Manual testing steps**

```gherkin
Feature: Token Details Collapsible Header

  Scenario: user views token details with collapsible header
    Given the user has a wallet with tokens

    When user taps on a token from the wallet home screen
    Then the Token Details page opens with an expanded header showing token name, price, and price change
    And a token avatar is displayed in the header
    And the price chart is visible below the header

  Scenario: user scrolls token details page
    Given the user is on the Token Details page

    When user scrolls down the page
    Then the header collapses to show a compact view with token symbol and price
    And the price chart and transaction activity remain visible

  Scenario: user views staked ETH details
    Given the user has staked ETH

    When user navigates to staked ETH token details
    Then the staking balance section displays with updated 40x40 ETH logo
    And earnings information is properly aligned with reduced spacing
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/f8999a64-fbd7-41d7-8979-a1b9e86c57c0


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/6669a1ac-9076-4c84-80b1-1d2980edab5c


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a scroll-collapsible header on the Token Details view and aligns related UI components.
> 
> - Replaces inline headers with `HeaderWithTitleLeftScrollable`/`HeaderCenter`; header now shows token name, current price, price delta, and avatar
> - Moves pricing out of `AssetOverview` when `hidePrice` is set; adds `timePeriod` and `onTimePeriodChange` props; renders only `PriceChart` in that mode
> - Updates `Transactions` and multichain list to forward full scroll events and hide scroll indicators; minor list item typography/icon size tweaks
> - Migrates `TransactionsFooter` to `@metamask/design-system-react-native` `Button`/`Text`
> - Refines spacing/typography across Token Details, Earnings, Staking, and related modals; increases various icon/avatar sizes
> - Adds tests for the new scrollable header integration on the Asset screen
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fac5eab1641bdffdc2165ea737f5b97de36eb146. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->