### PR TITLE
fix: disable "switch tokens" button when destination network is not enabled

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -637,11 +637,8 @@ describe('BridgeView', () => {
 
     // Button should be disabled when dest network is disabled
     expect(arrowButton.props.disabled).toBe(true);
-
-    // Pressing the button should not trigger token switch
-    fireEvent.press(arrowButton);
-    expect(setSourceToken).not.toHaveBeenCalled();
-    expect(setDestToken).not.toHaveBeenCalled();
+    // When disabled, onPress is set to undefined in FLipQuoteButton
+    expect(arrowButton.props.onPress).toBeUndefined();
   });
 
   describe('Solana Swap', () => {

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -636,7 +636,7 @@ describe('BridgeView', () => {
     const arrowButton = getByTestId('arrow-button');
 
     // Button should be disabled when dest network is disabled
-    expect(arrowButton.props.accessibilityState?.disabled).toBe(true);
+    expect(arrowButton.props.disabled).toBe(true);
 
     // Pressing the button should not trigger token switch
     fireEvent.press(arrowButton);

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -569,7 +569,7 @@ describe('BridgeView', () => {
     );
   });
 
-  it('should disable switch button when destination token network is disabled', () => {
+  it('disables switch button when destination token network is disabled', () => {
     const avalancheChainId = '0xa86a' as Hex; // Avalanche C-Chain
 
     // Create base state with the disabled network configuration

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -569,6 +569,81 @@ describe('BridgeView', () => {
     );
   });
 
+  it('should disable switch button when destination token network is disabled', () => {
+    const avalancheChainId = '0xa86a' as Hex; // Avalanche C-Chain
+
+    // Create base state with the disabled network configuration
+    const baseStateWithDisabledNetwork = {
+      ...mockState,
+      engine: {
+        ...mockState.engine,
+        backgroundState: {
+          ...mockState.engine?.backgroundState,
+          NetworkEnablementController: {
+            enabledNetworkMap: {
+              eip155: {
+                '0x1': true, // Ethereum enabled
+                [avalancheChainId]: false, // Avalanche disabled
+              },
+              solana: {
+                'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': true,
+              },
+              bip122: {
+                'bip122:000000000019d6689c085ae165831e93': true,
+              },
+              tron: {
+                'tron:728126428': true,
+              },
+            },
+          },
+        },
+      },
+    } as DeepPartial<RootState>;
+
+    const testState = createBridgeTestState(
+      {
+        bridgeReducerOverrides: {
+          sourceToken: {
+            address: '0x0000000000000000000000000000000000000000',
+            chainId: '0x1' as Hex,
+            decimals: 18,
+            image: '',
+            name: 'Ether',
+            symbol: 'ETH',
+          },
+          destToken: {
+            address: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E', // USDC on Avalanche
+            chainId: avalancheChainId,
+            decimals: 6,
+            image: '',
+            name: 'USD Coin',
+            symbol: 'USDC',
+          },
+          selectedDestChainId: avalancheChainId,
+        },
+      },
+      baseStateWithDisabledNetwork,
+    );
+
+    const { getByTestId } = renderScreen(
+      BridgeView,
+      {
+        name: Routes.BRIDGE.ROOT,
+      },
+      { state: testState },
+    );
+
+    const arrowButton = getByTestId('arrow-button');
+
+    // Button should be disabled when dest network is disabled
+    expect(arrowButton.props.accessibilityState?.disabled).toBe(true);
+
+    // Pressing the button should not trigger token switch
+    fireEvent.press(arrowButton);
+    expect(setSourceToken).not.toHaveBeenCalled();
+    expect(setDestToken).not.toHaveBeenCalled();
+  });
+
   describe('Solana Swap', () => {
     it('should set slippage to undefined when isSolanaSwap is true', async () => {
       const mockQuote = mockQuoteWithMetadata;

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -64,10 +64,7 @@ import { useInitialSourceToken } from '../../hooks/useInitialSourceToken';
 import { useInitialDestToken } from '../../hooks/useInitialDestToken';
 import { useGasFeeEstimates } from '../../../../Views/confirmations/hooks/gas/useGasFeeEstimates';
 import { selectSelectedNetworkClientId } from '../../../../../selectors/networkController';
-import {
-  selectEVMEnabledNetworks,
-  selectNonEVMEnabledNetworks,
-} from '../../../../../selectors/networkEnablementController';
+import { useIsNetworkEnabled } from '../../hooks/useIsNetworkEnabled';
 import { useMetrics, MetaMetricsEvents } from '../../../../hooks/useMetrics';
 import { BridgeQuoteResponse, BridgeToken, BridgeViewMode } from '../../types';
 import { useSwitchTokens } from '../../hooks/useSwitchTokens';
@@ -80,10 +77,7 @@ import { useInitialSlippage } from '../../hooks/useInitialSlippage/index.ts';
 import { useHasSufficientGas } from '../../hooks/useHasSufficientGas/index.ts';
 import { useRecipientInitialization } from '../../hooks/useRecipientInitialization';
 import ApprovalTooltip from '../../components/ApprovalText';
-import {
-  BRIDGE_MM_FEE_RATE,
-  isNonEvmChainId,
-} from '@metamask/bridge-controller';
+import { BRIDGE_MM_FEE_RATE } from '@metamask/bridge-controller';
 import { selectSourceWalletAddress } from '../../../../../selectors/bridge';
 import { isNullOrUndefined, Hex } from '@metamask/utils';
 import { useBridgeQuoteEvents } from '../../hooks/useBridgeQuoteEvents/index.ts';
@@ -143,22 +137,7 @@ const BridgeView = () => {
   const isEvmNonEvmBridge = useSelector(selectIsEvmNonEvmBridge);
   const isNonEvmNonEvmBridge = useSelector(selectIsNonEvmNonEvmBridge);
   const isSolanaSourced = useSelector(selectIsSolanaSourced);
-  const evmEnabledNetworks = useSelector(selectEVMEnabledNetworks);
-  const nonEvmEnabledNetworks = useSelector(selectNonEVMEnabledNetworks);
-
-  // Check if the destination token's network is enabled
-  // If not enabled, we should disable the switch button to prevent switching to a disabled network
-  const isDestNetworkEnabled = useMemo(() => {
-    if (!destToken?.chainId) return true; // No dest token = allow switching
-
-    const chainId = destToken.chainId;
-
-    if (isNonEvmChainId(chainId)) {
-      return nonEvmEnabledNetworks.includes(chainId);
-    }
-
-    return evmEnabledNetworks.includes(chainId as Hex);
-  }, [destToken?.chainId, evmEnabledNetworks, nonEvmEnabledNetworks]);
+  const isDestNetworkEnabled = useIsNetworkEnabled(destToken?.chainId);
 
   // inputRef is used to programmatically blur the input field after a delay
   // This gives users time to type before the keyboard disappears

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -64,6 +64,10 @@ import { useInitialSourceToken } from '../../hooks/useInitialSourceToken';
 import { useInitialDestToken } from '../../hooks/useInitialDestToken';
 import { useGasFeeEstimates } from '../../../../Views/confirmations/hooks/gas/useGasFeeEstimates';
 import { selectSelectedNetworkClientId } from '../../../../../selectors/networkController';
+import {
+  selectEVMEnabledNetworks,
+  selectNonEVMEnabledNetworks,
+} from '../../../../../selectors/networkEnablementController';
 import { useMetrics, MetaMetricsEvents } from '../../../../hooks/useMetrics';
 import { BridgeQuoteResponse, BridgeToken, BridgeViewMode } from '../../types';
 import { useSwitchTokens } from '../../hooks/useSwitchTokens';
@@ -76,7 +80,10 @@ import { useInitialSlippage } from '../../hooks/useInitialSlippage/index.ts';
 import { useHasSufficientGas } from '../../hooks/useHasSufficientGas/index.ts';
 import { useRecipientInitialization } from '../../hooks/useRecipientInitialization';
 import ApprovalTooltip from '../../components/ApprovalText';
-import { BRIDGE_MM_FEE_RATE } from '@metamask/bridge-controller';
+import {
+  BRIDGE_MM_FEE_RATE,
+  isNonEvmChainId,
+} from '@metamask/bridge-controller';
 import { selectSourceWalletAddress } from '../../../../../selectors/bridge';
 import { isNullOrUndefined, Hex } from '@metamask/utils';
 import { useBridgeQuoteEvents } from '../../hooks/useBridgeQuoteEvents/index.ts';
@@ -136,6 +143,23 @@ const BridgeView = () => {
   const isEvmNonEvmBridge = useSelector(selectIsEvmNonEvmBridge);
   const isNonEvmNonEvmBridge = useSelector(selectIsNonEvmNonEvmBridge);
   const isSolanaSourced = useSelector(selectIsSolanaSourced);
+  const evmEnabledNetworks = useSelector(selectEVMEnabledNetworks);
+  const nonEvmEnabledNetworks = useSelector(selectNonEVMEnabledNetworks);
+
+  // Check if the destination token's network is enabled
+  // If not enabled, we should disable the switch button to prevent switching to a disabled network
+  const isDestNetworkEnabled = useMemo(() => {
+    if (!destToken?.chainId) return true; // No dest token = allow switching
+
+    const chainId = destToken.chainId;
+
+    if (isNonEvmChainId(chainId)) {
+      return nonEvmEnabledNetworks.includes(chainId);
+    }
+
+    return evmEnabledNetworks.includes(chainId as Hex);
+  }, [destToken?.chainId, evmEnabledNetworks, nonEvmEnabledNetworks]);
+
   // inputRef is used to programmatically blur the input field after a delay
   // This gives users time to type before the keyboard disappears
   // The ref is typed to only expose the blur method we need
@@ -552,7 +576,12 @@ const BridgeView = () => {
           />
           <FLipQuoteButton
             onPress={handleSwitchTokens(destTokenAmount)}
-            disabled={!destChainId || !destToken || !sourceToken}
+            disabled={
+              !destChainId ||
+              !destToken ||
+              !sourceToken ||
+              !isDestNetworkEnabled
+            }
           />
           <TokenInputArea
             amount={destTokenAmount}

--- a/app/components/UI/Bridge/hooks/useIsNetworkEnabled/index.ts
+++ b/app/components/UI/Bridge/hooks/useIsNetworkEnabled/index.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { isNonEvmChainId } from '@metamask/bridge-controller';
+import { Hex } from '@metamask/utils';
+import {
+  selectEVMEnabledNetworks,
+  selectNonEVMEnabledNetworks,
+} from '../../../../../selectors/networkEnablementController';
+
+/**
+ * Hook to check if a network is enabled
+ * @param chainId - The chain ID to check (EVM hex or non-EVM CAIP format)
+ * @returns Whether the network is enabled
+ */
+export const useIsNetworkEnabled = (chainId: string | undefined): boolean => {
+  const evmEnabledNetworks = useSelector(selectEVMEnabledNetworks);
+  const nonEvmEnabledNetworks = useSelector(selectNonEVMEnabledNetworks);
+
+  return useMemo(() => {
+    if (!chainId) return true; // No chainId = assume enabled
+
+    if (isNonEvmChainId(chainId)) {
+      return nonEvmEnabledNetworks.includes(chainId);
+    }
+
+    return evmEnabledNetworks.includes(chainId as Hex);
+  }, [chainId, evmEnabledNetworks, nonEvmEnabledNetworks]);
+};


### PR DESCRIPTION
…nabled

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Disables "switch tokens" button when destination token is on a network that is not enabled.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Disabled the "switch tokens" button when destination token in on a disabled network

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents switching tokens when the destination network is disabled and aligns token selection behavior with the new guard.
> 
> - Adds `useIsNetworkEnabled` hook using `NetworkEnablementController` selectors to determine if a chain is enabled
> - `BridgeView`: disables `FLipQuoteButton` when `!destChainId || !destToken || !sourceToken || !isDestNetworkEnabled`
> - `useTokenSelection`: makes handler async, invokes `handleSwitchTokens(destAmount)` when selecting the opposite token, blocks swap if destination network is disabled, and dispatches `setIsDestTokenManuallySet(true)` on manual dest selection
> - Tests: new/updated coverage in `BridgeView.test.tsx` and `useTokenSelection.test.ts` for disabled switch state, guarded swaps, and new dispatch behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13105477f2b0ec831d518c952295ea5d8ed5760a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->