### PR TITLE
fix: component view test in main

### DIFF
--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
@@ -57,11 +57,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       ),
     ).toBeOnTheScreen();
     expect(
-      getByText(
-        strings('earn.musd_conversion.education.description', {
-          percentage: MUSD_CONVERSION_APY,
-        }),
-      ),
+      getByText(/Convert your stablecoins to mUSD.*receive up to a \d+% bonus/),
     ).toBeOnTheScreen();
     expect(
       getByText(strings('earn.musd_conversion.education.primary_button')),
@@ -393,12 +389,10 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
 
     // Assert
     const description = getByText(
-      strings('earn.musd_conversion.education.description', {
-        percentage: MUSD_CONVERSION_APY,
-      }),
+      /Convert your stablecoins to mUSD.*receive up to a \d+% bonus/,
     );
     expect(description).toBeOnTheScreen();
-    expect(description.props.children).toContain(`${MUSD_CONVERSION_APY}%`);
+    expect(description.props.children[0]).toContain(`${MUSD_CONVERSION_APY}%`);
   });
 
   it('renders education screen when education has been seen', () => {

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { View } from 'react-native';
 import MusdConversionAssetOverviewCta from './index';
 import { EARN_TEST_IDS } from '../../../constants/testIds';
+import { MUSD_CONVERSION_APY } from '../../../constants/musd';
 import { fireEvent } from '@testing-library/react-native';
 import { TokenI } from '../../../../Tokens/types';
 
@@ -97,11 +98,14 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     );
 
     // Assert
-    expect(getByText('Boost your stablecoin balance')).toBeOnTheScreen();
     expect(
-      getByText(/Earn a bonus every time you convert stablecoins to/),
+      getByText(`Get ${MUSD_CONVERSION_APY}% on your stablecoins`),
     ).toBeOnTheScreen();
-    expect(getByText('mUSD')).toBeOnTheScreen();
+    expect(
+      getByText(
+        `Convert your stablecoins to mUSD and receive up to a ${MUSD_CONVERSION_APY}% bonus.`,
+      ),
+    ).toBeOnTheScreen();
   });
 
   it('renders close button when onDismiss is provided', () => {
@@ -498,7 +502,9 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     );
 
     // Assert
-    expect(getByText('Boost your stablecoin balance')).toBeOnTheScreen();
+    expect(
+      getByText(`Get ${MUSD_CONVERSION_APY}% on your stablecoins`),
+    ).toBeOnTheScreen();
   });
 
   it('renders CTA with correct boost description text', () => {
@@ -530,9 +536,10 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
 
     // Assert
     expect(
-      getByText(/Earn a bonus every time you convert stablecoins to/),
+      getByText(
+        `Convert your stablecoins to mUSD and receive up to a ${MUSD_CONVERSION_APY}% bonus.`,
+      ),
     ).toBeOnTheScreen();
-    expect(getByText('mUSD')).toBeOnTheScreen();
   });
 
   it('renders CTA for USDT asset when in allowlist', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- MusdConversionAssetOverviewCta: Align text assertions with current i18n (boost_title / boost_description); use MUSD_CONVERSION_APY and drop redundant getByText('mUSD').

- EarnMusdConversionEducationView: Match description via regex (description is rendered with " Terms apply." in the same Text); assert APY percentage on children[0] instead of children.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to component-view test assertions and how text is matched/inspected, with no production logic modifications.
> 
> **Overview**
> Updates mUSD conversion component-view tests to match the current rendered copy and i18n behavior.
> 
> The education view tests now match the description via regex (to tolerate the appended “Terms apply.” text) and adjust APY assertions to check the first child node. The asset overview CTA tests switch to asserting the new `boost_title`/`boost_description` strings using `MUSD_CONVERSION_APY`, and remove redundant checks for a separate `mUSD` text node.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03c42f64200e198ddfaed43d1f674f0a156d63a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->