### PR TITLE
fix: prevent search field going out of bounds when keyboard shown

### DIFF
--- a/app/components/UI/Bridge/components/RecipientSelectorModal/RecipientSelectorModal.tsx
+++ b/app/components/UI/Bridge/components/RecipientSelectorModal/RecipientSelectorModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useEffect } from 'react';
+import React, { useCallback, useMemo, useEffect, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
 import BottomSheet from '../../../../../component-library/components/BottomSheets/BottomSheet';
@@ -27,6 +27,8 @@ import Engine from '../../../../../core/Engine';
 const RecipientSelectorModal: React.FC = () => {
   const navigation = useNavigation();
   const dispatch = useDispatch();
+  const [keyboardAvoidingViewEnabled, setKeyboardAvoidingViewEnabled] =
+    useState(true);
 
   const internalAccountsById = useSelector(selectInternalAccountsById);
   const accountToGroupMap = useSelector(selectAccountToGroupMap);
@@ -149,7 +151,10 @@ const RecipientSelectorModal: React.FC = () => {
   }, [destAddress, internalAccountsById]);
 
   return (
-    <BottomSheet onClose={handleClose} keyboardAvoidingViewEnabled>
+    <BottomSheet
+      onClose={handleClose}
+      keyboardAvoidingViewEnabled={keyboardAvoidingViewEnabled}
+    >
       <BottomSheetHeader onClose={handleClose}>
         Recipient account
       </BottomSheetHeader>
@@ -165,6 +170,8 @@ const RecipientSelectorModal: React.FC = () => {
         showExternalAccountOnEmptySearch
         onSelectExternalAccount={handleSelectExternalAccount}
         selectedExternalAddress={selectedExternalAddress}
+        setKeyboardAvoidingViewEnabled={setKeyboardAvoidingViewEnabled}
+        keyboardDismissMode="on-drag"
       />
     </BottomSheet>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes a bug where in the Swaps recipient account picker, if the user clicked on the search input bar, the keyboard would push the search input off screen.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where in the Swaps recipient account picker, if the user clicked on the search input bar, the keyboard would push the search input off screen.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3860

## **Manual testing steps**

```gherkin
Feature: Swaps recipient account search fix

  Scenario: user trying to bridge
    Given user is searching for a recipient account in Swaps

    When user clicks on the search bar
    Then the search bar remains on screen
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/46e7aeb8-cc69-4d01-ba07-cb9498802031



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to the recipient selector bottom sheet’s keyboard handling; no changes to quoting, routing, or address selection logic.
> 
> **Overview**
> Prevents the Bridge/Swaps recipient selector search field from being pushed off-screen when the keyboard appears by making `BottomSheet`’s `keyboardAvoidingViewEnabled` stateful and letting `MultichainAccountSelectorList` toggle it based on list size.
> 
> Also sets the list’s `keyboardDismissMode` to `on-drag` to improve keyboard dismissal while scrolling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9293d05784ce4d83ae03093f0cc781942c16551. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->