### PR TITLE
feat: Allow queueing of Snap dialogs

### DIFF
--- a/app/core/Engine/controllers/approval-controller/approval-controller-init.test.ts
+++ b/app/core/Engine/controllers/approval-controller/approval-controller-init.test.ts
@@ -10,6 +10,7 @@ import { ControllerInitRequest } from '../../types';
 import { ApprovalControllerInit } from './approval-controller-init';
 import { ApprovalTypes } from '../../../RPCMethods/RPCMethodMiddleware';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
+import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
 
 jest.mock('@metamask/approval-controller');
 
@@ -68,6 +69,7 @@ describe('ApprovalController Init', () => {
         ApprovalType.Transaction,
         ApprovalType.WatchAsset,
         ApprovalTypes.SMART_TRANSACTION_STATUS,
+        DIALOG_APPROVAL_TYPES.default,
       ]);
     });
 

--- a/app/core/Engine/controllers/approval-controller/approval-controller-init.ts
+++ b/app/core/Engine/controllers/approval-controller/approval-controller-init.ts
@@ -3,6 +3,7 @@ import {
   ApprovalControllerMessenger,
 } from '@metamask/approval-controller';
 import { ApprovalType } from '@metamask/controller-utils';
+import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
 
 import Logger from '../../../../util/Logger';
 import { ApprovalTypes } from '../../../RPCMethods/RPCMethodMiddleware';
@@ -22,6 +23,7 @@ export const ApprovalControllerInit: ControllerInitFunction<
         ApprovalType.Transaction,
         ApprovalType.WatchAsset,
         ApprovalTypes.SMART_TRANSACTION_STATUS,
+        DIALOG_APPROVAL_TYPES.default,
       ],
     });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Allow queueing of `snap_dialog` (the non-legacy type) by adding it to the `ApprovalController` configuration.

This allows Snaps to queue multiple dialogs in the same way that EVM flows do. This also impacts Solana, Bitcoin and Tron.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added support for queueing non-EVM confirmations

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-36

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for queueing `snap_dialog` (non-legacy) by updating `ApprovalController` init configuration.
> 
> - Includes `DIALOG_APPROVAL_TYPES.default` in `typesExcludedFromRateLimiting` to allow queued Snap dialogs alongside existing exclusions
> - Updates unit tests to reflect new exclusion and validate constructor options
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 885f306e3b977674270feb97dee1229990309550. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->