### PR TITLE
fix: update selectedGasFeeToken when payment token is selected for gasless flow cp-7.62.1

### DIFF
--- a/app/components/UI/Perps/controllers/PerpsController.test.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.test.ts
@@ -25,10 +25,6 @@ import type {
 import { HyperLiquidProvider } from './providers/HyperLiquidProvider';
 import { createMockHyperLiquidProvider } from '../__mocks__/providerMocks';
 import { createMockInfrastructure } from '../__mocks__/serviceMocks';
-import {
-  ARBITRUM_MAINNET_CHAIN_ID_HEX,
-  USDC_ARBITRUM_MAINNET_ADDRESS,
-} from '../constants/hyperLiquidConfig';
 import Engine from '../../../../core/Engine';
 
 jest.mock('./providers/HyperLiquidProvider');
@@ -2422,50 +2418,7 @@ describe('PerpsController', () => {
         origin: 'metamask',
         type: 'perpsDeposit',
         skipInitialGasEstimate: true,
-        gasFeeToken: undefined,
       });
-    });
-
-    it('adds gasFeeToken for Arbitrum USDC deposits', async () => {
-      markControllerAsInitialized();
-      controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
-
-      Engine.context.AccountTrackerController.state.accountsByChainId = {
-        [ARBITRUM_MAINNET_CHAIN_ID_HEX]: {
-          [mockTransaction.from.toLowerCase()]: {
-            balance: '0x0',
-          },
-        },
-      };
-
-      jest
-        .spyOn(mockDepositServiceInstance, 'prepareTransaction')
-        .mockResolvedValueOnce({
-          transaction: {
-            ...mockTransaction,
-            to: USDC_ARBITRUM_MAINNET_ADDRESS,
-          },
-          assetChainId: ARBITRUM_MAINNET_CHAIN_ID_HEX,
-          currentDepositId: mockDepositId,
-        });
-
-      await controller.depositWithConfirmation('100');
-
-      expect(
-        mockInfrastructure.controllers.transaction.submit,
-      ).toHaveBeenCalledWith(
-        {
-          ...mockTransaction,
-          to: USDC_ARBITRUM_MAINNET_ADDRESS,
-        },
-        {
-          networkClientId: mockNetworkClientId,
-          origin: 'metamask',
-          type: 'perpsDeposit',
-          skipInitialGasEstimate: true,
-          gasFeeToken: USDC_ARBITRUM_MAINNET_ADDRESS,
-        },
-      );
     });
 
     it('throws error when controller not initialized', async () => {

--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -13,12 +13,7 @@ import {
   TransactionControllerTransactionSubmittedEvent,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { Hex } from '@metamask/utils';
-import {
-  ARBITRUM_MAINNET_CHAIN_ID_HEX,
-  USDC_ARBITRUM_MAINNET_ADDRESS,
-  USDC_SYMBOL,
-} from '../constants/hyperLiquidConfig';
+import { USDC_SYMBOL } from '../constants/hyperLiquidConfig';
 import {
   LastTransactionResult,
   TransactionStatus,
@@ -1534,14 +1529,6 @@ export class PerpsController extends BaseController<
         );
       }
 
-      const gasFeeToken =
-        transaction.to &&
-        assetChainId.toLowerCase() === ARBITRUM_MAINNET_CHAIN_ID_HEX &&
-        transaction.to.toLowerCase() ===
-          USDC_ARBITRUM_MAINNET_ADDRESS.toLowerCase()
-          ? (transaction.to as Hex)
-          : undefined;
-
       // submit shows the confirmation screen and returns a promise
       // The promise will resolve when transaction completes or reject if cancelled/failed
       const { result, transactionMeta } = await controllers.transaction.submit(
@@ -1551,7 +1538,6 @@ export class PerpsController extends BaseController<
           origin: 'metamask',
           type: TransactionType.perpsDeposit,
           skipInitialGasEstimate: true,
-          gasFeeToken,
         },
       );
 

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -13,7 +13,6 @@ import {
 } from '@metamask/transaction-controller';
 import type { NetworkState } from '@metamask/network-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
-import type { Hex } from '@metamask/utils';
 
 import Engine from '../../../../core/Engine';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
@@ -22,7 +21,6 @@ import {
   addTransactionBatch,
 } from '../../../../util/transaction-controller';
 import { PolymarketProvider } from '../providers/polymarket/PolymarketProvider';
-import { MATIC_CONTRACTS } from '../providers/polymarket/constants';
 import type { OrderPreview } from '../providers/types';
 import {
   PredictBalance,
@@ -3005,7 +3003,6 @@ describe('PredictController', () => {
       mockPolymarketProvider.prepareDeposit.mockResolvedValue({
         transactions: mockTransactions,
         chainId: mockChainId,
-        gasFeeToken: MATIC_CONTRACTS.collateral as Hex,
       });
 
       (addTransactionBatch as jest.Mock).mockResolvedValue({
@@ -3073,7 +3070,6 @@ describe('PredictController', () => {
           disableUpgrade: true,
           skipInitialGasEstimate: true,
           transactions: mockTransactions,
-          gasFeeToken: MATIC_CONTRACTS.collateral,
         });
       });
     });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1953,7 +1953,7 @@ export class PredictController extends BaseController<
         throw new Error('Deposit preparation returned undefined');
       }
 
-      const { transactions, chainId, gasFeeToken } = depositPreparation;
+      const { transactions, chainId } = depositPreparation;
 
       if (!transactions || transactions.length === 0) {
         throw new Error('No transactions returned from deposit preparation');
@@ -2000,7 +2000,6 @@ export class PredictController extends BaseController<
         disableUpgrade: true,
         skipInitialGasEstimate: true,
         transactions,
-        gasFeeToken,
       });
 
       if (!batchResult?.batchId) {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -1512,15 +1512,9 @@ export class PolymarketProvider implements PredictProvider {
       type: TransactionType.predictDeposit,
     });
 
-    const chainId = CHAIN_IDS.POLYGON;
-    const isPolygonChain =
-      chainId.toLowerCase() ===
-      numberToHex(POLYGON_MAINNET_CHAIN_ID).toLowerCase();
-
     return {
-      chainId,
+      chainId: CHAIN_IDS.POLYGON,
       transactions,
-      gasFeeToken: isPolygonChain ? (collateral as Hex) : undefined,
     };
   }
 

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -187,7 +187,6 @@ export interface PrepareDepositResponse {
     };
     type?: TransactionType;
   }[];
-  gasFeeToken?: Hex;
 }
 
 export interface GetPredictWalletParams {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
@@ -198,7 +198,7 @@ describe('useTransactionPayToken', () => {
       expect(updateTransactionMock).toHaveBeenCalledWith(
         expect.objectContaining({
           selectedGasFeeToken: PAY_TOKEN_MOCK.address,
-          isGasFeeTokenIgnoredIfBalance: false,
+          isGasFeeTokenIgnoredIfBalance: true,
         }),
         TRANSACTION_ID_MOCK,
       );

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
@@ -10,9 +10,13 @@ import {
   tokenAddress1Mock,
 } from '../../__mocks__/controllers/other-controllers-mock';
 import { TransactionType } from '@metamask/transaction-controller';
-import { TransactionPaymentToken } from '@metamask/transaction-pay-controller';
+import {
+  TransactionPaymentToken,
+  TransactionPayRequiredToken,
+} from '@metamask/transaction-pay-controller';
 import Engine from '../../../../../core/Engine';
 import { flushPromises } from '../../../../../util/test/utils';
+import { updateTransaction } from '../../../../../util/transaction-controller';
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
@@ -26,6 +30,10 @@ jest.mock('../../../../../core/Engine', () => ({
       findNetworkClientIdByChainId: jest.fn(),
     },
   },
+}));
+
+jest.mock('../../../../../util/transaction-controller', () => ({
+  updateTransaction: jest.fn(),
 }));
 
 const STATE_MOCK = merge(
@@ -50,14 +58,22 @@ const PAY_TOKEN_MOCK = {
   symbol: 'TST',
 } as TransactionPaymentToken;
 
+const REQUIRED_TOKEN_MOCK = {
+  address: tokenAddress1Mock,
+  chainId: ChainId.mainnet,
+  skipIfBalance: false,
+} as unknown as TransactionPayRequiredToken;
+
 function runHook({
   currency,
   payToken,
   type,
+  requiredTokens,
 }: {
   currency?: string;
   payToken?: TransactionPaymentToken;
   type?: TransactionType;
+  requiredTokens?: TransactionPayRequiredToken[];
 } = {}) {
   const mockState = cloneDeep(STATE_MOCK);
 
@@ -66,7 +82,7 @@ function runHook({
       [TRANSACTION_ID_MOCK]: {
         isLoading: false,
         paymentToken: payToken,
-        tokens: [],
+        tokens: requiredTokens ?? [],
       },
     },
   };
@@ -156,5 +172,105 @@ describe('useTransactionPayToken', () => {
     });
 
     expect(result.current.isNative).toBe(true);
+  });
+
+  describe('selectedGasFeeToken update for predictDeposit', () => {
+    const updateTransactionMock = jest.mocked(updateTransaction);
+
+    beforeEach(() => {
+      updateTransactionMock.mockClear();
+    });
+
+    it('updates transaction with selectedGasFeeToken for predictDeposit when pay token matches required token', async () => {
+      const { result } = runHook({
+        payToken: PAY_TOKEN_MOCK,
+        type: TransactionType.predictDeposit,
+        requiredTokens: [REQUIRED_TOKEN_MOCK],
+      });
+
+      result.current.setPayToken({
+        address: PAY_TOKEN_MOCK.address,
+        chainId: PAY_TOKEN_MOCK.chainId as ChainId,
+      });
+
+      await flushPromises();
+
+      expect(updateTransactionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selectedGasFeeToken: PAY_TOKEN_MOCK.address,
+          isGasFeeTokenIgnoredIfBalance: false,
+        }),
+        TRANSACTION_ID_MOCK,
+      );
+    });
+
+    it('does not update transaction for non-predictDeposit transaction types', async () => {
+      const { result } = runHook({
+        payToken: PAY_TOKEN_MOCK,
+        type: TransactionType.simpleSend,
+        requiredTokens: [REQUIRED_TOKEN_MOCK],
+      });
+
+      result.current.setPayToken({
+        address: PAY_TOKEN_MOCK.address,
+        chainId: PAY_TOKEN_MOCK.chainId as ChainId,
+      });
+
+      await flushPromises();
+
+      expect(updateTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it('resets selectedGasFeeToken when pay token does not match required token', async () => {
+      const differentToken = {
+        address: '0xDifferentTokenAddress1234567890123456789012',
+        chainId: ChainId.mainnet,
+        skipIfBalance: false,
+      } as unknown as TransactionPayRequiredToken;
+
+      const { result } = runHook({
+        payToken: PAY_TOKEN_MOCK,
+        type: TransactionType.predictDeposit,
+        requiredTokens: [differentToken],
+      });
+
+      result.current.setPayToken({
+        address: PAY_TOKEN_MOCK.address,
+        chainId: PAY_TOKEN_MOCK.chainId as ChainId,
+      });
+
+      await flushPromises();
+
+      expect(updateTransactionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selectedGasFeeToken: undefined,
+          isGasFeeTokenIgnoredIfBalance: undefined,
+        }),
+        TRANSACTION_ID_MOCK,
+      );
+    });
+
+    it('resets selectedGasFeeToken when no required tokens exist', async () => {
+      const { result } = runHook({
+        payToken: PAY_TOKEN_MOCK,
+        type: TransactionType.predictDeposit,
+        requiredTokens: [],
+      });
+
+      result.current.setPayToken({
+        address: PAY_TOKEN_MOCK.address,
+        chainId: PAY_TOKEN_MOCK.chainId as ChainId,
+      });
+
+      await flushPromises();
+
+      expect(updateTransactionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selectedGasFeeToken: undefined,
+          isGasFeeTokenIgnoredIfBalance: undefined,
+        }),
+        TRANSACTION_ID_MOCK,
+      );
+    });
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -1,24 +1,33 @@
-import { useSelector } from 'react-redux';
-import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { useCallback } from 'react';
-import { RootState } from '../../../../../reducers';
-import Engine from '../../../../../core/Engine';
-import { selectTransactionPaymentTokenByTransactionId } from '../../../../../selectors/transactionPayController';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
+import { TransactionType } from '@metamask/transaction-controller';
+import { TransactionPaymentToken } from '@metamask/transaction-pay-controller';
 import { Hex } from '@metamask/utils';
 import { noop } from 'lodash';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import Engine from '../../../../../core/Engine';
 import EngineService from '../../../../../core/EngineService';
-import { TransactionPaymentToken } from '@metamask/transaction-pay-controller';
-import { getNativeTokenAddress } from '@metamask/assets-controllers';
+import { RootState } from '../../../../../reducers';
+import { selectTransactionPaymentTokenByTransactionId } from '../../../../../selectors/transactionPayController';
+import { updateTransaction } from '../../../../../util/transaction-controller';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 
 export function useTransactionPayToken(): {
   isNative?: boolean;
   payToken: TransactionPaymentToken | undefined;
   setPayToken: (newPayToken: { address: Hex; chainId: Hex }) => void;
 } {
-  const { id: transactionId } = useTransactionMetadataRequest() || { id: '' };
+  const transactionMeta = useTransactionMetadataRequest();
+  const { id: transactionId } = transactionMeta || { id: '' };
 
   const payToken = useSelector((state: RootState) =>
     selectTransactionPaymentTokenByTransactionId(state, transactionId),
+  );
+
+  const requiredTokens = useTransactionPayRequiredTokens();
+  const primaryRequiredToken = (requiredTokens ?? []).find(
+    (token) => !token.skipIfBalance,
   );
 
   const isNative =
@@ -43,13 +52,41 @@ export function useTransactionPayToken(): {
           tokenAddress: newPayToken.address,
           chainId: newPayToken.chainId,
         });
-
-        EngineService.flushState();
       } catch (e) {
         console.error('Error updating payment token', e);
       }
+
+      // perps deposits only use relay, so doesn't need gasFeeToken update
+      const isPredictDepositTransaction =
+        transactionMeta?.type === TransactionType.predictDeposit;
+
+      if (isPredictDepositTransaction) {
+        const isNewPayTokenRequiredToken =
+          newPayToken.chainId === primaryRequiredToken?.chainId &&
+          newPayToken.address.toLowerCase() ===
+            primaryRequiredToken?.address.toLowerCase();
+
+        const updatedTx = {
+          ...transactionMeta,
+          selectedGasFeeToken: isNewPayTokenRequiredToken
+            ? newPayToken.address
+            : undefined,
+          isGasFeeTokenIgnoredIfBalance: isNewPayTokenRequiredToken
+            ? false
+            : undefined,
+        };
+
+        updateTransaction(updatedTx, transactionMeta.id);
+      }
+
+      EngineService.flushState();
     },
-    [transactionId],
+    [
+      transactionId,
+      transactionMeta,
+      primaryRequiredToken?.chainId,
+      primaryRequiredToken?.address,
+    ],
   );
 
   return {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -72,7 +72,7 @@ export function useTransactionPayToken(): {
             ? newPayToken.address
             : undefined,
           isGasFeeTokenIgnoredIfBalance: isNewPayTokenRequiredToken
-            ? false
+            ? true
             : undefined,
         };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a regression from bcf7c34 ([see PR](https://github.com/MetaMask/metamask-mobile/pull/24290)) where passing `gasFeeToken` at transaction creation time caused premature balance validation, failing deposits with "Gas fee token not found and insufficient native balance".

Instead of setting `gasFeeToken` at transaction creation, we now update `selectedGasFeeToken` on the transaction metadata when the user selects a payment token in the MetaMask Pay UI. This allows the 7702 gasless flow to process the transaction correctly without triggering early validation.

Changes:
- Remove `gasFeeToken` from Perps/Predict transaction creation
- Update `useTransactionPayToken` to set `selectedGasFeeToken` on the transaction metadata when a payment token is selected
- Update tests to reflect the new approach

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/25185

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes gasless deposit flow by deferring gas fee token selection to the confirmation UI instead of at transaction creation.
> 
> - Removes `gasFeeToken` from Perps and Predict deposit submission paths (`PerpsController`, `PredictController`, Polymarket provider), and types/tests updated accordingly
> - Updates `useTransactionPayToken` to set `selectedGasFeeToken` (and `isGasFeeTokenIgnoredIfBalance`) for `predictDeposit` when the chosen pay token matches the required token; resets when it doesn’t; triggers gas estimate refresh
> - Adds unit tests validating `selectedGasFeeToken` update/reset logic and adjusts existing deposit tests to new behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0ad3ed448d7d29064cfecc707ca0b9b457928c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->