### PR TITLE
feat(perps): add error handling and toast for one-click trade tx creation failure

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsDepositStatus.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsDepositStatus.test.ts
@@ -149,6 +149,9 @@ describe('usePerpsDepositStatus', () => {
             hapticsType: NotificationFeedbackType.Success,
           })),
         },
+        oneClickTrade: {
+          txCreationFailed: {} as PerpsToastOptions,
+        },
         withdrawal: {
           withdrawalInProgress: {
             variant: ToastVariants.Icon,

--- a/app/components/UI/Perps/hooks/usePerpsNavigation.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsNavigation.test.ts
@@ -3,6 +3,8 @@ import { waitFor } from '@testing-library/react-native';
 import { useNavigation } from '@react-navigation/native';
 import { usePerpsNavigation } from './usePerpsNavigation';
 import { usePerpsTrading } from './usePerpsTrading';
+import usePerpsToasts from './usePerpsToasts';
+import { usePerpsEventTracking } from './usePerpsEventTracking';
 import Routes from '../../../../constants/navigation/Routes';
 
 jest.mock('@react-navigation/native', () => ({
@@ -10,8 +12,20 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockDepositWithOrder = jest.fn();
+const mockShowToast = jest.fn();
+const mockTrack = jest.fn();
+
 jest.mock('./usePerpsTrading', () => ({
   usePerpsTrading: jest.fn(),
+}));
+
+jest.mock('./usePerpsToasts', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('./usePerpsEventTracking', () => ({
+  usePerpsEventTracking: jest.fn(),
 }));
 
 describe('usePerpsNavigation', () => {
@@ -24,6 +38,11 @@ describe('usePerpsNavigation', () => {
   const mockUsePerpsTrading = usePerpsTrading as jest.MockedFunction<
     typeof usePerpsTrading
   >;
+  const mockUsePerpsToasts = usePerpsToasts as jest.MockedFunction<
+    typeof usePerpsToasts
+  >;
+  const mockUsePerpsEventTracking =
+    usePerpsEventTracking as jest.MockedFunction<typeof usePerpsEventTracking>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -34,6 +53,18 @@ describe('usePerpsNavigation', () => {
     } as Partial<ReturnType<typeof usePerpsTrading>> as ReturnType<
       typeof usePerpsTrading
     >);
+    mockUsePerpsToasts.mockReturnValue({
+      showToast: mockShowToast,
+      PerpsToastOptions: {
+        accountManagement: {
+          deposit: { error: {} },
+          oneClickTrade: { txCreationFailed: {} },
+        },
+      },
+    } as unknown as ReturnType<typeof usePerpsToasts>);
+    mockUsePerpsEventTracking.mockReturnValue({
+      track: mockTrack,
+    });
     mockUseNavigation.mockReturnValue({
       navigate: mockNavigate,
       canGoBack: mockCanGoBack,
@@ -207,6 +238,8 @@ describe('usePerpsNavigation', () => {
       });
 
       expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockShowToast).toHaveBeenCalledWith({});
+      expect(mockTrack).toHaveBeenCalled();
     });
 
     it('navigates to tutorial without params', () => {

--- a/app/components/UI/Perps/hooks/usePerpsNavigation.ts
+++ b/app/components/UI/Perps/hooks/usePerpsNavigation.ts
@@ -4,6 +4,13 @@ import Routes from '../../../../constants/navigation/Routes';
 import type { PerpsNavigationParamList } from '../types/navigation';
 import type { PerpsMarketData, Position, Order } from '../controllers/types';
 import { usePerpsTrading } from './usePerpsTrading';
+import usePerpsToasts from './usePerpsToasts';
+import { usePerpsEventTracking } from './usePerpsEventTracking';
+import {
+  PerpsEventProperties,
+  PerpsEventValues,
+} from '../constants/eventNames';
+import { MetaMetricsEvents } from '../../../hooks/useMetrics';
 import Logger from '../../../../util/Logger';
 import { ensureError } from '../../../../util/errorUtils';
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
@@ -129,6 +136,8 @@ export const usePerpsNavigation = (): PerpsNavigationHandlers => {
   );
 
   const { depositWithOrder } = usePerpsTrading();
+  const { showToast, PerpsToastOptions } = usePerpsToasts();
+  const { track } = usePerpsEventTracking();
 
   const navigateToOrder = useCallback(
     (params: PerpsNavigationParamList['PerpsOrder']) => {
@@ -140,14 +149,32 @@ export const usePerpsNavigation = (): PerpsNavigationHandlers => {
           );
         })
         .catch((error: unknown) => {
-          Logger.error(ensureError(error), {
+          const err = ensureError(error);
+          Logger.error(err, {
             feature: PERPS_CONSTANTS.FeatureName,
             message:
               'Failed to start one-click trade (deposit rejected or failed)',
           });
+
+          track(MetaMetricsEvents.PERPS_ERROR, {
+            [PerpsEventProperties.ERROR_TYPE]:
+              PerpsEventValues.ERROR_TYPE.BACKEND,
+            [PerpsEventProperties.ERROR_MESSAGE]: err.message,
+            [PerpsEventProperties.SOURCE]: PerpsEventValues.SOURCE.TRADE_ACTION,
+          });
+
+          showToast(
+            PerpsToastOptions.accountManagement.oneClickTrade.txCreationFailed,
+          );
         });
     },
-    [navigation, depositWithOrder],
+    [
+      navigation,
+      depositWithOrder,
+      showToast,
+      PerpsToastOptions.accountManagement.oneClickTrade.txCreationFailed,
+      track,
+    ],
   );
 
   const navigateToTutorial = useCallback(

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -47,6 +47,9 @@ export interface PerpsToastOptionsConfig {
       ) => PerpsToastOptions;
       error: PerpsToastOptions;
     };
+    oneClickTrade: {
+      txCreationFailed: PerpsToastOptions;
+    };
     withdrawal: {
       withdrawalInProgress: PerpsToastOptions;
       withdrawalSuccess: (
@@ -396,6 +399,15 @@ const usePerpsToasts = (): {
             labelOptions: getPerpsToastLabels(
               strings('perps.deposit.deposit_failed'),
               strings('perps.deposit.error_generic'),
+            ),
+          },
+        },
+        oneClickTrade: {
+          txCreationFailed: {
+            ...perpsBaseToastOptions.error,
+            labelOptions: getPerpsToastLabels(
+              strings('perps.one_click_trade.tx_creation_failed_title'),
+              strings('perps.one_click_trade.tx_creation_failed_description'),
             ),
           },
         },

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1094,6 +1094,10 @@
       "your_funds_are_available_to_trade": "Your funds are available to trade",
       "track": "Track"
     },
+    "one_click_trade": {
+      "tx_creation_failed_title": "Could not open position",
+      "tx_creation_failed_description": "Transaction creation failed. Please try again."
+    },
     "withdrawal": {
       "title": "Withdraw",
       "insufficient_funds": "Insufficient funds",


### PR DESCRIPTION
## **Description**

When a user starts a one-click trade (Long/Short from market details) and transaction creation fails—e.g. `depositWithOrder()` rejects due to rejection, network, or backend error—the app previously only logged the error. There was no user feedback or analytics.

This PR adds:

1. **Mixpanel / analytics**  
   On failure we send a `Perp Error` event with:
   - `error_type`: backend  
   - `error_message`: thrown error message  
   - `source`: trade_action  

2. **Toast**  
   A dedicated error toast is shown:
   - **Title:** "Could not open position"  
   - **Description:** "Transaction creation failed. Please try again."  


## **Changelog**

CHANGELOG entry: When one-click trade transaction creation fails, users now see an error toast ("Could not open position") and the failure is tracked in analytics.

## **Related issues**

Relates to https://github.com/MetaMask/metamask-mobile/pull/24964

## **Manual testing steps**

```gherkin
Feature: Perps one-click trade error handling

  Scenario: user tries one-click trade and tx creation fails
    Given user is on Perps market details (e.g. ETH) with one-click Long/Short
    When user taps Long or Short and deposit/tx creation fails (e.g. reject in confirmation or simulate failure)
    Then a toast appears: "Could not open position" / "Transaction creation failed. Please try again."
    And a Perp Error analytics event is sent with error_type backend and source trade_action

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="1206" height="2622" alt="simulator_screenshot_53600E3E-B994-46F9-9243-54FB873E070E" src="https://github.com/user-attachments/assets/95e49819-4e85-47d8-9694-0bb46a354e92" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds user-facing toast and error analytics in the one-click trade failure path without changing successful trade/navigation behavior.
> 
> **Overview**
> Adds explicit failure handling for one-click trade initiation: when `depositWithOrder()` rejects in `usePerpsNavigation.navigateToOrder`, the app now **tracks a `PERPS_ERROR` event** (backend error type, message, trade_action source) and **shows a dedicated error toast** instead of only logging.
> 
> Extends `usePerpsToasts` with `accountManagement.oneClickTrade.txCreationFailed` plus new English strings, and updates related hook tests to cover the new toast/tracking behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 375894518eabcbe34c621c1dbaf02cc73113306c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->