### PR TITLE
fix: Add storage type to enforce Android access controls

### DIFF
--- a/app/core/SecureKeychain.test.ts
+++ b/app/core/SecureKeychain.test.ts
@@ -71,6 +71,7 @@ describe('SecureKeychain - setGenericPassword', () => {
       expect.any(String),
       expect.objectContaining({
         accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
+        storage: Keychain.STORAGE_TYPE.AES_GCM,
       }),
     );
 
@@ -93,6 +94,7 @@ describe('SecureKeychain - setGenericPassword', () => {
       expect.any(String),
       expect.objectContaining({
         accessControl: Keychain.ACCESS_CONTROL.DEVICE_PASSCODE,
+        storage: Keychain.STORAGE_TYPE.AES_GCM,
       }),
     );
   });

--- a/app/core/SecureKeychain.ts
+++ b/app/core/SecureKeychain.ts
@@ -177,6 +177,8 @@ const SecureKeychain = {
     const metrics = MetaMetrics.getInstance();
     if (type === this.TYPES.BIOMETRICS) {
       authOptions.accessControl = Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET;
+      // Android requires this storage type so that the access control is enforced.
+      authOptions.storage = Keychain.STORAGE_TYPE.AES_GCM;
 
       await metrics.addTraitsToUser({
         [UserProfileProperty.AUTHENTICATION_TYPE]:
@@ -184,6 +186,9 @@ const SecureKeychain = {
       });
     } else if (type === this.TYPES.PASSCODE) {
       authOptions.accessControl = Keychain.ACCESS_CONTROL.DEVICE_PASSCODE;
+      // Android requires this storage type so that the access control is enforced.
+      authOptions.storage = Keychain.STORAGE_TYPE.AES_GCM;
+
       await metrics.addTraitsToUser({
         [UserProfileProperty.AUTHENTICATION_TYPE]: AUTHENTICATION_TYPE.PASSCODE,
       });
@@ -192,7 +197,6 @@ const SecureKeychain = {
         [UserProfileProperty.AUTHENTICATION_TYPE]:
           AUTHENTICATION_TYPE.REMEMBER_ME,
       });
-      //Don't need to add any parameter
     } else {
       // Setting a password without a type does not save it
       return await this.resetGenericPassword();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR adds an explicit storage type of AES_GCM for Android when using biometrics or pincode, which enforces the access controls. Fixes - https://github.com/MetaMask/MetaMask-planning/issues/6445. iOS is unaffected by these changes.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6445

## **Manual testing steps**

On Android
- Create a new wallet
- Go into settings and enable pincode or biometrics as well as immediate lock
- Fully background the app
- Foreground the app and notice that the system's OS should prompt either biometrics or pincode, prioritized in that order of which is available (This is Android's prioritization order)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

The black screen indicates that biometrics was prompted
https://github.com/user-attachments/assets/73ca1416-49b9-498c-b6eb-c647e2a094bb


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Security/auth behavior (Android)**
> 
> - In `SecureKeychain.setGenericPassword`, adds `storage: Keychain.STORAGE_TYPE.AES_GCM` when using `BIOMETRICS` or `PASSCODE` to ensure access controls are enforced on Android
> - Updates unit tests in `SecureKeychain.test.ts` to assert the new `storage` option alongside existing `accessControl` checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7f290f95ae7be68991fab710a5fa0e53a6a129c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->