### PR TITLE
chore: remove 'Powered by Relay' tooltip from conversion screen

### DIFF
--- a/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
@@ -160,23 +160,6 @@ describe('MusdConversionInfo', () => {
     });
   });
 
-  describe('footerText', () => {
-    it('does not pass footerText to CustomAmountInfo (Powered by Relay only in navbar tooltip)', () => {
-      mockRoute.params = {
-        outputChainId: '0x1' as Hex,
-      };
-
-      mockUseRoute.mockReturnValue(mockRoute);
-
-      renderWithProvider(<MusdConversionInfo />, {
-        state: {},
-      });
-
-      const call = (CustomAmountInfo as jest.Mock).mock.calls[0][0];
-      expect(call.footerText).toBeUndefined();
-    });
-  });
-
   describe('MusdOverrideContent', () => {
     it('calls useTransactionPayAvailableTokens when rendered', () => {
       mockRoute.params = {

--- a/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
@@ -8,7 +8,6 @@ import { CustomAmountInfo } from '../custom-amount-info';
 import { useCustomAmount } from '../../../hooks/earn/useCustomAmount';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 import { useMusdConversionNavbar } from '../../../../../UI/Earn/hooks/useMusdConversionNavbar';
-import { strings } from '../../../../../../../locales/i18n';
 
 jest.mock('../../../hooks/tokens/useAddToken');
 jest.mock('../../../hooks/earn/useCustomAmount');
@@ -162,7 +161,7 @@ describe('MusdConversionInfo', () => {
   });
 
   describe('footerText', () => {
-    it('passes footerText to CustomAmountInfo', () => {
+    it('does not pass footerText to CustomAmountInfo (Powered by Relay only in navbar tooltip)', () => {
       mockRoute.params = {
         outputChainId: '0x1' as Hex,
       };
@@ -173,12 +172,8 @@ describe('MusdConversionInfo', () => {
         state: {},
       });
 
-      expect(CustomAmountInfo).toHaveBeenCalledWith(
-        expect.objectContaining({
-          footerText: strings('earn.musd_conversion.powered_by_relay'),
-        }),
-        expect.anything(),
-      );
+      const call = (CustomAmountInfo as jest.Mock).mock.calls[0][0];
+      expect(call.footerText).toBeUndefined();
     });
   });
 

--- a/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
+++ b/app/components/Views/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
@@ -13,7 +13,6 @@ import { CustomAmountInfo } from '../custom-amount-info';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 import { useMusdConversionNavbar } from '../../../../../UI/Earn/hooks/useMusdConversionNavbar';
 import { useMusdConversionQuoteTrace } from '../../../../../UI/Earn/hooks/useMusdConversionQuoteTrace';
-import { strings } from '../../../../../../../locales/i18n';
 import { endTrace, TraceName } from '../../../../../../util/trace';
 
 interface MusdOverrideContentProps {
@@ -88,7 +87,6 @@ export const MusdConversionInfo = () => {
     <CustomAmountInfo
       preferredToken={preferredPaymentToken}
       overrideContent={renderOverrideContent}
-      footerText={strings('earn.musd_conversion.powered_by_relay')}
       hasMax
       onAmountSubmit={startQuoteTrace}
     />


### PR DESCRIPTION
## **Description**

"Powered by Relay" was appearing in two places—on the mUSD conversion input screen (as footer text) and in the navbar info tooltip. Per designs, it should appear only in the navbar tooltip.

- Removed the `footerText` prop from `MusdConversionInfo` so "Powered by Relay" is no longer shown on the conversion input screen.

## **Changelog**

CHANGELOG entry: Removed "Powered by Relay" from the mUSD conversion input screen

## **Related issues**

Fixes: [MUSD-253](https://consensyssoftware.atlassian.net/browse/MUSD-253)

## **Manual testing steps**

```gherkin
Feature: mUSD conversion screen copy

  Scenario: user opens mUSD conversion input screen
    Given the user has navigated to the mUSD conversion flow and is on the conversion input (amount) screen

    When the screen is displayed

    And when the user taps the info icon in the navbar, the tooltip opens and shows "Powered by Relay" in the tooltip footer
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-28 at 13 44 19" src="https://github.com/user-attachments/assets/7ca03588-fdb3-40e0-be3a-d3612ee4f392" />

### **After**
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-28 at 13 54 04" src="https://github.com/user-attachments/assets/65e8c7f1-d930-41c4-8b2d-7c2db9ae1599" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-253]: https://consensyssoftware.atlassian.net/browse/MUSD-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the "Powered by Relay" footer text from the mUSD conversion amount screen; the info remains in the navbar tooltip.
> 
> - Drops `footerText` prop (and `strings` import) from `MusdConversionInfo` and `CustomAmountInfo` usage
> - Updates tests by removing assertions for `footerText`; retains checks for `preferredToken`, `overrideContent`, navbar hook, and pay tokens behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e55e829714de688baa909640b1946c022b1741bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->