### PR TITLE
fix: don't pin selected asset if on different network

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -183,8 +183,13 @@ export const BridgeTokenSelector: React.FC = () => {
   // Selected token is prepended to pin it to the top of the list
   // Stringified to avoid triggering the useEffect when only balances change
   const includeAssets = useMemo(() => {
+    // Only include selected token if its network matches the current filter
+    const isSelectedTokenOnFilteredNetwork =
+      selectedToken &&
+      chainIdsToFetch.includes(formatChainIdToCaip(selectedToken.chainId));
+
     // Convert selected token first (will be pinned to top of list)
-    const selectedAsset = selectedToken
+    const selectedAsset = isSelectedTokenOnFilteredNetwork
       ? tokenToIncludeAsset(selectedToken)
       : null;
 
@@ -201,7 +206,7 @@ export const BridgeTokenSelector: React.FC = () => {
       : balanceAssets;
 
     return JSON.stringify(assets);
-  }, [filteredTokensWithBalance, selectedToken]);
+  }, [filteredTokensWithBalance, selectedToken, chainIdsToFetch]);
 
   // Fetch popular tokens
   const { popularTokens, isLoading: isPopularTokensLoading } = usePopularTokens(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a bug where the asset picker would pin the currently selected asset to the top of networks that didn't match the network of the selected token.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where the asset picker would pin the currently selected asset to the top of networks that didn't match the network of the selected token

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents cross-network pinning in the Bridge token selector.
> 
> - Updates `includeAssets` to include the selected token only if its `chainId` is within the current `chainIdsToFetch`, avoiding pinning on other networks
> - Adds `chainIdsToFetch` to `includeAssets` memo dependencies to keep the list in sync with network filters
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8210059b86b43f24d2297638c725739c5acc826b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->