### PR TITLE
fix: Swaps network pill style

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
@@ -20,8 +20,8 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     paddingTop: 8,
     paddingBottom: 8,
-    paddingLeft: 8,
-    paddingRight: 16,
+    paddingLeft: 12,
+    paddingRight: 12,
   },
 });
 

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import { StyleSheet } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
@@ -13,6 +14,16 @@ import { ButtonSize } from '../../../../../component-library/components/Buttons/
 import { TokenSelectorType } from '../../types';
 
 const PILL_WIDTH = 90; // Average pill width including gap
+
+const styles = StyleSheet.create({
+  pill: {
+    borderRadius: 12,
+    paddingTop: 8,
+    paddingBottom: 8,
+    paddingLeft: 8,
+    paddingRight: 16,
+  },
+});
 
 interface NetworkPillsProps {
   selectedChainId?: CaipChainId;
@@ -71,7 +82,8 @@ export const NetworkPills: React.FC<NetworkPillsProps> = ({
           label={chain.name}
           isActive={isSelected}
           onPress={() => handleChainPress(chain.chainId)}
-          size={ButtonSize.Sm}
+          size={ButtonSize.Md}
+          style={styles.pill}
         />
       );
     });
@@ -90,7 +102,8 @@ export const NetworkPills: React.FC<NetworkPillsProps> = ({
         label={strings('bridge.all')}
         isActive={!selectedChainId}
         onPress={handleAllPress}
-        size={ButtonSize.Sm}
+        style={styles.pill}
+        size={ButtonSize.Md}
       />
       {renderChainPills()}
     </ScrollView>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes some styling issues with the Swaps network pills.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adjusted padding and border radius for Swaps network pills

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3901

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="598" height="1144" alt="Screenshot 2026-01-28 at 3 41 28 PM" src="https://github.com/user-attachments/assets/55fe073b-d8e8-4ef5-83b8-2e5a7a02eae6" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks pill sizing and padding in the bridge/swaps network selector, with no logic, data, or API behavior changes.
> 
> **Overview**
> Adjusts the Swaps/Bridge `NetworkPills` UI to standardize pill styling by adding an explicit `StyleSheet` (padding + `borderRadius`) and applying it to all `ButtonToggle` pills.
> 
> Updates pill sizing from `ButtonSize.Sm` to `ButtonSize.Md` for both the "All" pill and per-network pills to improve layout/consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ed47705c090b67c6189314b67ec0a0ace9d0a2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->