### PR TITLE
fix(predict): update Seahawks team color for accessibility cp-7.63.0

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
+++ b/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
@@ -7,7 +7,7 @@ import { getPolymarketEndpoints } from './utils';
 
 const TEAM_COLOR_OVERRIDES: Record<string, string> = {
   ne: '#1D4E9B',
-  sea: '#69BE28',
+  sea: '#5BA423',
 };
 
 export class TeamsCache {


### PR DESCRIPTION
## **Description**

Updated the Seattle Seahawks team color from `#69BE28` to `#5BA423` to improve accessibility. The previous color did not provide sufficient contrast when used with white text labels, failing accessibility tests.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-545

## **Manual testing steps**

```gherkin
Feature: Predict Team Colors

  Scenario: user views Seahawks team in Predict
    Given user is on a Predict screen showing NFL teams

    When user views a market involving the Seattle Seahawks
    Then the Seahawks team color should display with accessible contrast
    And white text on the Seahawks color background should be readable
```

## **Screenshots/Recordings**

### **Before**

Color: `#69BE28` (lime green - insufficient contrast with white text)

### **After**

Color: `#5BA423` (darker green - meets accessibility contrast requirements)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Seahawks color override used by Predict Polymarket teams.
> 
> - Changes `TEAM_COLOR_OVERRIDES.sea` in `app/components/UI/Predict/providers/polymarket/TeamsCache.ts` from `#69BE28` to `#5BA423`, affecting the color applied when caching/fetching teams
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 512d128896ec8e451ca374c7dd4eaadc74e2cf97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->