### PR TITLE
Revert "fix: MUL-1331 modify android manifest file for correct BLE location permission."

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,12 +12,12 @@
   <!-- Android < 12 -->
   <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
 
   <!-- Bluetooth permissions: Android API >= 31 (Android 12)-->
   <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-  <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation"/>
+  <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
 
 	<uses-sdk tools:overrideLibrary="com.tectiv3.aes" />
 


### PR DESCRIPTION
Reverts MetaMask/metamask-mobile#23759

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts prior tightening of BLE/location permissions in `AndroidManifest.xml`.
> 
> - Removes `maxSdkVersion` from `ACCESS_FINE_LOCATION`, applying it to all Android versions
> - Drops `usesPermissionFlags="neverForLocation"` from `BLUETOOTH_SCAN`, restoring default behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 846ab2c34a16c89ecbe13877dfc05a9b58dc5ea6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->