### PR TITLE
fix: swaps network filtering

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -91,7 +91,10 @@ jest.mock('../../../../../core/redux/slices/bridge', () => {
     });
   return {
     selectBridgeFeatureFlags: jest.fn(() => getMockBridgeFeatureFlags()),
-    selectEnabledChainRanking: jest.fn(
+    selectSourceChainRanking: jest.fn(
+      () => getMockBridgeFeatureFlags().chainRanking,
+    ),
+    selectDestChainRanking: jest.fn(
       () => getMockBridgeFeatureFlags().chainRanking,
     ),
     setIsSelectingToken: jest.fn(() => ({

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -100,7 +100,7 @@ export const BridgeTokenSelector: React.FC = () => {
   const sourceChainRanking = useSelector(selectSourceChainRanking);
   const destChainRanking = useSelector(selectDestChainRanking);
   const enabledChainRanking =
-    route.params.type === TokenSelectorType.Source
+    route.params?.type === TokenSelectorType.Source
       ? sourceChainRanking
       : destChainRanking;
 
@@ -117,7 +117,7 @@ export const BridgeTokenSelector: React.FC = () => {
 
   // Use custom hook for token selection
   const { handleTokenPress, selectedToken } = useTokenSelection(
-    route.params.type,
+    route.params?.type,
   );
 
   // Initialize selectedChainId with the chain id of the selected token
@@ -502,7 +502,7 @@ export const BridgeTokenSelector: React.FC = () => {
         <NetworkPills
           selectedChainId={selectedChainId}
           onChainSelect={handleChainSelect}
-          type={route.params.type}
+          type={route.params?.type}
         />
 
         <TextFieldSearch

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -47,7 +47,7 @@ import { SkeletonItem } from '../BridgeTokenSelectorBase';
 import { TabEmptyState } from '../../../../../component-library/components-temp/TabEmptyState';
 import { TokenSelectorItem } from '../TokenSelectorItem';
 import { getNetworkImageSource } from '../../../../../util/networks';
-import { BridgeToken } from '../../types';
+import { BridgeToken, TokenSelectorType } from '../../types';
 import { usePopularTokens, IncludeAsset } from '../../hooks/usePopularTokens';
 import { useSearchTokens } from '../../hooks/useSearchTokens';
 import { useBalancesByAssetId } from '../../hooks/useBalancesByAssetId';
@@ -58,7 +58,7 @@ import Engine from '../../../../../core/Engine';
 import { isNonEvmChainId } from '../../../../../core/Multichain/utils';
 
 export interface BridgeTokenSelectorRouteParams {
-  type: 'source' | 'dest';
+  type: TokenSelectorType;
 }
 
 const MIN_SEARCH_LENGTH = 3;
@@ -100,7 +100,9 @@ export const BridgeTokenSelector: React.FC = () => {
   const sourceChainRanking = useSelector(selectSourceChainRanking);
   const destChainRanking = useSelector(selectDestChainRanking);
   const enabledChainRanking =
-    route.params.type === 'source' ? sourceChainRanking : destChainRanking;
+    route.params.type === TokenSelectorType.Source
+      ? sourceChainRanking
+      : destChainRanking;
 
   // Set navigation options for header
   useEffect(() => {
@@ -120,7 +122,7 @@ export const BridgeTokenSelector: React.FC = () => {
 
   // Initialize selectedChainId with the chain id of the selected token
   const [selectedChainId, setSelectedChainId] = useState(
-    selectedToken?.chainId && route.params?.type === 'dest'
+    selectedToken?.chainId && route.params?.type === TokenSelectorType.Dest
       ? formatChainIdToCaip(selectedToken.chainId)
       : undefined,
   );
@@ -372,7 +374,7 @@ export const BridgeTokenSelector: React.FC = () => {
       }
 
       const isNoFeeAsset =
-        route.params?.type === 'source'
+        route.params?.type === TokenSelectorType.Source
           ? item.noFee?.isSource
           : item.noFee?.isDestination;
       return (

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -21,7 +21,8 @@ import { CaipAssetType, CaipChainId } from '@metamask/utils';
 import { useStyles } from '../../../../../component-library/hooks';
 import TextFieldSearch from '../../../../../component-library/components/Form/TextFieldSearch';
 import {
-  selectEnabledChainRanking,
+  selectSourceChainRanking,
+  selectDestChainRanking,
   setIsSelectingToken,
 } from '../../../../../core/redux/slices/bridge';
 import {
@@ -95,7 +96,11 @@ export const BridgeTokenSelector: React.FC = () => {
     [searchString],
   );
 
-  const enabledChainRanking = useSelector(selectEnabledChainRanking);
+  // Use appropriate chain ranking based on selector type
+  const sourceChainRanking = useSelector(selectSourceChainRanking);
+  const destChainRanking = useSelector(selectDestChainRanking);
+  const enabledChainRanking =
+    route.params.type === 'source' ? sourceChainRanking : destChainRanking;
 
   // Set navigation options for header
   useEffect(() => {
@@ -495,6 +500,7 @@ export const BridgeTokenSelector: React.FC = () => {
         <NetworkPills
           selectedChainId={selectedChainId}
           onChainSelect={handleChainSelect}
+          type={route.params.type}
         />
 
         <TextFieldSearch

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
@@ -4,6 +4,7 @@ import { NetworkPills } from './NetworkPills';
 import { CaipChainId } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import { MOCK_CHAIN_IDS } from '../../testUtils/fixtures';
+import { TokenSelectorType } from '../../types';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -55,7 +56,7 @@ describe('NetworkPills', () => {
         <NetworkPills
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
-          type="source"
+          type={TokenSelectorType.Source}
         />,
       );
 
@@ -70,7 +71,7 @@ describe('NetworkPills', () => {
         <NetworkPills
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
-          type="dest"
+          type={TokenSelectorType.Dest}
         />,
       );
 
@@ -88,7 +89,7 @@ describe('NetworkPills', () => {
         <NetworkPills
           selectedChainId={MOCK_CHAIN_IDS.ethereum}
           onChainSelect={mockOnChainSelect}
-          type="source"
+          type={TokenSelectorType.Source}
         />,
       );
 
@@ -102,7 +103,7 @@ describe('NetworkPills', () => {
         <NetworkPills
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
-          type="source"
+          type={TokenSelectorType.Source}
         />,
       );
 
@@ -121,7 +122,7 @@ describe('NetworkPills', () => {
         <NetworkPills
           selectedChainId={selectedChainId as CaipChainId | undefined}
           onChainSelect={mockOnChainSelect}
-          type="source"
+          type={TokenSelectorType.Source}
         />,
       );
 

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
@@ -11,8 +11,8 @@ jest.mock('react-redux', () => ({
 
 const mockUseSelector = useSelector as jest.Mock;
 
-// Mock for selectEnabledChainRanking - returns filtered chain ranking array with names from feature flags
-const mockEnabledChainRanking = [
+// Mock chain ranking array with names from feature flags
+const mockChainRanking = [
   { chainId: MOCK_CHAIN_IDS.ethereum, name: 'Ethereum' },
   { chainId: MOCK_CHAIN_IDS.polygon, name: 'Polygon' },
   { chainId: MOCK_CHAIN_IDS.optimism, name: 'Optimism' },
@@ -46,15 +46,16 @@ describe('NetworkPills', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseSelector.mockReturnValue(mockEnabledChainRanking);
+    mockUseSelector.mockReturnValue(mockChainRanking);
   });
 
   describe('rendering', () => {
-    it('renders All pill and chain pills', () => {
+    it('renders All pill and chain pills in source mode', () => {
       const { getByText } = render(
         <NetworkPills
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
+          type="source"
         />,
       );
 
@@ -64,11 +65,12 @@ describe('NetworkPills', () => {
       expect(getByText('Optimism')).toBeTruthy();
     });
 
-    it('renders pills for each chain in chainRanking', () => {
+    it('renders pills for each chain in chainRanking in dest mode', () => {
       const { getByText } = render(
         <NetworkPills
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
+          type="dest"
         />,
       );
 
@@ -86,6 +88,7 @@ describe('NetworkPills', () => {
         <NetworkPills
           selectedChainId={MOCK_CHAIN_IDS.ethereum}
           onChainSelect={mockOnChainSelect}
+          type="source"
         />,
       );
 
@@ -99,6 +102,7 @@ describe('NetworkPills', () => {
         <NetworkPills
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
+          type="source"
         />,
       );
 
@@ -117,6 +121,7 @@ describe('NetworkPills', () => {
         <NetworkPills
           selectedChainId={selectedChainId as CaipChainId | undefined}
           onChainSelect={mockOnChainSelect}
+          type="source"
         />,
       );
 

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
@@ -2,27 +2,36 @@ import React, { useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
-import { selectEnabledChainRanking } from '../../../../../core/redux/slices/bridge';
+import {
+  selectSourceChainRanking,
+  selectDestChainRanking,
+} from '../../../../../core/redux/slices/bridge';
 import { CaipChainId } from '@metamask/utils';
 import { ScrollView } from 'react-native-gesture-handler';
 import ButtonToggle from '../../../../../component-library/components-temp/Buttons/ButtonToggle';
 import { ButtonSize } from '../../../../../component-library/components/Buttons/Button';
+import { TokenSelectorType } from '../../types';
 
 const PILL_WIDTH = 90; // Average pill width including gap
 
 interface NetworkPillsProps {
   selectedChainId?: CaipChainId;
   onChainSelect: (chainId?: CaipChainId) => void;
+  type: TokenSelectorType;
 }
 
 export const NetworkPills: React.FC<NetworkPillsProps> = ({
   selectedChainId,
   onChainSelect,
+  type,
 }) => {
   const tw = useTailwind();
   const scrollViewRef = useRef<ScrollView>(null);
   const hasScrolledRef = useRef(false);
-  const chainRanking = useSelector(selectEnabledChainRanking);
+  const sourceChainRanking = useSelector(selectSourceChainRanking);
+  const destChainRanking = useSelector(selectDestChainRanking);
+  const chainRanking =
+    type === TokenSelectorType.Source ? sourceChainRanking : destChainRanking;
 
   // Auto-scroll to selected network on initial layout
   const handleContentSizeChange = () => {

--- a/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-native';
-import { Hex, CaipChainId } from '@metamask/utils';
+import { Hex, CaipChainId, CaipAssetType } from '@metamask/utils';
 import { BtcAccountType } from '@metamask/keyring-api';
 import { useBalancesByAssetId } from './index';
 import { useTokensWithBalance } from '../useTokensWithBalance';
@@ -118,10 +118,14 @@ describe('useBalancesByAssetId', () => {
 
       expect(Object.keys(result.current.balancesByAssetId)).toHaveLength(1);
       expect(
-        result.current.balancesByAssetId['0x1/erc20:0xwithbalance'],
+        result.current.balancesByAssetId[
+          '0x1/erc20:0xwithbalance' as CaipAssetType
+        ],
       ).toBeDefined();
       expect(
-        result.current.balancesByAssetId['0x1/erc20:0xnobalance'],
+        result.current.balancesByAssetId[
+          '0x1/erc20:0xnobalance' as CaipAssetType
+        ],
       ).toBeUndefined();
     });
   });
@@ -149,10 +153,10 @@ describe('useBalancesByAssetId', () => {
       );
 
       expect(
-        result.current.balancesByAssetId['0x1/erc20:0xtoken1'],
+        result.current.balancesByAssetId['0x1/erc20:0xtoken1' as CaipAssetType],
       ).toBeDefined();
       expect(
-        result.current.balancesByAssetId['0xa/erc20:0xtoken2'],
+        result.current.balancesByAssetId['0xa/erc20:0xtoken2' as CaipAssetType],
       ).toBeDefined();
     });
 
@@ -171,7 +175,9 @@ describe('useBalancesByAssetId', () => {
       );
 
       expect(
-        result.current.balancesByAssetId['eip155:1/erc20:0xtoken1'],
+        result.current.balancesByAssetId[
+          'eip155:1/erc20:0xtoken1' as CaipAssetType
+        ],
       ).toBeDefined();
     });
   });
@@ -217,7 +223,9 @@ describe('useBalancesByAssetId', () => {
         }),
       );
 
-      expect(result.current.balancesByAssetId['0x1/erc20:0xtoken1']).toEqual({
+      expect(
+        result.current.balancesByAssetId['0x1/erc20:0xtoken1' as CaipAssetType],
+      ).toEqual({
         balance: '50.0',
         balanceFiat: undefined,
         tokenFiatAmount: undefined,
@@ -244,7 +252,11 @@ describe('useBalancesByAssetId', () => {
         }),
       );
 
-      expect(result.current.balancesByAssetId['0x1/erc20:0xbtctoken']).toEqual({
+      expect(
+        result.current.balancesByAssetId[
+          '0x1/erc20:0xbtctoken' as CaipAssetType
+        ],
+      ).toEqual({
         balance: '1.5',
         balanceFiat: '$45000',
         tokenFiatAmount: 45000,

--- a/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.ts
+++ b/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.ts
@@ -4,7 +4,7 @@ import {
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import { useTokensWithBalance } from '../useTokensWithBalance';
-import { CaipChainId, Hex } from '@metamask/utils';
+import { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 import { BridgeToken } from '../../types';
 
 /**
@@ -22,7 +22,7 @@ export interface BalanceData {
  * Map of assetId (CAIP format) to balance data for O(1) lookup
  * Example: { "eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": { balance: "0.0004", ... } }
  */
-export type BalancesByAssetId = Record<string, BalanceData>;
+export type BalancesByAssetId = Record<CaipAssetType, BalanceData>;
 
 /**
  * Hook to get balances indexed by assetId (CAIP format) for O(1) lookup
@@ -48,7 +48,7 @@ export const useBalancesByAssetId = ({
         // Normalize assetId because API returns assetId in lowercase for EVM chains
         const normalizedAssetId = isNonEvmChainId(token.chainId)
           ? assetId
-          : assetId.toLowerCase();
+          : (assetId.toLowerCase() as CaipAssetType);
         balancesMap[normalizedAssetId] = {
           balance: token.balance,
           balanceFiat: token.balanceFiat,

--- a/app/components/UI/Bridge/hooks/usePopularTokens.ts
+++ b/app/components/UI/Bridge/hooks/usePopularTokens.ts
@@ -1,9 +1,6 @@
 import { useState, useEffect } from 'react';
 import { CaipChainId, CaipAssetType } from '@metamask/utils';
-import {
-  BRIDGE_DEV_API_BASE_URL,
-  BRIDGE_PROD_API_BASE_URL,
-} from '@metamask/bridge-controller';
+import { BRIDGE_API_BASE_URL } from '../../../../constants/bridge';
 
 export interface PopularToken {
   assetId: CaipAssetType;
@@ -138,7 +135,7 @@ export const usePopularTokens = ({
         const parsedIncludeAssets: IncludeAsset[] = JSON.parse(includeAssets);
 
         const response = await fetch(
-          `${process.env.BRIDGE_USE_DEV_APIS === 'true' ? BRIDGE_DEV_API_BASE_URL : BRIDGE_PROD_API_BASE_URL}/getTokens/popular`,
+          `${BRIDGE_API_BASE_URL}/getTokens/popular`,
           {
             method: 'POST',
             headers: {

--- a/app/components/UI/Bridge/hooks/useSearchTokens.ts
+++ b/app/components/UI/Bridge/hooks/useSearchTokens.ts
@@ -2,10 +2,7 @@ import { useState, useRef, useCallback, useMemo, useEffect } from 'react';
 import { debounce } from 'lodash';
 import { CaipChainId } from '@metamask/utils';
 import { PopularToken, IncludeAsset } from './usePopularTokens';
-import {
-  BRIDGE_DEV_API_BASE_URL,
-  BRIDGE_PROD_API_BASE_URL,
-} from '@metamask/bridge-controller';
+import { BRIDGE_API_BASE_URL } from '../../../../constants/bridge';
 
 const MIN_SEARCH_LENGTH = 3;
 
@@ -116,7 +113,7 @@ export const useSearchTokens = ({
         }
 
         const response = await fetch(
-          `${process.env.BRIDGE_USE_DEV_APIS === 'true' ? BRIDGE_DEV_API_BASE_URL : BRIDGE_PROD_API_BASE_URL}/getTokens/search`,
+          `${BRIDGE_API_BASE_URL}/getTokens/search`,
           {
             method: 'POST',
             headers: {

--- a/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
@@ -5,6 +5,7 @@ import {
   setDestToken,
 } from '../../../../core/redux/slices/bridge';
 import { createMockToken } from '../testUtils/fixtures';
+import { TokenSelectorType } from '../types';
 
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => ({
@@ -48,7 +49,9 @@ describe('useTokenSelection', () => {
     });
 
     it('dispatches setSourceToken when selecting new source token', () => {
-      const { result } = renderHook(() => useTokenSelection('source'));
+      const { result } = renderHook(() =>
+        useTokenSelection(TokenSelectorType.Source),
+      );
       const newToken = createMockToken({
         address: '0xnewtoken',
         symbol: 'NEW',
@@ -63,7 +66,9 @@ describe('useTokenSelection', () => {
     });
 
     it('swaps tokens when selecting current dest token as source', () => {
-      const { result } = renderHook(() => useTokenSelection('source'));
+      const { result } = renderHook(() =>
+        useTokenSelection(TokenSelectorType.Source),
+      );
 
       act(() => {
         result.current.handleTokenPress(mockDestToken);
@@ -75,7 +80,9 @@ describe('useTokenSelection', () => {
     });
 
     it('returns source token as selectedToken', () => {
-      const { result } = renderHook(() => useTokenSelection('source'));
+      const { result } = renderHook(() =>
+        useTokenSelection(TokenSelectorType.Source),
+      );
 
       expect(result.current.selectedToken).toBe(mockSourceToken);
     });
@@ -89,7 +96,9 @@ describe('useTokenSelection', () => {
     });
 
     it('dispatches setDestToken when selecting new dest token', () => {
-      const { result } = renderHook(() => useTokenSelection('dest'));
+      const { result } = renderHook(() =>
+        useTokenSelection(TokenSelectorType.Dest),
+      );
       const newToken = createMockToken({
         address: '0xnewdest',
         symbol: 'NEWDST',
@@ -104,7 +113,9 @@ describe('useTokenSelection', () => {
     });
 
     it('swaps tokens when selecting current source token as dest', () => {
-      const { result } = renderHook(() => useTokenSelection('dest'));
+      const { result } = renderHook(() =>
+        useTokenSelection(TokenSelectorType.Dest),
+      );
 
       act(() => {
         result.current.handleTokenPress(mockSourceToken);
@@ -116,7 +127,9 @@ describe('useTokenSelection', () => {
     });
 
     it('returns dest token as selectedToken', () => {
-      const { result } = renderHook(() => useTokenSelection('dest'));
+      const { result } = renderHook(() =>
+        useTokenSelection(TokenSelectorType.Dest),
+      );
 
       expect(result.current.selectedToken).toBe(mockDestToken);
     });
@@ -124,24 +137,35 @@ describe('useTokenSelection', () => {
 
   describe('edge cases', () => {
     it.each([
-      ['null source token', { source: null, dest: mockDestToken }, 'source'],
-      ['null dest token', { source: mockSourceToken, dest: null }, 'dest'],
-      ['both tokens null', { source: null, dest: null }, 'source'],
+      [
+        'null source token',
+        { source: null, dest: mockDestToken },
+        TokenSelectorType.Source,
+      ],
+      [
+        'null dest token',
+        { source: mockSourceToken, dest: null },
+        TokenSelectorType.Dest,
+      ],
+      [
+        'both tokens null',
+        { source: null, dest: null },
+        TokenSelectorType.Source,
+      ],
     ])('handles %s', (_, tokens, type) => {
       mockUseSelector
         .mockReturnValueOnce(tokens.source)
         .mockReturnValueOnce(tokens.dest);
 
-      const { result } = renderHook(() =>
-        useTokenSelection(type as 'source' | 'dest'),
-      );
+      const { result } = renderHook(() => useTokenSelection(type));
       const newToken = createMockToken();
 
       act(() => {
         result.current.handleTokenPress(newToken);
       });
 
-      const expectedAction = type === 'source' ? setSourceToken : setDestToken;
+      const expectedAction =
+        type === TokenSelectorType.Source ? setSourceToken : setDestToken;
       expect(mockDispatch).toHaveBeenCalledWith(expectedAction(newToken));
       expect(mockGoBack).toHaveBeenCalled();
     });
@@ -151,7 +175,9 @@ describe('useTokenSelection', () => {
         .mockReturnValueOnce(mockSourceToken)
         .mockReturnValueOnce(mockDestToken);
 
-      const { result } = renderHook(() => useTokenSelection('source'));
+      const { result } = renderHook(() =>
+        useTokenSelection(TokenSelectorType.Source),
+      );
       const sameAddressToken = createMockToken({
         address: mockDestToken.address,
         chainId: '0x5',
@@ -172,7 +198,9 @@ describe('useTokenSelection', () => {
         .mockReturnValueOnce(mockSourceToken)
         .mockReturnValueOnce(mockDestToken);
 
-      const { result } = renderHook(() => useTokenSelection('source'));
+      const { result } = renderHook(() =>
+        useTokenSelection(TokenSelectorType.Source),
+      );
       const sameChainToken = createMockToken({
         address: '0xdifferent',
         chainId: mockDestToken.chainId,

--- a/app/components/UI/Bridge/hooks/useTokenSelection.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.ts
@@ -7,14 +7,14 @@ import {
   selectSourceToken,
   selectDestToken,
 } from '../../../../core/redux/slices/bridge';
-import { BridgeToken } from '../types';
+import { BridgeToken, TokenSelectorType } from '../types';
 
 /**
  * Hook to manage token selection logic for Bridge token selector
  * Handles both normal selection and token swapping when selecting the opposite token
  * @param type - Whether this is a source or dest token selector
  */
-export const useTokenSelection = (type: 'source' | 'dest') => {
+export const useTokenSelection = (type: TokenSelectorType) => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
   const sourceToken = useSelector(selectSourceToken);
@@ -22,7 +22,7 @@ export const useTokenSelection = (type: 'source' | 'dest') => {
 
   const handleTokenPress = useCallback(
     (token: BridgeToken) => {
-      const isSourcePicker = type === 'source';
+      const isSourcePicker = type === TokenSelectorType.Source;
       const otherToken = isSourcePicker ? destToken : sourceToken;
 
       // Check if the selected token matches the "other" token
@@ -45,7 +45,8 @@ export const useTokenSelection = (type: 'source' | 'dest') => {
     [type, sourceToken, destToken, dispatch, navigation],
   );
 
-  const selectedToken = type === 'source' ? sourceToken : destToken;
+  const selectedToken =
+    type === TokenSelectorType.Source ? sourceToken : destToken;
 
   return { handleTokenPress, selectedToken };
 };

--- a/app/components/UI/Bridge/hooks/useTokensWithBalances.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalances.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { parseCaipAssetType } from '@metamask/utils';
+import { CaipAssetType, parseCaipAssetType } from '@metamask/utils';
 import { constants } from 'ethers';
 import {
   isNonEvmChainId,
@@ -15,7 +15,7 @@ import { BalancesByAssetId } from './useBalancesByAssetId';
  */
 const convertAPITokensToBridgeTokens = (
   apiTokens: PopularToken[],
-): (BridgeToken & { assetId?: string })[] =>
+): (BridgeToken & { assetId: CaipAssetType })[] =>
   apiTokens.map((token) => {
     const { assetReference, chainId, assetNamespace } = parseCaipAssetType(
       token.assetId,
@@ -64,8 +64,8 @@ export const useTokensWithBalances = (
       // Normalize assetId because API returns assetId in lowercase for EVM chains
       const normalizedAssetId = isNonEvmChainId(token.chainId)
         ? token.assetId
-        : token.assetId?.toLowerCase();
-      const balanceData = balancesByAssetId[normalizedAssetId ?? ''];
+        : (token.assetId?.toLowerCase() as CaipAssetType);
+      const balanceData = balancesByAssetId[normalizedAssetId];
       if (balanceData) {
         return {
           ...token,

--- a/app/components/UI/Bridge/types.ts
+++ b/app/components/UI/Bridge/types.ts
@@ -40,3 +40,8 @@ export enum BridgeViewMode {
   Bridge = 'Bridge',
   Unified = 'Unified',
 }
+
+export enum TokenSelectorType {
+  Source = 'source',
+  Dest = 'dest',
+}

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -16,6 +16,7 @@ import reducer, {
   selectIsBridgeEnabledSource,
   selectIsBridgeEnabledDest,
   selectIsSwapsLive,
+  selectDestChainRanking,
 } from '.';
 import {
   BridgeToken,
@@ -593,6 +594,43 @@ describe('bridge slice', () => {
       );
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('selectDestChainRanking', () => {
+    it('returns chainRanking from feature flags', () => {
+      const result = selectDestChainRanking(
+        mockRootState as unknown as RootState,
+      );
+
+      // Verify it returns an array with chain ranking data
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeGreaterThan(0);
+
+      // Verify the structure of each item
+      result.forEach((chain) => {
+        expect(chain).toHaveProperty('chainId');
+        expect(chain).toHaveProperty('name');
+        expect(typeof chain.chainId).toBe('string');
+        expect(typeof chain.name).toBe('string');
+      });
+
+      // Verify Ethereum is included (commonly in chainRanking)
+      const hasEthereum = result.some(
+        (chain) => chain.chainId === 'eip155:1' && chain.name === 'Ethereum',
+      );
+      expect(hasEthereum).toBe(true);
+    });
+
+    it('returns all chains without filtering (unlike selectSourceChainRanking)', () => {
+      const result = selectDestChainRanking(
+        mockRootState as unknown as RootState,
+      );
+
+      // selectDestChainRanking should return all chains from feature flags
+      // This is the key difference from selectSourceChainRanking which filters
+      // by user-configured networks
+      expect(result.length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Changes network filtering logic to only filter the source networks.

Also includes several minor fast follow changes.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?

AI agent: Be specific about what you changed and why. Include context about the fix/feature, not generic descriptions.
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)

AI agent: Use format `CHANGELOG entry: [fix/feat/chore]: [User-facing description in past tense]`.
Examples: `fix: resolved token name display issue`, `feat: added dark mode toggle`, `chore: updated dependencies`.
For non-user-facing changes, use `CHANGELOG entry: null`.
-->

CHANGELOG entry: Changed swaps network filtering logic to only filter source networks

## **Related issues**

<!--
AI agent: Replace with `Fixes: #[ISSUE_NUMBER]` using the actual issue number you're implementing.
-->

Fixes:

## **Manual testing steps**

<!--
AI agent: Write specific, contextual Gherkin steps based on what you actually implemented.
Do NOT use generic placeholders like "my feature name". Be concrete about the feature, scenario, and steps.
-->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
AI agent: Check ALL boxes in this section (mark all as [x]).
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

<!--
AI agent: Leave ALL boxes unchecked ([ ]) - these are for reviewers to check, not the author.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Introduces `selectSourceChainRanking` (filters by user-configured networks) and `selectDestChainRanking` (returns all chains) replacing `selectEnabledChainRanking`; updates usage in `BridgeTokenSelector` and `NetworkPills`.
> - Refactors token selection to use `TokenSelectorType` enum across component and hooks; adjusts logic for `dest` initialization and `noFee` handling; passes `type` to `NetworkPills`.
> - Tightens balance typing: `BalancesByAssetId` now keyed by `CaipAssetType`; normalizes EVM asset IDs to lowercase; updates `useTokensWithBalances` accordingly.
> - Unifies Bridge API base URL via `BRIDGE_API_BASE_URL` for popular/search token endpoints.
> - Adds/updates unit tests for new selectors, components, and hooks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81f11c291bd43d802321c44dddef9ba2ce550811. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->