### PR TITLE
(closed) fix: Multiple bugs when editing SL via Stop Loss Banner

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -482,7 +482,9 @@ export const PerpsTutorialSelectorsIDs = {
 export const PerpsStopLossPromptSelectorsIDs = {
   CONTAINER: 'perps-stop-loss-prompt-container',
   ADD_MARGIN_BUTTON: 'perps-stop-loss-prompt-add-margin-button',
-  TOGGLE: 'perps-stop-loss-prompt-toggle',
+  SET_STOP_LOSS_BUTTON: 'perps-stop-loss-prompt-set-button',
+  SUCCESS_ICON: 'perps-stop-loss-prompt-success-icon',
+  TOGGLE: 'perps-stop-loss-prompt-toggle', // Deprecated - kept for backwards compatibility
   LOADING: 'perps-stop-loss-prompt-loading',
 } as const;
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -843,12 +843,18 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       };
 
       // Set the stop loss using the suggested price (keep existing TP if any)
-      await handleUpdateTPSL(
+      const result = await handleUpdateTPSL(
         existingPosition,
         existingPosition.takeProfitPrice, // Keep existing TP
         suggestedStopLossPrice, // Use suggested SL
         trackingData,
       );
+
+      // Only trigger success state if the update actually succeeded
+      if (!result.success) {
+        // Error toast is already shown by handleUpdateTPSL
+        return;
+      }
 
       // Trigger success state to start fade-out animation
       setIsStopLossSuccess(true);

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -399,9 +399,11 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       loadOnMount: true,
     });
 
-  // Fetch order fills to get position opened timestamp
+  // Get order fills to derive position opened timestamp
+  // skipInitialFetch: true - rely on WebSocket fills channel which is pre-warmed and cached
+  // This avoids REST API calls on mount that can deplete rate limits
   const { orderFills } = usePerpsOrderFills({
-    skipInitialFetch: false,
+    skipInitialFetch: true,
   });
 
   // Get position opened timestamp from fills data

--- a/app/components/UI/Perps/constants/perpsConfig.ts
+++ b/app/components/UI/Perps/constants/perpsConfig.ts
@@ -509,20 +509,20 @@ export const STOP_LOSS_PROMPT_CONFIG = {
 
   // ROE (Return on Equity) threshold (percentage)
   // Shows "Set stop loss" banner when ROE drops below this value
-  ROE_THRESHOLD: -10,
+  ROE_THRESHOLD: -1, // TODO: TESTING ONLY - restore to -10
 
   // Minimum loss threshold to show ANY banner (percentage)
   // No banner shown until ROE drops below this value
-  MIN_LOSS_THRESHOLD: -10,
+  MIN_LOSS_THRESHOLD: -1, // TODO: TESTING ONLY - restore to -10
 
   // Debounce duration for ROE threshold (milliseconds)
   // User must have ROE below threshold for this duration before showing banner
   // Prevents banner from appearing during temporary price fluctuations
-  ROE_DEBOUNCE_MS: 60_000, // 60 seconds
+  ROE_DEBOUNCE_MS: 1_000, // TODO: TESTING ONLY - restore to 60_000 (60 seconds)
 
   // Minimum position age before showing any banner (milliseconds)
   // Prevents banner from appearing immediately after opening a position
-  POSITION_MIN_AGE_MS: 60_000, // 60 seconds
+  POSITION_MIN_AGE_MS: 1_000, // TODO: TESTING ONLY - restore to 60_000 (60 seconds)
 
   // Suggested stop loss ROE percentage
   // When suggesting a stop loss, calculate price at this ROE from entry

--- a/app/components/UI/Perps/controllers/types/index.ts
+++ b/app/components/UI/Perps/controllers/types/index.ts
@@ -781,6 +781,12 @@ export interface UpdatePositionTPSLParams {
   // Optional tracking data for MetaMetrics events
   trackingData?: TPSLTrackingData;
   providerId?: PerpsProviderType; // Multi-provider: optional provider override for routing
+  /**
+   * Optional live position data from WebSocket.
+   * If provided, skips the REST API position fetch (avoids rate limiting issues).
+   * If not provided, falls back to fetching positions via REST API.
+   */
+  position?: Position;
 }
 
 export interface Order {

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -16,15 +16,14 @@ import { retryWithExponentialDelay } from '../../../../util/exponential-retry';
  * - Address-based: 1 request per 1 USDC traded (lifetime) + 10,000 initial buffer
  * - When rate limited: addresses receive 1 request every 10 seconds (drip recovery)
  *
- * Strategy: Use longer delays to allow rate limit to "drip" back capacity.
- * With base 3s and 4 retries: 3s → 6s → 12s → 24s = ~45s total window
- * This gives multiple 10-second drip cycles to recover request capacity.
+ * Strategy: Retry with exponential backoff, but fail fast (~14s total) to avoid
+ * leaving the user waiting too long. Sequence: 2s → 4s → 8s = ~14s total.
  *
  * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/rate-limits
  */
-const TPSL_UPDATE_MAX_RETRIES = 4;
-const TPSL_UPDATE_BASE_DELAY_MS = 3000;
-const TPSL_UPDATE_MAX_DELAY_MS = 30000;
+const TPSL_UPDATE_MAX_RETRIES = 3;
+const TPSL_UPDATE_BASE_DELAY_MS = 2000;
+const TPSL_UPDATE_MAX_DELAY_MS = 10000;
 
 interface UseTPSLUpdateOptions {
   onSuccess?: () => void;

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -40,6 +40,7 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
           takeProfitPrice,
           stopLossPrice,
           trackingData,
+          position, // Pass live WebSocket position to avoid REST API fetch (prevents rate limiting)
         });
 
         if (result.success) {

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -8,10 +8,23 @@ import usePerpsToasts from './usePerpsToasts';
 import { usePerpsStream } from '../providers/PerpsStreamManager';
 import { retryWithExponentialDelay } from '../../../../util/exponential-retry';
 
-// Retry configuration for rate limiting
-const TPSL_UPDATE_MAX_RETRIES = 3;
-const TPSL_UPDATE_BASE_DELAY_MS = 1000;
-const TPSL_UPDATE_MAX_DELAY_MS = 10000;
+/**
+ * Retry configuration for rate limiting resilience.
+ *
+ * HyperLiquid rate limits:
+ * - IP-based: 1,200 weighted requests per minute
+ * - Address-based: 1 request per 1 USDC traded (lifetime) + 10,000 initial buffer
+ * - When rate limited: addresses receive 1 request every 10 seconds (drip recovery)
+ *
+ * Strategy: Use longer delays to allow rate limit to "drip" back capacity.
+ * With base 3s and 4 retries: 3s → 6s → 12s → 24s = ~45s total window
+ * This gives multiple 10-second drip cycles to recover request capacity.
+ *
+ * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/rate-limits
+ */
+const TPSL_UPDATE_MAX_RETRIES = 4;
+const TPSL_UPDATE_BASE_DELAY_MS = 3000;
+const TPSL_UPDATE_MAX_DELAY_MS = 30000;
 
 interface UseTPSLUpdateOptions {
   onSuccess?: () => void;

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -30,7 +30,7 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
       takeProfitPrice: string | undefined,
       stopLossPrice: string | undefined,
       trackingData?: TPSLTrackingData,
-    ) => {
+    ): Promise<{ success: boolean }> => {
       setIsUpdating(true);
       DevLogger.log('usePerpsTPSLUpdate: Setting isUpdating to true');
 
@@ -59,20 +59,23 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
 
           // Call success callback if provided
           options?.onSuccess?.();
-        } else {
-          DevLogger.log('Failed to update position TP/SL:', result.error);
 
-          const errorMessage = result.error || strings('perps.errors.unknown');
-
-          showToast(
-            PerpsToastOptions.positionManagement.tpsl.updateTPSLError(
-              errorMessage,
-            ),
-          );
-
-          // Call error callback if provided
-          options?.onError?.(errorMessage);
+          return { success: true };
         }
+        DevLogger.log('Failed to update position TP/SL:', result.error);
+
+        const errorMessage = result.error || strings('perps.errors.unknown');
+
+        showToast(
+          PerpsToastOptions.positionManagement.tpsl.updateTPSLError(
+            errorMessage,
+          ),
+        );
+
+        // Call error callback if provided
+        options?.onError?.(errorMessage);
+
+        return { success: false };
       } catch (error) {
         DevLogger.log('Error updating position TP/SL:', error);
 
@@ -112,6 +115,8 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
 
         // Call error callback if provided
         options?.onError?.(errorMessage);
+
+        return { success: false };
       } finally {
         DevLogger.log('usePerpsTPSLUpdate: Setting isUpdating to false');
         setIsUpdating(false);


### PR DESCRIPTION
## **Description**

The "Protect against further losses" stop loss banner on the detail page had several UX bugs:
1. After setting then removing a stop loss, returning to the page showed the toggle incorrectly in the "on" state
2. Reusing the toggle caused the screen to flash/flicker
3. Users were seeing "No position found" and "429 Too Many Requests" errors when attempting to set stop loss

See "before" recording for more details.

**Summary of Changes**

**1. Replaced toggle with stateful button for clearer UX**
- Replaced the `Switch` component that felt buggy with async state with a stateful `Button`
- Button shows: text → loader → checkmark → banner fades out

**2. Banner rendering flickering**
- Mostly due to incorrect success state, and boolean rendering conditions
- Added  `preservedBannerVariantRef` to cache the banner variant during fade, preventing the banner from briefly disappearing and reappearing before fading out
- Updated render condition to `(isBannerVisible || isStopLossSuccess) && bannerVariant` to keep banner mounted during fade
- Changed `handleUpdateTPSL` to return `{ success: boolean }` so callers can check actual API result before showing success state
- Prevents success state from triggering when API actually failed

**3. Prefer WebSocket data over REST fetches**
- Attempts to reduce API calls to mitigate rate limiting
- `usePerpsOrderFills` now uses `skipInitialFetch: true` to rely on pre-warmed WebSocket fills channel
- `updatePositionTPSL` accepts optional `position` parameter from WebSocket, skipping the `getPositions()` REST call when provided

**4. Exponential backoff retry for rate limiting resilience**
- Added retry logic wrapping `updatePositionTPSL` to handle HyperLiquid's rate limiting. Details in code comment. Basically this helps by "failing slower and less often"

__

**Known Issue**: Navigation Causes Excessive API Calls (429s)

Navigating rapidly between Asset Details → Perps Tab → Asset Details → Stop Loss Banner Set, it consistently triggers 429 “Too Many Requests” errors, often blocking TP/SL actions.

Even with the changes in `3` and `4`, we are still hitting the rate limit more often than we probably should. When `PerpsMarketDetailsView` mounts, several hooks fire simultaneous REST requests, particularly when fetching candle data. The retry logic helps, but doesn't solve the issue, and TP/SL can often feel "slow" as it works through it's exponential backoff.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)

AI agent: Use format `CHANGELOG entry: [fix/feat/chore]: [User-facing description in past tense]`.
Examples: `fix: resolved token name display issue`, `feat: added dark mode toggle`, `chore: updated dependencies`.
For non-user-facing changes, use `CHANGELOG entry: null`.
-->

CHANGELOG entry:

## **Related issues**

<!--
AI agent: Replace with `Fixes: #[ISSUE_NUMBER]` using the actual issue number you're implementing.
-->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2435

## **Manual testing steps**

<!--
AI agent: Write specific, contextual Gherkin steps based on what you actually implemented.
Do NOT use generic placeholders like "my feature name". Be concrete about the feature, scenario, and steps.
-->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/f32310f5-85dc-4cc3-ac73-466417ae2aec

### **After**

https://github.com/user-attachments/assets/9030cd2a-3dc4-4ae4-8001-ab2b488c5150

## **Pre-merge author checklist**

<!--
AI agent: Check ALL boxes in this section (mark all as [x]).
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

<!--
AI agent: Leave ALL boxes unchecked ([ ]) - these are for reviewers to check, not the author.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
