### PR TITLE
fix(predict): remove game tag filter from market queries

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -2266,7 +2266,7 @@ describe('polymarket utils', () => {
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('event-1');
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://gamma-api.polymarket.com/events/pagination?limit=20&active=true&archived=false&closed=false&ascending=false&offset=0&liquidity_min=10000&volume_min=10000&exclude_tag_id=100639&order=volume24hr',
+        'https://gamma-api.polymarket.com/events/pagination?limit=20&active=true&archived=false&closed=false&ascending=false&offset=0&liquidity_min=10000&volume_min=10000&order=volume24hr',
       );
     });
 

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -788,9 +788,9 @@ export const getParsedMarketsFromPolymarketApi = async (
   let queryParamsEvents = `${limitParam}&${active}&${archived}&${closed}&${ascending}&${offsetParam}&${liquidity}&${volume}`;
 
   const categoryTagMap: Record<PredictCategory, string> = {
-    trending: '&exclude_tag_id=100639&order=volume24hr',
-    new: '&order=startDate&exclude_tag_id=100639&exclude_tag_id=102169',
-    sports: '&tag_slug=sports&&exclude_tag_id=100639&order=volume24hr',
+    trending: '&order=volume24hr',
+    new: '&order=startDate&exclude_tag_id=102169',
+    sports: '&tag_slug=sports&order=volume24hr',
     crypto: '&tag_slug=crypto&order=volume24hr',
     politics: '&tag_slug=politics&order=volume24hr',
   };


### PR DESCRIPTION
## **Description**

Removes the `exclude_tag_id=100639` query parameter that was filtering out markets with a `game` tag from the Predict feed. This allows game-tagged markets to appear in the trending, new, and sports categories.

Also fixes a minor typo (`&&` → `&`) in the sports category query string.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-537

## **Manual testing steps**

```gherkin
Feature: Predict Market Feed

  Scenario: user views game-tagged markets in Predict feed
    Given user has Predict feature enabled
    
    When user navigates to the Predict tab
    Then user can see game-tagged markets in the trending, new, and sports categories
```

## **Screenshots/Recordings**

### **Before**


### **After**

<img width="366" height="765" alt="Screenshot 2026-01-26 at 2 45 15 PM" src="https://github.com/user-attachments/assets/3ca7e1b5-9f34-46ed-bf6b-c9f0417ff1d0" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows game-tagged markets to appear in Predict feeds.
> 
> - Removes `exclude_tag_id=100639` from Polymarket events queries for `trending`, `new`, and `sports`; also fixes an extra `&` in the `sports` query
> - Updates tests to reflect new query URLs and parameters
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d165baf92be22511c2d1a176f6a190c8082c793c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->