### PR TITLE
chore: simplify local e2e testing setup

### DIFF
--- a/docs/readme/e2e-testing.md
+++ b/docs/readme/e2e-testing.md
@@ -72,21 +72,32 @@ Ensure that following devices are set up:
    export PREBUILT_ANDROID_TEST_APK_PATH='build/MetaMask-Test.apk'
    ```
 
-3. Create the build directory if it doesn't exist:
+### App Build
+
+You can either use prebuilt app files from Expo (iOS only) or build the app locally.
+
+#### Option 1: Use Expo Prebuilds (iOS Only)
+
+Choose one of the following methods to download the prebuilt iOS app:
+
+**Method A: Using Runway Script (Recommended)**
+
+```bash
+yarn install:ios:runway --skipInstall
+```
+
+**Method B: Manual Download from Runway**
+
+1. Navigate to [Runway builds](https://app.runway.team/bucket/aCddXOkg1p_nDryri-FMyvkC9KRqQeVT_12sf6Nw0u6iGygGo6BlNzjD6bOt-zma260EzAxdpXmlp2GQphp3TN1s6AJE4i6d_9V0Tv5h4pHISU49dFk=)
+2. Download the latest version of the app
+3. Copy and rename the build:
 
    ```bash
-   # In root of project
-   mkdir build
+   # Copy your downloaded .app file to the prebuild path
+   cp /path/to/your/downloaded/AAA.app build/MetaMask.app
    ```
 
-4. Install dependencies
-
-   ```bash
-   # In root of project
-   yarn setup:expo
-   ```
-
-### Build the app (optional)
+#### Option 2: Build the App Locally
 
 Sometimes it is necessary to build the app locally, for example, to enable build-time feature flags (like GNS), to debug issues more effectively, or to identify and update element locators.
 
@@ -102,57 +113,56 @@ yarn test:e2e:android:debug:build
 # These commands are hardcoded to build for `main` build type and `e2e` environment based on the .detoxrc.js file
 ```
 
-### Use Expo prebuilds (iOS Only)
-
-You can use prebuilt app files instead of building the app locally.
-
-#### iOS builds
-
-1. **Download iOS simulator builds** from Runway/Bitrise/GitHub workflows (build jobs)
-
-2. **Copy and rename the build**: Copy your downloaded .app file to the prebuild path
-
-   ```bash
-   # Copy your downloaded .app file to the prebuild path
-   cp /path/to/your/downloaded/AAA.app build/MetaMask.app
-   ```
-
-3. **Start the build watcher**:
-
-   ```bash
-   source .e2e.env && yarn watch:clean
-   ```
-
-4. **Launch the iPhone 15 Pro simulator** from Xcode or in a new terminal by:
-
-   ```bash
-   xcrun simctl boot "iPhone 15 Pro"
-   open -a Simulator # to open the simulator app GUI
-   ```
-
 ### Run the E2E Tests
 
+Running E2E tests requires two separate terminal sessions: one for the Metro bundler and one for executing the tests.
+
+#### Terminal 1: Start the Metro Bundler
+
+First, ensure the build watcher is running in a dedicated terminal for logs:
+
 ```bash
-# Firstly, make sure the build watcher is running in a dedicated terminal for the logs
-# and the emulators are up and running
-# Ensure METAMASK_BUILD_TYPE is set to `main` and METAMASK_ENVIRONMENT is set to `e2e` in .js.env
-source .e2e.env   # Ensure .js.env is sourced
+export METAMASK_ENVIRONMENT='e2e'
+export METAMASK_BUILD_TYPE='main'
+yarn setup:expo
 yarn watch:clean  # First time or after dependency changes
 yarn watch        # Subsequent runs
+```
 
-# Run all Tests
+#### Terminal 2: Execute Tests
+
+In a separate terminal, set up and run your tests:
+
+**Initial Setup (First Time Only)**
+
+```bash
+cp .e2e.env.example .e2e.env
+```
+
+**Run All Tests**
+
+```bash
 source .e2e.env && yarn test:e2e:ios:debug:run
 source .e2e.env && yarn test:e2e:android:debug:run
+```
 
-# Run specific folder
+**Run Specific Test Folder**
+
+```bash
 source .e2e.env && yarn test:e2e:ios:debug:run e2e/specs/your-folder
 source .e2e.env && yarn test:e2e:android:debug:run e2e/specs/your-folder
+```
 
-# Run specific test
+**Run Specific Test File**
+
+```bash
 source .e2e.env && yarn test:e2e:ios:debug:run e2e/specs/onboarding/create-wallet.spec.js
 source .e2e.env && yarn test:e2e:android:debug:run e2e/specs/onboarding/create-wallet.spec.js
+```
 
-# Run tests by tag
+**Run Tests by Tag**
+
+```bash
 source .e2e.env && yarn test:e2e:ios:debug:run --testNamePattern="Smoke"
 source .e2e.env && yarn test:e2e:android:debug:run --testNamePattern="Smoke"
 ```


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
After trying to debug an e2e test that was failing on the CI, I attempted to set up my local environment to run these same e2e tests.

After a lot of trial and error, I managed to get them running, I have updated the Docs that explain how to get started and improved the `install-ios-runway-app` script so that it can be reused for this scenario which simplifies the tester's life and prevents them from having to download the build manually from runway

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: simplify local e2e testing setup

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2569

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to developer documentation and a local iOS Runway install helper script; risk is mainly around breaking existing local workflows due to the new `build/` artifact location and fixed `MetaMask.app` naming.
> 
> **Overview**
> Simplifies local E2E setup docs by restructuring the flow into **App Build** (Expo prebuild download vs local build) and **Run the E2E Tests** (explicit two-terminal Metro/test execution steps), with clearer commands for running all tests, a folder, a file, or by tag.
> 
> Updates `install-ios-runway-app.sh` to store Runway artifacts in `build/`, always extract/expect `MetaMask.app`, and adds `--skipInstall` to support download-only runs without requiring a booted simulator.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fcfa65ac7373b0ec152f659515cbabfac1258e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->