### PR TITLE
fix(predict): format PnL dollar value with 2 decimal places in sell preview

### DIFF
--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
@@ -295,7 +295,7 @@ const PredictSellPreview = () => {
                 variant={TextVariant.BodyMd}
               >
                 {`${signal}${formatPrice(Math.abs(cashPnl), {
-                  maximumDecimals: 4,
+                  maximumDecimals: 2,
                 })} (${formatPercentage(percentPnl)})`}
               </Text>
             </>


### PR DESCRIPTION
## **Description**

The PnL (profit/loss) dollar value in the Predict sell preview screen was incorrectly formatted with 4 decimal places instead of 2.

**Problem**: When selling a position, the PnL displayed as `+$12.3456` instead of `+$12.35`

**Solution**: Changed `maximumDecimals: 4` to `maximumDecimals: 2` in the `formatPrice()` call, matching the standard dollar formatting used throughout the Predict feature.

## **Changelog**

CHANGELOG entry: Fixed PnL dollar value formatting in Predict sell preview to show 2 decimal places

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Predict Sell Preview PnL Formatting

  Scenario: user views sell preview with correct PnL formatting
    Given user has an open position in a prediction market

    When user taps "Cash Out" on the position
    Then the PnL dollar value should display with 2 decimal places (e.g., +$1.23)
    And the percentage should display normally (e.g., +5.25%)
```

## **Screenshots/Recordings**

### **Before**

<!-- PnL showing 4 decimal places: +$1.2345 -->

### **After**

<!-- PnL showing 2 decimal places: +$1.23 -->
<img width="360" height="762" alt="Screenshot 2026-01-26 at 1 48 17 PM" src="https://github.com/user-attachments/assets/aefba721-77f2-4bfb-b138-bcf6ebc09791" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts PnL cash display formatting in the Predict sell preview to match standard dollar precision.
> 
> - In `PredictSellPreview.tsx`, changes `formatPrice(Math.abs(cashPnl), { maximumDecimals: 2 })` so PnL shows 2 decimals (was 4); percentage display unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69277e9428371cb92526e32020297442b0677641. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->