### PR TITLE
feat: added deeplinking to the NFT screen

### DIFF
--- a/app/constants/deeplinks.ts
+++ b/app/constants/deeplinks.ts
@@ -45,6 +45,7 @@ export enum ACTIONS {
   ONBOARDING = 'onboarding',
   TRENDING = 'trending',
   EARN_MUSD = 'earn-musd',
+  NFT = 'nft',
 }
 
 export const PREFIXES = {
@@ -77,5 +78,6 @@ export const PREFIXES = {
   [ACTIONS.CARD_HOME]: '',
   [ACTIONS.TRENDING]: '',
   [ACTIONS.EARN_MUSD]: '',
+  [ACTIONS.NFT]: '',
   METAMASK: 'metamask://',
 };

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleNftUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleNftUrl.test.ts
@@ -1,0 +1,51 @@
+import { handleNftUrl } from '../handleNftUrl';
+import NavigationService from '../../../../NavigationService';
+import Routes from '../../../../../constants/navigation/Routes';
+
+jest.mock('../../../../NavigationService', () => ({
+  navigation: {
+    navigate: jest.fn(),
+  },
+}));
+
+jest.mock('../../../../SDKConnect/utils/DevLogger', () => ({
+  log: jest.fn(),
+}));
+
+describe('handleNftUrl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('navigates to NFTS_FULL_VIEW with no parameters', () => {
+    handleNftUrl({ nftPath: '' });
+
+    expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
+      Routes.WALLET.NFTS_FULL_VIEW,
+    );
+  });
+
+  it('navigates to NFTS_FULL_VIEW even with query parameters', () => {
+    handleNftUrl({ nftPath: '?someParam=test' });
+
+    expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
+      Routes.WALLET.NFTS_FULL_VIEW,
+    );
+  });
+
+  it('falls back to WALLET.HOME on error', () => {
+    // Force an error by mocking navigate to throw
+    (NavigationService.navigation.navigate as jest.Mock).mockImplementationOnce(
+      () => {
+        throw new Error('Navigation failed');
+      },
+    );
+
+    handleNftUrl({ nftPath: '' });
+
+    // Second call should be fallback
+    expect(NavigationService.navigation.navigate).toHaveBeenLastCalledWith(
+      Routes.WALLET.HOME,
+    );
+  });
+});

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleNftUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleNftUrl.test.ts
@@ -17,16 +17,8 @@ describe('handleNftUrl', () => {
     jest.clearAllMocks();
   });
 
-  it('navigates to NFTS_FULL_VIEW with no parameters', () => {
-    handleNftUrl({ nftPath: '' });
-
-    expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
-      Routes.WALLET.NFTS_FULL_VIEW,
-    );
-  });
-
-  it('navigates to NFTS_FULL_VIEW even with query parameters', () => {
-    handleNftUrl({ nftPath: '?someParam=test' });
+  it('navigates to NFTS_FULL_VIEW', () => {
+    handleNftUrl();
 
     expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
       Routes.WALLET.NFTS_FULL_VIEW,
@@ -41,7 +33,7 @@ describe('handleNftUrl', () => {
       },
     );
 
-    handleNftUrl({ nftPath: '' });
+    handleNftUrl();
 
     // Second call should be fallback
     expect(NavigationService.navigation.navigate).toHaveBeenLastCalledWith(

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleNftUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleNftUrl.test.ts
@@ -1,43 +1,91 @@
 import { handleNftUrl } from '../handleNftUrl';
 import NavigationService from '../../../../NavigationService';
 import Routes from '../../../../../constants/navigation/Routes';
+import DevLogger from '../../../../SDKConnect/utils/DevLogger';
+import Logger from '../../../../../util/Logger';
 
-jest.mock('../../../../NavigationService', () => ({
-  navigation: {
-    navigate: jest.fn(),
-  },
-}));
-
-jest.mock('../../../../SDKConnect/utils/DevLogger', () => ({
-  log: jest.fn(),
-}));
+jest.mock('../../../../NavigationService');
+jest.mock('../../../../SDKConnect/utils/DevLogger');
+jest.mock('../../../../../util/Logger');
 
 describe('handleNftUrl', () => {
+  let mockNavigate: jest.Mock;
+
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockNavigate = jest.fn();
+    NavigationService.navigation = {
+      navigate: mockNavigate,
+    } as unknown as typeof NavigationService.navigation;
+
+    (DevLogger.log as jest.Mock) = jest.fn();
+    (Logger.error as jest.Mock) = jest.fn();
   });
 
   it('navigates to NFTS_FULL_VIEW', () => {
     handleNftUrl();
 
-    expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
-      Routes.WALLET.NFTS_FULL_VIEW,
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.NFTS_FULL_VIEW);
+  });
+
+  it('logs start of deeplink handling', () => {
+    handleNftUrl();
+
+    expect(DevLogger.log).toHaveBeenCalledWith(
+      '[handleNftUrl] Starting NFT deeplink handling',
     );
   });
 
-  it('falls back to WALLET.HOME on error', () => {
-    // Force an error by mocking navigate to throw
-    (NavigationService.navigation.navigate as jest.Mock).mockImplementationOnce(
-      () => {
-        throw new Error('Navigation failed');
-      },
-    );
+  it('falls back to WALLET.HOME on navigation error', () => {
+    mockNavigate.mockImplementationOnce(() => {
+      throw new Error('Navigation error');
+    });
 
     handleNftUrl();
 
-    // Second call should be fallback
-    expect(NavigationService.navigation.navigate).toHaveBeenLastCalledWith(
-      Routes.WALLET.HOME,
+    expect(mockNavigate).toHaveBeenCalledTimes(2);
+    expect(mockNavigate).toHaveBeenLastCalledWith(Routes.WALLET.HOME);
+  });
+
+  it('logs error when navigation fails', () => {
+    const error = new Error('Navigation error');
+    mockNavigate.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    handleNftUrl();
+
+    expect(DevLogger.log).toHaveBeenCalledWith(
+      '[handleNftUrl] Failed to handle NFT deeplink:',
+      error,
+    );
+    expect(Logger.error).toHaveBeenCalledWith(
+      error,
+      '[handleNftUrl] Error handling NFT deeplink',
+    );
+  });
+
+  it('logs error when fallback navigation also fails', () => {
+    const primaryError = new Error('Primary navigation error');
+    const fallbackError = new Error('Fallback navigation error');
+    mockNavigate
+      .mockImplementationOnce(() => {
+        throw primaryError;
+      })
+      .mockImplementationOnce(() => {
+        throw fallbackError;
+      });
+
+    handleNftUrl();
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      primaryError,
+      '[handleNftUrl] Error handling NFT deeplink',
+    );
+    expect(Logger.error).toHaveBeenCalledWith(
+      fallbackError,
+      '[handleNftUrl] Failed to navigate to fallback screen',
     );
   });
 });

--- a/app/core/DeeplinkManager/handlers/legacy/handleNftUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleNftUrl.ts
@@ -2,21 +2,15 @@ import NavigationService from '../../../NavigationService';
 import Routes from '../../../../constants/navigation/Routes';
 import DevLogger from '../../../SDKConnect/utils/DevLogger';
 
-interface HandleNftUrlParams {
-  nftPath: string;
-}
-
 /**
  * NFT deeplink handler
  *
  * Supported URL formats:
  * - https://link.metamask.io/nft
  * - https://metamask.io/nft (mapped via Branch)
- *
- * @param params Object containing the NFT path
  */
-export const handleNftUrl = ({ nftPath }: HandleNftUrlParams) => {
-  DevLogger.log('[handleNftUrl] Starting NFT deeplink handling', nftPath);
+export const handleNftUrl = () => {
+  DevLogger.log('[handleNftUrl] Starting NFT deeplink handling');
 
   try {
     // Navigate to the NFT full view

--- a/app/core/DeeplinkManager/handlers/legacy/handleNftUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleNftUrl.ts
@@ -1,0 +1,29 @@
+import NavigationService from '../../../NavigationService';
+import Routes from '../../../../constants/navigation/Routes';
+import DevLogger from '../../../SDKConnect/utils/DevLogger';
+
+interface HandleNftUrlParams {
+  nftPath: string;
+}
+
+/**
+ * NFT deeplink handler
+ *
+ * Supported URL formats:
+ * - https://link.metamask.io/nft
+ * - https://metamask.io/nft (mapped via Branch)
+ *
+ * @param params Object containing the NFT path
+ */
+export const handleNftUrl = ({ nftPath }: HandleNftUrlParams) => {
+  DevLogger.log('[handleNftUrl] Starting NFT deeplink handling', nftPath);
+
+  try {
+    // Navigate to the NFT full view
+    NavigationService.navigation.navigate(Routes.WALLET.NFTS_FULL_VIEW);
+  } catch (error) {
+    DevLogger.log('Failed to handle NFT deeplink:', error);
+    // Fallback navigation on error
+    NavigationService.navigation.navigate(Routes.WALLET.HOME);
+  }
+};

--- a/app/core/DeeplinkManager/handlers/legacy/handleNftUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleNftUrl.ts
@@ -1,6 +1,7 @@
 import NavigationService from '../../../NavigationService';
 import Routes from '../../../../constants/navigation/Routes';
 import DevLogger from '../../../SDKConnect/utils/DevLogger';
+import Logger from '../../../../util/Logger';
 
 /**
  * NFT deeplink handler
@@ -13,11 +14,18 @@ export const handleNftUrl = () => {
   DevLogger.log('[handleNftUrl] Starting NFT deeplink handling');
 
   try {
-    // Navigate to the NFT full view
     NavigationService.navigation.navigate(Routes.WALLET.NFTS_FULL_VIEW);
   } catch (error) {
-    DevLogger.log('Failed to handle NFT deeplink:', error);
-    // Fallback navigation on error
-    NavigationService.navigation.navigate(Routes.WALLET.HOME);
+    DevLogger.log('[handleNftUrl] Failed to handle NFT deeplink:', error);
+    Logger.error(error as Error, '[handleNftUrl] Error handling NFT deeplink');
+
+    try {
+      NavigationService.navigation.navigate(Routes.WALLET.HOME);
+    } catch (navError) {
+      Logger.error(
+        navError as Error,
+        '[handleNftUrl] Failed to navigate to fallback screen',
+      );
+    }
   }
 };

--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -600,7 +600,7 @@ async function handleUniversalLink({
       break;
     }
     case SUPPORTED_ACTIONS.NFT: {
-      handleNftUrl({ nftPath: actionBasedRampPath });
+      handleNftUrl();
       break;
     }
   }

--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -32,6 +32,7 @@ import { handleCardOnboarding } from './handleCardOnboarding';
 import { handleCardHome } from './handleCardHome';
 import { handleTrendingUrl } from './handleTrendingUrl';
 import { handleEarnMusd } from './handleEarnMusd';
+import { handleNftUrl } from './handleNftUrl';
 import { RampType } from '../../../../reducers/fiatOrders/types';
 import { SHIELD_WEBSITE_URL } from '../../../../constants/shield';
 import {
@@ -82,6 +83,7 @@ const SUPPORTED_ACTIONS = {
   TRENDING: ACTIONS.TRENDING,
   SHIELD: ACTIONS.SHIELD,
   EARN_MUSD: ACTIONS.EARN_MUSD,
+  NFT: ACTIONS.NFT,
   // MetaMask SDK specific actions
   ANDROID_SDK: ACTIONS.ANDROID_SDK,
   CONNECT: ACTIONS.CONNECT,
@@ -595,6 +597,10 @@ async function handleUniversalLink({
     }
     case SUPPORTED_ACTIONS.EARN_MUSD: {
       handleEarnMusd();
+      break;
+    }
+    case SUPPORTED_ACTIONS.NFT: {
+      handleNftUrl({ nftPath: actionBasedRampPath });
       break;
     }
   }

--- a/app/core/DeeplinkManager/types/deepLink.types.ts
+++ b/app/core/DeeplinkManager/types/deepLink.types.ts
@@ -136,6 +136,7 @@ export const SUPPORTED_ACTIONS = [
   ACTIONS.CARD_ONBOARDING,
   ACTIONS.CARD_HOME,
   ACTIONS.SHIELD,
+  ACTIONS.NFT,
 ] as const satisfies readonly ACTIONS[];
 
 export type SupportedAction = (typeof SUPPORTED_ACTIONS)[number];

--- a/app/core/DeeplinkManager/types/deepLinkAnalytics.types.ts
+++ b/app/core/DeeplinkManager/types/deepLinkAnalytics.types.ts
@@ -54,6 +54,7 @@ export enum DeepLinkRoute {
   ENABLE_CARD_BUTTON = 'enable-card-button',
   CARD_ONBOARDING = 'card-onboarding',
   CARD_HOME = 'card-home',
+  NFT = 'nft',
   INVALID = 'invalid',
 }
 

--- a/app/core/DeeplinkManager/util/deeplinks/deepLinkAnalytics.ts
+++ b/app/core/DeeplinkManager/util/deeplinks/deepLinkAnalytics.ts
@@ -445,6 +445,18 @@ const extractShieldProperties = (
 };
 
 /**
+ * Extract properties for NFT route
+ * @param urlParams - URL parameters
+ * @param sensitiveProps - Object to add properties to
+ */
+const extractNftProperties = (
+  _urlParams: UrlParamValues,
+  _sensitiveProps: Record<string, string>,
+): void => {
+  // NFT route doesn't have sensitive parameters to extract
+};
+
+/**
  * Extract properties for INVALID route
  * No properties to extract, this function is a placeholder
  * to satisfy the type checker
@@ -483,6 +495,7 @@ const routeExtractors: Record<
   [DeepLinkRoute.ENABLE_CARD_BUTTON]: extractEnableCardButtonProperties,
   [DeepLinkRoute.CARD_ONBOARDING]: extractCardOnboardingProperties,
   [DeepLinkRoute.CARD_HOME]: extractCardHomeProperties,
+  [DeepLinkRoute.NFT]: extractNftProperties,
   [DeepLinkRoute.INVALID]: extractInvalidProperties,
 };
 
@@ -615,6 +628,8 @@ export const mapSupportedActionToRoute = (
       return DeepLinkRoute.CARD_ONBOARDING;
     case ACTIONS.CARD_HOME:
       return DeepLinkRoute.CARD_HOME;
+    case ACTIONS.NFT:
+      return DeepLinkRoute.NFT;
     default:
       return DeepLinkRoute.INVALID;
   }
@@ -667,6 +682,8 @@ export const extractRouteFromUrl = (url: string): DeepLinkRoute => {
         return DeepLinkRoute.CARD_ONBOARDING;
       case 'card-home':
         return DeepLinkRoute.CARD_HOME;
+      case 'nft':
+        return DeepLinkRoute.NFT;
       case undefined: // Empty path (no segments after filtering)
         return DeepLinkRoute.HOME;
       default:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The marketing team has asked for a deeplink to the NFTs screen/tab. After researching other components I found two kind of behaviors (taking users to the NFTs tab or taking users to the NFTs screen) and raised the question to the marketing team:
<img width="993" height="153" alt="image" src="https://github.com/user-attachments/assets/5d0d43b6-46e6-493d-8b15-c109f0f28ee4" />

Here is the video I attached them (Sound ON):
https://github.com/user-attachments/assets/f7b563c2-8d54-4e77-8297-662469828a6e

Here is their response:
<img width="1134" height="107" alt="image" src="https://github.com/user-attachments/assets/2e89c924-1d5c-4624-844a-6702bf00a7a7" />

Therefore we will be navigating to the NFTs screen (not tab) whenever the deeplink is opened


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added deeplinking to the NFT screen

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2570

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/a826ef60-6f5c-4493-8616-c68d739d69c8


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new deeplink route and handler that only performs in-app navigation plus analytics route mapping, with tests covering the new handler’s error paths.
> 
> **Overview**
> Adds support for the `/nft` universal link action so marketing links like `https://link.metamask.io/nft` navigate directly to the NFTs full view.
> 
> Wires the new `ACTIONS.NFT` through `handleUniversalLink`, the supported-action/type lists, and deep-link analytics route extraction/mapping (no sensitive params extracted). Includes unit tests for `handleNftUrl`, including fallback navigation to `Routes.WALLET.HOME` on errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c77e32ba62815e1c37bae355bcb2a52f2a01133e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->