### PR TITLE
fix(ramp): open contact support in in-app browser instead of external browser

### DIFF
--- a/app/components/UI/Ramp/components/Modals/SettingsModal/SettingsModal.test.tsx
+++ b/app/components/UI/Ramp/components/Modals/SettingsModal/SettingsModal.test.tsx
@@ -197,7 +197,9 @@ describe('SettingsModal', () => {
       const { getByText } = renderWithProvider(SettingsModal);
 
       const contactSupportButton = getByText('Contact support');
-      fireEvent.press(contactSupportButton);
+      await act(async () => {
+        fireEvent.press(contactSupportButton);
+      });
 
       await waitFor(() => {
         expect(InAppBrowser.isAvailable).toHaveBeenCalled();
@@ -211,7 +213,9 @@ describe('SettingsModal', () => {
       const { getByText } = renderWithProvider(SettingsModal);
 
       const contactSupportButton = getByText('Contact support');
-      fireEvent.press(contactSupportButton);
+      await act(async () => {
+        fireEvent.press(contactSupportButton);
+      });
 
       await waitFor(() => {
         expect(InAppBrowser.isAvailable).toHaveBeenCalled();

--- a/app/components/UI/Ramp/components/Modals/SettingsModal/SettingsModal.tsx
+++ b/app/components/UI/Ramp/components/Modals/SettingsModal/SettingsModal.tsx
@@ -5,7 +5,7 @@ import React, {
   useState,
   useEffect,
 } from 'react';
-import { Linking } from 'react-native';
+import InAppBrowser from 'react-native-inappbrowser-reborn';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../../component-library/components/BottomSheets/BottomSheet';
@@ -99,10 +99,25 @@ function SettingsModal() {
 
   const handleContactSupport = useCallback(() => {
     if (supportUrl) {
-      sheetRef.current?.onCloseBottomSheet();
-      Linking.openURL(supportUrl);
+      sheetRef.current?.onCloseBottomSheet(() => {
+        (async () => {
+          if (await InAppBrowser.isAvailable()) {
+            await InAppBrowser.open(supportUrl);
+          } else {
+            navigation.navigate('Webview', {
+              screen: 'SimpleWebview',
+              params: {
+                url: supportUrl,
+                title: strings(
+                  'fiat_on_ramp.build_quote_settings_modal.contact_support',
+                ),
+              },
+            });
+          }
+        })();
+      });
     }
-  }, [supportUrl]);
+  }, [navigation, supportUrl]);
 
   const handleLogOut = useCallback(async () => {
     try {


### PR DESCRIPTION
## **Description**

Opens the "Contact Support" link from the Ramp Settings modal in an in-app browser instead of the external Safari/Chrome browser. This provides a better user experience by keeping users within the app.

- Uses `InAppBrowser.open()` when available
- Falls back to `SimpleWebview` navigation when InAppBrowser is not available

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Ramp Settings Contact Support

  Scenario: user taps contact support in settings modal
    Given user is on the Buy/Sell quote screen with a preferred provider set

    When user opens the Settings modal and taps "Contact Support"
    Then the provider support page opens in an in-app browser overlay
    And user remains within the MetaMask app
```

## **Screenshots/Recordings**

### **Before**

N/A - (link opens in external browser)

### **After**

Link opens inside the in-app browser.

https://github.com/user-attachments/assets/4c583046-eaf6-49e9-8a65-f3696cd9481c


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to the Ramp Settings modal’s support link; primary risk is platform-specific in-app browser availability/handling.
> 
> **Overview**
> Updates `SettingsModal` so **Contact support** closes the bottom sheet and then opens the provider support URL via `react-native-inappbrowser-reborn` when available, with a fallback to navigating to `Webview`/`SimpleWebview` when it isn’t.
> 
> Updates `SettingsModal.test.tsx` to mock `InAppBrowser` and assert both the in-app browser path and the fallback navigation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfceb12945b7d3265e305be124cc9036792ed7f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->