### PR TITLE
fix: format input amount when validating balance

### DIFF
--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -411,7 +411,8 @@ export const TokenInputArea = forwardRef<
                 >
                   <Text
                     color={
-                      isInsufficientBalance
+                      isInsufficientBalance &&
+                      tokenType === TokenInputAreaType.Source
                         ? TextColor.Error
                         : TextColor.Alternative
                     }

--- a/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
@@ -29,10 +29,7 @@ const normalizeAmount = (value: string, decimals: number): string => {
   return value;
 };
 
-export const formatEffectiveGasFee = (
-  effectiveGasFee: string,
-  decimals: number,
-) => {
+export const formatAmount = (effectiveGasFee: string, decimals: number) => {
   // Truncate to token.decimals to avoid parseUnits overflow
   const decimalIndex = effectiveGasFee.indexOf('.');
   return decimalIndex === -1
@@ -40,11 +37,8 @@ export const formatEffectiveGasFee = (
     : effectiveGasFee.slice(0, decimalIndex + 1 + decimals);
 };
 
-export const transformEffectiveToAtomic = (
-  effectiveGasFee: string,
-  decimals: number,
-) => {
-  const formattedFee = formatEffectiveGasFee(effectiveGasFee, decimals);
+export const parseAmount = (effectiveGasFee: string, decimals: number) => {
+  const formattedFee = formatAmount(effectiveGasFee, decimals);
   return parseUnits(formattedFee, decimals);
 };
 
@@ -63,34 +57,26 @@ const useIsInsufficientBalance = ({
   const isValidAmount =
     amount !== undefined && amount !== '.' && token?.decimals;
 
-  // Safety check for decimal places before parsing
-  const hasValidDecimals =
-    isValidAmount &&
-    (() => {
-      // Convert scientific notation to decimal string if needed
-      const normalizedAmount = normalizeAmount(amount, token.decimals);
-      const decimalPlaces = normalizedAmount.includes('.')
-        ? normalizedAmount.split('.')[1].length
-        : 0;
-      return decimalPlaces <= token.decimals;
-    })();
-
-  // Only perform calculations if we have valid inputs and gas is not included
-  if (
-    !isValidAmount ||
-    !hasValidDecimals ||
-    !token ||
-    !latestAtomicBalance ||
-    !!isGasless ||
-    !!gasSponsored
-  ) {
+  // If we don't have valid inputs yet, return false (no error)
+  if (!isValidAmount || !token) {
     return false;
   }
 
-  const inputAmount = parseUnits(
-    normalizeAmount(amount, token.decimals),
-    token.decimals,
-  );
+  // If we don't have balance data yet (e.g., during token switching),
+  // return true to prevent invalid swaps until balance is loaded
+  if (!latestAtomicBalance) {
+    return true;
+  }
+
+  // Normalize amount to token decimals and handle excess decimals
+  let inputAmount: BigNumber;
+  try {
+    const normalizedAmount = normalizeAmount(amount, token.decimals);
+    inputAmount = parseAmount(normalizedAmount, token.decimals);
+  } catch (error) {
+    // If we can't parse the amount, treat it as invalid (insufficient balance)
+    return true;
+  }
 
   const isNativeToken = token.chainId && isNativeAddress(token.address);
   const isSOL = isNativeToken && isSolanaChainId(token.chainId);
@@ -99,8 +85,9 @@ const useIsInsufficientBalance = ({
   // For ERC-20 tokens (USDC, DAI, etc.), gas is checked separately in useHasSufficientGas
   // For native tokens (ETH, MATIC, etc.), gas comes from the SAME balance we're spending,
   // so we need to ensure: balance >= sourceAmount + gasAmount
+  // NOTE: If gas is sponsored/included, we skip adding gas to the calculation but still check token balance
   let atomicGasFee = BigNumber.from(0);
-  if (isNativeToken && !isGasless) {
+  if (isNativeToken && !isGasless && !gasSponsored) {
     const gasAmount = bestQuote?.gasFee?.effective?.amount;
     const effectiveGasFee = isNumberValue(gasAmount)
       ? // we guard against null and undefined values of gasAmount when checked isNumberValue
@@ -108,10 +95,7 @@ const useIsInsufficientBalance = ({
       : null;
 
     if (effectiveGasFee) {
-      atomicGasFee = transformEffectiveToAtomic(
-        effectiveGasFee,
-        token.decimals,
-      );
+      atomicGasFee = parseAmount(effectiveGasFee, token.decimals);
     }
   }
 
@@ -123,16 +107,22 @@ const useIsInsufficientBalance = ({
     const remainingBalance = latestAtomicBalance.sub(inputAmount);
     isInsufficientBalance =
       isInsufficientBalance || remainingBalance.lt(minSolBalanceLamports);
-  } else if (isNativeToken && !isGasless && atomicGasFee.gt(0)) {
+  } else if (
+    isNativeToken &&
+    !isGasless &&
+    !gasSponsored &&
+    atomicGasFee.gt(0)
+  ) {
     // Native tokens (ETH, MATIC, etc.): check balance >= sourceAmount + gasAmount
     // Example: User has 1 ETH, wants to send 1 ETH, needs 0.01 ETH gas = insufficient
     const totalRequired = inputAmount.add(atomicGasFee);
     isInsufficientBalance =
       isInsufficientBalance || totalRequired.gt(latestAtomicBalance);
   } else {
-    // ERC-20 tokens or gasless transactions: check balance >= sourceAmount only
+    // All other cases: ERC-20 tokens, gasless transactions, or gas-sponsored transactions
+    // Check balance >= sourceAmount only (gas is either not needed or checked separately)
     // Example: User has 100 USDC, wants to send 50 USDC = sufficient
-    // (Gas check happens separately in useHasSufficientGas for ERC-20 tokens)
+    // Example: User has 0.0004 BTC, wants to send 0.0114 BTC (gasless) = insufficient
     isInsufficientBalance =
       isInsufficientBalance || inputAmount.gt(latestAtomicBalance);
   }

--- a/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
@@ -73,7 +73,7 @@ const useIsInsufficientBalance = ({
   try {
     const normalizedAmount = normalizeAmount(amount, token.decimals);
     inputAmount = parseAmount(normalizedAmount, token.decimals);
-  } catch (error) {
+  } catch {
     // If we can't parse the amount, treat it as invalid (insufficient balance)
     return true;
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Format input amount when validating balance. Previously we only checked the amount against the token decimal places but not all tokens have the same amount of decimals and when we switch between chains we need to account for that by properly formatting the input amount. This PR addresses this issue.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: format input amount when validating balance

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3902

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/6ceb44ec-50d2-40a8-8534-8e9b7900852b


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x  I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes balance-validation logic used to gate swaps, including new behavior when balances are temporarily undefined and when gas is sponsored/included; mistakes could block valid swaps or allow invalid ones.
> 
> **Overview**
> Fixes bridge insufficient-balance validation by **normalizing and truncating input amounts to the selected token’s decimals** before parsing, avoiding overflow/precision issues when switching chains/tokens.
> 
> Updates `useIsInsufficientBalance` to treat missing balance data and unparseable amounts as insufficient, and to **skip adding gas to the required amount when gas is sponsored/included** while still checking token balance. The TokenInputArea subtitle now shows the error color only for the *source* input.
> 
> Renames helpers to `formatAmount`/`parseAmount` and adds extensive unit tests covering cross-chain decimal precision, truncation, and edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f68afa22b0049baead64e897a4e6c27182d49fde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->