### PR TITLE
feat: MUSD-233 remove stablecoin earn percentage cta to avoid conflicting with musd conversions

### DIFF
--- a/app/components/UI/Earn/hooks/useStablecoinLendingRedirect.test.ts
+++ b/app/components/UI/Earn/hooks/useStablecoinLendingRedirect.test.ts
@@ -1,0 +1,241 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import type { TokenI } from '../../Tokens/types';
+import { EVENT_LOCATIONS } from '../constants/events/earnEvents';
+import { useStablecoinLendingRedirect } from './useStablecoinLendingRedirect';
+
+const mockNavigate = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockCreateEventBuilder = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+  };
+});
+
+jest.mock('../../../../constants/navigation/Routes', () => ({
+  __esModule: true,
+  default: {
+    STAKING: {
+      STAKE: 'Stake',
+    },
+  },
+}));
+
+jest.mock('../../../hooks/useMetrics', () => ({
+  MetaMetricsEvents: {
+    EARN_BUTTON_CLICKED: 'EARN_BUTTON_CLICKED',
+  },
+  useMetrics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
+
+jest.mock('react-redux', () => {
+  const actual = jest.requireActual('react-redux');
+  return {
+    ...actual,
+    useSelector: (selector: (state: unknown) => unknown) => selector({}),
+  };
+});
+
+const mockTrace = jest.fn();
+jest.mock('../../../../util/trace', () => ({
+  TraceName: {
+    EarnDepositScreen: 'EarnDepositScreen',
+  },
+  trace: (arg: unknown) => mockTrace(arg),
+}));
+
+const mockSelectNetworkConfigurationByChainId = jest.fn();
+jest.mock('../../../../selectors/networkController', () => ({
+  selectNetworkConfigurationByChainId: (state: unknown, chainId: unknown) =>
+    mockSelectNetworkConfigurationByChainId(state, chainId),
+}));
+
+const mockSetActiveNetwork = jest.fn(
+  async (_networkClientId: string) => undefined,
+);
+const mockFindNetworkClientIdByChainId = jest.fn(
+  (_chainIdHex: string) => undefined as string | undefined,
+);
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    NetworkController: {
+      setActiveNetwork: (networkClientId: string) =>
+        mockSetActiveNetwork(networkClientId),
+      findNetworkClientIdByChainId: (chainIdHex: string) =>
+        mockFindNetworkClientIdByChainId(chainIdHex),
+    },
+  },
+}));
+
+describe('useStablecoinLendingRedirect', () => {
+  const createMockBuilder = () => {
+    const builder = {
+      addProperties: jest.fn(),
+      build: jest.fn(),
+    };
+
+    builder.addProperties.mockImplementation(() => builder);
+    builder.build.mockReturnValue({ event: 'EARN_BUTTON_CLICKED' });
+
+    return builder;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSelectNetworkConfigurationByChainId.mockReturnValue({
+      name: 'Mainnet',
+    });
+  });
+
+  it('does nothing when asset chainId is missing', async () => {
+    const { result } = renderHook(() =>
+      useStablecoinLendingRedirect({
+        asset: undefined,
+      }),
+    );
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(mockFindNetworkClientIdByChainId).not.toHaveBeenCalled();
+    expect(mockSetActiveNetwork).not.toHaveBeenCalled();
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('logs error and exits when network client id cannot be found', async () => {
+    mockFindNetworkClientIdByChainId.mockReturnValue(undefined);
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    const onNavigate = jest.fn();
+    const asset: TokenI = {
+      address: '0x123',
+      chainId: '1',
+      symbol: 'USDC',
+      decimals: 6,
+      isETH: false,
+      aggregators: [],
+      image: '',
+      name: 'USD Coin',
+      balance: '0',
+      logo: '',
+    };
+
+    const { result } = renderHook(() =>
+      useStablecoinLendingRedirect({
+        asset,
+        onNavigate,
+      }),
+    );
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Stablecoin lending redirect failed: could not retrieve networkClientId for chainId: 1',
+    );
+    expect(mockSetActiveNetwork).not.toHaveBeenCalled();
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('switches network, tracks event, and calls onNavigate when provided', async () => {
+    mockFindNetworkClientIdByChainId.mockReturnValue('mainnet');
+
+    const builder = createMockBuilder();
+    mockCreateEventBuilder.mockReturnValue(builder);
+
+    const onNavigate = jest.fn();
+    const asset: TokenI = {
+      address: '0x123',
+      chainId: '1',
+      symbol: 'USDC',
+      decimals: 6,
+      isETH: false,
+      aggregators: [],
+      image: '',
+      name: 'USD Coin',
+      balance: '0',
+      logo: '',
+    };
+
+    const { result } = renderHook(() =>
+      useStablecoinLendingRedirect({
+        asset,
+        location: EVENT_LOCATIONS.HOME_SCREEN,
+        onNavigate,
+      }),
+    );
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(mockFindNetworkClientIdByChainId).toHaveBeenCalledWith('0x1');
+    expect(mockTrace).toHaveBeenCalledWith({ name: 'EarnDepositScreen' });
+    expect(mockSetActiveNetwork).toHaveBeenCalledWith('mainnet');
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith('EARN_BUTTON_CLICKED');
+    expect(builder.addProperties).toHaveBeenCalledWith({
+      action_type: 'deposit',
+      location: EVENT_LOCATIONS.HOME_SCREEN,
+      network: 'Mainnet',
+      text: 'Earn',
+      token: 'USDC',
+      experience: 'STABLECOIN_LENDING',
+    });
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      event: 'EARN_BUTTON_CLICKED',
+    });
+    expect(onNavigate).toHaveBeenCalledWith(asset);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('switches network, tracks event, and navigates when onNavigate is not provided', async () => {
+    mockFindNetworkClientIdByChainId.mockReturnValue('mainnet');
+
+    const builder = createMockBuilder();
+    mockCreateEventBuilder.mockReturnValue(builder);
+
+    const asset: TokenI = {
+      address: '0x123',
+      chainId: '1',
+      symbol: 'USDC',
+      decimals: 6,
+      isETH: false,
+      aggregators: [],
+      image: '',
+      name: 'USD Coin',
+      balance: '0',
+      logo: '',
+    };
+
+    const { result } = renderHook(() =>
+      useStablecoinLendingRedirect({
+        asset,
+        location: EVENT_LOCATIONS.HOME_SCREEN,
+      }),
+    );
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('StakeScreens', {
+      screen: 'Stake',
+      params: {
+        token: asset,
+      },
+    });
+  });
+});

--- a/app/components/UI/Earn/hooks/useStablecoinLendingRedirect.ts
+++ b/app/components/UI/Earn/hooks/useStablecoinLendingRedirect.ts
@@ -1,0 +1,94 @@
+import { toHex } from '@metamask/controller-utils';
+import type { Hex } from '@metamask/utils';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import Engine from '../../../../core/Engine';
+import type { RootState } from '../../../../reducers';
+import { selectNetworkConfigurationByChainId } from '../../../../selectors/networkController';
+import { trace, TraceName } from '../../../../util/trace';
+import { MetaMetricsEvents, useMetrics } from '../../../hooks/useMetrics';
+import { EARN_EXPERIENCES } from '../constants/experiences';
+import { EVENT_LOCATIONS } from '../constants/events/earnEvents';
+import type { TokenI } from '../../Tokens/types';
+import { useNavigation } from '@react-navigation/native';
+import Routes from '../../../../constants/navigation/Routes';
+
+interface UseStablecoinLendingRedirectParams {
+  asset?: TokenI;
+  location?: (typeof EVENT_LOCATIONS)[keyof typeof EVENT_LOCATIONS];
+  onNavigate?: (asset: TokenI) => void;
+}
+
+export const useStablecoinLendingRedirect = ({
+  asset,
+  location = EVENT_LOCATIONS.HOME_SCREEN,
+  onNavigate,
+}: UseStablecoinLendingRedirectParams) => {
+  const { trackEvent, createEventBuilder } = useMetrics();
+
+  const network = useSelector((state: RootState) =>
+    selectNetworkConfigurationByChainId(state, asset?.chainId as Hex),
+  );
+
+  const navigation = useNavigation();
+
+  const navigateToStakeScreen = useCallback(
+    (token: TokenI) => {
+      if (onNavigate) {
+        onNavigate(token);
+        return;
+      }
+
+      navigation.navigate('StakeScreens', {
+        screen: Routes.STAKING.STAKE,
+        params: {
+          token,
+        },
+      });
+    },
+    [navigation, onNavigate],
+  );
+
+  const onPress = useCallback(async () => {
+    if (!asset?.chainId) return;
+
+    const networkClientId =
+      Engine.context.NetworkController.findNetworkClientIdByChainId(
+        toHex(asset.chainId),
+      );
+
+    if (!networkClientId) {
+      console.error(
+        `Stablecoin lending redirect failed: could not retrieve networkClientId for chainId: ${asset.chainId}`,
+      );
+      return;
+    }
+
+    trace({ name: TraceName.EarnDepositScreen });
+    await Engine.context.NetworkController.setActiveNetwork(networkClientId);
+
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.EARN_BUTTON_CLICKED)
+        .addProperties({
+          action_type: 'deposit',
+          location,
+          network: network?.name,
+          text: 'Earn',
+          token: asset.symbol,
+          experience: EARN_EXPERIENCES.STABLECOIN_LENDING,
+        })
+        .build(),
+    );
+
+    navigateToStakeScreen(asset);
+  }, [
+    asset,
+    createEventBuilder,
+    location,
+    navigateToStakeScreen,
+    network?.name,
+    trackEvent,
+  ]);
+
+  return onPress;
+};

--- a/app/components/UI/Stake/components/StakeButton/index.tsx
+++ b/app/components/UI/Stake/components/StakeButton/index.tsx
@@ -1,4 +1,3 @@
-import { toHex } from '@metamask/controller-utils';
 import { useNavigation } from '@react-navigation/native';
 import React from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
@@ -25,6 +24,7 @@ import {
   selectPooledStakingEnabledFlag,
   selectStablecoinLendingEnabledFlag,
 } from '../../../Earn/selectors/featureFlags';
+import { useStablecoinLendingRedirect } from '../../../Earn/hooks/useStablecoinLendingRedirect';
 import { TokenI } from '../../../Tokens/types';
 import { EVENT_LOCATIONS } from '../../constants/events';
 import useStakingChain from '../../hooks/useStakingChain';
@@ -140,44 +140,10 @@ const StakeButtonContent = ({ asset }: StakeButtonProps) => {
     });
   };
 
-  const handleLendingRedirect = async () => {
-    if (!asset?.chainId) return;
-
-    const networkClientId =
-      Engine.context.NetworkController.findNetworkClientIdByChainId(
-        toHex(asset.chainId),
-      );
-
-    if (!networkClientId) {
-      console.error(
-        `EarnTokenListItem redirect failed: could not retrieve networkClientId for chainId: ${asset.chainId}`,
-      );
-      return;
-    }
-
-    trace({ name: TraceName.EarnDepositScreen });
-    await Engine.context.NetworkController.setActiveNetwork(networkClientId);
-
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.EARN_BUTTON_CLICKED)
-        .addProperties({
-          action_type: 'deposit',
-          location: EVENT_LOCATIONS.HOME_SCREEN,
-          network: network?.name,
-          text: 'Earn',
-          token: asset.symbol,
-          experience: EARN_EXPERIENCES.STABLECOIN_LENDING,
-        })
-        .build(),
-    );
-
-    navigation.navigate('StakeScreens', {
-      screen: Routes.STAKING.STAKE,
-      params: {
-        token: asset,
-      },
-    });
-  };
+  const handleLendingRedirect = useStablecoinLendingRedirect({
+    asset,
+    location: EVENT_LOCATIONS.HOME_SCREEN,
+  });
 
   const onEarnButtonPress = async () => {
     if (primaryExperienceType === EARN_EXPERIENCES.POOLED_STAKING) {

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
@@ -298,7 +298,7 @@ export const TokenListItem = React.memo(
 
       if (
         isStablecoinLendingEnabled &&
-        earnToken?.experience.type === EARN_EXPERIENCES.STABLECOIN_LENDING
+        earnToken?.experience?.type === EARN_EXPERIENCES.STABLECOIN_LENDING
       ) {
         return {
           text: `${strings('stake.earn')}`,
@@ -331,7 +331,7 @@ export const TokenListItem = React.memo(
       hasClaimableBonus,
       shouldShowConvertToMusdCta,
       isStablecoinLendingEnabled,
-      earnToken?.experience.type,
+      earnToken?.experience?.type,
       hasPercentageChange,
       pricePercentChange1d,
       asset,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updated the stablecoin lending CTA to be right-aligned and not render the percentage. The existing "Earn %" CTA for pooled-staking remains untouched.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated stablecoin lending cta to be right-aligned and not render the percentage

## **Related issues**

Fixes: [MUSD-233: Remove Stablecoin Earn % in CTA to avoid conflict with mUSD Convert while running campaign.](https://consensyssoftware.atlassian.net/browse/MUSD-233)

## **Manual testing steps**

```gherkin
Feature: Token list Earn CTA visual treatment

  Scenario: user views a stablecoin lending-eligible token
    Given stablecoin lending is enabled
      And user views a token eligible for stablecoin lending

    When the token list item is rendered
    Then the Earn CTA is shown as right-aligned action text (consistent with the mUSD conversion CTA placement)
      And the Earn CTA does not display a percentage

  Scenario: user views a pooled-staking eligible token
    Given pooled staking is enabled
      And user views a token eligible for pooled staking

    When the token list item is rendered
    Then the pooled-staking Earn CTA continues to display "Earn <percentage>%"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
Stablecoin Lending CTA is now right-aligned and doesn't display the percentage.

<img width="488" height="1015" alt="Screenshot 2026-01-28 at 6 07 42 PM" src="https://github.com/user-attachments/assets/3e272677-bbbf-40c5-9163-f811a8a00913" />

Pooled-staking Earn CTA untouched
<img width="488" height="1015" alt="Screenshot 2026-01-28 at 6 07 58 PM" src="https://github.com/user-attachments/assets/eb577c9c-44bd-4b02-a550-1a76cb497586" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors the stablecoin-lending navigation/network-switching + analytics path used from multiple UI entry points; behavior is covered by new unit tests but could impact routing if miswired.
> 
> **Overview**
> **Stablecoin lending redirects are now centralized** via a new `useStablecoinLendingRedirect` hook that handles network switching, tracing, and `EARN_BUTTON_CLICKED` metrics before navigating (or delegating via an optional `onNavigate`).
> 
> **Token list CTA behavior changes:** stablecoin-lending eligible tokens now show a right-aligned `Earn` action in the secondary balance area (no percentage), and stablecoin lending is no longer surfaced via the `StakeButton` CTA there; pooled-staking `Earn <apr>%` remains unchanged.
> 
> Adds unit coverage for the new hook (`useStablecoinLendingRedirect.test.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c12d9972200afb6c19eee8ffa99229916902f5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->