### PR TITLE
fix: Enable the “Got it” button

### DIFF
--- a/app/components/hooks/useAlertsConfirmed.test.ts
+++ b/app/components/hooks/useAlertsConfirmed.test.ts
@@ -82,4 +82,25 @@ describe('useAlertsConfirmed', () => {
     );
     expect(result.current.hasUnconfirmedDangerAlerts).toBe(false);
   });
+
+  it('auto-confirms new alerts with skipConfirmation when alerts array updates', () => {
+    const { result, rerender } = renderHook(
+      ({ alerts }) => useAlertsConfirmed(alerts),
+      { initialProps: { alerts: alertsMock } },
+    );
+
+    // Initially, alert5 is not in the list
+    expect(result.current.isAlertConfirmed(skipConfirmationAlertMock.key)).toBe(
+      false,
+    );
+
+    // Add the skipConfirmation alert
+    rerender({ alerts: [...alertsMock, skipConfirmationAlertMock] });
+
+    // Alert5 should now be auto-confirmed
+    expect(result.current.isAlertConfirmed(skipConfirmationAlertMock.key)).toBe(
+      true,
+    );
+    expect(result.current.hasUnconfirmedDangerAlerts).toBe(true); // alert1 is still unconfirmed
+  });
 });

--- a/app/components/hooks/useAlertsConfirmed.ts
+++ b/app/components/hooks/useAlertsConfirmed.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, useMemo } from 'react';
+import { useCallback, useState, useMemo, useEffect } from 'react';
 import { Alert, Severity } from '../Views/confirmations/types/alerts';
 
 /**
@@ -16,6 +16,23 @@ export const useAlertsConfirmed = (alerts: Alert[]) => {
       {},
     ),
   );
+
+  // Update confirmed state when new alerts with skipConfirmation appear
+  useEffect(() => {
+    const newConfirmedAlerts = alerts.filter(
+      (alert) =>
+        alert.skipConfirmation === true && confirmed[alert.key] === undefined,
+    );
+    if (newConfirmedAlerts.length > 0) {
+      setConfirmed((prevConfirmed) => {
+        const autoConfirmed: Record<string, boolean> = {};
+        for (const alert of newConfirmedAlerts) {
+          autoConfirmed[alert.key] = true;
+        }
+        return { ...prevConfirmed, ...autoConfirmed };
+      });
+    }
+  }, [alerts, confirmed]);
 
   /**
    * Sets the confirmation status of an alert.


### PR DESCRIPTION
## **Description**
Enables the “Got it” button in an alert.

## **Changelog**

CHANGELOG entry: fix: Enables the “Got it” button in an alert

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/24875

## **Manual testing steps**

1. Have insufficient funds for gas
2. Start send transaction
3. Select token and recipient
4. Click on the Network fee alert
5. Click on 'Got it'
6. The alert is closed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
Disabled "Got it" button:
<img width="467" height="330" alt="image" src="https://github.com/user-attachments/assets/5e88438f-9896-44c4-a657-7bc4a9b97b31" />


### **After**
Enabled "Got it" button, which closes the alert:
<img width="466" height="324" alt="image" src="https://github.com/user-attachments/assets/7a052c85-efe1-4da5-9eb8-fa1d7010fcf1" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small change isolated to a React hook’s local state management, with added test coverage. Main risk is unintended confirmation state changes when the `alerts` array is updated dynamically.
> 
> **Overview**
> Ensures `useAlertsConfirmed` automatically marks newly added `skipConfirmation` alerts as confirmed when the `alerts` array changes, preventing those alerts from blocking dismissal/confirmation flows.
> 
> Adds a unit test that rerenders the hook with an updated `alerts` list to verify new `skipConfirmation` alerts become confirmed while other danger alerts remain unconfirmed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ad788d84f5adb0c47c688cb2019dda6634476cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->