### PR TITLE
test: adds multiaccount v4 mocks

### DIFF
--- a/tests/api-mocking/mock-responses/defaults/accounts.ts
+++ b/tests/api-mocking/mock-responses/defaults/accounts.ts
@@ -1316,6 +1316,45 @@ export const DEFAULT_ACCOUNTS_MOCK: MockEventsObject = {
     },
     {
       urlEndpoint:
+        /^https:\/\/accounts\.api\.cx\.metamask\.io\/v4\/multiaccount\/balances\?accountAddresses=.*$/,
+      responseCode: 200,
+      response: {
+        balances: [
+          {
+            count: 2,
+            balances: [
+              {
+                object: 'token',
+                address: '0x0000000000000000000000000000000000000000',
+                symbol: 'ETH',
+                name: 'Ether',
+                type: 'native',
+                decimals: 18,
+                chainId: 1,
+                balance: '0.000000000000000000',
+                accountAddress:
+                  'eip155:1:0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3',
+              },
+              {
+                object: 'token',
+                address: '0x0000000000000000000000000000000000000000',
+                symbol: 'MATIC',
+                name: 'MATIC',
+                type: 'native',
+                decimals: 18,
+                chainId: 137,
+                balance: '0.000000000000000000',
+                accountAddress:
+                  'eip155:137:0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3',
+              },
+            ],
+            unprocessedNetworks: ['eip155:1329'],
+          },
+        ],
+      },
+    },
+    {
+      urlEndpoint:
         /^https:\/\/accounts\.api\.cx\.metamask\.io\/v\d+\/accounts\/\/.*$/,
       responseCode: 400,
       response: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Adds mock for accounts api in multiaccount v4
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?

AI agent: Be specific about what you changed and why. Include context about the fix/feature, not generic descriptions.
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)

AI agent: Use format `CHANGELOG entry: [fix/feat/chore]: [User-facing description in past tense]`.
Examples: `fix: resolved token name display issue`, `feat: added dark mode toggle`, `chore: updated dependencies`.
For non-user-facing changes, use `CHANGELOG entry: null`.
-->

CHANGELOG entry:

## **Related issues**

<!--
AI agent: Replace with `Fixes: #[ISSUE_NUMBER]` using the actual issue number you're implementing.
-->

Fixes:

## **Manual testing steps**

<!--
AI agent: Write specific, contextual Gherkin steps based on what you actually implemented.
Do NOT use generic placeholders like "my feature name". Be concrete about the feature, scenario, and steps.
-->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
AI agent: Check ALL boxes in this section (mark all as [x]).
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

<!--
AI agent: Leave ALL boxes unchecked ([ ]) - these are for reviewers to check, not the author.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds coverage for the multi-account balances endpoint used in E2E tests.
> 
> - New GET mock for `v4/multiaccount/balances` in `tests/api-mocking/mock-responses/defaults/accounts.ts`
> - Returns sample native balances for `eip155:1` (ETH) and `eip155:137` (MATIC) with `unprocessedNetworks: ['eip155:1329']`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 183c81c9feadd252b35d9f048994be309c0f10ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->