### PR TITLE
Fix WalletConnect onboarding timeout edge-case

### DIFF
--- a/app/core/WalletConnect/wc-utils.test.ts
+++ b/app/core/WalletConnect/wc-utils.test.ts
@@ -193,6 +193,19 @@ describe('WalletConnect Utils', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('does not throw timeout when network is onboarded on the last allowed iteration', async () => {
+      networkModalOnboardingConfig.MAX_LOOP_COUNTER = 1;
+      mockStore.getState.mockReturnValue({
+        networkOnboarded: {
+          networkOnboardedState: { '1': true },
+        },
+      });
+
+      await expect(
+        waitForNetworkModalOnboarding({ chainId: '1' }),
+      ).resolves.toBeUndefined();
+    });
+
     it('throws timeout error after max iterations', async () => {
       networkModalOnboardingConfig.MAX_LOOP_COUNTER = 1;
       mockStore.getState.mockReturnValue({

--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -150,7 +150,10 @@ export const waitForNetworkModalOnboarding = async ({
       await wait(1000);
     }
 
-    if (loopCounter >= networkModalOnboardingConfig.MAX_LOOP_COUNTER) {
+    if (
+      waitForNetworkModalOnboarded &&
+      loopCounter >= networkModalOnboardingConfig.MAX_LOOP_COUNTER
+    ) {
       throw new Error('Timeout error');
     }
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes an edge-case in [waitForNetworkModalOnboarding](cci:1://file:///d:/0000A/000000-AAA-BOTS/github/metamask-mobile/app/core/WalletConnect/wc-utils.ts:130:0-159:2) where the function could throw a `Timeout error` even after the network was already onboarded on the last allowed loop iteration (e.g. when `MAX_LOOP_COUNTER = 1`).

The improvement is to enforce the timeout only while the function is still waiting for onboarding, preventing false-negative timeouts during WalletConnect flows.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: WalletConnect onboarding wait logic

  Scenario: network becomes onboarded before timeout triggers
    Given the network onboarding state for the target chainId becomes true
    When WalletConnect triggers waitForNetworkModalOnboarding for that chainId
    Then the function resolves without throwing a Timeout error

## **Screenshots/Recordings**

### **Before**

N/A (logic-only change)

### **After**

N/A (logic-only change)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes timeout logic in `waitForNetworkModalOnboarding` to only throw when still waiting, avoiding false timeouts if onboarding completes on the last allowed loop iteration.
> 
> - Updates timeout condition to check `waitForNetworkModalOnboarded` before throwing
> - Adds unit test covering last-iteration onboarding scenario and retains timeout behavior test
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fe15a50a181888722e532f71f72973a61f5998e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->