### PR TITLE
feat: implement usePendingMerklClaim hook for managing claim transaction states

### DIFF
--- a/app/components/UI/Earn/components/MerklRewards/ClaimMerklRewards.tsx
+++ b/app/components/UI/Earn/components/MerklRewards/ClaimMerklRewards.tsx
@@ -11,6 +11,7 @@ import {
 import { Hex } from '@metamask/utils';
 import { strings } from '../../../../../../locales/i18n';
 import { useMerklClaim } from './hooks/useMerklClaim';
+import { usePendingMerklClaim } from './hooks/usePendingMerklClaim';
 import { TokenI } from '../../../Tokens/types';
 import styleSheet from './MerklRewards.styles';
 import { useStyles } from '../../../../../component-library/hooks';
@@ -36,6 +37,11 @@ const ClaimMerklRewards: React.FC<ClaimMerklRewardsProps> = ({ asset }) => {
   );
 
   const { claimRewards, isClaiming, error: claimError } = useMerklClaim(asset);
+  const { hasPendingClaim } = usePendingMerklClaim();
+
+  // Show loading if currently claiming OR if there's an in-flight claim transaction
+  // (e.g., user navigated away and came back while tx is still processing)
+  const isLoading = isClaiming || hasPendingClaim;
 
   const handleClaim = async () => {
     const buttonText = strings('asset_overview.merkl_rewards.claim');
@@ -73,8 +79,8 @@ const ClaimMerklRewards: React.FC<ClaimMerklRewardsProps> = ({ asset }) => {
         size={ButtonSize.Lg}
         twClassName="w-full"
         onPress={handleClaim}
-        isDisabled={isClaiming}
-        isLoading={isClaiming}
+        isDisabled={isLoading}
+        isLoading={isLoading}
       >
         {strings('asset_overview.merkl_rewards.claim')}
       </Button>

--- a/app/components/UI/Earn/components/MerklRewards/MerklRewards.tsx
+++ b/app/components/UI/Earn/components/MerklRewards/MerklRewards.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Hex } from '@metamask/utils';
 import { TokenI } from '../../../Tokens/types';
 import {
   isEligibleForMerklRewards,
   useMerklRewards,
 } from './hooks/useMerklRewards';
+import { usePendingMerklClaim } from './hooks/usePendingMerklClaim';
 import PendingMerklRewards from './PendingMerklRewards';
 import ClaimMerklRewards from './ClaimMerklRewards';
 
@@ -23,7 +24,15 @@ const MerklRewards: React.FC<MerklRewardsProps> = ({ asset }) => {
   );
 
   // Fetch claimable rewards data
-  const { claimableReward } = useMerklRewards({ asset });
+  const { claimableReward, refetch } = useMerklRewards({ asset });
+
+  // Refetch rewards data when a pending claim is confirmed
+  // This ensures the UI updates to reflect zero claimable rewards after claim
+  const handleClaimConfirmed = useCallback(() => {
+    refetch();
+  }, [refetch]);
+
+  usePendingMerklClaim({ onClaimConfirmed: handleClaimConfirmed });
 
   if (!isEligible) {
     return null;

--- a/app/components/UI/Earn/components/MerklRewards/hooks/usePendingMerklClaim.test.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/usePendingMerklClaim.test.ts
@@ -1,0 +1,260 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { TransactionStatus } from '@metamask/transaction-controller';
+import { usePendingMerklClaim } from './usePendingMerklClaim';
+import { MERKL_CLAIM_ORIGIN } from '../constants';
+
+// Mock the selector
+const mockSelectTransactions = jest.fn();
+jest.mock('../../../../../../selectors/transactionController', () => ({
+  selectTransactions: (state: unknown) => mockSelectTransactions(state),
+}));
+
+// Mock react-redux
+jest.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+describe('usePendingMerklClaim', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const createMockTransaction = (
+    overrides: {
+      origin?: string;
+      status?: TransactionStatus;
+      id?: string;
+    } = {},
+  ) => ({
+    id: overrides.id ?? 'tx-123',
+    origin: overrides.origin ?? MERKL_CLAIM_ORIGIN,
+    status: overrides.status ?? TransactionStatus.submitted,
+    time: Date.now(),
+    txParams: {
+      from: '0x1234567890abcdef1234567890abcdef12345678',
+      to: '0xabcdef1234567890abcdef1234567890abcdef12',
+      value: '0x0',
+      data: '0x',
+    },
+    chainId: '0x1',
+  });
+
+  it('returns hasPendingClaim as false when no transactions exist', () => {
+    mockSelectTransactions.mockReturnValue([]);
+
+    const { result } = renderHook(() => usePendingMerklClaim());
+
+    expect(result.current.hasPendingClaim).toBe(false);
+  });
+
+  it('returns hasPendingClaim as false when no merkl claim transactions exist', () => {
+    mockSelectTransactions.mockReturnValue([
+      createMockTransaction({
+        origin: 'other-origin',
+        status: TransactionStatus.submitted,
+      }),
+    ]);
+
+    const { result } = renderHook(() => usePendingMerklClaim());
+
+    expect(result.current.hasPendingClaim).toBe(false);
+  });
+
+  it('returns hasPendingClaim as true when approved merkl claim transaction exists', () => {
+    mockSelectTransactions.mockReturnValue([
+      createMockTransaction({ status: TransactionStatus.approved }),
+    ]);
+
+    const { result } = renderHook(() => usePendingMerklClaim());
+
+    expect(result.current.hasPendingClaim).toBe(true);
+  });
+
+  it('returns hasPendingClaim as true when signed merkl claim transaction exists', () => {
+    mockSelectTransactions.mockReturnValue([
+      createMockTransaction({ status: TransactionStatus.signed }),
+    ]);
+
+    const { result } = renderHook(() => usePendingMerklClaim());
+
+    expect(result.current.hasPendingClaim).toBe(true);
+  });
+
+  it('returns hasPendingClaim as true when submitted merkl claim transaction exists', () => {
+    mockSelectTransactions.mockReturnValue([
+      createMockTransaction({ status: TransactionStatus.submitted }),
+    ]);
+
+    const { result } = renderHook(() => usePendingMerklClaim());
+
+    expect(result.current.hasPendingClaim).toBe(true);
+  });
+
+  it('returns hasPendingClaim as false when merkl claim transaction is confirmed', () => {
+    mockSelectTransactions.mockReturnValue([
+      createMockTransaction({ status: TransactionStatus.confirmed }),
+    ]);
+
+    const { result } = renderHook(() => usePendingMerklClaim());
+
+    expect(result.current.hasPendingClaim).toBe(false);
+  });
+
+  it('returns hasPendingClaim as false when merkl claim transaction failed', () => {
+    mockSelectTransactions.mockReturnValue([
+      createMockTransaction({ status: TransactionStatus.failed }),
+    ]);
+
+    const { result } = renderHook(() => usePendingMerklClaim());
+
+    expect(result.current.hasPendingClaim).toBe(false);
+  });
+
+  it('returns hasPendingClaim as false when merkl claim transaction was dropped', () => {
+    mockSelectTransactions.mockReturnValue([
+      createMockTransaction({ status: TransactionStatus.dropped }),
+    ]);
+
+    const { result } = renderHook(() => usePendingMerklClaim());
+
+    expect(result.current.hasPendingClaim).toBe(false);
+  });
+
+  it('returns hasPendingClaim as false when merkl claim transaction is unapproved', () => {
+    mockSelectTransactions.mockReturnValue([
+      createMockTransaction({ status: TransactionStatus.unapproved }),
+    ]);
+
+    const { result } = renderHook(() => usePendingMerklClaim());
+
+    expect(result.current.hasPendingClaim).toBe(false);
+  });
+
+  it('returns hasPendingClaim as true when at least one in-flight merkl claim exists among multiple transactions', () => {
+    mockSelectTransactions.mockReturnValue([
+      createMockTransaction({
+        id: 'tx-1',
+        origin: 'other-origin',
+        status: TransactionStatus.submitted,
+      }),
+      createMockTransaction({
+        id: 'tx-2',
+        status: TransactionStatus.confirmed,
+      }),
+      createMockTransaction({
+        id: 'tx-3',
+        status: TransactionStatus.submitted,
+      }),
+    ]);
+
+    const { result } = renderHook(() => usePendingMerklClaim());
+
+    expect(result.current.hasPendingClaim).toBe(true);
+  });
+
+  describe('onClaimConfirmed callback', () => {
+    it('calls onClaimConfirmed when a pending claim becomes confirmed', () => {
+      const onClaimConfirmed = jest.fn();
+      const txId = 'tx-pending-to-confirmed';
+
+      // Start with pending transaction
+      mockSelectTransactions.mockReturnValue([
+        createMockTransaction({
+          id: txId,
+          status: TransactionStatus.submitted,
+        }),
+      ]);
+
+      const { rerender } = renderHook(() =>
+        usePendingMerklClaim({ onClaimConfirmed }),
+      );
+
+      expect(onClaimConfirmed).not.toHaveBeenCalled();
+
+      // Transaction becomes confirmed
+      mockSelectTransactions.mockReturnValue([
+        createMockTransaction({
+          id: txId,
+          status: TransactionStatus.confirmed,
+        }),
+      ]);
+
+      rerender();
+
+      expect(onClaimConfirmed).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClaimConfirmed when transaction was not previously tracked as pending', () => {
+      const onClaimConfirmed = jest.fn();
+
+      // Start with already confirmed transaction (not tracked as pending)
+      mockSelectTransactions.mockReturnValue([
+        createMockTransaction({
+          id: 'tx-already-confirmed',
+          status: TransactionStatus.confirmed,
+        }),
+      ]);
+
+      renderHook(() => usePendingMerklClaim({ onClaimConfirmed }));
+
+      expect(onClaimConfirmed).not.toHaveBeenCalled();
+    });
+
+    it('does not call onClaimConfirmed when a pending claim fails', () => {
+      const onClaimConfirmed = jest.fn();
+      const txId = 'tx-pending-to-failed';
+
+      // Start with pending transaction
+      mockSelectTransactions.mockReturnValue([
+        createMockTransaction({
+          id: txId,
+          status: TransactionStatus.submitted,
+        }),
+      ]);
+
+      const { rerender } = renderHook(() =>
+        usePendingMerklClaim({ onClaimConfirmed }),
+      );
+
+      // Transaction fails
+      mockSelectTransactions.mockReturnValue([
+        createMockTransaction({
+          id: txId,
+          status: TransactionStatus.failed,
+        }),
+      ]);
+
+      rerender();
+
+      expect(onClaimConfirmed).not.toHaveBeenCalled();
+    });
+
+    it('does not call onClaimConfirmed when no callback is provided', () => {
+      const txId = 'tx-no-callback';
+
+      // Start with pending transaction
+      mockSelectTransactions.mockReturnValue([
+        createMockTransaction({
+          id: txId,
+          status: TransactionStatus.submitted,
+        }),
+      ]);
+
+      const { rerender } = renderHook(() => usePendingMerklClaim());
+
+      // Transaction becomes confirmed - should not throw
+      mockSelectTransactions.mockReturnValue([
+        createMockTransaction({
+          id: txId,
+          status: TransactionStatus.confirmed,
+        }),
+      ]);
+
+      expect(() => rerender()).not.toThrow();
+    });
+  });
+});

--- a/app/components/UI/Earn/components/MerklRewards/hooks/usePendingMerklClaim.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/usePendingMerklClaim.ts
@@ -1,0 +1,94 @@
+import { useMemo, useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import { TransactionStatus } from '@metamask/transaction-controller';
+import { selectTransactions } from '../../../../../../selectors/transactionController';
+import { MERKL_CLAIM_ORIGIN } from '../constants';
+
+/**
+ * Transaction statuses that indicate a claim is "in flight"
+ * - approved: User confirmed in wallet, waiting for submission
+ * - signed: Transaction signed, waiting for broadcast
+ * - submitted: Transaction submitted to network, waiting for confirmation
+ */
+const IN_FLIGHT_STATUSES = [
+  TransactionStatus.approved,
+  TransactionStatus.signed,
+  TransactionStatus.submitted,
+];
+
+interface UsePendingMerklClaimOptions {
+  onClaimConfirmed?: () => void;
+}
+
+/**
+ * Hook to check if there's a pending Merkl claim transaction in flight.
+ *
+ * This is used to show a loading state on the claim button when the user
+ * navigates back to the asset details page while a claim transaction is
+ * still being processed.
+ *
+ * @param options.onClaimConfirmed - Optional callback fired when a pending claim is confirmed
+ * @returns hasPendingClaim - true if there's an in-flight Merkl claim transaction
+ */
+export const usePendingMerklClaim = (
+  options: UsePendingMerklClaimOptions = {},
+) => {
+  const { onClaimConfirmed } = options;
+  const transactions = useSelector(selectTransactions);
+
+  // Track the IDs of pending claims we've seen
+  const pendingClaimIdsRef = useRef<Set<string>>(new Set());
+
+  const hasPendingClaim = useMemo(
+    () =>
+      transactions.some(
+        (tx) =>
+          tx.origin === MERKL_CLAIM_ORIGIN &&
+          IN_FLIGHT_STATUSES.includes(tx.status),
+      ),
+    [transactions],
+  );
+
+  // Stable callback ref to avoid effect re-running
+  const onClaimConfirmedRef = useRef(onClaimConfirmed);
+  useEffect(() => {
+    onClaimConfirmedRef.current = onClaimConfirmed;
+  }, [onClaimConfirmed]);
+
+  // Detect when a pending claim becomes confirmed
+  useEffect(() => {
+    const merklClaimTxs = transactions.filter(
+      (tx) => tx.origin === MERKL_CLAIM_ORIGIN,
+    );
+
+    // Get current pending claim IDs
+    const currentPendingIds = new Set(
+      merklClaimTxs
+        .filter((tx) => IN_FLIGHT_STATUSES.includes(tx.status))
+        .map((tx) => tx.id),
+    );
+
+    // Check if any previously pending claims are now confirmed
+    const confirmedIds = merklClaimTxs
+      .filter(
+        (tx) =>
+          tx.status === TransactionStatus.confirmed ||
+          tx.status === TransactionStatus.dropped,
+      )
+      .map((tx) => tx.id);
+
+    const hadPendingThatConfirmed = confirmedIds.some((id) =>
+      pendingClaimIdsRef.current.has(id),
+    );
+
+    // Update our tracking set
+    pendingClaimIdsRef.current = currentPendingIds;
+
+    // Fire callback if a pending claim was confirmed
+    if (hadPendingThatConfirmed && onClaimConfirmedRef.current) {
+      onClaimConfirmedRef.current();
+    }
+  }, [transactions]);
+
+  return { hasPendingClaim };
+};

--- a/app/components/UI/Earn/components/MerklRewards/hooks/usePendingMerklClaim.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/usePendingMerklClaim.ts
@@ -70,11 +70,7 @@ export const usePendingMerklClaim = (
 
     // Check if any previously pending claims are now confirmed
     const confirmedIds = merklClaimTxs
-      .filter(
-        (tx) =>
-          tx.status === TransactionStatus.confirmed ||
-          tx.status === TransactionStatus.dropped,
-      )
+      .filter((tx) => tx.status === TransactionStatus.confirmed)
       .map((tx) => tx.id);
 
     const hadPendingThatConfirmed = confirmedIds.some((id) =>

--- a/app/components/UI/Earn/components/MerklRewards/merkl-client.ts
+++ b/app/components/UI/Earn/components/MerklRewards/merkl-client.ts
@@ -60,7 +60,9 @@ const buildRewardsUrl = (
 ): string => {
   // Support multiple chain IDs (comma-separated)
   const chainIdParam = Array.isArray(chainIds)
-    ? chainIds.map((id) => Number(id)).join(',')
+    ? chainIds
+        .map((id) => Number(id === '0xe709' ? CHAIN_IDS.LINEA_MAINNET : id))
+        .join(',')
     : Number(chainIds);
 
   let url = `${MERKL_API_BASE_URL}/users/${userAddress}/rewards?chainId=${chainIdParam}`;

--- a/app/components/UI/Earn/components/MerklRewards/merkl-client.ts
+++ b/app/components/UI/Earn/components/MerklRewards/merkl-client.ts
@@ -60,9 +60,7 @@ const buildRewardsUrl = (
 ): string => {
   // Support multiple chain IDs (comma-separated)
   const chainIdParam = Array.isArray(chainIds)
-    ? chainIds
-        .map((id) => Number(id === '0xe709' ? CHAIN_IDS.LINEA_MAINNET : id))
-        .join(',')
+    ? chainIds.map((id) => Number(id)).join(',')
     : Number(chainIds);
 
   let url = `${MERKL_API_BASE_URL}/users/${userAddress}/rewards?chainId=${chainIdParam}`;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Problem:** When a user clicked "Claim" on the Merkl rewards section and confirmed the transaction, they were redirected to the home screen. However, if the user navigated back to the asset details page while the transaction was still in flight, the bonus section appeared without any loading state. This allowed users to potentially click the claim button again, which could lead to confusion or failed duplicate transactions.

**Solution:** Implemented a `usePendingMerklClaim` hook that:
1. Monitors the `TransactionController` for in-flight Merkl claim transactions (approved, signed, submitted statuses)
2. Shows a loading state on the claim button when a claim transaction is pending
3. Triggers a data refetch when the pending transaction is confirmed, which removes the bonus section once the claim is complete

## **Changelog**

CHANGELOG entry: Fixed bonus claim button on asset details page to show loading state when a claim transaction is in progress


## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-255

## **Manual testing steps**

```gherkin
Feature: Merkl rewards claim loading state persistence

  Scenario: user sees loading state when returning to asset details during pending claim
    Given user is on the asset details page for mUSD with claimable rewards
    And user clicks the "Claim" button and confirms the transaction
    And user is redirected to the home screen
    
    When user navigates back to the asset details page
    Then the claim button displays a loading state
    And the claim button is disabled

  Scenario: bonus section is removed after claim transaction confirms
    Given user is on the asset details page with a pending claim transaction
    And the claim button is showing a loading state
    
    When the claim transaction is confirmed on-chain
    Then the bonus section is removed from the asset details page
    And the claimable reward amount is no longer displayed

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/06d742d4-32c6-43ba-8c39-8acc7bcb525f


<!-- [screenshots/recordings] -->

### **After**
<img width="601" height="1268" alt="Screenshot 2026-01-28 at 14 36 23" src="https://github.com/user-attachments/assets/bfb0679c-a17e-4eed-800e-a6823cbbbe41" />

https://github.com/user-attachments/assets/6ef4fe42-b9b1-4e3a-bf90-79938fe801b4


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces pending-claim awareness for Merkl rewards and updates UI behavior accordingly.
> 
> - Adds `hooks/usePendingMerklClaim` to monitor Merkl claim txs via `TransactionController` (tracks approved/signed/submitted; optional `onClaimConfirmed` callback) with full unit tests
> - Integrates hook in `ClaimMerklRewards` to compute `isLoading`/`isDisabled` from `isClaiming || hasPendingClaim`, preventing duplicate presses
> - Integrates hook in `MerklRewards` with `onClaimConfirmed` to `refetch` rewards so the bonus section clears after confirmation; updates tests for both components
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3baaf57efc9f5ca978f7f05af3e09ddc62ff0ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->