### PR TITLE
fix(ramp): remove borders from deposit selectors for visual consistency

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.styles.ts
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.styles.ts
@@ -45,12 +45,10 @@ const styleSheet = (params: { theme: Theme }) => {
       textAlign: 'center',
     },
     fiatSelector: {
-      backgroundColor: theme.colors.background.default,
+      backgroundColor: theme.colors.background.muted,
       borderRadius: 12,
       paddingVertical: 8,
       paddingHorizontal: 16,
-      borderWidth: 1,
-      borderColor: theme.colors.border.muted,
     },
     regionContent: {
       flexDirection: 'row',
@@ -66,14 +64,11 @@ const styleSheet = (params: { theme: Theme }) => {
       paddingLeft: 8,
       paddingRight: 12,
       backgroundColor: theme.colors.background.muted,
-      borderWidth: 1,
-      borderColor: theme.colors.border.muted,
     },
     paymentMethodBox: {
       borderRadius: 12,
-      borderWidth: 1,
-      borderColor: theme.colors.border.muted,
       marginBottom: 16,
+      backgroundColor: theme.colors.background.muted,
     },
     errorText: {
       textAlign: 'center',

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
@@ -693,8 +693,10 @@ const BuildQuote = () => {
               <ListItemColumn>
                 {selectedPaymentMethod ? (
                   <TagBase
-                    includesBorder
                     textProps={{ variant: TextVariant.BodySM }}
+                    style={{
+                      backgroundColor: theme.colors.background.subsection,
+                    }}
                   >
                     {strings(
                       `deposit.payment_duration.${selectedPaymentMethod.duration}`,

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -520,9 +520,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -551,10 +549,8 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -652,9 +648,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -896,9 +890,8 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -984,7 +977,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -2332,9 +2325,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -2363,10 +2354,8 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -2464,9 +2453,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -2708,9 +2695,8 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -2796,7 +2782,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -4144,9 +4130,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -4175,10 +4159,8 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -4276,9 +4258,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -4520,9 +4500,8 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -4608,7 +4587,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -5956,9 +5935,7 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -5987,10 +5964,8 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -6105,9 +6080,7 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -6271,9 +6244,8 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -6359,7 +6331,7 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -7707,9 +7679,7 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -7738,10 +7708,8 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -7856,9 +7824,7 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -8022,9 +7988,8 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -8110,7 +8075,7 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -9457,9 +9422,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -9488,10 +9451,8 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -9606,9 +9567,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -9772,9 +9731,8 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -9860,7 +9818,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -11208,9 +11166,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -11239,10 +11195,8 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -11357,9 +11311,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -11616,9 +11568,8 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -11704,7 +11655,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -13052,9 +13003,7 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -13083,10 +13032,8 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -13201,9 +13148,7 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -13367,9 +13312,8 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -14758,9 +14702,7 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -14789,10 +14731,8 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -14907,9 +14847,7 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -15073,9 +15011,8 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -15161,7 +15098,7 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -16509,9 +16446,7 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -16540,10 +16475,8 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -16658,9 +16591,7 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -16824,9 +16755,8 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -16912,7 +16842,7 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -18260,9 +18190,7 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -18291,10 +18219,8 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -18409,9 +18335,7 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -18575,9 +18499,8 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -18663,7 +18586,7 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -20011,9 +19934,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -20042,10 +19963,8 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -20160,9 +20079,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -20326,9 +20243,8 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -20414,7 +20330,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -21762,9 +21678,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -21793,10 +21707,8 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -21911,9 +21823,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -22170,9 +22080,8 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -22258,7 +22167,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -23606,9 +23515,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -23637,10 +23544,8 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -23753,9 +23658,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -23919,9 +23822,8 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -24007,7 +23909,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -25355,9 +25257,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -25386,10 +25286,8 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -25502,9 +25400,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -25761,9 +25657,8 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -25849,7 +25744,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -27197,9 +27092,7 @@ exports[`BuildQuote Component User Details Error displays user details error ale
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -27228,10 +27121,8 @@ exports[`BuildQuote Component User Details Error displays user details error ale
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -27346,9 +27237,7 @@ exports[`BuildQuote Component User Details Error displays user details error ale
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -27605,9 +27494,8 @@ exports[`BuildQuote Component User Details Error displays user details error ale
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -27693,7 +27581,7 @@ exports[`BuildQuote Component User Details Error displays user details error ale
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,
@@ -29041,9 +28929,7 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                                     "alignItems": "center",
                                     "alignSelf": "flex-start",
                                     "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "#b7bbc866",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "gap": 10,
                                     "justifyContent": "space-between",
@@ -29072,10 +28958,8 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                                 onPress={[Function]}
                                 style={
                                   {
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#b7bbc866",
+                                    "backgroundColor": "#3c4d9d0f",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "paddingHorizontal": 16,
                                     "paddingVertical": 8,
                                   }
@@ -29190,9 +29074,7 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "#b7bbc866",
                                       "borderRadius": 100,
-                                      "borderWidth": 1,
                                       "flexDirection": "row",
                                       "gap": 8,
                                       "paddingLeft": 8,
@@ -29356,9 +29238,8 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                               onPress={[Function]}
                               style={
                                 {
-                                  "borderColor": "#b7bbc866",
+                                  "backgroundColor": "#3c4d9d0f",
                                   "borderRadius": 12,
-                                  "borderWidth": 1,
                                   "marginBottom": 16,
                                 }
                               }
@@ -29444,7 +29325,7 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                                           "backgroundColor": "#ffffff",
                                           "borderColor": "#b7bbc8",
                                           "borderRadius": 999,
-                                          "borderWidth": 1,
+                                          "borderWidth": 0,
                                           "color": "#121314",
                                           "padding": 16,
                                           "paddingHorizontal": 8,

--- a/app/components/UI/Ramp/Deposit/components/AccountSelector/AccountSelector.styles.ts
+++ b/app/components/UI/Ramp/Deposit/components/AccountSelector/AccountSelector.styles.ts
@@ -13,8 +13,6 @@ const stylesheet = (params: { theme: Theme }) => {
       backgroundColor: theme.colors.background.muted,
       borderRadius: 12,
       padding: 8,
-      borderWidth: 1,
-      borderColor: theme.colors.border.muted,
       alignSelf: 'flex-start',
     },
   });


### PR DESCRIPTION
## **Description**

This PR addresses [MDP-694](https://consensyssoftware.atlassian.net/browse/MDP-694) - "Fix the account selector background" (second action item from [MDP-274](https://consensyssoftware.atlassian.net/browse/MDP-274)).

### Problem
The Deposit page selectors (Account, Region, Token, Payment Method) had visible borders that made them visually inconsistent with the Aggregator (Buy/Sell) flow selectors. The Deposit selectors used:
- `borderWidth: 1`
- `borderColor: theme.colors.border.muted`
- Different background colors in some cases

This created a visual discrepancy between the two flows.

### Solution
Updated the Deposit selector styles to match the Aggregator styling pattern:
- Removed borders from all selector components
- Updated background colors to use consistent `background.muted` token
- Updated the payment duration tag to use `background.subsection` instead of a border

### Files Changed

1. **`AccountSelector.styles.ts`**
   - Removed `borderWidth: 1` and `borderColor` from the `selector` style

2. **`BuildQuote.styles.ts`**
   - `fiatSelector`: Changed background from `background.default` to `background.muted`, removed border
   - `cryptoPill`: Removed border (kept `borderRadius: 100` for pill shape)
   - `paymentMethodBox`: Removed border, added `background.muted`

3. **`BuildQuote.tsx`**
   - Updated `TagBase` component: Removed `includesBorder` prop, added custom `background.subsection` style

## **Changelog**

CHANGELOG entry: fix: Updated Deposit page selectors to have consistent styling without borders

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-694

## **Manual testing steps**

```gherkin
Feature: Deposit Page Selector Styling

  Scenario: User views Account selector without border
    Given user is on the Deposit BuildQuote screen
    When user looks at the Account selector pill
    Then the Account selector has no visible border
    And the Account selector has a muted background color

  Scenario: User views Region selector without border
    Given user is on the Deposit BuildQuote screen
    When user looks at the Region/Country selector (flag icon)
    Then the Region selector has no visible border
    And the Region selector has a muted background color

  Scenario: User views Token selector without border
    Given user is on the Deposit BuildQuote screen
    When user looks at the Token selector pill (e.g., MUSD)
    Then the Token selector has no visible border
    And the Token selector maintains its pill shape

  Scenario: User views Payment Method section without border
    Given user is on the Deposit BuildQuote screen
    When user looks at the "Pay with" section
    Then the Payment Method box has no visible border
    And the duration tag (e.g., "Instant") has a subtle background instead of a border

  Scenario: Visual consistency with Aggregator flow
    Given user has seen the Aggregator (Buy/Sell) BuildQuote screen
    When user navigates to the Deposit BuildQuote screen
    Then the selector styling is visually consistent between both flows
```

## **Screenshots/Recordings**

### **Before**

<!-- Selectors had visible borders (borderWidth: 1, borderColor: border.muted) -->
<img width="300" alt="before_mdp694" src="https://github.com/user-attachments/assets/8e8ceac1-5d2c-47e8-a494-f86a1006889c" />

### **After**

<!-- Selectors have no borders, using background colors only for visual distinction -->
<img width="300" alt="after_mdp694" src="https://github.com/user-attachments/assets/39a46f7f-a2a6-4280-ae56-6b26a5ff2dba" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MDP-694]: https://consensyssoftware.atlassian.net/browse/MDP-694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MDP-274]: https://consensyssoftware.atlassian.net/browse/MDP-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Deposit BuildQuote selector styling with Aggregator by removing borders and using consistent background tokens.
> 
> - Updates `AccountSelector`, `fiatSelector`, `cryptoPill`, and `paymentMethodBox` to drop borders and use `background.muted`
> - Changes payment duration `TagBase` to use `background.subsection` instead of border
> - Refreshes snapshots to reflect new visual styles
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 375b04384f825754e6fe866695945eea63f9878a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->