### PR TITLE
fix(predict): cp-7.63.0 override Super Bowl event title

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -659,7 +659,8 @@ export const parsePolymarketEvents = (
         id: event.id,
         slug: event.slug,
         providerId: 'polymarket',
-        title: event.title,
+        // TODO: remove this temporary fix for Super Bowl LX
+        title: event.id === '188978' ? 'Super Bowl LX' : event.title,
         description: event.description,
         image: event.icon,
         status: event.closed


### PR DESCRIPTION
## **Description**

Temporarily overrides the title for Super Bowl LX event (ID: 188978) in Polymarket to display "Super Bowl LX" instead of the original title from the API.

This is a targeted fix for the Super Bowl event display in the Predict feature.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-549

## **Manual testing steps**

```gherkin
Feature: Super Bowl event title display

  Scenario: user views Super Bowl LX event
    Given user has access to Predict feature
    And the Polymarket events are loaded

    When user views the Super Bowl LX event (ID: 188978)
    Then the event title displays as "Super Bowl LX"
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

<img width="352" height="263" alt="Screenshot 2026-01-26 at 10 55 15 AM" src="https://github.com/user-attachments/assets/d0d87b23-51d1-4e0f-a0b4-cdec8d8bb793" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily corrects the displayed title for the Super Bowl event in Predict.
> 
> - In `utils.ts`, sets `title` to `"Super Bowl LX"` when `event.id === 
> `188978`` (Polymarket), otherwise uses the API title
> - Marked with a TODO indicating this is a temporary override; no other logic or API behavior changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36e0d99aa240996a29d950ebc2edeb8a19879260. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->