### PR TITLE
chore: Updated headers for settings general page

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -366,7 +366,7 @@ const SettingsFlow = () => (
     <Stack.Screen
       name="GeneralSettings"
       component={GeneralSettings}
-      options={GeneralSettings.navigationOptions}
+      options={{ headerShown: false }}
     />
     <Stack.Screen
       name="AdvancedSettings"
@@ -1285,10 +1285,7 @@ const MainNavigator = () => {
       <Stack.Screen
         name="GeneralSettings"
         component={GeneralSettings}
-        options={{
-          headerShown: true,
-          ...GeneralSettings.navigationOptions,
-        }}
+        options={{ headerShown: false }}
       />
       {process.env.METAMASK_ENVIRONMENT !== 'production' && (
         <Stack.Screen

--- a/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
+++ b/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
@@ -275,7 +275,7 @@ exports[`MainNavigator Tab Bar Visibility hides tab bar when browser is active 1
     name="GeneralSettings"
     options={
       {
-        "headerShown": true,
+        "headerShown": false,
       }
     }
   />
@@ -593,7 +593,7 @@ exports[`MainNavigator Tab Bar Visibility shows tab bar when not in browser 1`] 
     name="GeneralSettings"
     options={
       {
-        "headerShown": true,
+        "headerShown": false,
       }
     }
   />
@@ -911,7 +911,7 @@ exports[`MainNavigator matches rendered snapshot 1`] = `
     name="GeneralSettings"
     options={
       {
-        "headerShown": true,
+        "headerShown": false,
       }
     }
   />

--- a/app/components/UI/SelectComponent/index.js
+++ b/app/components/UI/SelectComponent/index.js
@@ -14,6 +14,7 @@ import dismissKeyboard from 'react-native/Libraries/Utilities/dismissKeyboard';
 import IconCheck from 'react-native-vector-icons/MaterialCommunityIcons';
 import Device from '../../../util/device';
 import { ThemeContext, mockTheme } from '../../../util/theme';
+import HeaderCenter from '../../../component-library/components-temp/HeaderCenter';
 
 const ROW_HEIGHT = 35;
 const createStyles = (colors) =>
@@ -37,21 +38,6 @@ const createStyles = (colors) =>
       paddingTop: 10,
       paddingBottom: 10,
       ...fontStyles.normal,
-    },
-    accesoryBar: {
-      width: '100%',
-      paddingTop: 5,
-      height: 50,
-      borderBottomColor: colors.border.muted,
-      borderBottomWidth: 1,
-    },
-    label: {
-      textAlign: 'center',
-      flex: 1,
-      paddingVertical: 10,
-      fontSize: 17,
-      ...fontStyles.bold,
-      color: colors.text.default,
     },
     modal: {
       margin: 0,
@@ -196,9 +182,7 @@ export default class SelectComponent extends PureComponent {
           backdropOpacity={1}
         >
           <View style={styles.modalView}>
-            <View style={styles.accesoryBar}>
-              <Text style={styles.label}>{this.props.label}</Text>
-            </View>
+            <HeaderCenter title={this.props.label} onClose={this.hidePicker} />
             <ScrollView style={styles.list} ref={this.scrollView}>
               <View style={styles.listWrapper}>
                 {this.props.options.map((option) => (

--- a/app/components/Views/Settings/GeneralSettings/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/GeneralSettings/__snapshots__/index.test.tsx.snap
@@ -1,32 +1,1018 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`GeneralSettings should render correctly 1`] = `
-<ContextProvider
-  value={
+<RNCSafeAreaView
+  edges={
     {
-      "getServerState": undefined,
-      "noopCheck": "once",
-      "stabilityCheck": "once",
-      "store": {
-        "clearActions": [Function],
-        "dispatch": [Function],
-        "getActions": [Function],
-        "getState": [Function],
-        "replaceReducer": [Function],
-        "subscribe": [Function],
-      },
-      "subscription": {
-        "addNestedSub": [Function],
-        "getListeners": [Function],
-        "handleChangeWrapper": [Function],
-        "isSubscribed": [Function],
-        "notifyNestedSubs": [Function],
-        "trySubscribe": [Function],
-        "tryUnsubscribe": [Function],
-      },
+      "bottom": "additive",
+      "left": "off",
+      "right": "off",
+      "top": "off",
+    }
+  }
+  style={
+    {
+      "backgroundColor": "#ffffff",
+      "flex": 1,
     }
   }
 >
-  <Component />
-</ContextProvider>
+  <View
+    style={
+      [
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 16,
+          "height": 56,
+          "paddingLeft": 8,
+          "paddingRight": 8,
+        },
+        {
+          "marginTop": 0,
+        },
+        undefined,
+      ]
+    }
+    testID="header"
+  >
+    <View>
+      <View
+        onLayout={[Function]}
+      >
+        <View
+          style={
+            [
+              {
+                "transform": [
+                  {
+                    "scale": 1,
+                  },
+                ],
+              },
+              {
+                "alignItems": "center",
+                "justifyContent": "center",
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderRadius": 2,
+                  "height": 32,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "width": 32,
+                },
+                undefined,
+              ]
+            }
+            testID="button-icon"
+          >
+            <SvgMock
+              fill="currentColor"
+              name="ArrowLeft"
+              style={
+                [
+                  {
+                    "color": "#121314",
+                    "height": 20,
+                    "width": 20,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "display": "flex",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist-Bold",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              undefined,
+            ]
+          }
+        >
+          General
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        onLayout={[Function]}
+      />
+    </View>
+  </View>
+  <RCTScrollView
+    style={
+      {
+        "flex": 1,
+        "padding": 16,
+      }
+    }
+  >
+    <View>
+      <View
+        style={
+          {
+            "paddingBottom": 100,
+          }
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "marginTop": 30,
+              },
+              {
+                "marginTop": 0,
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#121314",
+                "fontFamily": "Geist-Medium",
+                "fontSize": 18,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Currency conversion
+          </Text>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+                "marginTop": 8,
+              }
+            }
+          >
+            Display fiat values in using a specific currency throughout the application.
+          </Text>
+          <View
+            style={
+              {
+                "marginTop": 16,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "borderColor": "#b7bbc8",
+                  "borderRadius": 5,
+                  "borderWidth": 2,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "flex": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <TouchableOpacity
+                    onPress={[Function]}
+                  >
+                    <View
+                      style={
+                        {
+                          "flexDirection": "row",
+                        }
+                      }
+                    >
+                      <Text
+                        numberOfLines={1}
+                        style={
+                          {
+                            "alignSelf": "flex-start",
+                            "color": "#121314",
+                            "flex": 1,
+                            "fontFamily": "Geist-Regular",
+                            "fontSize": 14,
+                            "paddingBottom": 10,
+                            "paddingHorizontal": 15,
+                            "paddingTop": 10,
+                          }
+                        }
+                      >
+                        USD - United States Dollar
+                      </Text>
+                      <Text
+                        allowFontScaling={false}
+                        selectable={false}
+                        style={
+                          [
+                            {
+                              "color": "#121314",
+                              "fontSize": 24,
+                            },
+                            {
+                              "height": 25,
+                              "justifyContent": "flex-end",
+                              "marginRight": 10,
+                              "marginTop": 7,
+                              "textAlign": "right",
+                            },
+                            {
+                              "fontFamily": "Material Icons",
+                              "fontStyle": "normal",
+                              "fontWeight": "normal",
+                            },
+                            {},
+                          ]
+                        }
+                      >
+                        
+                      </Text>
+                    </View>
+                  </TouchableOpacity>
+                  <View />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "marginTop": 30,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#121314",
+                "fontFamily": "Geist-Medium",
+                "fontSize": 18,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Primary currency
+          </Text>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+                "marginTop": 8,
+              }
+            }
+          >
+            Select Native to prioritize displaying values in the native currency of the chain (e.g. ETH). Select Fiat to prioritize displaying values in your selected fiat currency.
+          </Text>
+          <View
+            style={
+              {
+                "marginTop": 16,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "flex": 1,
+                  }
+                }
+              >
+                <TouchableOpacity
+                  disabled={false}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "height": 24,
+                      "opacity": 1,
+                    }
+                  }
+                >
+                  <View
+                    accessibilityRole="radio"
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#b7bbc8",
+                        "borderRadius": 99,
+                        "borderWidth": 2,
+                        "height": 20,
+                        "justifyContent": "center",
+                        "width": 20,
+                      }
+                    }
+                  />
+                  <View
+                    style={
+                      {
+                        "marginLeft": 12,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityRole="text"
+                      style={
+                        {
+                          "color": "#121314",
+                          "fontFamily": "Geist-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                        }
+                      }
+                    >
+                      Native
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+              </View>
+              <View
+                style={
+                  {
+                    "flex": 1,
+                  }
+                }
+              >
+                <TouchableOpacity
+                  disabled={false}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "height": 24,
+                      "opacity": 1,
+                    }
+                  }
+                >
+                  <View
+                    accessibilityRole="radio"
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#b7bbc8",
+                        "borderRadius": 99,
+                        "borderWidth": 2,
+                        "height": 20,
+                        "justifyContent": "center",
+                        "width": 20,
+                      }
+                    }
+                  />
+                  <View
+                    style={
+                      {
+                        "marginLeft": 12,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityRole="text"
+                      style={
+                        {
+                          "color": "#121314",
+                          "fontFamily": "Geist-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                        }
+                      }
+                    >
+                      Fiat
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "marginTop": 30,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#121314",
+                "fontFamily": "Geist-Medium",
+                "fontSize": 18,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Current language
+          </Text>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+                "marginTop": 8,
+              }
+            }
+          >
+            Translate the application to a different supported language.
+          </Text>
+          <View
+            style={
+              {
+                "marginTop": 16,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "borderColor": "#b7bbc8",
+                  "borderRadius": 5,
+                  "borderWidth": 2,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "flex": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <TouchableOpacity
+                    onPress={[Function]}
+                  >
+                    <View
+                      style={
+                        {
+                          "flexDirection": "row",
+                        }
+                      }
+                    >
+                      <Text
+                        numberOfLines={1}
+                        style={
+                          {
+                            "alignSelf": "flex-start",
+                            "color": "#121314",
+                            "flex": 1,
+                            "fontFamily": "Geist-Regular",
+                            "fontSize": 14,
+                            "paddingBottom": 10,
+                            "paddingHorizontal": 15,
+                            "paddingTop": 10,
+                          }
+                        }
+                      >
+                        English
+                      </Text>
+                      <Text
+                        allowFontScaling={false}
+                        selectable={false}
+                        style={
+                          [
+                            {
+                              "color": "#121314",
+                              "fontSize": 24,
+                            },
+                            {
+                              "height": 25,
+                              "justifyContent": "flex-end",
+                              "marginRight": 10,
+                              "marginTop": 7,
+                              "textAlign": "right",
+                            },
+                            {
+                              "fontFamily": "Material Icons",
+                              "fontStyle": "normal",
+                              "fontWeight": "normal",
+                            },
+                            {},
+                          ]
+                        }
+                      >
+                        
+                      </Text>
+                    </View>
+                  </TouchableOpacity>
+                  <View />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "marginTop": 30,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#121314",
+                "fontFamily": "Geist-Medium",
+                "fontSize": 18,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Search engine
+          </Text>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+                "marginTop": 8,
+              }
+            }
+          >
+            Change the default search engine used when entering search terms in the URL bar.
+          </Text>
+          <View
+            style={
+              {
+                "marginTop": 16,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "borderColor": "#b7bbc8",
+                  "borderRadius": 5,
+                  "borderWidth": 2,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "flex": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <TouchableOpacity
+                    onPress={[Function]}
+                  >
+                    <View
+                      style={
+                        {
+                          "flexDirection": "row",
+                        }
+                      }
+                    >
+                      <Text
+                        numberOfLines={1}
+                        style={
+                          {
+                            "alignSelf": "flex-start",
+                            "color": "#121314",
+                            "flex": 1,
+                            "fontFamily": "Geist-Regular",
+                            "fontSize": 14,
+                            "paddingBottom": 10,
+                            "paddingHorizontal": 15,
+                            "paddingTop": 10,
+                          }
+                        }
+                      >
+                        Google
+                      </Text>
+                      <Text
+                        allowFontScaling={false}
+                        selectable={false}
+                        style={
+                          [
+                            {
+                              "color": "#121314",
+                              "fontSize": 24,
+                            },
+                            {
+                              "height": 25,
+                              "justifyContent": "flex-end",
+                              "marginRight": 10,
+                              "marginTop": 7,
+                              "textAlign": "right",
+                            },
+                            {
+                              "fontFamily": "Material Icons",
+                              "fontStyle": "normal",
+                              "fontWeight": "normal",
+                            },
+                            {},
+                          ]
+                        }
+                      >
+                        
+                      </Text>
+                    </View>
+                  </TouchableOpacity>
+                  <View />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "marginTop": 30,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "flex": 1,
+                  "fontFamily": "Geist-Medium",
+                  "fontSize": 18,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Hide tokens without balance
+            </Text>
+            <View
+              style={
+                {
+                  "marginLeft": 16,
+                }
+              }
+            >
+              <RCTSwitch
+                accessibilityRole="switch"
+                onChange={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                onTintColor="#4459ff"
+                style={
+                  [
+                    {
+                      "height": 31,
+                      "width": 51,
+                    },
+                    [
+                      {
+                        "alignSelf": "flex-start",
+                      },
+                      {
+                        "backgroundColor": "#b7bbc866",
+                        "borderRadius": 16,
+                      },
+                    ],
+                  ]
+                }
+                thumbTintColor="#ffffff"
+                tintColor="#b7bbc866"
+                value={false}
+              />
+            </View>
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+                "marginTop": 8,
+              }
+            }
+          >
+            Prevents tokens with no balance from displaying in your token listing.
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "marginTop": 30,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#121314",
+                "fontFamily": "Geist-Medium",
+                "fontSize": 18,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Account icon
+          </Text>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+                "marginTop": 8,
+              }
+            }
+          >
+            Choose from three different styles of unique icons that can help you identify accounts at a glance.
+          </Text>
+          <View
+            style={
+              {
+                "marginTop": 16,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <TouchableOpacity
+                onPress={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "width": "33%",
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "borderRadius": 12,
+                        "borderWidth": 2,
+                        "height": 44,
+                        "justifyContent": "center",
+                        "width": 44,
+                      },
+                      {
+                        "borderColor": "#4459ff",
+                      },
+                    ]
+                  }
+                />
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist-Regular",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                      "marginTop": 12,
+                    }
+                  }
+                >
+                  Polycons
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "width": "33%",
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "borderRadius": 12,
+                        "borderWidth": 2,
+                        "height": 44,
+                        "justifyContent": "center",
+                        "width": 44,
+                      },
+                      {
+                        "borderColor": "transparent",
+                      },
+                    ]
+                  }
+                />
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist-Regular",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                      "marginTop": 12,
+                    }
+                  }
+                >
+                  Jazzicons
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "width": "33%",
+                  }
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "borderRadius": 12,
+                        "borderWidth": 2,
+                        "height": 44,
+                        "justifyContent": "center",
+                        "width": 44,
+                      },
+                      {
+                        "borderColor": "transparent",
+                      },
+                    ]
+                  }
+                />
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist-Regular",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                      "marginTop": 12,
+                    }
+                  }
+                >
+                  Blockies
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</RNCSafeAreaView>
 `;

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -7,6 +7,7 @@ import {
   View,
   TouchableOpacity,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { connect } from 'react-redux';
 
 import Engine from '../../../../core/Engine';
@@ -17,7 +18,7 @@ import I18n, {
 } from '../../../../../locales/i18n';
 import SelectComponent from '../../../UI/SelectComponent';
 import infuraCurrencies from '../../../../util/infura-conversion.json';
-import { getNavigationOptionsTitle } from '../../../UI/Navbar';
+import HeaderCenter from '../../../../component-library/components-temp/HeaderCenter';
 import {
   setSearchEngine,
   setPrimaryCurrency,
@@ -83,8 +84,10 @@ const createStyles = (colors) =>
     wrapper: {
       backgroundColor: colors.background.default,
       flex: 1,
+    },
+    content: {
       padding: 16,
-      zIndex: 99999999999999,
+      flex: 1,
     },
     titleContainer: {
       flexDirection: 'row',
@@ -242,21 +245,7 @@ class Settings extends PureComponent {
     this.props.setHideZeroBalanceTokens(toggleHideZeroBalanceTokens);
   };
 
-  updateNavBar = () => {
-    const { navigation } = this.props;
-    const colors = this.context.colors || mockTheme.colors;
-    navigation.setOptions(
-      getNavigationOptionsTitle(
-        strings('app_settings.general_title'),
-        navigation,
-        false,
-        colors,
-      ),
-    );
-  };
-
   componentDidMount = () => {
-    this.updateNavBar();
     const languages = getLanguages();
     this.setState({ languages });
     this.languageOptions = Object.keys(languages).map((key) => ({
@@ -280,10 +269,6 @@ class Settings extends PureComponent {
         key: 'Fiat',
       },
     ];
-  };
-
-  componentDidUpdate = () => {
-    this.updateNavBar();
   };
 
   // TODO - Reintroduce once we enable manual theme settings
@@ -322,228 +307,236 @@ class Settings extends PureComponent {
       setAvatarAccountType,
       selectedAddress,
       hideZeroBalanceTokens,
+      navigation,
     } = this.props;
     const themeTokens = this.context || mockTheme;
     const { colors } = themeTokens;
     const styles = createStyles(colors);
 
     return (
-      <ScrollView style={styles.wrapper}>
-        <View style={styles.inner}>
-          <View style={[styles.setting, styles.firstSetting]}>
-            <Text variant={TextVariant.BodyLGMedium}>
-              {strings('app_settings.conversion_title')}
-            </Text>
-            <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Alternative}
-              style={styles.desc}
-            >
-              {strings('app_settings.conversion_desc')}
-            </Text>
-            <View style={styles.accessory}>
-              <View style={styles.picker}>
-                <SelectComponent
-                  selectedValue={currentCurrency}
-                  onValueChange={this.selectCurrency}
-                  label={strings('app_settings.current_conversion')}
-                  options={infuraCurrencyOptions}
-                />
-              </View>
-            </View>
-          </View>
-          <View style={styles.setting}>
-            <Text variant={TextVariant.BodyLGMedium}>
-              {strings('app_settings.primary_currency_title')}
-            </Text>
-            <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Alternative}
-              style={styles.desc}
-            >
-              {strings('app_settings.primary_currency_desc')}
-            </Text>
-            {this.primaryCurrencyOptions && (
-              <View style={styles.accessory}>
-                <PickComponent
-                  pick={this.selectPrimaryCurrency}
-                  textFirst={strings(
-                    'app_settings.primary_currency_text_first',
-                  )}
-                  valueFirst={'ETH'}
-                  textSecond={strings(
-                    'app_settings.primary_currency_text_second',
-                  )}
-                  valueSecond={'Fiat'}
-                  selectedValue={primaryCurrency}
-                />
-              </View>
-            )}
-          </View>
-          <View style={styles.setting}>
-            <Text variant={TextVariant.BodyLGMedium}>
-              {strings('app_settings.current_language')}
-            </Text>
-            <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Alternative}
-              style={styles.desc}
-            >
-              {strings('app_settings.language_desc')}
-            </Text>
-            {this.languageOptions && (
-              <View style={styles.accessory}>
-                <View style={styles.picker}>
-                  <SelectComponent
-                    selectedValue={this.state.currentLanguage}
-                    onValueChange={this.selectLanguage}
-                    label={strings('app_settings.current_language')}
-                    options={this.languageOptions}
-                  />
-                </View>
-              </View>
-            )}
-          </View>
-          <View style={styles.setting}>
-            <Text variant={TextVariant.BodyLGMedium}>
-              {strings('app_settings.search_engine')}
-            </Text>
-            <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Alternative}
-              style={styles.desc}
-            >
-              {strings('app_settings.engine_desc')}
-            </Text>
-            {this.searchEngineOptions && (
-              <View style={styles.accessory}>
-                <View style={styles.picker}>
-                  <SelectComponent
-                    selectedValue={this.props.searchEngine}
-                    onValueChange={this.selectSearchEngine}
-                    label={strings('app_settings.search_engine')}
-                    options={this.searchEngineOptions}
-                  />
-                </View>
-              </View>
-            )}
-          </View>
-          <View style={styles.setting}>
-            <View style={styles.titleContainer}>
-              <Text variant={TextVariant.BodyLGMedium} style={styles.title}>
-                {strings('app_settings.hide_zero_balance_tokens_title')}
+      <SafeAreaView edges={{ bottom: 'additive' }} style={styles.wrapper}>
+        <HeaderCenter
+          title={strings('app_settings.general_title')}
+          onBack={() => navigation.goBack()}
+          includesTopInset
+        />
+        <ScrollView style={styles.content}>
+          <View style={styles.inner}>
+            <View style={[styles.setting, styles.firstSetting]}>
+              <Text variant={TextVariant.BodyLGMedium}>
+                {strings('app_settings.conversion_title')}
               </Text>
-              <View style={styles.toggle}>
-                <Switch
-                  value={hideZeroBalanceTokens}
-                  onValueChange={this.toggleHideZeroBalanceTokens}
-                  trackColor={{
-                    true: colors.primary.default,
-                    false: colors.border.muted,
-                  }}
-                  thumbColor={themeTokens.brandColors.white}
-                  style={styles.switch}
-                  ios_backgroundColor={colors.border.muted}
-                />
+              <Text
+                variant={TextVariant.BodyMD}
+                color={TextColor.Alternative}
+                style={styles.desc}
+              >
+                {strings('app_settings.conversion_desc')}
+              </Text>
+              <View style={styles.accessory}>
+                <View style={styles.picker}>
+                  <SelectComponent
+                    selectedValue={currentCurrency}
+                    onValueChange={this.selectCurrency}
+                    label={strings('app_settings.current_conversion')}
+                    options={infuraCurrencyOptions}
+                  />
+                </View>
               </View>
             </View>
-            <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Alternative}
-              style={styles.desc}
-            >
-              {strings('app_settings.hide_zero_balance_tokens_desc')}
-            </Text>
-          </View>
-          <View style={styles.setting}>
-            <Text variant={TextVariant.BodyLGMedium}>
-              {strings('app_settings.accounts_identicon_title')}
-            </Text>
-            <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Alternative}
-              style={styles.desc}
-            >
-              {strings('app_settings.accounts_identicon_desc')}
-            </Text>
-            <View style={styles.accessory}>
-              <View style={styles.identicon_container}>
-                <TouchableOpacity
-                  onPress={() =>
-                    setAvatarAccountType(AvatarAccountType.Maskicon)
-                  }
-                  style={styles.identicon_row}
-                >
-                  <View
-                    style={[
-                      styles.avatarWrapper,
-                      avatarAccountType === AvatarAccountType.Maskicon
-                        ? styles.selectedAvatarWrapper
-                        : styles.unselectedAvatarWrapper,
-                    ]}
-                  >
-                    <AvatarAccount
-                      type={AvatarAccountType.Maskicon}
-                      accountAddress={selectedAddress}
-                      size={diameter}
+            <View style={styles.setting}>
+              <Text variant={TextVariant.BodyLGMedium}>
+                {strings('app_settings.primary_currency_title')}
+              </Text>
+              <Text
+                variant={TextVariant.BodyMD}
+                color={TextColor.Alternative}
+                style={styles.desc}
+              >
+                {strings('app_settings.primary_currency_desc')}
+              </Text>
+              {this.primaryCurrencyOptions && (
+                <View style={styles.accessory}>
+                  <PickComponent
+                    pick={this.selectPrimaryCurrency}
+                    textFirst={strings(
+                      'app_settings.primary_currency_text_first',
+                    )}
+                    valueFirst={'ETH'}
+                    textSecond={strings(
+                      'app_settings.primary_currency_text_second',
+                    )}
+                    valueSecond={'Fiat'}
+                    selectedValue={primaryCurrency}
+                  />
+                </View>
+              )}
+            </View>
+            <View style={styles.setting}>
+              <Text variant={TextVariant.BodyLGMedium}>
+                {strings('app_settings.current_language')}
+              </Text>
+              <Text
+                variant={TextVariant.BodyMD}
+                color={TextColor.Alternative}
+                style={styles.desc}
+              >
+                {strings('app_settings.language_desc')}
+              </Text>
+              {this.languageOptions && (
+                <View style={styles.accessory}>
+                  <View style={styles.picker}>
+                    <SelectComponent
+                      selectedValue={this.state.currentLanguage}
+                      onValueChange={this.selectLanguage}
+                      label={strings('app_settings.current_language')}
+                      options={this.languageOptions}
                     />
                   </View>
-                  <Text style={styles.identiconText}>Polycons</Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  onPress={() =>
-                    setAvatarAccountType(AvatarAccountType.JazzIcon)
-                  }
-                  style={styles.identicon_row}
-                >
-                  <View
-                    style={[
-                      styles.avatarWrapper,
-                      avatarAccountType === AvatarAccountType.JazzIcon
-                        ? styles.selectedAvatarWrapper
-                        : styles.unselectedAvatarWrapper,
-                    ]}
-                  >
-                    <AvatarAccount
-                      type={AvatarAccountType.JazzIcon}
-                      accountAddress={selectedAddress}
-                      size={diameter}
+                </View>
+              )}
+            </View>
+            <View style={styles.setting}>
+              <Text variant={TextVariant.BodyLGMedium}>
+                {strings('app_settings.search_engine')}
+              </Text>
+              <Text
+                variant={TextVariant.BodyMD}
+                color={TextColor.Alternative}
+                style={styles.desc}
+              >
+                {strings('app_settings.engine_desc')}
+              </Text>
+              {this.searchEngineOptions && (
+                <View style={styles.accessory}>
+                  <View style={styles.picker}>
+                    <SelectComponent
+                      selectedValue={this.props.searchEngine}
+                      onValueChange={this.selectSearchEngine}
+                      label={strings('app_settings.search_engine')}
+                      options={this.searchEngineOptions}
                     />
                   </View>
-                  <Text style={styles.identiconText}>
-                    {strings('app_settings.jazzicons')}
-                  </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  onPress={() =>
-                    setAvatarAccountType(AvatarAccountType.Blockies)
-                  }
-                  style={styles.identicon_row}
-                >
-                  <View
-                    style={[
-                      styles.avatarWrapper,
-                      avatarAccountType === AvatarAccountType.Blockies
-                        ? styles.selectedAvatarWrapper
-                        : styles.unselectedAvatarWrapper,
-                    ]}
+                </View>
+              )}
+            </View>
+            <View style={styles.setting}>
+              <View style={styles.titleContainer}>
+                <Text variant={TextVariant.BodyLGMedium} style={styles.title}>
+                  {strings('app_settings.hide_zero_balance_tokens_title')}
+                </Text>
+                <View style={styles.toggle}>
+                  <Switch
+                    value={hideZeroBalanceTokens}
+                    onValueChange={this.toggleHideZeroBalanceTokens}
+                    trackColor={{
+                      true: colors.primary.default,
+                      false: colors.border.muted,
+                    }}
+                    thumbColor={themeTokens.brandColors.white}
+                    style={styles.switch}
+                    ios_backgroundColor={colors.border.muted}
+                  />
+                </View>
+              </View>
+              <Text
+                variant={TextVariant.BodyMD}
+                color={TextColor.Alternative}
+                style={styles.desc}
+              >
+                {strings('app_settings.hide_zero_balance_tokens_desc')}
+              </Text>
+            </View>
+            <View style={styles.setting}>
+              <Text variant={TextVariant.BodyLGMedium}>
+                {strings('app_settings.accounts_identicon_title')}
+              </Text>
+              <Text
+                variant={TextVariant.BodyMD}
+                color={TextColor.Alternative}
+                style={styles.desc}
+              >
+                {strings('app_settings.accounts_identicon_desc')}
+              </Text>
+              <View style={styles.accessory}>
+                <View style={styles.identicon_container}>
+                  <TouchableOpacity
+                    onPress={() =>
+                      setAvatarAccountType(AvatarAccountType.Maskicon)
+                    }
+                    style={styles.identicon_row}
                   >
-                    <AvatarAccount
-                      type={AvatarAccountType.Blockies}
-                      accountAddress={selectedAddress}
-                      size={diameter}
-                    />
-                  </View>
-                  <Text style={styles.identiconText}>
-                    {strings('app_settings.blockies')}
-                  </Text>
-                </TouchableOpacity>
+                    <View
+                      style={[
+                        styles.avatarWrapper,
+                        avatarAccountType === AvatarAccountType.Maskicon
+                          ? styles.selectedAvatarWrapper
+                          : styles.unselectedAvatarWrapper,
+                      ]}
+                    >
+                      <AvatarAccount
+                        type={AvatarAccountType.Maskicon}
+                        accountAddress={selectedAddress}
+                        size={diameter}
+                      />
+                    </View>
+                    <Text style={styles.identiconText}>Polycons</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={() =>
+                      setAvatarAccountType(AvatarAccountType.JazzIcon)
+                    }
+                    style={styles.identicon_row}
+                  >
+                    <View
+                      style={[
+                        styles.avatarWrapper,
+                        avatarAccountType === AvatarAccountType.JazzIcon
+                          ? styles.selectedAvatarWrapper
+                          : styles.unselectedAvatarWrapper,
+                      ]}
+                    >
+                      <AvatarAccount
+                        type={AvatarAccountType.JazzIcon}
+                        accountAddress={selectedAddress}
+                        size={diameter}
+                      />
+                    </View>
+                    <Text style={styles.identiconText}>
+                      {strings('app_settings.jazzicons')}
+                    </Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={() =>
+                      setAvatarAccountType(AvatarAccountType.Blockies)
+                    }
+                    style={styles.identicon_row}
+                  >
+                    <View
+                      style={[
+                        styles.avatarWrapper,
+                        avatarAccountType === AvatarAccountType.Blockies
+                          ? styles.selectedAvatarWrapper
+                          : styles.unselectedAvatarWrapper,
+                      ]}
+                    >
+                      <AvatarAccount
+                        type={AvatarAccountType.Blockies}
+                        accountAddress={selectedAddress}
+                        size={diameter}
+                      />
+                    </View>
+                    <Text style={styles.identiconText}>
+                      {strings('app_settings.blockies')}
+                    </Text>
+                  </TouchableOpacity>
+                </View>
               </View>
             </View>
+            {/* {this.renderThemeSettingsSection()} */}
           </View>
-          {/* {this.renderThemeSettingsSection()} */}
-        </View>
-      </ScrollView>
+        </ScrollView>
+      </SafeAreaView>
     );
   }
 }

--- a/app/components/Views/Settings/GeneralSettings/index.test.tsx
+++ b/app/components/Views/Settings/GeneralSettings/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, fireEvent } from '@testing-library/react-native';
 import GeneralSettings, {
   updateUserTraitsWithCurrentCurrency,
   updateUserTraitsWithCurrencyType,
@@ -11,9 +11,37 @@ import { backgroundState } from '../../../../util/test/initial-root-state';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { UserProfileProperty } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 import { MetricsEventBuilder } from '../../../../core/Analytics/MetricsEventBuilder';
-import { AvatarAccountType } from '../../../../component-library/components/Avatars/Avatar';
+import { AvatarAccountType } from '../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
+import { ThemeContext, mockTheme } from '../../../../util/theme';
 
 jest.mock('../../../../core/Analytics');
+jest.mock('../../../hooks/useMetrics', () => ({
+  useMetrics: () => ({
+    isEnabled: jest.fn().mockReturnValue(true),
+    enable: jest.fn(),
+    addTraitsToUser: jest.fn(),
+    createEventBuilder: jest.fn(),
+    trackEvent: jest.fn(),
+    trackAnonymousEvent: jest.fn(),
+    getMetaMetricsId: jest.fn(),
+  }),
+  withMetricsAwareness:
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Component: React.ComponentType<any>) =>
+      (props: Record<string, unknown>) => <Component {...props} metrics={{}} />,
+}));
+jest.mock(
+  '../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount',
+  () => ({
+    __esModule: true,
+    default: () => null,
+    AvatarAccountType: {
+      JazzIcon: 'JazzIcon',
+      Blockies: 'Blockies',
+      Maskicon: 'Maskicon',
+    },
+  }),
+);
 
 const mockStore = configureMockStore();
 const initialState = {
@@ -31,14 +59,41 @@ const initialState = {
 };
 const store = mockStore(initialState);
 
+const mockNavigation = {
+  goBack: jest.fn(),
+  navigate: jest.fn(),
+};
+
+const renderComponent = () =>
+  render(
+    <Provider store={store}>
+      <ThemeContext.Provider value={mockTheme}>
+        <GeneralSettings navigation={mockNavigation} />
+      </ThemeContext.Provider>
+    </Provider>,
+  );
+
 describe('GeneralSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render correctly', () => {
-    const wrapper = shallow(
-      <Provider store={store}>
-        <GeneralSettings />
-      </Provider>,
-    );
-    expect(wrapper).toMatchSnapshot();
+    const { toJSON } = renderComponent();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('renders header with correct title', () => {
+    const { getByText } = renderComponent();
+    expect(getByText('General')).toBeTruthy();
+  });
+
+  it('calls navigation.goBack when back button is pressed', () => {
+    const { getByTestId } = renderComponent();
+    const backButton = getByTestId('button-icon');
+    fireEvent.press(backButton);
+
+    expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## **Description**

This PR updates the General Settings page and SelectComponent modal to use the `HeaderCenter` component for consistent header styling across the app.

**Changes:**
1. **GeneralSettings page**: Replaced the dynamic navigation header (`getNavigationOptionsTitle`) with an inline `HeaderCenter` component, following the pattern established in the parent Settings page
2. **Navigation config**: Set `headerShown: false` at the stack level for GeneralSettings screens in MainNavigator.js
3. **SafeAreaView**: Wrapped GeneralSettings content in `SafeAreaView` for proper safe area handling
4. **SelectComponent modal**: Updated the "Base currency" (and other select) modal header to use `HeaderCenter` with a close button

## **Changelog**

CHANGELOG entry: Updated General Settings page and select modal headers to use consistent HeaderCenter component styling

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/jira/software/c/projects/MDP/boards/2972?assignee=62afb43d33a882e2be47c36f&quickFilter=3325&selectedIssue=MDP-697

## **Manual testing steps**

```gherkin
Feature: General Settings Header

  Scenario: User navigates to General Settings
    Given the user is on the Settings page

    When user taps on "General"
    Then the General Settings page opens with a centered "General" title header
    And a back arrow button is visible on the left

  Scenario: User opens currency selector modal
    Given the user is on the General Settings page

    When user taps on the currency dropdown
    Then a modal opens with "Base currency" as the centered title
    And a close (X) button is visible on the right
    When user taps the close button
    Then the modal closes
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/b75d366c-2479-42da-a9b0-459eef386c99

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation refactor that mainly changes header rendering and related tests; minimal impact to underlying settings behavior.
> 
> **Overview**
> **Unifies header UI for General Settings and select modals.** `GeneralSettings` now renders its own `HeaderCenter` (wrapped in `SafeAreaView`) instead of configuring a React Navigation header, and `MainNavigator` forces `headerShown: false` for `GeneralSettings` screens.
> 
> `SelectComponent`’s modal header is replaced with `HeaderCenter` (adds close button handling). Tests were migrated from Enzyme to Testing Library and snapshots updated to reflect the new header structure and navigation interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95f4c98085e06d99a9fa3b98715a099c725109c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->