### PR TITLE
refactor: adds tooltip to Bonus claim section and changes the way bonus amount is displayed

### DIFF
--- a/app/components/UI/Earn/components/MerklRewards/MerklRewards.test.tsx
+++ b/app/components/UI/Earn/components/MerklRewards/MerklRewards.test.tsx
@@ -55,17 +55,14 @@ jest.mock('./PendingMerklRewards', () => {
   return {
     __esModule: true,
     default: ({
-      asset,
       claimableReward,
       isProcessingClaim,
     }: {
-      asset: TokenI;
       claimableReward: string | null;
       isProcessingClaim: boolean;
     }) =>
       ReactActual.createElement(View, {
         testID: 'pending-merkl-rewards',
-        'data-asset': asset.symbol,
         'data-claimable': claimableReward,
         'data-processing': isProcessingClaim,
       }),

--- a/app/components/UI/Earn/components/MerklRewards/MerklRewards.tsx
+++ b/app/components/UI/Earn/components/MerklRewards/MerklRewards.tsx
@@ -107,7 +107,6 @@ const MerklRewards: React.FC<MerklRewardsProps> = ({ asset }) => {
   return (
     <>
       <PendingMerklRewards
-        asset={asset}
         claimableReward={claimableReward}
         isProcessingClaim={isProcessingClaim}
       />

--- a/app/components/UI/Earn/components/MerklRewards/PendingMerklRewards.tsx
+++ b/app/components/UI/Earn/components/MerklRewards/PendingMerklRewards.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
-import { ActivityIndicator } from 'react-native';
+import React, { useCallback } from 'react';
+import { ActivityIndicator, Linking } from 'react-native';
 import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
+  ButtonIcon,
+  ButtonIconSize,
   Icon,
+  IconColor,
   IconName,
   IconSize,
   Text,
@@ -13,11 +16,11 @@ import {
   FontWeight,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import { TokenI } from '../../../Tokens/types';
 import { useTheme } from '../../../../../util/theme';
+import useTooltipModal from '../../../../hooks/useTooltipModal';
+import AppConstants from '../../../../../core/AppConstants';
 
 interface PendingMerklRewardsProps {
-  asset: TokenI;
   claimableReward: string | null;
   isProcessingClaim?: boolean;
 }
@@ -26,11 +29,35 @@ interface PendingMerklRewardsProps {
  * Component to display pending Merkl rewards information (annual bonus and claimable bonus)
  */
 const PendingMerklRewards: React.FC<PendingMerklRewardsProps> = ({
-  asset,
   claimableReward,
   isProcessingClaim = false,
 }) => {
   const { colors } = useTheme();
+  const { openTooltipModal } = useTooltipModal();
+
+  const handleTermsPress = useCallback(() => {
+    Linking.openURL(AppConstants.URLS.MUSD_CONVERSION_BONUS_TERMS_OF_USE);
+  }, []);
+
+  const handleInfoPress = useCallback(() => {
+    openTooltipModal(
+      strings('asset_overview.merkl_rewards.claimable_bonus'),
+      <Text variant={TextVariant.BodyMd}>
+        {strings(
+          'asset_overview.merkl_rewards.claimable_bonus_tooltip_description',
+        )}{' '}
+        <Text
+          variant={TextVariant.BodyMd}
+          onPress={handleTermsPress}
+          twClassName="underline"
+        >
+          {strings('asset_overview.merkl_rewards.terms_apply')}
+        </Text>
+      </Text>,
+      undefined,
+      strings('asset_overview.merkl_rewards.ok'),
+    );
+  }, [openTooltipModal, handleTermsPress]);
 
   // Show loading state while processing claim
   if (isProcessingClaim) {
@@ -85,13 +112,26 @@ const PendingMerklRewards: React.FC<PendingMerklRewardsProps> = ({
 
           {/* Claimable Bonus Text and Amount */}
           <Box twClassName="flex-1">
-            <Text
-              variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Medium}
-              twClassName="text-text-default mb-1"
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              twClassName="mb-1"
             >
-              {strings('asset_overview.merkl_rewards.claimable_bonus')}
-            </Text>
+              <Text
+                variant={TextVariant.BodyMd}
+                fontWeight={FontWeight.Medium}
+                twClassName="text-text-default"
+              >
+                {strings('asset_overview.merkl_rewards.claimable_bonus')}
+              </Text>
+              <ButtonIcon
+                iconName={IconName.Info}
+                size={ButtonIconSize.Sm}
+                iconProps={{ color: IconColor.IconAlternative }}
+                onPress={handleInfoPress}
+                testID="claimable-bonus-info-button"
+              />
+            </Box>
             <Text
               variant={TextVariant.BodySm}
               twClassName="text-primary-default"
@@ -108,14 +148,13 @@ const PendingMerklRewards: React.FC<PendingMerklRewardsProps> = ({
         <Box
           alignItems={BoxAlignItems.Center}
           justifyContent={BoxJustifyContent.Center}
-          twClassName="px-4 py-2 rounded-xl border border-default bg-default"
         >
           <Text
             variant={TextVariant.BodyMd}
             fontWeight={FontWeight.Medium}
             twClassName="text-text-default"
           >
-            {claimableReward} {asset.symbol}
+            ${claimableReward}
           </Text>
         </Box>
       </Box>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3305,6 +3305,9 @@
     "merkl_rewards": {
       "annual_bonus": "{{apy}}% bonus",
       "claimable_bonus": "Claimable bonus",
+      "claimable_bonus_tooltip_description": "mUSD bonuses are claimed on Linea.",
+      "terms_apply": "Terms apply.",
+      "ok": "OK",
       "claim": "Claim",
       "processing_claim": "Processing claim..."
     },


### PR DESCRIPTION
## **Description**

Implements a tooltip on the Claimable Bonus CTA to inform users that mUSD bonuses are claimed on Linea.

**Reason for change:** Users will be claiming rewards on Linea, so we need to provide clear guidance about where the claim happens.

**Solution:** Added an info icon button next to the "Claimable bonus" text that opens a tooltip modal explaining that mUSD bonuses are claimed on Linea, with a link to the terms of use.

**Changes:**
- Added `ButtonIcon` (info icon) next to "Claimable bonus" text in `PendingMerklRewards`
- Integrated `useTooltipModal` hook to display tooltip with "Terms apply" link
- Added translation strings for tooltip content
- Updated tests to cover new tooltip functionality

## **Changelog**

CHANGELOG entry: Added tooltip on Claimable Bonus section explaining that mUSD bonuses are claimed on Linea

## **Related issues**

Fixes: [MUSD-259](https://consensyssoftware.atlassian.net/browse/MUSD-259)

## **Manual testing steps**

```gherkin
Feature: Claimable Bonus Tooltip

  Scenario: User views tooltip for claimable bonus information
    Given user has mUSD with claimable bonus rewards
    And user is on the asset details screen

    When user taps the info icon next to "Claimable bonus"
    Then a tooltip modal appears with title "Claimable bonus"
    And the modal displays "mUSD bonuses are claimed on Linea. Terms apply."
    And "Terms apply." is underlined and tappable

  Scenario: User opens terms from tooltip
    Given user has opened the claimable bonus tooltip

    When user taps "Terms apply."
    Then the browser opens the mUSD bonus terms of use URL

  Scenario: User dismisses tooltip
    Given user has opened the claimable bonus tooltip

    When user taps "OK" button
    Then the tooltip modal closes
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="397" height="828" alt="Screenshot 2026-01-28 at 13 08 03" src="https://github.com/user-attachments/assets/950c2ea9-fae9-40fc-8f33-4f325b222db6" />

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/c01f1970-e1e2-44f7-be61-fa32f91b6bba


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-259]: https://consensyssoftware.atlassian.net/browse/MUSD-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds contextual guidance and updates the bonus display in the Merkl Rewards UI.
> 
> - `PendingMerklRewards`: adds info `ButtonIcon` opening a tooltip via `useTooltipModal` explaining bonuses are claimed on Linea with a tappable "Terms apply" link (opens `MUSD_CONVERSION_BONUS_TERMS_OF_USE`)
> - Changes claimable bonus amount display from `token amount + symbol` to a fiat-style `"$<amount>"`
> - Removes `asset` prop from `PendingMerklRewards`; `MerklRewards` no longer passes it
> - Updates tests to cover tooltip behavior, link opening, and new display; adds i18n strings (`claimable_bonus_tooltip_description`, `terms_apply`, `ok`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f024e896b7e5d9c400f0092bdb121ea168eafeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->