### PR TITLE
fix: add whenEngineReady check before seedless authentication

### DIFF
--- a/app/core/OAuthService/OAuthService.test.ts
+++ b/app/core/OAuthService/OAuthService.test.ts
@@ -40,6 +40,10 @@ jest.mock('./OAuthLoginHandlers/constants', () => ({
   AppleServerRedirectUri: 'https://auth.example.com/api/v1/oauth/callback',
 }));
 
+jest.mock('../Analytics/whenEngineReady', () => ({
+  whenEngineReady: jest.fn().mockResolvedValue(undefined),
+}));
+
 import OAuthLoginService from './OAuthService';
 const mockLoginHandlerResponse = jest.fn().mockImplementation(() => ({
   idToken: MOCK_JWT_TOKEN,

--- a/app/core/OAuthService/OAuthService.test.ts
+++ b/app/core/OAuthService/OAuthService.test.ts
@@ -44,6 +44,12 @@ jest.mock('../Analytics/whenEngineReady', () => ({
   whenEngineReady: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock('../../util/analytics/analytics', () => ({
+  analytics: {
+    trackEvent: jest.fn(),
+  },
+}));
+
 import OAuthLoginService from './OAuthService';
 const mockLoginHandlerResponse = jest.fn().mockImplementation(() => ({
   idToken: MOCK_JWT_TOKEN,

--- a/app/core/OAuthService/OAuthService.ts
+++ b/app/core/OAuthService/OAuthService.ts
@@ -1,6 +1,7 @@
 import Engine from '../Engine';
 import Logger from '../../util/Logger';
 import { trace, endTrace, TraceName, TraceOperation } from '../../util/trace';
+import { whenEngineReady } from '../Analytics/whenEngineReady';
 
 import {
   HandleOAuthLoginResult,
@@ -138,6 +139,8 @@ export class OAuthService {
           'No revoke token found',
         );
       }
+
+      await whenEngineReady();
 
       const result =
         await Engine.context.SeedlessOnboardingController.authenticate({

--- a/app/core/OAuthService/OAuthService.ts
+++ b/app/core/OAuthService/OAuthService.ts
@@ -29,8 +29,8 @@ import {
   SeedlessOnboardingControllerError,
   SeedlessOnboardingControllerErrorType,
 } from '../Engine/controllers/seedless-onboarding-controller/error';
-import { MetaMetrics } from '../Analytics';
-import { MetricsEventBuilder } from '../Analytics/MetricsEventBuilder';
+import { analytics } from '../../util/analytics/analytics';
+import { AnalyticsEventBuilder } from '../../util/analytics/AnalyticsEventBuilder';
 import { MetaMetricsEvents } from '../Analytics/MetaMetrics.events';
 
 export interface MarketingOptInRequest {
@@ -193,8 +193,8 @@ export class OAuthService {
         : 'false';
     }
 
-    MetaMetrics.getInstance().trackEvent(
-      MetricsEventBuilder.createEventBuilder(
+    analytics.trackEvent(
+      AnalyticsEventBuilder.createEventBuilder(
         MetaMetricsEvents.SOCIAL_LOGIN_FAILED,
       )
         .addProperties({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* fix: engine not ready error dueing seedless authentication
* Jira: https://consensyssoftware.atlassian.net/browse/TO-459

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:
* Engine not ready error dueing seedless authentication.

## **Manual testing steps**

```gherkin
Feature: OAuth Login Engine Initialization

  Scenario: user completes OAuth login during app cold start
    Given the user opens the app for the first time
    And the user initiates OAuth login with Google or Apple

    When the OAuth provider returns before Engine is fully initialized
    Then the app waits for Engine to become ready
    And the seedless authentication proceeds without "Engine does not exist" error
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures OAuth seedless authentication only runs after the Engine is initialized to avoid initialization race conditions.
> 
> - Imports `whenEngineReady` and awaits it in `OAuthService.handleSeedlessAuthenticate` before calling `SeedlessOnboardingController.authenticate`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41075e4440f60880ca662add33bee27298cd3087. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->