### PR TITLE
fix: remove back arrow from recipient account picker modal

### DIFF
--- a/app/components/UI/Bridge/components/RecipientSelectorModal/RecipientSelectorModal.tsx
+++ b/app/components/UI/Bridge/components/RecipientSelectorModal/RecipientSelectorModal.tsx
@@ -150,7 +150,7 @@ const RecipientSelectorModal: React.FC = () => {
 
   return (
     <BottomSheet onClose={handleClose} keyboardAvoidingViewEnabled>
-      <BottomSheetHeader onBack={handleClose} onClose={handleClose}>
+      <BottomSheetHeader onClose={handleClose}>
         Recipient account
       </BottomSheetHeader>
       <MultichainAccountSelectorList


### PR DESCRIPTION
## **Description**

Removes the back arrow (chevron) from the recipient account picker modal header in the Bridge/Swaps flow. The modal now only displays the close (X) button on the right side, providing a cleaner UI.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)

AI agent: Use format `CHANGELOG entry: [fix/feat/chore]: [User-facing description in past tense]`.
Examples: `fix: resolved token name display issue`, `feat: added dark mode toggle`, `chore: updated dependencies`.
For non-user-facing changes, use `CHANGELOG entry: null`.
-->

CHANGELOG entry: fix: removed chevron from Swaps recipient address picker

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3861

## **Manual testing steps**

1. Go to Swaps
2. Select source and destination tokens on different chains (to enable recipient selection)
3. Click on the recipient selector to open the modal
4. Verify the modal header shows "Recipient account" with only a close (X) button
5. Verify the back arrow is no longer present on the left side

## **Screenshots/Recordings**

### After

<img width="598" height="1144" alt="Screenshot 2026-01-26 at 1 02 00 PM" src="https://github.com/user-attachments/assets/b41af052-51ec-4dc6-a82d-82bade43e78c" />



## **Pre-merge author checklist**

- [x] I've read the [Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR
- [x] I've properly reviewed the [Storybook for design guidelines](https://metamask.github.io/metamask-storybook/?path=/docs/getting-started--docs)

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all items listed in the description

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the Recipient selector modal header by removing the back navigation control.
> 
> - Updates `RecipientSelectorModal.tsx` to drop `onBack` from `BottomSheetHeader`, showing only `onClose` (X)
> - No changes to selection logic, polling control, or account filtering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd9b927434001fe1206786de82f490fd0a34190b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->