### PR TITLE
fix: Fix chainId assertions in `eth_sendTransaction` and `eth_signTypedData_v4` over the Multichain API

### DIFF
--- a/app/core/RPCMethods/RPCMethodMiddleware.test.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.test.ts
@@ -19,6 +19,7 @@ import Engine from '../Engine';
 import { store } from '../../store';
 import { getPermittedAccounts } from '../Permissions';
 import {
+  checkActiveAccountAndChainId,
   getRpcMethodMiddleware,
   getRpcMethodMiddlewareHooks,
 } from './RPCMethodMiddleware';
@@ -1729,6 +1730,111 @@ describe('getRpcMethodMiddleware', () => {
       const spy = jest.spyOn(PPOMUtil, 'validateRequest');
       await sendRequest();
       expect(spy).toBeCalledTimes(1);
+    });
+  });
+});
+
+describe('checkActiveAccountAndChainId', () => {
+  const mockGetNetworkConfigurationByNetworkClientId = jest.mocked(
+    Engine.context.NetworkController.getNetworkConfigurationByNetworkClientId,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetPermittedAccounts.mockReturnValue([]);
+  });
+
+  describe('chainId validation', () => {
+    it('validates when networkClientId chainId matches request hex chainId', async () => {
+      const networkConfig = { chainId: '0x1' };
+      mockGetNetworkConfigurationByNetworkClientId.mockReturnValue(
+        networkConfig as ReturnType<
+          typeof mockGetNetworkConfigurationByNetworkClientId
+        >,
+      );
+
+      await expect(
+        checkActiveAccountAndChainId({
+          hostname: 'test.com',
+          isWalletConnect: false,
+          chainId: '0x1',
+          networkClientId: 'mainnet',
+        }),
+      ).resolves.not.toThrow();
+
+      expect(mockGetNetworkConfigurationByNetworkClientId).toHaveBeenCalledWith(
+        'mainnet',
+      );
+    });
+
+    it('validates when networkClientId chainId matches request decimal chainId', async () => {
+      const networkConfig = { chainId: '0x89' };
+      mockGetNetworkConfigurationByNetworkClientId.mockReturnValue(
+        networkConfig as ReturnType<
+          typeof mockGetNetworkConfigurationByNetworkClientId
+        >,
+      );
+
+      await expect(
+        checkActiveAccountAndChainId({
+          hostname: 'test.com',
+          isWalletConnect: false,
+          chainId: 137,
+          networkClientId: 'polygon',
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it('throws internal error when network configuration is not found', async () => {
+      mockGetNetworkConfigurationByNetworkClientId.mockReturnValue(undefined);
+
+      await expect(
+        checkActiveAccountAndChainId({
+          hostname: 'test.com',
+          isWalletConnect: false,
+          chainId: 1,
+          networkClientId: 'unknown-network',
+        }),
+      ).rejects.toMatchObject({
+        code: -32603,
+        message: 'Failed to get active chainId.',
+      });
+    });
+
+    it('throws invalidParams error when chainIds do not match', async () => {
+      const networkConfig = { chainId: '0x1' };
+      mockGetNetworkConfigurationByNetworkClientId.mockReturnValue(
+        networkConfig as ReturnType<
+          typeof mockGetNetworkConfigurationByNetworkClientId
+        >,
+      );
+
+      await expect(
+        checkActiveAccountAndChainId({
+          hostname: 'test.com',
+          isWalletConnect: false,
+          chainId: 137,
+          networkClientId: 'mainnet',
+        }),
+      ).rejects.toMatchObject({
+        code: -32602,
+        message:
+          'Invalid parameters: active chainId is different than the one provided.',
+      });
+    });
+
+    it('skips chainId validation when chainId is not provided', async () => {
+      await expect(
+        checkActiveAccountAndChainId({
+          hostname: 'test.com',
+          isWalletConnect: false,
+          networkClientId: 'mainnet',
+        }),
+      ).resolves.not.toThrow();
+
+      expect(
+        mockGetNetworkConfigurationByNetworkClientId,
+      ).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -19,7 +19,7 @@ import {
   PermissionDoesNotExistError,
   RequestedPermissions,
 } from '@metamask/permission-controller';
-import { blockTagParamIndex, getAllNetworks } from '../../util/networks';
+import { blockTagParamIndex } from '../../util/networks';
 import { polyfillGasPrice } from './utils';
 import ImportedEngine from '../Engine';
 import { strings } from '../../../locales/i18n';

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -13,8 +13,7 @@ import {
   revokePermissionsHandler,
 } from '@metamask/eip1193-permission-middleware';
 import RPCMethods from './index.js';
-import { RPC } from '../../constants/network';
-import { ChainId, NetworkType, toHex } from '@metamask/controller-utils';
+import { toHex } from '@metamask/controller-utils';
 import {
   PermissionController,
   PermissionDoesNotExistError,
@@ -31,10 +30,6 @@ import { v1 as random } from 'uuid';
 import { getPermittedAccounts } from '../Permissions';
 import AppConstants from '../AppConstants';
 import PPOMUtil from '../../lib/ppom/ppom-util';
-import {
-  selectEvmChainId,
-  selectProviderConfig,
-} from '../../selectors/networkController';
 import { setEventStageError, setEventStage } from '../../actions/rpcEvents';
 import { isWhitelistedRPC, RPCStageTypes } from '../../reducers/rpcEvents';
 import { regex } from '../../../app/util/regex';
@@ -47,7 +42,6 @@ import {
   MessageParamsTyped,
   SignatureController,
 } from '@metamask/signature-controller';
-import { selectPerOriginChainId } from '../../selectors/selectedNetworkController';
 import type { NetworkController } from '@metamask/network-controller';
 import requestEthereumAccounts from './eth-request-accounts';
 import {
@@ -189,12 +183,11 @@ export const checkActiveAccountAndChainId = async ({
       Engine.context as { NetworkController: NetworkController }
     ).NetworkController;
 
-    let activeChainId: string | undefined;
     const networkConfig =
       networkController.getNetworkConfigurationByNetworkClientId(
         networkClientId || '',
       );
-    activeChainId = networkConfig?.chainId;
+    const activeChainId = networkConfig?.chainId;
     if (!activeChainId) {
       throw rpcErrors.internal({
         message: `Failed to get active chainId.`,
@@ -713,7 +706,6 @@ export const getRpcMethodMiddleware = ({
             from?: string;
             chainId?: number;
           }) => {
-            // TODO this needs to be modified for per dapp selected network
             await checkActiveAccountAndChainId({
               hostname,
               address: from,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Solves an issue where the incorrect value was being determined for the active chainId when asserting if a chainId in a `eth_sendTransaction` or `eth_signTypedData_v4` request params matches when the request is made over the Multichain API. This is because the previous assertion logic relied only on the per-dapp-selected network for the request origin to determine the current active chain ID when instead it should be relying entirely on the `networkClientId` property on the request object instead.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)

AI agent: Use format `CHANGELOG entry: [fix/feat/chore]: [User-facing description in past tense]`.
Examples: `fix: resolved token name display issue`, `feat: added dark mode toggle`, `chore: updated dependencies`.
For non-user-facing changes, use `CHANGELOG entry: null`.
-->

CHANGELOG entry: fix: fixed chainId assertions in `eth_sendTransaction` and `eth_signTypedData_v4` requests over the Multichain API

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-968

## **Manual testing steps**

<!--
AI agent: Write specific, contextual Gherkin steps based on what you actually implemented.
Do NOT use generic placeholders like "my feature name". Be concrete about the feature, scenario, and steps.
-->

1. In the In-App Browser, visit https://metamask.github.io/test-dapp-multichain/latest
2. Connect via postMessage
3. Select two or three evm networks to connect to
4. Press wallet_createSession
5. Accept the approval
6. On the dapp, select eth_sendTransaction from the dropdown of one of the cards and then press invoke method
7. You should get shown an approval (reject it)
8. Repeat 6 for the other evm networks you connected to. This should work for each of them.


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/e2cdff48-1c47-45e9-ae7b-14357f92f045


## **Pre-merge author checklist**

<!--
AI agent: Check ALL boxes in this section (mark all as [x]).
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

<!--
AI agent: Leave ALL boxes unchecked ([ ]) - these are for reviewers to check, not the author.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes chainId validation for Multichain requests by relying on `req.networkClientId` instead of per-origin network selectors.
> 
> - Refactors `checkActiveAccountAndChainId` to accept `networkClientId`, read chain ID from `NetworkController.getNetworkConfigurationByNetworkClientId`, and compare using `toHex`
> - Wires `networkClientId` through `eth_sendTransaction` and `eth_signTypedData_v3/v4` validation paths; updates `generateRawSignature` usage
> - Removes legacy selector-based chain ID logic and related imports
> - Adds targeted unit tests covering hex/decimal matches, missing config, mismatch, and skip-when-absent cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 894135946a445b75a7b5608c08fd20f2cc54901b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->