### PR TITLE
feat: pin selected token to top of asset picker list

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -10,7 +10,6 @@ import {
 } from '../../testUtils/fixtures';
 import { BridgeTokenSelector } from './BridgeTokenSelector';
 import { tokenToIncludeAsset } from '../../utils/tokenUtils';
-import { BridgeToken } from '../../types';
 
 let mockBridgeFeatureFlags = {
   chainRanking: [
@@ -365,17 +364,6 @@ const resetMocks = () => {
   mockIsNonEvmChainId.mockReturnValue(false);
 };
 
-const createTestToken = (
-  overrides: Partial<BridgeToken> = {},
-): BridgeToken => ({
-  address: '0x1234567890123456789012345678901234567890',
-  symbol: 'TEST',
-  decimals: 18,
-  chainId: '0x1',
-  name: 'Test Token',
-  ...overrides,
-});
-
 describe('tokenToIncludeAsset', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -385,7 +373,7 @@ describe('tokenToIncludeAsset', () => {
 
   it('returns null when formatAddressToAssetId returns null', () => {
     mockFormatAddressToAssetId.mockReturnValue(null);
-    const token = createTestToken();
+    const token = createMockToken();
 
     const result = tokenToIncludeAsset(token);
 
@@ -395,7 +383,7 @@ describe('tokenToIncludeAsset', () => {
   it('returns IncludeAsset with lowercase assetId for EVM token', () => {
     mockFormatAddressToAssetId.mockReturnValue('EIP155:1/ERC20:0xABCD');
     mockIsNonEvmChainId.mockReturnValue(false);
-    const token = createTestToken({
+    const token = createMockToken({
       symbol: 'USDC',
       name: 'USD Coin',
       decimals: 6,
@@ -416,7 +404,7 @@ describe('tokenToIncludeAsset', () => {
       'bip122:000000000019d6689c085ae165831e93/slip44:0',
     );
     mockIsNonEvmChainId.mockReturnValue(true);
-    const token = createTestToken({
+    const token = createMockToken({
       symbol: 'BTC',
       name: 'Bitcoin',
       decimals: 8,
@@ -434,7 +422,7 @@ describe('tokenToIncludeAsset', () => {
   });
 
   it('uses empty string for undefined token name', () => {
-    const token = createTestToken({ name: undefined });
+    const token = createMockToken({ name: undefined });
 
     const result = tokenToIncludeAsset(token);
 

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -191,22 +191,24 @@ jest.mock('../../../../../component-library/hooks', () => ({
   }),
 }));
 
-const mockFormatAddressToAssetId = jest.fn(() => 'eip155:1/erc20:0x1234');
-const mockIsNonEvmChainId = jest.fn(() => false);
+const mockFormatAddressToAssetId = jest.fn<string | null, [string, string]>(
+  () => 'eip155:1/erc20:0x1234',
+);
+const mockIsNonEvmChainId = jest.fn<boolean, [string]>(() => false);
 jest.mock('@metamask/bridge-controller', () => ({
-  formatAddressToAssetId: (...args: unknown[]) =>
-    mockFormatAddressToAssetId(...args),
+  formatAddressToAssetId: (address: string, chainId: string) =>
+    mockFormatAddressToAssetId(address, chainId),
   formatChainIdToCaip: jest.fn(
     (chainId: string) => `eip155:${parseInt(chainId, 16)}`,
   ),
-  isNonEvmChainId: (...args: unknown[]) => mockIsNonEvmChainId(...args),
+  isNonEvmChainId: (chainId: string) => mockIsNonEvmChainId(chainId),
   UnifiedSwapBridgeEventName: {
     AssetDetailTooltipClicked: 'AssetDetailTooltipClicked',
   },
 }));
 
 jest.mock('../../../../../core/Multichain/utils', () => ({
-  isNonEvmChainId: (...args: unknown[]) => mockIsNonEvmChainId(...args),
+  isNonEvmChainId: (chainId: string) => mockIsNonEvmChainId(chainId),
 }));
 
 jest.mock('@metamask/design-system-react-native', () => {

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -17,7 +17,7 @@ import { strings } from '../../../../../../locales/i18n';
 import { getHeaderCenterNavbarOptions } from '../../../../../component-library/components-temp/HeaderCenter';
 import { FlatList } from 'react-native-gesture-handler';
 import { NetworkPills } from './NetworkPills';
-import { CaipAssetType, CaipChainId } from '@metamask/utils';
+import { CaipChainId } from '@metamask/utils';
 import { useStyles } from '../../../../../component-library/hooks';
 import TextFieldSearch from '../../../../../component-library/components/Form/TextFieldSearch';
 import {
@@ -26,7 +26,6 @@ import {
   setIsSelectingToken,
 } from '../../../../../core/redux/slices/bridge';
 import {
-  formatAddressToAssetId,
   formatChainIdToCaip,
   UnifiedSwapBridgeEventName,
 } from '@metamask/bridge-controller';
@@ -55,7 +54,7 @@ import { useTokensWithBalances } from '../../hooks/useTokensWithBalances';
 import { useTokenSelection } from '../../hooks/useTokenSelection';
 import { createStyles } from './BridgeTokenSelector.styles';
 import Engine from '../../../../../core/Engine';
-import { isNonEvmChainId } from '../../../../../core/Multichain/utils';
+import { tokenToIncludeAsset } from '../../utils/tokenUtils';
 
 export interface BridgeTokenSelectorRouteParams {
   type: TokenSelectorType;
@@ -181,28 +180,28 @@ export const BridgeTokenSelector: React.FC = () => {
   }, [tokensWithBalance, searchString]);
 
   // Create includeAssets array from tokens with balance to be sent to API
+  // Selected token is prepended to pin it to the top of the list
   // Stringified to avoid triggering the useEffect when only balances change
   const includeAssets = useMemo(() => {
-    const assets = filteredTokensWithBalance.reduce<IncludeAsset[]>(
-      (acc, token) => {
-        const assetId = formatAddressToAssetId(token.address, token.chainId);
-        if (assetId) {
-          const normalizedAssetId = isNonEvmChainId(token.chainId)
-            ? assetId
-            : (assetId?.toLowerCase() as CaipAssetType);
-          acc.push({
-            assetId: normalizedAssetId,
-            name: token.name ?? '',
-            symbol: token.symbol,
-            decimals: token.decimals,
-          });
-        }
-        return acc;
-      },
-      [],
-    );
+    // Convert selected token first (will be pinned to top of list)
+    const selectedAsset = selectedToken
+      ? tokenToIncludeAsset(selectedToken)
+      : null;
+
+    // Convert balance tokens, excluding selected to avoid duplicates
+    const balanceAssets = filteredTokensWithBalance
+      .map(tokenToIncludeAsset)
+      .filter(
+        (asset): asset is IncludeAsset =>
+          asset !== null && asset.assetId !== selectedAsset?.assetId,
+      );
+
+    const assets = selectedAsset
+      ? [selectedAsset, ...balanceAssets]
+      : balanceAssets;
+
     return JSON.stringify(assets);
-  }, [filteredTokensWithBalance]);
+  }, [filteredTokensWithBalance, selectedToken]);
 
   // Fetch popular tokens
   const { popularTokens, isLoading: isPopularTokensLoading } = usePopularTokens(

--- a/app/components/UI/Bridge/utils/tokenUtils.ts
+++ b/app/components/UI/Bridge/utils/tokenUtils.ts
@@ -1,11 +1,13 @@
-import { CaipChainId, Hex } from '@metamask/utils';
+import { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 import {
+  formatAddressToAssetId,
   formatChainIdToHex,
   getNativeAssetForChainId,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import { BridgeToken } from '../types';
 import { DefaultSwapDestTokens } from '../constants/default-swap-dest-tokens';
+import { IncludeAsset } from '../hooks/usePopularTokens';
 
 /**
  * Creates a formatted native token object for the given chain ID
@@ -58,4 +60,24 @@ export const getDefaultDestToken = (
   }
 
   return undefined;
+};
+
+/**
+ * Converts a BridgeToken to IncludeAsset format for the API.
+ * Returns null if the token cannot be converted (invalid assetId).
+ */
+export const tokenToIncludeAsset = (
+  token: BridgeToken,
+): IncludeAsset | null => {
+  const assetId = formatAddressToAssetId(token.address, token.chainId);
+  if (!assetId) return null;
+
+  return {
+    assetId: isNonEvmChainId(token.chainId)
+      ? assetId
+      : (assetId.toLowerCase() as CaipAssetType),
+    name: token.name ?? '',
+    symbol: token.symbol,
+    decimals: token.decimals,
+  };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Pins selected token to top of asset picker list
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Changed asset picker to pin selected token to top of list

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3905?atlOrigin=eyJpIjoiYjZmOWYxYzAzZmNiNDViY2I3YzI1ZWJhZDAzMmNlMGQiLCJwIjoiaiJ9

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins the currently selected token to the top of the asset list by prepending it when building `includeAssets`.
> 
> - Refactors include-asset conversion into `utils/tokenUtils.ts` via `tokenToIncludeAsset`, handling EVM (lowercased `assetId`) vs non‑EVM (preserved case) and null safety
> - Updates `BridgeTokenSelector` to use `tokenToIncludeAsset` and include the selected token first; removes inline asset conversion logic
> - Expands tests in `BridgeTokenSelector.test.tsx` to cover `tokenToIncludeAsset` behavior and adjusted mocks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e101d8bc6d626de6a06a48ac8c79098b6d1ed0f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->