### PR TITLE
feat: update HyperEVM RPC and failover

### DIFF
--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -310,11 +310,11 @@ jobs:
       QUICKNODE_BASE_URL: ${{ secrets.QUICKNODE_BASE_URL }}
       QUICKNODE_LINEA_MAINNET_URL: ${{ secrets.QUICKNODE_LINEA_MAINNET_URL }}
       QUICKNODE_MONAD_URL: ${{ secrets.QUICKNODE_MONAD_URL }}
+      QUICKNODE_HYPEREVM_URL: ${{ secrets.QUICKNODE_HYPEREVM_URL }}
       QUICKNODE_OPTIMISM_URL: ${{ secrets.QUICKNODE_OPTIMISM_URL }}
       QUICKNODE_POLYGON_URL: ${{ secrets.QUICKNODE_POLYGON_URL }}
       QUICKNODE_BSC_URL: ${{ secrets.QUICKNODE_BSC_URL }}
       QUICKNODE_SEI_URL: ${{ secrets.QUICKNODE_SEI_URL }}
-      QUICKNODE_HYPEREVM_URL: ${{ secrets.QUICKNODE_HYPEREVM_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/app/core/Engine/controllers/network-controller/utils.test.ts
+++ b/app/core/Engine/controllers/network-controller/utils.test.ts
@@ -420,6 +420,7 @@ function setQuicknodeEnvironmentVariables() {
   process.env.QUICKNODE_BSC_URL = 'https://example.quicknode.com/bsc';
   process.env.QUICKNODE_SEI_URL = 'https://example.quicknode.com/sei';
   process.env.QUICKNODE_MONAD_URL = 'https://example.quicknode.com/monad';
+  process.env.QUICKNODE_HYPEREVM_URL = 'https://example.quicknode.com/hyperevm';
 }
 
 /**

--- a/app/store/migrations/123.test.ts
+++ b/app/store/migrations/123.test.ts
@@ -1,0 +1,610 @@
+import { captureException } from '@sentry/react-native';
+import { cloneDeep } from 'lodash';
+
+import { ensureValidState } from './util';
+import migrate, { migrationVersion, HYPEREVM_CHAIN_ID } from './123';
+import { Hex } from '@metamask/utils';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+  addFailoverUrlToNetworkConfiguration:
+    jest.requireActual('./util').addFailoverUrlToNetworkConfiguration, // Actual one
+}));
+
+jest.mock('uuid', () => ({ v4: () => 'mock-uuid' }));
+
+const mockedCaptureException = jest.mocked(captureException);
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+
+const QUICKNODE_HYPEREVM_URL = 'https://failover.com';
+
+const mainnetConfiguration = {
+  '0x1': {
+    chainId: '0x1',
+    name: 'Ethereum',
+    nativeCurrency: 'ETH',
+    blockExplorerUrls: ['https://explorer.com'],
+    defaultRpcEndpointIndex: 0,
+    defaultBlockExplorerUrlIndex: 0,
+    rpcEndpoints: [
+      {
+        networkClientId: 'mainnet',
+        type: 'custom',
+        url: 'https://mainnet.com',
+      },
+    ],
+  },
+};
+
+const hyperevmInitialConfiguration = {
+  [HYPEREVM_CHAIN_ID]: {
+    chainId: HYPEREVM_CHAIN_ID,
+    name: 'HyperEVM',
+    nativeCurrency: 'HYPE',
+    blockExplorerUrls: ['https://hyperevmscan.io/'],
+    defaultRpcEndpointIndex: 0,
+    defaultBlockExplorerUrlIndex: 0,
+    rpcEndpoints: [
+      {
+        networkClientId: 'hyperevm',
+        type: 'custom',
+        url: 'https://rpc.hyperliquid.xyz/evm',
+      },
+    ],
+  },
+};
+
+interface RpcEndpoint {
+  failoverUrls?: string[];
+  name?: string;
+  networkClientId: string;
+  url: string;
+  type: string;
+}
+
+interface NetworkConfiguration {
+  blockExplorerUrls: string[];
+  chainId: Hex;
+  defaultBlockExplorerUrlIndex?: number;
+  defaultRpcEndpointIndex: number;
+  name: string;
+  nativeCurrency: string;
+  rpcEndpoints: RpcEndpoint[];
+}
+
+const unitTestInfuraId = 'unitTestInfuraId';
+
+const NEW_TEST_INFURA_ENDPOINT = `https://hyperevm-mainnet.infura.io/v3/${unitTestInfuraId}`;
+
+export const HYPEREVM_CLEAN_CONFIG: NetworkConfiguration = {
+  chainId: HYPEREVM_CHAIN_ID,
+  name: 'HyperEVM',
+  nativeCurrency: 'HYPE',
+  blockExplorerUrls: ['https://hyperevmscan.io/'],
+  defaultRpcEndpointIndex: 0,
+  defaultBlockExplorerUrlIndex: 0,
+  rpcEndpoints: [
+    {
+      failoverUrls: [QUICKNODE_HYPEREVM_URL],
+      networkClientId: 'hyperevm',
+      type: 'custom',
+      url: NEW_TEST_INFURA_ENDPOINT,
+    },
+  ],
+};
+
+describe(`migration #${migrationVersion}`, () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+
+    originalEnv = { ...process.env };
+    process.env.MM_INFURA_PROJECT_ID = unitTestInfuraId;
+    process.env.QUICKNODE_HYPEREVM_URL = QUICKNODE_HYPEREVM_URL;
+  });
+
+  afterEach(() => {
+    for (const key of new Set([
+      ...Object.keys(originalEnv),
+      ...Object.keys(process.env),
+    ])) {
+      if (originalEnv[key]) {
+        process.env[key] = originalEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it('returns state unchanged if ensureValidState fails', () => {
+    const state = { some: 'state' };
+    mockedEnsureValidState.mockReturnValue(false);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toStrictEqual({ some: 'state' });
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  const invalidStates = [
+    {
+      state: {
+        engine: {},
+      },
+      scenario: 'empty engine state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {},
+        },
+      },
+      scenario: 'empty backgroundState',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: 'invalid',
+          },
+        },
+      },
+      scenario: 'invalid NetworkController state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {},
+          },
+        },
+      },
+      scenario: 'missing networkConfigurationsByChainId property',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {
+              networkConfigurationsByChainId: 'invalid',
+            },
+          },
+        },
+      },
+      scenario: 'invalid networkConfigurationsByChainId state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {
+              networkConfigurationsByChainId: {
+                [HYPEREVM_CHAIN_ID]: {
+                  chainId: HYPEREVM_CHAIN_ID,
+                  name: 'HyperEVM',
+                  nativeCurrency: 'HYPE',
+                  blockExplorerUrls: ['https://hyperevmscan.io/'],
+                  defaultRpcEndpointIndex: 0,
+                  defaultBlockExplorerUrlIndex: 0,
+                  rpcEndpoints: [
+                    {
+                      networkClientId: 'hyperevm',
+                      type: 'custom',
+                      url: 'https://rpc.hyperliquid.xyz/evm',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+      scenario: 'selectedNetworkClientId is missing',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {
+              selectedNetworkClientId: {},
+              networkConfigurationsByChainId: {
+                [HYPEREVM_CHAIN_ID]: {
+                  chainId: HYPEREVM_CHAIN_ID,
+                  name: 'HyperEVM',
+                  nativeCurrency: 'HYPE',
+                  blockExplorerUrls: ['https://hyperevmscan.io/'],
+                  defaultRpcEndpointIndex: 0,
+                  defaultBlockExplorerUrlIndex: 0,
+                  rpcEndpoints: [
+                    {
+                      networkClientId: 'HYPE',
+                      type: 'custom',
+                      url: 'https://rpc.hyperliquid.xyz/evm',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+      scenario: 'selectedNetworkClientId is not a string',
+    },
+  ];
+
+  it.each(invalidStates)('captures exception if $scenario', ({ state }) => {
+    const orgState = cloneDeep(state);
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = migrate(state);
+
+    // State should be unchanged
+    expect(migratedState).toStrictEqual(orgState);
+    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('keeps config as is without error, if already clean', async () => {
+    const orgState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'mainnet',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              [HYPEREVM_CHAIN_ID]: HYPEREVM_CLEAN_CONFIG,
+            },
+          },
+        },
+      },
+    };
+
+    const expectedState = cloneDeep(orgState);
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(orgState);
+
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+
+    expect(migratedState).toStrictEqual(expectedState);
+  });
+
+  it('merges the existing HyperEVM network configuration if there is one', async () => {
+    const orgState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              ...hyperevmInitialConfiguration,
+            },
+          },
+        },
+      },
+    };
+
+    const expectedState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              [HYPEREVM_CHAIN_ID]: {
+                ...HYPEREVM_CLEAN_CONFIG,
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'hyperevm',
+                    url: 'https://rpc.hyperliquid.xyz/evm',
+                    type: 'custom',
+                  },
+                  {
+                    ...HYPEREVM_CLEAN_CONFIG.rpcEndpoints[0],
+                    networkClientId: 'mock-uuid',
+                  },
+                ],
+                defaultRpcEndpointIndex: 1,
+                defaultBlockExplorerUrlIndex: 0,
+                blockExplorerUrls: ['https://hyperevmscan.io/'],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(orgState);
+
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+
+    expect(migratedState).toStrictEqual(expectedState);
+  });
+
+  it('keeps original RPC if no infura key is found, and does not add failover', async () => {
+    delete process.env.MM_INFURA_PROJECT_ID;
+
+    const orgState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              ...hyperevmInitialConfiguration,
+              [HYPEREVM_CHAIN_ID]: {
+                ...HYPEREVM_CLEAN_CONFIG,
+                name: 'HyperEVM',
+                nativeCurrency: 'HYPE',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'hyperevm',
+                    url: 'https://rpc.hyperliquid.xyz/evm',
+                    type: 'custom',
+                  },
+                ],
+                defaultRpcEndpointIndex: 0,
+                defaultBlockExplorerUrlIndex: 0,
+                blockExplorerUrls: ['https://hyperevmscan.io/'],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const expectedState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              [HYPEREVM_CHAIN_ID]: {
+                ...HYPEREVM_CLEAN_CONFIG,
+                rpcEndpoints: hyperevmInitialConfiguration[
+                  HYPEREVM_CHAIN_ID
+                ].rpcEndpoints.map((endpoint) => ({
+                  ...endpoint,
+                })),
+                defaultRpcEndpointIndex: 0,
+                defaultBlockExplorerUrlIndex: 0,
+                blockExplorerUrls: ['https://hyperevmscan.io/'],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(orgState);
+
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Infura project ID is not set, skip the HyperEVM RPC migration',
+        ),
+      }),
+    );
+
+    expect(migratedState).toStrictEqual(expectedState);
+  });
+
+  it('does not add failover URL if there is already a failover URL', async () => {
+    const orgState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              ...hyperevmInitialConfiguration,
+              [HYPEREVM_CHAIN_ID]: {
+                ...HYPEREVM_CLEAN_CONFIG,
+                name: 'HyperEVM',
+                nativeCurrency: 'HYPE',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'hyperevm',
+                    url: 'https://rpc.hyperliquid.xyz/evm',
+                    type: 'custom',
+                    failoverUrls: ['https://existingFailover'],
+                  },
+                ],
+                defaultRpcEndpointIndex: 0,
+                defaultBlockExplorerUrlIndex: 0,
+                blockExplorerUrls: ['https://hyperevmscan.io/'],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const expectedState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              [HYPEREVM_CHAIN_ID]: {
+                ...HYPEREVM_CLEAN_CONFIG,
+                rpcEndpoints: [
+                  {
+                    // Untouched first endpoint, including existing failover
+                    networkClientId: 'hyperevm',
+                    url: 'https://rpc.hyperliquid.xyz/evm',
+                    type: 'custom',
+                    failoverUrls: ['https://existingFailover'],
+                  },
+                  {
+                    // New endpoint, including QuickNode failover
+                    networkClientId: 'mock-uuid',
+                    url: NEW_TEST_INFURA_ENDPOINT,
+                    type: 'custom',
+                    failoverUrls: [QUICKNODE_HYPEREVM_URL],
+                  },
+                ],
+                defaultRpcEndpointIndex: 1,
+                defaultBlockExplorerUrlIndex: 0,
+                blockExplorerUrls: ['https://hyperevmscan.io/'],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(orgState);
+
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+
+    expect(migratedState).toStrictEqual(expectedState);
+  });
+
+  it('does not add failover URL if QUICKNODE_HYPEREVM_URL env variable is not set', async () => {
+    delete process.env.QUICKNODE_HYPEREVM_URL;
+
+    const orgState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              ...hyperevmInitialConfiguration,
+              [HYPEREVM_CHAIN_ID]: {
+                ...HYPEREVM_CLEAN_CONFIG,
+                name: 'HyperEVM',
+                nativeCurrency: 'HYPE',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'hyperevm',
+                    url: 'https://rpc.hyperliquid.xyz/evm',
+                    type: 'custom',
+                    failoverUrls: ['https://existingFailover'],
+                  },
+                ],
+                defaultRpcEndpointIndex: 0,
+                defaultBlockExplorerUrlIndex: 0,
+                blockExplorerUrls: ['https://hyperevmscan.io/'],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const expectedState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              [HYPEREVM_CHAIN_ID]: {
+                ...HYPEREVM_CLEAN_CONFIG,
+                rpcEndpoints: [
+                  {
+                    // Untouched first endpoint, including existing failover
+                    networkClientId: 'hyperevm',
+                    url: 'https://rpc.hyperliquid.xyz/evm',
+                    type: 'custom',
+                    failoverUrls: ['https://existingFailover'],
+                  },
+                  {
+                    // New endpoint, missing QuickNode failover because of the missing env var
+                    networkClientId: 'mock-uuid',
+                    url: NEW_TEST_INFURA_ENDPOINT,
+                    type: 'custom',
+                    failoverUrls: [],
+                  },
+                ],
+                defaultRpcEndpointIndex: 1,
+                defaultBlockExplorerUrlIndex: 0,
+                blockExplorerUrls: ['https://hyperevmscan.io/'],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(orgState);
+
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+
+    expect(migratedState).toStrictEqual(expectedState);
+  });
+
+  it('returns the original state if the HyperEVM network configuration exists but is invalid', async () => {
+    const orgState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              [HYPEREVM_CHAIN_ID]: {
+                ...HYPEREVM_CLEAN_CONFIG,
+                name: 'HyperEVM',
+                nativeCurrency: 'HYPE',
+                rpcEndpoints: 'invalid',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const expectedState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'uuid',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              ...mainnetConfiguration,
+              [HYPEREVM_CHAIN_ID]: {
+                ...HYPEREVM_CLEAN_CONFIG,
+                name: 'HyperEVM',
+                nativeCurrency: 'HYPE',
+                rpcEndpoints: 'invalid',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(orgState);
+
+    expect(migratedState).toStrictEqual(expectedState);
+  });
+});

--- a/app/store/migrations/123.ts
+++ b/app/store/migrations/123.ts
@@ -1,0 +1,268 @@
+import { captureException } from '@sentry/react-native';
+import {
+  getErrorMessage,
+  hasProperty,
+  Hex,
+  isHexString,
+  isObject,
+} from '@metamask/utils';
+import { v4 as uuidV4 } from 'uuid';
+
+import { ensureValidState, ValidState } from './util';
+import { cloneDeep } from 'lodash';
+
+/**
+ * A Copy of the RpcEndpoint type from the network controller,
+ * This is used to avoid the dependency on the network controller.
+ */
+interface RpcEndpoint {
+  failoverUrls?: string[];
+  name?: string;
+  networkClientId: string;
+  url: string;
+  type: string;
+}
+
+/**
+ * A Copy of the NetworkConfiguration type from the network controller,
+ * This is used to avoid the dependency on the network controller.
+ */
+interface NetworkConfiguration {
+  blockExplorerUrls: string[];
+  chainId: Hex;
+  defaultBlockExplorerUrlIndex?: number;
+  defaultRpcEndpointIndex: number;
+  name: string;
+  nativeCurrency: string;
+  rpcEndpoints: RpcEndpoint[];
+}
+
+export const migrationVersion = 123;
+
+// Export for tests
+export const HYPEREVM_CHAIN_ID = '0x3e7';
+
+/**
+ * This migration does:
+ * - Adds Infura RPC + Quicknode Failover to HyperEVM and set as default if Infura not already present.
+ * Otherwise leaves RPC config untouched (not adding the failover to existing Infura).
+ * - Adds Blockscout Explorer URL to list of explorers if not already present.
+ *
+ * @param versionedState - MetaMask state, exactly
+ * what we persist to disk.
+ * @returns Updated MetaMask state.
+ */
+export default function migrate(versionedState: unknown) {
+  // Putting env-fetching here for easier testing.
+  // Ideally all "infuraProjectId" logic should use a getter.
+  const INFURA_KEY = process.env.MM_INFURA_PROJECT_ID;
+  const infuraProjectId = INFURA_KEY === 'null' ? '' : INFURA_KEY;
+  const QUICKNODE_HYPEREVM_URL = process.env.QUICKNODE_HYPEREVM_URL;
+  const quickNodeUrl =
+    QUICKNODE_HYPEREVM_URL && QUICKNODE_HYPEREVM_URL !== 'null'
+      ? QUICKNODE_HYPEREVM_URL
+      : undefined;
+
+  const state = cloneDeep(versionedState);
+  try {
+    if (!ensureValidState(state, migrationVersion)) {
+      return state;
+    }
+
+    const networkState = validateNetworkController(state);
+    // No Migration should be performed if the NetworkController state is invalid.
+    if (networkState === undefined) {
+      console.warn(
+        `Migration ${migrationVersion}: Missing or invalid NetworkController state, skip the migration`,
+      );
+      return state;
+    }
+
+    const { networkConfigurationsByChainId } = networkState;
+
+    // Migrate NetworkController:
+    // - Merges the HyperEVM Mainnet network configuration if user already has it.
+    if (hasProperty(networkConfigurationsByChainId, HYPEREVM_CHAIN_ID)) {
+      const hyperevmConfiguration =
+        networkConfigurationsByChainId[HYPEREVM_CHAIN_ID];
+      if (!isValidNetworkConfiguration(hyperevmConfiguration)) {
+        console.warn(
+          `Migration ${migrationVersion}: Invalid HyperEVM network configuration, skip the migration`,
+        );
+        return state;
+      }
+
+      if (infuraProjectId) {
+        const newInfuraURL = `https://hyperevm-mainnet.infura.io/v3/${infuraProjectId}`;
+        const isInfuraRpcPresent = hyperevmConfiguration.rpcEndpoints.find(
+          (rpc) => rpc.url === newInfuraURL,
+        );
+        // Avoid RPC duplication if Infura is already present.
+        if (!isInfuraRpcPresent) {
+          const failoverUrls = quickNodeUrl ? [quickNodeUrl] : [];
+          // Add Infura RPC
+          hyperevmConfiguration.rpcEndpoints.push({
+            failoverUrls,
+            // Normally networkClientId should be 'hyperevm-mainnet' and type 'infura'.
+            // This is because "InfuraNetworkType" has this network missing.
+            // Planning to run a dedicated migration script for set all infura RPCs to 'infura' type.
+            // Dicussion: https://github.com/MetaMask/metamask-extension/pull/39635#issuecomment-3861983789
+            networkClientId: uuidV4(),
+            type: 'custom',
+            url: newInfuraURL,
+          });
+          // Set newly added Infura RPC as default RPC.
+          hyperevmConfiguration.defaultRpcEndpointIndex =
+            hyperevmConfiguration.rpcEndpoints.length - 1;
+        }
+      } else {
+        captureException(
+          new Error(
+            `Migration ${migrationVersion}: Infura project ID is not set, skip the HyperEVM RPC migration`,
+          ),
+        );
+      }
+    }
+
+    return state;
+  } catch (error) {
+    console.error(error);
+    captureException(
+      new Error(`Migration ${migrationVersion}: ${getErrorMessage(error)}`),
+    );
+    // Return the original state if migration fails to avoid breaking the app
+    return versionedState;
+  }
+}
+
+// Copied from 111.ts/113.ts
+function validateNetworkController(state: ValidState):
+  | {
+      networkConfigurationsByChainId: Record<Hex, unknown>;
+      selectedNetworkClientId: string;
+    }
+  | undefined {
+  if (!hasProperty(state.engine.backgroundState, 'NetworkController')) {
+    // We catch the exception here, as we don't expect the NetworkController state is missing.
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: missing NetworkController`,
+      ),
+    );
+    return undefined;
+  }
+
+  const networkState = state.engine.backgroundState.NetworkController;
+
+  // To narrow the type of the networkState to the expected type.
+  if (!isValidNetworkControllerState(networkState)) {
+    return undefined;
+  }
+
+  return networkState;
+}
+
+// Copied from 111.ts/113.ts
+function isValidNetworkControllerState(value: unknown): value is {
+  networkConfigurationsByChainId: Record<Hex, unknown>;
+  selectedNetworkClientId: string;
+} {
+  if (!isObject(value)) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: NetworkController state is not an object: '${typeof value}'`,
+      ),
+    );
+    return false;
+  }
+
+  if (!hasProperty(value, 'networkConfigurationsByChainId')) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: missing networkConfigurationsByChainId property`,
+      ),
+    );
+    return false;
+  }
+
+  if (
+    !isValidNetworkConfigurationsByChainId(value.networkConfigurationsByChainId)
+  ) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: networkConfigurationsByChainId is not a valid Record<Hex, unknown>`,
+      ),
+    );
+    return false;
+  }
+
+  if (!hasProperty(value, 'selectedNetworkClientId')) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: missing selectedNetworkClientId property`,
+      ),
+    );
+    return false;
+  }
+
+  if (typeof value.selectedNetworkClientId !== 'string') {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: selectedNetworkClientId is not a string: '${typeof value.selectedNetworkClientId}'`,
+      ),
+    );
+    return false;
+  }
+
+  return true;
+}
+
+// Copied from 111.ts/113.ts
+function isValidNetworkConfigurationsByChainId(
+  value: unknown,
+): value is Record<Hex, unknown> {
+  return (
+    isObject(value) &&
+    Object.entries(value).every(
+      ([chainId]) => typeof chainId === 'string' && isHexString(chainId),
+    )
+  );
+}
+
+// Copied from 111.ts/113.ts
+function isValidNetworkConfiguration(
+  object: unknown,
+): object is NetworkConfiguration {
+  return (
+    isObject(object) &&
+    hasProperty(object, 'chainId') &&
+    typeof object.chainId === 'string' &&
+    isHexString(object.chainId) &&
+    hasProperty(object, 'rpcEndpoints') &&
+    Array.isArray(object.rpcEndpoints) &&
+    object.rpcEndpoints.every(isValidRpcEndpoint) &&
+    hasProperty(object, 'name') &&
+    typeof object.name === 'string' &&
+    hasProperty(object, 'nativeCurrency') &&
+    typeof object.nativeCurrency === 'string' &&
+    hasProperty(object, 'blockExplorerUrls') &&
+    Array.isArray(object.blockExplorerUrls) &&
+    object.blockExplorerUrls.every((url) => typeof url === 'string') &&
+    hasProperty(object, 'defaultRpcEndpointIndex') &&
+    typeof object.defaultRpcEndpointIndex === 'number' &&
+    (!hasProperty(object, 'defaultBlockExplorerUrlIndex') ||
+      (hasProperty(object, 'defaultBlockExplorerUrlIndex') &&
+        typeof object.defaultBlockExplorerUrlIndex === 'number'))
+  );
+}
+
+// Copied from 111.ts/113.ts
+function isValidRpcEndpoint(object: unknown): boolean {
+  return (
+    isObject(object) &&
+    hasProperty(object, 'networkClientId') &&
+    typeof object.networkClientId === 'string' &&
+    hasProperty(object, 'url') &&
+    typeof object.url === 'string'
+  );
+}

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -123,6 +123,7 @@ import migration119 from './119';
 import migration120 from './120';
 import migration121 from './121';
 import migration122 from './122';
+import migration123 from './123';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -265,6 +266,7 @@ export const migrationList: MigrationsList = {
   120: migration120,
   121: migration121,
   122: migration122,
+  123: migration123,
 };
 
 // Enable both synchronous and asynchronous migrations

--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -27,6 +27,7 @@ export const QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME = {
   'bsc-mainnet': () => process.env.QUICKNODE_BSC_URL,
   'sei-mainnet': () => process.env.QUICKNODE_SEI_URL,
   'monad-mainnet': () => process.env.QUICKNODE_MONAD_URL,
+  'hyperevm-mainnet': () => process.env.QUICKNODE_HYPEREVM_URL,
 };
 
 export function getFailoverUrlsForInfuraNetwork(
@@ -93,8 +94,8 @@ export const PopularList = [
   {
     chainId: toHex('999'),
     nickname: 'HyperEVM',
-    rpcUrl: 'https://rpc.hyperliquid.xyz/evm',
-    failoverRpcUrls: [],
+    rpcUrl: `https://hyperevm-mainnet.infura.io/v3/${infuraProjectId}`,
+    failoverRpcUrls: getFailoverUrlsForInfuraNetwork('hyperevm-mainnet'),
     ticker: 'HYPE',
     warning: true,
     rpcPrefs: {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -707,6 +707,7 @@ createEnvFile() {
 		"QUICKNODE_MONAD_URL"
 		"QUICKNODE_OPTIMISM_URL"
 		"QUICKNODE_POLYGON_URL"
+		"QUICKNODE_HYPEREVM_URL"
 	)
 
 	# Create .env file and export to GITHUB_ENV


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

Note: The validators have been taken from https://github.com/MetaMask/metamask-mobile/pull/23479 after verifying that NetworkController hadn't evolved.

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- For new HyperEVM MM users: Making sure that when HyperEVM is added for the first time, it will use Infura RPC with a Quicknode failover
- For existing HyperEVM MM users: If they already have HyperEVM added as a network, the migration script will scans through the various RPCs and add Infura RPC as default one Infura is not already in the list. It will also add the Quicknode RPC as failover.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: sets Infura RPC for HyperEVM with Quicknode failover

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-200

## **Manual testing steps**

Scenario 1: Already added HyperEVM network (migration test).
1. First use `main` branch (not this branch)
2. Add HyperEVM network from the integrated network selector.
3. Go to "edit the network" on MetaMask and observe default RPC `rpc.hyperliquid.xyz/evm`.
4. Fetch **this** branch.
5. Compile and reload the mobile app.
6. Go to "edit the network".
7. Observe Infura RPC with failover set as default. Old RPC remains as secondary.

Scenario 2: HyperEVM network wasn't added before
0. First use **this** branch.
1. Find HyperEVM on chainlist: https://chainlist.org/?search=hyperevm
2. Add HyperEVM network
3. Go to "edit the network" on MetaMask and  observe Infura RPC with failover set as default and only RPC.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a persisted-state migration that modifies users' HyperEVM RPC endpoint ordering/defaults, which can impact connectivity if assumptions about existing configs or env vars are wrong. Changes are scoped to one chain and include extensive unit tests, lowering overall risk.
> 
> **Overview**
> Updates HyperEVM to prefer the Infura endpoint (with optional QuickNode failover via `QUICKNODE_HYPEREVM_URL`) instead of the previously hardcoded `rpc.hyperliquid.xyz/evm`, including wiring `hyperevm-mainnet` into the QuickNode failover mapping used by popular networks.
> 
> Adds migration `123` to update *existing* users’ persisted `NetworkController` config for chain `0x3e7`: if an Infura HyperEVM RPC is missing, it appends it (with failover URLs when configured) and sets it as the default RPC; invalid state/configs are detected and skipped with Sentry capture.
> 
> Extends CI/build plumbing to propagate `QUICKNODE_HYPEREVM_URL` (OTA workflow env + `build.sh` `.env` export list) and adds/updates tests to cover the new env var and migration behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd5c0cdb69d6cea1cb897e4ad7ac4cb04de37c96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->