### PR TITLE
fix: privacy mode on perps and predict

### DIFF
--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -1,12 +1,15 @@
 import React, { useCallback, useMemo } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { useNavigation, type NavigationProp } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
 import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
+import SensitiveText from '../../../../../component-library/components/Texts/SensitiveText';
 import { useStyles } from '../../../../../component-library/hooks';
 import Routes from '../../../../../constants/navigation/Routes';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { strings } from '../../../../../../locales/i18n';
 import {
   getPerpsDisplaySymbol,
@@ -45,6 +48,7 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
   const { styles } = useStyles(styleSheet, { iconSize });
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
   const { track } = usePerpsEventTracking();
+  const privacyMode = useSelector(selectPrivacyMode);
 
   // Determine which type of data we have
   const symbol = position?.symbol || order?.symbol || '';
@@ -164,12 +168,20 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
 
         {/* Right side: Value and label */}
         <View style={styles.cardRight}>
-          <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+          <SensitiveText
+            variant={TextVariant.BodyMDMedium}
+            color={TextColor.Default}
+            isHidden={privacyMode}
+          >
             {valueText}
-          </Text>
-          <Text variant={TextVariant.BodySM} color={valueColor}>
+          </SensitiveText>
+          <SensitiveText
+            variant={TextVariant.BodySM}
+            color={valueColor}
+            isHidden={privacyMode}
+          >
             {labelText}
-          </Text>
+          </SensitiveText>
         </View>
       </View>
     </TouchableOpacity>

--- a/app/components/UI/Perps/components/PerpsHomeSection/PerpsHomeSection.test.tsx
+++ b/app/components/UI/Perps/components/PerpsHomeSection/PerpsHomeSection.test.tsx
@@ -549,4 +549,74 @@ describe('PerpsHomeSection', () => {
       expect(queryByTestId('test-subtitle-suffix')).toBeNull();
     });
   });
+
+  describe('Privacy Mode', () => {
+    const { useSelector } = jest.requireMock('react-redux');
+
+    it('shows subtitle when privacy mode is disabled', () => {
+      // Arrange
+      useSelector.mockReturnValue(false);
+
+      // Act
+      const { getByText } = render(
+        <PerpsHomeSection
+          title="Positions"
+          subtitle="+$50.75"
+          subtitleTestID="test-subtitle"
+          isLoading={false}
+          isEmpty={false}
+          renderSkeleton={mockSkeleton}
+        >
+          {mockChildren}
+        </PerpsHomeSection>,
+      );
+
+      // Assert - subtitle amount should be visible
+      expect(getByText('+$50.75')).toBeTruthy();
+    });
+
+    it('hides subtitle when privacy mode is enabled', () => {
+      // Arrange
+      useSelector.mockReturnValue(true);
+
+      // Act
+      const { queryByText, getAllByText } = render(
+        <PerpsHomeSection
+          title="Positions"
+          subtitle="+$50.75"
+          subtitleTestID="test-subtitle"
+          isLoading={false}
+          isEmpty={false}
+          renderSkeleton={mockSkeleton}
+        >
+          {mockChildren}
+        </PerpsHomeSection>,
+      );
+
+      // Assert - subtitle should be hidden (replaced with bullets)
+      expect(queryByText('+$50.75')).toBeNull();
+      expect(getAllByText('••••••').length).toBeGreaterThan(0);
+    });
+
+    it('shows title regardless of privacy mode', () => {
+      // Arrange
+      useSelector.mockReturnValue(true);
+
+      // Act
+      const { getByText } = render(
+        <PerpsHomeSection
+          title="Positions"
+          subtitle="+$50.75"
+          isLoading={false}
+          isEmpty={false}
+          renderSkeleton={mockSkeleton}
+        >
+          {mockChildren}
+        </PerpsHomeSection>,
+      );
+
+      // Assert - title should always be visible (not sensitive)
+      expect(getByText('Positions')).toBeTruthy();
+    });
+  });
 });

--- a/app/components/UI/Perps/components/PerpsHomeSection/PerpsHomeSection.test.tsx
+++ b/app/components/UI/Perps/components/PerpsHomeSection/PerpsHomeSection.test.tsx
@@ -5,6 +5,17 @@ import PerpsHomeSection from './PerpsHomeSection';
 
 import { TextColor } from '../../../../../component-library/components/Texts/Text';
 
+// Mock privacy mode selector
+jest.mock('../../../../../selectors/preferencesController', () => ({
+  selectPrivacyMode: jest.fn(() => false),
+}));
+
+// Mock react-redux
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(() => false),
+}));
+
 describe('PerpsHomeSection', () => {
   const mockSkeleton = () => <View testID="skeleton-loader" />;
   const mockChildren = <Text testID="section-content">Content</Text>;

--- a/app/components/UI/Perps/components/PerpsHomeSection/PerpsHomeSection.tsx
+++ b/app/components/UI/Perps/components/PerpsHomeSection/PerpsHomeSection.tsx
@@ -1,14 +1,17 @@
 import React, { ReactNode } from 'react';
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import { useSelector } from 'react-redux';
 import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
+import SensitiveText from '../../../../../component-library/components/Texts/SensitiveText';
 import Icon, {
   IconName,
   IconSize,
   IconColor,
 } from '../../../../../component-library/components/Icons/Icon';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 
 export interface PerpsHomeSectionProps {
   /**
@@ -119,6 +122,8 @@ const PerpsHomeSection: React.FC<PerpsHomeSectionProps> = ({
   children,
   testID,
 }) => {
+  const privacyMode = useSelector(selectPrivacyMode);
+
   // Hide section if empty and showWhenEmpty is false
   if (!isLoading && isEmpty && !showWhenEmpty) {
     return null;
@@ -157,10 +162,11 @@ const PerpsHomeSection: React.FC<PerpsHomeSectionProps> = ({
 
         {/* Subtitle - NOT pressable */}
         {subtitle && (
-          <Text
+          <SensitiveText
             variant={TextVariant.BodySM}
             color={subtitleColor}
             testID={subtitleTestID}
+            isHidden={privacyMode}
           >
             {subtitle}
             {subtitleSuffix && (
@@ -173,7 +179,7 @@ const PerpsHomeSection: React.FC<PerpsHomeSectionProps> = ({
                 {subtitleSuffix}
               </Text>
             )}
-          </Text>
+          </SensitiveText>
         )}
       </View>
 

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
@@ -185,6 +185,11 @@ jest.mock('../../utils/formatUtils', () => ({
   formatPerpsFiat: jest.fn((amount) => `$${amount}`),
 }));
 
+// Mock privacy mode selector
+jest.mock('../../../../../selectors/preferencesController', () => ({
+  selectPrivacyMode: jest.fn(() => false),
+}));
+
 // Mock PerpsBottomSheetTooltip to avoid SafeArea issues
 jest.mock('../PerpsBottomSheetTooltip', () => {
   const { View, Text } = jest.requireActual('react-native');

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
@@ -186,8 +186,12 @@ jest.mock('../../utils/formatUtils', () => ({
 }));
 
 // Mock privacy mode selector
+// NOTE: Must include all selectors used transitively (e.g. by smartTransactionsController)
+// when renderWithProvider triggers loading reducers/index.ts → bridge → smartTransactionsController
 jest.mock('../../../../../selectors/preferencesController', () => ({
   selectPrivacyMode: jest.fn(() => false),
+  selectSmartTransactionsOptInStatus: jest.fn(() => false),
+  selectTokenNetworkFilter: jest.fn(() => ({})),
 }));
 
 // Mock PerpsBottomSheetTooltip to avoid SafeArea issues
@@ -647,6 +651,75 @@ describe('PerpsMarketBalanceActions', () => {
 
       // Assert
       expect(mockStopAnimation).toHaveBeenCalled();
+    });
+  });
+
+  describe('Privacy Mode', () => {
+    const getPrivacyModeMock = () =>
+      jest.requireMock('../../../../../selectors/preferencesController')
+        .selectPrivacyMode as jest.Mock;
+
+    afterEach(() => {
+      // Reset privacy mode to default (disabled) after each test
+      getPrivacyModeMock().mockReturnValue(false);
+    });
+
+    it('shows balance values when privacy mode is disabled', () => {
+      // Arrange
+      getPrivacyModeMock().mockReturnValue(false);
+
+      // Act
+      const { getByTestId, getByText } = renderWithProvider(
+        <PerpsMarketBalanceActions />,
+        { state: createMockState() },
+        false,
+      );
+
+      // Assert - balance value should be visible
+      expect(
+        getByTestId(PerpsMarketBalanceActionsSelectorsIDs.BALANCE_VALUE),
+      ).toBeOnTheScreen();
+      expect(getByText('$10.57')).toBeOnTheScreen();
+      // Available balance text should be visible
+      expect(
+        getByTestId(
+          PerpsMarketBalanceActionsSelectorsIDs.AVAILABLE_BALANCE_TEXT,
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('hides balance values when privacy mode is enabled', () => {
+      // Arrange
+      getPrivacyModeMock().mockReturnValue(true);
+
+      // Act
+      const { queryByText, getAllByText } = renderWithProvider(
+        <PerpsMarketBalanceActions />,
+        { state: createMockState() },
+        false,
+      );
+
+      // Assert - balance values should be hidden (replaced with bullets)
+      expect(queryByText('$10.57')).toBeNull();
+      // SensitiveText shows bullets when hidden
+      expect(getAllByText('••••••').length).toBeGreaterThan(0);
+    });
+
+    it('shows action buttons regardless of privacy mode', () => {
+      // Arrange
+      getPrivacyModeMock().mockReturnValue(true);
+
+      // Act
+      const { getByTestId } = renderWithProvider(
+        <PerpsMarketBalanceActions />,
+        { state: createMockState() },
+        false,
+      );
+
+      // Assert - action buttons should always be visible
+      expect(
+        getByTestId(PerpsMarketBalanceActionsSelectorsIDs.ADD_FUNDS_BUTTON),
+      ).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
@@ -13,6 +13,8 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
+import SensitiveText from '../../../../../component-library/components/Texts/SensitiveText';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { strings } from '../../../../../../locales/i18n';
 import { useColorPulseAnimation, useBalanceComparison } from '../../hooks';
 import { usePerpsHomeActions } from '../../hooks/usePerpsHomeActions';
@@ -65,6 +67,7 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
 }) => {
   const tw = useTailwind();
   const { isDepositInProgress } = usePerpsDepositProgress();
+  const privacyMode = useSelector(selectPrivacyMode);
 
   // Get withdrawal requests filtered by current account using memoized selector
   const withdrawalRequests = useSelector(
@@ -212,16 +215,17 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
               </Text>
               {/* Only show dollar value when there's a single transaction in progress */}
               {shouldShowDollarAmount && (
-                <Text
+                <SensitiveText
                   variant={TextVariant.BodySMMedium}
                   color={TextColor.Default}
+                  isHidden={privacyMode}
                 >
                   {isOnlyDepositInProgress && transactionAmountWei
                     ? convertPerpsAmountToUSD(transactionAmountWei)
                     : isOnlyWithdrawalInProgress && withdrawalAmount
                       ? convertPerpsAmountToUSD(withdrawalAmount)
                       : null}
-                </Text>
+                </SensitiveText>
               )}
             </Box>
           </Box>
@@ -235,28 +239,30 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
         ) : (
           <Box twClassName="px-4 pt-4 pb-4">
             <Animated.View style={[getBalanceAnimatedStyle]}>
-              <Text
+              <SensitiveText
                 variant={TextVariant.DisplayMD}
                 color={TextColor.Default}
                 testID={PerpsMarketBalanceActionsSelectorsIDs.BALANCE_VALUE}
+                isHidden={privacyMode}
               >
                 {formatPerpsFiat(totalBalance)}
-              </Text>
+              </SensitiveText>
             </Animated.View>
-            <Text
+            <SensitiveText
               variant={TextVariant.BodyMD}
               color={TextColor.Alternative}
               style={tw.style('mt-1')}
               testID={
                 PerpsMarketBalanceActionsSelectorsIDs.AVAILABLE_BALANCE_TEXT
               }
+              isHidden={privacyMode}
             >
               {formatPerpsFiat(availableBalance, {
                 ranges: PRICE_RANGES_MINIMAL_VIEW,
                 stripTrailingZeros: false,
               })}{' '}
               {strings('perps.available')}
-            </Text>
+            </SensitiveText>
             {/* Action Buttons */}
             {showActionButtons && (
               <Box

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { TouchableOpacity, View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { PerpsPositionCardSelectorsIDs } from '../../Perps.testIds';
 import { strings } from '../../../../../../locales/i18n';
 import ButtonIcon, {
@@ -18,6 +19,7 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
+import SensitiveText from '../../../../../component-library/components/Texts/SensitiveText';
 import { useStyles } from '../../../../../component-library/hooks';
 import {
   PERPS_CONSTANTS,
@@ -25,6 +27,7 @@ import {
   type Order,
   type Position,
 } from '@metamask/perps-controller';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import {
   formatPerpsFiat,
   formatPnl,
@@ -104,6 +107,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
 }) => {
   const { styles } = useStyles(styleSheet, { iconSize });
   const [showSizeInUSD, setShowSizeInUSD] = useState(false);
+  const privacyMode = useSelector(selectPrivacyMode);
 
   // Determine if position is long or short based on size
   const isLong = parseFloat(position.size) >= 0;
@@ -269,13 +273,14 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
             {strings('perps.position.card.pnl_label')}
           </Text>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodyMD}
             color={pnlNum >= 0 ? TextColor.Success : TextColor.Error}
             testID={PerpsPositionCardSelectorsIDs.PNL_VALUE}
+            isHidden={privacyMode}
           >
             {formatPnl(pnlNum)}
-          </Text>
+          </SensitiveText>
         </View>
 
         <View
@@ -285,14 +290,15 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
             {strings('perps.position.card.return_label')}
           </Text>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodyMD}
             color={roe >= 0 ? TextColor.Success : TextColor.Error}
             testID={PerpsPositionCardSelectorsIDs.RETURN_VALUE}
+            isHidden={privacyMode}
           >
             {roe >= 0 ? '+' : ''}
             {roe.toFixed(2)}%
-          </Text>
+          </SensitiveText>
         </View>
       </View>
 
@@ -307,17 +313,18 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
               {strings('perps.position.card.size_label')}
             </Text>
-            <Text
+            <SensitiveText
               variant={TextVariant.BodyMD}
               color={TextColor.Default}
               testID={PerpsPositionCardSelectorsIDs.SIZE_VALUE}
+              isHidden={privacyMode}
             >
               {showSizeInUSD && currentPrice
                 ? formatPerpsFiat(absoluteSize * currentPrice, {
                     ranges: PRICE_RANGES_MINIMAL_VIEW,
                   })
                 : `${formatPositionSize(absoluteSize.toString())} ${getPerpsDisplaySymbol(position.symbol)}`}
-            </Text>
+            </SensitiveText>
           </View>
           <View style={styles.iconButtonContainer}>
             <ButtonIcon
@@ -341,15 +348,16 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
               {strings('perps.position.card.margin_label')}
             </Text>
-            <Text
+            <SensitiveText
               variant={TextVariant.BodyMD}
               color={TextColor.Default}
               testID={PerpsPositionCardSelectorsIDs.MARGIN_VALUE}
+              isHidden={privacyMode}
             >
               {formatPerpsFiat(position.marginUsed, {
                 ranges: PRICE_RANGES_MINIMAL_VIEW,
               })}
-            </Text>
+            </SensitiveText>
           </View>
           {onMarginPress && (
             <View style={styles.iconButtonContainer}>
@@ -497,11 +505,15 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           >
             {strings('perps.position.card.entry_label')}
           </Text>
-          <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+          <SensitiveText
+            variant={TextVariant.BodyMD}
+            color={TextColor.Default}
+            isHidden={privacyMode}
+          >
             {formatPerpsFiat(position.entryPrice, {
               ranges: PRICE_RANGES_UNIVERSAL,
             })}
-          </Text>
+          </SensitiveText>
         </View>
 
         <View style={styles.detailRow}>
@@ -512,14 +524,18 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             {strings('perps.position.card.liquidation_price_label')}
           </Text>
           <View style={styles.liquidationPriceValue}>
-            <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+            <SensitiveText
+              variant={TextVariant.BodyMD}
+              color={TextColor.Default}
+              isHidden={privacyMode}
+            >
               {position.liquidationPrice !== undefined &&
               position.liquidationPrice !== null
                 ? formatPerpsFiat(position.liquidationPrice, {
                     ranges: PRICE_RANGES_UNIVERSAL,
                   })
                 : PERPS_CONSTANTS.FallbackPriceDisplay}
-            </Text>
+            </SensitiveText>
             {liquidationDistance !== null && (
               <>
                 <Text
@@ -546,9 +562,13 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           >
             {strings('perps.position.card.funding_payments_label')}
           </Text>
-          <Text variant={TextVariant.BodyMD} color={fundingColor}>
+          <SensitiveText
+            variant={TextVariant.BodyMD}
+            color={fundingColor}
+            isHidden={privacyMode}
+          >
             {fundingDisplay}
-          </Text>
+          </SensitiveText>
         </View>
       </View>
     </View>

--- a/app/components/UI/Perps/components/PerpsTabControlBar/PerpsTabControlBar.test.tsx
+++ b/app/components/UI/Perps/components/PerpsTabControlBar/PerpsTabControlBar.test.tsx
@@ -12,6 +12,17 @@ import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import * as PerpsHooks from '../../hooks';
 import PerpsTabControlBar from './PerpsTabControlBar';
 
+// Mock privacy mode selector
+jest.mock('../../../../../selectors/preferencesController', () => ({
+  selectPrivacyMode: jest.fn(() => false),
+}));
+
+// Mock react-redux
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(() => false),
+}));
+
 jest.mock('../../providers/PerpsStreamManager', () => ({
   usePerpsStream: jest.fn(() => ({
     account: {

--- a/app/components/UI/Perps/components/PerpsTabControlBar/PerpsTabControlBar.test.tsx
+++ b/app/components/UI/Perps/components/PerpsTabControlBar/PerpsTabControlBar.test.tsx
@@ -732,4 +732,84 @@ describe('PerpsTabControlBar', () => {
       });
     });
   });
+
+  describe('Privacy Mode', () => {
+    const { useSelector } = jest.requireMock('react-redux');
+
+    it('shows balance and PnL values when privacy mode is disabled', () => {
+      // Arrange
+      useSelector.mockReturnValue(false);
+      const accountWithPnl = {
+        ...defaultAccountState,
+        returnOnEquity: '0.15',
+      };
+      jest
+        .mocked(jest.requireMock('../../hooks/stream').usePerpsLiveAccount)
+        .mockReturnValue({
+          account: accountWithPnl,
+          isInitialLoading: false,
+        });
+
+      // Act
+      render(
+        <PerpsTabControlBar
+          hasPositions
+          hasOrders={false}
+          onManageBalancePress={mockOnManageBalancePress}
+        />,
+      );
+
+      // Assert - balance value should be visible via testID
+      const balanceValue = screen.getByTestId('perps-balance-value');
+      expect(balanceValue).toHaveTextContent('$1000.50');
+      // PnL value should be visible (text includes formatted PnL + percentage)
+      expect(screen.getByText(/\+\$50\.75/)).toBeTruthy();
+    });
+
+    it('hides balance and PnL values when privacy mode is enabled', () => {
+      // Arrange
+      useSelector.mockReturnValue(true);
+      const accountWithPnl = {
+        ...defaultAccountState,
+        returnOnEquity: '0.15',
+      };
+      jest
+        .mocked(jest.requireMock('../../hooks/stream').usePerpsLiveAccount)
+        .mockReturnValue({
+          account: accountWithPnl,
+          isInitialLoading: false,
+        });
+
+      // Act
+      render(
+        <PerpsTabControlBar
+          hasPositions
+          hasOrders={false}
+          onManageBalancePress={mockOnManageBalancePress}
+        />,
+      );
+
+      // Assert - sensitive values should be hidden (replaced with bullets)
+      expect(screen.queryByText(/\+\$50\.75/)).toBeNull();
+      expect(screen.queryByText('$1000.50')).toBeNull();
+      expect(screen.getAllByText('••••••').length).toBeGreaterThan(0);
+    });
+
+    it('shows labels regardless of privacy mode', () => {
+      // Arrange
+      useSelector.mockReturnValue(true);
+
+      // Act
+      render(
+        <PerpsTabControlBar
+          hasPositions
+          hasOrders={false}
+          onManageBalancePress={mockOnManageBalancePress}
+        />,
+      );
+
+      // Assert - labels should always be visible (not sensitive)
+      expect(screen.getByText('Total Balance')).toBeTruthy();
+    });
+  });
 });

--- a/app/components/UI/Perps/components/PerpsTabControlBar/PerpsTabControlBar.tsx
+++ b/app/components/UI/Perps/components/PerpsTabControlBar/PerpsTabControlBar.tsx
@@ -1,16 +1,19 @@
 import React, { useEffect, useRef } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import Animated from 'react-native-reanimated';
+import { useSelector } from 'react-redux';
 import { useStyles } from '../../../../../component-library/hooks';
 import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
+import SensitiveText from '../../../../../component-library/components/Texts/SensitiveText';
 import { strings } from '../../../../../../locales/i18n';
 import styleSheet from './PerpsTabControlBar.styles';
 import { useColorPulseAnimation, useBalanceComparison } from '../../hooks';
 import { usePerpsLiveAccount } from '../../hooks/stream';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import {
   formatPerpsFiat,
   formatPnl,
@@ -37,6 +40,7 @@ export const PerpsTabControlBar: React.FC<PerpsTabControlBarProps> = ({
   hasPositions = false,
 }) => {
   const { styles } = useStyles(styleSheet, {});
+  const privacyMode = useSelector(selectPrivacyMode);
   // Use live account data with 1 second throttle for balance display
   const { account: perpsAccount } = usePerpsLiveAccount({ throttleMs: 1000 });
 
@@ -177,16 +181,17 @@ export const PerpsTabControlBar: React.FC<PerpsTabControlBarProps> = ({
                 styles.availableBalanceContainer,
               ]}
             >
-              <Text
+              <SensitiveText
                 variant={TextVariant.BodyMD}
                 color={TextColor.Default}
                 testID={PerpsTabViewSelectorsIDs.BALANCE_VALUE}
+                isHidden={privacyMode}
               >
                 {formatPerpsFiat(totalBalance, {
                   ranges: PRICE_RANGES_MINIMAL_VIEW,
                   stripTrailingZeros: false,
                 })}
-              </Text>
+              </SensitiveText>
               <Icon
                 name={IconName.ArrowRight}
                 size={IconSize.Sm}
@@ -210,9 +215,13 @@ export const PerpsTabControlBar: React.FC<PerpsTabControlBarProps> = ({
           </View>
           <View style={styles.rightSection}>
             <Animated.View style={[getPnlAnimatedStyle]}>
-              <Text variant={TextVariant.BodyMD} color={pnlColor}>
+              <SensitiveText
+                variant={TextVariant.BodyMD}
+                color={pnlColor}
+                isHidden={privacyMode}
+              >
                 {formatPnl(pnlNum)} ({formatPercentage(roe, 1)})
-              </Text>
+              </SensitiveText>
             </Animated.View>
           </View>
         </View>

--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
@@ -5,9 +5,28 @@ import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PredictBalance from './PredictBalance';
 import { strings } from '../../../../../../locales/i18n';
 
-// Mock privacy mode selector
+// Mock preferencesController selectors to avoid import chain issues
 jest.mock('../../../../../selectors/preferencesController', () => ({
   selectPrivacyMode: jest.fn(() => false),
+  selectSmartTransactionsOptInStatus: jest.fn(() => false),
+  selectIpfsGateway: jest.fn(() => ''),
+  selectUseNftDetection: jest.fn(() => false),
+  selectShowMultiRpcModal: jest.fn(() => false),
+  selectUseTokenDetection: jest.fn(() => true),
+  selectDisplayNftMedia: jest.fn(() => true),
+  selectUseSafeChainsListValidation: jest.fn(() => true),
+  selectTokenSortConfig: jest.fn(() => ({})),
+  selectTokenNetworkFilter: jest.fn(() => ({})),
+  selectIsTokenNetworkFilterEqualCurrentNetwork: jest.fn(() => true),
+  selectIsMultiAccountBalancesEnabled: jest.fn(() => true),
+  selectShowTestNetworks: jest.fn(() => false),
+  selectIsIpfsGatewayEnabled: jest.fn(() => true),
+  selectIsSecurityAlertsEnabled: jest.fn(() => false),
+  selectUseTransactionSimulations: jest.fn(() => true),
+  selectSmartTransactionsMigrationApplied: jest.fn(() => false),
+  selectSmartTransactionsBannerDismissed: jest.fn(() => false),
+  selectDismissSmartAccountSuggestionEnabled: jest.fn(() => false),
+  selectSmartAccountOptIn: jest.fn(() => false),
 }));
 
 // Mock React Navigation

--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
@@ -631,4 +631,82 @@ describe('PredictBalance', () => {
       expect(getByText(/\$0\.00/)).toBeOnTheScreen();
     });
   });
+
+  describe('Privacy Mode', () => {
+    const getPrivacyModeMock = () =>
+      jest.requireMock('../../../../../selectors/preferencesController')
+        .selectPrivacyMode as jest.Mock;
+
+    afterEach(() => {
+      getPrivacyModeMock().mockReturnValue(false);
+    });
+
+    it('shows balance when privacy mode is disabled', () => {
+      // Arrange
+      getPrivacyModeMock().mockReturnValue(false);
+      mockUsePredictBalance.mockReturnValue({
+        balance: 250.75,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadBalance: jest.fn(),
+        hasNoBalance: false,
+      });
+
+      // Act
+      const { getByText } = renderWithProvider(<PredictBalance />, {
+        state: initialState,
+      });
+
+      // Assert - balance should be visible
+      expect(getByText('$250.75')).toBeOnTheScreen();
+    });
+
+    it('hides balance when privacy mode is enabled', () => {
+      // Arrange
+      getPrivacyModeMock().mockReturnValue(true);
+      mockUsePredictBalance.mockReturnValue({
+        balance: 250.75,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadBalance: jest.fn(),
+        hasNoBalance: false,
+      });
+
+      // Act
+      const { queryByText, getAllByText } = renderWithProvider(
+        <PredictBalance />,
+        {
+          state: initialState,
+        },
+      );
+
+      // Assert - balance should be hidden (replaced with bullets)
+      expect(queryByText('$250.75')).toBeNull();
+      expect(getAllByText('••••••').length).toBeGreaterThan(0);
+    });
+
+    it('shows action buttons regardless of privacy mode', () => {
+      // Arrange
+      getPrivacyModeMock().mockReturnValue(true);
+      mockUsePredictBalance.mockReturnValue({
+        balance: 250.75,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        loadBalance: jest.fn(),
+        hasNoBalance: false,
+      });
+
+      // Act
+      const { getByText } = renderWithProvider(<PredictBalance />, {
+        state: initialState,
+      });
+
+      // Assert - buttons should always be visible
+      expect(getByText(/Add funds/i)).toBeOnTheScreen();
+      expect(getByText(/Withdraw/i)).toBeOnTheScreen();
+    });
+  });
 });

--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
@@ -5,6 +5,11 @@ import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PredictBalance from './PredictBalance';
 import { strings } from '../../../../../../locales/i18n';
 
+// Mock privacy mode selector
+jest.mock('../../../../../selectors/preferencesController', () => ({
+  selectPrivacyMode: jest.fn(() => false),
+}));
+
 // Mock React Navigation
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),

--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
@@ -10,6 +10,9 @@ import { Spinner } from '@metamask/design-system-react-native/dist/components/te
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import images from 'images/image-icons';
 import React, { useCallback, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import SensitiveText from '../../../../../component-library/components/Texts/SensitiveText';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { strings } from '../../../../../../locales/i18n';
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
 import AvatarToken from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
@@ -40,6 +43,7 @@ interface PredictBalanceProps {
 
 const PredictBalance: React.FC<PredictBalanceProps> = ({ onLayout }) => {
   const tw = useTailwind();
+  const privacyMode = useSelector(selectPrivacyMode);
 
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
@@ -145,9 +149,12 @@ const PredictBalance: React.FC<PredictBalanceProps> = ({ onLayout }) => {
           alignItems={BoxAlignItems.Center}
         >
           <Box>
-            <Text style={tw.style('text-body-md font-bold')}>
+            <SensitiveText
+              style={tw.style('text-body-md font-bold')}
+              isHidden={privacyMode}
+            >
               {formatPrice(balance, { maximumDecimals: 2 })}
-            </Text>
+            </SensitiveText>
             <Text
               style={tw.style('color-alternative text-body-sm')}
               color={TextColor.TextAlternative}

--- a/app/components/UI/Predict/components/PredictPosition/PredictPosition.test.tsx
+++ b/app/components/UI/Predict/components/PredictPosition/PredictPosition.test.tsx
@@ -14,10 +14,29 @@ import {
 import { PredictPositionSelectorsIDs } from '../../Predict.testIds';
 import { usePredictPositions } from '../../hooks/usePredictPositions';
 
-// Mock privacy mode selector
+// Mock preferencesController selectors to avoid import chain issues
 const mockSelectPrivacyMode = jest.fn(() => false);
 jest.mock('../../../../../selectors/preferencesController', () => ({
   selectPrivacyMode: mockSelectPrivacyMode,
+  selectSmartTransactionsOptInStatus: jest.fn(() => false),
+  selectIpfsGateway: jest.fn(() => ''),
+  selectUseNftDetection: jest.fn(() => false),
+  selectShowMultiRpcModal: jest.fn(() => false),
+  selectUseTokenDetection: jest.fn(() => true),
+  selectDisplayNftMedia: jest.fn(() => true),
+  selectUseSafeChainsListValidation: jest.fn(() => true),
+  selectTokenSortConfig: jest.fn(() => ({})),
+  selectTokenNetworkFilter: jest.fn(() => ({})),
+  selectIsTokenNetworkFilterEqualCurrentNetwork: jest.fn(() => true),
+  selectIsMultiAccountBalancesEnabled: jest.fn(() => true),
+  selectShowTestNetworks: jest.fn(() => false),
+  selectIsIpfsGatewayEnabled: jest.fn(() => true),
+  selectIsSecurityAlertsEnabled: jest.fn(() => false),
+  selectUseTransactionSimulations: jest.fn(() => true),
+  selectSmartTransactionsMigrationApplied: jest.fn(() => false),
+  selectSmartTransactionsBannerDismissed: jest.fn(() => false),
+  selectDismissSmartAccountSuggestionEnabled: jest.fn(() => false),
+  selectSmartAccountOptIn: jest.fn(() => false),
 }));
 
 // Mock react-redux

--- a/app/components/UI/Predict/components/PredictPosition/PredictPosition.tsx
+++ b/app/components/UI/Predict/components/PredictPosition/PredictPosition.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Image, TouchableOpacity, View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { useStyles } from '../../../../../component-library/hooks';
 import { PredictPosition as PredictPositionType } from '../../types';
 import { formatPercentage, formatPrice } from '../../utils/format';
@@ -13,7 +14,10 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import SensitiveText from '../../../../../component-library/components/Texts/SensitiveText';
+import { TextVariant as ComponentTextVariant } from '../../../../../component-library/components/Texts/Text';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 
 interface PredictPositionProps {
   position: PredictPositionType;
@@ -26,6 +30,7 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
 }: PredictPositionProps) => {
   const { styles } = useStyles(styleSheet, {});
   const tw = useTailwind();
+  const privacyMode = useSelector(selectPrivacyMode);
 
   const currentPosition = usePredictOptimisticPositionRefresh({
     position,
@@ -59,10 +64,11 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
         >
           {title}
         </Text>
-        <Text
-          variant={TextVariant.BodySm}
+        <SensitiveText
+          variant={ComponentTextVariant.BodySM}
           color={TextColor.TextAlternative}
           style={tw.style('font-medium')}
+          isHidden={privacyMode}
         >
           {strings('predict.position_info', {
             initialValue: formatPrice(initialValue, {
@@ -73,7 +79,7 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
               maximumDecimals: 2,
             }),
           })}
-        </Text>
+        </SensitiveText>
       </View>
       <View style={styles.positionPnl}>
         {optimistic ? (
@@ -83,24 +89,26 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
           </>
         ) : (
           <>
-            <Text
-              variant={TextVariant.BodyMd}
+            <SensitiveText
+              variant={ComponentTextVariant.BodyMD}
               color={TextColor.TextDefault}
               style={tw.style('font-medium')}
+              isHidden={privacyMode}
             >
               {formatPrice(currentValue, { maximumDecimals: 2 })}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
+            </SensitiveText>
+            <SensitiveText
+              variant={ComponentTextVariant.BodySM}
               style={tw.style('font-medium')}
               color={
                 percentPnl > 0
                   ? TextColor.SuccessDefault
                   : TextColor.ErrorDefault
               }
+              isHidden={privacyMode}
             >
               {formatPercentage(percentPnl)}
-            </Text>
+            </SensitiveText>
           </>
         )}
       </View>

--- a/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
@@ -21,6 +21,11 @@ declare global {
   var __mockNavigate: jest.Mock;
 }
 
+// Mock privacy mode selector
+jest.mock('../../../../../selectors/preferencesController', () => ({
+  selectPrivacyMode: jest.fn(() => false),
+}));
+
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string, vars?: Record<string, string | number>) => {
     switch (key) {

--- a/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
@@ -21,9 +21,28 @@ declare global {
   var __mockNavigate: jest.Mock;
 }
 
-// Mock privacy mode selector
+// Mock preferencesController selectors to avoid import chain issues
 jest.mock('../../../../../selectors/preferencesController', () => ({
   selectPrivacyMode: jest.fn(() => false),
+  selectSmartTransactionsOptInStatus: jest.fn(() => false),
+  selectIpfsGateway: jest.fn(() => ''),
+  selectUseNftDetection: jest.fn(() => false),
+  selectShowMultiRpcModal: jest.fn(() => false),
+  selectUseTokenDetection: jest.fn(() => true),
+  selectDisplayNftMedia: jest.fn(() => true),
+  selectUseSafeChainsListValidation: jest.fn(() => true),
+  selectTokenSortConfig: jest.fn(() => ({})),
+  selectTokenNetworkFilter: jest.fn(() => ({})),
+  selectIsTokenNetworkFilterEqualCurrentNetwork: jest.fn(() => true),
+  selectIsMultiAccountBalancesEnabled: jest.fn(() => true),
+  selectShowTestNetworks: jest.fn(() => false),
+  selectIsIpfsGatewayEnabled: jest.fn(() => true),
+  selectIsSecurityAlertsEnabled: jest.fn(() => false),
+  selectUseTransactionSimulations: jest.fn(() => true),
+  selectSmartTransactionsMigrationApplied: jest.fn(() => false),
+  selectSmartTransactionsBannerDismissed: jest.fn(() => false),
+  selectDismissSmartAccountSuggestionEnabled: jest.fn(() => false),
+  selectSmartAccountOptIn: jest.fn(() => false),
 }));
 
 jest.mock('../../../../../../locales/i18n', () => ({

--- a/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.tsx
+++ b/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.tsx
@@ -12,6 +12,10 @@ import {
 } from '@react-navigation/native';
 import React, { useMemo } from 'react';
 import { Image } from 'react-native';
+import { useSelector } from 'react-redux';
+import SensitiveText from '../../../../../component-library/components/Texts/SensitiveText';
+import { TextVariant as ComponentTextVariant } from '../../../../../component-library/components/Texts/Text';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { PredictMarketDetailsSelectorsIDs } from '../../Predict.testIds';
 import { strings } from '../../../../../../locales/i18n';
 import Button, {
@@ -48,6 +52,7 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
   marketStatus,
 }: PredictPositionProps) => {
   const tw = useTailwind();
+  const privacyMode = useSelector(selectPrivacyMode);
 
   const currentPosition = usePredictOptimisticPositionRefresh({
     position,
@@ -133,30 +138,39 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
         return <Skeleton width={70} height={20} />;
       }
       return (
-        <Text
-          variant={TextVariant.BodyMd}
+        <SensitiveText
+          variant={ComponentTextVariant.BodyMD}
           color={TextColor.TextDefault}
           style={tw.style('font-medium')}
+          isHidden={privacyMode}
         >
           {formatPrice(currentValue, { maximumDecimals: 2 })}
-        </Text>
+        </SensitiveText>
       );
     }
 
     if (percentPnl > 0) {
       return (
-        <Text variant={TextVariant.BodyMd} color={TextColor.SuccessDefault}>
+        <SensitiveText
+          variant={ComponentTextVariant.BodyMD}
+          color={TextColor.SuccessDefault}
+          isHidden={privacyMode}
+        >
           {strings('predict.market_details.won')}{' '}
           {formatPrice(currentValue, { maximumDecimals: 2 })}
-        </Text>
+        </SensitiveText>
       );
     }
 
     return (
-      <Text variant={TextVariant.BodyMd} color={TextColor.ErrorDefault}>
+      <SensitiveText
+        variant={ComponentTextVariant.BodyMD}
+        color={TextColor.ErrorDefault}
+        isHidden={privacyMode}
+      >
         {strings('predict.market_details.lost')}{' '}
         {formatPrice(initialValue, { maximumDecimals: 2 })}
-      </Text>
+      </SensitiveText>
     );
   };
 
@@ -181,10 +195,11 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
           >
             {groupItemTitle ?? title}
           </Text>
-          <Text
-            variant={TextVariant.BodySm}
+          <SensitiveText
+            variant={ComponentTextVariant.BodySM}
             color={TextColor.TextAlternative}
             style={tw.style('font-medium')}
+            isHidden={privacyMode}
           >
             {strings('predict.position_info', {
               initialValue: formatPrice(initialValue, {
@@ -195,7 +210,7 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
                 maximumDecimals: 2,
               }),
             })}
-          </Text>
+          </SensitiveText>
         </Box>
         <Box twClassName="items-end justify-end ml-auto shrink-0">
           {renderValueText()}
@@ -203,17 +218,18 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
             (optimistic || isPreviewLoading ? (
               <Skeleton width={55} height={16} style={tw.style('mt-1')} />
             ) : (
-              <Text
-                variant={TextVariant.BodySm}
+              <SensitiveText
+                variant={ComponentTextVariant.BodySM}
                 color={
                   percentPnl > 0
                     ? TextColor.SuccessDefault
                     : TextColor.ErrorDefault
                 }
                 style={tw.style('font-medium')}
+                isHidden={privacyMode}
               >
                 {formatPercentage(percentPnl)}
-              </Text>
+              </SensitiveText>
             ))}
         </Box>
       </Box>

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
@@ -402,4 +402,53 @@ describe('MarketsWonCard', () => {
       expect(mockOnError).toHaveBeenCalledWith('Balance error');
     });
   });
+
+  describe('Privacy Mode', () => {
+    const getPrivacyModeMock = () =>
+      jest.requireMock('../../../../../selectors/preferencesController')
+        .selectPrivacyMode as jest.Mock;
+
+    afterEach(() => {
+      getPrivacyModeMock().mockReturnValue(false);
+    });
+
+    it('shows balance value when privacy mode is disabled', () => {
+      // Arrange
+      getPrivacyModeMock().mockReturnValue(false);
+      const state = createTestState(100.5);
+
+      // Act
+      renderWithProvider(<MarketsWonCard />, { state });
+
+      // Assert - balance value should be visible via testID
+      const balanceText = screen.getByTestId('claimable-amount');
+      expect(balanceText).toBeOnTheScreen();
+      expect(balanceText).toHaveTextContent('$100.50');
+    });
+
+    it('hides balance and P&L values when privacy mode is enabled', () => {
+      // Arrange
+      getPrivacyModeMock().mockReturnValue(true);
+      const state = createTestState(100.5);
+
+      // Act
+      renderWithProvider(<MarketsWonCard />, { state });
+
+      // Assert - sensitive values should be hidden (replaced with bullets)
+      expect(screen.queryByText('$100.50')).toBeNull();
+      expect(screen.getAllByText('••••••').length).toBeGreaterThan(0);
+    });
+
+    it('shows container regardless of privacy mode', () => {
+      // Arrange
+      getPrivacyModeMock().mockReturnValue(true);
+      const state = createTestState(100.5);
+
+      // Act
+      renderWithProvider(<MarketsWonCard />, { state });
+
+      // Assert - card container should always be visible
+      expect(screen.getByTestId('markets-won-card')).toBeOnTheScreen();
+    });
+  });
 });

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
@@ -94,6 +94,11 @@ jest.mock('../../hooks/usePredictPositions', () => ({
   }),
 }));
 
+// Mock privacy mode selector
+jest.mock('../../../../../selectors/preferencesController', () => ({
+  selectPrivacyMode: jest.fn(() => false),
+}));
+
 const mockClaim = jest.fn();
 jest.mock('../../hooks/usePredictClaim', () => ({
   usePredictClaim: () => ({

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
@@ -94,9 +94,28 @@ jest.mock('../../hooks/usePredictPositions', () => ({
   }),
 }));
 
-// Mock privacy mode selector
+// Mock preferencesController selectors to avoid import chain issues
 jest.mock('../../../../../selectors/preferencesController', () => ({
   selectPrivacyMode: jest.fn(() => false),
+  selectSmartTransactionsOptInStatus: jest.fn(() => false),
+  selectIpfsGateway: jest.fn(() => ''),
+  selectUseNftDetection: jest.fn(() => false),
+  selectShowMultiRpcModal: jest.fn(() => false),
+  selectUseTokenDetection: jest.fn(() => true),
+  selectDisplayNftMedia: jest.fn(() => true),
+  selectUseSafeChainsListValidation: jest.fn(() => true),
+  selectTokenSortConfig: jest.fn(() => ({})),
+  selectTokenNetworkFilter: jest.fn(() => ({})),
+  selectIsTokenNetworkFilterEqualCurrentNetwork: jest.fn(() => true),
+  selectIsMultiAccountBalancesEnabled: jest.fn(() => true),
+  selectShowTestNetworks: jest.fn(() => false),
+  selectIsIpfsGatewayEnabled: jest.fn(() => true),
+  selectIsSecurityAlertsEnabled: jest.fn(() => false),
+  selectUseTransactionSimulations: jest.fn(() => true),
+  selectSmartTransactionsMigrationApplied: jest.fn(() => false),
+  selectSmartTransactionsBannerDismissed: jest.fn(() => false),
+  selectDismissSmartAccountSuggestionEnabled: jest.fn(() => false),
+  selectSmartAccountOptIn: jest.fn(() => false),
 }));
 
 const mockClaim = jest.fn();

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -18,6 +18,9 @@ import React, {
 } from 'react';
 import { TouchableOpacity } from 'react-native';
 import { useSelector } from 'react-redux';
+import SensitiveText from '../../../../../component-library/components/Texts/SensitiveText';
+import { TextVariant as ComponentTextVariant } from '../../../../../component-library/components/Texts/Text';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { strings } from '../../../../../../locales/i18n';
 import { PredictPositionsHeaderSelectorsIDs } from '../../Predict.testIds';
 import Icon, {
@@ -61,6 +64,7 @@ const PredictPositionsHeader = forwardRef<
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const tw = useTailwind();
+  const privacyMode = useSelector(selectPrivacyMode);
   const { executeGuardedAction } = usePredictActionGuard({
     providerId: POLYMARKET_PROVIDER_ID,
     navigation,
@@ -176,11 +180,15 @@ const PredictPositionsHeader = forwardRef<
           onPress={handleClaim}
           style={tw.style('w-full')}
         >
-          <Text variant={TextVariant.BodyMd} color={TextColor.PrimaryInverse}>
+          <SensitiveText
+            variant={ComponentTextVariant.BodyMD}
+            color={TextColor.PrimaryInverse}
+            isHidden={privacyMode}
+          >
             {strings('predict.claim_amount_text', {
               amount: totalClaimableAmount.toFixed(2),
             })}
-          </Text>
+          </SensitiveText>
         </ButtonHero>
       )}
 
@@ -234,13 +242,14 @@ const PredictPositionsHeader = forwardRef<
                     />
                   ) : (
                     <>
-                      <Text
-                        variant={TextVariant.BodyMd}
-                        twClassName="text-primary mr-1"
+                      <SensitiveText
+                        variant={ComponentTextVariant.BodyMD}
+                        style={tw.style('text-primary mr-1')}
                         testID="claimable-amount"
+                        isHidden={privacyMode}
                       >
                         {formatPrice(balance, { maximumDecimals: 2 })}
-                      </Text>
+                      </SensitiveText>
                       <Icon
                         name={IconName.ArrowRight}
                         size={IconSize.Sm}
@@ -274,19 +283,20 @@ const PredictPositionsHeader = forwardRef<
                     style={tw.style('rounded-md')}
                   />
                 ) : (
-                  <Text
-                    variant={TextVariant.BodyMd}
-                    twClassName={
+                  <SensitiveText
+                    variant={ComponentTextVariant.BodyMD}
+                    style={tw.style(
                       unrealizedAmount >= 0
                         ? 'text-success-default'
-                        : 'text-error-default'
-                    }
+                        : 'text-error-default',
+                    )}
+                    isHidden={privacyMode}
                   >
                     {strings('predict.unrealized_pnl_value', {
                       amount: formatAmount(unrealizedAmount),
                       percent: formatPercent(unrealizedPercent),
                     })}
-                  </Text>
+                  </SensitiveText>
                 )}
               </Box>
             </>

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -43,6 +43,30 @@ jest.mock('../../../../../core/Engine', () => ({
   },
 }));
 
+// Mock preferencesController selectors to avoid import chain issues
+jest.mock('../../../../../selectors/preferencesController', () => ({
+  selectPrivacyMode: jest.fn(() => false),
+  selectSmartTransactionsOptInStatus: jest.fn(() => false),
+  selectIpfsGateway: jest.fn(() => ''),
+  selectUseNftDetection: jest.fn(() => false),
+  selectShowMultiRpcModal: jest.fn(() => false),
+  selectUseTokenDetection: jest.fn(() => true),
+  selectDisplayNftMedia: jest.fn(() => true),
+  selectUseSafeChainsListValidation: jest.fn(() => true),
+  selectTokenSortConfig: jest.fn(() => ({})),
+  selectTokenNetworkFilter: jest.fn(() => ({})),
+  selectIsTokenNetworkFilterEqualCurrentNetwork: jest.fn(() => true),
+  selectIsMultiAccountBalancesEnabled: jest.fn(() => true),
+  selectShowTestNetworks: jest.fn(() => false),
+  selectIsIpfsGatewayEnabled: jest.fn(() => true),
+  selectIsSecurityAlertsEnabled: jest.fn(() => false),
+  selectUseTransactionSimulations: jest.fn(() => true),
+  selectSmartTransactionsMigrationApplied: jest.fn(() => false),
+  selectSmartTransactionsBannerDismissed: jest.fn(() => false),
+  selectDismissSmartAccountSuggestionEnabled: jest.fn(() => false),
+  selectSmartAccountOptIn: jest.fn(() => false),
+}));
+
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
   useRoute: jest.fn(),


### PR DESCRIPTION
## **Description**

When users enable privacy mode (by tapping on their balance to hide amounts), the Perps and Predict features were not respecting this setting and continued to display sensitive financial information.

This PR ensures all sensitive amounts in the Perps and Predict tabs are hidden when privacy mode is enabled, providing consistent privacy behavior across the entire app.

### Changes

**Perps Components Updated:**
- `PerpsCard` - Hides position value and PnL
- `PerpsHomeSection` - Hides positions PnL subtitle
- `PerpsMarketBalanceActions` - Hides total balance, available balance, and transaction amounts
- `PerpsPositionCard` - Hides PnL, return percentage, size, margin, entry price, liquidation price, and funding payments
- `PerpsTabControlBar` - Hides total balance and unrealized P&L

**Predict Components Updated:**
- `PredictBalance` - Hides balance display
- `PredictPosition` - Hides position info, current value, and percentage PnL
- `PredictPositionDetail` - Hides current value and PnL across all position states (open/won/lost)
- `PredictPositionsHeader` - Hides claim amount, available balance, and unrealized PnL

### Implementation

All components now:
1. Import `selectPrivacyMode` from `preferencesController` selector
2. Use `useSelector(selectPrivacyMode)` to get the privacy mode state
3. Wrap sensitive values with `SensitiveText` component and `isHidden={privacyMode}` prop

When privacy mode is enabled, monetary values are replaced with `••••••` (bullet characters), while non-sensitive information (titles, direction, leverage) remains visible.


https://github.com/user-attachments/assets/1036e7f9-a30f-4f3d-ae21-f62548011895




## **Changelog**

CHANGELOG entry: Fixed privacy mode not being respected in Perps and Predict tabs - sensitive amounts are now hidden when privacy mode is enabled

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/23187

## **Manual testing steps**

```gherkin
Feature: Privacy Mode in Perps and Predict

  Scenario: User enables privacy mode and amounts are hidden in Perps tab
    Given the user has positions or balances in the Perps tab
    And privacy mode is disabled (amounts are visible)

    When user taps on their main wallet balance to enable privacy mode
    Then all amounts in the Perps tab should be replaced with bullet characters (••••••)
    And non-sensitive info like market names, direction, and leverage should remain visible

  Scenario: User enables privacy mode and amounts are hidden in Predict tab
    Given the user has positions or balances in the Predict tab
    And privacy mode is disabled (amounts are visible)

    When user taps on their main wallet balance to enable privacy mode
    Then all amounts in the Predict tab should be replaced with bullet characters (••••••)
    And non-sensitive info like market titles should remain visible

  Scenario: User disables privacy mode and amounts become visible
    Given privacy mode is enabled (amounts are hidden)

    When user taps on the hidden balance to disable privacy mode
    Then all amounts in Perps and Predict tabs should become visible again
```

## **Screenshots/Recordings**

### **Before**

When privacy mode was enabled, Perps and Predict tabs still showed all amounts.

### **After**

When privacy mode is enabled, all sensitive amounts in Perps and Predict tabs are now hidden with `••••••`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
