### PR TITLE
fix(ramp): replace deposit header close button with back button

### DIFF
--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -1691,19 +1691,20 @@ export function getDepositNavbarOptions(
   theme,
   onClose = undefined,
 ) {
-  const handleClose = () => {
-    navigation.dangerouslyGetParent()?.pop();
-    onClose?.();
-  };
-
-  let startButtonIconProps;
-  if (showBack) {
+  let startButtonIconProps, closeButtonProps;
+  if (showBack || showClose) {
     startButtonIconProps = {
       iconName: IconName.ArrowLeft,
-      onPress: () => navigation.pop(),
+      onPress: () => {
+        navigation.pop();
+        onClose?.();
+      },
+      testID: 'deposit-back-navbar-button',
     };
-  } else if (showConfiguration) {
-    startButtonIconProps = {
+  }
+
+  if (showConfiguration) {
+    closeButtonProps = {
       iconName: IconName.Setting,
       onPress: onConfigurationPress,
       testID: 'deposit-configuration-menu-button',
@@ -1713,9 +1714,7 @@ export function getDepositNavbarOptions(
   return getHeaderCenterNavbarOptions({
     title,
     startButtonIconProps,
-    closeButtonProps: showClose
-      ? { onPress: handleClose, testID: 'deposit-close-navbar-button' }
-      : undefined,
+    closeButtonProps,
     includesTopInset: true,
   });
 }

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -101,6 +101,7 @@ jest.mock('@react-navigation/native', () => {
       ),
       goBack: mockGoBack,
       reset: mockReset,
+      pop: mockPop,
       dangerouslyGetParent: () => ({
         pop: mockPop,
       }),
@@ -443,9 +444,9 @@ describe('BuildQuote View', () => {
     });
   });
 
-  it('navigates and tracks event on cancel button press', async () => {
+  it('navigates and tracks event on back button press', async () => {
     render(BuildQuote);
-    fireEvent.press(screen.getByTestId('deposit-close-navbar-button'));
+    fireEvent.press(screen.getByTestId('deposit-back-navbar-button'));
     expect(mockPop).toHaveBeenCalled();
     expect(mockTrackEvent).toHaveBeenCalledWith('ONRAMP_CANCELED', {
       chain_id_destination: '1',
@@ -459,7 +460,7 @@ describe('BuildQuote View', () => {
     mockUseRampSDKValues.isSell = true;
     mockUseRampSDKValues.rampType = RampType.SELL;
     render(BuildQuote);
-    fireEvent.press(screen.getByTestId('deposit-close-navbar-button'));
+    fireEvent.press(screen.getByTestId('deposit-back-navbar-button'));
     expect(mockPop).toHaveBeenCalled();
     expect(mockTrackEvent).toHaveBeenCalledWith('OFFRAMP_CANCELED', {
       chain_id_source: '1',

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -119,11 +119,11 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -249,11 +249,11 @@ exports[`BuildQuote View Balance display displays balance from useBalance for no
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -2571,11 +2571,11 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -2701,11 +2701,11 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -3190,56 +3190,6 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
           <View>
             <View
               onLayout={[Function]}
-            />
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flexBasis": "0%",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                undefined,
-              ]
-            }
-          >
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "display": "flex",
-                  },
-                  undefined,
-                ]
-              }
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  [
-                    {
-                      "color": "#121314",
-                      "fontFamily": "Geist-Bold",
-                      "fontSize": 16,
-                      "fontWeight": 400,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                Sell
-              </Text>
-            </View>
-          </View>
-          <View>
-            <View
-              onLayout={[Function]}
             >
               <View
                 style={
@@ -3302,11 +3252,11 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -3321,6 +3271,56 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                 </View>
               </View>
             </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexBasis": "0%",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "display": "flex",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  [
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist-Bold",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Sell
+              </Text>
+            </View>
+          </View>
+          <View>
+            <View
+              onLayout={[Function]}
+            />
           </View>
         </View>
       </View>
@@ -3853,11 +3853,11 @@ exports[`BuildQuote View Crypto Currency Data renders an error page when there i
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -3983,11 +3983,11 @@ exports[`BuildQuote View Crypto Currency Data renders an error page when there i
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -4534,11 +4534,11 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -4664,11 +4664,11 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -6832,11 +6832,11 @@ exports[`BuildQuote View Fiat Currency Data renders an error page when there is 
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -6962,11 +6962,11 @@ exports[`BuildQuote View Fiat Currency Data renders an error page when there is 
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -7513,11 +7513,11 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -7643,11 +7643,11 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -9791,11 +9791,11 @@ exports[`BuildQuote View Payment Method Data renders an error page when there is
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -9921,11 +9921,11 @@ exports[`BuildQuote View Payment Method Data renders an error page when there is
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -10472,11 +10472,11 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -10602,11 +10602,11 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -12881,11 +12881,11 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -13011,11 +13011,11 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -15283,11 +15283,11 @@ exports[`BuildQuote View Regions data renders an error page when there is a regi
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -15413,11 +15413,11 @@ exports[`BuildQuote View Regions data renders an error page when there is a regi
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -15964,11 +15964,11 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -16094,11 +16094,11 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -18218,11 +18218,11 @@ exports[`BuildQuote View renders correctly 1`] = `
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -18348,11 +18348,11 @@ exports[`BuildQuote View renders correctly 1`] = `
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -20608,56 +20608,6 @@ exports[`BuildQuote View renders correctly 2`] = `
           <View>
             <View
               onLayout={[Function]}
-            />
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flexBasis": "0%",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                undefined,
-              ]
-            }
-          >
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "display": "flex",
-                  },
-                  undefined,
-                ]
-              }
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  [
-                    {
-                      "color": "#121314",
-                      "fontFamily": "Geist-Bold",
-                      "fontSize": 16,
-                      "fontWeight": 400,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                Sell
-              </Text>
-            </View>
-          </View>
-          <View>
-            <View
-              onLayout={[Function]}
             >
               <View
                 style={
@@ -20720,11 +20670,11 @@ exports[`BuildQuote View renders correctly 2`] = `
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -20739,6 +20689,56 @@ exports[`BuildQuote View renders correctly 2`] = `
                 </View>
               </View>
             </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexBasis": "0%",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "display": "flex",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  [
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist-Bold",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Sell
+              </Text>
+            </View>
+          </View>
+          <View>
+            <View
+              onLayout={[Function]}
+            />
           </View>
         </View>
       </View>
@@ -23057,11 +23057,11 @@ exports[`BuildQuote View renders correctly when sdkError is present 1`] = `
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -23187,11 +23187,11 @@ exports[`BuildQuote View renders correctly when sdkError is present 1`] = `
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -23676,56 +23676,6 @@ exports[`BuildQuote View renders correctly when sdkError is present 2`] = `
           <View>
             <View
               onLayout={[Function]}
-            />
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "display": "flex",
-                  "flexBasis": "0%",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                undefined,
-              ]
-            }
-          >
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "display": "flex",
-                  },
-                  undefined,
-                ]
-              }
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  [
-                    {
-                      "color": "#121314",
-                      "fontFamily": "Geist-Bold",
-                      "fontSize": 16,
-                      "fontWeight": 400,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                Sell
-              </Text>
-            </View>
-          </View>
-          <View>
-            <View
-              onLayout={[Function]}
             >
               <View
                 style={
@@ -23788,11 +23738,11 @@ exports[`BuildQuote View renders correctly when sdkError is present 2`] = `
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -23807,6 +23757,56 @@ exports[`BuildQuote View renders correctly when sdkError is present 2`] = `
                 </View>
               </View>
             </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexBasis": "0%",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "display": "flex",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  [
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist-Bold",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Sell
+              </Text>
+            </View>
+          </View>
+          <View>
+            <View
+              onLayout={[Function]}
+            />
           </View>
         </View>
       </View>

--- a/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
@@ -73,7 +73,6 @@ const OrderDetails = () => {
         navigation,
         {
           title: strings('fiat_on_ramp_aggregator.order_details.details_main'),
-          showClose: false,
         },
         theme,
       ),

--- a/app/components/UI/Ramp/Aggregator/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`OrderDetails renders a cancelled order 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -1551,7 +1551,7 @@ exports[`OrderDetails renders a completed order 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -3001,7 +3001,7 @@ exports[`OrderDetails renders a created order 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -4429,7 +4429,7 @@ exports[`OrderDetails renders a failed order 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -5861,7 +5861,7 @@ exports[`OrderDetails renders a pending order 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -7289,7 +7289,7 @@ exports[`OrderDetails renders an empty screen layout if there is no order 1`] = 
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -7701,7 +7701,7 @@ exports[`OrderDetails renders an error screen if a CREATED order cannot be polle
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -8302,7 +8302,7 @@ exports[`OrderDetails renders non-transacted orders 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -9795,7 +9795,7 @@ exports[`OrderDetails renders the support links if the provider has them 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -11291,7 +11291,7 @@ exports[`OrderDetails renders transacted orders that do not have timeDescription
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -12719,7 +12719,7 @@ exports[`OrderDetails renders transacted orders that have timeDescriptionPending
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.test.tsx
@@ -68,6 +68,7 @@ jest.mock('@react-navigation/native', () => {
       ),
       goBack: mockGoBack,
       reset: mockReset,
+      pop: mockPop,
       dangerouslyGetParent: () => ({
         pop: mockPop,
       }),
@@ -230,9 +231,9 @@ describe('Quotes', () => {
     expect(mockSetOptions).toHaveBeenCalled();
   });
 
-  it('navigates and tracks event on cancel button press', async () => {
+  it('navigates and tracks event on back button press', async () => {
     render(Quotes);
-    fireEvent.press(screen.getByTestId('deposit-close-navbar-button'));
+    fireEvent.press(screen.getByTestId('deposit-back-navbar-button'));
     expect(mockPop).toHaveBeenCalled();
     expect(mockTrackEvent).toHaveBeenCalledWith('ONRAMP_CANCELED', {
       chain_id_destination: '1',
@@ -246,12 +247,12 @@ describe('Quotes', () => {
     });
   });
 
-  it('navigates and tracks event on SELL cancel button press', async () => {
+  it('navigates and tracks event on SELL back button press', async () => {
     mockUseRampSDKValues.rampType = RampType.SELL;
     mockUseRampSDKValues.isSell = true;
     mockUseRampSDKValues.isBuy = false;
     render(Quotes);
-    fireEvent.press(screen.getByTestId('deposit-close-navbar-button'));
+    fireEvent.press(screen.getByTestId('deposit-back-navbar-button'));
     expect(mockTrackEvent).toHaveBeenCalledWith('OFFRAMP_CANCELED', {
       chain_id_source: '1',
       location: 'Quotes Screen',

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -640,7 +640,7 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -708,87 +708,7 @@ exports[`Quotes custom action renders correctly after animation with the recomme
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -1742,7 +1662,7 @@ exports[`Quotes renders animation on first fetching 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -1810,87 +1730,7 @@ exports[`Quotes renders animation on first fetching 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -2870,7 +2710,7 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -2938,87 +2778,7 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -4730,7 +4490,7 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -4798,87 +4558,7 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -5982,7 +5662,7 @@ exports[`Quotes renders correctly after animation without quotes 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -6050,87 +5730,7 @@ exports[`Quotes renders correctly after animation without quotes 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -6744,7 +6344,7 @@ exports[`Quotes renders correctly when fetching quotes errors 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -6812,87 +6412,7 @@ exports[`Quotes renders correctly when fetching quotes errors 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -7506,7 +7026,7 @@ exports[`Quotes renders correctly with sdkError 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -7574,87 +7094,7 @@ exports[`Quotes renders correctly with sdkError 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -8268,7 +7708,7 @@ exports[`Quotes renders quotes expired screen 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -8336,87 +7776,7 @@ exports[`Quotes renders quotes expired screen 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>

--- a/app/components/UI/Ramp/Aggregator/Views/SendTransaction/SendTransaction.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/SendTransaction/SendTransaction.tsx
@@ -109,7 +109,6 @@ function SendTransaction() {
           title: strings(
             'fiat_on_ramp_aggregator.send_transaction.sell_crypto',
           ),
-          showClose: false,
         },
         theme,
       ),

--- a/app/components/UI/Ramp/Aggregator/Views/SendTransaction/__snapshots__/SendTransaction.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/SendTransaction/__snapshots__/SendTransaction.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`SendTransaction View renders correctly 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -891,7 +891,7 @@ exports[`SendTransaction View renders correctly for custom action payment method
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -1581,7 +1581,7 @@ exports[`SendTransaction View renders correctly for token 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"

--- a/app/components/UI/Ramp/Deposit/Views/AdditionalVerification/__snapshots__/AdditionalVerification.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/AdditionalVerification/__snapshots__/AdditionalVerification.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`AdditionalVerification Component render matches snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -187,87 +187,7 @@ exports[`AdditionalVerification Component render matches snapshot 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>

--- a/app/components/UI/Ramp/Deposit/Views/BankDetails/__snapshots__/BankDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BankDetails/__snapshots__/BankDetails.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`BankDetails Component render matches snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -187,87 +187,7 @@ exports[`BankDetails Component render matches snapshot 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -1167,7 +1087,7 @@ exports[`BankDetails Component render matches snapshot with bank info shown 1`] 
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -1235,87 +1155,7 @@ exports[`BankDetails Component render matches snapshot with bank info shown 1`] 
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>

--- a/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -187,87 +187,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -1639,7 +1559,7 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -1707,87 +1627,7 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -3159,7 +2999,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -3227,87 +3067,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -4679,7 +4439,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -4747,87 +4507,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -6199,7 +5879,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -6267,87 +5947,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -7779,7 +7379,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -7847,87 +7447,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -9344,7 +8864,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -9412,87 +8932,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
@@ -164,8 +164,6 @@ const BuildQuote = () => {
         navigation,
         {
           title: strings('deposit.buildQuote.title'),
-          showBack: false,
-          showClose: true,
           showConfiguration: true,
           onConfigurationPress: () => {
             navigation.navigate(

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -119,11 +119,11 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -249,11 +249,11 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -1931,11 +1931,11 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -2061,11 +2061,11 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -3743,11 +3743,11 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -3873,11 +3873,11 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -5555,11 +5555,11 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -5685,11 +5685,11 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -7306,11 +7306,11 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -7436,11 +7436,11 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -9056,11 +9056,11 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -9186,11 +9186,11 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -10807,11 +10807,11 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -10937,11 +10937,11 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -12651,11 +12651,11 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -12781,11 +12781,11 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -14357,11 +14357,11 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -14487,11 +14487,11 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -16108,11 +16108,11 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -16238,11 +16238,11 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -17859,11 +17859,11 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -17989,11 +17989,11 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -19610,11 +19610,11 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -19740,11 +19740,11 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -21361,11 +21361,11 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -21491,11 +21491,11 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -23205,11 +23205,11 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -23335,11 +23335,11 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -24954,11 +24954,11 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -25084,11 +25084,11 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -26796,11 +26796,11 @@ exports[`BuildQuote Component User Details Error displays user details error ale
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -26926,11 +26926,11 @@ exports[`BuildQuote Component User Details Error displays user details error ale
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {
@@ -28640,11 +28640,11 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="deposit-configuration-menu-button"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Setting"
+                    name="ArrowLeft"
                     style={
                       [
                         {
@@ -28770,11 +28770,11 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="deposit-close-navbar-button"
+                  testID="deposit-configuration-menu-button"
                 >
                   <SvgMock
                     fill="currentColor"
-                    name="Close"
+                    name="Setting"
                     style={
                       [
                         {

--- a/app/components/UI/Ramp/Deposit/Views/DepositOrderDetails/DepositOrderDetails.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/DepositOrderDetails/DepositOrderDetails.tsx
@@ -60,7 +60,6 @@ const DepositOrderDetails = () => {
         navigation,
         {
           title: strings('deposit.order_details.title'),
-          showClose: false,
         },
         theme,
       ),

--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -187,87 +187,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -1731,7 +1651,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -1799,87 +1719,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -3275,7 +3115,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -3343,87 +3183,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -4827,7 +4587,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -4895,87 +4655,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>

--- a/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -187,87 +187,7 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -918,7 +838,7 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -986,87 +906,7 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -1731,7 +1571,7 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -1799,87 +1639,7 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -2530,7 +2290,7 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -2598,87 +2358,7 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>

--- a/app/components/UI/Ramp/Deposit/Views/KycProcessing/__snapshots__/KycProcessing.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/KycProcessing/__snapshots__/KycProcessing.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`KycProcessing Component render matches snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -187,87 +187,7 @@ exports[`KycProcessing Component render matches snapshot 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -805,7 +725,7 @@ exports[`KycProcessing Component renders approved state snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -873,87 +793,7 @@ exports[`KycProcessing Component renders approved state snapshot 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -1549,7 +1389,7 @@ exports[`KycProcessing Component renders error state snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -1617,87 +1457,7 @@ exports[`KycProcessing Component renders error state snapshot 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -2279,7 +2039,7 @@ exports[`KycProcessing Component renders loading state snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -2347,87 +2107,7 @@ exports[`KycProcessing Component renders loading state snapshot 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -2965,7 +2645,7 @@ exports[`KycProcessing Component renders pending forms state snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -3033,87 +2713,7 @@ exports[`KycProcessing Component renders pending forms state snapshot 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>
@@ -3695,7 +3295,7 @@ exports[`KycProcessing Component renders rejected state snapshot 1`] = `
                       undefined,
                     ]
                   }
-                  testID="button-icon"
+                  testID="deposit-back-navbar-button"
                 >
                   <SvgMock
                     fill="currentColor"
@@ -3763,87 +3363,7 @@ exports[`KycProcessing Component renders rejected state snapshot 1`] = `
           <View>
             <View
               onLayout={[Function]}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "transform": [
-                        {
-                          "scale": 1,
-                        },
-                      ],
-                    },
-                    {
-                      "alignItems": "center",
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": false,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 2,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "opacity": 1,
-                        "width": 32,
-                      },
-                      undefined,
-                    ]
-                  }
-                  testID="deposit-close-navbar-button"
-                >
-                  <SvgMock
-                    fill="currentColor"
-                    name="Close"
-                    style={
-                      [
-                        {
-                          "color": "#121314",
-                          "height": 20,
-                          "width": 20,
-                        },
-                        undefined,
-                      ]
-                    }
-                  />
-                </View>
-              </View>
-            </View>
+            />
           </View>
         </View>
       </View>


### PR DESCRIPTION
## **Description**

This PR addresses the first action item of [MDP-274](https://consensyssoftware.atlassian.net/browse/MDP-274) - "Deposit: page header revisions".

### Problem
The Deposit page header had incorrect and misaligned button icons:
- **Left side**: Settings icon (⚙️) when `showConfiguration` was enabled
- **Right side**: Close button (✕) to dismiss the flow

This pattern was inconsistent with standard navigation patterns and the updated design requirements.

### Solution
Updated `getDepositNavbarOptions` in `app/components/UI/Navbar/index.js` to:
- **Left side**: Back arrow (←) button that navigates back and optionally calls `onClose` callback
- **Right side**: Settings/configuration icon (⚙️) when `showConfiguration` is enabled

### Changes Made
1. **Core navbar function** (`Navbar/index.js`):
   - Refactored `getDepositNavbarOptions` to show back button on left when `showBack || showClose`
   - Moved configuration (settings) icon to right side via `closeButtonProps`
   - Added new testID `deposit-back-navbar-button` for the back button
   - Removed old `deposit-close-navbar-button` testID

2. **Deposit views**:
   - `BuildQuote.tsx`: Simplified options (removed explicit `showBack: false, showClose: true`)
   - `DepositOrderDetails.tsx`: Removed `showClose: false`

3. **Aggregator views** (also use `getDepositNavbarOptions`):
   - `OrderDetails.tsx`: Removed `showClose: false`
   - `SendTransaction.tsx`: Removed `showClose: false`

4. **Test updates**:
   - Updated `BuildQuote.test.tsx` and `Quotes.test.tsx` to use new testID
   - Renamed tests from "cancel button press" to "back button press"
   - Added `pop: mockPop` to navigation mocks

5. **Snapshot updates**:
   - 11 snapshot files updated to reflect new header structure
   - Close button removed from right side
   - Back arrow with new testID on left side

## **Changelog**

CHANGELOG entry: fix: Updated Deposit page header to use back button instead of close button

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-274 (first action item)

## **Manual testing steps**

```gherkin
Feature: Deposit Page Header Navigation

  Scenario: User navigates back from Deposit BuildQuote screen
    Given user is on the Deposit BuildQuote screen
    And user sees a back arrow button on the left side of the header
    And user sees a settings icon on the right side of the header

    When user taps the back arrow button
    Then user is navigated back to the previous screen

  Scenario: User opens configuration from Deposit BuildQuote screen
    Given user is on the Deposit BuildQuote screen
    And user sees a settings icon on the right side of the header

    When user taps the settings icon
    Then the configuration modal is displayed

  Scenario: User navigates back from Deposit sub-screens
    Given user is on any Deposit sub-screen (EnterEmail, BasicInfo, etc.)
    And user sees a back arrow button on the left side of the header

    When user taps the back arrow button
    Then user is navigated back to the previous screen in the flow
```

## **Screenshots/Recordings**

### **Before**

<!-- Header had: Settings icon (left) | Title | Close X button (right) -->
<img width="220"  alt="before_mdp274_1" src="https://github.com/user-attachments/assets/50351593-4e22-4115-bd8d-9b43f98ae627" /> <img width="220"  alt="before_mdp274_2 png" src="https://github.com/user-attachments/assets/6c077435-828c-43ad-b6d0-51c0723d8e46" /> <img width="220"   alt="before_mdp274_3 png" src="https://github.com/user-attachments/assets/ec92acf1-9c21-49d3-88d8-8bbf00ba3b94" />


### **After**

<!-- Header now has: Back arrow (left) | Title | Settings icon (right) -->
<img width="220"  alt="after_mdp274_1" src="https://github.com/user-attachments/assets/f6f5ed61-0b14-4a47-8ec9-e9e247464dec" /> <img width="220"  alt="after_mdp274_2" src="https://github.com/user-attachments/assets/cd5a2ea0-2eb3-4f88-9752-eafb28f795d1" /> <img width="220"  height="2622" alt="after_mdp274_3" src="https://github.com/user-attachments/assets/ee9cb478-0e80-4e80-9d55-177d4fbafc9e" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MDP-274]: https://consensyssoftware.atlassian.net/browse/MDP-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Deposit and Aggregator headers with standard navigation.
> 
> - Refactors `getDepositNavbarOptions` to show back button when `showBack || showClose`; settings icon now on the right via `closeButtonProps`
> - Adds `deposit-back-navbar-button` testID; removes `deposit-close-navbar-button`
> - Simplifies screen options in Deposit/Aggregator views (removes explicit `showClose`); `BuildQuote` keeps configuration via right-side button
> - Updates unit tests to use back button semantics and navigation `pop`; adjusts navigation mocks
> - Refreshes snapshots across affected screens to reflect new header structure and icons
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cba5b0118eb0caf101c60deab4bb8e91d767f3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->