### PR TITLE
fix(predict): cp-7.63.0 compact game card in explore tab

### DIFF
--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.tsx
@@ -15,6 +15,7 @@ const PredictActionButtons: React.FC<PredictActionButtonsProps> = ({
   claimableAmount = 0,
   isLoading = false,
   testID = 'predict-action-buttons',
+  isCarousel,
 }) => {
   const isGameMarket = Boolean(market.game);
   const isMarketOpen = market.status === PredictMarketStatus.OPEN;
@@ -94,6 +95,7 @@ const PredictActionButtons: React.FC<PredictActionButtonsProps> = ({
           yesTeamColor={buttonConfig.yesTeamColor}
           noTeamColor={buttonConfig.noTeamColor}
           testID={`${testID}-bet`}
+          isCarousel={isCarousel}
         />
       </Box>
     );

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.types.ts
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.types.ts
@@ -3,6 +3,7 @@ import {
   PredictOutcome,
   PredictOutcomeToken,
 } from '../../types';
+import { ButtonBaseSize } from '@metamask/design-system-react-native';
 
 export type PredictBetButtonVariant = 'yes' | 'no';
 
@@ -14,6 +15,7 @@ export interface PredictBetButtonProps {
   teamColor?: string;
   disabled?: boolean;
   testID?: string;
+  size?: ButtonBaseSize;
 }
 
 export interface PredictBetButtonsProps {

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.types.ts
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.types.ts
@@ -29,6 +29,7 @@ export interface PredictBetButtonsProps {
   noTeamColor?: string;
   disabled?: boolean;
   testID?: string;
+  isCarousel?: boolean;
 }
 
 export interface PredictClaimButtonProps {
@@ -46,4 +47,5 @@ export interface PredictActionButtonsProps {
   claimableAmount?: number;
   isLoading?: boolean;
   testID?: string;
+  isCarousel?: boolean;
 }

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictBetButton.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictBetButton.tsx
@@ -12,6 +12,7 @@ const PredictBetButton: React.FC<PredictBetButtonProps> = ({
   teamColor,
   disabled = false,
   testID,
+  size,
 }) => {
   const tw = useTailwind();
   const { colors } = useTheme();
@@ -39,8 +40,9 @@ const PredictBetButton: React.FC<PredictBetButtonProps> = ({
       testID={testID}
       style={{ backgroundColor: getBackgroundColor() }}
       isFullWidth
+      size={size}
     >
-      <Text style={tw.style('font-medium ', getTextColor())}>
+      <Text style={tw.style('font-medium', getTextColor())}>
         {label.toUpperCase()} · {price}¢
       </Text>
     </Button>

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictBetButtons.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictBetButtons.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { Box, BoxFlexDirection } from '@metamask/design-system-react-native';
+import {
+  Box,
+  BoxFlexDirection,
+  ButtonBaseSize,
+} from '@metamask/design-system-react-native';
 import PredictBetButton from './PredictBetButton';
 import { PredictBetButtonsProps } from './PredictActionButtons.types';
 
@@ -14,6 +18,7 @@ const PredictBetButtons: React.FC<PredictBetButtonsProps> = ({
   noTeamColor,
   disabled = false,
   testID = 'predict-bet-buttons',
+  isCarousel,
 }) => (
   <Box flexDirection={BoxFlexDirection.Row} twClassName="w-full gap-3">
     <Box twClassName="flex-1">
@@ -25,6 +30,7 @@ const PredictBetButtons: React.FC<PredictBetButtonsProps> = ({
         teamColor={yesTeamColor}
         disabled={disabled}
         testID={`${testID}-yes`}
+        size={isCarousel ? ButtonBaseSize.Md : undefined}
       />
     </Box>
     <Box twClassName="flex-1">
@@ -36,6 +42,7 @@ const PredictBetButtons: React.FC<PredictBetButtonsProps> = ({
         teamColor={noTeamColor}
         disabled={disabled}
         testID={`${testID}-no`}
+        size={isCarousel ? ButtonBaseSize.Md : undefined}
       />
     </Box>
   </Box>

--- a/app/components/UI/Predict/components/PredictMarket/PredictMarket.tsx
+++ b/app/components/UI/Predict/components/PredictMarket/PredictMarket.tsx
@@ -25,6 +25,7 @@ const PredictMarket: React.FC<PredictMarketProps> = ({
         market={market}
         testID={testID}
         entryPoint={entryPoint}
+        isCarousel={isCarousel}
       />
     );
   }

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -51,7 +51,7 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
 
   return (
     <TouchableOpacity
-      style={tw.style('my-[8px]')}
+      style={tw.style(isCarousel ? '' : 'my-[8px]')}
       testID={testID}
       onPress={() => {
         navigation.navigate(Routes.PREDICT.ROOT, {
@@ -65,7 +65,7 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
         });
       }}
     >
-      <Box twClassName="bg-muted rounded-xl">
+      <Box twClassName="bg-muted rounded-[16px]">
         {onDismiss && (
           <Box twClassName="absolute top-3 right-3 z-10">
             <ButtonIcon

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -28,6 +28,7 @@ interface PredictMarketSportCardProps {
   testID?: string;
   entryPoint?: PredictEntryPoint;
   onDismiss?: () => void;
+  isCarousel?: boolean;
 }
 
 const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
@@ -35,6 +36,7 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
   testID,
   entryPoint = PredictEventValues.ENTRY_POINT.PREDICT_FEED,
   onDismiss,
+  isCarousel,
 }) => {
   const tw = useTailwind();
   const resolvedEntryPoint = TrendingFeedSessionManager.getInstance()
@@ -96,6 +98,7 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
             market={market}
             entryPoint={resolvedEntryPoint}
             testID={testID ? `${testID}-footer` : undefined}
+            isCarousel={isCarousel}
           />
         </Box>
       </Box>

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
@@ -73,7 +73,10 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
         () => {
           // When accessed from Carousel, we're outside the Predict navigator,
           // so we need to navigate through the ROOT first
-          if (resolvedEntryPoint === PredictEventValues.ENTRY_POINT.CAROUSEL) {
+          if (
+            isCarousel ||
+            resolvedEntryPoint === PredictEventValues.ENTRY_POINT.CAROUSEL
+          ) {
             navigation.navigate(Routes.PREDICT.ROOT, {
               screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
               params: {
@@ -98,7 +101,14 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
         },
       );
     },
-    [executeGuardedAction, navigation, market, outcome, resolvedEntryPoint],
+    [
+      executeGuardedAction,
+      isCarousel,
+      resolvedEntryPoint,
+      navigation,
+      market,
+      outcome,
+    ],
   );
 
   const handleClaimPress = useCallback(async () => {
@@ -117,7 +127,8 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
     0,
   );
 
-  const showBetButtons = isMarketOpen && !hasPositions && outcome;
+  const showBetButtons =
+    isMarketOpen && (!hasPositions || isCarousel) && outcome;
   const showClaimButton = hasClaimablePositions && outcome;
 
   if (isLoading) {

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
@@ -25,12 +25,14 @@ interface PredictSportCardFooterProps {
   market: PredictMarketType;
   testID?: string;
   entryPoint?: PredictEntryPoint;
+  isCarousel?: boolean;
 }
 
 const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
   market,
   testID,
   entryPoint = PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+  isCarousel,
 }) => {
   const tw = useTailwind();
   const navigation =
@@ -147,7 +149,7 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
 
   return (
     <>
-      {hasPositions && (
+      {!isCarousel && hasPositions && (
         <PredictPicksForCard
           marketId={market.id}
           positions={positions}
@@ -164,6 +166,7 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
           onClaimPress={handleClaimPress}
           claimableAmount={claimableAmount}
           testID={testID ? `${testID}-action-buttons` : undefined}
+          isCarousel={isCarousel}
         />
       )}
 
@@ -173,6 +176,7 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
           outcome={outcome}
           onBetPress={handleBetPress}
           testID={testID ? `${testID}-action-buttons` : undefined}
+          isCarousel={isCarousel}
         />
       )}
     </>


### PR DESCRIPTION
## **Description**

This PR makes the PredictMarketSportCard display a more compact UI when used in the carousel (Explore tab), consistent with other predict market card types.

**Changes:**
- Buttons use `ButtonBaseSize.Md` when in carousel mode (making them smaller/more compact)
- Picks/positions are hidden when in carousel mode (reducing visual clutter)
- Backward compatible: non-carousel usage remains unchanged

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-543

## **Manual testing steps**

```gherkin
Feature: Compact PredictMarketSportCard in Carousel

  Scenario: User views sport prediction card in Explore carousel
    Given the user is on the Explore tab
    And a sport prediction market is displayed in the carousel

    When user views the PredictMarketSportCard
    Then the buttons should appear at medium size (smaller than normal)
    And no picks/positions should be displayed

  Scenario: User views sport prediction card outside carousel
    Given the user navigates to the Predict feed
    And a sport prediction market is displayed

    When user views the PredictMarketSportCard
    Then the buttons should appear at normal size
    And picks/positions should display if user has any
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="368" height="755" alt="Screenshot 2026-01-26 at 11 23 55 AM" src="https://github.com/user-attachments/assets/17667142-b692-44ee-93a0-f1c835d7d255" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a compact, carousel-specific presentation for sport predict cards and action buttons.
> 
> - Plumbs `isCarousel` through `PredictMarket`, `PredictMarketSportCard`, `PredictSportCardFooter`, and `PredictActionButtons`
> - In carousel mode: bet buttons use `ButtonBaseSize.Md`, picks/positions are hidden, and bet buttons show even if user has positions
> - Adjusts navigation: buy preview navigates via `Routes.PREDICT.ROOT` when in carousel
> - Tweaks card styling for carousel (no vertical margin, rounded `[16px]`)
> - Minor cleanup in button text styling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cd7b8542906d0a9cd3b2f7357f7a5f091107fbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->