### PR TITLE
refactor(perps): use params in the controller and remove unused route

### DIFF
--- a/app/components/UI/Perps/controllers/PerpsController.test.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.test.ts
@@ -2381,7 +2381,9 @@ describe('PerpsController', () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
 
-      const result = await controller.depositWithConfirmation('100');
+      const result = await controller.depositWithConfirmation({
+        amount: '100',
+      });
 
       expect(result).toEqual({
         result: expect.any(Promise),
@@ -2392,7 +2394,7 @@ describe('PerpsController', () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
 
-      await controller.depositWithConfirmation('100');
+      await controller.depositWithConfirmation({ amount: '100' });
 
       expect(
         mockDepositServiceInstance.prepareTransaction,
@@ -2405,7 +2407,7 @@ describe('PerpsController', () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
 
-      await controller.depositWithConfirmation('100');
+      await controller.depositWithConfirmation({ amount: '100' });
 
       expect(
         mockInfrastructure.controllers.network.findNetworkClientIdForChain,
@@ -2416,7 +2418,7 @@ describe('PerpsController', () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
 
-      await controller.depositWithConfirmation('100');
+      await controller.depositWithConfirmation({ amount: '100' });
 
       expect(
         mockInfrastructure.controllers.transaction.submit,
@@ -2431,16 +2433,18 @@ describe('PerpsController', () => {
     it('throws error when controller not initialized', async () => {
       controller.testSetInitialized(false);
 
-      await expect(controller.depositWithConfirmation('100')).rejects.toThrow(
-        'CLIENT_NOT_INITIALIZED',
-      );
+      await expect(
+        controller.depositWithConfirmation({ amount: '100' }),
+      ).rejects.toThrow('CLIENT_NOT_INITIALIZED');
     });
 
     it('throws error when no active provider', async () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map());
 
-      await expect(controller.depositWithConfirmation('100')).rejects.toThrow();
+      await expect(
+        controller.depositWithConfirmation({ amount: '100' }),
+      ).rejects.toThrow();
     });
 
     it('propagates DepositService errors', async () => {
@@ -2451,9 +2455,9 @@ describe('PerpsController', () => {
         .spyOn(mockDepositServiceInstance, 'prepareTransaction')
         .mockRejectedValue(mockError);
 
-      await expect(controller.depositWithConfirmation('100')).rejects.toThrow(
-        'Deposit service failed',
-      );
+      await expect(
+        controller.depositWithConfirmation({ amount: '100' }),
+      ).rejects.toThrow('Deposit service failed');
     });
 
     it('propagates controllers.network.findNetworkClientIdForChain errors', async () => {
@@ -2467,9 +2471,9 @@ describe('PerpsController', () => {
         throw mockError;
       });
 
-      await expect(controller.depositWithConfirmation('100')).rejects.toThrow(
-        'Network client not found',
-      );
+      await expect(
+        controller.depositWithConfirmation({ amount: '100' }),
+      ).rejects.toThrow('Network client not found');
     });
 
     it('propagates controllers.transaction.submit errors', async () => {
@@ -2480,9 +2484,9 @@ describe('PerpsController', () => {
         mockInfrastructure.controllers.transaction.submit as jest.Mock
       ).mockRejectedValue(mockError);
 
-      await expect(controller.depositWithConfirmation('100')).rejects.toThrow(
-        'Transaction failed',
-      );
+      await expect(
+        controller.depositWithConfirmation({ amount: '100' }),
+      ).rejects.toThrow('Transaction failed');
     });
 
     it('clears transaction ID when error occurs and not user cancellation', async () => {
@@ -2496,9 +2500,9 @@ describe('PerpsController', () => {
         mockInfrastructure.controllers.transaction.submit as jest.Mock
       ).mockRejectedValue(mockError);
 
-      await expect(controller.depositWithConfirmation('100')).rejects.toThrow(
-        'Network error',
-      );
+      await expect(
+        controller.depositWithConfirmation({ amount: '100' }),
+      ).rejects.toThrow('Network error');
 
       expect(controller.state.lastDepositTransactionId).toBeNull();
     });
@@ -2514,9 +2518,9 @@ describe('PerpsController', () => {
         mockInfrastructure.controllers.transaction.submit as jest.Mock
       ).mockRejectedValue(mockError);
 
-      await expect(controller.depositWithConfirmation('100')).rejects.toThrow(
-        'User denied',
-      );
+      await expect(
+        controller.depositWithConfirmation({ amount: '100' }),
+      ).rejects.toThrow('User denied');
 
       // When user cancels, transaction ID is not cleared
       expect(controller.state.lastDepositTransactionId).toBe('old-tx-id');
@@ -2536,7 +2540,9 @@ describe('PerpsController', () => {
         };
       });
 
-      const { result } = await controller.depositWithConfirmation('100');
+      const { result } = await controller.depositWithConfirmation({
+        amount: '100',
+      });
 
       await result;
 
@@ -2549,7 +2555,7 @@ describe('PerpsController', () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
 
-      await controller.depositWithConfirmation('100');
+      await controller.depositWithConfirmation({ amount: '100' });
 
       expect(controller.state.lastDepositTransactionId).toBe('tx-meta-123');
     });
@@ -2558,7 +2564,7 @@ describe('PerpsController', () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
 
-      await controller.depositWithConfirmation('100');
+      await controller.depositWithConfirmation({ amount: '100' });
 
       expect(controller.state.depositRequests[0].id).toBe(mockDepositId);
     });
@@ -2567,7 +2573,7 @@ describe('PerpsController', () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
 
-      await controller.depositWithConfirmation('100');
+      await controller.depositWithConfirmation({ amount: '100' });
 
       expect(
         mockDepositServiceInstance.prepareTransaction,
@@ -2580,7 +2586,7 @@ describe('PerpsController', () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
 
-      await controller.depositWithConfirmation('100');
+      await controller.depositWithConfirmation({ amount: '100' });
 
       expect(controller.state.depositRequests).toHaveLength(1);
       expect(controller.state.depositRequests[0].id).toBe(mockDepositId);
@@ -2601,7 +2607,9 @@ describe('PerpsController', () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
 
-      const { result } = await controller.depositWithConfirmation('100');
+      const { result } = await controller.depositWithConfirmation({
+        amount: '100',
+      });
 
       await result;
 
@@ -2615,8 +2623,8 @@ describe('PerpsController', () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
 
-      const deposit1 = controller.depositWithConfirmation('100');
-      const deposit2 = controller.depositWithConfirmation('200');
+      const deposit1 = controller.depositWithConfirmation({ amount: '100' });
+      const deposit2 = controller.depositWithConfirmation({ amount: '200' });
 
       await Promise.all([deposit1, deposit2]);
 
@@ -2626,14 +2634,17 @@ describe('PerpsController', () => {
       expect(amounts).toContain('200');
     });
 
-    it('uses addTransaction when depositAndPlaceOrder is true', async () => {
+    it('uses addTransaction when placeOrder is true', async () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
       mockAddTransaction.mockResolvedValue({
         transactionMeta: mockTransactionMeta,
       });
 
-      await controller.depositWithConfirmation('100', true);
+      await controller.depositWithConfirmation({
+        amount: '100',
+        placeOrder: true,
+      });
 
       expect(mockAddTransaction).toHaveBeenCalledWith(mockTransaction, {
         networkClientId: mockNetworkClientId,
@@ -2652,7 +2663,9 @@ describe('PerpsController', () => {
       markControllerAsInitialized();
       controller.testSetProviders(new Map([['hyperliquid', mockProvider]]));
 
-      const { result } = await controller.depositWithConfirmation('100');
+      const { result } = await controller.depositWithConfirmation({
+        amount: '100',
+      });
 
       // Transaction succeeds
       await result;
@@ -2684,7 +2697,9 @@ describe('PerpsController', () => {
         transactionMeta: mockTransactionMeta,
       });
 
-      const { result } = await controller.depositWithConfirmation('100');
+      const { result } = await controller.depositWithConfirmation({
+        amount: '100',
+      });
 
       // Wait for the result promise to reject
       await expect(result).rejects.toThrow('Network error occurred');
@@ -2729,7 +2744,9 @@ describe('PerpsController', () => {
           transactionMeta: mockTransactionMeta,
         });
 
-        const { result } = await controller.depositWithConfirmation('100');
+        const { result } = await controller.depositWithConfirmation({
+          amount: '100',
+        });
 
         await expect(result).rejects.toThrow(message);
 

--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -57,6 +57,7 @@ import {
   type ClosePositionParams,
   type ClosePositionsParams,
   type ClosePositionsResult,
+  type DepositWithConfirmationParams,
   type EditOrderParams,
   type FeeCalculationParams,
   type FeeCalculationResult,
@@ -1484,13 +1485,12 @@ export class PerpsController extends BaseController<
   /**
    * Simplified deposit method that prepares transaction for confirmation screen
    * No complex state tracking - just sets a loading flag
-   * @param amount - Optional deposit amount
-   * @param depositAndPlaceOrder - If true, uses addTransaction instead of submit to avoid navigation
+   * @param params - Parameters for the deposit flow
+   * @param params.amount - Optional deposit amount
+   * @param params.placeOrder - If true, uses addTransaction instead of submit to avoid navigation
    */
-  async depositWithConfirmation(
-    amount?: string,
-    depositAndPlaceOrder?: boolean,
-  ) {
+  async depositWithConfirmation(params: DepositWithConfirmationParams = {}) {
+    const { amount, placeOrder } = params;
     const { controllers } = this.options.infrastructure;
 
     try {
@@ -1545,7 +1545,7 @@ export class PerpsController extends BaseController<
         skipInitialGasEstimate: true,
       };
 
-      if (depositAndPlaceOrder) {
+      if (placeOrder) {
         // Use addTransaction to create transaction without navigating to confirmation screen
         const { transactionMeta: addedTransactionMeta } = await addTransaction(
           transaction,
@@ -1577,7 +1577,7 @@ export class PerpsController extends BaseController<
       });
 
       // Track the transaction lifecycle only when using submit (deposit-only flow)
-      if (!depositAndPlaceOrder) {
+      if (!placeOrder) {
         // At this point, the confirmation modal is shown to the user
         // The result promise will resolve/reject based on user action and transaction outcome
 
@@ -1698,10 +1698,9 @@ export class PerpsController extends BaseController<
 
   /**
    * Same as depositWithConfirmation - prepares transaction for confirmation screen.
-   * @param amount - Optional deposit amount
    */
-  async depositWithOrder(amount?: string) {
-    return this.depositWithConfirmation(amount, true);
+  async depositWithOrder() {
+    return this.depositWithConfirmation({ placeOrder: true });
   }
 
   /**

--- a/app/components/UI/Perps/controllers/index.ts
+++ b/app/components/UI/Perps/controllers/index.ts
@@ -63,6 +63,7 @@ export type {
 
   // Deposit/withdrawal types
   DepositParams,
+  DepositWithConfirmationParams,
   DepositResult,
   WithdrawParams,
   WithdrawResult,

--- a/app/components/UI/Perps/controllers/types/index.ts
+++ b/app/components/UI/Perps/controllers/types/index.ts
@@ -459,6 +459,14 @@ export interface DepositParams {
   recipient?: Hex; // Recipient address (defaults to selected account)
 }
 
+/** Params for depositWithConfirmation: prepares transaction for confirmation screen */
+export interface DepositWithConfirmationParams {
+  /** Optional deposit amount (display/tracking; actual amount comes from prepared transaction) */
+  amount?: string;
+  /** If true, uses addTransaction instead of submit to avoid navigation (e.g. deposit + place order flow) */
+  placeOrder?: boolean;
+}
+
 export interface DepositResult {
   success: boolean;
   txHash?: string;

--- a/app/components/UI/Perps/hooks/usePerpsTrading.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTrading.ts
@@ -113,22 +113,17 @@ export function usePerpsTrading() {
       result: Promise<string>;
     }> => {
       const controller = Engine.context.PerpsController;
-      return controller.depositWithConfirmation(amount, false);
+      return controller.depositWithConfirmation({ amount, placeOrder: false });
     },
     [],
   );
 
-  const depositWithOrder = useCallback(
-    async (
-      amount?: string,
-    ): Promise<{
-      result: Promise<string>;
-    }> => {
-      const controller = Engine.context.PerpsController;
-      return controller.depositWithOrder(amount);
-    },
-    [],
-  );
+  const depositWithOrder = useCallback(async (): Promise<{
+    result: Promise<string>;
+  }> => {
+    const controller = Engine.context.PerpsController;
+    return controller.depositWithOrder();
+  }, []);
 
   const clearDepositResult = useCallback((): void => {
     const controller = Engine.context.PerpsController;

--- a/app/components/UI/Perps/routes/index.tsx
+++ b/app/components/UI/Perps/routes/index.tsx
@@ -16,7 +16,6 @@ import PerpsMarketListView from '../Views/PerpsMarketListView';
 import PerpsRedirect from '../Views/PerpsRedirect';
 import PerpsPositionsView from '../Views/PerpsPositionsView';
 import PerpsWithdrawView from '../Views/PerpsWithdrawView';
-import PerpsOrderView from '../Views/PerpsOrderView';
 import PerpsClosePositionView from '../Views/PerpsClosePositionView';
 import PerpsCloseAllPositionsView from '../Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView';
 import PerpsCancelAllOrdersView from '../Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView';
@@ -272,15 +271,6 @@ const PerpsScreenStack = () => {
             component={PerpsPositionsView}
             options={{
               title: strings('perps.position.title'),
-              headerShown: false,
-            }}
-          />
-
-          <Stack.Screen
-            name={Routes.PERPS.ORDER}
-            component={PerpsOrderView}
-            options={{
-              title: strings('perps.order.title'),
               headerShown: false,
             }}
           />

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -258,7 +258,6 @@ const Routes = {
   PERPS: {
     ROOT: 'Perps',
     PERPS_TAB: 'PerpsTradingView', // Redirect to wallet home and select perps tab
-    ORDER: 'PerpsOrder',
     WITHDRAW: 'PerpsWithdraw',
     POSITIONS: 'PerpsPositions',
     PERPS_HOME: 'PerpsMarketListView', // Home screen (positions, orders, watchlist, markets)


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Refactor perps controller and remove unused route

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
No visible change

### **After**

<!-- [screenshots/recordings] -->

No visible change

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public `PerpsController.depositWithConfirmation`/hook call signatures and the deposit+order transaction path toggle, which could break existing callers if any weren’t updated.
> 
> **Overview**
> **Refactors perps deposit entrypoints** by changing `PerpsController.depositWithConfirmation` from positional args to a single `DepositWithConfirmationParams` object (`amount`, `placeOrder`), and updates `depositWithOrder`/`usePerpsTrading` accordingly.
> 
> **Cleans up navigation** by removing the unused `Routes.PERPS.ORDER` constant and its screen registration from the perps route stack. Tests are updated to match the new deposit API shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ac40357a2f2731f493504bd2c5369f3a646ce40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->