### PR TITLE
test: Normalize re-run CI workflow on skipped tags

### DIFF
--- a/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
+++ b/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
@@ -1,4 +1,4 @@
-name: Rerun CI on skip-smart-e2e-selection label
+name: Rerun CI on skipped E2E labels
 
 on:
   pull_request:
@@ -11,7 +11,10 @@ env:
 
 jobs:
   rerun-ci:
-    if: github.event.label.name == 'skip-smart-e2e-selection'
+    if: >-
+      github.event.label.name == 'skip-smart-e2e-selection' ||
+      github.event.label.name == 'skip-e2e' ||
+      github.event.label.name == 'skip-e2e-quality-gate'
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This workflow automatically cancels and reruns the CI when E2E skip labels (skip-smart-e2e-selection, skip-e2e, skip-e2e-quality-gate) are added or removed from a PR. This is necessary because the main CI is not label-triggered, so label changes don't take effect until CI is rerun.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:
https://consensyssoftware.atlassian.net/browse/MMQA-1301

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only a GitHub Actions workflow condition to respond to additional labels, affecting when CI runs are canceled/rerun but not application code or data handling.
> 
> **Overview**
> Updates the `rerun-ci-on-skipped-e2e-labels.yml` GitHub Actions workflow so the rerun logic triggers not only for `skip-smart-e2e-selection`, but also for `skip-e2e` and `skip-e2e-quality-gate` label events on PRs, ensuring CI is canceled and rerun when any of these E2E-skip labels is added/removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f099fcfd15c790194e0a56fc0fe1aa0fb498bbc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->