### PR TITLE
fix: filter unclickable trending cp-7.63.0

### DIFF
--- a/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.tsx
+++ b/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.tsx
@@ -11,7 +11,6 @@ import {
   View,
   TouchableOpacity,
   RefreshControl,
-  ScrollView,
 } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useAppThemeFromContext } from '../../../../util/theme';
@@ -75,22 +74,18 @@ const createStyles = (theme: Theme) =>
       paddingHorizontal: 16,
       flexGrow: 0,
     },
-    controlBarScrollView: {
-      flexGrow: 0,
-      alignItems: 'center',
-    },
     controlButtonOuterWrapper: {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      minWidth: '100%',
     },
     controlButtonInnerWrapper: {
       flexDirection: 'row',
       gap: 8,
       alignItems: 'center',
-      flexShrink: 0,
+      flexShrink: 1,
       marginLeft: 8,
+      minWidth: 0,
     },
     controlButton: {
       paddingVertical: 8,
@@ -104,6 +99,15 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       borderRadius: 8,
       backgroundColor: theme.colors.background.muted,
+      flexShrink: 1,
+      minWidth: 0,
+    },
+    controlButtonRightFixed: {
+      padding: 8,
+      alignItems: 'center',
+      borderRadius: 8,
+      backgroundColor: theme.colors.background.muted,
+      flexShrink: 0,
     },
     controlButtonContent: {
       flexDirection: 'row',
@@ -117,6 +121,8 @@ const createStyles = (theme: Theme) =>
       fontWeight: '600',
       lineHeight: 19.6, // 140% of 14px
       fontStyle: 'normal',
+      flexShrink: 1,
+      minWidth: 0,
     },
     controlButtonDisabled: {
       opacity: 0.5,
@@ -330,12 +336,7 @@ const TrendingTokensFullView = () => {
         />
       </View>
       {!isSearchVisible ? (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={styles.controlBarScrollView}
-          style={styles.controlBarWrapper}
-        >
+        <View style={styles.controlBarWrapper}>
           <View style={styles.controlButtonOuterWrapper}>
             <TouchableOpacity
               testID="price-change-button"
@@ -366,7 +367,11 @@ const TrendingTokensFullView = () => {
                 activeOpacity={0.2}
               >
                 <View style={styles.controlButtonContent}>
-                  <Text style={styles.controlButtonText}>
+                  <Text
+                    style={styles.controlButtonText}
+                    numberOfLines={1}
+                    ellipsizeMode="tail"
+                  >
                     {selectedNetworkName}
                   </Text>
                   <Icon
@@ -380,7 +385,7 @@ const TrendingTokensFullView = () => {
                 testID="24h-button"
                 onPress={handle24hPress}
                 style={[
-                  styles.controlButtonRight,
+                  styles.controlButtonRightFixed,
                   searchQuery?.trim() && styles.controlButtonDisabled,
                 ]}
                 activeOpacity={0.2}
@@ -399,7 +404,7 @@ const TrendingTokensFullView = () => {
               </TouchableOpacity>
             </View>
           </View>
-        </ScrollView>
+        </View>
       ) : null}
 
       {isLoading ? (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Issue: After making the filters scrollable, there is a weird bug that makes the `24h` button unclickable on small font sizes.
Solution: I have removed the scrollable filters and instead added a ellipsis to the `network` filter

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix time filter not clickable on trending tokens page
 
## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2557

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/63ead594-414e-4367-9e3f-a9b6870c646a



### **After**

https://github.com/user-attachments/assets/5c88c690-13b1-4711-b5fd-5d585885c9fb



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the control bar in `TrendingTokensFullView` to improve touchability and layout.
> 
> - Replaces horizontal `ScrollView` with a static `View` for the control bar to prevent tap interception
> - Adds truncation to the network selector text (`numberOfLines=1`, tail ellipsis)
> - Adjusts layout constraints (`flexShrink`/`minWidth`) for buttons and text to avoid overlap and clipping
> - Introduces `controlButtonRightFixed` for the time filter to maintain fixed width while other controls shrink
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34d043c53f5e3b8e3e5bd04d369f8a66c5b1b83f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->