### PR TITLE
style: (cp-7.63.0) trending view browser button fix

### DIFF
--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -16,8 +16,6 @@ import {
   IconName,
   Icon,
   IconSize,
-  IconColor,
-  TextColor,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../locales/i18n';
 import AppConstants from '../../../core/AppConstants';
@@ -209,22 +207,13 @@ export const ExploreFeed: React.FC = () => {
           onPress={handleBrowserPress}
           testID="trending-view-browser-button"
         >
-          <Box twClassName="rounded-lg items-center justify-center bg-muted min-h-[44px] min-w-[44px]">
-            {browserTabsCount > 0 ? (
-              <Text
-                variant={TextVariant.BodyLg}
-                color={TextColor.TextAlternative}
-              >
-                {browserTabsCount}
-              </Text>
-            ) : (
-              <Icon
-                name={IconName.Explore}
-                size={IconSize.Lg}
-                color={IconColor.IconAlternative}
-              />
-            )}
-          </Box>
+          {browserTabsCount > 0 ? (
+            <Box twClassName="rounded-md items-center justify-center h-8 w-8 border-2 border-text-default">
+              <Text variant={TextVariant.BodyLg}>{browserTabsCount}</Text>
+            </Box>
+          ) : (
+            <Icon name={IconName.Explore} size={IconSize.Xl} />
+          )}
         </TouchableOpacity>
       </Box>
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Effectively reverts this PR: https://github.com/MetaMask/metamask-mobile/pull/24424

From discussion with PM and others: https://consensys.slack.com/archives/C07NF2K42LE/p1769204088197769
Makes the browser explore icons much more visible.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: style: trending view browser button fix

## **Related issues**

Fixes: https://consensys.slack.com/archives/C07NF2K42LE/p1769204088197769

## **Manual testing steps**

1. Go to Explore
2. EXPECTED: when no tabs are added, you should see the explore icon.
3. EXPECTED: when tabs are added, you should see the number w/ border.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

| Theme | No Tabs | Some Tabs |
|--------|--------|--------|
| Dark | <img width="407" height="122" alt="Screenshot 2026-01-26 at 11 29 29" src="https://github.com/user-attachments/assets/63caddf9-7f65-421f-ae8a-b796d0f908b6" /> | <img width="398" height="112" alt="Screenshot 2026-01-26 at 11 29 35" src="https://github.com/user-attachments/assets/5cce5178-6064-460f-a13b-338b061a37a9" /> |
| Light | <img width="391" height="119" alt="Screenshot 2026-01-26 at 11 29 52" src="https://github.com/user-attachments/assets/d7842ae5-822a-4903-b868-88fce701709d" /> | <img width="395" height="114" alt="Screenshot 2026-01-26 at 11 29 59" src="https://github.com/user-attachments/assets/675c0f2c-1e0c-4364-a510-e531ebec991c" /> | 

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<a href="https://cursor.com/background-agent?bcId=bc-25940dbd-c3d6-427b-acf8-d8f5d08eaabf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25940dbd-c3d6-427b-acf8-d8f5d08eaabf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves visibility and styling of the Trending Explore/browser button.
> 
> - Replaces muted square button with conditional render: large `IconName.Explore` (`IconSize.Xl`) when `browserTabsCount === 0`, or a compact bordered `Box` showing the tab count when `> 0`
> - Removes unused `IconColor`/`TextColor` imports and associated color props
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76bb9b5ff2b7b5eb5a2538a53d6bba4a02b69573. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->