### PR TITLE
fix: [Explore] search text is invisible on android cp-7.63.0

### DIFF
--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { Keyboard } from 'react-native';
+import { Keyboard, Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Box } from '@metamask/design-system-react-native';
@@ -20,7 +20,10 @@ const ExploreSearchScreen: React.FC = () => {
   }, [navigation]);
 
   return (
-    <Box style={{ paddingTop: insets.top }} twClassName="flex-1 bg-default">
+    <Box
+      style={{ paddingTop: insets.top + (Platform.OS === 'android' ? 16 : 0) }}
+      twClassName="flex-1 bg-default"
+    >
       <Box twClassName="px-4 pb-3">
         <ExploreSearchBar
           type="interactive"

--- a/app/components/Views/TrendingView/components/ExploreSearchBar/ExploreSearchBar.tsx
+++ b/app/components/Views/TrendingView/components/ExploreSearchBar/ExploreSearchBar.tsx
@@ -87,8 +87,8 @@ const ExploreSearchBar: React.FC<ExploreSearchBarProps> = (props) => {
             value={props.searchQuery}
             onChangeText={props.onSearchChange}
             placeholder={placeholder}
-            placeholderTextColor={colors.text.alternative}
-            style={tw.style('flex-1 text-body-md leading-0 text-default')}
+            placeholderTextColor={colors.text.muted}
+            style={tw.style('flex-1 text-base text-default')}
             testID="explore-view-search-input"
             autoFocus={props.type === 'interactive'}
             autoCapitalize="none"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Typing any text in the search bar of Explore is not visible on Android, this PR fixes this by changing the text color so that it is correctly picked up. Furthermore I have added some top margin for the search bar since it was too close to the top on android

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix text invisible when searching on explore (Android)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/25115 & https://consensyssoftware.atlassian.net/browse/ASSETS-2536

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

No placeholder or text can be seen
https://github.com/user-attachments/assets/b39bc0e3-0c3c-4dc5-b2bf-45088364849e


<!-- [screenshots/recordings] -->

### **After**

It looks slow cause my laptop is currently running quite slow
https://github.com/user-attachments/assets/5fba7ec4-b156-4fe6-9940-c1734dd80f0b


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Android visibility and spacing issues in Explore search.
> 
> - Update `ExploreSearchBar` `TextInput` styling: use `colors.text.muted` for `placeholderTextColor` and `text-base text-default` to ensure entered text/placeholder display correctly on Android
> - Add Android-only top padding (`+16`) in `ExploreSearchScreen` for improved spacing from the status bar
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0760a7c60ab0678048179bff139c70627b74c88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->