### PR TITLE
refactor(analytics): migrate Batch 1-3 and 1-7: platform team or no CO

### DIFF
--- a/app/components/hooks/useAnalytics/useAnalytics.types.ts
+++ b/app/components/hooks/useAnalytics/useAnalytics.types.ts
@@ -13,6 +13,18 @@ type AnalyticsEventBuilderType = ReturnType<
   typeof AnalyticsEventBuilder.createEventBuilder
 >;
 
+/**
+ * Source type constants for analytics tracking
+ */
+export const SourceType = {
+  SDK: 'sdk',
+  SDK_CONNECT_V2: 'sdk_connect_v2',
+  WALLET_CONNECT: 'walletconnect',
+  IN_APP_BROWSER: 'in-app browser',
+  PERMISSION_SYSTEM: 'permission system',
+  DAPP_DEEPLINK_URL: 'dapp-deeplink-url',
+} as const;
+
 export interface UseAnalyticsHook {
   isEnabled(): boolean;
   enable(enable?: boolean): Promise<void>;

--- a/app/components/hooks/useMetrics/useMetrics.types.ts
+++ b/app/components/hooks/useMetrics/useMetrics.types.ts
@@ -8,6 +8,11 @@ import {
 } from '../../../core/Analytics/MetaMetrics.types';
 import { MetricsEventBuilder } from '../../../core/Analytics/MetricsEventBuilder';
 
+/**
+ * @deprecated SourceType has been moved to useAnalytics.types.ts
+ * This export is kept for backward compatibility with files outside Phase 1 migration.
+ * New code should import SourceType from './useAnalytics/useAnalytics.types' instead.
+ */
 export const SourceType = {
   SDK: 'sdk',
   SDK_CONNECT_V2: 'sdk_connect_v2',

--- a/app/components/hooks/useOriginSource.test.ts
+++ b/app/components/hooks/useOriginSource.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useOriginSource } from './useOriginSource';
-import { SourceType } from './useMetrics/useMetrics.types';
+import { SourceType } from './useAnalytics/useAnalytics.types';
 import AppConstants from '../../core/AppConstants';
 import { RootState } from '../../reducers';
 

--- a/app/components/hooks/useOriginSource.ts
+++ b/app/components/hooks/useOriginSource.ts
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 import SDKConnect from '../../core/SDKConnect/SDKConnect';
 import { RootState } from '../../reducers';
 import { isUUID } from '../../core/SDKConnect/utils/isUUID';
-import { SourceType } from './useMetrics/useMetrics.types';
+import { SourceType } from './useAnalytics/useAnalytics.types';
 import AppConstants from '../../core/AppConstants';
 
 interface UseOriginSourceProps {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Establish patterns and migrate low-risk batches that don't block others.

- Completed: Batch 1-3 (SourceType migration) and Batch 1-7 (App initialization)
- Cancelled: Batch 1-1 (test mocks, no migration needed for now - deferred until MetaMetrics is fully removed)
- TODO in other PRs: Batches 1-2, 1-4, 1-5, and 1-6 as other CodeOwners, to minimise CO reviews.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-297

## **Manual testing steps**

```gherkin
  Scenario: App initializes successfully after update
    Given the app is installed and user has an existing wallet
    When user opens the app
    Then the app should initialize successfully
      And user should be able to unlock the wallet
      And no initialization errors should appear
      And analytics should be configured correctly (no errors in logs)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

<img width="500" alt="logs" src="https://github.com/user-attachments/assets/c801e4e1-f5ba-47f0-8c55-cb81df557bc8" />
<img width="500" alt="Segment dev source" src="https://github.com/user-attachments/assets/d371d8fe-0c1a-4d87-bbd1-a30fac0fa601" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates analytics source typing and updates references.
> 
> - Adds `SourceType` constants to `useAnalytics.types.ts` (authoritative export)
> - Deprecates `SourceType` in `useMetrics.types.ts` (kept for backward compatibility)
> - Updates `useOriginSource` and `useOriginSource.test` to import `SourceType` from `useAnalytics.types.ts`
> 
> No behavioral changes expected beyond type/import relocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79b36074285c1c0646ffe4078b8ae6234a310810. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->