### PR TITLE
fix(ramp): display currency with correct decimal places in BuildQuote

### DIFF
--- a/app/components/UI/Ramp/components/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/components/BuildQuote/BuildQuote.tsx
@@ -115,7 +115,6 @@ function BuildQuote() {
               >
                 {formatCurrency(amountAsNumber, currency, {
                   currencyDisplay: 'narrowSymbol',
-                  maximumFractionDigits: 0,
                 })}
               </Text>
               <PaymentMethodPill


### PR DESCRIPTION
## **Description**

The `Keypad` component allows decimal input for currencies like USD (configured with 2 decimal places), but `formatCurrency` was being called with `maximumFractionDigits: 0`, causing the displayed amount to be rounded to whole numbers.

**Problem**: If a user enters "$100.50", the display shows "$101" (rounded), creating a confusing mismatch between typed input and displayed value. This breaks user trust and could lead to unintended purchase amounts.

**Solution**: Remove `maximumFractionDigits: 0` from the `formatCurrency` call. The `Intl.NumberFormat` API automatically uses the appropriate decimal places for each currency:
- 2 decimal places for USD, EUR, GBP, etc.
- 0 decimal places for JPY, KRW, etc.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Ramp BuildQuote currency display

  Scenario: user enters a decimal amount in USD
    Given the app is open on the BuildQuote screen with USD currency

    When user enters "100.50" using the keypad
    Then the display should show "$100.50" (not "$101")

  Scenario: user enters a whole number amount
    Given the app is open on the BuildQuote screen with USD currency

    When user enters "100" using the keypad
    Then the display should show "$100.00"

  Scenario: user enters amount in zero-decimal currency (JPY)
    Given the app is open on the BuildQuote screen with JPY currency

    When user enters "1000" using the keypad
    Then the display should show "¥1,000" (no decimal places)
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/600c7d32-6961-4066-9679-a257cd617712" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects currency formatting in `BuildQuote.tsx`.
> 
> - Removes `maximumFractionDigits: 0` from `formatCurrency` options so amounts use the currency’s default decimals (e.g., 2 for USD, 0 for JPY)
> - Affects only the displayed amount in the main heading; no API or navigation changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36683df30e396f42d76230738219138530aabe05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->