### PR TITLE
fix(predict): ensure Polygon network exists before fetching Predict account state

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictAccountState.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictAccountState.test.ts
@@ -25,6 +25,14 @@ jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
   },
 }));
 
+// Mock usePredictNetworkManagement
+const mockEnsurePolygonNetworkExists = jest.fn().mockResolvedValue(undefined);
+jest.mock('./usePredictNetworkManagement', () => ({
+  usePredictNetworkManagement: () => ({
+    ensurePolygonNetworkExists: mockEnsurePolygonNetworkExists,
+  }),
+}));
+
 import { useFocusEffect } from '@react-navigation/native';
 
 const mockGetAccountState = Engine.context.PredictController
@@ -40,12 +48,11 @@ describe('usePredictAccountState', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Reset useFocusEffect to do nothing by default
     mockUseFocusEffect.mockImplementation(() => {
       // Default no-op implementation
     });
-    // Provide a default resolved value to prevent crashes
     mockGetAccountState.mockResolvedValue(mockAccountState);
+    mockEnsurePolygonNetworkExists.mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/app/components/UI/Predict/hooks/usePredictAccountState.ts
+++ b/app/components/UI/Predict/hooks/usePredictAccountState.ts
@@ -6,6 +6,7 @@ import Logger from '../../../../util/Logger';
 import { PREDICT_CONSTANTS } from '../constants/errors';
 import { ensureError } from '../utils/predictErrorHandler';
 import { AccountState } from '../providers/types';
+import { usePredictNetworkManagement } from './usePredictNetworkManagement';
 
 interface UsePredictWalletParams {
   /**
@@ -29,6 +30,7 @@ export const usePredictAccountState = ({
   loadOnMount = true,
   refreshOnFocus = true,
 }: UsePredictWalletParams = {}) => {
+  const { ensurePolygonNetworkExists } = usePredictNetworkManagement();
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -52,6 +54,15 @@ export const usePredictAccountState = ({
           setIsLoading(true);
         }
         setError(null);
+
+        try {
+          await ensurePolygonNetworkExists();
+        } catch (networkError) {
+          DevLogger.log(
+            'usePredictAccountState: Failed to ensure Polygon network exists',
+            networkError,
+          );
+        }
 
         const controller = Engine.context.PredictController;
         const accountStateResponse = await controller.getAccountState({
@@ -95,7 +106,7 @@ export const usePredictAccountState = ({
         setIsRefreshing(false);
       }
     },
-    [providerId],
+    [providerId, ensurePolygonNetworkExists],
   );
 
   // Load account state on mount if enabled


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Call ensurePolygonNetworkExists() in usePredictAccountState to ensure
the Polygon network configuration is available before attempting to
fetch account state from the PredictController.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-502

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures Predict account state loading runs after confirming Polygon network config, with graceful degradation and added tests.
> 
> - Hook `usePredictAccountState` now calls `ensurePolygonNetworkExists()` before `PredictController.getAccountState`; failures are caught and logged via `DevLogger` without blocking fetch
> - Dependency array updated to include `ensurePolygonNetworkExists`
> - Tests updated to mock network management and validate call order, error logging, and non-blocking behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e205ccb20c11b6483578f259fb43e7cda6ab064e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->