### PR TITLE
chore: moves Ramps, Multisrp, Swap and Assets specs to tests

### DIFF
--- a/e2e/specs/identity/account-syncing/multi-srp.spec.ts
+++ b/e2e/specs/identity/account-syncing/multi-srp.spec.ts
@@ -10,7 +10,10 @@ import {
   UserStorageMockttpControllerEvents,
   UserStorageMockttpController,
 } from '../utils/user-storage/userStorageMockttpController';
-import { goToImportSrp, inputSrp } from '../../multisrp/utils';
+import {
+  goToImportSrp,
+  inputSrp,
+} from '../../../../tests/flows/accounts.flow.ts';
 import ImportSrpView from '../../../pages/importSrp/ImportSrpView';
 import { IDENTITY_TEAM_SEED_PHRASE_2 } from '../utils/constants';
 import { createUserStorageController } from '../utils/mocks';

--- a/e2e/specs/multichain-accounts/export-credentials.spec.ts
+++ b/e2e/specs/multichain-accounts/export-credentials.spec.ts
@@ -5,7 +5,7 @@ import {
   withMultichainAccountDetailsEnabledFixtures,
 } from './common';
 import AccountDetails from '../../pages/MultichainAccounts/AccountDetails';
-import { completeSrpQuiz } from '../multisrp/utils';
+import { completeSrpQuiz } from '../../../tests/flows/accounts.flow.ts';
 import { defaultOptions } from '../../../tests/seeder/anvil-manager';
 import TestHelpers from '../../helpers';
 

--- a/e2e/specs/quarantine/create-wallet-account.failing.ts
+++ b/e2e/specs/quarantine/create-wallet-account.failing.ts
@@ -6,7 +6,7 @@ import { withMultichainAccountDetailsV2EnabledFixtures } from '../multichain-acc
 import AccountDetails from '../../pages/MultichainAccounts/AccountDetails.js';
 import AddressList from '../../pages/MultichainAccounts/AddressList.js';
 import { defaultGanacheOptions } from '../../../tests/framework/Constants.js';
-import { completeSrpQuiz } from '../multisrp/utils.js';
+import { completeSrpQuiz } from '../../../tests/flows/accounts.flow.js';
 
 // Quarantining, See open ticket here: https://github.com/MetaMask/metamask-mobile/issues/21429
 describe(SmokeAccounts('Create wallet accounts'), () => {

--- a/tests/flows/accounts.flow.ts
+++ b/tests/flows/accounts.flow.ts
@@ -1,16 +1,16 @@
-import ImportSrpView from '../../pages/importSrp/ImportSrpView';
-import AccountListBottomSheet from '../../pages/wallet/AccountListBottomSheet';
-import AddAccountBottomSheet from '../../pages/wallet/AddAccountBottomSheet';
-import WalletView from '../../pages/wallet/WalletView';
-import Assertions from '../../../tests/framework/Assertions.ts';
-import SRPListItemComponent from '../../pages/wallet/MultiSrp/Common/SRPListItemComponent';
-import SrpQuizModal from '../../pages/Settings/SecurityAndPrivacy/SrpQuizModal';
-import RevealSecretRecoveryPhrase from '../../pages/Settings/SecurityAndPrivacy/RevealSecretRecoveryPhrase';
-import { RevealSeedViewSelectorsText } from '../../../app/components/Views/RevealPrivateCredential/RevealSeedView.testIds';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
-import SettingsView from '../../pages/Settings/SettingsView';
-import SecurityAndPrivacyView from '../../pages/Settings/SecurityAndPrivacy/SecurityAndPrivacyView';
-import AccountDetails from '../../pages/MultichainAccounts/AccountDetails.ts';
+import ImportSrpView from '../../e2e/pages/importSrp/ImportSrpView.ts';
+import AccountListBottomSheet from '../../e2e/pages/wallet/AccountListBottomSheet.ts';
+import AddAccountBottomSheet from '../../e2e/pages/wallet/AddAccountBottomSheet.ts';
+import WalletView from '../../e2e/pages/wallet/WalletView.ts';
+import Assertions from '../framework/Assertions.ts';
+import SRPListItemComponent from '../../e2e/pages/wallet/MultiSrp/Common/SRPListItemComponent.ts';
+import SrpQuizModal from '../../e2e/pages/Settings/SecurityAndPrivacy/SrpQuizModal.ts';
+import RevealSecretRecoveryPhrase from '../../e2e/pages/Settings/SecurityAndPrivacy/RevealSecretRecoveryPhrase.ts';
+import { RevealSeedViewSelectorsText } from '../../app/components/Views/RevealPrivateCredential/RevealSeedView.testIds.ts';
+import TabBarComponent from '../../e2e/pages/wallet/TabBarComponent.ts';
+import SettingsView from '../../e2e/pages/Settings/SettingsView.ts';
+import SecurityAndPrivacyView from '../../e2e/pages/Settings/SecurityAndPrivacy/SecurityAndPrivacyView.ts';
+import AccountDetails from '../../e2e/pages/MultichainAccounts/AccountDetails.ts';
 
 const PASSWORD = '123123123';
 

--- a/tests/regression/assets/asset-sort.spec.ts
+++ b/tests/regression/assets/asset-sort.spec.ts
@@ -1,15 +1,15 @@
-import { RegressionAssets } from '../../tags';
-import WalletView from '../../pages/wallet/WalletView';
-import SortModal from '../../pages/wallet/TokenSortBottomSheet';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { loginToApp } from '../../viewHelper';
-import Assertions from '../../../tests/framework/Assertions';
-import ConfirmAddAssetView from '../../pages/wallet/ImportTokenFlow/ConfirmAddAsset';
-import ImportTokensView from '../../pages/wallet/ImportTokenFlow/ImportTokensView';
-import { MockApiEndpoint } from '../../../tests/framework';
+import { RegressionAssets } from '../../../e2e/tags';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import SortModal from '../../../e2e/pages/wallet/TokenSortBottomSheet';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { loginToApp } from '../../../e2e/viewHelper';
+import Assertions from '../../framework/Assertions';
+import ConfirmAddAssetView from '../../../e2e/pages/wallet/ImportTokenFlow/ConfirmAddAsset';
+import ImportTokensView from '../../../e2e/pages/wallet/ImportTokenFlow/ImportTokensView';
+import { MockApiEndpoint } from '../../framework';
 import { Mockttp } from 'mockttp';
-import { setupMockRequest } from '../../../tests/api-mocking/helpers/mockHelpers';
+import { setupMockRequest } from '../../api-mocking/helpers/mockHelpers';
 
 const AAVE_MAINNET_DETAILS = {
   address: '0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9',

--- a/tests/regression/assets/defi/view-defi-tab.spec.ts
+++ b/tests/regression/assets/defi/view-defi-tab.spec.ts
@@ -1,18 +1,18 @@
-import { RegressionNetworkAbstractions } from '../../../tags';
-import WalletView from '../../../pages/wallet/WalletView';
-import Assertions from '../../../../tests/framework/Assertions';
-import FixtureBuilder from '../../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../../tests/framework/fixtures/FixtureHelper';
+import { RegressionNetworkAbstractions } from '../../../../e2e/tags';
+import WalletView from '../../../../e2e/pages/wallet/WalletView';
+import Assertions from '../../../framework/Assertions';
+import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
 import { WalletViewSelectorsText } from '../../../../app/components/Views/Wallet/WalletView.testIds';
-import { loginToApp } from '../../../viewHelper';
-import { setupMockRequest } from '../../../../tests/api-mocking/helpers/mockHelpers';
+import { loginToApp } from '../../../../e2e/viewHelper';
+import { setupMockRequest } from '../../../api-mocking/helpers/mockHelpers';
 import { Mockttp } from 'mockttp';
 import {
   defiPositionsError,
   defiPositionsWithData,
   defiPositionsWithNoData,
-} from '../../../../tests/api-mocking/mock-responses/defi-api-mocks';
-import NetworkManager from '../../../pages/wallet/NetworkManager';
+} from '../../../api-mocking/mock-responses/defi-api-mocks.ts';
+import NetworkManager from '../../../../e2e/pages/wallet/NetworkManager.ts';
 
 describe(RegressionNetworkAbstractions('View DeFi tab'), () => {
   it('open the DeFi tab with an address that has no positions', async () => {

--- a/tests/regression/assets/import-custom-token.spec.ts
+++ b/tests/regression/assets/import-custom-token.spec.ts
@@ -1,16 +1,16 @@
-import { RegressionAssets } from '../../tags';
-import TestHelpers from '../../helpers';
-import WalletView from '../../pages/wallet/WalletView';
-import ConfirmAddAssetView from '../../pages/wallet/ImportTokenFlow/ConfirmAddAsset';
-import ImportTokensView from '../../pages/wallet/ImportTokenFlow/ImportTokensView';
-import Assertions from '../../../tests/framework/Assertions';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { loginToApp } from '../../viewHelper';
+import { RegressionAssets } from '../../../e2e/tags';
+import TestHelpers from '../../../e2e/helpers';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import ConfirmAddAssetView from '../../../e2e/pages/wallet/ImportTokenFlow/ConfirmAddAsset';
+import ImportTokensView from '../../../e2e/pages/wallet/ImportTokenFlow/ImportTokensView';
+import Assertions from '../../framework/Assertions';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { loginToApp } from '../../../e2e/viewHelper';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
-import { AnvilPort } from '../../../tests/framework/fixtures/FixtureUtils';
-import { LocalNode } from '../../../tests/framework/types';
-import { AnvilManager } from '../../../tests/seeder/anvil-manager';
+import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
+import { LocalNode } from '../../framework';
+import { AnvilManager } from '../../seeder/anvil-manager';
 
 describe(RegressionAssets('Import custom token'), () => {
   beforeAll(async () => {

--- a/tests/regression/assets/import-tokens-via-asset-watcher.spec.ts
+++ b/tests/regression/assets/import-tokens-via-asset-watcher.spec.ts
@@ -1,28 +1,28 @@
-import { RegressionNetworkAbstractions } from '../../tags';
-import TestHelpers from '../../helpers';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
+import { RegressionNetworkAbstractions } from '../../../e2e/tags';
+import TestHelpers from '../../../e2e/helpers';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
 import FixtureBuilder, {
   DEFAULT_FIXTURE_ACCOUNT,
-} from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
+} from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
-import TestDApp from '../../pages/Browser/TestDApp';
-import Assertions from '../../../tests/framework/Assertions';
-import AssetWatchBottomSheet from '../../pages/Transactions/AssetWatchBottomSheet';
-import WalletView from '../../pages/wallet/WalletView';
-import NetworkListModal from '../../pages/Network/NetworkListModal';
+import TabBarComponent from '../../../e2e/pages/wallet/TabBarComponent';
+import TestDApp from '../../../e2e/pages/Browser/TestDApp';
+import Assertions from '../../framework/Assertions';
+import AssetWatchBottomSheet from '../../../e2e/pages/Transactions/AssetWatchBottomSheet';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import NetworkListModal from '../../../e2e/pages/Network/NetworkListModal';
 import {
   AnvilPort,
   buildPermissions,
-} from '../../../tests/framework/fixtures/FixtureUtils';
-import { DappVariants } from '../../../tests/framework/Constants';
+} from '../../framework/fixtures/FixtureUtils';
+import { DappVariants } from '../../framework/Constants';
 import {
   setEthAccounts,
   Caip25EndowmentPermissionName,
 } from '@metamask/chain-agnostic-permission';
-import { LocalNode } from '../../../tests/framework/types';
-import { AnvilManager } from '../../../tests/seeder/anvil-manager';
+import { LocalNode } from '../../framework';
+import { AnvilManager } from '../../seeder/anvil-manager';
 
 const ERC20_CONTRACT = SMART_CONTRACTS.HST;
 

--- a/tests/regression/assets/import-tokens.spec.ts
+++ b/tests/regression/assets/import-tokens.spec.ts
@@ -1,13 +1,13 @@
-import { RegressionAssets } from '../../tags';
-import WalletView from '../../pages/wallet/WalletView';
-import ImportTokensView from '../../pages/wallet/ImportTokenFlow/ImportTokensView';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { loginToApp } from '../../viewHelper';
-import ConfirmAddAssetView from '../../pages/wallet/ImportTokenFlow/ConfirmAddAsset';
-import Assertions from '../../../tests/framework/Assertions';
+import { RegressionAssets } from '../../../e2e/tags';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import ImportTokensView from '../../../e2e/pages/wallet/ImportTokenFlow/ImportTokensView';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { loginToApp } from '../../../e2e/viewHelper';
+import ConfirmAddAssetView from '../../../e2e/pages/wallet/ImportTokenFlow/ConfirmAddAsset';
+import Assertions from '../../framework/Assertions';
 import { Mockttp } from 'mockttp';
-import { setupMockRequest } from '../../../tests/api-mocking/helpers/mockHelpers';
+import { setupMockRequest } from '../../api-mocking/helpers/mockHelpers';
 
 describe(RegressionAssets('Import Tokens'), () => {
   const testSpecificMock = async (mockServer: Mockttp) => {

--- a/tests/regression/assets/multichain/asset-list.spec.ts
+++ b/tests/regression/assets/multichain/asset-list.spec.ts
@@ -1,16 +1,16 @@
-import { RegressionAssets } from '../../../tags';
-import WalletView from '../../../pages/wallet/WalletView';
-import FixtureBuilder from '../../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../../tests/framework/fixtures/FixtureHelper';
-import { loginToApp } from '../../../viewHelper';
-import Assertions from '../../../../tests/framework/Assertions';
-import TokenOverview from '../../../pages/wallet/TokenOverview';
-import NetworkManager from '../../../pages/wallet/NetworkManager';
-import { setupRemoteFeatureFlagsMock } from '../../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
+import { RegressionAssets } from '../../../../e2e/tags';
+import WalletView from '../../../../e2e/pages/wallet/WalletView';
+import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
+import { loginToApp } from '../../../../e2e/viewHelper';
+import Assertions from '../../../framework/Assertions';
+import TokenOverview from '../../../../e2e/pages/wallet/TokenOverview';
+import NetworkManager from '../../../../e2e/pages/wallet/NetworkManager';
+import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper';
 import {
   remoteFeatureFlagTronAccounts,
   remoteFeatureMultichainAccountsAccountDetailsV2,
-} from '../../../../tests/api-mocking/mock-responses/feature-flags-mocks';
+} from '../../../api-mocking/mock-responses/feature-flags-mocks.ts';
 
 const ETHEREUM_NAME = 'Ethereum';
 const AVAX_NAME = 'AVAX';

--- a/tests/regression/assets/nft-details.spec.ts
+++ b/tests/regression/assets/nft-details.spec.ts
@@ -1,20 +1,20 @@
-import { RegressionAssets } from '../../tags';
-import TestHelpers from '../../helpers';
-import { loginToApp } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
+import { RegressionAssets } from '../../../e2e/tags';
+import TestHelpers from '../../../e2e/helpers';
+import { loginToApp } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
-import WalletView from '../../pages/wallet/WalletView';
-import ImportNFTView from '../../pages/wallet/ImportNFTFlow/ImportNFTView';
-import Assertions from '../../../tests/framework/Assertions';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import ImportNFTView from '../../../e2e/pages/wallet/ImportNFTFlow/ImportNFTView';
+import Assertions from '../../framework/Assertions';
 import enContent from '../../../locales/languages/en.json';
 import {
   AnvilPort,
   buildPermissions,
-} from '../../../tests/framework/fixtures/FixtureUtils';
-import { DappVariants } from '../../../tests/framework/Constants';
-import { LocalNode } from '../../../tests/framework/types';
-import { AnvilManager } from '../../../tests/seeder/anvil-manager';
+} from '../../framework/fixtures/FixtureUtils';
+import { DappVariants } from '../../framework/Constants';
+import { LocalNode } from '../../framework';
+import { AnvilManager } from '../../seeder/anvil-manager';
 
 describe.skip(RegressionAssets('NFT Details page'), () => {
   const NFT_CONTRACT = SMART_CONTRACTS.NFTS;

--- a/tests/regression/assets/nft-detection-modal.spec.ts
+++ b/tests/regression/assets/nft-detection-modal.spec.ts
@@ -1,13 +1,13 @@
-import WalletView from '../../pages/wallet/WalletView';
-import { loginToApp } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestHelpers from '../../helpers';
-import Assertions from '../../../tests/framework/Assertions';
-import NftDetectionModal from '../../pages/wallet/NftDetectionModal';
-import { RegressionAssets } from '../../tags';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import { loginToApp } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestHelpers from '../../../e2e/helpers';
+import Assertions from '../../framework/Assertions';
+import NftDetectionModal from '../../../e2e/pages/wallet/NftDetectionModal';
+import { RegressionAssets } from '../../../e2e/tags';
 
-import { NftDetectionModalSelectorsText } from '../../../app/components/Views/NFTAutoDetectionModal/NftDetectionModal.testIds';
+import { NftDetectionModalSelectorsText } from '../../../app/components/Views/NFTAutoDetectionModal/NftDetectionModal.testIds.ts';
 
 describe.skip(RegressionAssets('NFT Detection Modal'), () => {
   beforeAll(async () => {

--- a/tests/regression/assets/token-detection-import-all.spec.ts
+++ b/tests/regression/assets/token-detection-import-all.spec.ts
@@ -1,11 +1,11 @@
 'use strict';
-import { loginToApp } from '../../viewHelper';
-import { RegressionAssets } from '../../tags';
-import WalletView from '../../pages/wallet/WalletView';
-import Assertions from '../../../tests/framework/Assertions';
-import TestHelpers from '../../helpers';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
+import { loginToApp } from '../../../e2e/viewHelper';
+import { RegressionAssets } from '../../../e2e/tags';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import Assertions from '../../framework/Assertions';
+import TestHelpers from '../../../e2e/helpers';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 
 const ETHEREUM_NAME = 'Ethereum';
 const USDC_NAME = 'USDCoin';

--- a/tests/regression/assets/transaction.spec.ts
+++ b/tests/regression/assets/transaction.spec.ts
@@ -1,22 +1,22 @@
-import TestHelpers from '../../helpers';
-import { RegressionAssets } from '../../tags';
-import RedesignedSendView from '../../pages/Send/RedesignedSendView';
-import TransactionConfirmationView from '../../pages/Send/TransactionConfirmView';
-import { loginToApp } from '../../viewHelper';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
+import TestHelpers from '../../../e2e/helpers';
+import { RegressionAssets } from '../../../e2e/tags';
+import RedesignedSendView from '../../../e2e/pages/Send/RedesignedSendView';
+import TransactionConfirmationView from '../../../e2e/pages/Send/TransactionConfirmView';
+import { loginToApp } from '../../../e2e/viewHelper';
+import TabBarComponent from '../../../e2e/pages/wallet/TabBarComponent';
 import enContent from '../../../locales/languages/en.json';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import Assertions from '../../../tests/framework/Assertions';
-import WalletView from '../../pages/wallet/WalletView';
-import TokenOverview from '../../pages/wallet/TokenOverview';
-import ToastModal from '../../pages/wallet/ToastModal';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import Assertions from '../../framework/Assertions';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import TokenOverview from '../../../e2e/pages/wallet/TokenOverview';
+import ToastModal from '../../../e2e/pages/wallet/ToastModal';
 import { Mockttp } from 'mockttp';
-import { setupRemoteFeatureFlagsMock } from '../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
-import { confirmationFeatureFlags } from '../../../tests/api-mocking/mock-responses/feature-flags-mocks';
-import { LocalNode } from '../../../tests/framework/types';
-import { AnvilPort } from '../../../tests/framework/fixtures/FixtureUtils';
-import { AnvilManager } from '../../../tests/seeder/anvil-manager';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
+import { confirmationFeatureFlags } from '../../api-mocking/mock-responses/feature-flags-mocks';
+import { LocalNode } from '../../framework/types';
+import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
+import { AnvilManager } from '../../seeder/anvil-manager';
 
 describe(RegressionAssets('Transaction'), () => {
   beforeAll(async () => {

--- a/tests/regression/ramps/onramp-parameters.spec.ts
+++ b/tests/regression/ramps/onramp-parameters.spec.ts
@@ -1,29 +1,26 @@
-import { loginToApp } from '../../viewHelper';
-import WalletView from '../../pages/wallet/WalletView';
-import FundActionMenu from '../../pages/UI/FundActionMenu';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { CustomNetworks } from '../../../tests/resources/networks.e2e';
-import { RegressionTrade } from '../../tags';
-import Assertions from '../../../tests/framework/Assertions';
-import BuildQuoteView from '../../pages/Ramps/BuildQuoteView';
-import SelectCurrencyView from '../../pages/Ramps/SelectCurrencyView';
-import TokenSelectBottomSheet from '../../pages/Ramps/TokenSelectBottomSheet';
-import SelectRegionView from '../../pages/Ramps/SelectRegionView';
-import SelectPaymentMethodView from '../../pages/Ramps/SelectPaymentMethodView';
-import BuyGetStartedView from '../../pages/Ramps/BuyGetStartedView';
+import { loginToApp } from '../../../e2e/viewHelper.ts';
+import WalletView from '../../../e2e/pages/wallet/WalletView.ts';
+import FundActionMenu from '../../../e2e/pages/UI/FundActionMenu.ts';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.ts';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.ts';
+import { CustomNetworks } from '../../resources/networks.e2e';
+import { RegressionTrade } from '../../../e2e/tags';
+import Assertions from '../../framework/Assertions.ts';
+import BuildQuoteView from '../../../e2e/pages/Ramps/BuildQuoteView.ts';
+import SelectCurrencyView from '../../../e2e/pages/Ramps/SelectCurrencyView.ts';
+import TokenSelectBottomSheet from '../../../e2e/pages/Ramps/TokenSelectBottomSheet.ts';
+import SelectRegionView from '../../../e2e/pages/Ramps/SelectRegionView.ts';
+import SelectPaymentMethodView from '../../../e2e/pages/Ramps/SelectPaymentMethodView.ts';
+import BuyGetStartedView from '../../../e2e/pages/Ramps/BuyGetStartedView.ts';
 import {
   EventPayload,
   getEventsPayloads,
-} from '../../../tests/helpers/analytics/helpers';
-import SoftAssert from '../../../tests/framework/SoftAssert';
-import {
-  RampsRegions,
-  RampsRegionsEnum,
-} from '../../../tests/framework/Constants';
-import Matchers from '../../../tests/framework/Matchers';
+} from '../../helpers/analytics/helpers.ts';
+import SoftAssert from '../../framework/SoftAssert.ts';
+import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants.ts';
+import Matchers from '../../framework/Matchers.ts';
 import { Mockttp } from 'mockttp';
-import { setupRegionAwareOnRampMocks } from '../../../tests/api-mocking/mock-responses/ramps/ramps-region-aware-mock-setup';
+import { setupRegionAwareOnRampMocks } from '../../api-mocking/mock-responses/ramps/ramps-region-aware-mock-setup.ts';
 
 const eventsToCheck: EventPayload[] = [];
 

--- a/tests/regression/ramps/ramps-account-switch.spec.ts
+++ b/tests/regression/ramps/ramps-account-switch.spec.ts
@@ -1,22 +1,19 @@
-import { loginToApp } from '../../viewHelper';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
-import WalletView from '../../pages/wallet/WalletView';
-import FundActionMenu from '../../pages/UI/FundActionMenu';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { Assertions } from '../../../tests/framework';
-import BuyGetStartedView from '../../pages/Ramps/BuyGetStartedView';
-import AccountListBottomSheet from '../../pages/wallet/AccountListBottomSheet';
-import BuildQuoteView from '../../pages/Ramps/BuildQuoteView';
-import { RegressionTrade } from '../../tags';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { LocalNodeType } from '../../../tests/framework/types';
-import { Hardfork } from '../../../tests/seeder/anvil-manager';
-import {
-  RampsRegions,
-  RampsRegionsEnum,
-} from '../../../tests/framework/Constants';
+import { loginToApp } from '../../../e2e/viewHelper.ts';
+import TabBarComponent from '../../../e2e/pages/wallet/TabBarComponent.ts';
+import WalletView from '../../../e2e/pages/wallet/WalletView.ts';
+import FundActionMenu from '../../../e2e/pages/UI/FundActionMenu.ts';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.ts';
+import { Assertions } from '../../framework';
+import BuyGetStartedView from '../../../e2e/pages/Ramps/BuyGetStartedView.ts';
+import AccountListBottomSheet from '../../../e2e/pages/wallet/AccountListBottomSheet.ts';
+import BuildQuoteView from '../../../e2e/pages/Ramps/BuildQuoteView.ts';
+import { RegressionTrade } from '../../../e2e/tags';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.ts';
+import { LocalNodeType } from '../../framework/types.ts';
+import { Hardfork } from '../../seeder/anvil-manager.ts';
+import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants.ts';
 import { Mockttp } from 'mockttp';
-import { setupRegionAwareOnRampMocks } from '../../../tests/api-mocking/mock-responses/ramps/ramps-region-aware-mock-setup';
+import { setupRegionAwareOnRampMocks } from '../../api-mocking/mock-responses/ramps/ramps-region-aware-mock-setup.ts';
 
 // Anvil configuration for local blockchain node
 const anvilLocalNodeOptions = {

--- a/tests/smoke/accounts/reveal-secret-recovery-phrase.spec.ts
+++ b/tests/smoke/accounts/reveal-secret-recovery-phrase.spec.ts
@@ -6,7 +6,7 @@ import SecurityAndPrivacy from '../../../e2e/pages/Settings/SecurityAndPrivacy/S
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import Assertions from '../../framework/Assertions';
-import { completeSrpQuiz } from '../../../e2e/specs/multisrp/utils';
+import { completeSrpQuiz } from '../../flows/accounts.flow.ts';
 import { defaultGanacheOptions } from '../../framework/Constants';
 
 describe(SmokeAccounts('Secret Recovery Phrase Reveal from Settings'), () => {

--- a/tests/smoke/accounts/wallet-details.spec.ts
+++ b/tests/smoke/accounts/wallet-details.spec.ts
@@ -4,7 +4,7 @@ import Assertions from '../../framework/Assertions';
 import WalletView from '../../../e2e/pages/wallet/WalletView';
 import AccountDetails from '../../../e2e/pages/MultichainAccounts/AccountDetails';
 import WalletDetails from '../../../e2e/pages/MultichainAccounts/WalletDetails';
-import { completeSrpQuiz } from '../../../e2e/specs/multisrp/utils';
+import { completeSrpQuiz } from '../../flows/accounts.flow.ts';
 import { defaultGanacheOptions } from '../../framework/Constants';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';

--- a/tests/smoke/assets/defi/view-defi-details.spec.ts
+++ b/tests/smoke/assets/defi/view-defi-details.spec.ts
@@ -1,12 +1,12 @@
-import { SmokeNetworkAbstractions } from '../../../tags';
-import WalletView from '../../../pages/wallet/WalletView';
-import Assertions from '../../../../tests/framework/Assertions';
-import { withFixtures } from '../../../../tests/framework/fixtures/FixtureHelper';
-import FixtureBuilder from '../../../../tests/framework/fixtures/FixtureBuilder';
-import { loginToApp } from '../../../viewHelper';
+import { SmokeNetworkAbstractions } from '../../../../e2e/tags';
+import WalletView from '../../../../e2e/pages/wallet/WalletView';
+import Assertions from '../../../framework/Assertions';
+import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
+import { loginToApp } from '../../../../e2e/viewHelper';
 import { Mockttp } from 'mockttp';
-import { setupMockRequest } from '../../../../tests/api-mocking/helpers/mockHelpers';
-import { defiPositionsWithData } from '../../../../tests/api-mocking/mock-responses/defi-api-mocks';
+import { setupMockRequest } from '../../../api-mocking/helpers/mockHelpers';
+import { defiPositionsWithData } from '../../../api-mocking/mock-responses/defi-api-mocks';
 
 describe(SmokeNetworkAbstractions('View DeFi details'), () => {
   it('open the Aave V3 position details', async () => {

--- a/tests/smoke/multisrp/add-account.spec.ts
+++ b/tests/smoke/multisrp/add-account.spec.ts
@@ -1,15 +1,15 @@
-import { SmokeWalletPlatform } from '../../tags';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import WalletView from '../../pages/wallet/WalletView';
-import { loginToApp } from '../../viewHelper';
-import Assertions from '../../../tests/framework/Assertions';
-import AccountListBottomSheet from '../../pages/wallet/AccountListBottomSheet';
-import AddAccountBottomSheet from '../../pages/wallet/AddAccountBottomSheet';
-import SRPListItemComponent from '../../pages/wallet/MultiSrp/Common/SRPListItemComponent';
-import AddNewHdAccountComponent from '../../pages/wallet/MultiSrp/AddAccountToSrp/AddNewHdAccountComponent';
-import { setupRemoteFeatureFlagsMock } from '../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../../tests/api-mocking/mock-responses/feature-flags-mocks';
+import { SmokeWalletPlatform } from '../../../e2e/tags';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.ts';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.ts';
+import WalletView from '../../../e2e/pages/wallet/WalletView.ts';
+import { loginToApp } from '../../../e2e/viewHelper.ts';
+import Assertions from '../../framework/Assertions.ts';
+import AccountListBottomSheet from '../../../e2e/pages/wallet/AccountListBottomSheet.ts';
+import AddAccountBottomSheet from '../../../e2e/pages/wallet/AddAccountBottomSheet.ts';
+import SRPListItemComponent from '../../../e2e/pages/wallet/MultiSrp/Common/SRPListItemComponent.ts';
+import AddNewHdAccountComponent from '../../../e2e/pages/wallet/MultiSrp/AddAccountToSrp/AddNewHdAccountComponent.ts';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper.ts';
+import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../api-mocking/mock-responses/feature-flags-mocks.ts';
 
 const SRP_1 = {
   index: 1,

--- a/tests/smoke/multisrp/export-srp-from-account-actions.spec.ts
+++ b/tests/smoke/multisrp/export-srp-from-account-actions.spec.ts
@@ -1,11 +1,14 @@
-import { SmokeWalletPlatform } from '../../tags';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { loginToApp } from '../../viewHelper';
-import { goToAccountActions, completeSrpQuiz } from './utils';
-import { defaultOptions } from '../../../tests/seeder/anvil-manager';
-import { setupRemoteFeatureFlagsMock } from '../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../../tests/api-mocking/mock-responses/feature-flags-mocks';
+import { SmokeWalletPlatform } from '../../../e2e/tags';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.ts';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.ts';
+import { loginToApp } from '../../../e2e/viewHelper.ts';
+import {
+  goToAccountActions,
+  completeSrpQuiz,
+} from '../../flows/accounts.flow.ts';
+import { defaultOptions } from '../../seeder/anvil-manager.ts';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper.ts';
+import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../api-mocking/mock-responses/feature-flags-mocks.ts';
 
 const FIRST_DEFAULT_HD_KEYRING_ACCOUNT = 0;
 const FIRST_IMPORTED_HD_KEYRING_ACCOUNT = 2;

--- a/tests/smoke/multisrp/export-srp-from-settings.spec.ts
+++ b/tests/smoke/multisrp/export-srp-from-settings.spec.ts
@@ -1,9 +1,12 @@
-import { SmokeWalletPlatform } from '../../tags';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { loginToApp } from '../../viewHelper';
-import { startExportForKeyring, completeSrpQuiz } from './utils';
-import { defaultOptions } from '../../../tests/seeder/anvil-manager';
+import { SmokeWalletPlatform } from '../../../e2e/tags';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.ts';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.ts';
+import { loginToApp } from '../../../e2e/viewHelper.ts';
+import {
+  startExportForKeyring,
+  completeSrpQuiz,
+} from '../../flows/accounts.flow.ts';
+import { defaultOptions } from '../../seeder/anvil-manager.ts';
 
 const SRP_1 = {
   index: 1,

--- a/tests/smoke/ramps/offramp-token-amount.spec.ts
+++ b/tests/smoke/ramps/offramp-token-amount.spec.ts
@@ -1,18 +1,15 @@
-import { loginToApp } from '../../viewHelper';
-import WalletView from '../../pages/wallet/WalletView';
-import FundActionMenu from '../../pages/UI/FundActionMenu';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { SmokeRamps } from '../../tags';
-import { CustomNetworks } from '../../../tests/resources/networks.e2e';
-import BuildQuoteView from '../../pages/Ramps/BuildQuoteView';
-import Assertions from '../../../tests/framework/Assertions';
-import {
-  RampsRegions,
-  RampsRegionsEnum,
-} from '../../../tests/framework/Constants';
+import { loginToApp } from '../../../e2e/viewHelper.ts';
+import WalletView from '../../../e2e/pages/wallet/WalletView.ts';
+import FundActionMenu from '../../../e2e/pages/UI/FundActionMenu.ts';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.ts';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.ts';
+import { SmokeRamps } from '../../../e2e/tags';
+import { CustomNetworks } from '../../resources/networks.e2e';
+import BuildQuoteView from '../../../e2e/pages/Ramps/BuildQuoteView.ts';
+import Assertions from '../../framework/Assertions.ts';
+import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants.ts';
 import { Mockttp } from 'mockttp';
-import { setupRegionAwareOnRampMocks } from '../../../tests/api-mocking/mock-responses/ramps/ramps-region-aware-mock-setup';
+import { setupRegionAwareOnRampMocks } from '../../api-mocking/mock-responses/ramps/ramps-region-aware-mock-setup.ts';
 
 describe(SmokeRamps('Off-ramp token amounts'), () => {
   beforeEach(async () => {

--- a/tests/smoke/stake/stake-action-smoke.spec.ts
+++ b/tests/smoke/stake/stake-action-smoke.spec.ts
@@ -1,17 +1,17 @@
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { LocalNode, LocalNodeType } from '../../../tests/framework/types';
-import { loginToApp } from '../../viewHelper';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
-import ActivitiesView from '../../pages/Transactions/ActivitiesView';
-import { ActivitiesViewSelectorsText } from '../../../app/components/Views/ActivityView/ActivitiesView.testIds';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import WalletView from '../../pages/wallet/WalletView';
-import NetworkListModal from '../../pages/Network/NetworkListModal';
-import { SmokeTrade } from '../../tags';
-import Assertions from '../../../tests/framework/Assertions';
-import StakeView from '../../pages/Stake/StakeView';
-import { AnvilPort } from '../../../tests/framework/fixtures/FixtureUtils';
-import { AnvilManager } from '../../../tests/seeder/anvil-manager';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.ts';
+import { LocalNode, LocalNodeType } from '../../framework/types.ts';
+import { loginToApp } from '../../../e2e/viewHelper.ts';
+import TabBarComponent from '../../../e2e/pages/wallet/TabBarComponent.ts';
+import ActivitiesView from '../../../e2e/pages/Transactions/ActivitiesView.ts';
+import { ActivitiesViewSelectorsText } from '../../../app/components/Views/ActivityView/ActivitiesView.testIds.ts';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.ts';
+import WalletView from '../../../e2e/pages/wallet/WalletView.ts';
+import NetworkListModal from '../../../e2e/pages/Network/NetworkListModal.ts';
+import { SmokeTrade } from '../../../e2e/tags';
+import Assertions from '../../framework/Assertions.ts';
+import StakeView from '../../../e2e/pages/Stake/StakeView.ts';
+import { AnvilPort } from '../../framework/fixtures/FixtureUtils.ts';
+import { AnvilManager } from '../../seeder/anvil-manager.ts';
 
 describe(SmokeTrade('Stake from Actions'), (): void => {
   const FIRST_ROW: number = 0;

--- a/tests/smoke/wallet/import-srp.spec.ts
+++ b/tests/smoke/wallet/import-srp.spec.ts
@@ -5,7 +5,7 @@ import WalletView from '../../../e2e/pages/wallet/WalletView';
 import { loginToApp } from '../../../e2e/viewHelper';
 import Assertions from '../../framework/Assertions';
 import ImportSrpView from '../../../e2e/pages/importSrp/ImportSrpView';
-import { goToImportSrp, inputSrp } from '../../../e2e/specs/multisrp/utils';
+import { goToImportSrp, inputSrp } from '../../flows/accounts.flow.ts';
 import { IDENTITY_TEAM_SEED_PHRASE } from '../../../e2e/specs/identity/utils/constants';
 
 // We now have account indexes "per wallets", thus the new account for that new SRP (wallet), will


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Following https://github.com/MetaMask/metamask-mobile/pull/24313 we're looking to centralize all tools and test resources in one place.
This PR moves spec files for `Assets`, `MultiSRP`, `Swap` and `Ramps` to `/tests`.

Previous related PRs:
- https://github.com/MetaMask/metamask-mobile/pull/24988
- https://github.com/MetaMask/metamask-mobile/pull/24313
- https://github.com/MetaMask/metamask-mobile/pull/25031
- https://github.com/MetaMask/metamask-mobile/pull/25095
- https://github.com/MetaMask/metamask-mobile/pull/25167
- https://github.com/MetaMask/metamask-mobile/pull/25198
- https://github.com/MetaMask/metamask-mobile/pull/25219
- https://github.com/MetaMask/metamask-mobile/pull/25263


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Test-only refactor, but it touches many specs and import paths; the main risk is broken CI/test execution due to module resolution or path mismatches.
> 
> **Overview**
> **Moves and rewires test specs** to run from `tests/` (notably Assets, Ramps, and Multi-SRP-related coverage), updating imports to consistently reference shared `e2e` page objects, tags, and `tests` fixtures/mocking utilities.
> 
> **Centralizes SRP/account helpers** by switching various specs from local `multisrp/utils` helpers to `tests/flows/accounts.flow.ts` (`goToImportSrp`, `inputSrp`, `completeSrpQuiz`, etc.), and adjusts `accounts.flow.ts` itself to import UI page objects from `e2e/pages` and framework utilities from `tests/framework`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95ebe1fd6e16aed1bb0732c257b8b628b3667585. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->