### PR TITLE
feat: MUSD-252 added "terms apply" link to musd conversion education screen + navbar tooltip

### DIFF
--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.styles.ts
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.styles.ts
@@ -36,4 +36,7 @@ export const styleSheet = (_params: { theme: Theme }) =>
       gap: 8,
       marginBottom: 16,
     },
+    termsText: {
+      textDecorationLine: 'underline',
+    },
   });

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, waitFor, act } from '@testing-library/react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useDispatch } from 'react-redux';
 import { Hex } from '@metamask/utils';
+import { Linking } from 'react-native';
 import EarnMusdConversionEducationView from './index';
 import {
   setMusdConversionEducationSeen,
@@ -14,6 +15,7 @@ import { strings } from '../../../../../../locales/i18n';
 import { useMusdConversion } from '../../hooks/useMusdConversion';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { MUSD_CONVERSION_APY } from '../../constants/musd';
+import AppConstants from '../../../../../core/AppConstants';
 
 const FIXED_NOW_MS = 1730000000000;
 const mockTrackEvent = jest.fn();
@@ -160,6 +162,13 @@ describe('EarnMusdConversionEducationView', () => {
         { state: {} },
       );
 
+      const descriptionText = strings(
+        'earn.musd_conversion.education.description',
+        {
+          percentage: MUSD_CONVERSION_APY,
+        },
+      );
+
       expect(
         getByText(
           strings('earn.musd_conversion.education.heading', {
@@ -167,12 +176,9 @@ describe('EarnMusdConversionEducationView', () => {
           }),
         ),
       ).toBeOnTheScreen();
+      expect(getByText(descriptionText, { exact: false })).toBeOnTheScreen();
       expect(
-        getByText(
-          strings('earn.musd_conversion.education.description', {
-            percentage: MUSD_CONVERSION_APY,
-          }),
-        ),
+        getByText(strings('earn.musd_conversion.education.terms_apply')),
       ).toBeOnTheScreen();
       expect(
         getByText(strings('earn.musd_conversion.education.primary_button')),
@@ -180,6 +186,28 @@ describe('EarnMusdConversionEducationView', () => {
       expect(
         getByText(strings('earn.musd_conversion.education.secondary_button')),
       ).toBeOnTheScreen();
+    });
+  });
+
+  describe('external links', () => {
+    it('opens bonus terms of use when "Terms apply" is pressed', () => {
+      const openUrlSpy = jest
+        .spyOn(Linking, 'openURL')
+        .mockResolvedValueOnce(undefined);
+
+      const { getByText } = renderWithProvider(
+        <EarnMusdConversionEducationView />,
+        { state: {} },
+      );
+
+      fireEvent.press(
+        getByText(strings('earn.musd_conversion.education.terms_apply')),
+      );
+
+      expect(openUrlSpy).toHaveBeenCalledTimes(1);
+      expect(openUrlSpy).toHaveBeenCalledWith(
+        AppConstants.URLS.MUSD_CONVERSION_BONUS_TERMS_OF_USE,
+      );
     });
   });
 

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Hex } from '@metamask/utils';
 import { useDispatch } from 'react-redux';
-import { View, Image, useColorScheme } from 'react-native';
+import { View, Image, useColorScheme, Linking } from 'react-native';
 import { setMusdConversionEducationSeen } from '../../../../../actions/user';
 import Logger from '../../../../../util/Logger';
 import Text, {
@@ -28,6 +28,7 @@ import { strings } from '../../../../../../locales/i18n';
 import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
 import { MUSD_EVENTS_CONSTANTS } from '../../constants/events';
 import { MUSD_CONVERSION_APY } from '../../constants/musd';
+import AppConstants from '../../../../../core/AppConstants';
 interface EarnMusdConversionEducationViewRouteParams {
   /**
    * The payment token to preselect in the confirmation screen
@@ -176,6 +177,10 @@ const EarnMusdConversionEducationView = () => {
     }
   };
 
+  const handleTermsOfUsePressed = () => {
+    Linking.openURL(AppConstants.URLS.MUSD_CONVERSION_BONUS_TERMS_OF_USE);
+  };
+
   return (
     // Do not remove the top edge as this screen does not have a navbar set in the route options.
     <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
@@ -188,7 +193,14 @@ const EarnMusdConversionEducationView = () => {
         <Text variant={TextVariant.BodyMD} style={styles.bodyText}>
           {strings('earn.musd_conversion.education.description', {
             percentage: MUSD_CONVERSION_APY,
-          })}
+          })}{' '}
+          <Text
+            variant={TextVariant.BodyMD}
+            style={styles.termsText}
+            onPress={handleTermsOfUsePressed}
+          >
+            {strings('earn.musd_conversion.education.terms_apply')}
+          </Text>
         </Text>
       </View>
       <View style={styles.imageContainer}>

--- a/app/components/UI/Earn/hooks/useMusdConversionNavbar.test.tsx
+++ b/app/components/UI/Earn/hooks/useMusdConversionNavbar.test.tsx
@@ -34,6 +34,10 @@ describe('useMusdConversionNavbar', () => {
     });
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('calls useNavbar with correct title and addBackButton parameters', () => {
     renderHook(() => useMusdConversionNavbar());
 

--- a/app/components/UI/Earn/hooks/useMusdConversionNavbar.test.tsx
+++ b/app/components/UI/Earn/hooks/useMusdConversionNavbar.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { renderHook } from '@testing-library/react-hooks';
+import { Linking } from 'react-native';
 import { useMusdConversionNavbar } from './useMusdConversionNavbar';
 import useNavbar from '../../../Views/confirmations/hooks/ui/useNavbar';
 import { strings } from '../../../../../locales/i18n';
 import { NavbarOverrides } from '../../../Views/confirmations/components/UI/navbar/navbar';
 import useTooltipModal from '../../../hooks/useTooltipModal';
 import { MUSD_CONVERSION_APY } from '../constants/musd';
+import AppConstants from '../../../../core/AppConstants';
 
 jest.mock('../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => key),
@@ -145,9 +147,38 @@ describe('useMusdConversionNavbar', () => {
     expect(mockOpenTooltipModal).toHaveBeenCalledTimes(1);
     expect(mockOpenTooltipModal).toHaveBeenCalledWith(
       'earn.musd_conversion.convert_and_get_percentage_bonus',
-      'earn.musd_conversion.education.description',
+      expect.any(Object),
       'earn.musd_conversion.powered_by_relay',
       'earn.musd_conversion.ok',
+    );
+  });
+
+  it('opens bonus terms of use when "Terms apply" is pressed in tooltip content', () => {
+    const openUrlSpy = jest
+      .spyOn(Linking, 'openURL')
+      .mockResolvedValueOnce(undefined);
+
+    let capturedOverrides: NavbarOverrides | undefined;
+    mockUseNavbar.mockImplementation((_title, _addBackButton, overrides) => {
+      capturedOverrides = overrides;
+    });
+
+    renderHook(() => useMusdConversionNavbar());
+
+    const HeaderRight = capturedOverrides?.headerRight as React.FC;
+    const { getByTestId } = render(<HeaderRight />);
+
+    fireEvent.press(getByTestId('button-icon'));
+
+    const tooltipBody = mockOpenTooltipModal.mock
+      .calls[0][1] as React.ReactElement;
+    const { getByText } = render(tooltipBody);
+
+    fireEvent.press(getByText('earn.musd_conversion.education.terms_apply'));
+
+    expect(openUrlSpy).toHaveBeenCalledTimes(1);
+    expect(openUrlSpy).toHaveBeenCalledWith(
+      AppConstants.URLS.MUSD_CONVERSION_BONUS_TERMS_OF_USE,
     );
   });
 });

--- a/app/components/UI/Earn/hooks/useMusdConversionNavbar.tsx
+++ b/app/components/UI/Earn/hooks/useMusdConversionNavbar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Linking } from 'react-native';
 import Text, {
   TextVariant,
 } from '../../../../component-library/components/Texts/Text';
@@ -13,6 +13,7 @@ import {
 } from '@metamask/design-system-react-native';
 import useNavbar from '../../../Views/confirmations/hooks/ui/useNavbar';
 import useTooltipModal from '../../../hooks/useTooltipModal';
+import AppConstants from '../../../../core/AppConstants';
 
 const styles = StyleSheet.create({
   headerTitle: {
@@ -24,6 +25,9 @@ const styles = StyleSheet.create({
   },
   headerRight: {
     marginRight: 16,
+  },
+  termsText: {
+    textDecorationLine: 'underline',
   },
 });
 
@@ -62,14 +66,25 @@ export function useMusdConversionNavbar() {
     [],
   );
 
+  const handleTermsOfUsePressed = () => {
+    Linking.openURL(AppConstants.URLS.MUSD_CONVERSION_BONUS_TERMS_OF_USE);
+  };
+
   const onInfoPress = useCallback(() => {
     openTooltipModal(
       strings('earn.musd_conversion.convert_and_get_percentage_bonus', {
         percentage: MUSD_CONVERSION_APY,
       }),
-      strings('earn.musd_conversion.education.description', {
-        percentage: MUSD_CONVERSION_APY,
-      }),
+      <Text variant={TextVariant.BodyMD}>
+        {strings('earn.musd_conversion.education.description', {
+          percentage: MUSD_CONVERSION_APY,
+        })}{' '}
+        <Text variant={TextVariant.BodyMD}>
+          <Text onPress={handleTermsOfUsePressed} style={styles.termsText}>
+            {strings('earn.musd_conversion.education.terms_apply')}
+          </Text>
+        </Text>
+      </Text>,
       strings('earn.musd_conversion.powered_by_relay'),
       strings('earn.musd_conversion.ok'),
     );

--- a/app/core/AppConstants.ts
+++ b/app/core/AppConstants.ts
@@ -164,6 +164,8 @@ export default {
     PRIVACY_NOTICE: 'https://consensys.io/privacy-notice',
     MULTICHAIN_ACCOUNTS:
       'https://support.metamask.io/configure/accounts/multichain-accounts/',
+    MUSD_CONVERSION_BONUS_TERMS_OF_USE:
+      'https://metamask.io/musd-bonus-terms-of-use',
   },
   DECODING_API_URL:
     process.env.DECODING_API_URL ||

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5764,7 +5764,8 @@
       },
       "education": {
         "heading": "GET {{percentage}}% ON\nSTABLECOINS",
-        "description": "Convert your stablecoins to mUSD, MetaMask’s US dollar-backed stablecoin, and receive up to a {{percentage}}% bonus. Terms apply.",
+        "description": "Convert your stablecoins to mUSD, MetaMask’s US dollar-backed stablecoin, and receive up to a {{percentage}}% bonus.",
+        "terms_apply": "Terms apply.",
         "primary_button": "Get Started",
         "secondary_button": "Not now"
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Added clickable "terms apply" link to the mUSD conversion education screen and navbar tooltip on conversion input screen.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added "terms apply" clickable link to mUSD conversion education screen and navbar tooltip

## **Related issues**

Fixes: [MUSD-252: Add marketing "terms apply" URL to conversion screens](https://consensyssoftware.atlassian.net/browse/MUSD-252)

## **Manual testing steps**

```gherkin
Feature: mUSD conversion terms link

  Scenario: user opens terms from the mUSD conversion education screen
    Given user is viewing the mUSD conversion education screen

    When user taps "Terms apply."
    Then the in-app browser opens the "mUSD bonus terms of use" page

  Scenario: user opens terms from the mUSD conversion navbar tooltip
    Given user is in the mUSD conversion flow
    And the user opens the conversion info tooltip

    When user taps "Terms apply."
    Then the in-app browser opens the "mUSD bonus terms of use" page
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/c9daddc0-5b4a-4bbe-995e-a59e2d228801

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a tappable terms link across mUSD conversion surfaces.
> 
> - Adds clickable `terms_apply` link in `EarnMusdConversionEducationView` and the navbar tooltip (`useMusdConversionNavbar`); opens `AppConstants.URLS.MUSD_CONVERSION_BONUS_TERMS_OF_USE` via `Linking.openURL`.
> - Introduces `MUSD_CONVERSION_BONUS_TERMS_OF_USE` in `AppConstants` and underlined `termsText` style.
> - Updates i18n: moves "Terms apply." to `earn.musd_conversion.education.terms_apply` and removes it from `education.description`.
> - Tests updated/added to verify UI presence and external link behavior for both the screen and tooltip.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32d5c89bd85e19b6464715deb6449d0adbbd6f16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->