### PR TITLE
fix: prevent long token names from pushing balance off screen

### DIFF
--- a/app/components/Views/confirmations/components/UI/token/token.tsx
+++ b/app/components/Views/confirmations/components/UI/token/token.tsx
@@ -51,7 +51,7 @@ export function Token({ asset, onPress }: TokenProps) {
       }
       onPress={handlePress}
     >
-      <Box twClassName="flex-row items-center px-4">
+      <Box twClassName="flex-row items-center px-4 flex-1 min-w-0">
         <Box twClassName="h-12 justify-center">
           <BadgeWrapper
             badgePosition={BadgePosition.BottomRight}
@@ -84,7 +84,7 @@ export function Token({ asset, onPress }: TokenProps) {
           </BadgeWrapper>
         </Box>
 
-        <Box twClassName="ml-4 h-12 justify-center">
+        <Box twClassName="ml-4 h-12 justify-center flex-1 min-w-0">
           <Box twClassName="flex-row items-center">
             <Text
               variant={TextVariant.BodyMd}
@@ -106,7 +106,7 @@ export function Token({ asset, onPress }: TokenProps) {
           </Text>
         </Box>
       </Box>
-      <Box twClassName="px-4 h-12 justify-center items-end flex-1">
+      <Box twClassName="px-4 h-12 justify-center items-end shrink-0">
         <Text
           variant={TextVariant.BodyMd}
           fontWeight={FontWeight.Medium}


### PR DESCRIPTION
## **Description**

Long token names in the Send flow and MM Pay token picker were pushing the balance display off the screen. This fix adds proper flex constraints to allow the token name container to shrink while keeping the balance visible.

1. **Reason for change:** Tokens with long names (e.g., DAI on Linea, USDT on Base) push the balance completely off screen in the Send flow token picker and MM Pay deposit confirmation.
2. **Solution:** Add flex constraints (`flex-1`, `min-w-0`) to the token info container to allow proper shrinking, and change the balance container to `shrink-0` to prevent it from being pushed off screen. This matches the behavior of the home page token list.

## **Changelog**

CHANGELOG entry: Fixed long token names pushing balance off screen in Send flow and MM Pay token picker

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6940

## **Manual testing steps**

```gherkin
Feature: Token picker displays long token names correctly

  Scenario: User views token with long name in Send flow
    Given user has a token with a long name (e.g., DAI on Linea, USDT on Base)

    When user starts a Send flow and opens the token picker
    Then the long token name is truncated with ellipsis
    And the balance is visible on the right side of the screen

  Scenario: User views token with long name in MM Pay deposit
    Given user has a token with a long name

    When user starts a Perps or Predict deposit and views the token picker
    Then the long token name is truncated with ellipsis
    And the balance is visible on the right side of the screen
```

## **Screenshots/Recordings**

### **Before**

Long token names push the balance off the screen (see issue for screenshots).

### **After**

Long token names truncate with ellipsis while the balance remains visible.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.