### PR TITLE
fix: adjust asset details cta text copy

### DIFF
--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.test.tsx
@@ -125,11 +125,12 @@ describe('MusdConversionAssetOverviewCta', () => {
         { state: initialRootState },
       );
 
-      expect(getByText('Boost your stablecoin balance')).toBeOnTheScreen();
+      expect(getByText('Get 3% on your stablecoins')).toBeOnTheScreen();
       expect(
-        getByText(/Earn a bonus every time you convert stablecoins to/),
+        getByText(
+          /Convert your stablecoins to mUSD and receive up to a 3% bonus\./,
+        ),
       ).toBeOnTheScreen();
-      expect(getByText('mUSD')).toBeOnTheScreen();
     });
 
     it('renders close button when onDismiss is provided', () => {
@@ -382,14 +383,16 @@ describe('MusdConversionAssetOverviewCta', () => {
 
       const asset = createMockToken();
 
-      const { getByText } = renderWithProvider(
+      const { getByTestId } = renderWithProvider(
         <MusdConversionAssetOverviewCta asset={asset} />,
         { state: initialRootState },
       );
 
       // Act
       await act(async () => {
-        fireEvent.press(getByText('mUSD'));
+        fireEvent.press(
+          getByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
+        );
       });
 
       // Assert
@@ -425,14 +428,16 @@ describe('MusdConversionAssetOverviewCta', () => {
 
       const asset = createMockToken();
 
-      const { getByText } = renderWithProvider(
+      const { getByTestId } = renderWithProvider(
         <MusdConversionAssetOverviewCta asset={asset} />,
         { state: initialRootState },
       );
 
       // Act
       await act(async () => {
-        fireEvent.press(getByText('mUSD'));
+        fireEvent.press(
+          getByTestId(EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA),
+        );
       });
 
       // Assert

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.test.tsx
@@ -21,6 +21,7 @@ import { useMetrics, MetaMetricsEvents } from '../../../../../hooks/useMetrics';
 import { useNetworkName } from '../../../../../Views/confirmations/hooks/useNetworkName';
 import { MUSD_EVENTS_CONSTANTS } from '../../../constants/events';
 import { strings } from '../../../../../../../locales/i18n';
+import { MUSD_CONVERSION_APY } from '../../../constants/musd';
 
 const createMockToken = (overrides: Partial<TokenI> = {}): TokenI => ({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
@@ -125,10 +126,12 @@ describe('MusdConversionAssetOverviewCta', () => {
         { state: initialRootState },
       );
 
-      expect(getByText('Get 3% on your stablecoins')).toBeOnTheScreen();
+      expect(
+        getByText(`Get ${MUSD_CONVERSION_APY}% on your stablecoins`),
+      ).toBeOnTheScreen();
       expect(
         getByText(
-          /Convert your stablecoins to mUSD and receive up to a 3% bonus\./,
+          `Convert your stablecoins to mUSD and receive up to a ${MUSD_CONVERSION_APY}% bonus.`,
         ),
       ).toBeOnTheScreen();
     });

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/index.tsx
@@ -108,10 +108,7 @@ const MusdConversionAssetOverviewCta = ({
           {strings('earn.musd_conversion.boost_title')}
         </Text>
         <Text variant={TextVariant.BodySMMedium} color={TextColor.Alternative}>
-          {strings('earn.musd_conversion.boost_description')}{' '}
-          <Text variant={TextVariant.BodySMMedium} color={TextColor.Primary}>
-            mUSD
-          </Text>
+          {strings('earn.musd_conversion.boost_description')}
         </Text>
       </View>
 

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/index.tsx
@@ -19,6 +19,7 @@ import Routes from '../../../../../../constants/navigation/Routes';
 import Logger from '../../../../../../util/Logger';
 import { strings } from '../../../../../../../locales/i18n';
 import { EARN_TEST_IDS } from '../../../constants/testIds';
+import { MUSD_CONVERSION_APY } from '../../../constants/musd';
 import { useMusdConversionTokens } from '../../../hooks/useMusdConversionTokens';
 import { MetaMetricsEvents, useMetrics } from '../../../../../hooks/useMetrics';
 import { MUSD_EVENTS_CONSTANTS } from '../../../constants/events';
@@ -105,10 +106,14 @@ const MusdConversionAssetOverviewCta = ({
       {/* Text content in the center */}
       <View style={styles.textContainer}>
         <Text variant={TextVariant.BodySMMedium} style={styles.title}>
-          {strings('earn.musd_conversion.boost_title')}
+          {strings('earn.musd_conversion.boost_title', {
+            percentage: MUSD_CONVERSION_APY,
+          })}
         </Text>
         <Text variant={TextVariant.BodySMMedium} color={TextColor.Alternative}>
-          {strings('earn.musd_conversion.boost_description')}
+          {strings('earn.musd_conversion.boost_description', {
+            percentage: MUSD_CONVERSION_APY,
+          })}
         </Text>
       </View>
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5780,8 +5780,8 @@
       },
       "buy_musd": "Buy mUSD",
       "get_musd": "Get mUSD",
-      "boost_title": "Boost your stablecoin balance",
-      "boost_description": "Earn a bonus every time you convert stablecoins to",
+      "boost_title": "Get 3% on your stablecoins",
+      "boost_description": "Convert your stablecoins to mUSD and receive up to a 3% bonus.",
       "powered_by_relay": "Powered by Relay"
     },
     "rewards": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5780,8 +5780,8 @@
       },
       "buy_musd": "Buy mUSD",
       "get_musd": "Get mUSD",
-      "boost_title": "Get 3% on your stablecoins",
-      "boost_description": "Convert your stablecoins to mUSD and receive up to a 3% bonus.",
+      "boost_title": "Get {{percentage}}% on your stablecoins",
+      "boost_description": "Convert your stablecoins to mUSD and receive up to a {{percentage}}% bonus.",
       "powered_by_relay": "Powered by Relay"
     },
     "rewards": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates the mUSD conversion asset overview CTA copy

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Changes the mUSD conversion asset overview CTA copy

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-251

## **Manual testing steps**

```gherkin
Feature: mUSD Conversion Asset Overview CTA

  Background:
    Given the user is on the asset overview screen
    And the mUSD conversion CTA is visible

  Scenario: CTA displays updated copy
    Then the CTA title displays "Get 3% on your stablecoins"
    And the CTA description displays "Convert your stablecoins to mUSD and receive up to a 3% bonus."
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/1345a66c-1f41-4afa-b83b-8a7e9c84f74e" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revises the mUSD conversion CTA to display the configured APY and updates related tests and translations.
> 
> - CTA now renders `boost_title` and `boost_description` with `MUSD_CONVERSION_APY` via i18n placeholders
> - Updates `en.json` strings to the new copy with `{{percentage}}` interpolation
> - Adjusts tests to assert the new copy and trigger presses via `EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA` instead of text
> - Minor imports added for `MUSD_CONVERSION_APY`; no behavioral changes to conversion flow or telemetry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68b34a946297c14ff93a05f9852c60240de90832. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->