### PR TITLE
fix(perps): geo-restrict modify and close cp-7.63.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -1372,6 +1372,117 @@ describe('PerpsMarketDetailsView', () => {
 
       expect(queryByText('Geo Block Tooltip')).toBeNull();
     });
+
+    // TAT-2449: Geo-restriction tests for close/modify actions
+    it('shows geo block modal when close position button is pressed and user is not eligible', () => {
+      const { useSelector } = jest.requireMock('react-redux');
+      const mockSelectPerpsEligibility = jest.requireMock(
+        '../../selectors/perpsController',
+      ).selectPerpsEligibility;
+      useSelector.mockImplementation((selector: unknown) => {
+        if (selector === mockSelectPerpsEligibility) {
+          return false;
+        }
+        return undefined;
+      });
+
+      // Set up existing position to show close button
+      mockUseHasExistingPosition.mockReturnValue({
+        hasPosition: true,
+        isLoading: false,
+        error: null,
+        existingPosition: {
+          symbol: 'BTC',
+          size: '0.5',
+          entryPrice: '44000',
+          positionValue: '22000',
+          unrealizedPnl: '50',
+          marginUsed: '500',
+          leverage: { type: 'isolated', value: 5 },
+          liquidationPrice: '40000',
+          maxLeverage: 20,
+          returnOnEquity: '1.14',
+          cumulativeFunding: {
+            allTime: '0',
+            sinceOpen: '0',
+            sinceChange: '0',
+          },
+        },
+        refreshPosition: jest.fn(),
+      });
+
+      const { getByTestId, getByText } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        {
+          state: initialState,
+        },
+      );
+
+      const closeButton = getByTestId(
+        PerpsMarketDetailsViewSelectorsIDs.CLOSE_BUTTON,
+      );
+      fireEvent.press(closeButton);
+
+      expect(getByText('Geo Block Tooltip')).toBeTruthy();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('shows geo block modal when modify button is pressed and user is not eligible', () => {
+      const { useSelector } = jest.requireMock('react-redux');
+      const mockSelectPerpsEligibility = jest.requireMock(
+        '../../selectors/perpsController',
+      ).selectPerpsEligibility;
+      useSelector.mockImplementation((selector: unknown) => {
+        if (selector === mockSelectPerpsEligibility) {
+          return false;
+        }
+        return undefined;
+      });
+
+      // Set up existing position to show modify button
+      mockUseHasExistingPosition.mockReturnValue({
+        hasPosition: true,
+        isLoading: false,
+        error: null,
+        existingPosition: {
+          symbol: 'BTC',
+          size: '0.5',
+          entryPrice: '44000',
+          positionValue: '22000',
+          unrealizedPnl: '50',
+          marginUsed: '500',
+          leverage: { type: 'isolated', value: 5 },
+          liquidationPrice: '40000',
+          maxLeverage: 20,
+          returnOnEquity: '1.14',
+          cumulativeFunding: {
+            allTime: '0',
+            sinceOpen: '0',
+            sinceChange: '0',
+          },
+        },
+        refreshPosition: jest.fn(),
+      });
+
+      const { getByTestId, getByText } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        {
+          state: initialState,
+        },
+      );
+
+      const modifyButton = getByTestId(
+        PerpsMarketDetailsViewSelectorsIDs.MODIFY_BUTTON,
+      );
+      fireEvent.press(modifyButton);
+
+      expect(getByText('Geo Block Tooltip')).toBeTruthy();
+      // Modify sheet should NOT open when user is not eligible
+    });
   });
 
   describe('Notification tooltip functionality', () => {

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -784,14 +784,40 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   // Close position handler
   const handleClosePosition = useCallback(() => {
     if (!existingPosition) return;
+
+    // Geo-restriction check for close position action
+    if (!isEligible) {
+      track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
+        [PerpsEventProperties.SCREEN_TYPE]:
+          PerpsEventValues.SCREEN_TYPE.GEO_BLOCK_NOTIF,
+        [PerpsEventProperties.SOURCE]:
+          PerpsEventValues.SOURCE.CLOSE_POSITION_ACTION,
+      });
+      setIsEligibilityModalVisible(true);
+      return;
+    }
+
     navigateToClosePosition(existingPosition);
-  }, [existingPosition, navigateToClosePosition]);
+  }, [existingPosition, navigateToClosePosition, isEligible, track]);
 
   // Modify position handler - opens the modify action sheet
   const handleModifyPress = useCallback(() => {
     if (!existingPosition) return;
+
+    // Geo-restriction check for modify position action
+    if (!isEligible) {
+      track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
+        [PerpsEventProperties.SCREEN_TYPE]:
+          PerpsEventValues.SCREEN_TYPE.GEO_BLOCK_NOTIF,
+        [PerpsEventProperties.SOURCE]:
+          PerpsEventValues.SOURCE.MODIFY_POSITION_ACTION,
+      });
+      setIsEligibilityModalVisible(true);
+      return;
+    }
+
     openModifySheet();
-  }, [existingPosition, openModifySheet]);
+  }, [existingPosition, openModifySheet, isEligible, track]);
 
   // Handler for "Add Margin" from stop loss prompt banner
   const handleAddMarginFromBanner = useCallback(() => {

--- a/app/components/UI/Perps/constants/eventNames.ts
+++ b/app/components/UI/Perps/constants/eventNames.ts
@@ -214,6 +214,9 @@ export const PerpsEventValues = {
     ADD_FUNDS_ACTION: 'add_funds_action',
     CANCEL_ORDER: 'cancel_order',
     ASSET_DETAIL_SCREEN: 'asset_detail_screen',
+    // TAT-2449: Geo-block sources for close/modify actions
+    CLOSE_POSITION_ACTION: 'close_position_action',
+    MODIFY_POSITION_ACTION: 'modify_position_action',
   },
   WARNING_TYPE: {
     MINIMUM_DEPOSIT: 'minimum_deposit',


### PR DESCRIPTION
## **Description**

Implements geo-restriction for 'close position' and 'modify' actions in Perps trading to ensure compliance with regional regulations.

**Problem:** Currently, there is no geo-restriction check for the 'close position' and 'modify' actions. Users in geo-restricted regions can access these features, which should be blocked for compliance.

**Solution:** Added geo-restriction checks to both `handleClosePosition` and `handleModifyPress` handlers in `PerpsMarketDetailsView`. When a geo-restricted user taps either button:
1. The geo-block bottom sheet is displayed
2. The action is blocked (no navigation occurs)
3. Analytics event is tracked with the specific action source for monitoring

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #25315
Jira: https://consensyssoftware.atlassian.net/browse/TAT-2449

## **Manual testing steps**

```gherkin
Feature: Geo-restriction for close position and modify actions

  Scenario: Geo-restricted user tries to close position
    Given user is in a geo-restricted region
    And user has an open position in Perps

    When user taps the "Close" button on the market details screen
    Then the geo-restriction bottom sheet is displayed
    And the close position flow is not initiated

  Scenario: Geo-restricted user tries to modify position
    Given user is in a geo-restricted region
    And user has an open position in Perps

    When user taps the "Modify" button on the market details screen
    Then the geo-restriction bottom sheet is displayed
    And the modify action sheet is not opened

  Scenario: Eligible user can close position
    Given user is NOT in a geo-restricted region
    And user has an open position in Perps

    When user taps the "Close" button on the market details screen
    Then user is navigated to the close position flow

  Scenario: Eligible user can modify position
    Given user is NOT in a geo-restricted region
    And user has an open position in Perps

    When user taps the "Modify" button on the market details screen
    Then the modify action sheet is opened
```

## **Screenshots/Recordings**

### **Before**

Geo-restricted users could tap Close/Modify buttons and proceed with the actions.

### **After**

Geo-restricted users see the geo-block bottom sheet when tapping Close or Modify buttons.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.