### PR TITLE
test: component view test fix testids

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
@@ -1,0 +1,10 @@
+export const BridgeViewSelectorsIDs = {
+  SOURCE_TOKEN_AREA: 'source-token-area',
+  DESTINATION_TOKEN_AREA: 'dest-token-area',
+  SOURCE_TOKEN_INPUT: 'source-token-area-input',
+  DESTINATION_TOKEN_INPUT: 'dest-token-area-input',
+  CONFIRM_BUTTON: 'bridge-confirm-button',
+  BRIDGE_VIEW_SCROLL: 'bridge-view-scroll',
+} as const;
+
+export type BridgeViewSelectorsIDsType = typeof BridgeViewSelectorsIDs;

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
@@ -10,7 +10,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { initialStateBridge } from '../../../../../util/test/component-view/presets/bridge';
 import BridgeView from './index';
 import { describeForPlatforms } from '../../../../../util/test/platform';
-import { QuoteViewSelectorIDs } from '../../../../../../e2e/selectors/Bridge/QuoteView.selectors';
+import { BridgeViewSelectorsIDs } from './BridgeView.testIds';
 import { BuildQuoteSelectors } from '../../../Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds';
 import { CommonSelectorsIDs } from '../../../../../util/Common.testIds';
 
@@ -35,14 +35,14 @@ describeForPlatforms('BridgeView', () => {
 
     // Input areas are rendered
     expect(
-      getByTestId(QuoteViewSelectorIDs.SOURCE_TOKEN_AREA),
+      getByTestId(BridgeViewSelectorsIDs.SOURCE_TOKEN_AREA),
     ).toBeOnTheScreen();
     expect(
-      getByTestId(QuoteViewSelectorIDs.DESTINATION_TOKEN_INPUT),
+      getByTestId(BridgeViewSelectorsIDs.DESTINATION_TOKEN_AREA),
     ).toBeOnTheScreen();
 
     // Confirm button should NOT be rendered without valid inputs and quote
-    expect(queryByTestId(QuoteViewSelectorIDs.CONFIRM_BUTTON)).toBeNull();
+    expect(queryByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON)).toBeNull();
   });
 
   it('types 9.5 with keypad and displays $19,000.00 fiat value', async () => {
@@ -80,7 +80,7 @@ describeForPlatforms('BridgeView', () => {
     });
 
     // Type 9.5 using keypad buttons inside the bridge scroll container
-    const scroll = getByTestId(QuoteViewSelectorIDs.BRIDGE_VIEW_SCROLL);
+    const scroll = getByTestId(BridgeViewSelectorsIDs.BRIDGE_VIEW_SCROLL);
     fireEvent.press(within(scroll).getByText('9'));
     fireEvent.press(within(scroll).getByText('.'));
     fireEvent.press(within(scroll).getByText('5'));
@@ -131,7 +131,7 @@ describeForPlatforms('BridgeView', () => {
       } as unknown as Record<string, unknown>,
     });
 
-    const button = getByTestId(QuoteViewSelectorIDs.CONFIRM_BUTTON);
+    const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
     expect(button).toBeOnTheScreen();
     expect(
       (button as unknown as { props: { isDisabled?: boolean } }).props

--- a/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
+++ b/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
@@ -819,6 +819,7 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                           "paddingHorizontal": 16,
                                         }
                                       }
+                                      testID="dest-token-area"
                                     >
                                       <Text
                                         accessibilityRole="text"
@@ -2659,6 +2660,7 @@ exports[`BridgeView renders 1`] = `
                                           "paddingHorizontal": 16,
                                         }
                                       }
+                                      testID="dest-token-area"
                                     >
                                       <Text
                                         accessibilityRole="text"

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -86,6 +86,7 @@ import { FLipQuoteButton } from '../../components/FlipQuoteButton/index.tsx';
 import { useIsGasIncludedSTXSendBundleSupported } from '../../hooks/useIsGasIncludedSTXSendBundleSupported/index.ts';
 import { useIsGasIncluded7702Supported } from '../../hooks/useIsGasIncluded7702Supported/index.ts';
 import { useRefreshSmartTransactionsLiveness } from '../../../../hooks/useRefreshSmartTransactionsLiveness';
+import { BridgeViewSelectorsIDs } from './BridgeView.testIds';
 
 export interface BridgeRouteParams {
   sourcePage: string;
@@ -490,7 +491,7 @@ const BridgeView = () => {
               label={getButtonLabel()}
               onPress={handleContinue}
               style={styles.button}
-              testID="bridge-confirm-button"
+              testID={BridgeViewSelectorsIDs.CONFIRM_BUTTON}
               isDisabled={submitDisabled}
             />
           )}
@@ -538,7 +539,7 @@ const BridgeView = () => {
                   })
                 : undefined
             }
-            testID="source-token-area"
+            testID={BridgeViewSelectorsIDs.SOURCE_TOKEN_AREA}
             tokenType={TokenInputAreaType.Source}
             onTokenPress={handleSourceTokenPress}
             onFocus={() => setIsInputFocused(true)}
@@ -561,7 +562,7 @@ const BridgeView = () => {
                 ? getNetworkImageSource({ chainId: destToken?.chainId })
                 : undefined
             }
-            testID="dest-token-area"
+            testID={BridgeViewSelectorsIDs.DESTINATION_TOKEN_AREA}
             tokenType={TokenInputAreaType.Destination}
             onTokenPress={handleDestTokenPress}
             isLoading={!destTokenAmount && isLoading}
@@ -572,7 +573,7 @@ const BridgeView = () => {
 
         {/* Scrollable Dynamic Content */}
         <ScrollView
-          testID="bridge-view-scroll"
+          testID={BridgeViewSelectorsIDs.BRIDGE_VIEW_SCROLL}
           style={styles.scrollView}
           contentContainerStyle={styles.scrollViewContent}
           showsVerticalScrollIndicator={false}

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -383,6 +383,7 @@ export const TokenInputArea = forwardRef<
                     ? navigateToSourceTokenSelector
                     : navigateToDestTokenSelector
                 }
+                testID={testID}
               />
             )}
           </Box>

--- a/app/util/test/component-view/stateFixture.ts
+++ b/app/util/test/component-view/stateFixture.ts
@@ -538,6 +538,9 @@ export function createStateFixture(): StateFixtureBuilder {
         string,
         unknown
       >;
+      const existingRemoteFlags = (
+        (bg as PlainObject)?.RemoteFeatureFlagController as PlainObject
+      )?.remoteFeatureFlags as PlainObject;
       current = deepMerge(
         current as PlainObject,
         {
@@ -546,6 +549,25 @@ export function createStateFixture(): StateFixtureBuilder {
               ...bg,
               SmartTransactionsController: {
                 smartTransactionsState: {},
+              },
+              RemoteFeatureFlagController: {
+                ...((bg as PlainObject)
+                  ?.RemoteFeatureFlagController as PlainObject),
+                remoteFeatureFlags: {
+                  ...existingRemoteFlags,
+                  smartTransactionsNetworks: {
+                    default: {
+                      mobileActive: false,
+                      mobileActiveIOS: false,
+                      mobileActiveAndroid: false,
+                    },
+                    '0x1': {
+                      mobileActive: false,
+                      mobileActiveIOS: false,
+                      mobileActiveAndroid: false,
+                    },
+                  },
+                },
               },
             },
           },

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,7 +29,7 @@ const config = {
   setupFilesAfterEnv: ['<rootDir>/app/util/test/testSetup.js'],
   testEnvironment: 'jest-environment-node',
   transformIgnorePatterns: [
-    'node_modules/(?!((@metamask/)?(@react-native|react-native|redux-persist-filesystem|@react-navigation|@react-native-community|@react-native-masked-view|react-navigation|react-navigation-redux-helpers|@sentry|d3-color|d3-shape|d3-path|d3-scale|d3-array|d3-time|d3-format|d3-interpolate|d3-selection|d3-axis|d3-transition|internmap|react-native-wagmi-charts|react-native-nitro-modules|@notifee|expo-file-system|expo-modules-core|expo(nent)?|@expo(nent)?/.*)|@noble/.*|@nktkas/hyperliquid|@metamask/design-system-twrnc-preset|@metamask/design-system-react-native|@metamask/native-utils|@tommasini/react-native-scrollable-tab-view))',
+    'node_modules/(?!((@metamask/)?(@react-native|react-native|redux-persist-filesystem|@react-navigation|@react-native-community|@react-native-masked-view|react-navigation|react-navigation-redux-helpers|@sentry|d3-color|d3-shape|d3-path|d3-scale|d3-array|d3-time|d3-format|d3-interpolate|d3-selection|d3-axis|d3-transition|internmap|react-native-wagmi-charts|react-native-nitro-modules|@notifee|expo-file-system|expo-modules-core|expo(nent)?|@expo(nent)?/.*)|@noble/.*|@nktkas/hyperliquid|@metamask/design-system-twrnc-preset|@metamask/design-system-react-native|@metamask/native-utils|@metamask/smart-transactions-controller|@tommasini/react-native-scrollable-tab-view))',
   ],
   transform: {
     '^.+\\.[jt]sx?$': ['babel-jest', { configFile: './babel.config.tests.js' }],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
## Fix: Replace hardcoded testIDs with constants in BridgeView component-view tests

### Problem
The `BridgeView.view.test.tsx` test was using selectors from `e2e/selectors/Bridge/QuoteView.selectors.ts` instead of constants from a `.testIds.ts` file within `/app`. The component also had hardcoded testID strings.

### Solution
- Created `BridgeView.testIds.ts` with testID constants
- Updated `BridgeView` component to use constants instead of hardcoded strings
- Updated test to reference constants from `/app` instead of e2e selectors
- Fixed `TokenInputArea` to include testID on Button when no token is present
- Configured Redux state for smart transactions in component-view tests
- Added `@metamask/smart-transactions-controller` to Jest `transformIgnorePatterns`

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces centralized testIDs for BridgeView and aligns component-view tests and implementation.
> 
> - Adds `BridgeView.testIds.ts` and replaces hardcoded `testID` strings in `BridgeView` and `BridgeView.view.test.tsx`
> - Ensures `TokenInputArea` forwards `testID` to its Button when no token is selected
> - Updates component-view state fixture to include minimal Smart Transactions remote flags
> - Extends Jest `transformIgnorePatterns` to include `@metamask/smart-transactions-controller`
> - Refreshes related snapshots
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e28420c42f60e66c5ecf4e2e87ff94abc862d919. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->