### PR TITLE
feat: change password ui fixes

### DIFF
--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -26,7 +26,6 @@ import { fontStyles, baseStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
 import { getNavigationOptionsTitle } from '../../UI/Navbar';
 import AppConstants from '../../../core/AppConstants';
-import zxcvbn from 'zxcvbn';
 import { PREVIOUS_SCREEN } from '../../../constants/navigation';
 import {
   TRUE,
@@ -34,7 +33,6 @@ import {
   PASSCODE_DISABLED,
 } from '../../../constants/storage';
 import {
-  getPasswordStrengthWord,
   passwordRequirementsMet,
   MIN_PASSWORD_LENGTH,
 } from '../../../util/password';
@@ -257,15 +255,6 @@ const createStyles = (colors) =>
       top: 0,
       right: 0,
     },
-    strength_weak: {
-      color: colors.error.default,
-    },
-    strength_good: {
-      color: colors.primary.default,
-    },
-    strength_strong: {
-      color: colors.success.default,
-    },
     showMatchingPasswords: {
       position: 'absolute',
       top: 50,
@@ -314,6 +303,10 @@ const createStyles = (colors) =>
     },
     warningButton: {
       flex: 1,
+    },
+    errorBorder: {
+      borderColor: colors.error.default,
+      borderWidth: 1,
     },
   });
 
@@ -370,6 +363,7 @@ class ResetPassword extends PureComponent {
     ready: true,
     showPasswordIndex: [0, 1],
     showPasswordChangeWarning: false,
+    isPasswordFieldTouched: false,
   };
 
   mounted = true;
@@ -555,7 +549,7 @@ class ResetPassword extends PureComponent {
       this.props.passwordSet();
 
       // Track password changed event
-      const { biometryChoice, passwordStrength } = this.state;
+      const { biometryChoice } = this.state;
       const eventBuilder = MetricsEventBuilder.createEventBuilder(
         MetaMetricsEvents.PASSWORD_CHANGED,
       ).addProperties({
@@ -685,13 +679,18 @@ class ResetPassword extends PureComponent {
   };
 
   onPasswordChange = (val) => {
-    const passInfo = zxcvbn(val);
-
     this.setState((prevState) => ({
       password: val,
-      passwordStrength: passInfo.score,
       confirmPassword: val === '' ? '' : prevState.confirmPassword,
     }));
+  };
+
+  handlePasswordFocus = () => {
+    this.setState({ isPasswordFieldTouched: false });
+  };
+
+  handlePasswordBlur = () => {
+    this.setState({ isPasswordFieldTouched: true });
   };
 
   learnMore = () => {
@@ -718,35 +717,34 @@ class ResetPassword extends PureComponent {
 
   setConfirmPassword = (val) => this.setState({ confirmPassword: val });
 
-  // Helper method to render password strength text
-  renderPasswordStrengthText = (password, passwordStrengthWord, styles) => {
-    if (!password) return null;
+  // Method to check if password field should show error state
+  isPasswordTooShort = () => {
+    const { isPasswordFieldTouched, password } = this.state;
+    return (
+      isPasswordFieldTouched &&
+      password !== '' &&
+      password.length < MIN_PASSWORD_LENGTH
+    );
+  };
 
-    if (password.length < MIN_PASSWORD_LENGTH) {
-      return (
-        <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
-          {strings('reset_password.must_be_at_least', {
-            number: MIN_PASSWORD_LENGTH,
-          })}
-        </Text>
-      );
+  // Helper method to render password helper text
+  renderPasswordHelperText = () => {
+    // Only show helper text when password doesn't meet minimum length
+    const { password } = this.state;
+    if (password && password.length >= MIN_PASSWORD_LENGTH) {
+      return null;
     }
 
+    // Show error color only when field has been touched and password is too short
+    const showError = this.isPasswordTooShort();
     return (
       <Text
         variant={TextVariant.BodySM}
-        color={TextColor.Alternative}
-        testID={ChoosePasswordSelectorsIDs.PASSWORD_STRENGTH_ID}
+        color={showError ? TextColor.Error : TextColor.Alternative}
       >
-        {strings('reset_password.password_strength')}
-        <Text
-          variant={TextVariant.BodySM}
-          color={TextColor.Alternative}
-          style={styles[`strength_${passwordStrengthWord}`]}
-        >
-          {' '}
-          {strings(`reset_password.strength_${passwordStrengthWord}`)}
-        </Text>
+        {strings('reset_password.must_be_at_least', {
+          number: MIN_PASSWORD_LENGTH,
+        })}
       </Text>
     );
   };
@@ -907,14 +905,12 @@ class ResetPassword extends PureComponent {
   };
 
   renderResetPassword() {
-    const { isSelected, password, passwordStrength, confirmPassword, loading } =
-      this.state;
+    const { isSelected, password, confirmPassword, loading } = this.state;
     const colors = this.getThemeColors();
     const themeAppearance = this.getThemeAppearance();
     const styles = this.getStyles();
     const passwordsMatch = password !== '' && password === confirmPassword;
     const previousScreen = this.props.route.params?.[PREVIOUS_SCREEN];
-    const passwordStrengthWord = getPasswordStrengthWord(passwordStrength);
 
     const canSubmit =
       passwordsMatch && isSelected && password.length >= MIN_PASSWORD_LENGTH;
@@ -959,6 +955,8 @@ class ResetPassword extends PureComponent {
                     size={TextFieldSize.Lg}
                     value={password}
                     onChangeText={this.onPasswordChange}
+                    onFocus={this.handlePasswordFocus}
+                    onBlur={this.handlePasswordBlur}
                     secureTextEntry={this.state.showPasswordIndex.includes(0)}
                     placeholder={strings(
                       'reset_password.new_password_placeholder',
@@ -970,6 +968,10 @@ class ResetPassword extends PureComponent {
                     autoComplete="new-password"
                     autoCapitalize="none"
                     keyboardAppearance={themeAppearance}
+                    isError={this.isPasswordTooShort()}
+                    style={
+                      this.isPasswordTooShort() ? styles.errorBorder : undefined
+                    }
                     endAccessory={
                       <Icon
                         name={
@@ -986,11 +988,7 @@ class ResetPassword extends PureComponent {
                       />
                     }
                   />
-                  {this.renderPasswordStrengthText(
-                    password,
-                    passwordStrengthWord,
-                    styles,
-                  )}
+                  {this.renderPasswordHelperText()}
                 </View>
 
                 <View style={styles.field}>

--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -363,7 +363,7 @@ class ResetPassword extends PureComponent {
     ready: true,
     showPasswordIndex: [0, 1],
     showPasswordChangeWarning: false,
-    isPasswordFieldTouched: false,
+    isPasswordFieldFocused: false,
   };
 
   mounted = true;
@@ -686,11 +686,11 @@ class ResetPassword extends PureComponent {
   };
 
   handlePasswordFocus = () => {
-    this.setState({ isPasswordFieldTouched: false });
+    this.setState({ isPasswordFieldFocused: true });
   };
 
   handlePasswordBlur = () => {
-    this.setState({ isPasswordFieldTouched: true });
+    this.setState({ isPasswordFieldFocused: false });
   };
 
   learnMore = () => {
@@ -719,10 +719,10 @@ class ResetPassword extends PureComponent {
 
   // Method to check if password field should show error state
   isPasswordTooShort = () => {
-    const { isPasswordFieldTouched, password } = this.state;
+    const { isPasswordFieldFocused, password } = this.state;
     return (
-      isPasswordFieldTouched &&
-      password !== '' &&
+      !isPasswordFieldFocused &&
+      !!password &&
       password.length < MIN_PASSWORD_LENGTH
     );
   };

--- a/app/components/Views/ResetPassword/index.test.tsx
+++ b/app/components/Views/ResetPassword/index.test.tsx
@@ -494,6 +494,86 @@ describe('ResetPassword', () => {
     ).toBeOnTheScreen();
   });
 
+  it('shows error state only after password field loses focus with invalid password', async () => {
+    const component = await renderConfirmPasswordView();
+
+    const newPasswordInput = component.getByTestId(
+      ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+    );
+
+    // Type a short password
+    await act(async () => {
+      fireEvent.changeText(newPasswordInput, '1234567');
+    });
+
+    // Helper text should be visible
+    const helperText = component.getByText(
+      strings('reset_password.must_be_at_least', { number: 8 }),
+    );
+    expect(helperText).toBeOnTheScreen();
+
+    // Blur the password field to trigger error state
+    await act(async () => {
+      fireEvent(newPasswordInput, 'blur');
+    });
+
+    // After blur, helper text should still be visible
+    expect(
+      component.getByText(
+        strings('reset_password.must_be_at_least', { number: 8 }),
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('hides error state when user focuses back on password field', async () => {
+    const component = await renderConfirmPasswordView();
+
+    const newPasswordInput = component.getByTestId(
+      ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+    );
+
+    // Type a short password
+    await act(async () => {
+      fireEvent.changeText(newPasswordInput, '1234567');
+    });
+
+    // Blur to trigger error state
+    await act(async () => {
+      fireEvent(newPasswordInput, 'blur');
+    });
+
+    // Focus back on the password field
+    await act(async () => {
+      fireEvent(newPasswordInput, 'focus');
+    });
+
+    // Helper text should still be visible but error state should be reset
+    const helperText = component.getByText(
+      strings('reset_password.must_be_at_least', { number: 8 }),
+    );
+    expect(helperText).toBeOnTheScreen();
+  });
+
+  it('helper text disappears when password meets minimum length', async () => {
+    const component = await renderConfirmPasswordView();
+
+    const newPasswordInput = component.getByTestId(
+      ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+    );
+
+    // Type a password that meets minimum length
+    await act(async () => {
+      fireEvent.changeText(newPasswordInput, '12345678');
+    });
+
+    // Helper text should not be visible when password meets minimum length
+    expect(
+      component.queryByText(
+        strings('reset_password.must_be_at_least', { number: 8 }),
+      ),
+    ).toBeNull();
+  });
+
   it('password does not match, it shows an error', async () => {
     const component = await renderConfirmPasswordView();
 

--- a/package.json
+++ b/package.json
@@ -493,8 +493,7 @@
     "uuid": "^8.3.2",
     "valid-url": "1.0.9",
     "viem": "^2.28.0",
-    "vm-browserify": "1.1.2",
-    "zxcvbn": "4.4.2"
+    "vm-browserify": "1.1.2"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.71.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34937,7 +34937,6 @@ __metadata:
     webpack-cli: "npm:^5.1.4"
     xhr2: "npm:^0.2.1"
     xml2js: "npm:^0.5.0"
-    zxcvbn: "npm:4.4.2"
   dependenciesMeta:
     "@img/sharp-darwin-arm64":
       optional: true
@@ -46550,12 +46549,5 @@ __metadata:
   version: 0.1.5
   resolution: "zstd-codec@npm:0.1.5"
   checksum: 10/deee384c29129e3ed86b4f2ac4dc415fd8dad8b62b12ad07cc092c89481bee362477478c6179f2beb252bec67b57120fad8fd84f0a7f7b5914a77e24b3608094
-  languageName: node
-  linkType: hard
-
-"zxcvbn@npm:4.4.2":
-  version: 4.4.2
-  resolution: "zxcvbn@npm:4.4.2"
-  checksum: 10/00c4636f10556174858bddd67758ef1e3046d005e9890a208fa5dd9296ec69a3e93ce8300a54d84cf72deea188503d8c5aa67c515daf79da40de378786832807
   languageName: node
   linkType: hard


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* change password  screen ui fixes
   * Remove password strength check.
   * Password field error styling now shows red border and red helper text only after blur.
* Jira: https://consensyssoftware.atlassian.net/browse/TO-464

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: change password  screen ui fixes

## **Related issues**

Fixes:
* Remove password strength check.
* Password field error styling now shows red border and red helper text only after blur.

## **Manual testing steps**

```gherkin
Feature: change password  screen ui fixes

  Scenario: User sees helper text while typing password
    Given user is on the Change Password screen
    And user has entered their current password to proceed

    When user types a password with less than 8 characters
    Then user sees "Must be at least 8 characters" helper text in gray color
    And the password field does not show error styling

  Scenario: User sees error state after leaving password field with invalid password
    Given user is on the Change Password screen
    And user has typed a password with less than 8 characters

    When user moves focus to another field (blurs password field)
    Then the password field shows red border styling
    And the helper text "Must be at least 8 characters" turns red

  Scenario: User error state resets when focusing back on password field
    Given user is on the Change Password screen
    And the password field is showing error state (red border and text)

    When user taps on the password field to edit
    Then the error styling is removed
    And the helper text returns to gray color
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/3fd020cc-1634-4549-9f66-86b6cdd343ec


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the Change Password UI by removing the strength meter and introducing clearer, focus-aware validation.
> 
> - Removes `zxcvbn` and all password strength logic/UI from `ResetPassword` (including strength styles and text)
> - Adds helper text for minimum length (`must_be_at_least`) that turns red and applies a red input border only after the password field blurs; resets on focus (`isPasswordFieldTouched`, `handlePasswordFocus/Blur`, `isPasswordTooShort`, `errorBorder`)
> - Passes `isError` and conditional `style` to `TextField` for password input; keeps confirm mismatch error behavior
> - Cleans up analytics event (no passwordStrength)
> - Updates/extends tests to cover helper text visibility, blur/focus behavior, and disappearance once length is met
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc351d2c9e797df4d210f581b68f0b8e6834b601. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->