### PR TITLE
test: mUSD conversion component view test

### DIFF
--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
@@ -138,7 +138,11 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
 
     // Verify screen renders with heading (image is rendered as part of component tree)
     expect(
-      getByText(strings('earn.musd_conversion.education.heading')),
+      getByText(
+        strings('earn.musd_conversion.education.heading', {
+          percentage: MUSD_CONVERSION_APY,
+        }),
+      ),
     ).toBeOnTheScreen();
   });
 

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
@@ -71,7 +71,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
     ).toBeOnTheScreen();
   });
 
-  it('renders background image based on color scheme', () => {
+  it('renders education screen heading', () => {
     // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
@@ -101,7 +101,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
     );
 
     // Assert
-    // Verify screen renders with heading (image is rendered as part of component tree)
+    // Verify screen renders with heading
     expect(
       getByText(
         strings('earn.musd_conversion.education.heading', {
@@ -111,7 +111,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
     ).toBeOnTheScreen();
   });
 
-  it('keeps go back button visible after press', () => {
+  it('keeps go back button visible after press', async () => {
     // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
@@ -144,7 +144,9 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
     );
 
     // Act
-    fireEvent.press(goBackButton);
+    await act(async () => {
+      fireEvent.press(goBackButton);
+    });
 
     // Assert
     // Button should still be on screen after press
@@ -321,58 +323,6 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
     ).toBeOnTheScreen();
   });
 
-  it('renders all required UI elements on education screen', () => {
-    // Arrange
-    const state = initialStateWallet()
-      .withMinimalMultichainAssets()
-      .withRemoteFeatureFlags({
-        earnMusdConversionFlowEnabled: { enabled: true },
-      })
-      .withOverrides({
-        engine: {
-          backgroundState: {
-            AssetsController: {
-              assets: {},
-            },
-          },
-        },
-      } as unknown as Record<string, unknown>)
-      .build();
-
-    // Act
-    const { getByText } = renderScreenWithRoutes(
-      EarnMusdConversionEducationView as unknown as React.ComponentType,
-      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
-      [],
-      {
-        state,
-      },
-      mockRouteParams,
-    );
-
-    // Assert
-    expect(
-      getByText(
-        strings('earn.musd_conversion.education.heading', {
-          percentage: MUSD_CONVERSION_APY,
-        }),
-      ),
-    ).toBeOnTheScreen();
-    expect(
-      getByText(
-        strings('earn.musd_conversion.education.description', {
-          percentage: MUSD_CONVERSION_APY,
-        }),
-      ),
-    ).toBeOnTheScreen();
-    expect(
-      getByText(strings('earn.musd_conversion.education.primary_button')),
-    ).toBeOnTheScreen();
-    expect(
-      getByText(strings('earn.musd_conversion.education.secondary_button')),
-    ).toBeOnTheScreen();
-  });
-
   it('renders education screen with correct APY percentage in heading', () => {
     // Arrange
     const state = initialStateWallet()
@@ -409,7 +359,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       }),
     );
     expect(heading).toBeOnTheScreen();
-    expect(heading.props.children).toContain('3%');
+    expect(heading.props.children).toContain(`${MUSD_CONVERSION_APY}%`);
   });
 
   it('renders education screen with correct APY percentage in description', () => {
@@ -448,7 +398,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       }),
     );
     expect(description).toBeOnTheScreen();
-    expect(description.props.children).toContain('3%');
+    expect(description.props.children).toContain(`${MUSD_CONVERSION_APY}%`);
   });
 
   it('renders education screen when education has been seen', () => {

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
@@ -68,47 +68,6 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
     ).toBeOnTheScreen();
   });
 
-  it('keeps continue button visible after press', async () => {
-    const state = initialStateWallet()
-      .withMinimalMultichainAssets()
-      .withRemoteFeatureFlags({
-        earnMusdConversionFlowEnabled: { enabled: true },
-      })
-      .withOverrides({
-        engine: {
-          backgroundState: {
-            AssetsController: {
-              assets: {},
-            },
-          },
-        },
-        user: {
-          musdConversionEducationSeen: false,
-        },
-      } as unknown as Record<string, unknown>)
-      .build();
-
-    const { getByText } = renderScreenWithRoutes(
-      EarnMusdConversionEducationView as unknown as React.ComponentType,
-      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
-      [],
-      {
-        state,
-      },
-      mockRouteParams,
-    );
-
-    const continueButton = getByText(
-      strings('earn.musd_conversion.education.primary_button'),
-    );
-
-    await act(async () => {
-      fireEvent.press(continueButton);
-    });
-
-    expect(continueButton).toBeOnTheScreen();
-  });
-
   it('renders background image based on color scheme', () => {
     const state = initialStateWallet()
       .withMinimalMultichainAssets()

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
@@ -20,6 +20,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
   };
 
   it('renders education screen with all UI elements', () => {
+    // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -36,6 +37,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { getByText } = renderScreenWithRoutes(
       EarnMusdConversionEducationView as unknown as React.ComponentType,
       { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
@@ -46,6 +48,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       mockRouteParams,
     );
 
+    // Assert
     expect(
       getByText(
         strings('earn.musd_conversion.education.heading', {
@@ -69,6 +72,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
   });
 
   it('renders background image based on color scheme', () => {
+    // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -85,6 +89,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { getByText } = renderScreenWithRoutes(
       EarnMusdConversionEducationView as unknown as React.ComponentType,
       { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
@@ -95,6 +100,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       mockRouteParams,
     );
 
+    // Assert
     // Verify screen renders with heading (image is rendered as part of component tree)
     expect(
       getByText(
@@ -106,6 +112,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
   });
 
   it('keeps go back button visible after press', () => {
+    // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -135,13 +142,17 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
     const goBackButton = getByText(
       strings('earn.musd_conversion.education.secondary_button'),
     );
+
+    // Act
     fireEvent.press(goBackButton);
 
+    // Assert
     // Button should still be on screen after press
     expect(goBackButton).toBeOnTheScreen();
   });
 
   it('keeps continue button visible after press when education not seen', async () => {
+    // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -175,14 +186,17 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       strings('earn.musd_conversion.education.primary_button'),
     );
 
+    // Act
     await act(async () => {
       fireEvent.press(continueButton);
     });
 
+    // Assert
     expect(continueButton).toBeOnTheScreen();
   });
 
   it('renders screen when route params are missing', () => {
+    // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -199,6 +213,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { getByText } = renderScreenWithRoutes(
       EarnMusdConversionEducationView as unknown as React.ComponentType,
       { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
@@ -209,6 +224,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       {}, // Missing params
     );
 
+    // Assert
     // Component should still render
     expect(
       getByText(
@@ -220,6 +236,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
   });
 
   it('renders screen when outputChainId is missing in route params', () => {
+    // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -236,6 +253,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { getByText } = renderScreenWithRoutes(
       EarnMusdConversionEducationView as unknown as React.ComponentType,
       { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
@@ -249,6 +267,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       },
     );
 
+    // Assert
     // Component should still render
     expect(
       getByText(
@@ -260,6 +279,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
   });
 
   it('renders screen when preferredPaymentToken is missing in route params', () => {
+    // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -276,6 +296,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { getByText } = renderScreenWithRoutes(
       EarnMusdConversionEducationView as unknown as React.ComponentType,
       { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
@@ -289,7 +310,222 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       },
     );
 
+    // Assert
     // Component should still render
+    expect(
+      getByText(
+        strings('earn.musd_conversion.education.heading', {
+          percentage: MUSD_CONVERSION_APY,
+        }),
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders all required UI elements on education screen', () => {
+    // Arrange
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    // Act
+    const { getByText } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+      },
+      mockRouteParams,
+    );
+
+    // Assert
+    expect(
+      getByText(
+        strings('earn.musd_conversion.education.heading', {
+          percentage: MUSD_CONVERSION_APY,
+        }),
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(
+        strings('earn.musd_conversion.education.description', {
+          percentage: MUSD_CONVERSION_APY,
+        }),
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('earn.musd_conversion.education.primary_button')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('earn.musd_conversion.education.secondary_button')),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders education screen with correct APY percentage in heading', () => {
+    // Arrange
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    // Act
+    const { getByText } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+      },
+      mockRouteParams,
+    );
+
+    // Assert
+    const heading = getByText(
+      strings('earn.musd_conversion.education.heading', {
+        percentage: MUSD_CONVERSION_APY,
+      }),
+    );
+    expect(heading).toBeOnTheScreen();
+    expect(heading.props.children).toContain('3%');
+  });
+
+  it('renders education screen with correct APY percentage in description', () => {
+    // Arrange
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    // Act
+    const { getByText } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+      },
+      mockRouteParams,
+    );
+
+    // Assert
+    const description = getByText(
+      strings('earn.musd_conversion.education.description', {
+        percentage: MUSD_CONVERSION_APY,
+      }),
+    );
+    expect(description).toBeOnTheScreen();
+    expect(description.props.children).toContain('3%');
+  });
+
+  it('renders education screen when education has been seen', () => {
+    // Arrange
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+        user: {
+          musdConversionEducationSeen: true,
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    // Act
+    const { getByText } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+      },
+      mockRouteParams,
+    );
+
+    // Assert
+    expect(
+      getByText(
+        strings('earn.musd_conversion.education.heading', {
+          percentage: MUSD_CONVERSION_APY,
+        }),
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders education screen with all route params provided', () => {
+    // Arrange
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    // Act
+    const { getByText } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+      },
+      {
+        preferredPaymentToken: mockRouteParams.preferredPaymentToken,
+        outputChainId: mockRouteParams.outputChainId,
+      },
+    );
+
+    // Assert
     expect(
       getByText(
         strings('earn.musd_conversion.education.heading', {

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
@@ -5,9 +5,10 @@ import { describeForPlatforms } from '../../../../../util/test/platform';
 import React from 'react';
 import EarnMusdConversionEducationView from './index';
 import { strings } from '../../../../../../locales/i18n';
-import { fireEvent } from '@testing-library/react-native';
+import { fireEvent, act } from '@testing-library/react-native';
 import Routes from '../../../../../constants/navigation/Routes';
 import { Hex } from '@metamask/utils';
+import { MUSD_CONVERSION_APY } from '../../constants/musd';
 
 describeForPlatforms('EarnMusdConversionEducationView', () => {
   const mockRouteParams = {
@@ -46,10 +47,18 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
     );
 
     expect(
-      getByText(strings('earn.musd_conversion.education.heading')),
+      getByText(
+        strings('earn.musd_conversion.education.heading', {
+          percentage: MUSD_CONVERSION_APY,
+        }),
+      ),
     ).toBeOnTheScreen();
     expect(
-      getByText(strings('earn.musd_conversion.education.description')),
+      getByText(
+        strings('earn.musd_conversion.education.description', {
+          percentage: MUSD_CONVERSION_APY,
+        }),
+      ),
     ).toBeOnTheScreen();
     expect(
       getByText(strings('earn.musd_conversion.education.primary_button')),
@@ -59,7 +68,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
     ).toBeOnTheScreen();
   });
 
-  it('dispatches setMusdConversionEducationSeen when continue button pressed', async () => {
+  it('keeps continue button visible after press', async () => {
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -89,15 +98,15 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       },
     );
 
-    fireEvent.press(
-      getByText(strings('earn.musd_conversion.education.primary_button')),
+    const continueButton = getByText(
+      strings('earn.musd_conversion.education.primary_button'),
     );
 
-    // Verify that the action would be dispatched (via Engine mock)
-    // The actual dispatch happens through Redux, which is mocked in component-view tests
-    expect(
-      getByText(strings('earn.musd_conversion.education.primary_button')),
-    ).toBeOnTheScreen();
+    await act(async () => {
+      fireEvent.press(continueButton);
+    });
+
+    expect(continueButton).toBeOnTheScreen();
   });
 
   it('renders background image based on color scheme', () => {
@@ -117,7 +126,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
-    const { UNSAFE_root } = renderScreenWithRoutes(
+    const { getByText } = renderScreenWithRoutes(
       EarnMusdConversionEducationView as unknown as React.ComponentType,
       { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
       [],
@@ -127,12 +136,13 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       },
     );
 
-    // Verify image is rendered (component uses Image from react-native)
-    // Image component is rendered as part of the component tree
-    expect(UNSAFE_root).toBeDefined();
+    // Verify screen renders with heading (image is rendered as part of component tree)
+    expect(
+      getByText(strings('earn.musd_conversion.education.heading')),
+    ).toBeOnTheScreen();
   });
 
-  it('handles go back button press', () => {
+  it('keeps go back button visible after press', () => {
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -168,7 +178,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
     expect(goBackButton).toBeOnTheScreen();
   });
 
-  it('marks education as seen when continue pressed', () => {
+  it('keeps continue button visible after press when education not seen', async () => {
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -201,14 +211,15 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
     const continueButton = getByText(
       strings('earn.musd_conversion.education.primary_button'),
     );
-    fireEvent.press(continueButton);
 
-    // Button should still be on screen after press
-    // The actual state update happens through Redux dispatch
+    await act(async () => {
+      fireEvent.press(continueButton);
+    });
+
     expect(continueButton).toBeOnTheScreen();
   });
 
-  it('handles missing route params gracefully', () => {
+  it('renders screen when route params are missing', () => {
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -237,11 +248,15 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
 
     // Component should still render
     expect(
-      getByText(strings('earn.musd_conversion.education.heading')),
+      getByText(
+        strings('earn.musd_conversion.education.heading', {
+          percentage: MUSD_CONVERSION_APY,
+        }),
+      ),
     ).toBeOnTheScreen();
   });
 
-  it('handles missing outputChainId in route params', () => {
+  it('renders screen when outputChainId is missing in route params', () => {
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -273,11 +288,15 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
 
     // Component should still render
     expect(
-      getByText(strings('earn.musd_conversion.education.heading')),
+      getByText(
+        strings('earn.musd_conversion.education.heading', {
+          percentage: MUSD_CONVERSION_APY,
+        }),
+      ),
     ).toBeOnTheScreen();
   });
 
-  it('handles missing preferredPaymentToken in route params', () => {
+  it('renders screen when preferredPaymentToken is missing in route params', () => {
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -309,7 +328,11 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
 
     // Component should still render
     expect(
-      getByText(strings('earn.musd_conversion.education.heading')),
+      getByText(
+        strings('earn.musd_conversion.education.heading', {
+          percentage: MUSD_CONVERSION_APY,
+        }),
+      ),
     ).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
@@ -42,8 +42,8 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       [],
       {
         state,
-        initialParams: mockRouteParams,
       },
+      mockRouteParams,
     );
 
     expect(
@@ -94,8 +94,8 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       [],
       {
         state,
-        initialParams: mockRouteParams,
       },
+      mockRouteParams,
     );
 
     const continueButton = getByText(
@@ -132,8 +132,8 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       [],
       {
         state,
-        initialParams: mockRouteParams,
       },
+      mockRouteParams,
     );
 
     // Verify screen renders with heading (image is rendered as part of component tree)
@@ -169,8 +169,8 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       [],
       {
         state,
-        initialParams: mockRouteParams,
       },
+      mockRouteParams,
     );
 
     const goBackButton = getByText(
@@ -208,8 +208,8 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       [],
       {
         state,
-        initialParams: mockRouteParams,
       },
+      mockRouteParams,
     );
 
     const continueButton = getByText(
@@ -246,8 +246,8 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       [],
       {
         state,
-        initialParams: {}, // Missing params
       },
+      {}, // Missing params
     );
 
     // Component should still render
@@ -283,10 +283,10 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       [],
       {
         state,
-        initialParams: {
-          preferredPaymentToken: mockRouteParams.preferredPaymentToken,
-          // Missing outputChainId
-        },
+      },
+      {
+        preferredPaymentToken: mockRouteParams.preferredPaymentToken,
+        // Missing outputChainId
       },
     );
 
@@ -323,10 +323,10 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       [],
       {
         state,
-        initialParams: {
-          outputChainId: mockRouteParams.outputChainId,
-          // Missing preferredPaymentToken
-        },
+      },
+      {
+        outputChainId: mockRouteParams.outputChainId,
+        // Missing preferredPaymentToken
       },
     );
 

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
@@ -1,0 +1,170 @@
+import '../../../../../util/test/component-view/mocks';
+import { renderScreenWithRoutes } from '../../../../../util/test/component-view/render';
+import { initialStateWallet } from '../../../../../util/test/component-view/presets/wallet';
+import { describeForPlatforms } from '../../../../../util/test/platform';
+import React from 'react';
+import EarnMusdConversionEducationView from './index';
+import { strings } from '../../../../../../locales/i18n';
+import { fireEvent } from '@testing-library/react-native';
+import Routes from '../../../../../constants/navigation/Routes';
+import { Hex } from '@metamask/utils';
+
+describeForPlatforms('EarnMusdConversionEducationView', () => {
+  const mockRouteParams = {
+    preferredPaymentToken: {
+      address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as Hex,
+      chainId: '0x1' as Hex,
+    },
+    outputChainId: '0x1' as Hex,
+  };
+
+  it('renders education screen with all UI elements', () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { getByText } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+        initialParams: mockRouteParams,
+      },
+    );
+
+    expect(
+      getByText(strings('earn.musd_conversion.education.heading')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('earn.musd_conversion.education.description')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('earn.musd_conversion.education.primary_button')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('earn.musd_conversion.education.secondary_button')),
+    ).toBeOnTheScreen();
+  });
+
+  it('dispatches setMusdConversionEducationSeen when continue button pressed', async () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+        user: {
+          musdConversionEducationSeen: false,
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { getByText } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+        initialParams: mockRouteParams,
+      },
+    );
+
+    fireEvent.press(
+      getByText(strings('earn.musd_conversion.education.primary_button')),
+    );
+
+    // Verify that the action would be dispatched (via Engine mock)
+    // The actual dispatch happens through Redux, which is mocked in component-view tests
+    expect(
+      getByText(strings('earn.musd_conversion.education.primary_button')),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders background image based on color scheme', () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { UNSAFE_root } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+        initialParams: mockRouteParams,
+      },
+    );
+
+    // Verify image is rendered (component uses Image from react-native)
+    // Image component is rendered as part of the component tree
+    expect(UNSAFE_root).toBeDefined();
+  });
+
+  it('handles go back button press', () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { getByText } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+        initialParams: mockRouteParams,
+      },
+    );
+
+    const goBackButton = getByText(
+      strings('earn.musd_conversion.education.secondary_button'),
+    );
+    fireEvent.press(goBackButton);
+
+    // Button should still be on screen after press
+    expect(goBackButton).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
@@ -167,4 +167,149 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
     // Button should still be on screen after press
     expect(goBackButton).toBeOnTheScreen();
   });
+
+  it('marks education as seen when continue pressed', () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+        user: {
+          musdConversionEducationSeen: false,
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { getByText } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+        initialParams: mockRouteParams,
+      },
+    );
+
+    const continueButton = getByText(
+      strings('earn.musd_conversion.education.primary_button'),
+    );
+    fireEvent.press(continueButton);
+
+    // Button should still be on screen after press
+    // The actual state update happens through Redux dispatch
+    expect(continueButton).toBeOnTheScreen();
+  });
+
+  it('handles missing route params gracefully', () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { getByText } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+        initialParams: {}, // Missing params
+      },
+    );
+
+    // Component should still render
+    expect(
+      getByText(strings('earn.musd_conversion.education.heading')),
+    ).toBeOnTheScreen();
+  });
+
+  it('handles missing outputChainId in route params', () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { getByText } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+        initialParams: {
+          preferredPaymentToken: mockRouteParams.preferredPaymentToken,
+          // Missing outputChainId
+        },
+      },
+    );
+
+    // Component should still render
+    expect(
+      getByText(strings('earn.musd_conversion.education.heading')),
+    ).toBeOnTheScreen();
+  });
+
+  it('handles missing preferredPaymentToken in route params', () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { getByText } = renderScreenWithRoutes(
+      EarnMusdConversionEducationView as unknown as React.ComponentType,
+      { name: Routes.EARN.MUSD.CONVERSION_EDUCATION },
+      [],
+      {
+        state,
+        initialParams: {
+          outputChainId: mockRouteParams.outputChainId,
+          // Missing preferredPaymentToken
+        },
+      },
+    );
+
+    // Component should still render
+    expect(
+      getByText(strings('earn.musd_conversion.education.heading')),
+    ).toBeOnTheScreen();
+  });
 });

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.view.test.tsx
@@ -1,0 +1,75 @@
+import '../../../../../../util/test/component-view/mocks';
+import { renderComponentViewScreen } from '../../../../../../util/test/component-view/render';
+import { initialStateWallet } from '../../../../../../util/test/component-view/presets/wallet';
+import { describeForPlatforms } from '../../../../../../util/test/platform';
+import React from 'react';
+import { View } from 'react-native';
+import MusdConversionAssetListCta from './index';
+import { EARN_TEST_IDS } from '../../../constants/testIds';
+
+// Wrapper component to render the CTA in a screen context
+const MusdConversionAssetListCtaScreen = () => (
+  <View>
+    <MusdConversionAssetListCta />
+  </View>
+);
+
+describeForPlatforms('MusdConversionAssetListCta', () => {
+  it('hides CTA when feature flag disabled', () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdCtaEnabled: { enabled: false },
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { queryByTestId } = renderComponentViewScreen(
+      MusdConversionAssetListCtaScreen,
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    expect(
+      queryByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA),
+    ).toBeNull();
+  });
+
+  it('hides CTA when conversion flow feature flag disabled', () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: false },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { queryByTestId } = renderComponentViewScreen(
+      MusdConversionAssetListCtaScreen,
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    expect(
+      queryByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA),
+    ).toBeNull();
+  });
+});

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.view.test.tsx
@@ -108,10 +108,10 @@ describeForPlatforms('MusdConversionAssetListCta', () => {
     );
 
     // Assert
-    // Component may or may not render depending on hook logic
-    // This test verifies the component handles the case gracefully
+    // Component returns null when visibility conditions are not met
+    // This test verifies the component handles the case gracefully without crashing
     const cta = queryByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA);
-    // Component either renders or returns null - both are valid behaviors
-    expect(cta === null || cta).toBeTruthy();
+    // When conditions aren't met, component should return null
+    expect(cta).toBeNull();
   });
 });

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.view.test.tsx
@@ -16,6 +16,7 @@ const MusdConversionAssetListCtaScreen = () => (
 
 describeForPlatforms('MusdConversionAssetListCta', () => {
   it('hides CTA when feature flag disabled', () => {
+    // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -33,18 +34,21 @@ describeForPlatforms('MusdConversionAssetListCta', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { queryByTestId } = renderComponentViewScreen(
       MusdConversionAssetListCtaScreen,
       { name: 'TestScreen' },
       { state },
     );
 
+    // Assert
     expect(
       queryByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA),
     ).toBeNull();
   });
 
   it('hides CTA when conversion flow feature flag disabled', () => {
+    // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -62,14 +66,52 @@ describeForPlatforms('MusdConversionAssetListCta', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { queryByTestId } = renderComponentViewScreen(
       MusdConversionAssetListCtaScreen,
       { name: 'TestScreen' },
       { state },
     );
 
+    // Assert
     expect(
       queryByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA),
     ).toBeNull();
+  });
+
+  it('does not render CTA when visibility conditions are not met', () => {
+    // Arrange
+    // Component visibility depends on complex hook logic that requires
+    // specific state configuration. When conditions aren't met, component returns null.
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: true },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    // Act
+    const { queryByTestId } = renderComponentViewScreen(
+      MusdConversionAssetListCtaScreen,
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    // Assert
+    // Component may or may not render depending on hook logic
+    // This test verifies the component handles the case gracefully
+    const cta = queryByTestId(EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA);
+    // Component either renders or returns null - both are valid behaviors
+    expect(cta === null || cta).toBeTruthy();
   });
 });

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
@@ -209,7 +209,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     expect(mockOnDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it('hides CTA when asset is not in allowlist', () => {
+  it('renders CTA when asset is not in allowlist', () => {
     const mockAssetNotInAllowlist = {
       ...mockAsset,
       symbol: 'USDT', // Not in allowlist
@@ -286,7 +286,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     ).toBeOnTheScreen();
   });
 
-  it('handles different asset symbols correctly', () => {
+  it('renders CTA for different asset symbols', () => {
     const mockDAIAsset = {
       ...mockAsset,
       symbol: 'DAI',
@@ -322,7 +322,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     ).toBeOnTheScreen();
   });
 
-  it('handles missing asset address gracefully', () => {
+  it('renders CTA when asset address is missing', () => {
     const mockAssetWithoutAddress = {
       ...mockAsset,
       address: '',

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
@@ -225,7 +225,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     expect(mockOnDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it('renders CTA component regardless of allowlist status', () => {
+  it('renders CTA component as presentational component regardless of allowlist', () => {
     // Arrange
     const mockAssetNotInAllowlist = {
       ...mockAsset,

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
@@ -210,7 +210,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     expect(mockOnDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it('renders CTA when asset is not in allowlist', () => {
+  it('renders CTA component regardless of allowlist status', () => {
     const mockAssetNotInAllowlist = {
       ...mockAsset,
       symbol: 'USDT', // Not in allowlist
@@ -242,8 +242,9 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       { state },
     );
 
-    // Component always renders, but visibility is controlled by parent
-    // The parent would hide it based on shouldShowAssetOverviewCta hook
+    // Component always renders when called - it's a presentational component
+    // Visibility logic (including allowlist checks) is handled by the parent
+    // component via shouldShowAssetOverviewCta hook, not by this component itself
     expect(
       queryByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
     ).toBeOnTheScreen();

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
@@ -7,13 +7,14 @@ import { View } from 'react-native';
 import MusdConversionAssetOverviewCta from './index';
 import { EARN_TEST_IDS } from '../../../constants/testIds';
 import { fireEvent } from '@testing-library/react-native';
+import { TokenI } from '../../../../Tokens/types';
 
 // Wrapper component to render the CTA in a screen context
 const MusdConversionAssetOverviewCtaScreen = ({
   asset,
   onDismiss,
 }: {
-  asset: { symbol: string; address: string; chainId: string };
+  asset: TokenI;
   onDismiss?: () => void;
 }) => (
   <View>

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
@@ -535,44 +535,6 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     expect(getByText('mUSD')).toBeOnTheScreen();
   });
 
-  it('renders CTA without close button when onDismiss is undefined', () => {
-    // Arrange
-    const state = initialStateWallet()
-      .withMinimalMultichainAssets()
-      .withRemoteFeatureFlags({
-        earnMusdConversionAssetOverviewCtaEnabled: { enabled: true },
-        earnMusdConversionFlowEnabled: { enabled: true },
-        earnMusdConversionCtaTokens: { '*': ['USDC'] },
-      })
-      .withOverrides({
-        engine: {
-          backgroundState: {
-            AssetsController: {
-              assets: {},
-            },
-          },
-        },
-      } as unknown as Record<string, unknown>)
-      .build();
-
-    // Act
-    const { queryByTestId, getByTestId } = renderComponentViewScreen(
-      () => <MusdConversionAssetOverviewCtaScreen asset={mockAsset} />,
-      { name: 'TestScreen' },
-      { state },
-    );
-
-    // Assert
-    expect(
-      getByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
-    ).toBeOnTheScreen();
-    expect(
-      queryByTestId(
-        EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA_CLOSE_BUTTON,
-      ),
-    ).toBeNull();
-  });
-
   it('renders CTA for USDT asset when in allowlist', () => {
     // Arrange
     const mockUSDTAsset = {

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
@@ -1,0 +1,211 @@
+import '../../../../../../util/test/component-view/mocks';
+import { renderComponentViewScreen } from '../../../../../../util/test/component-view/render';
+import { initialStateWallet } from '../../../../../../util/test/component-view/presets/wallet';
+import { describeForPlatforms } from '../../../../../../util/test/platform';
+import React from 'react';
+import { View } from 'react-native';
+import MusdConversionAssetOverviewCta from './index';
+import { EARN_TEST_IDS } from '../../../constants/testIds';
+import { fireEvent } from '@testing-library/react-native';
+
+// Wrapper component to render the CTA in a screen context
+const MusdConversionAssetOverviewCtaScreen = ({
+  asset,
+  onDismiss,
+}: {
+  asset: { symbol: string; address: string; chainId: string };
+  onDismiss?: () => void;
+}) => (
+  <View>
+    <MusdConversionAssetOverviewCta asset={asset} onDismiss={onDismiss} />
+  </View>
+);
+
+describeForPlatforms('MusdConversionAssetOverviewCta', () => {
+  const mockAsset = {
+    address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    chainId: '0x1',
+    symbol: 'USDC',
+    aggregators: [],
+    decimals: 6,
+    image: 'https://example.com/usdc.png',
+    name: 'USD Coin',
+    balance: '1000000000',
+    logo: 'https://example.com/usdc.png',
+    isETH: false,
+  };
+
+  it('renders CTA with asset', () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionAssetOverviewCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: true },
+        earnMusdConversionCtaTokens: { '*': ['USDC'] },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { getByTestId } = renderComponentViewScreen(
+      () => <MusdConversionAssetOverviewCtaScreen asset={mockAsset} />,
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    expect(
+      getByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
+    ).toBeOnTheScreen();
+  });
+
+  it('displays CTA text correctly', () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionAssetOverviewCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: true },
+        earnMusdConversionCtaTokens: { '*': ['USDC'] },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { getByText } = renderComponentViewScreen(
+      () => <MusdConversionAssetOverviewCtaScreen asset={mockAsset} />,
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    expect(getByText('Boost your stablecoin balance')).toBeOnTheScreen();
+    expect(
+      getByText(/Earn a bonus every time you convert stablecoins to/),
+    ).toBeOnTheScreen();
+    expect(getByText('mUSD')).toBeOnTheScreen();
+  });
+
+  it('renders close button when onDismiss is provided', () => {
+    const mockOnDismiss = jest.fn();
+
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionAssetOverviewCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: true },
+        earnMusdConversionCtaTokens: { '*': ['USDC'] },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { getByTestId } = renderComponentViewScreen(
+      () => (
+        <MusdConversionAssetOverviewCtaScreen
+          asset={mockAsset}
+          onDismiss={mockOnDismiss}
+        />
+      ),
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    expect(
+      getByTestId(
+        EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA_CLOSE_BUTTON,
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('does not render close button when onDismiss is not provided', () => {
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionAssetOverviewCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: true },
+        earnMusdConversionCtaTokens: { '*': ['USDC'] },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { queryByTestId } = renderComponentViewScreen(
+      () => <MusdConversionAssetOverviewCtaScreen asset={mockAsset} />,
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    expect(
+      queryByTestId(
+        EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA_CLOSE_BUTTON,
+      ),
+    ).toBeNull();
+  });
+
+  it('calls onDismiss when close button is pressed', () => {
+    const mockOnDismiss = jest.fn();
+
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionAssetOverviewCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: true },
+        earnMusdConversionCtaTokens: { '*': ['USDC'] },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    const { getByTestId } = renderComponentViewScreen(
+      () => (
+        <MusdConversionAssetOverviewCtaScreen
+          asset={mockAsset}
+          onDismiss={mockOnDismiss}
+        />
+      ),
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    fireEvent.press(
+      getByTestId(
+        EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA_CLOSE_BUTTON,
+      ),
+    );
+
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
@@ -37,6 +37,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
   };
 
   it('renders CTA with asset', () => {
+    // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -55,18 +56,21 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { getByTestId } = renderComponentViewScreen(
       () => <MusdConversionAssetOverviewCtaScreen asset={mockAsset} />,
       { name: 'TestScreen' },
       { state },
     );
 
+    // Assert
     expect(
       getByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
     ).toBeOnTheScreen();
   });
 
   it('displays CTA text correctly', () => {
+    // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -85,12 +89,14 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { getByText } = renderComponentViewScreen(
       () => <MusdConversionAssetOverviewCtaScreen asset={mockAsset} />,
       { name: 'TestScreen' },
       { state },
     );
 
+    // Assert
     expect(getByText('Boost your stablecoin balance')).toBeOnTheScreen();
     expect(
       getByText(/Earn a bonus every time you convert stablecoins to/),
@@ -99,6 +105,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
   });
 
   it('renders close button when onDismiss is provided', () => {
+    // Arrange
     const mockOnDismiss = jest.fn();
 
     const state = initialStateWallet()
@@ -119,6 +126,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { getByTestId } = renderComponentViewScreen(
       () => (
         <MusdConversionAssetOverviewCtaScreen
@@ -130,6 +138,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       { state },
     );
 
+    // Assert
     expect(
       getByTestId(
         EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA_CLOSE_BUTTON,
@@ -138,6 +147,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
   });
 
   it('does not render close button when onDismiss is not provided', () => {
+    // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
       .withRemoteFeatureFlags({
@@ -156,12 +166,14 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { queryByTestId } = renderComponentViewScreen(
       () => <MusdConversionAssetOverviewCtaScreen asset={mockAsset} />,
       { name: 'TestScreen' },
       { state },
     );
 
+    // Assert
     expect(
       queryByTestId(
         EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA_CLOSE_BUTTON,
@@ -170,6 +182,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
   });
 
   it('calls onDismiss when close button is pressed', () => {
+    // Arrange
     const mockOnDismiss = jest.fn();
 
     const state = initialStateWallet()
@@ -201,16 +214,19 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       { state },
     );
 
+    // Act
     fireEvent.press(
       getByTestId(
         EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA_CLOSE_BUTTON,
       ),
     );
 
+    // Assert
     expect(mockOnDismiss).toHaveBeenCalledTimes(1);
   });
 
   it('renders CTA component regardless of allowlist status', () => {
+    // Arrange
     const mockAssetNotInAllowlist = {
       ...mockAsset,
       symbol: 'USDT', // Not in allowlist
@@ -234,6 +250,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { queryByTestId } = renderComponentViewScreen(
       () => (
         <MusdConversionAssetOverviewCtaScreen asset={mockAssetNotInAllowlist} />
@@ -242,6 +259,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       { state },
     );
 
+    // Assert
     // Component always renders when called - it's a presentational component
     // Visibility logic (including allowlist checks) is handled by the parent
     // component via shouldShowAssetOverviewCta hook, not by this component itself
@@ -251,6 +269,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
   });
 
   it('renders CTA when asset balance is above minimum', () => {
+    // Arrange
     const mockAssetWithBalance = {
       ...mockAsset,
       balance: '1000000000', // 1000 USDC (above minimum)
@@ -275,6 +294,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { getByTestId } = renderComponentViewScreen(
       () => (
         <MusdConversionAssetOverviewCtaScreen asset={mockAssetWithBalance} />
@@ -283,12 +303,14 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       { state },
     );
 
+    // Assert
     expect(
       getByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
     ).toBeOnTheScreen();
   });
 
   it('renders CTA for different asset symbols', () => {
+    // Arrange
     const mockDAIAsset = {
       ...mockAsset,
       symbol: 'DAI',
@@ -313,18 +335,21 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     const { getByTestId } = renderComponentViewScreen(
       () => <MusdConversionAssetOverviewCtaScreen asset={mockDAIAsset} />,
       { name: 'TestScreen' },
       { state },
     );
 
+    // Assert
     expect(
       getByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
     ).toBeOnTheScreen();
   });
 
   it('renders CTA when asset address is missing', () => {
+    // Arrange
     const mockAssetWithoutAddress = {
       ...mockAsset,
       address: '',
@@ -348,6 +373,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       } as unknown as Record<string, unknown>)
       .build();
 
+    // Act
     // Component should still render, error handling happens in handlePress
     const { getByTestId } = renderComponentViewScreen(
       () => (
@@ -357,6 +383,231 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
       { state },
     );
 
+    // Assert
+    expect(
+      getByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders CTA with asset having low balance', () => {
+    // Arrange
+    const mockAssetLowBalance = {
+      ...mockAsset,
+      balance: '1000', // 0.001 USDC (very low)
+    };
+
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionAssetOverviewCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: true },
+        earnMusdConversionCtaTokens: { '*': ['USDC'] },
+        earnMusdConversionMinAssetBalanceRequired: 0.01,
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    // Act
+    const { getByTestId } = renderComponentViewScreen(
+      () => (
+        <MusdConversionAssetOverviewCtaScreen asset={mockAssetLowBalance} />
+      ),
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    // Assert
+    // Component renders regardless of balance - balance check is in parent
+    expect(
+      getByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders CTA for asset on different chain', () => {
+    // Arrange
+    const mockLineaAsset = {
+      ...mockAsset,
+      chainId: '0xe708', // Linea Mainnet
+      address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    };
+
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionAssetOverviewCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: true },
+        earnMusdConversionCtaTokens: { '*': ['USDC'] },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    // Act
+    const { getByTestId } = renderComponentViewScreen(
+      () => <MusdConversionAssetOverviewCtaScreen asset={mockLineaAsset} />,
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    // Assert
+    expect(
+      getByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders CTA with correct boost title text', () => {
+    // Arrange
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionAssetOverviewCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: true },
+        earnMusdConversionCtaTokens: { '*': ['USDC'] },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    // Act
+    const { getByText } = renderComponentViewScreen(
+      () => <MusdConversionAssetOverviewCtaScreen asset={mockAsset} />,
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    // Assert
+    expect(getByText('Boost your stablecoin balance')).toBeOnTheScreen();
+  });
+
+  it('renders CTA with correct boost description text', () => {
+    // Arrange
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionAssetOverviewCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: true },
+        earnMusdConversionCtaTokens: { '*': ['USDC'] },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    // Act
+    const { getByText } = renderComponentViewScreen(
+      () => <MusdConversionAssetOverviewCtaScreen asset={mockAsset} />,
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    // Assert
+    expect(
+      getByText(/Earn a bonus every time you convert stablecoins to/),
+    ).toBeOnTheScreen();
+    expect(getByText('mUSD')).toBeOnTheScreen();
+  });
+
+  it('renders CTA without close button when onDismiss is undefined', () => {
+    // Arrange
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionAssetOverviewCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: true },
+        earnMusdConversionCtaTokens: { '*': ['USDC'] },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    // Act
+    const { queryByTestId, getByTestId } = renderComponentViewScreen(
+      () => <MusdConversionAssetOverviewCtaScreen asset={mockAsset} />,
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    // Assert
+    expect(
+      getByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(
+        EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA_CLOSE_BUTTON,
+      ),
+    ).toBeNull();
+  });
+
+  it('renders CTA for USDT asset when in allowlist', () => {
+    // Arrange
+    const mockUSDTAsset = {
+      ...mockAsset,
+      symbol: 'USDT',
+      address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+      name: 'Tether USD',
+    };
+
+    const state = initialStateWallet()
+      .withMinimalMultichainAssets()
+      .withRemoteFeatureFlags({
+        earnMusdConversionAssetOverviewCtaEnabled: { enabled: true },
+        earnMusdConversionFlowEnabled: { enabled: true },
+        earnMusdConversionCtaTokens: { '*': ['USDC', 'USDT'] },
+      })
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            AssetsController: {
+              assets: {},
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>)
+      .build();
+
+    // Act
+    const { getByTestId } = renderComponentViewScreen(
+      () => <MusdConversionAssetOverviewCtaScreen asset={mockUSDTAsset} />,
+      { name: 'TestScreen' },
+      { state },
+    );
+
+    // Assert
     expect(
       getByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
     ).toBeOnTheScreen();

--- a/app/util/test/component-view/mocks.ts
+++ b/app/util/test/component-view/mocks.ts
@@ -143,6 +143,11 @@ jest.mock('../../../core/Engine', () => {
       unsubscribe() {
         return undefined;
       },
+      call(_action: string, ..._args: unknown[]) {
+        // Analytics calls are side effects - return resolved promise to prevent errors
+        // but don't execute actual analytics tracking in tests
+        return Promise.resolve(undefined);
+      },
     },
     getTotalEvmFiatAccountBalance() {
       return { balance: '0', fiatBalance: '0' };

--- a/app/util/test/component-view/presets/bridge.ts
+++ b/app/util/test/component-view/presets/bridge.ts
@@ -33,6 +33,7 @@ export const initialStateBridge = (options?: InitialStateBridgeOptions) => {
     .withMinimalTokenRates()
     .withMinimalMultichainAssetsRates()
     .withMinimalMultichainBalances()
+    .withMinimalAnalyticsController()
     .withAccountTreeForSelectedAccount()
     .withRemoteFeatureFlags({});
 

--- a/app/util/test/component-view/presets/wallet.ts
+++ b/app/util/test/component-view/presets/wallet.ts
@@ -28,6 +28,7 @@ export const initialStateWallet = (options?: InitialStateWalletOptions) => {
     .withMinimalKeyringController()
     .withMinimalTokenRates()
     .withMinimalMultichainAssetsRates()
+    .withMinimalAnalyticsController()
     .withAccountTreeForSelectedAccount()
     .withRemoteFeatureFlags({})
     .withOverrides({

--- a/app/util/test/component-view/presets/wallet.ts
+++ b/app/util/test/component-view/presets/wallet.ts
@@ -50,6 +50,15 @@ export const initialStateWallet = (options?: InitialStateWalletOptions) => {
           TokenBalancesController: {
             tokenBalances: {},
           },
+          TokensController: {
+            allTokens: {
+              '0x1': {
+                '0x0000000000000000000000000000000000000001': [],
+              },
+            },
+            allDetectedTokens: {},
+            allIgnoredTokens: {},
+          },
           MultichainBalancesController: {
             balances: {},
           },

--- a/app/util/test/component-view/stateFixture.ts
+++ b/app/util/test/component-view/stateFixture.ts
@@ -148,6 +148,10 @@ export interface StateFixtureBuilder {
   withMinimalMultichainBalances(): StateFixtureBuilder;
   withMinimalMultichainAssets(): StateFixtureBuilder;
   withMinimalMultichainTransactions(): StateFixtureBuilder;
+  withMinimalAnalyticsController(options?: {
+    optedIn?: boolean;
+    analyticsId?: string;
+  }): StateFixtureBuilder;
   withBridgeRecommendedQuoteEvmSimple(params?: {
     srcAmount?: string;
     srcTokenAddress?: string;
@@ -680,6 +684,28 @@ export function createStateFixture(): StateFixtureBuilder {
               AccountTreeController: {
                 ...((bg as PlainObject)?.AccountTreeController as PlainObject),
                 accountTree: normalizedAccountTree,
+              },
+            },
+          },
+        } as unknown as DeepPartial<RootState> as PlainObject,
+      );
+      return api;
+    },
+    withMinimalAnalyticsController(options = {}) {
+      const bg = (current.engine?.backgroundState ?? {}) as unknown as Record<
+        string,
+        unknown
+      >;
+      const { optedIn = false, analyticsId = 'test-analytics-id' } = options;
+      current = deepMerge(
+        current as PlainObject,
+        {
+          engine: {
+            backgroundState: {
+              ...bg,
+              AnalyticsController: {
+                optedIn,
+                analyticsId,
               },
             },
           },

--- a/app/util/test/testSetupView.js
+++ b/app/util/test/testSetupView.js
@@ -7,6 +7,28 @@
 /* eslint-disable import/no-commonjs */
 /* eslint-disable react/prop-types */
 /* eslint-disable react/display-name */
+
+// Mock @metamask/analytics-controller FIRST before any other imports
+// This must be hoisted to the top before any module imports it
+jest.mock('@metamask/analytics-controller', () => ({
+  AnalyticsController: jest.fn(),
+  analyticsControllerSelectors: {
+    getAnalyticsEnabled: jest.fn(() => false),
+  },
+}));
+
+// Also mock the analytics utility that imports it
+jest.mock('../../util/analytics/analytics', () => ({
+  trackEvent: jest.fn(),
+  trackView: jest.fn(),
+  identify: jest.fn(),
+  optIn: jest.fn().mockResolvedValue(undefined),
+  optOut: jest.fn().mockResolvedValue(undefined),
+  getAnalyticsId: jest.fn().mockResolvedValue('test-analytics-id'),
+  isEnabled: jest.fn(() => false),
+  isOptedIn: jest.fn().mockResolvedValue(false),
+}));
+
 const { NativeModules } = require('react-native');
 // eslint-disable-next-line import/no-nodejs-modules
 const nodeCrypto = require('crypto');

--- a/app/util/test/testSetupView.js
+++ b/app/util/test/testSetupView.js
@@ -8,57 +8,6 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/display-name */
 
-// Mock @metamask/analytics-controller FIRST before any other imports
-// This must be hoisted to the top before any module imports it
-jest.mock('@metamask/analytics-controller', () => ({
-  AnalyticsController: jest.fn(),
-  analyticsControllerSelectors: {
-    getAnalyticsEnabled: jest.fn(() => false),
-  },
-}));
-
-// Also mock the analytics utility that imports it
-jest.mock('../../util/analytics/analytics', () => ({
-  analytics: {
-    trackEvent: jest.fn(),
-    trackView: jest.fn(),
-    identify: jest.fn(),
-    optIn: jest.fn().mockResolvedValue(undefined),
-    optOut: jest.fn().mockResolvedValue(undefined),
-    getAnalyticsId: jest.fn().mockResolvedValue('test-analytics-id'),
-    isEnabled: jest.fn(() => false),
-    isOptedIn: jest.fn().mockResolvedValue(false),
-  },
-}));
-
-// Mock MetaMetrics for useMetrics hook
-jest.mock('../../core/Analytics/MetaMetrics', () => {
-  const mockInstance = {
-    updateDataRecordingFlag: jest.fn(),
-    createDataDeletionTask: jest.fn().mockResolvedValue(undefined),
-    checkDataDeleteStatus: jest.fn().mockResolvedValue(undefined),
-    getDeleteRegulationCreationDate: jest.fn().mockResolvedValue(undefined),
-    getDeleteRegulationId: jest.fn().mockResolvedValue(undefined),
-    isDataRecorded: jest.fn().mockReturnValue(false),
-    isEnabled: jest.fn().mockReturnValue(false),
-  };
-  return {
-    __esModule: true,
-    default: {
-      getInstance: jest.fn(() => mockInstance),
-    },
-  };
-});
-
-// Mock @metamask/smart-transactions-controller for selectors
-jest.mock('@metamask/smart-transactions-controller', () => ({
-  selectSmartTransactionsFeatureFlagsForChain: jest.fn(() => ({
-    mobileActive: false,
-    mobileActiveIOS: false,
-    mobileActiveAndroid: false,
-  })),
-}));
-
 const { NativeModules } = require('react-native');
 // eslint-disable-next-line import/no-nodejs-modules
 const nodeCrypto = require('crypto');

--- a/app/util/test/testSetupView.js
+++ b/app/util/test/testSetupView.js
@@ -19,14 +19,44 @@ jest.mock('@metamask/analytics-controller', () => ({
 
 // Also mock the analytics utility that imports it
 jest.mock('../../util/analytics/analytics', () => ({
-  trackEvent: jest.fn(),
-  trackView: jest.fn(),
-  identify: jest.fn(),
-  optIn: jest.fn().mockResolvedValue(undefined),
-  optOut: jest.fn().mockResolvedValue(undefined),
-  getAnalyticsId: jest.fn().mockResolvedValue('test-analytics-id'),
-  isEnabled: jest.fn(() => false),
-  isOptedIn: jest.fn().mockResolvedValue(false),
+  analytics: {
+    trackEvent: jest.fn(),
+    trackView: jest.fn(),
+    identify: jest.fn(),
+    optIn: jest.fn().mockResolvedValue(undefined),
+    optOut: jest.fn().mockResolvedValue(undefined),
+    getAnalyticsId: jest.fn().mockResolvedValue('test-analytics-id'),
+    isEnabled: jest.fn(() => false),
+    isOptedIn: jest.fn().mockResolvedValue(false),
+  },
+}));
+
+// Mock MetaMetrics for useMetrics hook
+jest.mock('../../core/Analytics/MetaMetrics', () => {
+  const mockInstance = {
+    updateDataRecordingFlag: jest.fn(),
+    createDataDeletionTask: jest.fn().mockResolvedValue(undefined),
+    checkDataDeleteStatus: jest.fn().mockResolvedValue(undefined),
+    getDeleteRegulationCreationDate: jest.fn().mockResolvedValue(undefined),
+    getDeleteRegulationId: jest.fn().mockResolvedValue(undefined),
+    isDataRecorded: jest.fn().mockReturnValue(false),
+    isEnabled: jest.fn().mockReturnValue(false),
+  };
+  return {
+    __esModule: true,
+    default: {
+      getInstance: jest.fn(() => mockInstance),
+    },
+  };
+});
+
+// Mock @metamask/smart-transactions-controller for selectors
+jest.mock('@metamask/smart-transactions-controller', () => ({
+  selectSmartTransactionsFeatureFlagsForChain: jest.fn(() => ({
+    mobileActive: false,
+    mobileActiveIOS: false,
+    mobileActiveAndroid: false,
+  })),
 }));
 
 const { NativeModules } = require('react-native');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Added comprehensive component view tests for the following mUSD conversion components:

1. **MusdConversionAssetListCta** (3 test cases)
   - Feature flag visibility logic (`earnMusdCtaEnabled` and `earnMusdConversionFlowEnabled`)
   - Component behavior when visibility conditions are not met
   - Graceful handling when component returns null

2. **MusdConversionAssetOverviewCta** (15 test cases)
   - Component rendering with different asset configurations (USDC, DAI, USDT)
   - CTA text content verification (title and description)
   - Close button visibility and interaction (`onDismiss` callback)
   - Presentational component behavior (renders regardless of allowlist - logic handled by parent)
   - Asset balance scenarios (above minimum, low balance)
   - Multi-chain support (different chainIds)
   - Edge cases (missing asset address, assets not in allowlist)
   - Feature flag configuration (`earnMusdConversionAssetOverviewCtaEnabled`, `earnMusdConversionFlowEnabled`, `earnMusdConversionCtaTokens`)

3. **EarnMusdConversionEducationView** (12 test cases)
   - Complete UI rendering (heading, description, primary and secondary buttons)
   - APY percentage display in heading and description
   - Button interaction states (go back and continue buttons remain visible after press)
   - Route parameter handling (missing params, partial params, complete params)
   - Education seen state management (`musdConversionEducationSeen`)
   - Feature flag configuration (`earnMusdConversionFlowEnabled`)


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive component-view tests for mUSD conversion UI and strengthens the test harness/mocks for stable execution.
> 
> - New tests cover `EarnMusdConversionEducationView`, `MusdConversionAssetListCta`, and `MusdConversionAssetOverviewCta` including feature flag gating, visibility conditions, APY text, route params handling, and interaction (press/close)
> - Test utilities enhanced: Engine mock gains `controllerMessenger.call`; state fixture builder adds `withMinimalAnalyticsController`; wallet/bridge presets include minimal analytics and `TokensController` defaults; expanded RN/analytics/filesystem mocks in `testSetupView`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a53be73da666f2d5185906dc13b358bec720c6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->