### PR TITLE
chore(rewards): modal copy changes for eos

### DIFF
--- a/app/components/UI/Rewards/hooks/useRewardDashboardModals.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardDashboardModals.test.tsx
@@ -43,15 +43,15 @@ jest.mock('../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
     const mockStrings: Record<string, string> = {
       'rewards.dashboard_modal_info.multiple_unlinked_accounts.title':
-        'Start earning rewards',
+        "Don't miss out",
       'rewards.dashboard_modal_info.multiple_unlinked_accounts.description':
-        'Link your accounts to start earning',
+        'Add your accounts to Rewards.',
       'rewards.dashboard_modal_info.multiple_unlinked_accounts.confirm':
-        'Go to Settings',
+        'Add accounts',
       'rewards.dashboard_modal_info.active_account.title': "Don't miss out",
       'rewards.dashboard_modal_info.active_account.description':
-        'Link this account to earn rewards',
-      'rewards.dashboard_modal_info.active_account.confirm': 'Link Account',
+        'Add your account to Rewards.',
+      'rewards.dashboard_modal_info.active_account.confirm': 'Add account',
       'rewards.dashboard_modal_info.account_not_supported.title':
         'Account not supported',
       'rewards.dashboard_modal_info.account_not_supported.description_hardware':
@@ -144,11 +144,11 @@ describe('useRewardDashboardModals', () => {
       expect(mockNavigate).toHaveBeenCalledWith(
         Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL,
         {
-          title: 'Start earning rewards',
-          description: 'Link your accounts to start earning',
+          title: "Don't miss out",
+          description: 'Add your accounts to Rewards.',
           customIcon: expect.any(Object),
           confirmAction: {
-            label: 'Go to Settings',
+            label: 'Add accounts',
             onPress: expect.any(Function),
             variant: 'Primary',
           },
@@ -284,10 +284,10 @@ describe('useRewardDashboardModals', () => {
         Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL,
         {
           title: "Don't miss out",
-          description: 'Link this account to earn rewards',
+          description: 'Add your account to Rewards.',
           customIcon: expect.any(Object),
           confirmAction: {
-            label: 'Link Account',
+            label: 'Add account',
             loadOnPress: true,
             onPress: expect.any(Function),
             variant: 'Primary',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7184,12 +7184,12 @@
     "dashboard_modal_info": {
       "active_account": {
         "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
+        "description": "Add your account to Rewards.",
         "confirm": "Add account"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
+        "title": "Don't miss out",
+        "description": "Add your accounts to Rewards.",
         "confirm": "Add accounts"
       },
       "account_not_supported": {


### PR DESCRIPTION
## **Description**

Updates the Rewards dashboard modal copy for the end of season (EOS). The text changes simplify messaging and make it more consistent across different modal states, replacing "earning points" language with more direct calls to action to add accounts to Rewards.
## **Changelog**

CHANGELOG entry: rewards modal copy changes for eos

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Rewards dashboard modal text with EOS messaging, replacing “earning points” phrasing with direct CTAs.
> 
> - Updates `en.json` strings for `dashboard_modal_info` (`active_account`, `multiple_unlinked_accounts`) to use "Don't miss out" titles and "Add your account(s) to Rewards." descriptions and confirms
> - Adjusts `useRewardDashboardModals.test.tsx` expectations to match new titles, descriptions, and button labels
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d62a700e42585eaf08c2747809baee2a3b89e7fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->