### PR TITLE
fix(ramp): update postal code input to allow punctuation

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/EnterAddress.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/EnterAddress.tsx
@@ -349,7 +349,7 @@ const EnterAddress = (): JSX.Element => {
                 ref={postCodeInputRef}
                 autoComplete="postal-code"
                 textContentType="postalCode"
-                keyboardType="number-pad"
+                keyboardType="numbers-and-punctuation"
                 onSubmitEditing={() => Keyboard.dismiss()}
               />
 

--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
@@ -1175,7 +1175,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                           autoFocus={false}
                                           editable={true}
                                           keyboardAppearance="light"
-                                          keyboardType="number-pad"
+                                          keyboardType="numbers-and-punctuation"
                                           onBlur={[Function]}
                                           onChangeText={[Function]}
                                           onFocus={[Function]}
@@ -2654,7 +2654,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                           autoFocus={false}
                                           editable={true}
                                           keyboardAppearance="light"
-                                          keyboardType="number-pad"
+                                          keyboardType="numbers-and-punctuation"
                                           onBlur={[Function]}
                                           onChangeText={[Function]}
                                           onFocus={[Function]}
@@ -4126,7 +4126,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                           autoFocus={false}
                                           editable={true}
                                           keyboardAppearance="light"
-                                          keyboardType="number-pad"
+                                          keyboardType="numbers-and-punctuation"
                                           onBlur={[Function]}
                                           onChangeText={[Function]}
                                           onFocus={[Function]}
@@ -5618,7 +5618,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                           autoFocus={false}
                                           editable={true}
                                           keyboardAppearance="light"
-                                          keyboardType="number-pad"
+                                          keyboardType="numbers-and-punctuation"
                                           onBlur={[Function]}
                                           onChangeText={[Function]}
                                           onFocus={[Function]}


### PR DESCRIPTION
## **Description**

This PR fixes a bug where users could not enter postal codes containing punctuation, spaces, or letters in the Deposit flow address form.

### Problem
The postal code input field in the `EnterAddress` screen was using `keyboardType="number-pad"`, which only allows numeric input. This prevented users from entering valid postal codes that contain non-numeric characters, such as:
- **UK postcodes**: `SW1A 1AA` (contains spaces and letters)
- **Canadian postal codes**: `K1A 0B1` (alphanumeric with space)
- **Dutch postcodes**: `1234 AB` (numbers + letters)
- **Codes with dashes**: `12345-6789`

### Solution
Changed the `keyboardType` prop from `"number-pad"` to `"numbers-and-punctuation"` for the postal code input field. This keyboard type allows users to enter numbers along with punctuation marks, spaces, and other characters needed for international postal codes.

### Technical Details
- **File modified**: `app/components/UI/Ramp/Deposit/Views/EnterAddress/EnterAddress.tsx`
- **Change**: Line 352, `keyboardType` prop value
- **Snapshot updated**: The test snapshot was updated to reflect the new keyboard type

## **Changelog**

CHANGELOG entry: Fixed postal code input in Deposit flow to allow entering codes with punctuation, spaces, and letters

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3242

## **Manual testing steps**

```gherkin
Feature: Postal code input in Deposit address form

  Scenario: User enters a UK postcode with spaces and letters
    Given the user is on the Enter Address screen in the Deposit flow
    And the user has filled in the required address fields

    When user taps on the Postal code input field
    Then the keyboard displayed should allow numbers and punctuation

    When user types "SW1A 1AA"
    Then the input should accept and display "SW1A 1AA"
    And no validation error should be shown

  Scenario: User enters a Canadian postal code
    Given the user is on the Enter Address screen in the Deposit flow

    When user taps on the Postal code input field
    And user types "K1A 0B1"
    Then the input should accept and display "K1A 0B1"

  Scenario: User enters a numeric-only US ZIP code
    Given the user is on the Enter Address screen in the Deposit flow

    When user taps on the Postal code input field
    And user types "10001"
    Then the input should accept and display "10001"
```

## **Screenshots/Recordings**

### **Before**

The `number-pad` keyboard only shows numeric keys, preventing entry of letters or spaces required for many international postal codes.

### **After**

The `numbers-and-punctuation` keyboard allows entry of numbers, letters, spaces, and punctuation marks needed for postal codes worldwide.

> Note: This is a keyboard type change - the visual difference is in the iOS/Android keyboard that appears when the field is focused.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables international postal code entry in the Deposit flow address form.
> 
> - Changes `keyboardType` from `number-pad` to `numbers-and-punctuation` for `postal code` in `EnterAddress.tsx`
> - Updates related test snapshots to reflect the new keyboard type
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2581387b7c4e6eeb3fcd075c68f988812479650d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->