### PR TITLE
Fix WalletConnect onboarding timeout edge-case 

### DIFF
--- a/app/core/WalletConnect/wc-utils.test.ts
+++ b/app/core/WalletConnect/wc-utils.test.ts
@@ -77,10 +77,13 @@ jest.mock('@walletconnect/utils', () => ({
 
 describe('WalletConnect Utils', () => {
   let mockNavigation: jest.Mocked<NavigationContainerRef>;
+  let originalMaxLoopCounter: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const mockStore = (StoreModule as any).store;
 
   beforeEach(() => {
+    originalMaxLoopCounter = networkModalOnboardingConfig.MAX_LOOP_COUNTER;
+
     mockNavigation = {
       getCurrentRoute: jest.fn(),
       navigate: jest.fn(),
@@ -95,6 +98,10 @@ describe('WalletConnect Utils', () => {
     });
 
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    networkModalOnboardingConfig.MAX_LOOP_COUNTER = originalMaxLoopCounter;
   });
 
   describe('parseWalletConnectUri', () => {
@@ -188,6 +195,19 @@ describe('WalletConnect Utils', () => {
           networkOnboardedState: { '1': true },
         },
       });
+      await expect(
+        waitForNetworkModalOnboarding({ chainId: '1' }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('does not throw timeout when network is onboarded on the last allowed iteration', async () => {
+      networkModalOnboardingConfig.MAX_LOOP_COUNTER = 1;
+      mockStore.getState.mockReturnValue({
+        networkOnboarded: {
+          networkOnboardedState: { '1': true },
+        },
+      });
+
       await expect(
         waitForNetworkModalOnboarding({ chainId: '1' }),
       ).resolves.toBeUndefined();

--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -150,7 +150,10 @@ export const waitForNetworkModalOnboarding = async ({
       await wait(1000);
     }
 
-    if (loopCounter >= networkModalOnboardingConfig.MAX_LOOP_COUNTER) {
+    if (
+      waitForNetworkModalOnboarded &&
+      loopCounter >= networkModalOnboardingConfig.MAX_LOOP_COUNTER
+    ) {
       throw new Error('Timeout error');
     }
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes an edge-case in WalletConnect onboarding waiting logic where [waitForNetworkModalOnboarding](cci:1://file:///d:/0000A/000000-AAA-BOTS/github/metamask-mobile/app/core/WalletConnect/wc-utils.ts:130:0-159:2) could throw a `Timeout error` even after the network became onboarded on the last allowed iteration.

### Motivation / context
In some flows (especially under tight retry/timeout configurations), onboarding state can flip to `true` right at the edge of the loop counter. The previous timeout check did not account for the “already onboarded” exit condition and could still throw, causing false failures during WalletConnect setup.

### What changed
- Updated the timeout condition to only throw when we are **still** waiting for onboarding.
- Added a regression unit test covering “onboarded on last allowed iteration”.
- Ensured test isolation by restoring `networkModalOnboardingConfig.MAX_LOOP_COUNTER` after each test.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (no linked issue)

## **Manual testing steps**

```gherkin
Feature: WalletConnect onboarding timeout edge-case

  Scenario: WalletConnect does not fail when onboarding completes on the final loop
    Given a WalletConnect flow that triggers waitForNetworkModalOnboarding for chainId "1"
      And networkOnboardedState["1"] transitions to true by the final allowed iteration
    When the app waits for network modal onboarding
    Then the wait resolves successfully
      And no Timeout error is thrown
      And the WalletConnect flow proceeds normally

  Scenario: WalletConnect still times out when onboarding never completes
    Given a WalletConnect flow that triggers waitForNetworkModalOnboarding for chainId "1"
      And networkOnboardedState["1"] remains false
      And the loop counter reaches MAX_LOOP_COUNTER
    When the app waits for network modal onboarding
    Then a Timeout error is thrown