### PR TITLE
chore: updating unit testing cursor rules to prevent unnecessary mocking

### DIFF
--- a/.cursor/rules/unit-testing-guidelines.mdc
+++ b/.cursor/rules/unit-testing-guidelines.mdc
@@ -204,14 +204,15 @@ expect(element).not.toBeNull(); // Use toBeOnTheScreen() instead
 | `not.toBeNull()` | `not.toBeOnTheScreen()` or `queryByTestId` returning null |
 | `toHaveLength(1)` for single element | `toBeOnTheScreen()` |
 
-## Mocking Rules - MOCK WISELY, NOT EXCESSIVELY
+## Mocking Rules
+
+### General Mocking Guidelines
 
 - **Mock external boundaries** - APIs, native modules, third-party services
-- **Avoid over-mocking** - Don't mock internal utilities or simple functions unnecessarily
-- **Prefer real implementations** when they are fast, deterministic, and side-effect free
 - **NO** use of `require` - use ES6 imports only
 - **NO** use of `any` type - use proper TypeScript types
 - **Use realistic mock data** that reflects real usage
+- **Never mock the component under test** - only mock its external dependencies
 
 ### What to Mock
 
@@ -234,49 +235,18 @@ jest.mock('@react-navigation/native', () => ({
 }));
 ```
 
-### What NOT to Mock - CRITICAL
+## UI Component Testing - TestID Guidelines - CRITICAL
 
-```ts
-// ❌ NEVER mock @metamask/design-system-react-native
-// These components already provide testID support and should render in tests
-jest.mock('@metamask/design-system-react-native', () => ({
-  Box: 'View',      // ❌ WRONG - loses all testID functionality
-  Text: 'Text',     // ❌ WRONG - loses variant behavior
-  Button: 'Button', // ❌ WRONG - loses accessibility
-}));
+**NEVER mock `@metamask/design-system-react-native` or `app/component-library` components to inject testIDs.** These components already support testIDs through props and child prop objects.
 
-// ✅ CORRECT: Let design system components render naturally
-// They work in tests and provide testID props for selection
-render(<MyComponent testID="my-button" />);
-expect(screen.getByTestId('my-button')).toBeOnTheScreen();
+### Why This Matters
 
-// ❌ AVOID: Over-mocking simple utilities
-jest.mock('../utils/formatNumber'); // Usually unnecessary
-
-// ❌ AVOID: Mocking the component under test
-jest.mock('./MyComponent'); // Never mock what you're testing
-
-// ❌ AVOID: Mocking child components excessively
-jest.mock('./Button'); // Prefer rendering real children when possible
-
-// ✅ BETTER: Test with real child components for integration confidence
-render(<ParentComponent />); // Children render naturally
-```
-
-### Why NOT to Mock @metamask/design-system-react-native
-
-The design system library provides:
-- **Built-in testID support** on Box, Text, Button, etc.
+ALL `@metamask/design-system-react-native` and `app/component-library` components provide:
+- **Built-in testID support** via the `testID` prop
 - **Child prop objects** (`closeButtonProps`, `iconProps`, etc.) for passing testIDs to internal elements
-- **Proper accessibility attributes** for testing
-- **Consistent behavior** that tests should verify
+- This eliminates the need to mock components just to inject testIDs
 
-When you mock it:
-- Tests pass but don't verify real rendering behavior
-- testID props get lost, forcing fragile text-based queries
-- You're testing mocks, not your actual component
-- Maintenance burden: mocks must match real API changes
-- **You miss the child prop objects that already exist for testID injection**
+### The Problem: Mocking to Inject TestIDs
 
 ```tsx
 // ❌ BAD: 84+ test files in the codebase do this unnecessarily
@@ -309,14 +279,12 @@ render(<MyComponent />);
 expect(screen.getByTestId('modal-close-button')).toBeOnTheScreen();
 ```
 
-### Libraries That Should NOT Be Mocked
+### Libraries That Should NOT Be Mocked for TestID Injection
 
-| Library | Why |
-|---------|-----|
-| `@metamask/design-system-react-native` | Components support testID and child prop objects |
-| `@metamask/design-system-twrnc-preset` | useTailwind works in test environment |
-| `app/component-library/*` | Support testID and child prop objects (e.g., `closeButtonProps`) |
-| Simple utility functions | No side effects, fast execution |
+| Library | TestID Support |
+|---------|----------------|
+| `@metamask/design-system-react-native` | All components support `testID` prop and child prop objects |
+| `app/component-library/*` | All components support `testID` prop and child prop objects (e.g., `closeButtonProps`, `iconProps`) |
 
 ### Why These Mocks Are Coupled (Important Context)
 
@@ -330,12 +298,12 @@ Mocking `@metamask/design-system-react-native` creates a chain reaction that for
 
 **60+ test files** in the codebase mock both libraries together for this reason. The solution is to mock **neither** - they're designed to work together in tests.
 
-### Before You Mock, Ask These Questions
+### Before You Mock for TestIDs, Ask These Questions
 
-1. **Does the component have a `testID` prop?** → Use it directly
-2. **Does the component have child prop objects?** → Pass testID through them (e.g., `closeButtonProps={{ testID: '...' }}`)
-3. **Is this a design system or component-library component?** → It almost certainly supports both - DON'T MOCK
-4. **Am I mocking just to add a testID?** → STOP - find the prop object instead
+1. **Am I mocking just to add a testID?** → STOP - the component likely already supports testID
+2. **Does the component have a `testID` prop?** → Use it directly
+3. **Does the component have child prop objects?** → Pass testID through them (e.g., `closeButtonProps={{ testID: '...' }}`)
+4. **Is this from `@metamask/design-system-react-native` or `app/component-library`?** → It supports testID - DON'T MOCK
 
 ### Correct Mocking Pattern
 
@@ -564,8 +532,9 @@ expect(result).toBe(false);
 # Quality Checklist - MANDATORY
 
 Before submitting any test file, verify:
-- [ ] **No mocking of `@metamask/design-system-react-native`** - All components support testID
-- [ ] **No mocking of `app/component-library`** - All components support testID and child prop objects
+- [ ] **No mocking components to inject testIDs** - Use `testID` props and child prop objects instead
+- [ ] **No mocking of `@metamask/design-system-react-native` for testIDs** - All components support testID
+- [ ] **No mocking of `app/component-library` for testIDs** - All components support testID and child prop objects
 - [ ] **testIDs passed via child prop objects** - Use `closeButtonProps={{ testID }}` not mocks
 - [ ] **No "should" in any test name**
 - [ ] **All tests follow AAA pattern**
@@ -578,14 +547,13 @@ Before submitting any test file, verify:
 - [ ] **Elements selected by `testID`** - NOT fragile text queries
 - [ ] **Test names are descriptive**
 - [ ] **No test duplication**
-- [ ] **Mocking is minimal** - only external APIs/native modules, not UI components
 - [ ] **Async operations wrapped in act()** when they trigger state updates
 
 # Common Mistakes to AVOID - CRITICAL
 
 - ❌ **Mocking to inject testIDs** - Check for child prop objects first (`closeButtonProps`, `iconProps`, etc.)
-- ❌ **Mocking @metamask/design-system-react-native** - NEVER. Use real components with testID.
-- ❌ **Mocking component-library components** - They support testID via child prop objects
+- ❌ **Mocking @metamask/design-system-react-native for testIDs** - Components already support testID props
+- ❌ **Mocking component-library components for testIDs** - They support testID via child prop objects
 - ❌ **Using "should" in test names** - Use action-oriented descriptions
 - ❌ **Testing multiple behaviors in one test** - One test, one behavior
 - ❌ **Sharing state between tests** - Each test must be independent
@@ -595,19 +563,17 @@ Before submitting any test file, verify:
 - ❌ **Not testing edge cases** - Test null, undefined, empty values
 - ❌ **Using weak matchers** - Use `toBeOnTheScreen()` instead of `toBeTruthy()`/`toBeDefined()`
 - ❌ **Selecting elements by text** - Use `testID` props for reliable selection
-- ❌ **Over-mocking** - Only mock external boundaries, not internal utilities
 - ❌ **Not wrapping async state updates in act()** - Causes flaky "terminated" errors
 
 # Anti-patterns to Avoid
 
-- ❌ **NEVER mock `@metamask/design-system-react-native`** - ALL components support testID and child prop objects.
-- ❌ **NEVER mock `app/component-library` components** - ALL components support testID and child prop objects.
-- ❌ **NEVER mock to inject testIDs** - The capability already exists via child prop objects (`closeButtonProps`, etc.).
+- ❌ **NEVER mock `@metamask/design-system-react-native` to inject testIDs** - ALL components support testID props and child prop objects.
+- ❌ **NEVER mock `app/component-library` components to inject testIDs** - ALL components support testID props and child prop objects.
+- ❌ **NEVER mock components just to inject testIDs** - The capability already exists via child prop objects (`closeButtonProps`, etc.).
 - ❌ Do not consider snapshot coverage as functional coverage.
 - ❌ Do not rely on code coverage percentage without real assertions.
 - ❌ Do not use weak matchers like `toBeDefined` or `toBeTruthy` to assert element presence. Use `toBeOnTheScreen()`.
 - ❌ Do not select elements by text that might change (i18n keys, copy updates). Use `testID` props instead.
-- ❌ Do not over-mock internal utilities or child components. Prefer real implementations for better integration confidence.
 - ❌ Do not mock the component or function under test - only mock its external dependencies.
 
 ### Design System & Component Library Mocking - STRICTLY PROHIBITED

--- a/.cursor/rules/unit-testing-guidelines.mdc
+++ b/.cursor/rules/unit-testing-guidelines.mdc
@@ -204,15 +204,57 @@ expect(element).not.toBeNull(); // Use toBeOnTheScreen() instead
 | `not.toBeNull()` | `not.toBeOnTheScreen()` or `queryByTestId` returning null |
 | `toHaveLength(1)` for single element | `toBeOnTheScreen()` |
 
+## UI Component TestID Guidelines - DO NOT MOCK FOR TESTIDS
+
+**CRITICAL: Never mock `@metamask/design-system-react-native` or `app/component-library` components just to inject testIDs.**
+
+### The Rule
+
+All design system and component library components already support testIDs through:
+- Direct `testID` prop on the component
+- Child prop objects (`closeButtonProps`, `iconProps`, etc.) for internal elements
+
+### Example: The Wrong Way vs The Right Way
+
+```tsx
+// ❌ WRONG: 30+ lines of mock code to inject a testID
+jest.mock('BottomSheetHeader', () => {
+  return ({ onClose }) => (
+    <TouchableOpacity testID="close-button" onPress={onClose}>Close</TouchableOpacity>
+  );
+});
+
+// ✅ RIGHT: Use the component's built-in API
+<BottomSheetHeader
+  onClose={handleClose}
+  closeButtonProps={{ testID: 'modal-close-button' }}
+/>
+```
+
+### Quick Check Before Mocking
+
+**Am I mocking just to add a testID?** → STOP
+- Check if component has `testID` prop → use it directly
+- Check if component has child prop objects → pass testID through them
+- From `@metamask/design-system-react-native` or `app/component-library`? → It supports testID
+
+### Common Child Prop Objects
+
+```tsx
+// Most component-library components support these patterns:
+<Component
+  testID="component-id"                              // Main component
+  closeButtonProps={{ testID: 'close-btn' }}        // Close button
+  backButtonProps={{ testID: 'back-btn' }}          // Back button
+  iconProps={{ testID: 'icon' }}                    // Icons
+  startAccessoryProps={{ testID: 'start' }}         // Start accessory
+  endAccessoryProps={{ testID: 'end' }}             // End accessory
+/>
+```
+
+**See [PR #25548](https://github.com/MetaMask/metamask-mobile/pull/25548) for a complete refactoring example (eliminated 133 lines of unnecessary mocks).**
+
 ## Mocking Rules
-
-### General Mocking Guidelines
-
-- **Mock external boundaries** - APIs, native modules, third-party services
-- **NO** use of `require` - use ES6 imports only
-- **NO** use of `any` type - use proper TypeScript types
-- **Use realistic mock data** that reflects real usage
-- **Never mock the component under test** - only mock its external dependencies
 
 ### What to Mock
 
@@ -222,107 +264,23 @@ jest.mock('../services/api');
 
 // ✅ MOCK: Native modules and platform-specific code
 jest.mock('react-native-keychain');
-jest.mock('@react-native-async-storage/async-storage');
 
 // ✅ MOCK: Non-deterministic functions
 jest.useFakeTimers();
-jest.spyOn(Math, 'random').mockReturnValue(0.5);
 
 // ✅ MOCK: Navigation and routing
-const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 ```
 
-## UI Component Testing - TestID Guidelines - CRITICAL
+### General Guidelines
 
-**NEVER mock `@metamask/design-system-react-native` or `app/component-library` components to inject testIDs.** These components already support testIDs through props and child prop objects.
-
-### Why This Matters
-
-ALL `@metamask/design-system-react-native` and `app/component-library` components provide:
-- **Built-in testID support** via the `testID` prop
-- **Child prop objects** (`closeButtonProps`, `iconProps`, etc.) for passing testIDs to internal elements
-- This eliminates the need to mock components just to inject testIDs
-
-### The Problem: Mocking to Inject TestIDs
-
-```tsx
-// ❌ BAD: 84+ test files in the codebase do this unnecessarily
-jest.mock('@metamask/design-system-react-native', () => ({
-  Box: 'View',
-  Text: 'Text',
-  TextVariant: { BodyMd: 'BodyMd' },
-  // ... 20+ lines of mock boilerplate
-}));
-
-// ❌ ALSO BAD: Mocking the Tailwind preset
-jest.mock('@metamask/design-system-twrnc-preset', () => ({
-  useTailwind: () => ({
-    style: jest.fn(() => ({})),
-    color: jest.fn(() => '#000000'),
-  }),
-}));
-
-// ❌ BAD: Mocking component-library components to add testIDs
-jest.mock('BottomSheetHeader', () => /* 30+ lines recreating the component */);
-
-// ✅ GOOD: Use child prop objects to pass testIDs to internal elements
-<BottomSheetHeader
-  onClose={handleClose}
-  closeButtonProps={{ testID: 'modal-close-button' }}
-/>
-
-// ✅ GOOD: Just render and use testID
-render(<MyComponent />);
-expect(screen.getByTestId('modal-close-button')).toBeOnTheScreen();
-```
-
-### Libraries That Should NOT Be Mocked for TestID Injection
-
-| Library | TestID Support |
-|---------|----------------|
-| `@metamask/design-system-react-native` | All components support `testID` prop and child prop objects |
-| `app/component-library/*` | All components support `testID` prop and child prop objects (e.g., `closeButtonProps`, `iconProps`) |
-
-### Why These Mocks Are Coupled (Important Context)
-
-Mocking `@metamask/design-system-react-native` creates a chain reaction that forces you to mock `@metamask/design-system-twrnc-preset` too:
-
-1. You mock `Box` → `'View'` (basic React Native View)
-2. The mocked View doesn't understand `twClassName` prop
-3. Tailwind styles from `tw.style()` have nowhere to go / cause warnings
-4. So you mock `useTailwind` → returns empty `{}` to silence errors
-5. Tests pass... but you're now testing mocks, not real components
-
-**60+ test files** in the codebase mock both libraries together for this reason. The solution is to mock **neither** - they're designed to work together in tests.
-
-### Before You Mock for TestIDs, Ask These Questions
-
-1. **Am I mocking just to add a testID?** → STOP - the component likely already supports testID
-2. **Does the component have a `testID` prop?** → Use it directly
-3. **Does the component have child prop objects?** → Pass testID through them (e.g., `closeButtonProps={{ testID: '...' }}`)
-4. **Is this from `@metamask/design-system-react-native` or `app/component-library`?** → It supports testID - DON'T MOCK
-
-### Correct Mocking Pattern
-
-```ts
-// ✅ CORRECT
-import { apiService } from '../services/api';
-jest.mock('../services/api');
-const mockApiService = apiService as jest.Mocked<typeof apiService>;
-
-interface MockEvent {
-  type: EventType;
-  event: string;
-  timestamp: string;
-}
-
-// ❌ WRONG
-const mockApi = require('../services/api'); // ❌ no require
-const mockApi: any = jest.fn();             // ❌ no any type
-```
+- **Mock external boundaries** - APIs, native modules, third-party services
+- **Never mock the component under test** - only mock its external dependencies
+- **NO** use of `require` - use ES6 imports only
+- **NO** use of `any` type - use proper TypeScript types
+- **Use realistic mock data** that reflects real usage
 
 ## Test Isolation and Focus - MANDATORY
 
@@ -532,85 +490,30 @@ expect(result).toBe(false);
 # Quality Checklist - MANDATORY
 
 Before submitting any test file, verify:
-- [ ] **No mocking components to inject testIDs** - Use `testID` props and child prop objects instead
-- [ ] **No mocking of `@metamask/design-system-react-native` for testIDs** - All components support testID
-- [ ] **No mocking of `app/component-library` for testIDs** - All components support testID and child prop objects
-- [ ] **testIDs passed via child prop objects** - Use `closeButtonProps={{ testID }}` not mocks
+- [ ] **No mocking to inject testIDs** - Use component's built-in testID support
+- [ ] **testIDs via child prop objects** - Use `closeButtonProps={{ testID }}` not mocks
 - [ ] **No "should" in any test name**
 - [ ] **All tests follow AAA pattern**
 - [ ] **Each test has one clear purpose**
 - [ ] **All code paths are tested**
 - [ ] **Edge cases are covered**
-- [ ] **Test data is realistic**
 - [ ] **Tests are independent**
-- [ ] **Assertions use `toBeOnTheScreen()`** - NOT `toBeTruthy()` or `toBeDefined()` for elements
+- [ ] **Assertions use `toBeOnTheScreen()`** - NOT `toBeTruthy()` or `toBeDefined()`
 - [ ] **Elements selected by `testID`** - NOT fragile text queries
-- [ ] **Test names are descriptive**
-- [ ] **No test duplication**
 - [ ] **Async operations wrapped in act()** when they trigger state updates
 
-# Common Mistakes to AVOID - CRITICAL
+# Common Mistakes to AVOID
 
-- ❌ **Mocking to inject testIDs** - Check for child prop objects first (`closeButtonProps`, `iconProps`, etc.)
-- ❌ **Mocking @metamask/design-system-react-native for testIDs** - Components already support testID props
-- ❌ **Mocking component-library components for testIDs** - They support testID via child prop objects
+- ❌ **Mocking to inject testIDs** - Components already support testID (see guidelines above)
 - ❌ **Using "should" in test names** - Use action-oriented descriptions
 - ❌ **Testing multiple behaviors in one test** - One test, one behavior
 - ❌ **Sharing state between tests** - Each test must be independent
 - ❌ **Not testing error conditions** - Test both success and failure paths
-- ❌ **Using unrealistic test data** - Use data that reflects real usage
 - ❌ **Not following AAA pattern** - Always Arrange, Act, Assert
 - ❌ **Not testing edge cases** - Test null, undefined, empty values
 - ❌ **Using weak matchers** - Use `toBeOnTheScreen()` instead of `toBeTruthy()`/`toBeDefined()`
 - ❌ **Selecting elements by text** - Use `testID` props for reliable selection
 - ❌ **Not wrapping async state updates in act()** - Causes flaky "terminated" errors
-
-# Anti-patterns to Avoid
-
-- ❌ **NEVER mock `@metamask/design-system-react-native` to inject testIDs** - ALL components support testID props and child prop objects.
-- ❌ **NEVER mock `app/component-library` components to inject testIDs** - ALL components support testID props and child prop objects.
-- ❌ **NEVER mock components just to inject testIDs** - The capability already exists via child prop objects (`closeButtonProps`, etc.).
-- ❌ Do not consider snapshot coverage as functional coverage.
-- ❌ Do not rely on code coverage percentage without real assertions.
-- ❌ Do not use weak matchers like `toBeDefined` or `toBeTruthy` to assert element presence. Use `toBeOnTheScreen()`.
-- ❌ Do not select elements by text that might change (i18n keys, copy updates). Use `testID` props instead.
-- ❌ Do not mock the component or function under test - only mock its external dependencies.
-
-### Design System & Component Library Mocking - STRICTLY PROHIBITED
-
-```tsx
-// ❌ WRONG - This pattern appears in 84+ test files and must be refactored
-jest.mock('@metamask/design-system-react-native', () => ({
-  Box: 'View',
-  Text: 'Text',
-  TextVariant: { BodyMd: 'BodyMd' },
-}));
-
-// ❌ WRONG - Mocking component-library to inject testIDs
-jest.mock('BottomSheetHeader', () => {
-  return ({ onClose }) => (
-    <TouchableOpacity testID="close-button" onPress={onClose}>Close</TouchableOpacity>
-  );
-});
-// This is 30+ lines of code to add a testID that already exists via closeButtonProps!
-
-// ✅ CORRECT - Use child prop objects to pass testIDs
-<BottomSheetHeader
-  onClose={handleClose}
-  closeButtonProps={{ testID: 'modal-close-button' }}
-/>
-
-// ✅ CORRECT - No mock needed, use real components with testID
-import { render, screen, fireEvent } from '@testing-library/react-native';
-
-it('closes modal when close button pressed', () => {
-  render(<MyModal />);
-  
-  fireEvent.press(screen.getByTestId('modal-close-button'));
-  
-  expect(mockOnClose).toHaveBeenCalled();
-});
-```
 
 # Unit tests developement workflow
 

--- a/.cursor/rules/unit-testing-guidelines.mdc
+++ b/.cursor/rules/unit-testing-guidelines.mdc
@@ -49,6 +49,7 @@ it('returns false for email without domain', () => {
 ```
 
 **Helper Functions**:
+
 ```ts
 const createTestEvent = (overrides = {}) => ({
   type: EventType.TrackEvent,
@@ -64,21 +65,16 @@ const createTestEvent = (overrides = {}) => ({
 - **Use `getByTestId`** as the primary query method for reliable element selection
 - **Add `testID` props** to components when writing new code or updating existing code
 - **Avoid selecting by text** when the text might change (i18n, copy updates)
-- **Use semantic queries** (`getByRole`, `getByLabelText`) for accessibility-critical elements
 
 ```tsx
 // ✅ CORRECT - Use testID for reliable selection
 <Button testID="submit-button" onPress={handleSubmit}>
   {t('common.submit')}
-</Button>
+</Button>;
 
 // In test:
 const submitButton = screen.getByTestId('submit-button');
 expect(submitButton).toBeOnTheScreen();
-
-// ✅ ALSO GOOD - Semantic queries for accessibility
-const input = screen.getByRole('textbox', { name: 'Email' });
-const checkbox = screen.getByLabelText('Accept terms');
 
 // ✅ ALSO GOOD - Locale keys (safe from content updates)
 const button = screen.getByText(strings('common.submit'));
@@ -93,6 +89,7 @@ const input = screen.getByPlaceholderText('Enter email'); // Fragile
 **ALL `@metamask/design-system-react-native` and `app/component-library` components support child prop objects for passing testIDs to internal elements.** This is a universal design pattern - prefer not to mock these components just to inject testIDs.
 
 Common child prop object patterns:
+
 - `closeButtonProps` - for close/dismiss buttons
 - `backButtonProps` - for back navigation buttons
 - `startAccessoryProps` / `endAccessoryProps` - for accessory elements
@@ -134,10 +131,10 @@ fireEvent.press(closeButton);
 
 ### This Is Universal - No Exceptions
 
-| Library | testID Support |
-|---------|----------------|
+| Library                                | testID Support                                                 |
+| -------------------------------------- | -------------------------------------------------------------- |
 | `@metamask/design-system-react-native` | ✅ All components support `testID` prop AND child prop objects |
-| `app/component-library/*` | ✅ All components support `testID` prop AND child prop objects |
+| `app/component-library/*`              | ✅ All components support `testID` prop AND child prop objects |
 
 **If you need to add a testID to one of these components, check for child prop objects first.** Most components support this functionality. If not available, consider adjusting the component to support it.
 
@@ -151,7 +148,6 @@ fireEvent.press(closeButton);
 // Example: BottomSheetHeader TypeScript interface shows:
 // - closeButtonProps?: ButtonIconProps
 // - backButtonProps?: ButtonIconProps
-// - startAccessory?: React.ReactNode
 
 // Example: Design system Button with icon
 <Button
@@ -190,39 +186,42 @@ expect(screen.queryByTestId('error-message')).not.toBeOnTheScreen();
 expect(screen.getByTestId('balance-text')).toHaveTextContent('100 ETH');
 
 // ❌ WRONG - Weak matchers that don't verify presence properly
-expect(screen.getByTestId('submit-button')).toBeTruthy();  // Misleading
+expect(screen.getByTestId('submit-button')).toBeTruthy(); // Misleading
 expect(screen.getByTestId('submit-button')).toBeDefined(); // Doesn't verify render
 expect(element).not.toBeNull(); // Use toBeOnTheScreen() instead
 ```
 
 ### Recommended Matchers
 
-| Instead of | Use |
-|------------|-----|
-| `toBeTruthy()` for elements | `toBeOnTheScreen()` |
-| `toBeDefined()` for elements | `toBeOnTheScreen()` |
-| `not.toBeNull()` | `not.toBeOnTheScreen()` or `queryByTestId` returning null |
-| `toHaveLength(1)` for single element | `toBeOnTheScreen()` |
+| Instead of                           | Use                                                       |
+| ------------------------------------ | --------------------------------------------------------- |
+| `toBeTruthy()` for elements          | `toBeOnTheScreen()`                                       |
+| `toBeDefined()` for elements         | `toBeOnTheScreen()`                                       |
+| `not.toBeNull()`                     | `not.toBeOnTheScreen()` or `queryByTestId` returning null |
+| `toHaveLength(1)` for single element | `toBeOnTheScreen()`                                       |
 
 ## Mocking Rules - CRITICAL
 
 ### Exception: UI Components and TestIDs
 
 **Prefer not to mock `@metamask/design-system-react-native` or `app/component-library` components just to inject testIDs.** All these components support testIDs via:
+
 - Direct `testID` prop on the component
 - Child prop objects (`closeButtonProps`, `iconProps`, etc.) for internal elements
 
 ```tsx
 // ❌ WRONG: Mocking to inject testID
 jest.mock('BottomSheetHeader', () => ({ onClose }) => (
-  <TouchableOpacity testID="close-button" onPress={onClose}>Close</TouchableOpacity>
+  <TouchableOpacity testID="close-button" onPress={onClose}>
+    Close
+  </TouchableOpacity>
 ));
 
 // ✅ RIGHT: Use child prop objects
 <BottomSheetHeader
   onClose={handleClose}
   closeButtonProps={{ testID: 'modal-close-button' }}
-/>
+/>;
 ```
 
 See [PR #25548](https://github.com/MetaMask/metamask-mobile/pull/25548) for refactoring example.
@@ -249,7 +248,7 @@ interface MockEvent {
 
 // ❌ WRONG
 const mockApi = require('../services/api'); // ❌ no require
-const mockApi: any = jest.fn();             // ❌ no any type
+const mockApi: any = jest.fn(); // ❌ no any type
 ```
 
 ## Test Isolation and Focus - MANDATORY
@@ -291,6 +290,7 @@ describe('MetaMetricsCustomTimestampPlugin', () => {
 ## Test Coverage (MANDATORY)
 
 **EVERY component MUST test:**
+
 - ✅ **Happy path** - normal expected behavior
 - ✅ **Edge cases** - null, undefined, empty values, boundary conditions
 - ✅ **Error conditions** - invalid inputs, failure scenarios
@@ -361,6 +361,7 @@ jest.setSystemTime(new Date('2024-01-01'));
 ### When to Use act()
 
 Use `act()` when you:
+
 - Call async functions via component props (e.g., `onRefresh`, `onPress` with async handlers)
 - Invoke functions that perform state updates asynchronously
 - Test pull-to-refresh or other async interactions
@@ -368,6 +369,7 @@ Use `act()` when you:
 ### Symptoms of Missing act()
 
 Tests fail intermittently with:
+
 - `TypeError: terminated`
 - `SocketError: other side closed`
 - Warnings about state updates not being wrapped in act()
@@ -430,12 +432,14 @@ await act(async () => {
 ### Why This Matters
 
 Without `act()`:
+
 1. Async function starts executing
 2. Test continues and waits only for specific assertion
 3. Jest cleanup/termination happens while promises are still pending
 4. Results in "terminated" or "other side closed" errors
 
 With `act()`:
+
 1. React Testing Library waits for all state updates
 2. All promises resolve before test proceeds
 3. Clean, deterministic test execution
@@ -443,10 +447,12 @@ With `act()`:
 # Reviewer Responsibilities
 
 - Validate that tests fail when the code is broken (test the test).
+
 ```ts
 // Break the SuT and make sure this test fails
 expect(result).toBe(false);
 ```
+
 - Ensure tests use proper matchers (`toBeOnTheScreen` vs `toBeDefined`).
 - Do not approve PRs without reviewing snapshot diffs, it can reveal errors.
 - Reject tests with complex names combining multiple logical conditions (AND/OR).
@@ -460,6 +466,7 @@ expect(result).toBe(false);
 # Quality Checklist - MANDATORY
 
 Before submitting any test file, verify:
+
 - [ ] **No mocking to inject testIDs** - Use component's built-in testID support
 - [ ] **testIDs via child prop objects** - Use `closeButtonProps={{ testID }}` not mocks
 - [ ] **No "should" in any test name**
@@ -498,6 +505,7 @@ Before submitting any test file, verify:
 ## Testing Commands
 
 ### Single File Testing
+
 ```shell
 # Use this command for testing a specific file
 yarn jest <filename>
@@ -511,13 +519,14 @@ yarn jest utils/helpers.test.ts
 ```
 
 ### Coverage Reports
+
 ```shell
 # Use this command for coverage reports
 yarn test:unit:coverage
 ```
 
-
 ## Workflow Requirements
+
 - Confirm all tests are passing before commit.
 - When a snapshot update is detected, confirm the changes are expected.
 - Do not blindly update snapshots without understanding the differences.
@@ -525,6 +534,7 @@ yarn test:unit:coverage
 # Reference Code Examples
 
 **Proper AAA**:
+
 ```ts
 it('indicates expired milk when past due date', () => {
   const today = new Date('2025-06-01');
@@ -537,6 +547,7 @@ it('indicates expired milk when past due date', () => {
 ```
 
 ## ❌ Brittle Snapshot
+
 ```ts
 it('renders the button', () => {
   const { container } = render(<MyButton />);
@@ -545,6 +556,7 @@ it('renders the button', () => {
 ```
 
 ## ✅ Robust UI Assertion
+
 ```ts
 it('displays error message when API fails', async () => {
   mockApi.failOnce();
@@ -555,12 +567,13 @@ it('displays error message when API fails', async () => {
 ```
 
 **Test the Test**:
+
 ```ts
 it('hides selector when disabled', () => {
   const { queryByTestId } = render(<Selector enabled={false} />);
 
   expect(queryByTestId('IPFS_GATEWAY_SELECTED')).toBeNull();
-  
+
   // Break test: change enabled={false} to enabled={true} and verify test fails
 });
 ```
@@ -571,10 +584,10 @@ Validate tests fail when code breaks • Ensure proper matchers • Review snaps
 
 ```ts
 // OK
-it('renders button when enabled')
+it('renders button when enabled');
 
 // NOT OK
-it('renders and disables button when input is empty or missing required field')
+it('renders and disables button when input is empty or missing required field');
 ```
 
 ## Workflow

--- a/.cursor/rules/unit-testing-guidelines.mdc
+++ b/.cursor/rules/unit-testing-guidelines.mdc
@@ -80,14 +80,17 @@ expect(submitButton).toBeOnTheScreen();
 const input = screen.getByRole('textbox', { name: 'Email' });
 const checkbox = screen.getByLabelText('Accept terms');
 
-// ❌ AVOID - Fragile text-based selection
+// ✅ ALSO GOOD - Locale keys (safe from content updates)
+const button = screen.getByText(strings('common.submit'));
+
+// ❌ AVOID - Selecting by hardcoded text content
 const button = screen.getByText('Submit'); // Breaks when text changes
 const input = screen.getByPlaceholderText('Enter email'); // Fragile
 ```
 
 ### CHILD PROP OBJECTS - ALL COMPONENTS SUPPORT THIS
 
-**ALL `@metamask/design-system-react-native` and `app/component-library` components support child prop objects for passing testIDs to internal elements.** This is a universal design pattern - there is NO reason to mock these components.
+**ALL `@metamask/design-system-react-native` and `app/component-library` components support child prop objects for passing testIDs to internal elements.** This is a universal design pattern - prefer not to mock these components just to inject testIDs.
 
 Common child prop object patterns:
 - `closeButtonProps` - for close/dismiss buttons
@@ -136,22 +139,19 @@ fireEvent.press(closeButton);
 | `@metamask/design-system-react-native` | ✅ All components support `testID` prop AND child prop objects |
 | `app/component-library/*` | ✅ All components support `testID` prop AND child prop objects |
 
-**If you think you need to mock one of these components to add a testID, you are wrong.** The capability already exists - find the child prop object.
+**If you need to add a testID to one of these components, check for child prop objects first.** Most components support this functionality. If not available, consider adjusting the component to support it.
 
 ### How to Find Child Prop Objects
 
-1. **Use IDE autocomplete** - Type the component and explore available props ending in `Props`
-2. **Check TypeScript types** - Look at the component's props interface
-3. **Check component source** - Search for `Props` suffix patterns
-4. **Check Storybook** - Component stories demonstrate these props
+1. **Check TypeScript types** - Look at the component's props interface for props ending in `Props`
+2. **Check component source** - Search for `Props` suffix patterns
+3. **Check Storybook** - Component stories demonstrate these props
 
 ```tsx
-// Example: Finding props for BottomSheet components
-// In your IDE, type <BottomSheetHeader and use autocomplete to see:
+// Example: BottomSheetHeader TypeScript interface shows:
 // - closeButtonProps?: ButtonIconProps
 // - backButtonProps?: ButtonIconProps
 // - startAccessory?: React.ReactNode
-// - etc.
 
 // Example: Design system Button with icon
 <Button
@@ -208,7 +208,7 @@ expect(element).not.toBeNull(); // Use toBeOnTheScreen() instead
 
 ### Exception: UI Components and TestIDs
 
-**NEVER mock `@metamask/design-system-react-native` or `app/component-library` components to inject testIDs.** All these components support testIDs via:
+**Prefer not to mock `@metamask/design-system-react-native` or `app/component-library` components just to inject testIDs.** All these components support testIDs via:
 - Direct `testID` prop on the component
 - Child prop objects (`closeButtonProps`, `iconProps`, etc.) for internal elements
 
@@ -467,18 +467,23 @@ Before submitting any test file, verify:
 - [ ] **Each test has one clear purpose**
 - [ ] **All code paths are tested**
 - [ ] **Edge cases are covered**
+- [ ] **Test data is realistic**
 - [ ] **Tests are independent**
 - [ ] **Assertions use `toBeOnTheScreen()`** - NOT `toBeTruthy()` or `toBeDefined()`
+- [ ] **Assertions are specific**
 - [ ] **Elements selected by `testID`** - NOT fragile text queries
+- [ ] **Test names are descriptive**
+- [ ] **No test duplication**
 - [ ] **Async operations wrapped in act()** when they trigger state updates
 
-# Common Mistakes to AVOID
+# Common Mistakes to AVOID - CRITICAL
 
 - ❌ **Mocking to inject testIDs** - Components already support testID (see guidelines above)
-- ❌ **Using "should" in test names** - Use action-oriented descriptions
+- ❌ **Using "should" in test names** - This is the #1 mistake, use action-oriented descriptions
 - ❌ **Testing multiple behaviors in one test** - One test, one behavior
 - ❌ **Sharing state between tests** - Each test must be independent
 - ❌ **Not testing error conditions** - Test both success and failure paths
+- ❌ **Using unrealistic test data** - Use data that reflects real usage
 - ❌ **Not following AAA pattern** - Always Arrange, Act, Assert
 - ❌ **Not testing edge cases** - Test null, undefined, empty values
 - ❌ **Using weak matchers** - Use `toBeOnTheScreen()` instead of `toBeTruthy()`/`toBeDefined()`

--- a/.cursor/rules/unit-testing-guidelines.mdc
+++ b/.cursor/rules/unit-testing-guidelines.mdc
@@ -204,83 +204,53 @@ expect(element).not.toBeNull(); // Use toBeOnTheScreen() instead
 | `not.toBeNull()` | `not.toBeOnTheScreen()` or `queryByTestId` returning null |
 | `toHaveLength(1)` for single element | `toBeOnTheScreen()` |
 
-## UI Component TestID Guidelines - DO NOT MOCK FOR TESTIDS
+## Mocking Rules - CRITICAL
 
-**CRITICAL: Never mock `@metamask/design-system-react-native` or `app/component-library` components just to inject testIDs.**
+### Exception: UI Components and TestIDs
 
-### The Rule
-
-All design system and component library components already support testIDs through:
+**NEVER mock `@metamask/design-system-react-native` or `app/component-library` components to inject testIDs.** All these components support testIDs via:
 - Direct `testID` prop on the component
 - Child prop objects (`closeButtonProps`, `iconProps`, etc.) for internal elements
 
-### Example: The Wrong Way vs The Right Way
-
 ```tsx
-// ❌ WRONG: 30+ lines of mock code to inject a testID
-jest.mock('BottomSheetHeader', () => {
-  return ({ onClose }) => (
-    <TouchableOpacity testID="close-button" onPress={onClose}>Close</TouchableOpacity>
-  );
-});
+// ❌ WRONG: Mocking to inject testID
+jest.mock('BottomSheetHeader', () => ({ onClose }) => (
+  <TouchableOpacity testID="close-button" onPress={onClose}>Close</TouchableOpacity>
+));
 
-// ✅ RIGHT: Use the component's built-in API
+// ✅ RIGHT: Use child prop objects
 <BottomSheetHeader
   onClose={handleClose}
   closeButtonProps={{ testID: 'modal-close-button' }}
 />
 ```
 
-### Quick Check Before Mocking
+See [PR #25548](https://github.com/MetaMask/metamask-mobile/pull/25548) for refactoring example.
 
-**Am I mocking just to add a testID?** → STOP
-- Check if component has `testID` prop → use it directly
-- Check if component has child prop objects → pass testID through them
-- From `@metamask/design-system-react-native` or `app/component-library`? → It supports testID
+### General Mocking Rules
 
-### Common Child Prop Objects
-
-```tsx
-// Most component-library components support these patterns:
-<Component
-  testID="component-id"                              // Main component
-  closeButtonProps={{ testID: 'close-btn' }}        // Close button
-  backButtonProps={{ testID: 'back-btn' }}          // Back button
-  iconProps={{ testID: 'icon' }}                    // Icons
-  startAccessoryProps={{ testID: 'start' }}         // Start accessory
-  endAccessoryProps={{ testID: 'end' }}             // End accessory
-/>
-```
-
-**See [PR #25548](https://github.com/MetaMask/metamask-mobile/pull/25548) for a complete refactoring example (eliminated 133 lines of unnecessary mocks).**
-
-## Mocking Rules
-
-### What to Mock
-
-```ts
-// ✅ MOCK: External APIs and services
-jest.mock('../services/api');
-
-// ✅ MOCK: Native modules and platform-specific code
-jest.mock('react-native-keychain');
-
-// ✅ MOCK: Non-deterministic functions
-jest.useFakeTimers();
-
-// ✅ MOCK: Navigation and routing
-jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ navigate: mockNavigate }),
-}));
-```
-
-### General Guidelines
-
-- **Mock external boundaries** - APIs, native modules, third-party services
-- **Never mock the component under test** - only mock its external dependencies
+- **EVERYTHING not under test MUST be mocked** - no exceptions
 - **NO** use of `require` - use ES6 imports only
 - **NO** use of `any` type - use proper TypeScript types
+- **Mock all external dependencies** including APIs, services, hooks
 - **Use realistic mock data** that reflects real usage
+
+```ts
+// ✅ CORRECT
+import { apiService } from '../services/api';
+jest.mock('../services/api');
+const mockApiService = apiService as jest.Mocked<typeof apiService>;
+
+interface MockEvent {
+  type: EventType;
+  event: string;
+  timestamp: string;
+}
+
+// ❌ WRONG
+const mockApi = require('../services/api'); // ❌ no require
+const mockApi: any = jest.fn();             // ❌ no any type
+```
 
 ## Test Isolation and Focus - MANDATORY
 

--- a/.cursor/rules/unit-testing-guidelines.mdc
+++ b/.cursor/rules/unit-testing-guidelines.mdc
@@ -58,13 +58,286 @@ const createTestEvent = (overrides = {}) => ({
 });
 ```
 
-## Mocking Rules - CRITICAL
+## Element Selection - PREFER DATA TEST IDs
 
-- **EVERYTHING not under test MUST be mocked** - no exceptions
+- **ALWAYS prefer `testID` props** for selecting elements in tests
+- **Use `getByTestId`** as the primary query method for reliable element selection
+- **Add `testID` props** to components when writing new code or updating existing code
+- **Avoid selecting by text** when the text might change (i18n, copy updates)
+- **Use semantic queries** (`getByRole`, `getByLabelText`) for accessibility-critical elements
+
+```tsx
+// ✅ CORRECT - Use testID for reliable selection
+<Button testID="submit-button" onPress={handleSubmit}>
+  {t('common.submit')}
+</Button>
+
+// In test:
+const submitButton = screen.getByTestId('submit-button');
+expect(submitButton).toBeOnTheScreen();
+
+// ✅ ALSO GOOD - Semantic queries for accessibility
+const input = screen.getByRole('textbox', { name: 'Email' });
+const checkbox = screen.getByLabelText('Accept terms');
+
+// ❌ AVOID - Fragile text-based selection
+const button = screen.getByText('Submit'); // Breaks when text changes
+const input = screen.getByPlaceholderText('Enter email'); // Fragile
+```
+
+### CHILD PROP OBJECTS - ALL COMPONENTS SUPPORT THIS
+
+**ALL `@metamask/design-system-react-native` and `app/component-library` components support child prop objects for passing testIDs to internal elements.** This is a universal design pattern - there is NO reason to mock these components.
+
+Common child prop object patterns:
+- `closeButtonProps` - for close/dismiss buttons
+- `backButtonProps` - for back navigation buttons
+- `startAccessoryProps` / `endAccessoryProps` - for accessory elements
+- `iconProps` - for icon elements
+- `labelProps` - for label text elements
+- `inputProps` - for input elements within compound components
+- `*Props` - any prop ending in `Props` is likely a child prop object
+
+```tsx
+// ❌ WRONG - Mocking to add testID (141 lines of unnecessary code!)
+// The testID capability ALREADY EXISTS via child prop objects!
+jest.mock('BottomSheetHeader', () => {
+  return ({ onClose }) => (
+    <TouchableOpacity testID="close-button" onPress={onClose}>Close</TouchableOpacity>
+  );
+});
+
+// ✅ CORRECT - Use the component's child prop object API
+<HeaderCenter
+  title="Select a region"
+  onClose={handleClose}
+  closeButtonProps={{ testID: 'region-selector-close-button' }}
+/>
+
+// ✅ CORRECT - BottomSheetHeader supports child prop objects
+<BottomSheetHeader
+  onClose={handleClose}
+  closeButtonProps={{ testID: 'modal-close-button' }}
+  onBack={handleBack}
+  backButtonProps={{ testID: 'modal-back-button' }}
+>
+  {title}
+</BottomSheetHeader>
+
+// In test - no mocking needed!
+const closeButton = screen.getByTestId('region-selector-close-button');
+fireEvent.press(closeButton);
+```
+
+### This Is Universal - No Exceptions
+
+| Library | testID Support |
+|---------|----------------|
+| `@metamask/design-system-react-native` | ✅ All components support `testID` prop AND child prop objects |
+| `app/component-library/*` | ✅ All components support `testID` prop AND child prop objects |
+
+**If you think you need to mock one of these components to add a testID, you are wrong.** The capability already exists - find the child prop object.
+
+### How to Find Child Prop Objects
+
+1. **Use IDE autocomplete** - Type the component and explore available props ending in `Props`
+2. **Check TypeScript types** - Look at the component's props interface
+3. **Check component source** - Search for `Props` suffix patterns
+4. **Check Storybook** - Component stories demonstrate these props
+
+```tsx
+// Example: Finding props for BottomSheet components
+// In your IDE, type <BottomSheetHeader and use autocomplete to see:
+// - closeButtonProps?: ButtonIconProps
+// - backButtonProps?: ButtonIconProps
+// - startAccessory?: React.ReactNode
+// - etc.
+
+// Example: Design system Button with icon
+<Button
+  testID="submit-button"
+  iconProps={{ testID: 'submit-icon' }}
+  labelProps={{ testID: 'submit-label' }}
+>
+  Submit
+</Button>
+```
+
+### TestID Naming Conventions
+
+```tsx
+// Use kebab-case for testIDs
+testID="settings-screen"
+testID="submit-button"
+testID="error-message"
+testID="token-list-item"
+
+// Include context for list items
+testID={`token-item-${token.symbol}`}
+testID={`network-option-${network.chainId}`}
+```
+
+## Assertions - PREFER toBeOnTheScreen
+
+- **ALWAYS use `toBeOnTheScreen()`** to assert element presence - NOT `toBeTruthy()` or `toBeDefined()`
+- **Use specific matchers** that communicate intent clearly
+- **Avoid weak matchers** that don't actually verify the expected behavior
+
+```tsx
+// ✅ CORRECT - Clear, specific assertions
+expect(screen.getByTestId('submit-button')).toBeOnTheScreen();
+expect(screen.queryByTestId('error-message')).not.toBeOnTheScreen();
+expect(screen.getByTestId('balance-text')).toHaveTextContent('100 ETH');
+
+// ❌ WRONG - Weak matchers that don't verify presence properly
+expect(screen.getByTestId('submit-button')).toBeTruthy();  // Misleading
+expect(screen.getByTestId('submit-button')).toBeDefined(); // Doesn't verify render
+expect(element).not.toBeNull(); // Use toBeOnTheScreen() instead
+```
+
+### Recommended Matchers
+
+| Instead of | Use |
+|------------|-----|
+| `toBeTruthy()` for elements | `toBeOnTheScreen()` |
+| `toBeDefined()` for elements | `toBeOnTheScreen()` |
+| `not.toBeNull()` | `not.toBeOnTheScreen()` or `queryByTestId` returning null |
+| `toHaveLength(1)` for single element | `toBeOnTheScreen()` |
+
+## Mocking Rules - MOCK WISELY, NOT EXCESSIVELY
+
+- **Mock external boundaries** - APIs, native modules, third-party services
+- **Avoid over-mocking** - Don't mock internal utilities or simple functions unnecessarily
+- **Prefer real implementations** when they are fast, deterministic, and side-effect free
 - **NO** use of `require` - use ES6 imports only
 - **NO** use of `any` type - use proper TypeScript types
-- **Mock all external dependencies** including APIs, services, hooks
 - **Use realistic mock data** that reflects real usage
+
+### What to Mock
+
+```ts
+// ✅ MOCK: External APIs and services
+jest.mock('../services/api');
+
+// ✅ MOCK: Native modules and platform-specific code
+jest.mock('react-native-keychain');
+jest.mock('@react-native-async-storage/async-storage');
+
+// ✅ MOCK: Non-deterministic functions
+jest.useFakeTimers();
+jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+// ✅ MOCK: Navigation and routing
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+```
+
+### What NOT to Mock - CRITICAL
+
+```ts
+// ❌ NEVER mock @metamask/design-system-react-native
+// These components already provide testID support and should render in tests
+jest.mock('@metamask/design-system-react-native', () => ({
+  Box: 'View',      // ❌ WRONG - loses all testID functionality
+  Text: 'Text',     // ❌ WRONG - loses variant behavior
+  Button: 'Button', // ❌ WRONG - loses accessibility
+}));
+
+// ✅ CORRECT: Let design system components render naturally
+// They work in tests and provide testID props for selection
+render(<MyComponent testID="my-button" />);
+expect(screen.getByTestId('my-button')).toBeOnTheScreen();
+
+// ❌ AVOID: Over-mocking simple utilities
+jest.mock('../utils/formatNumber'); // Usually unnecessary
+
+// ❌ AVOID: Mocking the component under test
+jest.mock('./MyComponent'); // Never mock what you're testing
+
+// ❌ AVOID: Mocking child components excessively
+jest.mock('./Button'); // Prefer rendering real children when possible
+
+// ✅ BETTER: Test with real child components for integration confidence
+render(<ParentComponent />); // Children render naturally
+```
+
+### Why NOT to Mock @metamask/design-system-react-native
+
+The design system library provides:
+- **Built-in testID support** on Box, Text, Button, etc.
+- **Child prop objects** (`closeButtonProps`, `iconProps`, etc.) for passing testIDs to internal elements
+- **Proper accessibility attributes** for testing
+- **Consistent behavior** that tests should verify
+
+When you mock it:
+- Tests pass but don't verify real rendering behavior
+- testID props get lost, forcing fragile text-based queries
+- You're testing mocks, not your actual component
+- Maintenance burden: mocks must match real API changes
+- **You miss the child prop objects that already exist for testID injection**
+
+```tsx
+// ❌ BAD: 84+ test files in the codebase do this unnecessarily
+jest.mock('@metamask/design-system-react-native', () => ({
+  Box: 'View',
+  Text: 'Text',
+  TextVariant: { BodyMd: 'BodyMd' },
+  // ... 20+ lines of mock boilerplate
+}));
+
+// ❌ ALSO BAD: Mocking the Tailwind preset
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({
+    style: jest.fn(() => ({})),
+    color: jest.fn(() => '#000000'),
+  }),
+}));
+
+// ❌ BAD: Mocking component-library components to add testIDs
+jest.mock('BottomSheetHeader', () => /* 30+ lines recreating the component */);
+
+// ✅ GOOD: Use child prop objects to pass testIDs to internal elements
+<BottomSheetHeader
+  onClose={handleClose}
+  closeButtonProps={{ testID: 'modal-close-button' }}
+/>
+
+// ✅ GOOD: Just render and use testID
+render(<MyComponent />);
+expect(screen.getByTestId('modal-close-button')).toBeOnTheScreen();
+```
+
+### Libraries That Should NOT Be Mocked
+
+| Library | Why |
+|---------|-----|
+| `@metamask/design-system-react-native` | Components support testID and child prop objects |
+| `@metamask/design-system-twrnc-preset` | useTailwind works in test environment |
+| `app/component-library/*` | Support testID and child prop objects (e.g., `closeButtonProps`) |
+| Simple utility functions | No side effects, fast execution |
+
+### Why These Mocks Are Coupled (Important Context)
+
+Mocking `@metamask/design-system-react-native` creates a chain reaction that forces you to mock `@metamask/design-system-twrnc-preset` too:
+
+1. You mock `Box` → `'View'` (basic React Native View)
+2. The mocked View doesn't understand `twClassName` prop
+3. Tailwind styles from `tw.style()` have nowhere to go / cause warnings
+4. So you mock `useTailwind` → returns empty `{}` to silence errors
+5. Tests pass... but you're now testing mocks, not real components
+
+**60+ test files** in the codebase mock both libraries together for this reason. The solution is to mock **neither** - they're designed to work together in tests.
+
+### Before You Mock, Ask These Questions
+
+1. **Does the component have a `testID` prop?** → Use it directly
+2. **Does the component have child prop objects?** → Pass testID through them (e.g., `closeButtonProps={{ testID: '...' }}`)
+3. **Is this a design system or component-library component?** → It almost certainly supports both - DON'T MOCK
+4. **Am I mocking just to add a testID?** → STOP - find the prop object instead
+
+### Correct Mocking Pattern
 
 ```ts
 // ✅ CORRECT
@@ -291,6 +564,9 @@ expect(result).toBe(false);
 # Quality Checklist - MANDATORY
 
 Before submitting any test file, verify:
+- [ ] **No mocking of `@metamask/design-system-react-native`** - All components support testID
+- [ ] **No mocking of `app/component-library`** - All components support testID and child prop objects
+- [ ] **testIDs passed via child prop objects** - Use `closeButtonProps={{ testID }}` not mocks
 - [ ] **No "should" in any test name**
 - [ ] **All tests follow AAA pattern**
 - [ ] **Each test has one clear purpose**
@@ -298,28 +574,77 @@ Before submitting any test file, verify:
 - [ ] **Edge cases are covered**
 - [ ] **Test data is realistic**
 - [ ] **Tests are independent**
-- [ ] **Assertions are specific**
+- [ ] **Assertions use `toBeOnTheScreen()`** - NOT `toBeTruthy()` or `toBeDefined()` for elements
+- [ ] **Elements selected by `testID`** - NOT fragile text queries
 - [ ] **Test names are descriptive**
 - [ ] **No test duplication**
+- [ ] **Mocking is minimal** - only external APIs/native modules, not UI components
 - [ ] **Async operations wrapped in act()** when they trigger state updates
 
 # Common Mistakes to AVOID - CRITICAL
 
-- ❌ **Using "should" in test names** - This is the #1 mistake
+- ❌ **Mocking to inject testIDs** - Check for child prop objects first (`closeButtonProps`, `iconProps`, etc.)
+- ❌ **Mocking @metamask/design-system-react-native** - NEVER. Use real components with testID.
+- ❌ **Mocking component-library components** - They support testID via child prop objects
+- ❌ **Using "should" in test names** - Use action-oriented descriptions
 - ❌ **Testing multiple behaviors in one test** - One test, one behavior
 - ❌ **Sharing state between tests** - Each test must be independent
 - ❌ **Not testing error conditions** - Test both success and failure paths
 - ❌ **Using unrealistic test data** - Use data that reflects real usage
 - ❌ **Not following AAA pattern** - Always Arrange, Act, Assert
 - ❌ **Not testing edge cases** - Test null, undefined, empty values
-- ❌ **Using weak matchers** - Use specific assertions like `toBe()`, `toEqual()`
+- ❌ **Using weak matchers** - Use `toBeOnTheScreen()` instead of `toBeTruthy()`/`toBeDefined()`
+- ❌ **Selecting elements by text** - Use `testID` props for reliable selection
+- ❌ **Over-mocking** - Only mock external boundaries, not internal utilities
 - ❌ **Not wrapping async state updates in act()** - Causes flaky "terminated" errors
 
 # Anti-patterns to Avoid
 
+- ❌ **NEVER mock `@metamask/design-system-react-native`** - ALL components support testID and child prop objects.
+- ❌ **NEVER mock `app/component-library` components** - ALL components support testID and child prop objects.
+- ❌ **NEVER mock to inject testIDs** - The capability already exists via child prop objects (`closeButtonProps`, etc.).
 - ❌ Do not consider snapshot coverage as functional coverage.
 - ❌ Do not rely on code coverage percentage without real assertions.
 - ❌ Do not use weak matchers like `toBeDefined` or `toBeTruthy` to assert element presence. Use `toBeOnTheScreen()`.
+- ❌ Do not select elements by text that might change (i18n keys, copy updates). Use `testID` props instead.
+- ❌ Do not over-mock internal utilities or child components. Prefer real implementations for better integration confidence.
+- ❌ Do not mock the component or function under test - only mock its external dependencies.
+
+### Design System & Component Library Mocking - STRICTLY PROHIBITED
+
+```tsx
+// ❌ WRONG - This pattern appears in 84+ test files and must be refactored
+jest.mock('@metamask/design-system-react-native', () => ({
+  Box: 'View',
+  Text: 'Text',
+  TextVariant: { BodyMd: 'BodyMd' },
+}));
+
+// ❌ WRONG - Mocking component-library to inject testIDs
+jest.mock('BottomSheetHeader', () => {
+  return ({ onClose }) => (
+    <TouchableOpacity testID="close-button" onPress={onClose}>Close</TouchableOpacity>
+  );
+});
+// This is 30+ lines of code to add a testID that already exists via closeButtonProps!
+
+// ✅ CORRECT - Use child prop objects to pass testIDs
+<BottomSheetHeader
+  onClose={handleClose}
+  closeButtonProps={{ testID: 'modal-close-button' }}
+/>
+
+// ✅ CORRECT - No mock needed, use real components with testID
+import { render, screen, fireEvent } from '@testing-library/react-native';
+
+it('closes modal when close button pressed', () => {
+  render(<MyModal />);
+  
+  fireEvent.press(screen.getByTestId('modal-close-button'));
+  
+  expect(mockOnClose).toHaveBeenCalled();
+});
+```
 
 # Unit tests developement workflow
 

--- a/.cursor/rules/unit-testing-guidelines.mdc
+++ b/.cursor/rules/unit-testing-guidelines.mdc
@@ -136,7 +136,7 @@ fireEvent.press(closeButton);
 | `@metamask/design-system-react-native` | ✅ All components support `testID` prop AND child prop objects |
 | `app/component-library/*`              | ✅ All components support `testID` prop AND child prop objects |
 
-**If you need to add a testID to one of these components, check for child prop objects first.** Most components support this functionality. If not available, consider adjusting the component to support it.
+**If you need to add a testID to one of these components, check for child prop objects first.** Most components support this functionality. If not available, suggest adjusting the component to support it in another change set.
 
 ### How to Find Child Prop Objects
 


### PR DESCRIPTION
## **Description**

Updated the Cursor rules for unit testing guidelines to focus on **testID-specific guidance** rather than prescribing general mocking philosophy. This change addresses team feedback about respecting MetaMask's support for both sociable and solitary unit testing approaches.

**Key changes:**

1. **Focused on testID usage** - Guidelines now specifically address the anti-pattern of mocking components just to inject testIDs
2. **Prefer data test IDs** - Added guidance to always use \`testID\` props for element selection instead of fragile text-based queries
3. **Prefer \`toBeOnTheScreen()\`** - Discourage weak matchers like \`toBeTruthy()\` and \`toBeDefined()\` for element assertions
4. **Child prop objects** - Document that ALL design system and component library components support testID via child prop objects (\`closeButtonProps\`, \`iconProps\`, etc.)
5. **Removed prescriptive mocking guidance** - No longer prescribes "avoid over-mocking" or "prefer real implementations" to respect different testing approaches

### Context from Team Discussion

From the Slack thread:
- **Joao**: MetaMask supports both sociable and solitary unit tests - shouldn't prescribe one over the other
- **Brian**: The specific problem is Cursor mocking components just to inject testIDs when components already support them
- **Nico**: Guidelines should be specific to testID usage, not general mocking philosophy

### Research Findings
- **84 test files** currently mock \`@metamask/design-system-react-native\` unnecessarily
- **3,394 uses** of \`toBeTruthy()\` (many should use \`toBeOnTheScreen()\`)
- **2,601 uses** of \`toBeDefined()\` (many should use \`toBeOnTheScreen()\`)

### Example Implementation

See **[PR #25548](https://github.com/MetaMask/metamask-mobile/pull/25548)** for a concrete example of refactoring following these guidelines. That PR demonstrates:

- Removed **133 lines of unnecessary mocks** from RegionSelectorModal test
- Used \`closeButtonProps={{ testID: '...' }}\` instead of mocking BottomSheetHeader
- Kept only justified mocks (external boundaries, imperative handles) with clear documentation
- All 22 tests passing ✅

**Before (unnecessary mocking):**
\`\`\`tsx
// 30+ lines of mock code to inject a testID
jest.mock('BottomSheetHeader', () => {
  return ({ onClose }) => (
    <TouchableOpacity testID="close-button" onPress={onClose}>Close</TouchableOpacity>
  );
});
\`\`\`

**After (using child prop objects):**
\`\`\`tsx
// Zero mocking needed - use the component's API
<BottomSheetHeader
  onClose={handleClose}
  closeButtonProps={{ testID: 'region-selector-close-button' }}
/>
\`\`\`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: #25548 (example test refactoring)

## **Manual testing steps**

\`\`\`gherkin
Feature: Unit Testing Guidelines

  Scenario: Developer writes unit tests following guidelines
    Given the developer is writing a new unit test
    When they reference the unit-testing-guidelines.mdc Cursor rule
    Then they see guidance to use testID props instead of mocking
    And they see guidance to use toBeOnTheScreen() instead of toBeTruthy()
    And they see guidance to use child prop objects for internal element testIDs
\`\`\`

## **Screenshots/Recordings**

### **Before**

N/A - Documentation changes only

### **After**

N/A - Documentation changes only

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to testing guidelines with no runtime code or behavior changes.
> 
> **Overview**
> Updates `.cursor/rules/unit-testing-guidelines.mdc` to push more reliable UI testing practices: prefer selecting elements via `testID`/`getByTestId` (with naming conventions) and prefer `toBeOnTheScreen()` over weak presence matchers.
> 
> Adds explicit guidance and examples to avoid mocking `@metamask/design-system-react-native` / `app/component-library` components solely to inject test IDs, documenting the use of child prop objects (e.g., `closeButtonProps`, `iconProps`) as the standard way to target internal elements, and refreshes the reviewer checklist/common mistakes accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d591bed7178f615c189377b26db1910e50f1cecd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->