### PR TITLE
fix: standardize fiat value decimal places in asset picker

### DIFF
--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
@@ -22,7 +22,7 @@ import { selectTokenSortConfig } from '../../../../../selectors/preferencesContr
 import { selectAccountTokensAcrossChainsForAddress } from '../../../../../selectors/multichain/evm';
 import { BridgeToken } from '../../types';
 import { RootState } from '../../../../../reducers';
-import { renderNumber, renderFiat } from '../../../../../util/number';
+import { renderNumber, addCurrencySymbol } from '../../../../../util/number';
 import { formatUnits } from 'ethers/lib/utils';
 import { BigNumber } from 'ethers';
 import { selectAccountsByChainId } from '../../../../../selectors/accountTrackerController';
@@ -229,7 +229,7 @@ export const useTokensWithBalance: ({
         const chainId = token.chainId as Hex | CaipChainId;
 
         const evmBalanceFiat = evmBalances?.[i]?.balanceFiat;
-        const nonEvmBalanceFiat = renderFiat(
+        const nonEvmBalanceFiat = addCurrencySymbol(
           Number(token.balanceFiat ?? 0),
           currentCurrency,
         );

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
@@ -22,7 +22,8 @@ import { selectTokenSortConfig } from '../../../../../selectors/preferencesContr
 import { selectAccountTokensAcrossChainsForAddress } from '../../../../../selectors/multichain/evm';
 import { BridgeToken } from '../../types';
 import { RootState } from '../../../../../reducers';
-import { renderNumber, addCurrencySymbol } from '../../../../../util/number';
+import { renderNumber } from '../../../../../util/number';
+import { formatCurrency } from '../../utils/currencyUtils';
 import { formatUnits } from 'ethers/lib/utils';
 import { BigNumber } from 'ethers';
 import { selectAccountsByChainId } from '../../../../../selectors/accountTrackerController';
@@ -228,14 +229,15 @@ export const useTokensWithBalance: ({
         const nonEvmBalance = renderNumber(token.balance ?? '0');
         const chainId = token.chainId as Hex | CaipChainId;
 
-        const evmBalanceFiat = evmBalances?.[i]?.balanceFiat;
-        const nonEvmBalanceFiat = addCurrencySymbol(
-          Number(token.balanceFiat ?? 0),
-          currentCurrency,
-        );
-
         const evmTokenFiatAmount = evmBalances?.[i]?.tokenFiatAmount;
         const nonEvmTokenFiatAmount = Number(token.balanceFiat);
+        const tokenFiatAmount = evmTokenFiatAmount ?? nonEvmTokenFiatAmount;
+
+        // Use formatCurrency for consistent decimal formatting across all currencies
+        const balanceFiat = formatCurrency(
+          tokenFiatAmount ?? 0,
+          currentCurrency,
+        );
 
         return {
           address: token.address,
@@ -248,9 +250,9 @@ export const useTokensWithBalance: ({
               formatAddressToAssetId(token.address, chainId),
               isNonEvmChainId(chainId),
             ) || token.image,
-          tokenFiatAmount: evmTokenFiatAmount ?? nonEvmTokenFiatAmount,
+          tokenFiatAmount,
           balance: evmBalance ?? nonEvmBalance,
-          balanceFiat: evmBalanceFiat ?? nonEvmBalanceFiat,
+          balanceFiat,
           accountType: token.accountType,
         };
       });

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
@@ -23,7 +23,8 @@ import { selectAccountTokensAcrossChainsForAddress } from '../../../../../select
 import { BridgeToken } from '../../types';
 import { RootState } from '../../../../../reducers';
 import { renderNumber } from '../../../../../util/number';
-import { formatCurrency } from '../../utils/currencyUtils';
+import { formatWithThreshold } from '../../../../../util/assets';
+import I18n from '../../../../../../locales/i18n';
 import { formatUnits } from 'ethers/lib/utils';
 import { BigNumber } from 'ethers';
 import { selectAccountsByChainId } from '../../../../../selectors/accountTrackerController';
@@ -233,10 +234,16 @@ export const useTokensWithBalance: ({
         const nonEvmTokenFiatAmount = Number(token.balanceFiat);
         const tokenFiatAmount = evmTokenFiatAmount ?? nonEvmTokenFiatAmount;
 
-        // Use formatCurrency for consistent decimal formatting across all currencies
-        const balanceFiat = formatCurrency(
+        // Use formatWithThreshold for consistent decimal formatting across all currencies
+        // Matches the formatting used by the main asset list (assets-list.ts)
+        const balanceFiat = formatWithThreshold(
           tokenFiatAmount ?? 0,
-          currentCurrency,
+          0.01,
+          I18n.locale,
+          {
+            style: 'currency',
+            currency: currentCurrency,
+          },
         );
 
         return {

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/useTokensWithBalance.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/useTokensWithBalance.test.ts
@@ -48,7 +48,7 @@ describe('useTokensWithBalance', () => {
         decimals: 18,
         chainId: mockChainId,
         balance: '3.0',
-        balanceFiat: '$6000',
+        balanceFiat: '$6,000.00',
         tokenFiatAmount: 6000,
       });
     });
@@ -76,13 +76,13 @@ describe('useTokensWithBalance', () => {
 
       expect(token1).toMatchObject({
         balance: '1.0',
-        balanceFiat: '$20000',
+        balanceFiat: '$20,000.00',
         tokenFiatAmount: 20000,
       });
 
       expect(token2).toMatchObject({
         balance: '2.0',
-        balanceFiat: '$200000',
+        balanceFiat: '$200,000.00',
         tokenFiatAmount: 200000,
       });
 
@@ -97,7 +97,7 @@ describe('useTokensWithBalance', () => {
         symbol: 'ETH',
         chainId: optimismChainId,
         balance: '20.0',
-        balanceFiat: '$40000',
+        balanceFiat: '$40,000.00',
         tokenFiatAmount: 40000,
       });
 
@@ -108,7 +108,7 @@ describe('useTokensWithBalance', () => {
         name: 'Foo Token',
         chainId: optimismChainId,
         balance: '5.0',
-        balanceFiat: '$80000',
+        balanceFiat: '$80,000.00',
         tokenFiatAmount: 80000,
       });
     });
@@ -190,10 +190,10 @@ describe('useTokensWithBalance', () => {
 
     await waitFor(() => {
       const token1 = result.current.find((t) => t.address === token1Address);
-      expect(token1?.balanceFiat).toBe('$0');
+      expect(token1?.balanceFiat).toBe('$0.00');
 
       const token3 = result.current.find((t) => t.address === token3Address);
-      expect(token3?.balanceFiat).toBe('$0');
+      expect(token3?.balanceFiat).toBe('$0.00');
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an issue where the non EVM tokens with zero balance did not show decimal places but the EVM ones showed 2. Now all tokens will show 2 decimal places with zero balance. Also tested on other non USD currencies and it looks good.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Swaps Non EVM tokens with zero balance now show 2 decimal places just like the EVM ones 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3900

## **Manual testing steps**

```gherkin
Feature: Align zero balance token display

  Scenario: user is looking at swaps tokens
    Given user is on the swaps token picker

    When user is looking at swaps tokens
    Then zero balance tokens always show 0.00
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="429" height="860" alt="Screenshot 2026-01-28 at 2 05 08 PM" src="https://github.com/user-attachments/assets/1e4bb8d2-5718-4598-8d16-69581370c580" />
<img width="428" height="858" alt="Screenshot 2026-01-28 at 2 05 20 PM" src="https://github.com/user-attachments/assets/a90d9476-4929-4220-b93b-f94efe019a2b" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes how fiat values are formatted for display in `useTokensWithBalance`, plus corresponding test expectation updates.
> 
> **Overview**
> Standardizes `balanceFiat` formatting in the Bridge token picker by deriving it from `tokenFiatAmount` and formatting via `formatWithThreshold` (locale-aware currency formatting with a 0.01 threshold), replacing the previous mix of `renderFiat`/preformatted values.
> 
> Updates `useTokensWithBalance` tests to match the new output (thousands separators and fixed 2-decimal currency formatting, including `$0.00` for very small values).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a71b40dd733a56cf1272e3135caa27e91814a6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->