### PR TITLE
fix: compute spread from HL bbo top-of-book feed cp-7.63.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
@@ -175,6 +175,17 @@ jest.mock('../../hooks/usePerpsOrderBookGrouping', () => ({
   })),
 }));
 
+// Mock usePerpsTopOfBook
+const mockUsePerpsTopOfBook = jest.fn(() => ({
+  bestBid: '50000',
+  bestAsk: '50001',
+  spread: '1.00000',
+}));
+
+jest.mock('../../hooks/stream/usePerpsTopOfBook', () => ({
+  usePerpsTopOfBook: () => mockUsePerpsTopOfBook(),
+}));
+
 // Mock usePerpsEventTracking
 const mockTrack = jest.fn();
 
@@ -284,6 +295,11 @@ describe('PerpsOrderBookView', () => {
       orderBook: mockOrderBook,
       isLoading: false,
       error: null,
+    });
+    mockUsePerpsTopOfBook.mockReturnValue({
+      bestBid: '50000',
+      bestAsk: '50001',
+      spread: '1.00000',
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
@@ -65,12 +65,17 @@ import {
 } from '../../hooks';
 import { useHasExistingPosition } from '../../hooks/useHasExistingPosition';
 import { usePerpsLiveOrderBook } from '../../hooks/stream/usePerpsLiveOrderBook';
+import { usePerpsTopOfBook } from '../../hooks/stream/usePerpsTopOfBook';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
 import { usePerpsOrderBookGrouping } from '../../hooks/usePerpsOrderBookGrouping';
 import { selectPerpsButtonColorTestVariant } from '../../selectors/featureFlags';
 import { BUTTON_COLOR_TEST } from '../../utils/abTesting/tests';
 import { usePerpsABTest } from '../../utils/abTesting/usePerpsABTest';
+import {
+  formatPerpsFiat,
+  PRICE_RANGES_UNIVERSAL,
+} from '../../utils/formatUtils';
 import { getPerpsDisplaySymbol } from '../../utils/marketUtils';
 import {
   calculateAggregationParams,
@@ -186,6 +191,37 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
     }
     return null;
   }, [selectedGrouping, groupingOptions]);
+
+  // Subscribe to top-of-book (best bid/ask) for spread display.
+  // This is intentionally independent from order book aggregation/grouping.
+  const topOfBook = usePerpsTopOfBook({ symbol: symbol || '' });
+
+  const spreadMetrics = useMemo(() => {
+    const bidStr = topOfBook?.bestBid;
+    const askStr = topOfBook?.bestAsk;
+    if (!bidStr || !askStr) return null;
+
+    const bid = parseFloat(bidStr);
+    const ask = parseFloat(askStr);
+    if (
+      !Number.isFinite(bid) ||
+      !Number.isFinite(ask) ||
+      bid <= 0 ||
+      ask <= 0
+    ) {
+      return null;
+    }
+
+    // Round to eliminate floating point artifacts (e.g., 0.09999999999990905 → 0.1)
+    const spread = Number((ask - bid).toPrecision(10));
+    const mid = (ask + bid) / 2;
+    const spreadPercentage = mid > 0 ? ((spread / mid) * 100).toFixed(3) : '0';
+
+    return {
+      spread,
+      spreadPercentage,
+    };
+  }, [topOfBook]);
 
   // Calculate aggregation params (nSigFigs + mantissa) based on grouping
   const aggregationParams = useMemo(() => {
@@ -506,16 +542,18 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
       {/* Footer with Spread and Actions */}
       <View style={footerStyle}>
         {/* Spread Row */}
-        {orderBook && (
+        {spreadMetrics && (
           <View style={styles.spreadContainer}>
             <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
               {strings('perps.order_book.spread')}:
             </Text>
             <Text variant={TextVariant.BodySM} color={TextColor.Default}>
-              ${parseFloat(orderBook.spread).toLocaleString()}
+              {formatPerpsFiat(spreadMetrics.spread, {
+                ranges: PRICE_RANGES_UNIVERSAL,
+              })}
             </Text>
             <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
-              ({orderBook.spreadPercentage}%)
+              ({spreadMetrics.spreadPercentage}%)
             </Text>
             <TouchableOpacity
               onPress={() => handleTooltipPress('spread')}

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
@@ -251,8 +251,6 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
       return rawOrderBook;
     }
 
-    // No client-side aggregation needed - API handles it via nSigFigs
-    // Just return the raw order book data directly
     return rawOrderBook;
   }, [rawOrderBook]);
 

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -6,6 +6,7 @@ import {
   type UserFillsWsEvent,
   type ActiveAssetCtxWsEvent,
   type ActiveSpotAssetCtxWsEvent,
+  type BboWsEvent,
   type L2BookResponse,
   type AssetCtxsWsEvent,
   type FrontendOpenOrdersResponse,
@@ -41,7 +42,7 @@ import type { HyperLiquidWalletService } from './HyperLiquidWalletService';
 import type { CaipAccountId } from '@metamask/utils';
 import { TP_SL_CONFIG, PERPS_CONSTANTS } from '../constants/perpsConfig';
 import { ensureError } from '../../../../util/errorUtils';
-import { processL2BookData } from '../utils/hyperLiquidOrderBookProcessor';
+import { processBboData } from '../utils/hyperLiquidOrderBookProcessor';
 import { calculateOpenInterestUSD } from '../utils/marketDataTransform';
 
 /**
@@ -93,7 +94,7 @@ export class HyperLiquidSubscriptionService {
     Set<(prices: PriceUpdate[]) => void>
   >();
 
-  // Track which subscribers want L2Book (order book) data
+  // Track which subscribers want top-of-book (best bid/ask) data
   private readonly orderBookSubscribers = new Map<
     string,
     Set<(prices: PriceUpdate[]) => void>
@@ -106,7 +107,7 @@ export class HyperLiquidSubscriptionService {
     string,
     ISubscription
   >();
-  private readonly globalL2BookSubscriptions = new Map<string, ISubscription>();
+  private readonly globalBboSubscriptions = new Map<string, ISubscription>();
   // Order fill subscriptions keyed by accountId (normalized: undefined -> 'default')
   private readonly orderFillSubscriptions = new Map<string, ISubscription>();
   private readonly symbolSubscriberCounts = new Map<string, number>();
@@ -885,7 +886,7 @@ export class HyperLiquidSubscriptionService {
         this.ensureActiveAssetSubscription(symbol);
       }
       if (includeOrderBook) {
-        this.ensureL2BookSubscription(symbol);
+        this.ensureBboSubscription(symbol);
       }
     });
 
@@ -906,7 +907,7 @@ export class HyperLiquidSubscriptionService {
           this.cleanupActiveAssetSubscription(symbol);
         }
         if (includeOrderBook) {
-          this.cleanupL2BookSubscription(symbol);
+          this.cleanupBboSubscription(symbol);
         }
       });
 
@@ -1904,7 +1905,11 @@ export class HyperLiquidSubscriptionService {
 
     return () => {
       if (subscribers instanceof Map && key) {
-        subscribers.get(key)?.delete(callback);
+        const set = subscribers.get(key);
+        set?.delete(callback);
+        if (set && set.size === 0) {
+          subscribers.delete(key);
+        }
       } else if (subscribers instanceof Set) {
         subscribers.delete(callback);
       }
@@ -2370,11 +2375,13 @@ export class HyperLiquidSubscriptionService {
   }
 
   /**
-   * Ensure L2 book subscription for specific symbol (with reference counting)
+   * Ensure BBO subscription for specific symbol (singleton)
+   *
+   * BBO provides best bid/ask without being affected by L2Book aggregation parameters,
+   * keeping spread consistent across order book grouping selections (matches Hyperliquid UI).
    */
-  private ensureL2BookSubscription(symbol: string): void {
-    // If subscription already exists, just return
-    if (this.globalL2BookSubscriptions.has(symbol)) {
+  private ensureBboSubscription(symbol: string): void {
+    if (this.globalBboSubscriptions.has(symbol)) {
       return;
     }
 
@@ -2384,8 +2391,8 @@ export class HyperLiquidSubscriptionService {
     }
 
     subscriptionClient
-      .l2Book({ coin: symbol, nSigFigs: 5 }, (data: L2BookResponse) => {
-        processL2BookData({
+      .bbo({ coin: symbol }, (data: BboWsEvent) => {
+        processBboData({
           symbol,
           data,
           orderBookCache: this.orderBookCache,
@@ -2395,36 +2402,41 @@ export class HyperLiquidSubscriptionService {
         });
       })
       .then((sub) => {
-        this.globalL2BookSubscriptions.set(symbol, sub);
+        this.globalBboSubscriptions.set(symbol, sub);
         this.deps.debugLogger.log(
-          `HyperLiquid: L2 book subscription established for ${symbol}`,
+          `HyperLiquid: BBO subscription established for ${symbol}`,
         );
       })
       .catch((error) => {
         this.deps.logger.error(
           ensureError(error),
-          this.getErrorContext('ensureL2BookSubscription', { symbol }),
+          this.getErrorContext('ensureBboSubscription', { symbol }),
         );
       });
   }
 
   /**
-   * Cleanup L2 book subscription when no longer needed
+   * Cleanup BBO subscription when no longer needed
    */
-  private cleanupL2BookSubscription(symbol: string): void {
-    const subscription = this.globalL2BookSubscriptions.get(symbol);
+  private cleanupBboSubscription(symbol: string): void {
+    // If anyone still wants order book (top-of-book) data for this symbol, keep the subscription alive.
+    if ((this.orderBookSubscribers.get(symbol)?.size ?? 0) > 0) {
+      return;
+    }
+
+    const subscription = this.globalBboSubscriptions.get(symbol);
     if (subscription && typeof subscription.unsubscribe === 'function') {
       const unsubscribeResult = Promise.resolve(subscription.unsubscribe());
       unsubscribeResult.catch(() => {
         // Ignore errors during cleanup
       });
 
-      this.globalL2BookSubscriptions.delete(symbol);
+      this.globalBboSubscriptions.delete(symbol);
       this.orderBookCache.delete(symbol);
     } else if (subscription) {
       // Subscription exists but unsubscribe is not a function or doesn't return a Promise
       // Just clean up the reference
-      this.globalL2BookSubscriptions.delete(symbol);
+      this.globalBboSubscriptions.delete(symbol);
       this.orderBookCache.delete(symbol);
     }
   }
@@ -2721,17 +2733,17 @@ export class HyperLiquidSubscriptionService {
       });
     }
 
-    // Re-establish L2Book subscriptions if there are order book subscribers
+    // Re-establish BBO subscriptions if there are order book subscribers
     if (this.orderBookSubscribers.size > 0) {
       // Clear existing subscriptions (they're dead after reconnection)
-      this.globalL2BookSubscriptions.clear();
+      this.globalBboSubscriptions.clear();
 
       // Re-establish subscriptions for all symbols with order book subscribers
       const symbolsNeedingOrderBook = Array.from(
         this.orderBookSubscribers.keys(),
       );
       symbolsNeedingOrderBook.forEach((symbol) => {
-        this.ensureL2BookSubscription(symbol);
+        this.ensureBboSubscription(symbol);
       });
     }
 
@@ -2833,7 +2845,7 @@ export class HyperLiquidSubscriptionService {
     // Clear subscription references (actual cleanup handled by client service)
     this.globalAllMidsSubscription = undefined;
     this.globalActiveAssetSubscriptions.clear();
-    this.globalL2BookSubscriptions.clear();
+    this.globalBboSubscriptions.clear();
     this.webData3Subscriptions.clear();
     this.webData3SubscriptionPromise = undefined;
 

--- a/app/components/UI/Perps/utils/hyperLiquidOrderBookProcessor.test.ts
+++ b/app/components/UI/Perps/utils/hyperLiquidOrderBookProcessor.test.ts
@@ -2,11 +2,13 @@
  * Unit tests for HyperLiquid Order Book Processor
  */
 
-import type { L2BookResponse } from '@nktkas/hyperliquid';
+import type { BboWsEvent, L2BookResponse } from '@nktkas/hyperliquid';
 import type { PriceUpdate } from '../controllers/types';
 import {
+  processBboData,
   processL2BookData,
   type OrderBookCacheEntry,
+  type ProcessBboDataParams,
   type ProcessL2BookDataParams,
 } from './hyperLiquidOrderBookProcessor';
 
@@ -500,6 +502,121 @@ describe('hyperLiquidOrderBookProcessor', () => {
       expect(ethCache?.bestBid).toBe('2990');
       expect(ethCache?.bestAsk).toBe('3010');
       expect(mockNotifySubscribers).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('processBboData', () => {
+    it('processes valid BBO data with bid and ask', () => {
+      const symbol = 'BTC';
+      const data: BboWsEvent = {
+        coin: 'BTC',
+        time: Date.now(),
+        bbo: [
+          { px: '49900', sz: '1.5', n: 3 }, // Bid
+          { px: '50100', sz: '2.0', n: 5 }, // Ask
+        ],
+      };
+
+      mockCachedPriceData.set('BTC', {
+        symbol: 'BTC',
+        price: '50000',
+        timestamp: Date.now(),
+      });
+
+      const params: ProcessBboDataParams = {
+        symbol,
+        data,
+        orderBookCache: mockOrderBookCache,
+        cachedPriceData: mockCachedPriceData,
+        createPriceUpdate: mockCreatePriceUpdate,
+        notifySubscribers: mockNotifySubscribers,
+      };
+
+      processBboData(params);
+
+      const cacheEntry = mockOrderBookCache.get('BTC');
+      expect(cacheEntry).toBeDefined();
+      expect(cacheEntry?.bestBid).toBe('49900');
+      expect(cacheEntry?.bestAsk).toBe('50100');
+      expect(cacheEntry?.spread).toBe('200.00000');
+      expect(cacheEntry?.lastUpdated).toBeGreaterThan(0);
+      expect(mockCreatePriceUpdate).toHaveBeenCalledWith('BTC', '50000');
+      expect(mockNotifySubscribers).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns early when coin does not match symbol', () => {
+      const data: BboWsEvent = {
+        coin: 'ETH',
+        time: Date.now(),
+        bbo: [
+          { px: '2990', sz: '5.0', n: 2 },
+          { px: '3010', sz: '5.0', n: 2 },
+        ],
+      };
+
+      const params: ProcessBboDataParams = {
+        symbol: 'BTC',
+        data,
+        orderBookCache: mockOrderBookCache,
+        cachedPriceData: mockCachedPriceData,
+        createPriceUpdate: mockCreatePriceUpdate,
+        notifySubscribers: mockNotifySubscribers,
+      };
+
+      processBboData(params);
+
+      expect(mockOrderBookCache.size).toBe(0);
+      expect(mockCreatePriceUpdate).not.toHaveBeenCalled();
+      expect(mockNotifySubscribers).not.toHaveBeenCalled();
+    });
+
+    it('returns early when both bid and ask are missing', () => {
+      const data = {
+        coin: 'BTC',
+        time: Date.now(),
+        bbo: [undefined, undefined],
+      } as unknown as BboWsEvent;
+
+      const params: ProcessBboDataParams = {
+        symbol: 'BTC',
+        data,
+        orderBookCache: mockOrderBookCache,
+        cachedPriceData: mockCachedPriceData,
+        createPriceUpdate: mockCreatePriceUpdate,
+        notifySubscribers: mockNotifySubscribers,
+      };
+
+      processBboData(params);
+
+      expect(mockOrderBookCache.size).toBe(0);
+      expect(mockCreatePriceUpdate).not.toHaveBeenCalled();
+      expect(mockNotifySubscribers).not.toHaveBeenCalled();
+    });
+
+    it('updates order book cache but does not notify when no cached price exists', () => {
+      const data: BboWsEvent = {
+        coin: 'BTC',
+        time: Date.now(),
+        bbo: [
+          { px: '49900', sz: '1.5', n: 3 },
+          { px: '50100', sz: '2.0', n: 5 },
+        ],
+      };
+
+      const params: ProcessBboDataParams = {
+        symbol: 'BTC',
+        data,
+        orderBookCache: mockOrderBookCache,
+        cachedPriceData: mockCachedPriceData,
+        createPriceUpdate: mockCreatePriceUpdate,
+        notifySubscribers: mockNotifySubscribers,
+      };
+
+      processBboData(params);
+
+      expect(mockOrderBookCache.get('BTC')).toBeDefined();
+      expect(mockCreatePriceUpdate).not.toHaveBeenCalled();
+      expect(mockNotifySubscribers).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Perps/utils/hyperLiquidOrderBookProcessor.test.ts
+++ b/app/components/UI/Perps/utils/hyperLiquidOrderBookProcessor.test.ts
@@ -593,6 +593,28 @@ describe('hyperLiquidOrderBookProcessor', () => {
       expect(mockNotifySubscribers).not.toHaveBeenCalled();
     });
 
+    it('returns early when bbo is a truthy non-array value', () => {
+      const data = {
+        coin: 'BTC',
+        time: Date.now(),
+        bbo: {},
+      } as unknown as BboWsEvent;
+
+      const params: ProcessBboDataParams = {
+        symbol: 'BTC',
+        data,
+        orderBookCache: mockOrderBookCache,
+        cachedPriceData: mockCachedPriceData,
+        createPriceUpdate: mockCreatePriceUpdate,
+        notifySubscribers: mockNotifySubscribers,
+      };
+
+      expect(() => processBboData(params)).not.toThrow();
+      expect(mockOrderBookCache.size).toBe(0);
+      expect(mockCreatePriceUpdate).not.toHaveBeenCalled();
+      expect(mockNotifySubscribers).not.toHaveBeenCalled();
+    });
+
     it('updates order book cache but does not notify when no cached price exists', () => {
       const data: BboWsEvent = {
         coin: 'BTC',

--- a/app/components/UI/Perps/utils/hyperLiquidOrderBookProcessor.ts
+++ b/app/components/UI/Perps/utils/hyperLiquidOrderBookProcessor.ts
@@ -113,7 +113,7 @@ export function processBboData(params: ProcessBboDataParams): void {
     notifySubscribers,
   } = params;
 
-  if (data?.coin !== symbol || !data?.bbo) {
+  if (data?.coin !== symbol || !Array.isArray(data?.bbo)) {
     return;
   }
 

--- a/app/components/UI/Perps/utils/hyperLiquidOrderBookProcessor.ts
+++ b/app/components/UI/Perps/utils/hyperLiquidOrderBookProcessor.ts
@@ -1,4 +1,4 @@
-import type { L2BookResponse } from '@nktkas/hyperliquid';
+import type { BboWsEvent, L2BookResponse } from '@nktkas/hyperliquid';
 import type { PriceUpdate } from '../controllers/types';
 
 /**
@@ -24,6 +24,15 @@ export interface OrderBookCacheEntry {
 export interface ProcessL2BookDataParams {
   symbol: string;
   data: L2BookResponse;
+  orderBookCache: Map<string, OrderBookCacheEntry>;
+  cachedPriceData: Map<string, PriceUpdate> | null;
+  createPriceUpdate: (symbol: string, price: string) => PriceUpdate;
+  notifySubscribers: () => void;
+}
+
+export interface ProcessBboDataParams {
+  symbol: string;
+  data: BboWsEvent;
   orderBookCache: Map<string, OrderBookCacheEntry>;
   cachedPriceData: Map<string, PriceUpdate> | null;
   createPriceUpdate: (symbol: string, price: string) => PriceUpdate;
@@ -82,6 +91,55 @@ export function processL2BookData(params: ProcessL2BookDataParams): void {
   const updatedPrice = createPriceUpdate(symbol, currentCachedPrice.price);
 
   // Ensure cache exists before setting
+  if (cachedPriceData) {
+    cachedPriceData.set(symbol, updatedPrice);
+    notifySubscribers();
+  }
+}
+
+/**
+ * Process BBO (best bid/offer) data and update caches
+ *
+ * BBO is lightweight and independent from L2Book aggregation parameters,
+ * making it ideal for spread / top-of-book display.
+ */
+export function processBboData(params: ProcessBboDataParams): void {
+  const {
+    symbol,
+    data,
+    orderBookCache,
+    cachedPriceData,
+    createPriceUpdate,
+    notifySubscribers,
+  } = params;
+
+  if (data?.coin !== symbol || !data?.bbo) {
+    return;
+  }
+
+  const [bestBid, bestAsk] = data.bbo;
+  if (!bestBid && !bestAsk) {
+    return;
+  }
+
+  const bidPrice = bestBid ? parseFloat(bestBid.px) : 0;
+  const askPrice = bestAsk ? parseFloat(bestAsk.px) : 0;
+  const spread =
+    bidPrice > 0 && askPrice > 0 ? (askPrice - bidPrice).toFixed(5) : undefined;
+
+  orderBookCache.set(symbol, {
+    bestBid: bestBid?.px,
+    bestAsk: bestAsk?.px,
+    spread,
+    lastUpdated: Date.now(),
+  });
+
+  const currentCachedPrice = cachedPriceData?.get(symbol);
+  if (!currentCachedPrice) {
+    return;
+  }
+
+  const updatedPrice = createPriceUpdate(symbol, currentCachedPrice.price);
   if (cachedPriceData) {
     cachedPriceData.set(symbol, updatedPrice);
     notifySubscribers();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
                                    
  ### Summary                                             
                                                      
  - Fixes incorrect spread display in Perps order book that changed when users change the aggregate dropdown                                            
  - Spread now uses BBO (best bid/offer) feed instead of aggregated L2Book, matching Hyperliquid UI       
  behavior                                            
  - Adds missing test coverage for `subscribeToOrderBook` L2Book subscriptions
  
  https://consensyssoftware.atlassian.net/browse/TAT-2425           
                                                      
  ### Problem                                             
                                                      
  The spread displayed under the order book depth chart was incorrect and would change when the use changed the aggregation dropdown. This diverged from Hyperliquid's UI where spread remains stable regardless of grouping selection.            
                                                      
  Root cause: Spread was derived from aggregated orderbook levels. When requesting an aggregated book,   the best bid/ask are bucketed/rounded prices, causing the spread to inflate to increments resembling the grouping step.                       
                                                      
  ### Solution                                            
                                                      
  Split the data sources:                             
  - Depth/table display: `subscribeToOrderBook` -> `l2Book` with aggregation params (existing)                 
  - Spread display: `subscribeToPrices(includeOrderBook: true)` -> bbo feed (new)                                              

The L2Book -> BBO change only affects `subscribeToPrices({ includeOrderBook: true })`, which feeds `usePerpsTopOfBook`. All 5 consumers only need best bid/ask:                                       
                                                      
  - Fee calculation (3 views) - compares limit price to best bid/ask for maker/taker determination       
  - Bid/Ask presets - single best prices for quick buttons                                             
  - Spread display - bestAsk - bestBid                
                                                      
  Full L2Book depth is still used via separate `subscribeToOrderBook()` path for the order book table/chart.
                                                        
  This matches Hyperliquid's frontend: grouping affects the book display, spread is based on actual top-of-book.                                        
                                                      
  ### Test plan                                           
                                                      
  - Unit tests for processBboData                     
  - Unit tests for BBO subscription lifecycle         
  - Unit tests for subscribeToOrderBook (L2Book) - 10 new tests                                           


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?

AI agent: Be specific about what you changed and why. Include context about the fix/feature, not generic descriptions.
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)

AI agent: Use format `CHANGELOG entry: [fix/feat/chore]: [User-facing description in past tense]`.
Examples: `fix: resolved token name display issue`, `feat: added dark mode toggle`, `chore: updated dependencies`.
For non-user-facing changes, use `CHANGELOG entry: null`.
-->

CHANGELOG entry: Fixed incorrect spread displayed below Perps orderbook depth chart
## **Related issues**

<!--
AI agent: Replace with `Fixes: #[ISSUE_NUMBER]` using the actual issue number you're implementing.
-->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/25162

## **Manual testing steps**
  - Verify spread matches Hyperliquid UI across all grouping values                                     
  - Verify changing grouping doesn't affect spread display

<!--
AI agent: Write specific, contextual Gherkin steps based on what you actually implemented.
Do NOT use generic placeholders like "my feature name". Be concrete about the feature, scenario, and steps.
-->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<!-- [screenshots/recordings] -->
https://github.com/user-attachments/assets/43c6c40c-162c-4809-9295-1acaf684d64d


## **Pre-merge author checklist**

<!--
AI agent: Check ALL boxes in this section (mark all as [x]).
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

<!--
AI agent: Leave ALL boxes unchecked ([ ]) - these are for reviewers to check, not the author.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns spread display with Hyperliquid by decoupling it from aggregated order book data.
> 
> - PerpsOrderBookView now derives spread from `usePerpsTopOfBook` and formats via `formatPerpsFiat`; no change to depth/table which still uses L2Book with server-side aggregation
> - HyperLiquidSubscriptionService: replace L2Book usage with `bbo` for `includeOrderBook` path; introduce `globalBboSubscriptions`, cleanup/restore logic, and use new `processBboData`
> - Add `processBboData` alongside existing L2Book processor; comprehensive unit tests for BBO processing and subscription lifecycle
> - Add/expand tests for `subscribeToOrderBook` (L2Book) to validate params, data shaping, limits, errors, and unsubscribe behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c22479611dac16fb482aedd993f84ef8171994f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->