### PR TITLE
fix: skip biometric cancellation error recording in mixpanel

### DIFF
--- a/app/components/Views/Login/index.test.tsx
+++ b/app/components/Views/Login/index.test.tsx
@@ -210,6 +210,39 @@ jest.mock('../../../util/metrics/TrackOnboarding/trackOnboarding', () =>
   jest.fn(),
 );
 
+jest.mock('../../hooks/useMetrics', () => {
+  const ReactModule = jest.requireActual('react');
+  const mockMetrics = {
+    trackEvent: jest.fn(),
+    createEventBuilder: jest.fn(() => ({
+      addProperties: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({}),
+    })),
+  };
+  return {
+    useMetrics: () => ({
+      trackEvent: jest.fn(),
+      isEnabled: jest.fn().mockReturnValue(true),
+      enable: jest.fn().mockResolvedValue(undefined),
+      addTraitsToUser: jest.fn(),
+      createEventBuilder: jest.fn(() => ({
+        addProperties: jest.fn().mockReturnThis(),
+        build: jest.fn().mockReturnValue({}),
+      })),
+    }),
+    withMetricsAwareness:
+      <P extends Record<string, unknown>>(Component: React.ComponentType<P>) =>
+      (props: P) =>
+        ReactModule.createElement(Component, {
+          ...props,
+          metrics: mockMetrics,
+        }),
+    MetaMetricsEvents: jest.requireActual(
+      '../../../core/Analytics/MetaMetrics.events',
+    ).MetaMetricsEvents,
+  };
+});
+
 jest.mock('../../../util/trace', () => {
   const actualTrace = jest.requireActual('../../../util/trace');
   return {
@@ -286,6 +319,11 @@ describe('Login', () => {
 
     BackHandler.addEventListener = mockBackHandlerAddEventListener;
     BackHandler.removeEventListener = mockBackHandlerRemoveEventListener;
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
   it('renders matching snapshot', () => {

--- a/app/components/Views/OAuthRehydration/index.test.tsx
+++ b/app/components/Views/OAuthRehydration/index.test.tsx
@@ -746,7 +746,7 @@ describe('OAuthRehydration', () => {
     it('does not track REHYDRATION_PASSWORD_FAILED when Android biometric is cancelled', async () => {
       // Arrange
       (Authentication.userEntryAuth as jest.Mock).mockRejectedValue(
-        new Error('Error: Cancel'),
+        new Error('Cancel'),
       );
       mockTrackOnboarding.mockClear();
       const { getByTestId } = renderWithProvider(<OAuthRehydration />);

--- a/app/components/Views/OAuthRehydration/index.test.tsx
+++ b/app/components/Views/OAuthRehydration/index.test.tsx
@@ -19,6 +19,8 @@ import {
 import trackOnboarding from '../../../util/metrics/TrackOnboarding/trackOnboarding';
 import { useNetInfo } from '@react-native-community/netinfo';
 import Logger from '../../../util/Logger';
+import { UNLOCK_WALLET_ERROR_MESSAGES } from '../../../core/Authentication/constants';
+import { MetaMetricsEvents } from '../../../core/Analytics/MetaMetrics.events';
 
 const mockEngine = jest.mocked(Engine);
 
@@ -737,6 +739,62 @@ describe('OAuthRehydration', () => {
 
       // Assert
       expect(Authentication.resetPassword).toHaveBeenCalled();
+    });
+  });
+
+  describe('biometric cancellation', () => {
+    it('does not track REHYDRATION_PASSWORD_FAILED when Android biometric is cancelled', async () => {
+      // Arrange
+      (Authentication.userEntryAuth as jest.Mock).mockRejectedValue(
+        new Error('Error: Cancel'),
+      );
+      mockTrackOnboarding.mockClear();
+      const { getByTestId } = renderWithProvider(<OAuthRehydration />);
+      const passwordInput = getByTestId(LoginViewSelectors.PASSWORD_INPUT);
+
+      // Act
+      await act(async () => {
+        fireEvent.changeText(passwordInput, 'password123');
+      });
+      await act(async () => {
+        fireEvent(passwordInput, 'submitEditing');
+      });
+
+      // Assert
+      expect(Logger.error).not.toHaveBeenCalled();
+      const rehydrationFailedCalls = mockTrackOnboarding.mock.calls.filter(
+        (call) =>
+          call[0]?.properties?.name ===
+          MetaMetricsEvents.REHYDRATION_PASSWORD_FAILED.category,
+      );
+      expect(rehydrationFailedCalls).toHaveLength(0);
+    });
+
+    it('does not track REHYDRATION_PASSWORD_FAILED when iOS biometric is cancelled', async () => {
+      // Arrange
+      (Authentication.userEntryAuth as jest.Mock).mockRejectedValue(
+        new Error(UNLOCK_WALLET_ERROR_MESSAGES.IOS_USER_CANCELLED_BIOMETRICS),
+      );
+      mockTrackOnboarding.mockClear();
+      const { getByTestId } = renderWithProvider(<OAuthRehydration />);
+      const passwordInput = getByTestId(LoginViewSelectors.PASSWORD_INPUT);
+
+      // Act
+      await act(async () => {
+        fireEvent.changeText(passwordInput, 'password123');
+      });
+      await act(async () => {
+        fireEvent(passwordInput, 'submitEditing');
+      });
+
+      // Assert
+      expect(Logger.error).not.toHaveBeenCalled();
+      const rehydrationFailedCalls = mockTrackOnboarding.mock.calls.filter(
+        (call) =>
+          call[0]?.properties?.name ===
+          MetaMetricsEvents.REHYDRATION_PASSWORD_FAILED.category,
+      );
+      expect(rehydrationFailedCalls).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* fix: skip biometric cancellation error recording in mixpanel.
* Jira: https://consensyssoftware.atlassian.net/browse/SL-460, https://consensyssoftware.atlassian.net/browse/SL-461
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:
1) https://consensyssoftware.atlassian.net/browse/SL-460
2) https://consensyssoftware.atlassian.net/browse/SL-461

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips logging and analytics when biometric auth is cancelled to avoid noisy error reporting during unlock flows.
> 
> - **Login**: Detects biometric cancellation (`DENY_PIN_ERROR_ANDROID`, `UNLOCK_WALLET_ERROR_MESSAGES.IOS_USER_CANCELLED_BIOMETRICS`), disables biometry, stops loading, and returns early without logging or tracking; minor refactor of error branches and vault corruption handling.
> - **OAuth Rehydration**: Adds the same cancellation handling and prevents `REHYDRATION_PASSWORD_FAILED` tracking; refines error tracking to use `error_type: passcode_not_set` when relevant.
> - **Tests**: New tests verify no `Logger.error` or Mixpanel tracking on biometric cancellations (Android/iOS); supporting mocks and timer cleanup added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30a47a8f28cad750d5c814504dd66550c5178d9f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->