### PR TITLE
fix(ramp): remove background from payment method list item icons

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/PaymentMethodSelectorModal.styles.ts
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/PaymentMethodSelectorModal.styles.ts
@@ -8,20 +8,12 @@ const styleSheet = (params: {
   theme: Theme;
   vars: PaymentSelectorModalStyleSheetVars;
 }) => {
-  const { vars, theme } = params;
+  const { vars } = params;
   const { screenHeight } = vars;
 
   return StyleSheet.create({
     list: {
       maxHeight: screenHeight * 0.4,
-    },
-    iconContainer: {
-      width: 32,
-      height: 32,
-      justifyContent: 'center',
-      alignItems: 'center',
-      backgroundColor: theme.colors.primary.muted,
-      borderRadius: 8,
     },
   });
 };

--- a/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/PaymentMethodSelectorModal.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/PaymentMethodSelectorModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from 'react';
-import { View, useWindowDimensions } from 'react-native';
+import { useWindowDimensions } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import Text, {
   TextVariant,
@@ -91,16 +91,14 @@ function PaymentMethodSelectorModal() {
         accessible
       >
         <ListItemColumn widthType={WidthType.Auto}>
-          <View style={styles.iconContainer}>
-            <Icon
-              name={paymentMethod.icon as IconName}
-              color={
-                typeof paymentMethod.iconColor === 'object'
-                  ? paymentMethod.iconColor[themeAppearance]
-                  : (paymentMethod.iconColor ?? IconColor.Primary)
-              }
-            />
-          </View>
+          <Icon
+            name={paymentMethod.icon as IconName}
+            color={
+              typeof paymentMethod.iconColor === 'object'
+                ? paymentMethod.iconColor[themeAppearance]
+                : (paymentMethod.iconColor ?? IconColor.Default)
+            }
+          />
         </ListItemColumn>
         <ListItemColumn widthType={WidthType.Fill}>
           <Text variant={TextVariant.BodyLGMedium}>{paymentMethod.name}</Text>
@@ -115,7 +113,6 @@ function PaymentMethodSelectorModal() {
     [
       handleSelectPaymentMethodIdCallback,
       selectedPaymentMethod?.id,
-      styles.iconContainer,
       themeAppearance,
     ],
   );

--- a/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -678,32 +678,19 @@ exports[`PaymentMethodSelectorModal Component renders correctly and matches snap
                                         }
                                         testID="listitemcolumn"
                                       >
-                                        <View
+                                        <SvgMock
+                                          color="#121314"
+                                          fill="currentColor"
+                                          height={20}
+                                          name="Card"
                                           style={
                                             {
-                                              "alignItems": "center",
-                                              "backgroundColor": "#4459ff1a",
-                                              "borderRadius": 8,
-                                              "height": 32,
-                                              "justifyContent": "center",
-                                              "width": 32,
+                                              "height": 20,
+                                              "width": 20,
                                             }
                                           }
-                                        >
-                                          <SvgMock
-                                            color="#4459ff"
-                                            fill="currentColor"
-                                            height={20}
-                                            name="Card"
-                                            style={
-                                              {
-                                                "height": 20,
-                                                "width": 20,
-                                              }
-                                            }
-                                            width={20}
-                                          />
-                                        </View>
+                                          width={20}
+                                        />
                                       </View>
                                       <View
                                         accessible={false}
@@ -832,32 +819,19 @@ exports[`PaymentMethodSelectorModal Component renders correctly and matches snap
                                         }
                                         testID="listitemcolumn"
                                       >
-                                        <View
+                                        <SvgMock
+                                          color="var(--color-icon-default)"
+                                          fill="currentColor"
+                                          height={20}
+                                          name="Apple"
                                           style={
                                             {
-                                              "alignItems": "center",
-                                              "backgroundColor": "#4459ff1a",
-                                              "borderRadius": 8,
-                                              "height": 32,
-                                              "justifyContent": "center",
-                                              "width": 32,
+                                              "height": 20,
+                                              "width": 20,
                                             }
                                           }
-                                        >
-                                          <SvgMock
-                                            color="var(--color-icon-default)"
-                                            fill="currentColor"
-                                            height={20}
-                                            name="Apple"
-                                            style={
-                                              {
-                                                "height": 20,
-                                                "width": 20,
-                                              }
-                                            }
-                                            width={20}
-                                          />
-                                        </View>
+                                          width={20}
+                                        />
                                       </View>
                                       <View
                                         accessible={false}


### PR DESCRIPTION
## **Description**

Removes the background color from list item icons in the Payment Method Selector modal in the Deposit flow.

**Issue:** The list item icons in the "Select a Payment Method" bottom sheet were displaying with a background color, which was inconsistent with other list item menus in the app.

**Solution:** Updated the icon rendering to display icons only (default white) without background color, aligning with design system consistency.

## **Changelog**

CHANGELOG entry: fix: removed background from payment method icons in deposit flow

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-285

## **Manual testing steps**

```gherkin
Feature: Payment Method Selector Modal in Deposit Flow

  Scenario: User views payment method options without icon backgrounds
    Given the user is on the Deposit flow
    And the user has selected a token and region

    When user taps on the payment method selector
    Then the "Select a payment method" bottom sheet appears
    And the payment method icons are displayed without background color
    And the icons match the styling of other list item menus
```

## **Screenshots/Recordings**

### **Before**

<img width="300" alt="image"  src="https://github.com/user-attachments/assets/f81ae4bf-eca4-421e-8833-17469b6222f8" />


### **After**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/c5f65df4-691e-465b-837a-a7bb40a68c17" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Payment Method Selector modal icon styling with design by removing background containers and rendering bare icons.
> 
> - PaymentMethodSelectorModal: remove `iconContainer` wrapper/styles and related import; render `Icon` directly
> - Default icon color changed from `IconColor.Primary` to `IconColor.Default`, still supports theme-based `iconColor`
> - Update Jest snapshots to reflect icon-only rendering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8368eb781d9a928e00b397b0349e324a2b7facb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->