### PR TITLE
feat: enhance claimable reward display for small amounts in useMerklRewards

### DIFF
--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
@@ -535,6 +535,46 @@ describe('useMerklRewards', () => {
     expect(result.current.claimableReward).toBe(null);
   });
 
+  it('converts "< 0.00001" to "< 0.01" for small amounts', async () => {
+    const mockRewardData = [
+      {
+        rewards: [
+          {
+            token: {
+              address: '0x8d652c6d4A8F3Db96Cd866C1a9220B1447F29898',
+              chainId: 1,
+              symbol: 'aglaMerkl',
+              decimals: 18,
+              price: null,
+            },
+            accumulated: '0',
+            unclaimed: '100', // Very small but non-zero amount
+            pending: '0',
+            proofs: [],
+            amount: '100',
+            claimed: '0',
+            recipient: mockSelectedAddress,
+          },
+        ],
+      },
+    ];
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockRewardData),
+    });
+
+    // renderFromTokenMinimalUnit returns "< 0.00001" for very small amounts
+    mockRenderFromTokenMinimalUnit.mockReturnValue('< 0.00001');
+
+    const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
+
+    await waitFor(() => {
+      // Should convert to "< 0.01" for consistency with 2 decimal places
+      expect(result.current.claimableReward).toBe('< 0.01');
+    });
+  });
+
   it('resets claimableReward when switching assets', async () => {
     const mockRewardData1 = [
       {

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.ts
@@ -119,16 +119,21 @@ export const useMerklRewards = ({
             tokenDecimals,
             2, // Show 2 decimal places
           );
+          // Handle the "< 0.00001" case from renderFromTokenMinimalUnit
+          // by showing "< 0.01" for consistency with 2 decimal places
+          const displayAmount = unclaimedAmount.startsWith('<')
+            ? '< 0.01'
+            : unclaimedAmount;
           // Double-check that the rendered amount is not '0' or '0.00'
           // This handles edge cases where very small amounts round to zero
           if (
-            unclaimedAmount &&
-            unclaimedAmount !== '0' &&
-            unclaimedAmount !== '0.00'
+            displayAmount &&
+            displayAmount !== '0' &&
+            displayAmount !== '0.00'
           ) {
             // Final check before setting state to ensure effect is still active
             if (!abortController.signal.aborted) {
-              setClaimableReward(unclaimedAmount);
+              setClaimableReward(displayAmount);
             }
           }
         }


### PR DESCRIPTION
## **Description**

The claimable bonus display for very small rewards was showing "< 0.00001" which takes too much horizontal space in the UI. This change converts the display to "< 0.01" when `renderFromTokenMinimalUnit` returns the hardcoded "< 0.00001" string, making it consistent with the 2 decimal places format used elsewhere.

## **Changelog**

CHANGELOG entry: Fixed claimable reward display rounding to show "< 0.01" instead of "< 0.00001" for very small amounts

## **Related issues**

Fixes: [MUSD-240](https://consensyssoftware.atlassian.net/browse/MUSD-240)

## **Manual testing steps**
```gherkin
Feature: Claimable MUSD rewards display

  Scenario: user views very small claimable reward
    Given user has reward tokens on Linea with a very small claimable bonus (less than 0.0000)

    When user views the tokens asset details screen
    Then the claimable bonus should display "< 0.01" instead of "< 0.00001"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="401" height="841" alt="Screenshot 2026-01-26 at 13 09 58" src="https://github.com/user-attachments/assets/e15efe50-51bd-49be-9081-d2babaddd1f5" />

<!-- [screenshots/recordings] -->

### **After**
<img width="396" height="835" alt="Screenshot 2026-01-26 at 13 09 09" src="https://github.com/user-attachments/assets/248739be-7b93-4fa0-853d-00d7bed55e1c" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-240]: https://consensyssoftware.atlassian.net/browse/MUSD-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability and consistency of claimable rewards display for tiny amounts.
> 
> - In `useMerklRewards`, map `renderFromTokenMinimalUnit` outputs starting with `<` to `"< 0.01"` when showing 2 decimals, and use this `displayAmount` when setting state
> - Add unit test in `useMerklRewards.test.ts` verifying conversion of `"< 0.00001"` to `"< 0.01"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74443937ded8254f13d1a27c077a7961f121b089. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->