### PR TITLE
fix: Remove unexpected header background when confirmation modal shown

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -845,21 +845,6 @@ const MultichainPrivateKeyList = () => {
   );
 };
 
-const ModalConfirmationRequest = () => (
-  <Stack.Navigator
-    screenOptions={{
-      headerShown: false,
-      cardStyle: { backgroundColor: importedColors.transparent },
-    }}
-    mode={'modal'}
-  >
-    <Stack.Screen
-      name={Routes.CONFIRMATION_REQUEST_MODAL}
-      component={Confirm}
-    />
-  </Stack.Navigator>
-);
-
 const ModalSwitchAccountType = () => (
   <Stack.Navigator
     screenOptions={{
@@ -1077,7 +1062,7 @@ const AppFlow = () => {
         <Stack.Screen
           name={Routes.CONFIRMATION_REQUEST_MODAL}
           options={emptyNavHeaderOptions}
-          component={ModalConfirmationRequest}
+          component={Confirm}
         />
         <Stack.Screen
           name={Routes.CONFIRMATION_SWITCH_ACCOUNT_TYPE}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to remove unexpected header when confirmations modal shown. It appears that it was causing misuse of `Stack.Navigator` unnecessarily - see the background marked in ss.

<img width="524" height="1040" alt="Screenshot 2026-01-29 at 10 00 43" src="https://github.com/user-attachments/assets/a36b2480-5ed5-4684-b555-d492dfa2fd12" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/24805

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/90c8de1a-7330-49c2-9fc8-cec6c3c67b51



### **After**


https://github.com/user-attachments/assets/cddcdbe4-4c4a-4017-8d42-97d27cec7e95



## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk navigation refactor that only changes how `Routes.CONFIRMATION_REQUEST_MODAL` is mounted; behavior should remain the same aside from removing the unintended header/background styling.
> 
> **Overview**
> Removes the extra nested `Stack.Navigator` wrapper (`ModalConfirmationRequest`) around `Routes.CONFIRMATION_REQUEST_MODAL` and mounts `Confirm` directly as the screen component.
> 
> This simplifies the confirmation modal navigation setup and prevents the modal from inheriting an unexpected header/background from the additional stack configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16cff86f451ecdd1abe9c318dddecc75b09217e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->