### PR TITLE
feat: enhance Merkl rewards handling with multi-chain support

### DIFF
--- a/app/components/UI/Earn/components/MerklRewards/constants.ts
+++ b/app/components/UI/Earn/components/MerklRewards/constants.ts
@@ -1,3 +1,5 @@
+import { Hex } from '@metamask/utils';
+
 export const MERKL_API_BASE_URL = 'https://api.merkl.xyz/v4';
 export const AGLAMERKL_ADDRESS_MAINNET =
   '0x8d652c6d4A8F3Db96Cd866C1a9220B1447F29898'; // Used for test campaigns
@@ -6,6 +8,12 @@ export const AGLAMERKL_ADDRESS_LINEA =
 
 export const MERKL_DISTRIBUTOR_ADDRESS =
   '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae' as const;
+
+/**
+ * The chain where Merkl rewards are claimed (Linea mainnet = 0xe708 = 59144).
+ * Even if a user holds mUSD on mainnet, rewards are always claimed on Linea.
+ */
+export const MERKL_CLAIM_CHAIN_ID = '0xe708' as Hex;
 
 // ABI for the claimed mapping
 export const DISTRIBUTOR_CLAIMED_ABI = [

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklClaim.test.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklClaim.test.ts
@@ -7,6 +7,28 @@ import { TokenI } from '../../../../Tokens/types';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { RootState } from '../../../../../../reducers';
 
+// Mock @metamask/transaction-controller to avoid import issues
+jest.mock('@metamask/transaction-controller', () => ({
+  CHAIN_IDS: {
+    MAINNET: '0x1',
+    LINEA_MAINNET: '0xe708',
+  },
+  TransactionType: {
+    contractInteraction: 'contractInteraction',
+  },
+  WalletDevice: {
+    MM_MOBILE: 'metamask_mobile',
+  },
+}));
+
+// Mock musd constants
+jest.mock('../../../constants/musd', () => ({
+  MUSD_TOKEN_ADDRESS_BY_CHAIN: {
+    '0x1': '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+    '0xe708': '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+  },
+}));
+
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
@@ -23,6 +23,8 @@ jest.mock('../../../../../../util/number', () => ({
 jest.mock('../merkl-client', () => ({
   fetchMerklRewardsForAsset: jest.fn(),
   getClaimedAmountFromContract: jest.fn(),
+  // Return the asset's chainId by default (non-mUSD behavior)
+  getClaimChainId: jest.fn((asset: { chainId: string }) => asset.chainId),
 }));
 
 // Mock Engine for refreshTokenBalances

--- a/app/components/UI/Earn/components/MerklRewards/merkl-client.ts
+++ b/app/components/UI/Earn/components/MerklRewards/merkl-client.ts
@@ -175,11 +175,17 @@ export const fetchMerklRewardsForAsset = async (
     tokenAddress,
   );
 
+  // For mUSD, always search for MUSD_TOKEN_ADDRESS rewards
+  // For other tokens, use the asset's address
+  const rewardTokenAddress = isMusdToken(tokenAddress)
+    ? MUSD_TOKEN_ADDRESS
+    : tokenAddress;
+
   return fetchMerklRewards(
     {
       userAddress,
       chainIds,
-      tokenAddress: MUSD_TOKEN_ADDRESS,
+      tokenAddress: rewardTokenAddress,
       signal,
     },
     throwOnError,

--- a/app/components/UI/Earn/components/MerklRewards/merkl-client.ts
+++ b/app/components/UI/Earn/components/MerklRewards/merkl-client.ts
@@ -144,8 +144,8 @@ const getChainIdsForRewardsFetch = (
   tokenAddress: Hex,
 ): Hex | Hex[] => {
   if (isMusdToken(tokenAddress)) {
-    // For mUSD, fetch from both mainnet and Linea
-    return [CHAIN_IDS.MAINNET, CHAIN_IDS.LINEA_MAINNET];
+    // For mUSD, fetch only Linea
+    return [CHAIN_IDS.LINEA_MAINNET];
   }
   return [assetChainId];
 };

--- a/app/components/UI/Earn/components/MerklRewards/merkl-client.ts
+++ b/app/components/UI/Earn/components/MerklRewards/merkl-client.ts
@@ -9,8 +9,14 @@ import {
   AGLAMERKL_ADDRESS_LINEA,
   MERKL_API_BASE_URL,
   MERKL_DISTRIBUTOR_ADDRESS,
+  MERKL_CLAIM_CHAIN_ID,
   DISTRIBUTOR_CLAIMED_ABI,
 } from './constants';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../../constants/musd';
+
+// mUSD token address (same on all chains)
+const MUSD_TOKEN_ADDRESS = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.LINEA_MAINNET];
 
 /**
  * Merkl API reward data structure
@@ -37,20 +43,27 @@ export interface MerklRewardData {
  */
 export interface FetchMerklRewardsOptions {
   userAddress: string;
-  chainId: Hex;
+  /** Single chainId or array of chainIds to fetch rewards from */
+  chainIds: Hex | Hex[];
   tokenAddress: Hex;
   signal?: AbortSignal;
 }
 
 /**
  * Build the Merkl API URL for fetching rewards
+ * @param chainIds - Single chainId or array of chainIds (CSV format in URL)
  */
 const buildRewardsUrl = (
   userAddress: string,
-  chainId: Hex,
+  chainIds: Hex | Hex[],
   tokenAddress: Hex,
 ): string => {
-  let url = `${MERKL_API_BASE_URL}/users/${userAddress}/rewards?chainId=${Number(chainId)}`;
+  // Support multiple chain IDs (comma-separated)
+  const chainIdParam = Array.isArray(chainIds)
+    ? chainIds.map((id) => Number(id)).join(',')
+    : Number(chainIds);
+
+  let url = `${MERKL_API_BASE_URL}/users/${userAddress}/rewards?chainId=${chainIdParam}`;
 
   // Add test parameter for test token (case-insensitive comparison)
   if (
@@ -87,16 +100,16 @@ const findMatchingReward = (
 
 /**
  * Fetch Merkl rewards from the API for a given user and token
- * @param options - Fetch options including user address, chain ID, and token address
+ * @param options - Fetch options including user address, chain IDs, and token address
  * @param options.throwOnError - If true, throws on API errors. If false, returns null on errors (default: true)
  * @returns The matching reward data or null if not found or if error occurs (when throwOnError is false)
  * @throws Error if the API request fails and throwOnError is true
  */
 export const fetchMerklRewards = async (
-  { userAddress, chainId, tokenAddress, signal }: FetchMerklRewardsOptions,
+  { userAddress, chainIds, tokenAddress, signal }: FetchMerklRewardsOptions,
   throwOnError = true,
 ): Promise<MerklRewardData['rewards'][0] | null> => {
-  const url = buildRewardsUrl(userAddress, chainId, tokenAddress);
+  const url = buildRewardsUrl(userAddress, chainIds, tokenAddress);
 
   const response = await fetch(url, {
     signal,
@@ -115,8 +128,35 @@ export const fetchMerklRewards = async (
 };
 
 /**
+ * Check if the given token is mUSD on any supported chain
+ * mUSD has the same address on all chains
+ */
+const isMusdToken = (tokenAddress: Hex): boolean =>
+  tokenAddress.toLowerCase() === MUSD_TOKEN_ADDRESS.toLowerCase();
+
+/**
+ * Get the chain IDs to fetch Merkl rewards from.
+ * For mUSD, we fetch from both mainnet and Linea since users can earn
+ * rewards by holding mUSD on either chain, but rewards are on Linea.
+ */
+const getChainIdsForRewardsFetch = (
+  assetChainId: Hex,
+  tokenAddress: Hex,
+): Hex | Hex[] => {
+  if (isMusdToken(tokenAddress)) {
+    // For mUSD, fetch from both mainnet and Linea
+    return [CHAIN_IDS.MAINNET, CHAIN_IDS.LINEA_MAINNET];
+  }
+  return [assetChainId];
+};
+
+/**
  * Fetch Merkl rewards for a given asset
  * Convenience wrapper that extracts necessary data from TokenI
+ *
+ * For mUSD tokens: fetches from both mainnet and Linea chains, and looks
+ * for Linea mUSD rewards (since rewards are always claimed on Linea).
+ *
  * @param asset - The token asset to fetch rewards for
  * @param userAddress - The user's wallet address
  * @param signal - Optional AbortSignal for cancelling the request
@@ -128,16 +168,35 @@ export const fetchMerklRewardsForAsset = async (
   userAddress: string,
   signal?: AbortSignal,
   throwOnError = true,
-): Promise<MerklRewardData['rewards'][0] | null> =>
-  fetchMerklRewards(
+): Promise<MerklRewardData['rewards'][0] | null> => {
+  const tokenAddress = asset.address as Hex;
+  const chainIds = getChainIdsForRewardsFetch(
+    asset.chainId as Hex,
+    tokenAddress,
+  );
+
+  return fetchMerklRewards(
     {
       userAddress,
-      chainId: asset.chainId as Hex,
-      tokenAddress: asset.address as Hex,
+      chainIds,
+      tokenAddress: MUSD_TOKEN_ADDRESS,
       signal,
     },
     throwOnError,
   );
+};
+
+/**
+ * Get the chain ID to use for claiming rewards.
+ * For mUSD, claims always go to Linea regardless of which chain the user is viewing.
+ */
+export const getClaimChainId = (asset: TokenI): Hex => {
+  const tokenAddress = asset.address as Hex;
+  if (isMusdToken(tokenAddress)) {
+    return MERKL_CLAIM_CHAIN_ID;
+  }
+  return asset.chainId as Hex;
+};
 
 /**
  * Read the claimed amount from the Merkl Distributor contract


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Users earn mUSD bonuses for holding mUSD on both Ethereum mainnet and Linea, however they could only see and claim rewards when viewing Linea mUSD in the asset overview.

This created a "cold start problem" where users couldn't access the claim button if they didn't already hold Linea mUSD (even if they had mainnet mUSD with claimable rewards).

**Solution:**
- Fetch Merkl rewards for both chains by using CSV format in the API URL (e.g., `chainId=1,59144`)
- Show the claim button in both the Linea mUSD and mainnet mUSD asset overview
- Ensure the claim transaction always goes to Linea (where the distributor contract is deployed)

**Key changes:**
1. Added mainnet mUSD to the `eligibleTokens` map so the claim button appears when viewing mainnet mUSD
2. Modified `fetchMerklRewardsForAsset` to fetch rewards from both mainnet and Linea chains for mUSD
3. Added `getClaimChainId()` to ensure claims always target Linea regardless of which chain's mUSD is being viewed
4. Updated `useMerklClaim` to use the correct network client for Linea when claiming mUSD rewards

## **Changelog**

CHANGELOG entry: Added ability to claim Merkl rewards from mainnet mUSD asset overview (rewards still claimed on Linea)


## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-245

## **Manual testing steps**

```gherkin
Feature: Claim Merkl rewards from mainnet mUSD

  Scenario: User claims mUSD rewards while viewing mainnet mUSD
    Given user has mUSD on Ethereum mainnet
    And user has claimable Merkl rewards for mUSD

    When user opens Asset Overview for mainnet mUSD
    Then user should see the pending rewards banner
    And user should see the "Claim" button

    When user taps the "Claim" button
    Then transaction should be submitted to Linea network
    And rewards should be claimed successfully

  Scenario: User claims mUSD rewards while viewing Linea mUSD
    Given user has mUSD on Linea
    And user has claimable Merkl rewards for mUSD

    When user opens Asset Overview for Linea mUSD
    Then user should see the pending rewards banner
    And user should see the "Claim" button

    When user taps the "Claim" button
    Then transaction should be submitted to Linea network
    And rewards should be claimed successfully

  Scenario: Cold start - User with only mainnet mUSD can claim
    Given user has mUSD only on Ethereum mainnet (no Linea mUSD)
    And user has claimable Merkl rewards

    When user opens Asset Overview for mainnet mUSD
    Then user should see the pending rewards banner
    And user should see the "Claim" button
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="399" height="833" alt="Screenshot 2026-01-27 at 13 45 37" src="https://github.com/user-attachments/assets/5685c1c3-dd68-4aa9-afcd-7020769f1133" />

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/e7cf5bcd-9aa8-46ff-9254-26811e2b3407


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Merkl rewards UX for mUSD by surfacing rewards on both Mainnet and Linea while always claiming on Linea.
> 
> - Adds `MERKL_CLAIM_CHAIN_ID` and `getClaimChainId()` to consistently target Linea for claims
> - Updates `fetchMerklRewardsForAsset` to support multi-chain queries (CSV `chainId`) and mUSD-specific handling
> - Expands `eligibleTokens` to include mainnet mUSD so claim UI appears on mainnet asset
> - Adjusts `useMerklClaim`/`useMerklRewards` to use claim-chain-aware network selection and contract reads for accurate claimed amounts
> - Adds/updates comprehensive tests for claim routing, rewards fetching, and eligibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f835f190602dfa16f81195be2990755449e46d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->