### PR TITLE
fix(confirmations): handle batch predict deposits and quote‑based alerts

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
@@ -15,6 +15,9 @@ import { useBurnAddressAlert } from './useBurnAddressAlert';
 import { useTokenTrustSignalAlerts } from './useTokenTrustSignalAlerts';
 import { useAddressTrustSignalAlerts } from './useAddressTrustSignalAlerts';
 import { useOriginTrustSignalAlerts } from './useOriginTrustSignalAlerts';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { TransactionType } from '@metamask/transaction-controller';
+import { hasTransactionType } from '../../utils/transaction';
 
 function useSignatureAlerts(): Alert[] {
   const domainMismatchAlerts = useDomainMismatchAlerts();
@@ -23,8 +26,14 @@ function useSignatureAlerts(): Alert[] {
 }
 
 function useTransactionAlerts(): Alert[] {
+  const transactionMetadata = useTransactionMetadataRequest();
+  const ignoreGasFeeToken = hasTransactionType(transactionMetadata, [
+    TransactionType.perpsDeposit,
+  ]);
   const gasEstimateFailedAlert = useGasEstimateFailedAlert();
-  const insufficientBalanceAlert = useInsufficientBalanceAlert();
+  const insufficientBalanceAlert = useInsufficientBalanceAlert({
+    ignoreGasFeeToken,
+  });
   const signedOrSubmittedAlert = useSignedOrSubmittedAlert();
   const pendingTransactionAlert = usePendingTransactionAlert();
   const batchedUnusedApprovalsAlert = useBatchedUnusedApprovalsAlert();

--- a/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
@@ -15,9 +15,6 @@ import { useBurnAddressAlert } from './useBurnAddressAlert';
 import { useTokenTrustSignalAlerts } from './useTokenTrustSignalAlerts';
 import { useAddressTrustSignalAlerts } from './useAddressTrustSignalAlerts';
 import { useOriginTrustSignalAlerts } from './useOriginTrustSignalAlerts';
-import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { TransactionType } from '@metamask/transaction-controller';
-import { hasTransactionType } from '../../utils/transaction';
 
 function useSignatureAlerts(): Alert[] {
   const domainMismatchAlerts = useDomainMismatchAlerts();
@@ -26,14 +23,8 @@ function useSignatureAlerts(): Alert[] {
 }
 
 function useTransactionAlerts(): Alert[] {
-  const transactionMetadata = useTransactionMetadataRequest();
-  const ignoreGasFeeToken = hasTransactionType(transactionMetadata, [
-    TransactionType.perpsDeposit,
-  ]);
   const gasEstimateFailedAlert = useGasEstimateFailedAlert();
-  const insufficientBalanceAlert = useInsufficientBalanceAlert({
-    ignoreGasFeeToken,
-  });
+  const insufficientBalanceAlert = useInsufficientBalanceAlert();
   const signedOrSubmittedAlert = useSignedOrSubmittedAlert();
   const pendingTransactionAlert = usePendingTransactionAlert();
   const batchedUnusedApprovalsAlert = useBatchedUnusedApprovalsAlert();

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -94,7 +94,6 @@ describe('useInsufficientBalanceAlert', () => {
   const useTransactionPayHasSourceAmountMock = jest.mocked(
     useTransactionPayHasSourceAmount,
   );
-  const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const useHasInsufficientBalanceMock = jest.mocked(useHasInsufficientBalance);
 
   const mockChainId = '0x1' as Hex;
@@ -159,7 +158,7 @@ describe('useInsufficientBalanceAlert', () => {
     useIsTransactionPayLoadingMock.mockReturnValue(false);
     useTransactionPayHasSourceAmountMock.mockReturnValue(false);
 
-    useTransactionPayTokenMock.mockReturnValue({
+    mockUseTransactionPayToken.mockReturnValue({
       payToken: undefined,
       setPayToken: jest.fn(),
     });
@@ -307,7 +306,7 @@ describe('useInsufficientBalanceAlert', () => {
   });
 
   it('returns no alert if pay token', () => {
-    useTransactionPayTokenMock.mockReturnValue({
+    mockUseTransactionPayToken.mockReturnValue({
       payToken: {
         address: '0x123' as Hex,
       } as TransactionPaymentToken,
@@ -320,7 +319,7 @@ describe('useInsufficientBalanceAlert', () => {
   });
 
   it('returns alert if pay token matches required token', () => {
-    useTransactionPayTokenMock.mockReturnValue({
+    mockUseTransactionPayToken.mockReturnValue({
       payToken: {
         address: '0x123' as Hex,
         chainId: mockChainId,
@@ -341,7 +340,7 @@ describe('useInsufficientBalanceAlert', () => {
   });
 
   it('returns no alert when pay token matches required token and quotes are available', () => {
-    useTransactionPayTokenMock.mockReturnValue({
+    mockUseTransactionPayToken.mockReturnValue({
       payToken: {
         address: '0x123' as Hex,
         chainId: mockChainId,

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -11,24 +11,13 @@ import { AlertKeys } from '../../constants/alerts';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { Severity } from '../../types/alerts';
 import { useConfirmActions } from '../useConfirmActions';
-import { useTransactionPayToken } from '../pay/useTransactionPayToken';
-import { noop } from 'lodash';
 import { useConfirmationContext } from '../../context/confirmation-context';
 import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
-import {
-  useIsTransactionPayLoading,
-  useTransactionPayQuotes,
-  useTransactionPayRequiredTokens,
-} from '../pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
-import {
-  TransactionPayRequiredToken,
-  TransactionPaymentToken,
-} from '@metamask/transaction-pay-controller';
-import { Hex } from '@metamask/utils';
 import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
 import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
+import { Hex } from '@metamask/utils';
 
 jest.mock('../../../../../util/navigation/navUtils', () => ({
   ...jest.requireActual('../../../../../util/navigation/navUtils'),
@@ -58,7 +47,6 @@ jest.mock('../../../../../selectors/preferencesController');
 jest.mock('../useHasInsufficientBalance');
 jest.mock('../useConfirmActions');
 jest.mock('../transactions/useTransactionMetadataRequest');
-jest.mock('../pay/useTransactionPayToken');
 jest.mock('../useAccountNativeBalance');
 jest.mock('../../../../../../locales/i18n');
 jest.mock('../../../../../selectors/networkController');
@@ -67,7 +55,6 @@ jest.mock('../../../../UI/Ramp/hooks/useRampNavigation', () => ({
   useRampNavigation: jest.fn(),
 }));
 jest.mock('../gas/useIsGaslessSupported');
-jest.mock('../pay/useTransactionPayData');
 jest.mock('../pay/useTransactionPayHasSourceAmount');
 
 describe('useInsufficientBalanceAlert', () => {
@@ -79,18 +66,10 @@ describe('useInsufficientBalanceAlert', () => {
   const mockSelectUseTransactionSimulations = jest.mocked(
     selectUseTransactionSimulations,
   );
-  const mockUseTransactionPayToken = jest.mocked(useTransactionPayToken);
   const mockUseConfirmationContext = jest.mocked(useConfirmationContext);
   const mockUseRampNavigation = jest.mocked(useRampNavigation);
   const mockGoToBuy = jest.fn();
   const useIsGaslessSupportedMock = jest.mocked(useIsGaslessSupported);
-  const useTransactionPayRequiredTokensMock = jest.mocked(
-    useTransactionPayRequiredTokens,
-  );
-  const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
-  const useIsTransactionPayLoadingMock = jest.mocked(
-    useIsTransactionPayLoading,
-  );
   const useTransactionPayHasSourceAmountMock = jest.mocked(
     useTransactionPayHasSourceAmount,
   );
@@ -122,10 +101,6 @@ describe('useInsufficientBalanceAlert', () => {
     } as unknown as ReturnType<typeof useAccountNativeBalance>);
     mockUseTransactionMetadataRequest.mockReturnValue(mockTransaction);
     mockSelectUseTransactionSimulations.mockReturnValue(false);
-    mockUseTransactionPayToken.mockReturnValue({
-      payToken: undefined,
-      setPayToken: noop as never,
-    });
 
     (strings as jest.Mock).mockImplementation((key, params) => {
       if (key === 'alert_system.insufficient_balance.buy_action') {
@@ -153,15 +128,7 @@ describe('useInsufficientBalanceAlert', () => {
       goToDeposit: jest.fn(),
     });
 
-    useTransactionPayRequiredTokensMock.mockReturnValue([]);
-    useTransactionPayQuotesMock.mockReturnValue([]);
-    useIsTransactionPayLoadingMock.mockReturnValue(false);
     useTransactionPayHasSourceAmountMock.mockReturnValue(false);
-
-    mockUseTransactionPayToken.mockReturnValue({
-      payToken: undefined,
-      setPayToken: jest.fn(),
-    });
 
     useHasInsufficientBalanceMock.mockReturnValue({
       hasInsufficientBalance: true,
@@ -305,86 +272,7 @@ describe('useInsufficientBalanceAlert', () => {
     expect(result.current).toStrictEqual([]);
   });
 
-  it('returns no alert if pay token', () => {
-    mockUseTransactionPayToken.mockReturnValue({
-      payToken: {
-        address: '0x123' as Hex,
-      } as TransactionPaymentToken,
-      setPayToken: jest.fn(),
-    });
-
-    const { result } = renderHook(() => useInsufficientBalanceAlert());
-
-    expect(result.current).toStrictEqual([]);
-  });
-
-  it('returns alert if pay token matches required token', () => {
-    mockUseTransactionPayToken.mockReturnValue({
-      payToken: {
-        address: '0x123' as Hex,
-        chainId: mockChainId,
-      } as TransactionPaymentToken,
-      setPayToken: jest.fn(),
-    });
-
-    useTransactionPayRequiredTokensMock.mockReturnValue([
-      {
-        address: '0x123' as Hex,
-        chainId: mockChainId,
-      } as TransactionPayRequiredToken,
-    ]);
-
-    const { result } = renderHook(() => useInsufficientBalanceAlert());
-
-    expect(result.current).toHaveLength(1);
-  });
-
-  it('returns no alert when pay token matches required token and quotes are available', () => {
-    mockUseTransactionPayToken.mockReturnValue({
-      payToken: {
-        address: '0x123' as Hex,
-        chainId: mockChainId,
-      } as TransactionPaymentToken,
-      setPayToken: jest.fn(),
-    });
-
-    useTransactionPayRequiredTokensMock.mockReturnValue([
-      {
-        address: '0x123' as Hex,
-        chainId: mockChainId,
-      } as TransactionPayRequiredToken,
-    ]);
-
-    useTransactionPayQuotesMock.mockReturnValue([
-      {
-        provider: 'mock-provider',
-      },
-    ] as unknown as ReturnType<typeof useTransactionPayQuotes>);
-    useTransactionPayHasSourceAmountMock.mockReturnValue(true);
-
-    const { result } = renderHook(() => useInsufficientBalanceAlert());
-
-    expect(result.current).toEqual([]);
-  });
-
-  it('returns no alert when pay token matches required token and quotes are loading', () => {
-    mockUseTransactionPayToken.mockReturnValue({
-      payToken: {
-        address: '0x123' as Hex,
-        chainId: mockChainId,
-      } as TransactionPaymentToken,
-      setPayToken: jest.fn(),
-    });
-
-    useTransactionPayRequiredTokensMock.mockReturnValue([
-      {
-        address: '0x123' as Hex,
-        chainId: mockChainId,
-      } as TransactionPayRequiredToken,
-    ]);
-
-    useTransactionPayQuotesMock.mockReturnValue([]);
-    useIsTransactionPayLoadingMock.mockReturnValue(true);
+  it('returns empty array when using pay source amounts', () => {
     useTransactionPayHasSourceAmountMock.mockReturnValue(true);
 
     const { result } = renderHook(() => useInsufficientBalanceAlert());

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -16,7 +16,11 @@ import { noop } from 'lodash';
 import { useConfirmationContext } from '../../context/confirmation-context';
 import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
-import { useTransactionPayRequiredTokens } from '../pay/useTransactionPayData';
+import {
+  useIsTransactionPayLoading,
+  useTransactionPayQuotes,
+  useTransactionPayRequiredTokens,
+} from '../pay/useTransactionPayData';
 import {
   TransactionPayRequiredToken,
   TransactionPaymentToken,
@@ -82,6 +86,10 @@ describe('useInsufficientBalanceAlert', () => {
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
   );
+  const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
+  const useIsTransactionPayLoadingMock = jest.mocked(
+    useIsTransactionPayLoading,
+  );
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const useHasInsufficientBalanceMock = jest.mocked(useHasInsufficientBalance);
 
@@ -143,6 +151,8 @@ describe('useInsufficientBalanceAlert', () => {
     });
 
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
+    useTransactionPayQuotesMock.mockReturnValue([]);
+    useIsTransactionPayLoadingMock.mockReturnValue(false);
 
     useTransactionPayTokenMock.mockReturnValue({
       payToken: undefined,
@@ -323,6 +333,33 @@ describe('useInsufficientBalanceAlert', () => {
     const { result } = renderHook(() => useInsufficientBalanceAlert());
 
     expect(result.current).toHaveLength(1);
+  });
+
+  it('returns no alert when pay token matches required token and quotes are available', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: {
+        address: '0x123' as Hex,
+        chainId: mockChainId,
+      } as TransactionPaymentToken,
+      setPayToken: jest.fn(),
+    });
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      {
+        address: '0x123' as Hex,
+        chainId: mockChainId,
+      } as TransactionPayRequiredToken,
+    ]);
+
+    useTransactionPayQuotesMock.mockReturnValue([
+      {
+        provider: 'mock-provider',
+      },
+    ] as unknown as ReturnType<typeof useTransactionPayQuotes>);
+
+    const { result } = renderHook(() => useInsufficientBalanceAlert());
+
+    expect(result.current).toEqual([]);
   });
 
   describe('when ignoreGasFeeToken is true', () => {

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -21,6 +21,7 @@ import {
   useTransactionPayQuotes,
   useTransactionPayRequiredTokens,
 } from '../pay/useTransactionPayData';
+import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
 import {
   TransactionPayRequiredToken,
   TransactionPaymentToken,
@@ -67,7 +68,7 @@ jest.mock('../../../../UI/Ramp/hooks/useRampNavigation', () => ({
 }));
 jest.mock('../gas/useIsGaslessSupported');
 jest.mock('../pay/useTransactionPayData');
-jest.mock('../pay/useTransactionPayData');
+jest.mock('../pay/useTransactionPayHasSourceAmount');
 
 describe('useInsufficientBalanceAlert', () => {
   const mockUseTransactionMetadataRequest = jest.mocked(
@@ -89,6 +90,9 @@ describe('useInsufficientBalanceAlert', () => {
   const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
   const useIsTransactionPayLoadingMock = jest.mocked(
     useIsTransactionPayLoading,
+  );
+  const useTransactionPayHasSourceAmountMock = jest.mocked(
+    useTransactionPayHasSourceAmount,
   );
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const useHasInsufficientBalanceMock = jest.mocked(useHasInsufficientBalance);
@@ -153,6 +157,7 @@ describe('useInsufficientBalanceAlert', () => {
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
     useTransactionPayQuotesMock.mockReturnValue([]);
     useIsTransactionPayLoadingMock.mockReturnValue(false);
+    useTransactionPayHasSourceAmountMock.mockReturnValue(false);
 
     useTransactionPayTokenMock.mockReturnValue({
       payToken: undefined,
@@ -356,6 +361,7 @@ describe('useInsufficientBalanceAlert', () => {
         provider: 'mock-provider',
       },
     ] as unknown as ReturnType<typeof useTransactionPayQuotes>);
+    useTransactionPayHasSourceAmountMock.mockReturnValue(true);
 
     const { result } = renderHook(() => useInsufficientBalanceAlert());
 

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -367,6 +367,31 @@ describe('useInsufficientBalanceAlert', () => {
     expect(result.current).toEqual([]);
   });
 
+  it('returns no alert when pay token matches required token and quotes are loading', () => {
+    mockUseTransactionPayToken.mockReturnValue({
+      payToken: {
+        address: '0x123' as Hex,
+        chainId: mockChainId,
+      } as TransactionPaymentToken,
+      setPayToken: jest.fn(),
+    });
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      {
+        address: '0x123' as Hex,
+        chainId: mockChainId,
+      } as TransactionPayRequiredToken,
+    ]);
+
+    useTransactionPayQuotesMock.mockReturnValue([]);
+    useIsTransactionPayLoadingMock.mockReturnValue(true);
+    useTransactionPayHasSourceAmountMock.mockReturnValue(true);
+
+    const { result } = renderHook(() => useInsufficientBalanceAlert());
+
+    expect(result.current).toEqual([]);
+  });
+
   describe('when ignoreGasFeeToken is true', () => {
     it('returns empty array', () => {
       useHasInsufficientBalanceMock.mockReturnValue({

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -68,8 +68,8 @@ export const useInsufficientBalanceAlert = ({
     // Simulation is complete if it's disabled, or if enabled and gasFeeTokens is loaded
     const isSimulationComplete = !isSimulationEnabled || Boolean(gasFeeTokens);
 
-    // Check if user has selected a gas fee token (or we're ignoring that check)
-    const hasNoGasFeeTokenSelected = ignoreGasFeeToken || !selectedGasFeeToken;
+    // Check if user has selected a gas fee token (ignore when flag is set)
+    const hasNoGasFeeTokenSelected = !ignoreGasFeeToken && !selectedGasFeeToken;
 
     // Gasless check is complete AND one of:
     //  - Gasless is NOT supported (native currency needed for gas)
@@ -79,7 +79,7 @@ export const useInsufficientBalanceAlert = ({
       isGaslessCheckComplete &&
       (!isGaslessSupported ||
         isGasFeeTokensEmpty ||
-        (!isGasFeeTokensEmpty && !selectedGasFeeToken));
+        (!isGasFeeTokensEmpty && !selectedGasFeeToken && !ignoreGasFeeToken));
 
     const showAlert =
       hasInsufficientBalance &&

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -11,12 +11,6 @@ import { useConfirmationContext } from '../../context/confirmation-context';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import { TransactionType } from '@metamask/transaction-controller';
 import { hasTransactionType } from '../../utils/transaction';
-import { useTransactionPayToken } from '../pay/useTransactionPayToken';
-import {
-  useIsTransactionPayLoading,
-  useTransactionPayQuotes,
-  useTransactionPayRequiredTokens,
-} from '../pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
 import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
 import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
@@ -34,35 +28,13 @@ export const useInsufficientBalanceAlert = ({
   const { onReject } = useConfirmActions();
   const { isSupported: isGaslessSupported, pending: isGaslessCheckPending } =
     useIsGaslessSupported();
-  const { payToken } = useTransactionPayToken();
-  const quotes = useTransactionPayQuotes();
-  const isQuotesLoading = useIsTransactionPayLoading();
   const isUsingPay = useTransactionPayHasSourceAmount();
-  const requiredTokens = useTransactionPayRequiredTokens();
   const isSimulationEnabled = useSelector(selectUseTransactionSimulations);
   const { hasInsufficientBalance, nativeCurrency } =
     useHasInsufficientBalance();
 
-  const primaryRequiredToken = (requiredTokens ?? []).find(
-    (token) => !token.skipIfBalance,
-  );
-
-  const isPayTokenTarget =
-    payToken &&
-    payToken.chainId === primaryRequiredToken?.chainId &&
-    payToken.address.toLowerCase() ===
-      primaryRequiredToken?.address.toLowerCase();
-
-  const hasPayTokenQuotes = Boolean(quotes?.length);
-  const shouldSkipInsufficientBalanceForPayToken =
-    isUsingPay && (isQuotesLoading || hasPayTokenQuotes);
-
   return useMemo(() => {
-    if (
-      !transactionMetadata ||
-      isTransactionValueUpdating ||
-      (payToken && !isPayTokenTarget && !isUsingPay)
-    ) {
+    if (!transactionMetadata || isTransactionValueUpdating || isUsingPay) {
       return [];
     }
 
@@ -94,7 +66,6 @@ export const useInsufficientBalanceAlert = ({
         (!isGasFeeTokensEmpty && !selectedGasFeeToken));
 
     const showAlert =
-      !shouldSkipInsufficientBalanceForPayToken &&
       hasInsufficientBalance &&
       isSimulationComplete &&
       hasNoGasFeeTokenSelected &&
@@ -131,13 +102,10 @@ export const useInsufficientBalanceAlert = ({
   }, [
     transactionMetadata,
     isTransactionValueUpdating,
-    payToken,
-    isPayTokenTarget,
     isGaslessCheckPending,
     isGaslessSupported,
     isSimulationEnabled,
     ignoreGasFeeToken,
-    shouldSkipInsufficientBalanceForPayToken,
     isUsingPay,
     hasInsufficientBalance,
     nativeCurrency,

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -17,6 +17,7 @@ import {
   useTransactionPayQuotes,
   useTransactionPayRequiredTokens,
 } from '../pay/useTransactionPayData';
+import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
 import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
 import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
 
@@ -36,6 +37,7 @@ export const useInsufficientBalanceAlert = ({
   const { payToken } = useTransactionPayToken();
   const quotes = useTransactionPayQuotes();
   const isQuotesLoading = useIsTransactionPayLoading();
+  const isUsingPay = useTransactionPayHasSourceAmount();
   const requiredTokens = useTransactionPayRequiredTokens();
   const isSimulationEnabled = useSelector(selectUseTransactionSimulations);
   const { hasInsufficientBalance, nativeCurrency } =
@@ -53,13 +55,13 @@ export const useInsufficientBalanceAlert = ({
 
   const hasPayTokenQuotes = Boolean(quotes?.length);
   const shouldSkipInsufficientBalanceForPayToken =
-    isPayTokenTarget && (isQuotesLoading || hasPayTokenQuotes);
+    isUsingPay && (isQuotesLoading || hasPayTokenQuotes);
 
   return useMemo(() => {
     if (
       !transactionMetadata ||
       isTransactionValueUpdating ||
-      (payToken && !isPayTokenTarget)
+      (payToken && !isPayTokenTarget && !isUsingPay)
     ) {
       return [];
     }
@@ -136,6 +138,7 @@ export const useInsufficientBalanceAlert = ({
     isSimulationEnabled,
     ignoreGasFeeToken,
     shouldSkipInsufficientBalanceForPayToken,
+    isUsingPay,
     hasInsufficientBalance,
     nativeCurrency,
     goToBuy,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -60,12 +60,18 @@ export function useTransactionPayToken(): {
         console.error('Error updating payment token', e);
       }
 
-      // perps deposits only use relay, so doesn't need gasFeeToken update
       const isPredictDepositTransaction = hasTransactionType(transactionMeta, [
         TransactionType.predictDeposit,
       ]);
+      const isPerpsDepositTransaction = hasTransactionType(transactionMeta, [
+        TransactionType.perpsDeposit,
+      ]);
 
-      if (isPredictDepositTransaction && transactionMeta) {
+      const shouldUpdateGasFeeToken =
+        (isPredictDepositTransaction || isPerpsDepositTransaction) &&
+        transactionMeta;
+
+      if (shouldUpdateGasFeeToken) {
         const isNewPayTokenRequiredToken =
           newPayToken.chainId === primaryRequiredToken?.chainId &&
           newPayToken.address.toLowerCase() ===

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -64,9 +64,6 @@ export function useTransactionPayToken(): {
       const isPredictDepositTransaction = hasTransactionType(transactionMeta, [
         TransactionType.predictDeposit,
       ]);
-      const isPerpsDepositTransaction = hasTransactionType(transactionMeta, [
-        TransactionType.perpsDeposit,
-      ]);
 
       if (isPredictDepositTransaction && transactionMeta) {
         const isNewPayTokenRequiredToken =
@@ -85,8 +82,6 @@ export function useTransactionPayToken(): {
         };
 
         updateTransaction(updatedTx, transactionMeta.id);
-      } else if (isPerpsDepositTransaction) {
-        // No selectedGasFeeToken update for perps deposits.
       }
 
       EngineService.flushState();

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -60,18 +60,12 @@ export function useTransactionPayToken(): {
         console.error('Error updating payment token', e);
       }
 
+      // perps deposits only use relay, so doesn't need gasFeeToken update
       const isPredictDepositTransaction = hasTransactionType(transactionMeta, [
         TransactionType.predictDeposit,
       ]);
-      const isPerpsDepositTransaction = hasTransactionType(transactionMeta, [
-        TransactionType.perpsDeposit,
-      ]);
 
-      const shouldUpdateGasFeeToken =
-        (isPredictDepositTransaction || isPerpsDepositTransaction) &&
-        transactionMeta;
-
-      if (shouldUpdateGasFeeToken) {
+      if (isPredictDepositTransaction && transactionMeta) {
         const isNewPayTokenRequiredToken =
           newPayToken.chainId === primaryRequiredToken?.chainId &&
           newPayToken.address.toLowerCase() ===


### PR DESCRIPTION
- Update pay token selection to use hasTransactionType for predict deposit detection (covers nested/batch txs), and tighten typing/guarding around transactionMeta when updating selectedGasFeeToken. Perps behavior remains unchanged.
- Suppress the native insufficient balance alert when the pay token matches the required token and pay‑controller quotes are loading/available, letting pay‑token balance/fee alerts drive blocking instead.
- Add unit coverage for the quote‑present case and expand mocks for quote/loading state in useInsufficientBalanceAlert tests.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes blocking alert behavior and updates how `selectedGasFeeToken` is set during pay-token selection for `predictDeposit`, which could impact confirmation gating and gas/token selection in edge cases.
> 
> **Overview**
> **Confirmation alerts now defer to transaction-pay UI when pay quotes/source amounts are in play.** `useInsufficientBalanceAlert` stops emitting the native insufficient-balance blocking alert whenever `useTransactionPayHasSourceAmount()` indicates pay source amounts are being used, replacing the prior pay-token/required-token matching logic.
> 
> **Pay-token selection for `predictDeposit` is more robust.** `useTransactionPayToken` uses `hasTransactionType` to detect `predictDeposit` (covering nested/batch transactions) and only updates `selectedGasFeeToken` when `transactionMeta` is present, with tighter typing.
> 
> Tests for `useInsufficientBalanceAlert` were updated to mock `useTransactionPayHasSourceAmount` and cover the new suppression behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 567382ea1d7ebe73e8de1f40c6adaa0f051ff9c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->