### PR TITLE
fix(predict): cp-7.63.0 override team colors for Super Bowl

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
+++ b/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
@@ -1,8 +1,14 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex */
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import Logger from '../../../../../util/Logger';
 import { PredictSportsLeague } from '../../types';
 import { PolymarketApiTeam } from './types';
 import { getPolymarketEndpoints } from './utils';
+
+const TEAM_COLOR_OVERRIDES: Record<string, string> = {
+  ne: '#1D4E9B',
+  sea: '#69BE28',
+};
 
 export class TeamsCache {
   private static instance: TeamsCache | null = null;
@@ -113,6 +119,7 @@ export class TeamsCache {
 
       for (const team of teams) {
         if (team.abbreviation) {
+          team.color = TEAM_COLOR_OVERRIDES[team.abbreviation] ?? team.color;
           leagueCache.set(team.abbreviation.toLowerCase(), team);
         }
       }


### PR DESCRIPTION
## **Description**

Override team colors for Super Bowl teams to ensure correct branding display. The Polymarket API returns incorrect team colors for the New England Patriots and Seattle Seahawks, so we apply manual overrides when caching team data.

**Changes:**
- Added `TEAM_COLOR_OVERRIDES` constant with corrected colors for NE (Patriots blue) and SEA (Seahawks green)
- Applied color overrides during team cache population

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-545

## **Manual testing steps**

```gherkin
Feature: Predict team colors display

  Scenario: user views Super Bowl market with correct team colors
    Given user has navigated to a Super Bowl prediction market

    When user views the market details
    Then Patriots (NE) should display with color #1D4E9B
    And Seahawks (SEA) should display with color #69BE28
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="373" height="772" alt="Screenshot 2026-01-26 at 9 50 42 AM" src="https://github.com/user-attachments/assets/0e9cde1a-2179-491c-b592-b55ea260ded7" />
<img width="367" height="764" alt="Screenshot 2026-01-26 at 9 50 29 AM" src="https://github.com/user-attachments/assets/5558cf8f-86b9-4fa6-8125-dc85a9c51d7a" />




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures correct team branding colors in Predict for Polymarket teams.
> 
> - Introduces `TEAM_COLOR_OVERRIDES` with corrected hex colors for `ne` and `sea`
> - Applies overrides in `TeamsCache.fetchAndCacheTeams` when populating the league cache
> - Adds file-level ESLint disable for hex color tokens
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad4835d1ef71953fddf03cfe8eae3e2d0dbc1347. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->