### PR TITLE
test: Add `SnapBridge` unit tests

### DIFF
--- a/app/core/Snaps/SnapBridge.test.ts
+++ b/app/core/Snaps/SnapBridge.test.ts
@@ -1,0 +1,128 @@
+import { SnapId } from '@metamask/snaps-sdk';
+import { Json, JsonRpcRequest, PendingJsonRpcResponse } from '@metamask/utils';
+import ObjectMultiplex from '@metamask/object-multiplex';
+import { JsonRpcEngineNextCallback } from '@metamask/json-rpc-engine';
+// eslint-disable-next-line import/no-nodejs-modules
+import { Duplex } from 'stream';
+import SnapBridge from './SnapBridge';
+import getRpcMethodMiddleware from '../RPCMethods/RPCMethodMiddleware';
+import { setupMultiplex } from '../../util/streams';
+
+jest.mock('../Engine/Engine', () => ({
+  ...jest.requireActual('../Engine/Engine'),
+  controllerMessenger: {
+    call: jest.fn(),
+  },
+  context: {
+    AccountsController: {
+      listAccounts: jest.fn(),
+    },
+    ApprovalController: {
+      addAndShowApprovalRequest: jest.fn(),
+    },
+    SelectedNetworkController: {
+      getProviderAndBlockTracker: jest.fn().mockReturnValue({
+        blockTracker: {},
+        provider: {
+          request: jest.fn().mockResolvedValue('0x1'),
+        },
+      }),
+    },
+    NetworkController: {
+      findNetworkClientIdByChainId: jest.fn(),
+    },
+    PermissionController: {
+      createPermissionMiddleware: jest
+        .fn()
+        .mockReturnValue(
+          (
+            _req: JsonRpcRequest,
+            _res: PendingJsonRpcResponse,
+            next: JsonRpcEngineNextCallback,
+          ) => next(),
+        ),
+      getPermissions: jest.fn(),
+      hasPermission: jest.fn(),
+      getCaveat: jest.fn(),
+      updateCaveat: jest.fn(),
+      executeRestrictedMethod: jest.fn(),
+      revokePermission: jest.fn(),
+    },
+  },
+}));
+
+function createBridge() {
+  const streamA = new Duplex({
+    objectMode: true,
+    write(chunk, _encoding, callback) {
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      streamB.push(chunk);
+      callback();
+    },
+    read() {
+      // no-op
+    },
+  });
+
+  const streamB = new Duplex({
+    objectMode: true,
+    write(chunk, _encoding, callback) {
+      streamA.push(chunk);
+      callback();
+    },
+    read() {
+      // no-op
+    },
+  });
+
+  const mux = setupMultiplex(streamA) as ObjectMultiplex;
+
+  const streamAMux = mux.createStream('metamask-provider');
+
+  const bridge = new SnapBridge({
+    snapId: 'npm:@metamask/example-snap' as SnapId,
+    connectionStream: streamB,
+    getRPCMethodMiddleware: ({ hostname, getProviderState }) =>
+      getRpcMethodMiddleware({
+        hostname,
+        getProviderState,
+        navigation: null,
+        title: { current: 'Snap' },
+        icon: { current: undefined },
+        isHomepage: () => false,
+        fromHomepage: { current: false },
+        toggleUrlModal: () => null,
+        tabId: false,
+        isWalletConnect: false,
+        isMMSDK: false,
+        url: { current: '' },
+        analytics: {},
+        injectHomePageScripts: () => null,
+      }),
+  });
+
+  bridge.setupProviderConnection();
+
+  const request = (json: Json) =>
+    new Promise((resolve) => {
+      streamAMux.once('data', (chunk) => resolve(chunk));
+      streamAMux.write(json);
+    });
+
+  return { bridge, stream: streamAMux, request };
+}
+
+describe('SnapBridge', () => {
+  it('responds to a basic JSON-RPC request', async () => {
+    const { request } = createBridge();
+
+    const response = await request({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_blockNumber',
+      params: [],
+    });
+
+    expect(response).toStrictEqual({ jsonrpc: '2.0', id: 1, result: '0x1' });
+  });
+});

--- a/app/core/Snaps/SnapBridge.ts
+++ b/app/core/Snaps/SnapBridge.ts
@@ -179,6 +179,7 @@ export default class SnapBridge {
 
     const providerStream = createEngineStream({ engine });
 
+    /* istanbul ignore next 2 */
     pump(stream, providerStream, stream, (error: Error | null) => {
       engine.destroy();
 

--- a/app/core/Snaps/SnapBridge.ts
+++ b/app/core/Snaps/SnapBridge.ts
@@ -20,7 +20,7 @@ import { createEngineStream } from '@metamask/json-rpc-middleware-stream';
 import { SnapId } from '@metamask/snaps-sdk';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 
-import Engine from '../Engine';
+import Engine from '../Engine/Engine';
 import { setupMultiplex } from '../../util/streams';
 import Logger from '../../util/Logger';
 import { createOriginMiddleware } from '../../util/middlewares';

--- a/app/core/Snaps/SnapsMethodMiddleware.ts
+++ b/app/core/Snaps/SnapsMethodMiddleware.ts
@@ -29,7 +29,7 @@ import {
   WebSocketServiceCloseAction,
   WebSocketServiceGetAllAction,
   WebSocketServiceSendMessageAction,
-} from '../Engine/controllers/snaps';
+} from '../Engine/controllers/snaps/constants';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { MetaMetrics } from '../../../app/core/Analytics';
 import { MetricsEventBuilder } from '../Analytics/MetricsEventBuilder';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add unit test harness for `SnapBridge` and write a couple of basic tests. This should make it easier for us to test changes to the Snaps JSON-RPC pipeline.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a basic test harness for `SnapBridge` and verifies core JSON-RPC flows.
> 
> - New `SnapBridge.test.ts` covering: `eth_blockNumber` passthrough, `snap_getClientStatus`, and auto-permission grant for preinstalled Snaps
> - Minor code tweaks: fix `Engine` import path in `SnapBridge.ts`, update snaps constants import in `SnapsMethodMiddleware.ts`, and add `istanbul` ignore around `pump` callback
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cf0a5ecfed8c8deb5a1c766f96bc83aa7637fb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->