### PR TITLE
chore(perps): remove withdrawals restrictions

### DIFF
--- a/app/components/UI/Perps/constants/eventNames.ts
+++ b/app/components/UI/Perps/constants/eventNames.ts
@@ -121,6 +121,9 @@ export const PerpsEventProperties = {
   // Balance properties
   HAS_PERP_BALANCE: 'has_perp_balance',
 
+  // Geo-blocking properties (TAT-2337: track geo-blocked withdrawals for monitoring)
+  IS_GEO_BLOCKED: 'is_geo_blocked',
+
   // TP/SL differentiation properties
   HAS_TAKE_PROFIT: 'has_take_profit',
   HAS_STOP_LOSS: 'has_stop_loss',

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
@@ -149,6 +149,7 @@ export const usePerpsHomeActions = (
   ]);
 
   const handleWithdraw = useCallback(async () => {
+    // Track withdrawal button click with geo-block status for monitoring (TAT-2337)
     track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
       [PerpsEventProperties.INTERACTION_TYPE]:
         PerpsEventValues.INTERACTION_TYPE.BUTTON_CLICKED,
@@ -156,24 +157,19 @@ export const usePerpsHomeActions = (
         PerpsEventValues.BUTTON_CLICKED.WITHDRAW,
       [PerpsEventProperties.BUTTON_LOCATION]:
         buttonLocation || PerpsEventValues.BUTTON_LOCATION.PERPS_HOME,
+      [PerpsEventProperties.IS_GEO_BLOCKED]: !isEligible,
     });
 
-    if (!isEligible) {
-      DevLogger.log('[usePerpsHomeActions] User not eligible for withdraw');
-      // Track geo-block screen viewed
-      track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
-        [PerpsEventProperties.SCREEN_TYPE]:
-          PerpsEventValues.SCREEN_TYPE.GEO_BLOCK_NOTIF,
-        [PerpsEventProperties.SOURCE]: PerpsEventValues.SOURCE.WITHDRAW_BUTTON,
-      });
-      setIsEligibilityModalVisible(true);
-      return;
-    }
+    // Note: Withdrawals are intentionally NOT geo-blocked (TAT-2337)
+    // Users in restricted regions can withdraw their funds but cannot deposit or trade
+    // We track IS_GEO_BLOCKED property above to monitor geo-blocked withdrawals
 
     setIsProcessing(true);
     setError(null);
 
-    DevLogger.log('[usePerpsHomeActions] Starting withdraw flow');
+    DevLogger.log('[usePerpsHomeActions] Starting withdraw flow', {
+      isGeoBlocked: !isEligible,
+    });
 
     try {
       await ensureArbitrumNetworkExists();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

## Summary

Removes geo-restriction on perp withdrawals to allow users in restricted regions to withdraw their funds (TAT-2337).

**Context:** US users reported being able to deposit into perps but unable to trade or withdraw, leaving their funds stuck.

## Changes

- **`usePerpsHomeActions.ts`** - Removed geo-blocking check from `handleWithdraw`; withdrawals now proceed regardless of eligibility status
- **`eventNames.ts`** - Added `IS_GEO_BLOCKED` analytics property for monitoring
- **`usePerpsHomeActions.test.ts`** - Updated tests for new withdrawal behavior and geo-block tracking

## Behavior

| Action | Eligible User | Geo-Blocked User |
|--------|--------------|------------------|
| Deposit | ✅ Allowed | ❌ Blocked |
| Trade | ✅ Allowed | ❌ Blocked |
| Withdraw | ✅ Allowed | ✅ **Now Allowed** |

## Monitoring

All withdrawal attempts now include `is_geo_blocked: true/false` in analytics events for dashboard monitoring.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: chore(perps): remove withdrawals restrictions

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Withdrawals unblocked:** Removed eligibility check in `usePerpsHomeActions.handleWithdraw`; users always proceed to `WITHDRAW` after network check. No geo-block modal or screen-view event on withdraw.
> - **Analytics:** Added `PerpsEventProperties.IS_GEO_BLOCKED` and include it on `PERPS_UI_INTERACTION` for withdraws to indicate geo-block status; updated logs accordingly.
> - **Tests:** Adjusted `usePerpsHomeActions.test` to reflect new withdraw behavior and analytics tracking; deposit behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbc65132dc676c954d79b0f6ed948b4671eaf931. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->