### PR TITLE
fix(perps): geo-restrictions on ui cp-7.63.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -95,7 +95,9 @@ jest.mock('../../hooks/usePerpsHomeActions', () => ({
 }));
 
 jest.mock('../../hooks/usePerpsEventTracking', () => ({
-  usePerpsEventTracking: jest.fn(),
+  usePerpsEventTracking: jest.fn(() => ({
+    track: jest.fn(),
+  })),
 }));
 
 jest.mock('../../hooks/stream', () => ({

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -99,11 +99,17 @@ const PerpsHomeView = () => {
   const {
     handleAddFunds,
     handleWithdraw,
+    isEligible,
     isEligibilityModalVisible,
     closeEligibilityModal,
   } = usePerpsHomeActions({
     buttonLocation: PerpsEventValues.BUTTON_LOCATION.PERPS_HOME,
   });
+
+  // Separate geo-block modal state for close all / cancel all actions
+  const [isCloseAllGeoBlockVisible, setIsCloseAllGeoBlockVisible] =
+    useState(false);
+  const { track } = usePerpsEventTracking();
 
   // Section scroll tracking for analytics
   const { handleSectionLayout, handleScroll, resetTracking } =
@@ -341,10 +347,21 @@ const PerpsHomeView = () => {
     handleGiveFeedback,
   ]);
 
-  // Bottom sheet handlers - open sheets directly
+  // Bottom sheet handlers - open sheets directly with geo-restriction check
   const handleCloseAllPress = useCallback(() => {
+    // Geo-restriction check for close all positions
+    if (!isEligible) {
+      track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
+        [PerpsEventProperties.SCREEN_TYPE]:
+          PerpsEventValues.SCREEN_TYPE.GEO_BLOCK_NOTIF,
+        [PerpsEventProperties.SOURCE]:
+          PerpsEventValues.SOURCE.CLOSE_ALL_POSITIONS_BUTTON,
+      });
+      setIsCloseAllGeoBlockVisible(true);
+      return;
+    }
     setShowCloseAllSheet(true);
-  }, []);
+  }, [isEligible, track]);
 
   const handleCancelAllPress = useCallback(() => {
     setShowCancelAllSheet(true);
@@ -580,6 +597,20 @@ const PerpsHomeView = () => {
               onClose={closeEligibilityModal}
               contentKey={'geo_block'}
               testID={'perps-home-geo-block-tooltip'}
+            />
+          </Modal>
+        </View>
+      )}
+
+      {/* Close All / Cancel All Geo-Block Modal */}
+      {isCloseAllGeoBlockVisible && (
+        <View>
+          <Modal visible transparent animationType="none" statusBarTranslucent>
+            <PerpsBottomSheetTooltip
+              isVisible
+              onClose={() => setIsCloseAllGeoBlockVisible(false)}
+              contentKey={'geo_block'}
+              testID={'perps-home-close-all-geo-block-tooltip'}
             />
           </Modal>
         </View>

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -478,10 +478,69 @@ jest.mock('../../components/PerpsMarketStatisticsCard', () => {
   };
 });
 
-// Mock PerpsPositionCard
+// Mock PerpsPositionCard - render clickable buttons for testing
 jest.mock('../../components/PerpsPositionCard', () => ({
   __esModule: true,
-  default: () => null,
+  default: (props: {
+    onAutoClosePress?: () => void;
+    onMarginPress?: () => void;
+  }) => {
+    const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
+    return (
+      <View testID="perps-position-card">
+        {props.onAutoClosePress && (
+          <TouchableOpacity
+            testID="perps-position-card-auto-close-button"
+            onPress={props.onAutoClosePress}
+          >
+            <Text>Auto Close</Text>
+          </TouchableOpacity>
+        )}
+        {props.onMarginPress && (
+          <TouchableOpacity
+            testID="perps-position-card-margin-button"
+            onPress={props.onMarginPress}
+          >
+            <Text>Margin</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    );
+  },
+}));
+
+// Mock PerpsStopLossPromptBanner - render clickable buttons for testing
+jest.mock('../../components/PerpsStopLossPromptBanner', () => ({
+  __esModule: true,
+  default: (props: {
+    onSetStopLoss?: () => void;
+    onAddMargin?: () => void;
+    variant?: string;
+    testID?: string;
+  }) => {
+    const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
+    if (!props.variant) return null;
+    return (
+      <View testID={props.testID || 'perps-stop-loss-prompt-banner'}>
+        {props.variant === 'add_margin' && props.onAddMargin && (
+          <TouchableOpacity
+            testID="stop-loss-prompt-add-margin-button"
+            onPress={props.onAddMargin}
+          >
+            <Text>Add Margin Banner</Text>
+          </TouchableOpacity>
+        )}
+        {props.variant === 'stop_loss' && props.onSetStopLoss && (
+          <TouchableOpacity
+            testID="stop-loss-prompt-set-sl-button"
+            onPress={props.onSetStopLoss}
+          >
+            <Text>Set Stop Loss Banner</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    );
+  },
 }));
 
 // Mock notification utility
@@ -537,6 +596,19 @@ jest.mock(
     };
   },
 );
+
+// Mock useStopLossPrompt hook
+jest.mock('../../hooks/useStopLossPrompt', () => ({
+  useStopLossPrompt: jest.fn(() => ({
+    variant: null,
+    liquidationDistance: null,
+    suggestedStopLossPrice: null,
+    suggestedStopLossPercent: null,
+    isVisible: false,
+    isDismissing: false,
+    onDismissComplete: jest.fn(),
+  })),
+}));
 
 const initialState = {
   engine: {
@@ -1492,6 +1564,234 @@ describe('PerpsMarketDetailsView', () => {
 
       expect(getByText('Geo Block Tooltip')).toBeTruthy();
       // Modify sheet should NOT open when user is not eligible
+    });
+
+    it('shows geo block modal when auto-close button is pressed and user is not eligible', () => {
+      const { useSelector } = jest.requireMock('react-redux');
+      const mockSelectPerpsEligibility = jest.requireMock(
+        '../../selectors/perpsController',
+      ).selectPerpsEligibility;
+      useSelector.mockImplementation((selector: unknown) => {
+        if (selector === mockSelectPerpsEligibility) {
+          return false;
+        }
+        return undefined;
+      });
+
+      // Set up existing position to show position card
+      mockUseHasExistingPosition.mockReturnValue({
+        hasPosition: true,
+        isLoading: false,
+        error: null,
+        existingPosition: {
+          symbol: 'BTC',
+          size: '0.5',
+          entryPrice: '50000',
+          leverage: { value: 10, type: 'isolated' },
+          marginUsed: '5000',
+          unrealizedPnl: '100',
+          returnOnEquity: '0.02',
+          liquidationPrice: '45000',
+        },
+        refreshPosition: jest.fn(),
+        positionOpenedTimestamp: undefined,
+      });
+
+      const { getByTestId, getByText } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        {
+          state: initialState,
+        },
+      );
+
+      // Click the auto-close button from mocked position card
+      const autoCloseButton = getByTestId(
+        'perps-position-card-auto-close-button',
+      );
+      fireEvent.press(autoCloseButton);
+
+      expect(getByText('Geo Block Tooltip')).toBeTruthy();
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ screen: expect.stringContaining('TPSL') }),
+      );
+    });
+
+    it('shows geo block modal when margin button is pressed and user is not eligible', () => {
+      const { useSelector } = jest.requireMock('react-redux');
+      const mockSelectPerpsEligibility = jest.requireMock(
+        '../../selectors/perpsController',
+      ).selectPerpsEligibility;
+      useSelector.mockImplementation((selector: unknown) => {
+        if (selector === mockSelectPerpsEligibility) {
+          return false;
+        }
+        return undefined;
+      });
+
+      // Set up existing position to show position card
+      mockUseHasExistingPosition.mockReturnValue({
+        hasPosition: true,
+        isLoading: false,
+        error: null,
+        existingPosition: {
+          symbol: 'BTC',
+          size: '0.5',
+          entryPrice: '50000',
+          leverage: { value: 10, type: 'isolated' },
+          marginUsed: '5000',
+          unrealizedPnl: '100',
+          returnOnEquity: '0.02',
+          liquidationPrice: '45000',
+        },
+        refreshPosition: jest.fn(),
+        positionOpenedTimestamp: undefined,
+      });
+
+      const { getByTestId, getByText } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        {
+          state: initialState,
+        },
+      );
+
+      // Click the margin button from mocked position card
+      const marginButton = getByTestId('perps-position-card-margin-button');
+      fireEvent.press(marginButton);
+
+      expect(getByText('Geo Block Tooltip')).toBeTruthy();
+    });
+
+    it('shows geo block modal when add margin from banner is pressed and user is not eligible', () => {
+      const { useSelector } = jest.requireMock('react-redux');
+      const mockSelectPerpsEligibility = jest.requireMock(
+        '../../selectors/perpsController',
+      ).selectPerpsEligibility;
+      useSelector.mockImplementation((selector: unknown) => {
+        if (selector === mockSelectPerpsEligibility) {
+          return false;
+        }
+        return undefined;
+      });
+
+      // Set up existing position and stop loss prompt conditions
+      mockUseHasExistingPosition.mockReturnValue({
+        hasPosition: true,
+        isLoading: false,
+        error: null,
+        existingPosition: {
+          symbol: 'BTC',
+          size: '0.5',
+          entryPrice: '50000',
+          leverage: { value: 10, type: 'isolated' },
+          marginUsed: '5000',
+          unrealizedPnl: '-500',
+          returnOnEquity: '-0.10',
+          liquidationPrice: '45000',
+        },
+        refreshPosition: jest.fn(),
+        positionOpenedTimestamp: Date.now() - 120000, // 2 minutes ago
+      });
+
+      // Mock useStopLossPrompt to return add_margin variant
+      const { useStopLossPrompt } = jest.requireMock(
+        '../../hooks/useStopLossPrompt',
+      );
+      useStopLossPrompt.mockReturnValue({
+        variant: 'add_margin',
+        liquidationDistance: 2.5,
+        suggestedStopLossPrice: null,
+        suggestedStopLossPercent: null,
+        isVisible: true,
+        onDismissComplete: jest.fn(),
+      });
+
+      const { getByTestId, getByText } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        {
+          state: initialState,
+        },
+      );
+
+      // Click the add margin button from mocked stop loss prompt banner
+      const addMarginBannerButton = getByTestId(
+        'stop-loss-prompt-add-margin-button',
+      );
+      fireEvent.press(addMarginBannerButton);
+
+      expect(getByText('Geo Block Tooltip')).toBeTruthy();
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ mode: 'add' }),
+      );
+    });
+
+    it('shows geo block modal when set stop loss from banner is pressed and user is not eligible', () => {
+      const { useSelector } = jest.requireMock('react-redux');
+      const mockSelectPerpsEligibility = jest.requireMock(
+        '../../selectors/perpsController',
+      ).selectPerpsEligibility;
+      useSelector.mockImplementation((selector: unknown) => {
+        if (selector === mockSelectPerpsEligibility) {
+          return false;
+        }
+        return undefined;
+      });
+
+      // Set up existing position and stop loss prompt conditions
+      mockUseHasExistingPosition.mockReturnValue({
+        hasPosition: true,
+        isLoading: false,
+        error: null,
+        existingPosition: {
+          symbol: 'BTC',
+          size: '0.5',
+          entryPrice: '50000',
+          leverage: { value: 10, type: 'isolated' },
+          marginUsed: '5000',
+          unrealizedPnl: '-500',
+          returnOnEquity: '-0.10',
+          liquidationPrice: '45000',
+        },
+        refreshPosition: jest.fn(),
+        positionOpenedTimestamp: Date.now() - 120000, // 2 minutes ago
+      });
+
+      // Mock useStopLossPrompt to return stop_loss variant
+      const { useStopLossPrompt } = jest.requireMock(
+        '../../hooks/useStopLossPrompt',
+      );
+      useStopLossPrompt.mockReturnValue({
+        variant: 'stop_loss',
+        liquidationDistance: 15,
+        suggestedStopLossPrice: '45000',
+        suggestedStopLossPercent: -50,
+        isVisible: true,
+        onDismissComplete: jest.fn(),
+      });
+
+      const { getByTestId, getByText } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        {
+          state: initialState,
+        },
+      );
+
+      // Click the set stop loss button from mocked stop loss prompt banner
+      const setStopLossBannerButton = getByTestId(
+        'stop-loss-prompt-set-sl-button',
+      );
+      fireEvent.press(setStopLossBannerButton);
+
+      expect(getByText('Geo Block Tooltip')).toBeTruthy();
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -733,6 +733,18 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   const handleAutoClosePress = useCallback(() => {
     if (!existingPosition) return;
 
+    // Geo-restriction check for auto-close (TP/SL) action
+    if (!isEligible) {
+      track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
+        [PerpsEventProperties.SCREEN_TYPE]:
+          PerpsEventValues.SCREEN_TYPE.GEO_BLOCK_NOTIF,
+        [PerpsEventProperties.SOURCE]:
+          PerpsEventValues.SOURCE.AUTO_CLOSE_ACTION,
+      });
+      setIsEligibilityModalVisible(true);
+      return;
+    }
+
     navigation.navigate(Routes.PERPS.TPSL, {
       asset: existingPosition.symbol,
       currentPrice,
@@ -760,12 +772,32 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
         return result;
       },
     });
-  }, [existingPosition, currentPrice, navigation, handleUpdateTPSL]);
+  }, [
+    existingPosition,
+    currentPrice,
+    navigation,
+    handleUpdateTPSL,
+    isEligible,
+    track,
+  ]);
 
   const handleMarginPress = useCallback(() => {
     if (!existingPosition) return;
+
+    // Geo-restriction check for add/remove margin action
+    if (!isEligible) {
+      track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
+        [PerpsEventProperties.SCREEN_TYPE]:
+          PerpsEventValues.SCREEN_TYPE.GEO_BLOCK_NOTIF,
+        [PerpsEventProperties.SOURCE]:
+          PerpsEventValues.SOURCE.ADJUST_MARGIN_ACTION,
+      });
+      setIsEligibilityModalVisible(true);
+      return;
+    }
+
     openAdjustMarginSheet();
-  }, [existingPosition, openAdjustMarginSheet]);
+  }, [existingPosition, openAdjustMarginSheet, isEligible, track]);
 
   const handleSharePress = useCallback(() => {
     if (!existingPosition) return;
@@ -846,6 +878,18 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   const handleAddMarginFromBanner = useCallback(() => {
     if (!existingPosition) return;
 
+    // Geo-restriction check for add margin from banner
+    if (!isEligible) {
+      track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
+        [PerpsEventProperties.SCREEN_TYPE]:
+          PerpsEventValues.SCREEN_TYPE.GEO_BLOCK_NOTIF,
+        [PerpsEventProperties.SOURCE]:
+          PerpsEventValues.SOURCE.STOP_LOSS_PROMPT_ADD_MARGIN,
+      });
+      setIsEligibilityModalVisible(true);
+      return;
+    }
+
     // Navigate directly to PerpsAdjustMarginView with mode='add'
     navigation.navigate(Routes.PERPS.ADJUST_MARGIN, {
       position: existingPosition,
@@ -860,11 +904,23 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       [PerpsEventProperties.SOURCE]:
         PerpsEventValues.SOURCE.STOP_LOSS_PROMPT_BANNER,
     });
-  }, [existingPosition, navigation, track]);
+  }, [existingPosition, navigation, track, isEligible]);
 
   // Handler for "Set Stop Loss" from stop loss prompt banner
   const handleSetStopLossFromBanner = useCallback(async () => {
     if (!existingPosition || !suggestedStopLossPrice) return;
+
+    // Geo-restriction check for set stop loss from banner
+    if (!isEligible) {
+      track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
+        [PerpsEventProperties.SCREEN_TYPE]:
+          PerpsEventValues.SCREEN_TYPE.GEO_BLOCK_NOTIF,
+        [PerpsEventProperties.SOURCE]:
+          PerpsEventValues.SOURCE.STOP_LOSS_PROMPT_SET_SL,
+      });
+      setIsEligibilityModalVisible(true);
+      return;
+    }
 
     // Capture symbol before async to detect market changes during API call
     const originalSymbol = existingPosition.symbol;
@@ -919,7 +975,13 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     } finally {
       setIsSettingStopLoss(false);
     }
-  }, [existingPosition, suggestedStopLossPrice, handleUpdateTPSL, track]);
+  }, [
+    existingPosition,
+    suggestedStopLossPrice,
+    handleUpdateTPSL,
+    track,
+    isEligible,
+  ]);
 
   // Handler for when banner fade-out animation completes
   const handleBannerFadeOutComplete = useCallback(() => {

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
@@ -282,6 +282,26 @@ jest.mock('../PerpsSelectModifyActionView', () => {
   };
 });
 
+// Mock PerpsBottomSheetTooltip for geo-block modal
+jest.mock(
+  '../../components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip',
+  () => {
+    const { View } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: (props: { testID?: string; isVisible?: boolean }) =>
+        props.isVisible ? (
+          <View testID={props.testID || 'perps-bottom-sheet-tooltip'} />
+        ) : null,
+    };
+  },
+);
+
+// Mock perpsController selectors - return eligible by default for action button tests
+jest.mock('../../selectors/perpsController', () => ({
+  selectPerpsEligibility: jest.fn(() => true),
+}));
+
 describe('PerpsOrderBookView', () => {
   const initialState = {
     engine: {
@@ -783,6 +803,154 @@ describe('PerpsOrderBookView', () => {
       expect(
         queryByTestId(PerpsOrderBookViewSelectorsIDs.CLOSE_BUTTON),
       ).toBeNull();
+    });
+  });
+
+  describe('geo-restriction', () => {
+    const mockLongPosition = {
+      symbol: 'BTC',
+      size: '1.5',
+      entryPrice: '50000',
+      leverage: { value: 10, type: 'cross' as const },
+      margin: '5000',
+      unrealizedPnl: '100',
+      unrealizedPnlPercent: '2',
+      liquidationPrice: '45000',
+      takeProfitPrice: undefined,
+      stopLossPrice: undefined,
+      returnOnEquity: '2',
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('shows geo-block modal when Long button pressed and user is not eligible', () => {
+      const { selectPerpsEligibility } = jest.requireMock(
+        '../../selectors/perpsController',
+      );
+      selectPerpsEligibility.mockReturnValue(false);
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <PerpsOrderBookView />,
+        {
+          state: initialState,
+        },
+      );
+
+      const longButton = getByTestId(
+        PerpsOrderBookViewSelectorsIDs.LONG_BUTTON,
+      );
+      fireEvent.press(longButton);
+
+      // Navigation should NOT be called
+      expect(mockNavigateToOrder).not.toHaveBeenCalled();
+      // Geo-block tooltip should be shown
+      expect(
+        queryByTestId(
+          `${PerpsOrderBookViewSelectorsIDs.CONTAINER}-geo-block-tooltip`,
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('shows geo-block modal when Short button pressed and user is not eligible', () => {
+      const { selectPerpsEligibility } = jest.requireMock(
+        '../../selectors/perpsController',
+      );
+      selectPerpsEligibility.mockReturnValue(false);
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <PerpsOrderBookView />,
+        {
+          state: initialState,
+        },
+      );
+
+      const shortButton = getByTestId(
+        PerpsOrderBookViewSelectorsIDs.SHORT_BUTTON,
+      );
+      fireEvent.press(shortButton);
+
+      // Navigation should NOT be called
+      expect(mockNavigateToOrder).not.toHaveBeenCalled();
+      // Geo-block tooltip should be shown
+      expect(
+        queryByTestId(
+          `${PerpsOrderBookViewSelectorsIDs.CONTAINER}-geo-block-tooltip`,
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('shows geo-block modal when Close button pressed and user is not eligible', () => {
+      const { selectPerpsEligibility } = jest.requireMock(
+        '../../selectors/perpsController',
+      );
+      selectPerpsEligibility.mockReturnValue(false);
+
+      const { useHasExistingPosition } = jest.requireMock(
+        '../../hooks/useHasExistingPosition',
+      );
+      useHasExistingPosition.mockReturnValue({
+        isLoading: false,
+        existingPosition: mockLongPosition,
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <PerpsOrderBookView />,
+        {
+          state: initialState,
+        },
+      );
+
+      const closeButton = getByTestId(
+        PerpsOrderBookViewSelectorsIDs.CLOSE_BUTTON,
+      );
+      fireEvent.press(closeButton);
+
+      // Navigation should NOT be called
+      expect(mockNavigateToClosePosition).not.toHaveBeenCalled();
+      // Geo-block tooltip should be shown
+      expect(
+        queryByTestId(
+          `${PerpsOrderBookViewSelectorsIDs.CONTAINER}-geo-block-tooltip`,
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('shows geo-block modal when Modify button pressed and user is not eligible', () => {
+      const { selectPerpsEligibility } = jest.requireMock(
+        '../../selectors/perpsController',
+      );
+      selectPerpsEligibility.mockReturnValue(false);
+
+      const { useHasExistingPosition } = jest.requireMock(
+        '../../hooks/useHasExistingPosition',
+      );
+      useHasExistingPosition.mockReturnValue({
+        isLoading: false,
+        existingPosition: mockLongPosition,
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <PerpsOrderBookView />,
+        {
+          state: initialState,
+        },
+      );
+
+      const modifyButton = getByTestId(
+        PerpsOrderBookViewSelectorsIDs.MODIFY_BUTTON,
+      );
+      fireEvent.press(modifyButton);
+
+      // Modify sheet should NOT be opened
+      expect(mockOpenModifySheet).not.toHaveBeenCalled();
+      // Geo-block tooltip should be shown
+      expect(
+        queryByTestId(
+          `${PerpsOrderBookViewSelectorsIDs.CONTAINER}-geo-block-tooltip`,
+        ),
+      ).toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -26,6 +26,7 @@ import PerpsCard from '../../components/PerpsCard';
 import { PerpsTabControlBar } from '../../components/PerpsTabControlBar';
 import { useSelector } from 'react-redux';
 import { selectHomepageRedesignV1Enabled } from '../../../../../selectors/featureFlagController/homepage';
+import { selectPerpsEligibility } from '../../selectors/perpsController';
 import {
   PerpsEventProperties,
   PerpsEventValues,
@@ -68,6 +69,8 @@ const PerpsTabView = () => {
   const isHomepageRedesignV1Enabled = useSelector(
     selectHomepageRedesignV1Enabled,
   );
+  const isEligible = useSelector(selectPerpsEligibility);
+  const { track } = usePerpsEventTracking();
 
   const { positions, isInitialLoading } = usePerpsLivePositions({
     throttleMs: 1000, // Update positions every second
@@ -149,12 +152,23 @@ const PerpsTabView = () => {
     }
   }, [navigation, isFirstTimeUser]);
 
-  // Modal handlers - now using navigation to modal stack
+  // Modal handlers - now using navigation to modal stack with geo-restriction check
   const handleCloseAllPress = useCallback(() => {
+    // Geo-restriction check for close all positions
+    if (!isEligible) {
+      track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
+        [PerpsEventProperties.SCREEN_TYPE]:
+          PerpsEventValues.SCREEN_TYPE.GEO_BLOCK_NOTIF,
+        [PerpsEventProperties.SOURCE]:
+          PerpsEventValues.SOURCE.CLOSE_ALL_POSITIONS_BUTTON,
+      });
+      setIsEligibilityModalVisible(true);
+      return;
+    }
     navigation.navigate(Routes.PERPS.MODALS.ROOT, {
       screen: Routes.PERPS.MODALS.CLOSE_ALL_POSITIONS,
     });
-  }, [navigation]);
+  }, [isEligible, navigation, track]);
 
   const handleCancelAllPress = useCallback(() => {
     navigation.navigate(Routes.PERPS.MODALS.ROOT, {

--- a/app/components/UI/Perps/constants/eventNames.ts
+++ b/app/components/UI/Perps/constants/eventNames.ts
@@ -217,6 +217,16 @@ export const PerpsEventValues = {
     // TAT-2449: Geo-block sources for close/modify actions
     CLOSE_POSITION_ACTION: 'close_position_action',
     MODIFY_POSITION_ACTION: 'modify_position_action',
+    // Geo-block sources for order book actions
+    ORDER_BOOK_LONG_BUTTON: 'order_book_long_button',
+    ORDER_BOOK_SHORT_BUTTON: 'order_book_short_button',
+    ORDER_BOOK_CLOSE_BUTTON: 'order_book_close_button',
+    ORDER_BOOK_MODIFY_BUTTON: 'order_book_modify_button',
+    // Geo-block sources for position management actions
+    AUTO_CLOSE_ACTION: 'auto_close_action',
+    ADJUST_MARGIN_ACTION: 'adjust_margin_action',
+    STOP_LOSS_PROMPT_ADD_MARGIN: 'stop_loss_prompt_add_margin',
+    STOP_LOSS_PROMPT_SET_SL: 'stop_loss_prompt_set_sl',
   },
   WARNING_TYPE: {
     MINIMUM_DEPOSIT: 'minimum_deposit',

--- a/app/components/UI/Perps/constants/eventNames.ts
+++ b/app/components/UI/Perps/constants/eventNames.ts
@@ -227,6 +227,8 @@ export const PerpsEventValues = {
     ADJUST_MARGIN_ACTION: 'adjust_margin_action',
     STOP_LOSS_PROMPT_ADD_MARGIN: 'stop_loss_prompt_add_margin',
     STOP_LOSS_PROMPT_SET_SL: 'stop_loss_prompt_set_sl',
+    // Geo-block sources for bulk actions
+    CLOSE_ALL_POSITIONS_BUTTON: 'close_all_positions_button',
   },
   WARNING_TYPE: {
     MINIMUM_DEPOSIT: 'minimum_deposit',


### PR DESCRIPTION
## **Description**

This PR fixes the missing geo-restriction checks in several perpetuals trading flows as reported in #25374.

**PerpsOrderBookView.tsx:**
- Added geo-restriction check to `handleLongPress` - shows geo-block modal instead of navigating to long order
- Added geo-restriction check to `handleShortPress` - shows geo-block modal instead of navigating to short order
- Added geo-restriction check to `handleClosePosition` - shows geo-block modal instead of navigating to close position
- Added geo-restriction check to `handleModifyPress` - shows geo-block modal instead of opening modify sheet

**PerpsMarketDetailsView.tsx:**
- Added geo-restriction check to `handleAutoClosePress` - shows geo-block modal instead of navigating to TP/SL screen
- Added geo-restriction check to `handleMarginPress` - shows geo-block modal instead of opening adjust margin sheet
- Added geo-restriction check to `handleAddMarginFromBanner` - shows geo-block modal instead of navigating to add margin
- Added geo-restriction check to `handleSetStopLossFromBanner` - shows geo-block modal instead of setting stop loss

**PerpsTabView.tsx:**
- Added geo-restriction check to `handleCloseAllPress` - shows geo-block modal instead of navigating to close all positions modal

**PerpsHomeView.tsx:**
- Added geo-restriction check to `handleCloseAllPress` - shows geo-block modal instead of opening close all positions sheet

**eventNames.ts:**
- Added new analytics source values for tracking geo-block notifications from each flow

**Note:** Cancel all orders is intentionally NOT geo-blocked - users should be able to cancel their existing orders similar to withdrawals.

## **Changelog**

CHANGELOG entry: Fixed geo-restriction enforcement for perpetuals trading flows including order book actions, position management, stop-loss prompts, and close all positions

## **Related issues**

Fixes: #25374

## **Manual testing steps**

```gherkin
Feature: Geo-restriction on perps trading flows

  Scenario: User in geo-blocked region cannot trade via order book
    Given user is in a geo-blocked region (e.g., US)
    And user has navigated to the perps order book screen

    When user taps on Long button
    Then geo-restriction modal should appear
    And user should not navigate to long order screen

    When user taps on Short button
    Then geo-restriction modal should appear
    And user should not navigate to short order screen

    When user taps on Close button (with existing position)
    Then geo-restriction modal should appear
    And user should not navigate to close position screen

    When user taps on Modify button (with existing position)
    Then geo-restriction modal should appear
    And modify sheet should not open

  Scenario: User in geo-blocked region cannot manage positions
    Given user is in a geo-blocked region (e.g., US)
    And user has an existing perpetuals position

    When user taps on Auto-close button on position card
    Then geo-restriction modal should appear
    And user should not navigate to TP/SL screen

    When user taps on Margin button on position card
    Then geo-restriction modal should appear
    And adjust margin sheet should not open

  Scenario: User in geo-blocked region cannot use stop-loss prompt actions
    Given user is in a geo-blocked region (e.g., US)
    And user has an existing position with stop-loss prompt visible

    When user taps on Add Margin from stop-loss prompt banner
    Then geo-restriction modal should appear
    And user should not navigate to add margin screen

    When user taps on Set Stop Loss from stop-loss prompt banner
    Then geo-restriction modal should appear
    And stop loss should not be set

  Scenario: User in geo-blocked region cannot close all positions
    Given user is in a geo-blocked region (e.g., US)
    And user has existing perpetuals positions

    When user taps on Close All button in perps tab
    Then geo-restriction modal should appear
    And close all positions modal should not open

    When user taps on Close All button in perps home
    Then geo-restriction modal should appear
    And close all positions sheet should not open

  Scenario: User in geo-blocked region CAN cancel all orders
    Given user is in a geo-blocked region (e.g., US)
    And user has existing perpetuals orders

    When user taps on Cancel All button
    Then cancel all orders modal should open (NOT geo-blocked)
```

## **Screenshots/Recordings**

### **Before**

Users in geo-blocked regions could access trading flows without restriction

### **After**

Geo-restriction modal appears for all trading flows when user is not eligible

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes eligibility gating on core trading/position-management actions and adds new analytics sources, which could block legitimate users if eligibility state is wrong.
> 
> **Overview**
> Adds geo-restriction checks (with `PERPS_SCREEN_VIEWED` tracking) to additional Perps entry points so ineligible users are shown the `geo_block` tooltip instead of proceeding.
> 
> This gates actions in `PerpsOrderBookView` (Long/Short/Close/Modify), `PerpsMarketDetailsView` (Auto-close/Adjust margin/Stop-loss prompt actions), and bulk Close All from `PerpsTabView` and `PerpsHomeView` (with a dedicated close-all geo-block modal state). Updates `eventNames.ts` with new `SOURCE` values for these block points and expands/adjusts tests and mocks to cover the new geo-block behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aa982af99d50214f27a7957713b75fbff6d5859. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->