### PR TITLE
feat(analytics): migrate Batch 1-2 Ramp useAnalytics to analytics utility

### DIFF
--- a/app/components/UI/Ramp/hooks/useAnalytics.test.ts
+++ b/app/components/UI/Ramp/hooks/useAnalytics.test.ts
@@ -1,15 +1,12 @@
-import { MetaMetrics, MetaMetricsEvents } from '../../../../core/Analytics';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
 import useAnalytics from './useAnalytics';
-import { MetricsEventBuilder } from '../../../../core/Analytics/MetricsEventBuilder';
+import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
+import { analytics } from '../../../../util/analytics/analytics';
 
-jest.mock('../../../../core/Analytics', () => ({
-  ...jest.requireActual('../../../../core/Analytics'),
-  MetaMetrics: {
-    getInstance: jest.fn().mockReturnValue({
-      trackEvent: jest.fn(),
-      updateDataRecordingFlag: jest.fn(),
-    }),
+jest.mock('../../../../util/analytics/analytics', () => ({
+  analytics: {
+    trackEvent: jest.fn(),
   },
 }));
 
@@ -35,8 +32,8 @@ describe('useAnalytics', () => {
 
     result.current(testEvent, testEventParams);
 
-    expect(MetaMetrics.getInstance().trackEvent).toHaveBeenCalledWith(
-      MetricsEventBuilder.createEventBuilder(MetaMetricsEvents[testEvent])
+    expect(analytics.trackEvent).toHaveBeenCalledWith(
+      AnalyticsEventBuilder.createEventBuilder(MetaMetricsEvents[testEvent])
         .addProperties(testEventParams)
         .build(),
     );

--- a/app/components/UI/Ramp/hooks/useAnalytics.ts
+++ b/app/components/UI/Ramp/hooks/useAnalytics.ts
@@ -2,8 +2,9 @@ import { useCallback } from 'react';
 import { AnalyticsEvents as AggregatorEvents } from '../Aggregator/types';
 import { AnalyticsEvents as DepositEvents } from '../Deposit/types';
 
-import { MetaMetrics, MetaMetricsEvents } from '../../../../core/Analytics';
-import { MetricsEventBuilder } from '../../../../core/Analytics/MetricsEventBuilder';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+import { analytics } from '../../../../util/analytics/analytics';
+import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
 
 interface MergedRampEvents extends AggregatorEvents, DepositEvents {}
 
@@ -11,9 +12,8 @@ export function trackEvent<T extends keyof MergedRampEvents>(
   eventType: T,
   params: MergedRampEvents[T],
 ) {
-  const metrics = MetaMetrics.getInstance();
-  metrics.trackEvent(
-    MetricsEventBuilder.createEventBuilder(MetaMetricsEvents[eventType])
+  analytics.trackEvent(
+    AnalyticsEventBuilder.createEventBuilder(MetaMetricsEvents[eventType])
       .addProperties({ ...params })
       .build(),
   );


### PR DESCRIPTION
## **Description**

Phase 1 analytics migration (Batch 1-2): migrate Ramp's `useAnalytics` hook from `MetaMetrics.getInstance()` to the new analytics system.

1. **Reason**: Deprecate MetaMetrics in favour of the shared analytics utility and AnalyticsController.
2. **Changes**: Ramp `useAnalytics.ts` now uses `analytics.trackEvent()` and `AnalyticsEventBuilder` from `app/util/analytics`; test mocks updated to mock the analytics utility instead of MetaMetrics.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-297 (Batch 1-2)

## **Manual testing steps**

```gherkin
Feature: Ramp analytics

  Scenario: user triggers a Ramp flow event
    Given app is open and user is in a Ramp flow

    When user performs an action that triggers analytics (e.g. button click)
    Then the event is tracked via analytics utility (Mixpanel)
```

## **Screenshots/Recordings**

N/A – analytics migration, no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 3a36c7a02f2ccc4ed8e4490eb1dd7055f5ed4788. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->