### PR TITLE
fix(perps): Estimate new liquidation price using HL price and delta

### DIFF
--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx
@@ -78,6 +78,9 @@ const PerpsAdjustMarginView: React.FC = () => {
   const { handleAddMargin, handleRemoveMargin, isAdjusting } =
     usePerpsMarginAdjustment({
       onSuccess: () => navigation.goBack(),
+      onError: () => {
+        submittedEstimateRef.current = null;
+      },
     });
 
   // Get all margin data from dedicated hook (uses live subscriptions)

--- a/app/components/UI/Perps/hooks/usePerpsAdjustMarginData.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsAdjustMarginData.test.ts
@@ -262,11 +262,11 @@ describe('usePerpsAdjustMarginData', () => {
         }),
       );
 
-      // newMargin = 5000 + 1000 = 6000
-      // positionSize = 0.5
-      // marginPerUnit = 6000 / 0.5 = 12000
-      // For long: liquidationPrice = entryPrice - marginPerUnit = 100000 - 12000 = 88000
-      expect(result.current.newLiquidationPrice).toBe(88000);
+      // Uses anchored + delta approach with maintenance margin factor:
+      // marginDelta = 1000, positionSize = 0.5, currentLiqPrice = 80000
+      // maintenanceMarginRate = 1/(2*50) = 0.01, denominator = 1 - 0.01 = 0.99
+      // For long (direction=-1): newLiqPrice = 80000 + (-1 * 1000 / 0.5) / 0.99 ≈ 77979.80
+      expect(result.current.newLiquidationPrice).toBeCloseTo(77979.8, 1);
     });
 
     it('calculates new liquidation price when removing margin', () => {
@@ -288,10 +288,11 @@ describe('usePerpsAdjustMarginData', () => {
         }),
       );
 
-      // newMargin = 8000 - 1000 = 7000
-      // marginPerUnit = 7000 / 0.5 = 14000
-      // For long: liquidationPrice = 100000 - 14000 = 86000
-      expect(result.current.newLiquidationPrice).toBe(86000);
+      // Uses anchored + delta approach with maintenance margin factor:
+      // marginDelta = -1000 (removing), positionSize = 0.5, currentLiqPrice = 80000
+      // maintenanceMarginRate = 1/(2*50) = 0.01, denominator = 0.99
+      // For long (direction=-1): newLiqPrice = 80000 + (-1 * -1000 / 0.5) / 0.99 ≈ 82020.20
+      expect(result.current.newLiquidationPrice).toBeCloseTo(82020.2, 1);
     });
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsAdjustMarginData.ts
+++ b/app/components/UI/Perps/hooks/usePerpsAdjustMarginData.ts
@@ -7,7 +7,7 @@ import {
 import { usePerpsMarkets } from './usePerpsMarkets';
 import {
   calculateMaxRemovableMargin,
-  calculateNewLiquidationPrice,
+  estimateLiquidationPrice,
 } from '../utils/marginUtils';
 import { MARGIN_ADJUSTMENT_CONFIG } from '../constants/perpsConfig';
 import type { Position } from '../controllers/types';
@@ -166,31 +166,28 @@ export function usePerpsAdjustMarginData(
     return Math.max(0, currentMargin - inputAmount);
   }, [isAddMode, currentMargin, inputAmount]);
 
-  // Calculate new liquidation price
+  // Estimate new liquidation price using anchored + delta approach.
+  // Starts from Hyperliquid's actual liquidation price and applies margin delta.
+  // To avoid flicker on submit, the view resets inputAmount to 0 immediately,
+  // which makes newMargin === currentMargin, returning currentLiquidationPrice.
   const newLiquidationPrice = useMemo(() => {
     if (newMargin === 0 || positionSize === 0) return currentLiquidationPrice;
 
-    if (isAddMode) {
-      const marginPerUnit = newMargin / positionSize;
-      return isLong
-        ? Math.max(0, entryPrice - marginPerUnit)
-        : entryPrice + marginPerUnit;
-    }
-
-    return calculateNewLiquidationPrice({
+    return estimateLiquidationPrice({
+      isLong,
+      currentMargin,
       newMargin,
       positionSize,
-      entryPrice,
-      isLong,
       currentLiquidationPrice,
+      maxLeverage,
     });
   }, [
-    isAddMode,
+    isLong,
+    currentMargin,
     newMargin,
     positionSize,
-    entryPrice,
-    isLong,
     currentLiquidationPrice,
+    maxLeverage,
   ]);
 
   // Calculate liquidation distance

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -485,7 +485,7 @@ export class HyperLiquidSubscriptionService {
    * Uses string concatenation of key fields instead of JSON.stringify()
    * Performance: ~100x faster than JSON.stringify() for typical objects
    * Tracks structural changes (coin, size, entryPrice, leverage, TP/SL prices/counts)
-   * and value changes (unrealizedPnl, returnOnEquity) for live P&L updates
+   * and value changes (unrealizedPnl, returnOnEquity, liquidationPrice, marginUsed) for live updates
    */
   private hashPositions(positions: Position[]): string {
     if (!positions || positions.length === 0) return '0';
@@ -496,7 +496,7 @@ export class HyperLiquidSubscriptionService {
             p.takeProfitPrice || ''
           }:${p.stopLossPrice || ''}:${p.takeProfitCount}:${p.stopLossCount}:${
             p.unrealizedPnl
-          }:${p.returnOnEquity}`,
+          }:${p.returnOnEquity}:${p.liquidationPrice || ''}:${p.marginUsed || ''}`,
       )
       .join('|');
   }

--- a/app/components/UI/Perps/utils/marginUtils.test.ts
+++ b/app/components/UI/Perps/utils/marginUtils.test.ts
@@ -2,6 +2,7 @@ import {
   assessMarginRemovalRisk,
   calculateMaxRemovableMargin,
   calculateNewLiquidationPrice,
+  estimateLiquidationPrice,
 } from './marginUtils';
 
 describe('marginUtils', () => {
@@ -441,6 +442,112 @@ describe('marginUtils', () => {
       expect(result.riskLevel).toBe('safe');
       expect(result.priceDiff).toBe(0);
       expect(result.riskRatio).toBe(0);
+    });
+  });
+
+  describe('estimateLiquidationPrice', () => {
+    it('returns current liquidation price when no margin change', () => {
+      const result = estimateLiquidationPrice({
+        isLong: true,
+        currentMargin: 5000,
+        newMargin: 5000,
+        positionSize: 0.5,
+        currentLiquidationPrice: 80000,
+        maxLeverage: 20,
+      });
+
+      expect(result).toBe(80000);
+    });
+
+    it('applies maintenance factor when adding margin (long)', () => {
+      // Adding $1000 margin to long position
+      // maxLeverage=20 => l=0.025 => denominator=0.975
+      // delta=+1000, move = -1000/0.5/0.975 = -2051.28
+      // new liq = 80000 - 2051.28 = 77948.72
+      const result = estimateLiquidationPrice({
+        isLong: true,
+        currentMargin: 5000,
+        newMargin: 6000,
+        positionSize: 0.5,
+        currentLiquidationPrice: 80000,
+        maxLeverage: 20,
+      });
+
+      expect(result).toBeCloseTo(77948.72, 0);
+    });
+
+    it('applies maintenance factor when removing margin (long)', () => {
+      // Removing $1000 margin from long position
+      // delta=-1000, move = +1000/0.5/0.975 = +2051.28
+      // new liq = 80000 + 2051.28 = 82051.28
+      const result = estimateLiquidationPrice({
+        isLong: true,
+        currentMargin: 5000,
+        newMargin: 4000,
+        positionSize: 0.5,
+        currentLiquidationPrice: 80000,
+        maxLeverage: 20,
+      });
+
+      expect(result).toBeCloseTo(82051.28, 0);
+    });
+
+    it('applies maintenance factor for short position', () => {
+      // Removing $500 margin from short position
+      // maxLeverage=20 => l=0.025 => denominator=1.025 (for short)
+      // delta=-500, move = -500/10/1.025 = -48.78
+      // new liq = 2100 - 48.78 = 2051.22
+      const result = estimateLiquidationPrice({
+        isLong: false,
+        currentMargin: 1000,
+        newMargin: 500,
+        positionSize: 10,
+        currentLiquidationPrice: 2100,
+        maxLeverage: 20,
+      });
+
+      expect(result).toBeCloseTo(2051.22, 0);
+    });
+
+    it('returns currentLiquidationPrice when newMargin is invalid', () => {
+      expect(
+        estimateLiquidationPrice({
+          isLong: true,
+          currentMargin: 5000,
+          newMargin: 0,
+          positionSize: 0.5,
+          currentLiquidationPrice: 80000,
+          maxLeverage: 20,
+        }),
+      ).toBe(80000);
+    });
+
+    it('returns currentLiquidationPrice when positionSize is invalid', () => {
+      expect(
+        estimateLiquidationPrice({
+          isLong: true,
+          currentMargin: 5000,
+          newMargin: 6000,
+          positionSize: 0,
+          currentLiquidationPrice: 80000,
+          maxLeverage: 20,
+        }),
+      ).toBe(80000);
+    });
+
+    it('falls back to no maintenance factor when maxLeverage is invalid', () => {
+      // Without maintenance factor: move = -1000/0.5/1 = -2000
+      // new liq = 80000 - 2000 = 78000
+      const result = estimateLiquidationPrice({
+        isLong: true,
+        currentMargin: 5000,
+        newMargin: 6000,
+        positionSize: 0.5,
+        currentLiquidationPrice: 80000,
+        maxLeverage: 0,
+      });
+
+      expect(result).toBe(78000);
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

### Summary                                                                          
 Improves liquidation price estimation accuracy in the margin adjustment form and fixes stale values after errors.
https://consensyssoftware.atlassian.net/browse/TAT-2432                                                     
                                                                                      
 ### Problem                                                                          
 Users reported issues with the margin adjustment screen:                             
 1. Forecasted liquidation price differed from actual result after transaction        
 2. Liquidation price didn't update until switching screens                           
 3. Estimation used a simplified formula that ignored Hyperliquid's maintenance margin factor                                                                        
                                                                                      
 ### Solution                                                                         
 1. **Accurate estimation algorithm**: Replaced the simplified `marginPerUnit` calculation with `estimateLiquidationPrice()` that uses an "anchored + delta" approach:                                                                            
    - Anchors to Hyperliquid's authoritative current liquidation price                
    - Applies margin delta accounting for maintenance margin (half of initial margin at max leverage)                                                                     
    - Unified calculation for both add and remove margin modes                        
    - See: https://hyperliquid.gitbook.io/hyperliquid-docs/trading/margin-and-pnl     
                                                                                      
 2. **Error handling fix**: Added `onError` callback to clear `submittedEstimateRef` when API failures occur through the non-throwing path, ensuring UI returns to live values

## **Changelog** 

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Made liquidation price estimate in margin adjustment form to accurately reflect Hyperliquid's maintenance margin rules

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://consensyssoftware.atlassian.net/browse/TAT-2432
### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/6e02836e-81e2-415c-9809-5d09dcfd04b7

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves liquidation forecasting and UI stability in the perps margin adjustment flow.
> 
> - Replaces `calculateNewLiquidationPrice` with `estimateLiquidationPrice` (anchored to current HL `liquidationPrice` plus margin delta, factoring maintenance via `maxLeverage`) and integrates it into `usePerpsAdjustMarginData`.
> - Updates tests to validate the new estimation model and edge cases.
> - Adds `submittedEstimateRef` in `PerpsAdjustMarginView` to persist displayed `newLiquidationPrice`/distance during the exit animation, with `onError` clearing the ref to revert to live values; updates rendering to use `displayNewLiquidationPrice`/distance and `showTransition`.
> - Extends `HyperLiquidSubscriptionService.hashPositions` to include `liquidationPrice` and `marginUsed` for more accurate live change detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36e817a0a211ea8e4d13bc2dc32a8d1c73c4e601. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->