### PR TITLE
fix(tron): use BigNumber for staked balance arithmetic to prevent dec…

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -72,23 +72,6 @@ jest.mock('./Balance', () => {
   };
 });
 
-jest.mock('../../../selectors/assets/assets-list', () => ({
-  ...jest.requireActual('../../../selectors/assets/assets-list'),
-  selectTronResourcesBySelectedAccountGroup: jest.fn().mockReturnValue({
-    energy: undefined,
-    bandwidth: undefined,
-    maxEnergy: undefined,
-    maxBandwidth: undefined,
-    stakedTrxForEnergy: undefined,
-    stakedTrxForBandwidth: undefined,
-  }),
-}));
-
-jest.mock('../../../selectors/multichainAccounts/accounts', () => ({
-  ...jest.requireActual('../../../selectors/multichainAccounts/accounts'),
-  selectSelectedInternalAccountByScope: jest.fn(),
-}));
-
 const MOCK_CHAIN_ID = '0x1';
 
 const mockInitialState = {
@@ -312,11 +295,17 @@ jest.mock('../../../selectors/multichainAccounts/accounts', () => ({
     mockSelectSelectedInternalAccountByScope,
 }));
 
-const mockSelectTronResourcesBySelectedAccountGroup = jest.fn();
 jest.mock('../../../selectors/assets/assets-list', () => ({
   ...jest.requireActual('../../../selectors/assets/assets-list'),
-  selectTronResourcesBySelectedAccountGroup: () =>
-    mockSelectTronResourcesBySelectedAccountGroup(),
+  selectTronResourcesBySelectedAccountGroup: jest.fn().mockReturnValue({
+    energy: undefined,
+    bandwidth: undefined,
+    maxEnergy: undefined,
+    maxBandwidth: undefined,
+    stakedTrxForEnergy: undefined,
+    stakedTrxForBandwidth: undefined,
+    totalStakedTrx: 0,
+  }),
 }));
 
 const mockSelectSelectedAccountGroup = jest.fn();
@@ -382,8 +371,19 @@ describe('AssetOverview', () => {
       type: 'eip155:eoa',
     });
 
-    // Default mock for tron resources - return empty array
-    mockSelectTronResourcesBySelectedAccountGroup.mockReturnValue([]);
+    // Default mock for tron resources
+    const { selectTronResourcesBySelectedAccountGroup } = jest.requireMock(
+      '../../../selectors/assets/assets-list',
+    );
+    selectTronResourcesBySelectedAccountGroup.mockReturnValue({
+      energy: undefined,
+      bandwidth: undefined,
+      maxEnergy: undefined,
+      maxBandwidth: undefined,
+      stakedTrxForEnergy: undefined,
+      stakedTrxForBandwidth: undefined,
+      totalStakedTrx: 0,
+    });
 
     // Default mock for unified V1 flag - disabled
     mockUseRampsUnifiedV1Enabled.mockReturnValue(false);
@@ -1028,6 +1028,7 @@ describe('AssetOverview', () => {
       maxBandwidth: undefined,
       stakedTrxForEnergy: { symbol: 'strx-energy', balance: '10' },
       stakedTrxForBandwidth: { symbol: 'strx-bandwidth', balance: '20' },
+      totalStakedTrx: 30,
     });
 
     const tronAsset = {

--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -72,6 +72,23 @@ jest.mock('./Balance', () => {
   };
 });
 
+jest.mock('../../../selectors/assets/assets-list', () => ({
+  ...jest.requireActual('../../../selectors/assets/assets-list'),
+  selectTronResourcesBySelectedAccountGroup: jest.fn().mockReturnValue({
+    energy: undefined,
+    bandwidth: undefined,
+    maxEnergy: undefined,
+    maxBandwidth: undefined,
+    stakedTrxForEnergy: undefined,
+    stakedTrxForBandwidth: undefined,
+  }),
+}));
+
+jest.mock('../../../selectors/multichainAccounts/accounts', () => ({
+  ...jest.requireActual('../../../selectors/multichainAccounts/accounts'),
+  selectSelectedInternalAccountByScope: jest.fn(),
+}));
+
 const MOCK_CHAIN_ID = '0x1';
 
 const mockInitialState = {
@@ -1000,10 +1017,18 @@ describe('AssetOverview', () => {
   });
 
   it('renders staked TRX details when viewing TRX on Tron', () => {
-    mockSelectTronResourcesBySelectedAccountGroup.mockReturnValue([
-      { symbol: 'strx-energy', balance: '10' },
-      { symbol: 'strx-bandwidth', balance: '20' },
-    ]);
+    const { selectTronResourcesBySelectedAccountGroup } = jest.requireMock(
+      '../../../selectors/assets/assets-list',
+    );
+
+    selectTronResourcesBySelectedAccountGroup.mockReturnValue({
+      energy: undefined,
+      bandwidth: undefined,
+      maxEnergy: undefined,
+      maxBandwidth: undefined,
+      stakedTrxForEnergy: { symbol: 'strx-energy', balance: '10' },
+      stakedTrxForBandwidth: { symbol: 'strx-bandwidth', balance: '20' },
+    });
 
     const tronAsset = {
       address: 'tron:mainnet/slip44:195',

--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -244,13 +244,8 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
   ///: END:ONLY_INCLUDE_IF
 
   ///: BEGIN:ONLY_INCLUDE_IF(tron)
-  const tronResources = useSelector(selectTronResourcesBySelectedAccountGroup);
-
-  const strxEnergy = tronResources.find(
-    (a) => a.symbol.toLowerCase() === 'strx-energy',
-  );
-  const strxBandwidth = tronResources.find(
-    (a) => a.symbol.toLowerCase() === 'strx-bandwidth',
+  const { stakedTrxForEnergy, stakedTrxForBandwidth } = useSelector(
+    selectTronResourcesBySelectedAccountGroup,
   );
 
   // Use selector to get live Tron asset balance (not static navigation params)
@@ -600,7 +595,11 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
 
   // create Staked TRX derived asset (same as native TRX but with a new name and balance)
   const stakedTrxAsset = isTronNative
-    ? createStakedTrxAsset(asset, strxEnergy?.balance, strxBandwidth?.balance)
+    ? createStakedTrxAsset(
+        asset,
+        stakedTrxForEnergy?.balance,
+        stakedTrxForBandwidth?.balance,
+      )
     : undefined;
   ///: END:ONLY_INCLUDE_IF
 

--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail.test.tsx
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail.test.tsx
@@ -5,7 +5,10 @@ import { IconName } from '@metamask/design-system-react-native';
 import ResourceRing from './ResourceRing';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../util/test/initial-root-state';
-import { selectTronResourcesBySelectedAccountGroup } from '../../../../selectors/assets/assets-list';
+import {
+  selectTronResourcesBySelectedAccountGroup,
+  TronResourcesMap,
+} from '../../../../selectors/assets/assets-list';
 
 jest.mock('./ResourceRing', () => ({
   __esModule: true,
@@ -36,10 +39,22 @@ jest.mock('../../../../selectors/assets/assets-list', () => ({
 type SelectorReturn = ReturnType<
   typeof selectTronResourcesBySelectedAccountGroup
 >;
+
+const createEmptyResourcesMap = (): TronResourcesMap => ({
+  energy: undefined,
+  bandwidth: undefined,
+  maxEnergy: undefined,
+  maxBandwidth: undefined,
+  stakedTrxForEnergy: undefined,
+  stakedTrxForBandwidth: undefined,
+  totalStakedTrx: 0,
+});
+
 interface Resource {
   symbol: string;
   balance: number | string;
 }
+
 const res = (symbol: string, balance: number | string): Resource => ({
   symbol,
   balance,
@@ -63,16 +78,14 @@ describe('TronEnergyBandwidthDetail', () => {
   });
 
   it('renders values, coverage counts, and passes correct progress to ResourceRing', () => {
-    jest
-      .mocked(selectTronResourcesBySelectedAccountGroup)
-      .mockReturnValue([
-        res('energy', 130000),
-        res('bandwidth', 560),
-        res('max-energy', 200000),
-        res('max-bandwidth', 1000),
-        res('strx-energy', 70000),
-        res('strx-bandwidth', 500),
-      ] as unknown as SelectorReturn);
+    jest.mocked(selectTronResourcesBySelectedAccountGroup).mockReturnValue({
+      energy: res('energy', 130000),
+      bandwidth: res('bandwidth', 560),
+      maxEnergy: res('max-energy', 200000),
+      maxBandwidth: res('max-bandwidth', 1000),
+      stakedTrxForEnergy: res('strx-energy', 70000),
+      stakedTrxForBandwidth: res('strx-bandwidth', 500),
+    } as unknown as SelectorReturn);
 
     const { getByText } = renderWithProvider(<TronEnergyBandwidthDetail />, {
       state: baseState,
@@ -96,16 +109,14 @@ describe('TronEnergyBandwidthDetail', () => {
   });
 
   it('parses balances and caps progress', () => {
-    jest
-      .mocked(selectTronResourcesBySelectedAccountGroup)
-      .mockReturnValue([
-        res('energy', '1000'),
-        res('bandwidth', '2000'),
-        res('max-energy', '400'),
-        res('max-bandwidth', '1000'),
-        res('strx-energy', '500'),
-        res('strx-bandwidth', '500'),
-      ] as unknown as SelectorReturn);
+    jest.mocked(selectTronResourcesBySelectedAccountGroup).mockReturnValue({
+      energy: res('energy', '1000'),
+      bandwidth: res('bandwidth', '2000'),
+      maxEnergy: res('max-energy', '400'),
+      maxBandwidth: res('max-bandwidth', '1000'),
+      stakedTrxForEnergy: res('strx-energy', '500'),
+      stakedTrxForBandwidth: res('strx-bandwidth', '500'),
+    } as unknown as SelectorReturn);
 
     const { getByText } = renderWithProvider(<TronEnergyBandwidthDetail />, {
       state: baseState,
@@ -124,7 +135,7 @@ describe('TronEnergyBandwidthDetail', () => {
   it('handles missing resources by showing zeros and 0 progress', () => {
     jest
       .mocked(selectTronResourcesBySelectedAccountGroup)
-      .mockReturnValue([] as unknown as SelectorReturn);
+      .mockReturnValue(createEmptyResourcesMap());
 
     const { getAllByText, getByText } = renderWithProvider(
       <TronEnergyBandwidthDetail />,

--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail.test.tsx
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail.test.tsx
@@ -85,7 +85,8 @@ describe('TronEnergyBandwidthDetail', () => {
       maxBandwidth: res('max-bandwidth', 1000),
       stakedTrxForEnergy: res('strx-energy', 70000),
       stakedTrxForBandwidth: res('strx-bandwidth', 500),
-    } as unknown as SelectorReturn);
+      totalStakedTrx: 70500,
+    } as SelectorReturn);
 
     const { getByText } = renderWithProvider(<TronEnergyBandwidthDetail />, {
       state: baseState,
@@ -116,7 +117,8 @@ describe('TronEnergyBandwidthDetail', () => {
       maxBandwidth: res('max-bandwidth', '1000'),
       stakedTrxForEnergy: res('strx-energy', '500'),
       stakedTrxForBandwidth: res('strx-bandwidth', '500'),
-    } as unknown as SelectorReturn);
+      totalStakedTrx: 1000,
+    } as SelectorReturn);
 
     const { getByText } = renderWithProvider(<TronEnergyBandwidthDetail />, {
       state: baseState,

--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/useTronResources.ts
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/useTronResources.ts
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import BigNumber from 'bignumber.js';
 
 import { selectTronResourcesBySelectedAccountGroup } from '../../../../selectors/assets/assets-list';
-import { TRON_RESOURCE } from '../../../../core/Multichain/constants';
 
 export interface TronResource {
   type: 'energy' | 'bandwidth';
@@ -15,25 +14,33 @@ export interface TronResource {
   percentage: number;
 }
 
+/**
+ * Parses a value to a number, defaulting to 0.
+ * Use for system values (balances from state) where invalid values should be treated as 0.
+ */
+function parseValue(value?: string | number): number {
+  if (value === undefined || value === null) return 0;
+  // Remove commas from string values before parsing
+  const cleanValue =
+    typeof value === 'string' ? value.replace(/,/g, '') : value;
+  const num = Number(cleanValue);
+  return Number.isNaN(num) ? 0 : num;
+}
+
 function createResource(
   type: TronResource['type'],
   current: number,
   max: number,
 ): TronResource {
   const currentBN = new BigNumber(current);
-  // Use max of 1 only for percentage calculation to avoid division by zero
-  const divisor = new BigNumber(Math.max(1, max));
-  const percentageBN = currentBN.dividedBy(divisor).multipliedBy(100);
 
-  const percentage = BigNumber.min(
-    100,
-    BigNumber.max(0, percentageBN),
-  ).toNumber();
+  const divisor = Math.max(1, max);
+  const percentage = currentBN.div(divisor).multipliedBy(100).toNumber();
 
   return {
     type,
     current,
-    max, // Keep actual max for display (can be 0)
+    max,
     percentage,
   };
 }
@@ -50,43 +57,11 @@ export const useTronResources = (): {
   energy: TronResource;
   bandwidth: TronResource;
 } => {
-  const tronResources = useSelector(selectTronResourcesBySelectedAccountGroup);
+  const { energy, bandwidth, maxEnergy, maxBandwidth } = useSelector(
+    selectTronResourcesBySelectedAccountGroup,
+  );
 
   return useMemo(() => {
-    let energy;
-    let bandwidth;
-    let maxEnergy;
-    let maxBandwidth;
-
-    // Extract the different Tron resource entries from the flat list.
-    for (const asset of tronResources) {
-      switch (asset.symbol?.toLowerCase()) {
-        case TRON_RESOURCE.ENERGY:
-          energy = asset;
-          break;
-        case TRON_RESOURCE.BANDWIDTH:
-          bandwidth = asset;
-          break;
-        case TRON_RESOURCE.MAX_ENERGY:
-          maxEnergy = asset;
-          break;
-        case TRON_RESOURCE.MAX_BANDWIDTH:
-          maxBandwidth = asset;
-          break;
-        default:
-          break;
-      }
-    }
-
-    const parseValue = (value?: string | number): number => {
-      if (value === undefined || value === null) return 0;
-      // Remove commas from string values before parsing
-      const cleanValue =
-        typeof value === 'string' ? value.replace(/,/g, '') : value;
-      const num = Number(cleanValue);
-      return Number.isNaN(num) ? 0 : num;
-    };
-
     const energyCurrent = parseValue(energy?.balance);
     const bandwidthCurrent = parseValue(bandwidth?.balance);
     const maxEnergyValue = parseValue(maxEnergy?.balance);
@@ -100,5 +75,5 @@ export const useTronResources = (): {
         maxBandwidthValue,
       ),
     };
-  }, [tronResources]);
+  }, [energy, bandwidth, maxEnergy, maxBandwidth]);
 };

--- a/app/components/UI/Earn/components/EarnBalance/EarnBalance.test.tsx
+++ b/app/components/UI/Earn/components/EarnBalance/EarnBalance.test.tsx
@@ -144,6 +144,7 @@ const createEmptyResourcesMap = () => ({
   maxBandwidth: undefined,
   stakedTrxForEnergy: undefined,
   stakedTrxForBandwidth: undefined,
+  totalStakedTrx: 0,
 });
 
 describe('EarnBalance', () => {
@@ -285,6 +286,7 @@ describe('EarnBalance', () => {
         ...createEmptyResourcesMap(),
         stakedTrxForEnergy: { symbol: 'strx-energy', balance: '1' },
         stakedTrxForBandwidth: { symbol: 'strx-bandwidth', balance: '2' },
+        totalStakedTrx: 3,
       });
 
       renderWithProvider(<EarnBalance asset={strx as TokenI} />);

--- a/app/components/UI/Earn/components/EarnBalance/EarnBalance.test.tsx
+++ b/app/components/UI/Earn/components/EarnBalance/EarnBalance.test.tsx
@@ -137,13 +137,22 @@ jest.mock('../../hooks/useTronStakeApy', () => ({
   }),
 }));
 
+const createEmptyResourcesMap = () => ({
+  energy: undefined,
+  bandwidth: undefined,
+  maxEnergy: undefined,
+  maxBandwidth: undefined,
+  stakedTrxForEnergy: undefined,
+  stakedTrxForBandwidth: undefined,
+});
+
 describe('EarnBalance', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (jest.mocked(selectTrxStakingEnabled) as jest.Mock).mockReturnValue(false);
     (
       jest.mocked(selectTronResourcesBySelectedAccountGroup) as jest.Mock
-    ).mockReturnValue([]);
+    ).mockReturnValue(createEmptyResourcesMap());
   });
 
   describe('Ethereum Mainnet', () => {
@@ -251,7 +260,7 @@ describe('EarnBalance', () => {
       };
 
       mockFlag.mockReturnValue(true);
-      mockTronResources.mockReturnValue([]);
+      mockTronResources.mockReturnValue(createEmptyResourcesMap());
 
       renderWithProvider(<EarnBalance asset={trx as TokenI} />);
 
@@ -272,10 +281,11 @@ describe('EarnBalance', () => {
       };
 
       mockFlag.mockReturnValue(true);
-      mockTronResources.mockReturnValue([
-        { symbol: 'strx-energy', balance: '1' },
-        { symbol: 'strx-bandwidth', balance: '2' },
-      ]);
+      mockTronResources.mockReturnValue({
+        ...createEmptyResourcesMap(),
+        stakedTrxForEnergy: { symbol: 'strx-energy', balance: '1' },
+        stakedTrxForBandwidth: { symbol: 'strx-bandwidth', balance: '2' },
+      });
 
       renderWithProvider(<EarnBalance asset={strx as TokenI} />);
 

--- a/app/components/UI/Earn/components/Tron/StakePreview/TronStakePreview.test.tsx
+++ b/app/components/UI/Earn/components/Tron/StakePreview/TronStakePreview.test.tsx
@@ -38,6 +38,12 @@ jest.mock('../../../../../../../locales/i18n', () => ({
   },
 }));
 
+const mockUseTronStakeApy = jest.fn();
+jest.mock('../../../hooks/useTronStakeApy', () => ({
+  __esModule: true,
+  default: () => mockUseTronStakeApy(),
+}));
+
 const mockUseSelector = useSelector as jest.Mock;
 
 const createMockResourcesMap = (totalStakedTrx: number): TronResourcesMap => ({
@@ -52,6 +58,15 @@ const createMockResourcesMap = (totalStakedTrx: number): TronResourcesMap => ({
 
 describe('TronStakePreview', () => {
   beforeEach(() => {
+    // Default APY mock
+    mockUseTronStakeApy.mockReturnValue({
+      isLoading: false,
+      errorMessage: null,
+      apyDecimal: '2.44',
+      apyPercent: '2.44%',
+      refetch: jest.fn(),
+    });
+
     // Default: 10 + 5 = 15 TRX staked
     const mockResourcesMap = createMockResourcesMap(15);
 
@@ -68,16 +83,14 @@ describe('TronStakePreview', () => {
   });
 
   it('displays estimated annual reward based on staked balance and input amount', () => {
+    // (15 staked + 5 input) * (2.44 / 100) APR = 0.488 TRX
     const { getByText } = render(<TronStakePreview stakeAmount="5" />);
 
     expect(getByText('Est. annual reward')).toBeOnTheScreen();
-    expect(getByText(/0[,.]670 TRX/)).toBeOnTheScreen();
+    expect(getByText(/0[,.]488 TRX/)).toBeOnTheScreen();
   });
 
   it('calculates annual reward from floating-point balances without precision errors', () => {
-    // This test verifies BigNumber is used for calculations.
-    // totalStakedTrx is now pre-computed in the selector using BigNumber,
-    // so floating-point errors like 65.48463 + 65.48463 = 130.96926000000002 are avoided.
     const mockResourcesMap = createMockResourcesMap(130.96926);
 
     mockUseSelector.mockImplementation((selector: unknown) => {
@@ -88,23 +101,23 @@ describe('TronStakePreview', () => {
     });
 
     // Stake amount of 10, total staked is 130.96926 + 10 = 140.96926
-    // Annual reward = 140.96926 * 0.0335 = 4.722 (rounded to 3 decimals)
+    // Annual reward = 140.96926 * (2.44 / 100) = 3.440 (rounded to 3 decimals)
     const { getByText } = render(<TronStakePreview stakeAmount="10" />);
 
     expect(getByText('Est. annual reward')).toBeOnTheScreen();
-    expect(getByText(/4[,.]722 TRX/)).toBeOnTheScreen();
+    expect(getByText(/3[,.]440 TRX/)).toBeOnTheScreen();
   });
 
   it('displays existing staked balance reward when stakeAmount is empty string', () => {
     // When user clears input, stakeAmount becomes ''.
     // new BigNumber('') returns NaN, which must not propagate to the UI.
-    // With existing staked balance (15 TRX), reward = 15 * 0.0335 = 0.503 TRX
+    // With existing staked balance (15 TRX), reward = 15 * (2.44 / 100) = 0.366 TRX
     const { getByText, queryByText } = render(
       <TronStakePreview stakeAmount="" />,
     );
 
     expect(getByText('Est. annual reward')).toBeOnTheScreen();
-    expect(getByText(/0[,.]503 TRX/)).toBeOnTheScreen();
+    expect(getByText(/0[,.]366 TRX/)).toBeOnTheScreen();
     expect(queryByText(/NaN/)).toBeNull();
   });
 
@@ -117,6 +130,63 @@ describe('TronStakePreview', () => {
     expect(getByText('released in minimum time')).toBeOnTheScreen();
     expect(queryByText('Est. annual reward')).toBeNull();
     expect(queryByText('TRX locked for')).toBeNull();
+  });
+
+  it('returns empty reward when apyDecimal is not available', () => {
+    mockUseTronStakeApy.mockReturnValue({
+      isLoading: true,
+      errorMessage: null,
+      apyDecimal: null,
+      apyPercent: null,
+      refetch: jest.fn(),
+    });
+
+    const { getByText, queryByText } = render(
+      <TronStakePreview stakeAmount="5" />,
+    );
+
+    expect(getByText('Est. annual reward')).toBeOnTheScreen();
+    // Reward value should be empty when APY is not available
+    // Use specific pattern to match numeric reward format, not "TRX locked for" label
+    expect(queryByText(/\d+[,.]?\d* TRX/)).toBeNull();
+  });
+
+  it('returns empty reward when stakeAmount is a non-numeric string', () => {
+    const { getByText, queryByText } = render(
+      <TronStakePreview stakeAmount="abc" />,
+    );
+
+    expect(getByText('Est. annual reward')).toBeOnTheScreen();
+    // BigNumber('abc') is NaN, so reward should be empty
+    expect(queryByText(/\d+[,.]?\d* TRX/)).toBeNull();
+  });
+
+  it('returns empty reward when unstaking more than total staked balance', () => {
+    // With 15 TRX staked and unstaking 20, totalForRewards = max(15 - 20, 0) = 0
+    const { queryByText } = render(
+      <TronStakePreview stakeAmount="20" mode="unstake" />,
+    );
+
+    // In unstake mode, the annual reward row is not rendered,
+    // but the useMemo still runs and returns '' for lte(0)
+    expect(queryByText('Est. annual reward')).toBeNull();
+  });
+
+  it('returns empty reward when total staked balance is zero in stake mode', () => {
+    mockUseSelector.mockImplementation((selector: unknown) => {
+      if (selector === selectTronResourcesBySelectedAccountGroup) {
+        return createMockResourcesMap(0);
+      }
+      return undefined;
+    });
+
+    const { getByText, queryByText } = render(
+      <TronStakePreview stakeAmount="0" mode="stake" />,
+    );
+
+    expect(getByText('Est. annual reward')).toBeOnTheScreen();
+    // totalForRewards = 0 + 0 = 0, lte(0) returns ''
+    expect(queryByText(/\d+[,.]?\d* TRX/)).toBeNull();
   });
 
   it.each([

--- a/app/components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx
+++ b/app/components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Animated, Easing } from 'react-native';
+import BigNumber from 'bignumber.js';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
@@ -69,42 +70,58 @@ const TronStakePreview = ({
     };
   }, [tronResources]);
 
-  const parseNum = (v?: string | number) =>
-    typeof v === 'number' ? v : parseFloat(String(v ?? '0').replace(/,/g, ''));
+  // Use BigNumber to prevent floating-point precision errors
+  // e.g., 65.48463 + 65.48463 should equal 130.96926, not 130.96926000000002
+  const parseBN = (v?: string | number) =>
+    new BigNumber(String(v ?? '0').replace(/,/g, ''));
 
-  const strxEnergyValue = parseNum(strxEnergy?.balance);
-  const strxBandwidthValue = parseNum(strxBandwidth?.balance);
-  const totalStakedTrx = (strxEnergyValue || 0) + (strxBandwidthValue || 0);
+  const totalStakedTrxBN = React.useMemo(
+    () => parseBN(strxEnergy?.balance).plus(parseBN(strxBandwidth?.balance)),
+    [strxEnergy?.balance, strxBandwidth?.balance],
+  );
 
   const feeItem: ComputeFeeResult[0] | undefined = Array.isArray(fee)
     ? fee[0]
     : fee;
 
   const estimatedAnnualReward = React.useMemo(() => {
-    const inputAmount = stakeAmount ? Number(stakeAmount) : 0;
-    const baseStaked = Number.isNaN(totalStakedTrx) ? 0 : totalStakedTrx;
-    const stake = Number.isNaN(inputAmount) ? 0 : inputAmount;
+    // Use truthy check to handle empty string (falsy) the same as null/undefined
+    // new BigNumber('') returns NaN, so we default empty string to '0'
+    const inputAmountBN = new BigNumber(stakeAmount || '0');
 
-    let totalForRewards = baseStaked;
-
-    if (mode === 'stake') {
-      totalForRewards = baseStaked + stake;
-    } else if (mode === 'unstake') {
-      totalForRewards = Math.max(baseStaked - stake, 0);
-    }
-
-    if (totalForRewards <= 0) {
+    // Guard against NaN from invalid input
+    if (inputAmountBN.isNaN()) {
       return '';
     }
 
-    const reward = totalForRewards * TRON_STAKING_APR;
-    const rewardRounded = Math.round(reward * 1000) / 1000;
+    let totalForRewardsBN = totalStakedTrxBN;
 
-    return `${rewardRounded.toLocaleString(undefined, {
+    // Guard against NaN from staked balance calculation
+    if (totalForRewardsBN.isNaN()) {
+      totalForRewardsBN = new BigNumber(0);
+    }
+
+    if (mode === 'stake') {
+      totalForRewardsBN = totalForRewardsBN.plus(inputAmountBN);
+    } else if (mode === 'unstake') {
+      totalForRewardsBN = BigNumber.max(
+        totalForRewardsBN.minus(inputAmountBN),
+        0,
+      );
+    }
+
+    if (totalForRewardsBN.lte(0)) {
+      return '';
+    }
+
+    const reward = totalForRewardsBN.multipliedBy(TRON_STAKING_APR);
+    const rewardRounded = reward.decimalPlaces(3, BigNumber.ROUND_HALF_UP);
+
+    return `${rewardRounded.toNumber().toLocaleString(undefined, {
       minimumFractionDigits: 3,
       maximumFractionDigits: 3,
     })} TRX`;
-  }, [stakeAmount, totalStakedTrx, mode]);
+  }, [stakeAmount, totalStakedTrxBN, mode]);
 
   const translateY = React.useRef(new Animated.Value(40)).current;
   const opacity = React.useRef(new Animated.Value(0)).current;

--- a/app/components/UI/Earn/hooks/useTronUnstake.test.ts
+++ b/app/components/UI/Earn/hooks/useTronUnstake.test.ts
@@ -103,8 +103,13 @@ describe('useTronUnstake', () => {
     mockSelectSelectedInternalAccountByScope.mockReturnValue(mockAccount);
     mockSelectTrxStakingEnabled.mockReturnValue(true);
     mockSelectTronResourcesBySelectedAccountGroup.mockReturnValue({
-      energy: { staked: 50 },
-      bandwidth: { staked: 50 },
+      energy: undefined,
+      bandwidth: undefined,
+      maxEnergy: undefined,
+      maxBandwidth: undefined,
+      stakedTrxForEnergy: { symbol: 'strx-energy', balance: '50' },
+      stakedTrxForBandwidth: { symbol: 'strx-bandwidth', balance: '50' },
+      totalStakedTrx: 100,
     });
   });
 

--- a/app/components/UI/Earn/utils/tron.test.ts
+++ b/app/components/UI/Earn/utils/tron.test.ts
@@ -1,9 +1,9 @@
 import type { NavigationProp, ParamListBase } from '@react-navigation/native';
-import { TRON_RESOURCE } from '../../../../core/Multichain/constants';
 import Routes from '../../../../constants/navigation/Routes';
 import { EARN_EXPERIENCES } from '../constants/experiences';
 import type { EarnTokenDetails } from '../types/lending.types';
 import type { TokenI } from '../../Tokens/types';
+import type { TronResourcesMap } from '../../../../selectors/assets/assets-list';
 import {
   buildTronEarnTokenIfEligible,
   getLocalizedErrorMessage,
@@ -58,111 +58,57 @@ describe('tron utils', () => {
       expect(total).toBe(0);
     });
 
-    it('returns sum of sTRX energy and bandwidth balances', () => {
-      const resources = [
-        {
-          symbol: TRON_RESOURCE.STRX_ENERGY,
-          balance: '10',
-        },
-        {
-          symbol: TRON_RESOURCE.STRX_BANDWIDTH,
-          balance: '5',
-        },
-        {
-          symbol: 'OTHER',
-          balance: '1000',
-        },
-      ];
+    it('returns zero when resources are null', () => {
+      const total = getStakedTrxTotalFromResources(null);
+
+      expect(total).toBe(0);
+    });
+
+    it('returns totalStakedTrx from resources', () => {
+      // totalStakedTrx is now pre-computed in the selector
+      const resources: TronResourcesMap = {
+        energy: undefined,
+        bandwidth: undefined,
+        maxEnergy: undefined,
+        maxBandwidth: undefined,
+        stakedTrxForEnergy: undefined,
+        stakedTrxForBandwidth: undefined,
+        totalStakedTrx: 15,
+      };
 
       const total = getStakedTrxTotalFromResources(resources);
 
       expect(total).toBe(15);
     });
-
-    it('sums floating-point balances without precision errors', () => {
-      // This test verifies the BigNumber fix using real user data:
-      // User staked 65 TRX for Energy + 65 TRX for Bandwidth = 130 TRX originally
-      // Staking rewards accumulated to give 65.48463 + 65.48463 = 130.96926 TRX total
-      // In native JS: 65.48463 + 65.48463 = 130.96926000000002 (floating-point error!)
-      // With BigNumber: 65.48463 + 65.48463 = 130.96926 (correct)
-      const resources = [
-        {
-          symbol: TRON_RESOURCE.STRX_ENERGY,
-          balance: '65.48463',
-        },
-        {
-          symbol: TRON_RESOURCE.STRX_BANDWIDTH,
-          balance: '65.48463',
-        },
-      ];
-
-      const total = getStakedTrxTotalFromResources(resources);
-
-      expect(total).toBe(130.96926);
-      // Verify it doesn't have floating-point artifacts
-      expect(total.toString()).toBe('130.96926');
-    });
-
-    it('sums balances with many decimal places', () => {
-      const resources = [
-        {
-          symbol: TRON_RESOURCE.STRX_ENERGY,
-          balance: '100.123456',
-        },
-        {
-          symbol: TRON_RESOURCE.STRX_BANDWIDTH,
-          balance: '50.654321',
-        },
-      ];
-
-      const total = getStakedTrxTotalFromResources(resources);
-
-      expect(total).toBe(150.777777);
-    });
-
-    it('parses and sums comma-formatted balance strings', () => {
-      const resources = [
-        {
-          symbol: TRON_RESOURCE.STRX_ENERGY,
-          balance: '1,000.5',
-        },
-        {
-          symbol: TRON_RESOURCE.STRX_BANDWIDTH,
-          balance: '2,500.25',
-        },
-      ];
-
-      const total = getStakedTrxTotalFromResources(resources);
-
-      expect(total).toBe(3500.75);
-    });
   });
 
   describe('hasStakedTrxPositions', () => {
-    it('returns false when total staked balance is zero', () => {
-      const resources = [
-        {
-          symbol: TRON_RESOURCE.STRX_ENERGY,
-          balance: '0',
-        },
-        {
-          symbol: TRON_RESOURCE.STRX_BANDWIDTH,
-          balance: '0',
-        },
-      ];
+    it('returns false when totalStakedTrx is zero', () => {
+      const resources: TronResourcesMap = {
+        energy: undefined,
+        bandwidth: undefined,
+        maxEnergy: undefined,
+        maxBandwidth: undefined,
+        stakedTrxForEnergy: undefined,
+        stakedTrxForBandwidth: undefined,
+        totalStakedTrx: 0,
+      };
 
       const result = hasStakedTrxPositions(resources);
 
       expect(result).toBe(false);
     });
 
-    it('returns true when total staked balance is greater than zero', () => {
-      const resources = [
-        {
-          symbol: TRON_RESOURCE.STRX_ENERGY,
-          balance: '1',
-        },
-      ];
+    it('returns true when totalStakedTrx is greater than zero', () => {
+      const resources: TronResourcesMap = {
+        energy: undefined,
+        bandwidth: undefined,
+        maxEnergy: undefined,
+        maxBandwidth: undefined,
+        stakedTrxForEnergy: undefined,
+        stakedTrxForBandwidth: undefined,
+        totalStakedTrx: 1,
+      };
 
       const result = hasStakedTrxPositions(resources);
 

--- a/app/components/UI/Earn/utils/tron.test.ts
+++ b/app/components/UI/Earn/utils/tron.test.ts
@@ -78,6 +78,64 @@ describe('tron utils', () => {
 
       expect(total).toBe(15);
     });
+
+    it('sums floating-point balances without precision errors', () => {
+      // This test verifies the BigNumber fix using real user data:
+      // User staked 65 TRX for Energy + 65 TRX for Bandwidth = 130 TRX originally
+      // Staking rewards accumulated to give 65.48463 + 65.48463 = 130.96926 TRX total
+      // In native JS: 65.48463 + 65.48463 = 130.96926000000002 (floating-point error!)
+      // With BigNumber: 65.48463 + 65.48463 = 130.96926 (correct)
+      const resources = [
+        {
+          symbol: TRON_RESOURCE.STRX_ENERGY,
+          balance: '65.48463',
+        },
+        {
+          symbol: TRON_RESOURCE.STRX_BANDWIDTH,
+          balance: '65.48463',
+        },
+      ];
+
+      const total = getStakedTrxTotalFromResources(resources);
+
+      expect(total).toBe(130.96926);
+      // Verify it doesn't have floating-point artifacts
+      expect(total.toString()).toBe('130.96926');
+    });
+
+    it('sums balances with many decimal places', () => {
+      const resources = [
+        {
+          symbol: TRON_RESOURCE.STRX_ENERGY,
+          balance: '100.123456',
+        },
+        {
+          symbol: TRON_RESOURCE.STRX_BANDWIDTH,
+          balance: '50.654321',
+        },
+      ];
+
+      const total = getStakedTrxTotalFromResources(resources);
+
+      expect(total).toBe(150.777777);
+    });
+
+    it('parses and sums comma-formatted balance strings', () => {
+      const resources = [
+        {
+          symbol: TRON_RESOURCE.STRX_ENERGY,
+          balance: '1,000.5',
+        },
+        {
+          symbol: TRON_RESOURCE.STRX_BANDWIDTH,
+          balance: '2,500.25',
+        },
+      ];
+
+      const total = getStakedTrxTotalFromResources(resources);
+
+      expect(total).toBe(3500.75);
+    });
   });
 
   describe('hasStakedTrxPositions', () => {
@@ -174,6 +232,97 @@ describe('tron utils', () => {
       expect(result.balanceFormatted).toBe('24');
       // 24 TRX with 6 decimals = 24 * 10^6
       expect(result.balanceMinimalUnit).toBe('24000000');
+    });
+
+    it('truncates floating-point precision errors in stakedBalanceOverride', () => {
+      // This test verifies the BigNumber truncation fix:
+      // A value like 130.96926000000002 should be truncated to 130.96926
+      // before converting to minimal units
+      const result = buildTronEarnTokenIfEligible(baseToken, {
+        isTrxStakingEnabled: true,
+        isTronEligible: true,
+        stakedBalanceOverride: 130.96926000000002,
+      }) as EarnTokenDetails;
+
+      expect(result.balanceFormatted).toBe('130.96926000000002');
+      // 130.96926 TRX with 6 decimals = 130969260
+      // The truncation ensures this doesn't throw "too many decimal places"
+      expect(result.balanceMinimalUnit).toBe('130969260');
+    });
+
+    it('truncates floating-point artifacts from 130.96926000000002 to valid minimal units', () => {
+      // This is the exact error case from the bug report:
+      // "Error: [number] while converting number 130.96926000000002 to token minimal util, too many decimal places"
+      // This value was produced by floating-point addition and has 14 decimal places,
+      // but TRX only has 6 decimals. Without the fix, toTokenMinimalUnit would throw.
+      const problematicValue = 130.96926000000002;
+
+      // Verify this would have too many decimals without truncation
+      expect(problematicValue.toString().split('.')[1]?.length).toBeGreaterThan(
+        6,
+      );
+
+      const result = buildTronEarnTokenIfEligible(baseToken, {
+        isTrxStakingEnabled: true,
+        isTronEligible: true,
+        stakedBalanceOverride: problematicValue,
+      }) as EarnTokenDetails;
+
+      // Should not throw and should produce correct minimal unit
+      expect(result.balanceMinimalUnit).toBe('130969260');
+    });
+
+    it('truncates string balance override to token decimals', () => {
+      const result = buildTronEarnTokenIfEligible(baseToken, {
+        isTrxStakingEnabled: true,
+        isTronEligible: true,
+        stakedBalanceOverride: '50.12345678901234',
+      }) as EarnTokenDetails;
+
+      // Should truncate to 6 decimals (TRX decimals)
+      // 50.123456 * 10^6 = 50123456
+      expect(result.balanceMinimalUnit).toBe('50123456');
+    });
+
+    it('defaults to zero when stakedBalanceOverride is empty string', () => {
+      // When stakedBalanceOverride is an empty string, normalizeToDotDecimal('')
+      // returns an empty string. new BigNumber('') creates BigNumber(NaN),
+      // and BigNumber(NaN).toFixed() returns 'NaN'. This would cause
+      // toTokenMinimalUnit to throw. The fix defaults to '0' in this case.
+      const result = buildTronEarnTokenIfEligible(baseToken, {
+        isTrxStakingEnabled: true,
+        isTronEligible: true,
+        stakedBalanceOverride: '',
+      }) as EarnTokenDetails;
+
+      expect(result.balanceMinimalUnit).toBe('0');
+    });
+
+    it('defaults to zero when stakedBalanceOverride is non-numeric string', () => {
+      // When stakedBalanceOverride is 'abc', normalizeToDotDecimal('abc')
+      // strips non-digit characters and returns ''. This is the same as
+      // the empty string case and should default to '0'.
+      const result = buildTronEarnTokenIfEligible(baseToken, {
+        isTrxStakingEnabled: true,
+        isTronEligible: true,
+        stakedBalanceOverride: 'abc',
+      }) as EarnTokenDetails;
+
+      expect(result.balanceMinimalUnit).toBe('0');
+    });
+
+    it('defaults to zero when token balance is empty string', () => {
+      const tokenWithEmptyBalance = {
+        ...baseToken,
+        balance: '',
+      };
+
+      const result = buildTronEarnTokenIfEligible(tokenWithEmptyBalance, {
+        isTrxStakingEnabled: true,
+        isTronEligible: true,
+      }) as EarnTokenDetails;
+
+      expect(result.balanceMinimalUnit).toBe('0');
     });
   });
 

--- a/app/components/UI/Earn/utils/tron.test.ts
+++ b/app/components/UI/Earn/utils/tron.test.ts
@@ -80,6 +80,23 @@ describe('tron utils', () => {
 
       expect(total).toBe(15);
     });
+
+    it('defaults to zero when totalStakedTrx is undefined at runtime', () => {
+      // Simulates a malformed object where totalStakedTrx is missing,
+      // exercising the ?? 0 fallback in getStakedTrxTotalFromResources
+      const resources = {
+        energy: undefined,
+        bandwidth: undefined,
+        maxEnergy: undefined,
+        maxBandwidth: undefined,
+        stakedTrxForEnergy: undefined,
+        stakedTrxForBandwidth: undefined,
+      } as unknown as TronResourcesMap;
+
+      const total = getStakedTrxTotalFromResources(resources);
+
+      expect(total).toBe(0);
+    });
   });
 
   describe('hasStakedTrxPositions', () => {

--- a/app/components/UI/Earn/utils/tron.ts
+++ b/app/components/UI/Earn/utils/tron.ts
@@ -12,6 +12,7 @@ import type { TronStakeResult, TronUnstakeResult } from './tron-staking-snap';
 import { TokenI } from '../../Tokens/types';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
+import { safeParseBigNumber } from '../../../../util/number/bignumber';
 import type { TronResourcesMap } from '../../../../selectors/assets/assets-list';
 
 /**
@@ -58,14 +59,11 @@ export const buildTronEarnTokenIfEligible = (
 
   // Truncate to token decimals to prevent "too many decimal places" error
   // from toTokenMinimalUnit when floating-point arithmetic produces extra decimals.
-  // Also handle empty/invalid input: new BigNumber('').toFixed() returns 'NaN',
-  // which would cause toTokenMinimalUnit to throw.
+  // safeParseBigNumber handles empty/invalid input by defaulting to BigNumber(0).
   const decimals = token.decimals ?? 6;
-  const balanceBN = new BigNumber(balanceSource);
-  const truncatedBalance =
-    !balanceSource || balanceBN.isNaN()
-      ? '0'
-      : balanceBN.decimalPlaces(decimals, BigNumber.ROUND_DOWN).toFixed();
+  const truncatedBalance = safeParseBigNumber(balanceSource)
+    .decimalPlaces(decimals, BigNumber.ROUND_DOWN)
+    .toFixed();
 
   const balanceMinimalUnit = toTokenMinimalUnit(
     truncatedBalance,

--- a/app/components/UI/Earn/utils/tron.ts
+++ b/app/components/UI/Earn/utils/tron.ts
@@ -1,6 +1,5 @@
 import { NavigationProp, ParamListBase } from '@react-navigation/native';
 import BigNumber from 'bignumber.js';
-import { TRON_RESOURCE } from '../../../../core/Multichain/constants';
 import {
   normalizeToDotDecimal,
   toTokenMinimalUnit,
@@ -13,44 +12,23 @@ import type { TronStakeResult, TronUnstakeResult } from './tron-staking-snap';
 import { TokenI } from '../../Tokens/types';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
+import type { TronResourcesMap } from '../../../../selectors/assets/assets-list';
 
-interface TronResource {
-  symbol?: string;
-  balance?: string | number;
+/**
+ * Returns the total staked TRX (sTRX) amount from TRON resources.
+ * This is pre-computed in the selector using BigNumber to avoid floating-point precision errors.
+ */
+export function getStakedTrxTotalFromResources(
+  resources?: TronResourcesMap | null,
+): number {
+  return resources?.totalStakedTrx ?? 0;
 }
 
 /**
- * Returns the total staked TRX (sTRX) amount derived from TRON resources.
- * Sums both sTRX Energy and sTRX Bandwidth balances.
- * Uses BigNumber to avoid floating-point precision errors.
+ * True if the user holds any sTRX according to TRON resources.
  */
-export const getStakedTrxTotalFromResources = (
-  resources?: TronResource[] | null,
-): number => {
-  if (!Array.isArray(resources)) return 0;
-
-  const strxEnergy = resources.find(
-    (a) => a.symbol?.toLowerCase() === TRON_RESOURCE.STRX_ENERGY,
-  );
-  const strxBandwidth = resources.find(
-    (a) => a.symbol?.toLowerCase() === TRON_RESOURCE.STRX_BANDWIDTH,
-  );
-
-  // Use BigNumber to prevent floating-point precision errors
-  // e.g., 65.48463 + 65.48463 should equal 130.96926, not 130.96926000000002
-  const energyBN = new BigNumber(
-    String(strxEnergy?.balance ?? '0').replace(/,/g, ''),
-  );
-  const bandwidthBN = new BigNumber(
-    String(strxBandwidth?.balance ?? '0').replace(/,/g, ''),
-  );
-
-  return energyBN.plus(bandwidthBN).toNumber();
-};
-
-// True if the user holds any sTRX according to TRON resources.
 export const hasStakedTrxPositions = (
-  resources?: TronResource[] | null,
+  resources?: TronResourcesMap | null,
 ): boolean => getStakedTrxTotalFromResources(resources) > 0;
 
 export const buildTronEarnTokenIfEligible = (

--- a/app/components/UI/Earn/utils/tron.ts
+++ b/app/components/UI/Earn/utils/tron.ts
@@ -1,4 +1,5 @@
 import { NavigationProp, ParamListBase } from '@react-navigation/native';
+import BigNumber from 'bignumber.js';
 import { TRON_RESOURCE } from '../../../../core/Multichain/constants';
 import {
   normalizeToDotDecimal,
@@ -21,14 +22,12 @@ interface TronResource {
 /**
  * Returns the total staked TRX (sTRX) amount derived from TRON resources.
  * Sums both sTRX Energy and sTRX Bandwidth balances.
+ * Uses BigNumber to avoid floating-point precision errors.
  */
 export const getStakedTrxTotalFromResources = (
   resources?: TronResource[] | null,
 ): number => {
   if (!Array.isArray(resources)) return 0;
-
-  const parseNum = (v?: string | number) =>
-    typeof v === 'number' ? v : parseFloat(String(v ?? '0').replace(/,/g, ''));
 
   const strxEnergy = resources.find(
     (a) => a.symbol?.toLowerCase() === TRON_RESOURCE.STRX_ENERGY,
@@ -37,7 +36,16 @@ export const getStakedTrxTotalFromResources = (
     (a) => a.symbol?.toLowerCase() === TRON_RESOURCE.STRX_BANDWIDTH,
   );
 
-  return parseNum(strxEnergy?.balance) + parseNum(strxBandwidth?.balance);
+  // Use BigNumber to prevent floating-point precision errors
+  // e.g., 65.48463 + 65.48463 should equal 130.96926, not 130.96926000000002
+  const energyBN = new BigNumber(
+    String(strxEnergy?.balance ?? '0').replace(/,/g, ''),
+  );
+  const bandwidthBN = new BigNumber(
+    String(strxBandwidth?.balance ?? '0').replace(/,/g, ''),
+  );
+
+  return energyBN.plus(bandwidthBN).toNumber();
 };
 
 // True if the user holds any sTRX according to TRON resources.
@@ -70,9 +78,20 @@ export const buildTronEarnTokenIfEligible = (
       ? normalizeToDotDecimal(stakedBalanceOverride)
       : normalizeToDotDecimal(token.balance);
 
+  // Truncate to token decimals to prevent "too many decimal places" error
+  // from toTokenMinimalUnit when floating-point arithmetic produces extra decimals.
+  // Also handle empty/invalid input: new BigNumber('').toFixed() returns 'NaN',
+  // which would cause toTokenMinimalUnit to throw.
+  const decimals = token.decimals ?? 6;
+  const balanceBN = new BigNumber(balanceSource);
+  const truncatedBalance =
+    !balanceSource || balanceBN.isNaN()
+      ? '0'
+      : balanceBN.decimalPlaces(decimals, BigNumber.ROUND_DOWN).toFixed();
+
   const balanceMinimalUnit = toTokenMinimalUnit(
-    balanceSource,
-    token.decimals ?? 0,
+    truncatedBalance,
+    decimals,
   ).toString();
 
   const experiences = [

--- a/app/components/UI/TokenDetails/hooks/useTokenBalance.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenBalance.test.ts
@@ -4,13 +4,30 @@ import { TokenI } from '../../Tokens/types';
 import {
   selectAsset,
   selectTronResourcesBySelectedAccountGroup,
+  TronResourcesMap,
 } from '../../../../selectors/assets/assets-list';
 import { createStakedTrxAsset } from '../../AssetOverview/utils/createStakedTrxAsset';
-import { Asset } from '@metamask/assets-controllers';
+
+const createEmptyResourcesMap = (): TronResourcesMap => ({
+  energy: undefined,
+  bandwidth: undefined,
+  maxEnergy: undefined,
+  maxBandwidth: undefined,
+  stakedTrxForEnergy: undefined,
+  stakedTrxForBandwidth: undefined,
+  totalStakedTrx: 0,
+});
 
 jest.mock('../../../../selectors/assets/assets-list', () => ({
   selectAsset: jest.fn(),
-  selectTronResourcesBySelectedAccountGroup: jest.fn(() => []),
+  selectTronResourcesBySelectedAccountGroup: jest.fn(() => ({
+    energy: undefined,
+    bandwidth: undefined,
+    maxEnergy: undefined,
+    maxBandwidth: undefined,
+    stakedTrxForEnergy: undefined,
+    stakedTrxForBandwidth: undefined,
+  })),
 }));
 
 jest.mock('../../AssetOverview/utils/createStakedTrxAsset', () => ({
@@ -26,7 +43,7 @@ const mockCreateStakedTrxAsset = jest.mocked(createStakedTrxAsset);
 describe('useTokenBalance', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSelectTronResources.mockReturnValue([]);
+    mockSelectTronResources.mockReturnValue(createEmptyResourcesMap());
   });
 
   afterEach(() => {
@@ -98,10 +115,11 @@ describe('useTokenBalance', () => {
       symbol: 'TRX',
     } as TokenI);
 
-    mockSelectTronResources.mockReturnValue([
-      { symbol: 'strx-energy', balance: '100' },
-      { symbol: 'strx-bandwidth', balance: '200' },
-    ] as Asset[]);
+    mockSelectTronResources.mockReturnValue({
+      ...createEmptyResourcesMap(),
+      stakedTrxForEnergy: { symbol: 'strx-energy', balance: '100' },
+      stakedTrxForBandwidth: { symbol: 'strx-bandwidth', balance: '200' },
+    } as TronResourcesMap);
 
     mockCreateStakedTrxAsset.mockReturnValue(mockStakedAsset);
 

--- a/app/components/UI/TokenDetails/hooks/useTokenBalance.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenBalance.test.ts
@@ -20,14 +20,17 @@ const createEmptyResourcesMap = (): TronResourcesMap => ({
 
 jest.mock('../../../../selectors/assets/assets-list', () => ({
   selectAsset: jest.fn(),
-  selectTronResourcesBySelectedAccountGroup: jest.fn(() => ({
-    energy: undefined,
-    bandwidth: undefined,
-    maxEnergy: undefined,
-    maxBandwidth: undefined,
-    stakedTrxForEnergy: undefined,
-    stakedTrxForBandwidth: undefined,
-  })),
+  selectTronResourcesBySelectedAccountGroup: jest.fn(
+    (): TronResourcesMap => ({
+      energy: undefined,
+      bandwidth: undefined,
+      maxEnergy: undefined,
+      maxBandwidth: undefined,
+      stakedTrxForEnergy: undefined,
+      stakedTrxForBandwidth: undefined,
+      totalStakedTrx: 0,
+    }),
+  ),
 }));
 
 jest.mock('../../AssetOverview/utils/createStakedTrxAsset', () => ({

--- a/app/components/UI/TokenDetails/hooks/useTokenBalance.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenBalance.ts
@@ -33,19 +33,19 @@ export const useTokenBalance = (token: TokenI): UseTokenBalanceResult => {
   );
 
   ///: BEGIN:ONLY_INCLUDE_IF(tron)
-  const tronResources = useSelector(selectTronResourcesBySelectedAccountGroup);
-  const strxEnergy = tronResources.find(
-    (a) => a.symbol.toLowerCase() === 'strx-energy',
-  );
-  const strxBandwidth = tronResources.find(
-    (a) => a.symbol.toLowerCase() === 'strx-bandwidth',
+  const { stakedTrxForEnergy, stakedTrxForBandwidth } = useSelector(
+    selectTronResourcesBySelectedAccountGroup,
   );
 
   const isTronNative =
     token.ticker === 'TRX' && String(token.chainId).startsWith('tron:');
 
   const stakedTrxAsset = isTronNative
-    ? createStakedTrxAsset(token, strxEnergy?.balance, strxBandwidth?.balance)
+    ? createStakedTrxAsset(
+        token,
+        stakedTrxForEnergy?.balance,
+        stakedTrxForBandwidth?.balance,
+      )
     : undefined;
   ///: END:ONLY_INCLUDE_IF
 

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -1056,13 +1056,16 @@ describe('selectTronResourcesBySelectedAccountGroup', () => {
     const result =
       selectTronResourcesBySelectedAccountGroup(stateWithTronAssets);
 
-    expect(result.map((a) => a.assetId).sort()).toEqual([
-      'tron:728126428/slip44:bandwidth',
-      'tron:728126428/slip44:energy',
-    ]);
+    // Verify the object structure with named properties
+    expect(result.energy?.assetId).toBe('tron:728126428/slip44:energy');
+    expect(result.bandwidth?.assetId).toBe('tron:728126428/slip44:bandwidth');
+    expect(result.maxEnergy).toBeUndefined();
+    expect(result.maxBandwidth).toBeUndefined();
+    expect(result.stakedTrxForEnergy).toBeUndefined();
+    expect(result.stakedTrxForBandwidth).toBeUndefined();
   });
 
-  it('returns empty list when Tron network is disabled', () => {
+  it('returns empty object when Tron network is disabled', () => {
     const stateWithTronDisabled = {
       ...mockState(),
       engine: {
@@ -1125,6 +1128,15 @@ describe('selectTronResourcesBySelectedAccountGroup', () => {
       stateWithTronDisabled,
     );
 
-    expect(result).toEqual([]);
+    // When Tron is disabled, all asset properties should be undefined and total should be 0
+    expect(result).toEqual({
+      energy: undefined,
+      bandwidth: undefined,
+      maxEnergy: undefined,
+      maxBandwidth: undefined,
+      stakedTrxForEnergy: undefined,
+      stakedTrxForBandwidth: undefined,
+      totalStakedTrx: 0,
+    });
   });
 });

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -24,8 +24,10 @@ import {
   selectCurrencyRates,
   selectCurrentCurrency,
 } from '../currencyRateController';
+import { safeParseBigNumber } from '../../util/number/bignumber';
 import { selectAccountsByChainId } from '../accountTrackerController';
 import {
+  TRON_RESOURCE,
   TRON_RESOURCE_SYMBOLS_SET,
   TronResourceSymbol,
 } from '../../core/Multichain/constants';
@@ -33,6 +35,40 @@ import { sortAssetsWithPriority } from '../../components/UI/Tokens/util/sortAsse
 import { selectAllTokens } from '../tokensController';
 import { selectSelectedInternalAccountAddress } from '../accountsController';
 import { selectSelectedInternalAccountByScope } from '../multichainAccounts/accounts';
+
+/**
+ * Structured map of Tron resources for efficient access.
+ * Each property corresponds to a specific Tron resource type.
+ */
+export interface TronResourcesMap {
+  /** Current available energy */
+  energy: Asset | undefined;
+  /** Current available bandwidth */
+  bandwidth: Asset | undefined;
+  /** Maximum energy capacity */
+  maxEnergy: Asset | undefined;
+  /** Maximum bandwidth capacity */
+  maxBandwidth: Asset | undefined;
+  /** TRX staked for energy (sTRX-Energy) */
+  stakedTrxForEnergy: Asset | undefined;
+  /** TRX staked for bandwidth (sTRX-Bandwidth) */
+  stakedTrxForBandwidth: Asset | undefined;
+  /** Total staked TRX (sum of energy + bandwidth staking) */
+  totalStakedTrx: number;
+}
+
+/**
+ * Empty constant to avoid creating new objects on each call when no Tron networks are enabled.
+ */
+const EMPTY_TRON_RESOURCES_MAP: TronResourcesMap = Object.freeze({
+  energy: undefined,
+  bandwidth: undefined,
+  maxEnergy: undefined,
+  maxBandwidth: undefined,
+  stakedTrxForEnergy: undefined,
+  stakedTrxForBandwidth: undefined,
+  totalStakedTrx: 0,
+});
 
 const getStateForAssetSelector = (state: RootState) => {
   const {
@@ -382,25 +418,86 @@ function assetToToken(
   };
 }
 
-// This is used to select Tron resources (Energy & Bandwidth)
+/**
+ * Selects Tron resources (Energy, Bandwidth, Max values, and staked TRX) for the
+ * currently selected account group.
+ *
+ * Returns a structured object with all resources pre-mapped for efficient access,
+ * eliminating the need for consumers to iterate/search the array.
+ */
 export const selectTronResourcesBySelectedAccountGroup =
   createDeepEqualSelector(
     [getStateForAssetSelector, selectEnabledNetworks],
-    (assetsState, enabledNetworks) => {
+    (assetsState, enabledNetworks): TronResourcesMap => {
+      const enabledTronNetworks = enabledNetworks.filter((networkId) =>
+        networkId.startsWith('tron:'),
+      );
+
+      if (enabledTronNetworks.length === 0) {
+        return EMPTY_TRON_RESOURCES_MAP;
+      }
+
       const allAssets = _selectAssetsBySelectedAccountGroup(assetsState, {
         filterTronStakedTokens: false,
       });
-      const tronResources = Object.entries(allAssets)
-        .filter(([networkId, _]) => enabledNetworks.includes(networkId))
-        .flatMap(([_, chainAssets]) => chainAssets)
-        .filter(
-          (asset) =>
-            asset.chainId?.includes('tron:') &&
-            TRON_RESOURCE_SYMBOLS_SET.has(
-              asset.symbol?.toLowerCase() as TronResourceSymbol,
-            ),
-        );
 
-      return tronResources;
+      const enabledTronNetworksSet = new Set(enabledTronNetworks);
+
+      const resourceMap: TronResourcesMap = {
+        energy: undefined,
+        bandwidth: undefined,
+        maxEnergy: undefined,
+        maxBandwidth: undefined,
+        stakedTrxForEnergy: undefined,
+        stakedTrxForBandwidth: undefined,
+        totalStakedTrx: 0,
+      };
+
+      for (const [networkId, chainAssets] of Object.entries(allAssets)) {
+        if (!enabledTronNetworksSet.has(networkId)) continue;
+
+        for (const asset of chainAssets) {
+          const symbol = asset.symbol?.toLowerCase() as TronResourceSymbol;
+          if (!TRON_RESOURCE_SYMBOLS_SET.has(symbol)) continue;
+
+          switch (symbol) {
+            case TRON_RESOURCE.ENERGY:
+              resourceMap.energy = asset;
+              break;
+            case TRON_RESOURCE.BANDWIDTH:
+              resourceMap.bandwidth = asset;
+              break;
+            case TRON_RESOURCE.MAX_ENERGY:
+              resourceMap.maxEnergy = asset;
+              break;
+            case TRON_RESOURCE.MAX_BANDWIDTH:
+              resourceMap.maxBandwidth = asset;
+              break;
+            case TRON_RESOURCE.STRX_ENERGY:
+              resourceMap.stakedTrxForEnergy = asset;
+              break;
+            case TRON_RESOURCE.STRX_BANDWIDTH:
+              resourceMap.stakedTrxForBandwidth = asset;
+              break;
+          }
+        }
+      }
+
+      /**
+       * Compute total staked TRX using BigNumber to avoid floating-point precision errors
+       */
+      const stakedTrxForEnergyBN = safeParseBigNumber(
+        resourceMap.stakedTrxForEnergy?.balance,
+      );
+      const stakedTrxForBandwidthBN = safeParseBigNumber(
+        resourceMap.stakedTrxForBandwidth?.balance,
+      );
+      const totalStakedTrxBN = stakedTrxForEnergyBN.plus(
+        stakedTrxForBandwidthBN,
+      );
+
+      resourceMap.totalStakedTrx = totalStakedTrxBN.toNumber();
+
+      return resourceMap;
     },
   );

--- a/app/util/number/bignumber.test.ts
+++ b/app/util/number/bignumber.test.ts
@@ -1,0 +1,84 @@
+import BigNumber from 'bignumber.js';
+import { safeParseBigNumber } from './bignumber';
+
+describe('safeParseBigNumber', () => {
+  describe('valid numeric inputs', () => {
+    it('parses a plain numeric string', () => {
+      expect(safeParseBigNumber('123.45')).toEqual(new BigNumber('123.45'));
+    });
+
+    it('parses an integer string', () => {
+      expect(safeParseBigNumber('1000')).toEqual(new BigNumber('1000'));
+    });
+
+    it('parses a number type', () => {
+      expect(safeParseBigNumber(42)).toEqual(new BigNumber(42));
+    });
+
+    it('parses zero as a number', () => {
+      expect(safeParseBigNumber(0)).toEqual(new BigNumber(0));
+    });
+
+    it('parses zero as a string', () => {
+      expect(safeParseBigNumber('0')).toEqual(new BigNumber(0));
+    });
+
+    it('parses negative numbers', () => {
+      expect(safeParseBigNumber('-99.5')).toEqual(new BigNumber('-99.5'));
+    });
+  });
+
+  describe('comma-formatted strings', () => {
+    it('strips commas from thousand-separated values', () => {
+      expect(safeParseBigNumber('1,000.50')).toEqual(new BigNumber('1000.50'));
+    });
+
+    it('strips multiple commas', () => {
+      expect(safeParseBigNumber('1,234,567')).toEqual(new BigNumber('1234567'));
+    });
+
+    it('strips commas with decimals', () => {
+      expect(safeParseBigNumber('10,000.123456')).toEqual(
+        new BigNumber('10000.123456'),
+      );
+    });
+  });
+
+  describe('invalid and edge-case inputs', () => {
+    it('returns BigNumber(0) for undefined', () => {
+      expect(safeParseBigNumber(undefined)).toEqual(new BigNumber(0));
+    });
+
+    it('returns BigNumber(0) for empty string', () => {
+      expect(safeParseBigNumber('')).toEqual(new BigNumber(0));
+    });
+
+    it('returns BigNumber(0) for non-numeric string', () => {
+      expect(safeParseBigNumber('abc')).toEqual(new BigNumber(0));
+    });
+
+    it('returns BigNumber(0) for NaN number', () => {
+      expect(safeParseBigNumber(NaN)).toEqual(new BigNumber(0));
+    });
+
+    it('preserves Infinity (not treated as NaN)', () => {
+      const result = safeParseBigNumber(Infinity);
+      expect(result.isFinite()).toBe(false);
+      expect(result.isNaN()).toBe(false);
+    });
+  });
+
+  describe('precision', () => {
+    it('preserves high-precision decimal strings', () => {
+      const precise = '130.96926000000002';
+      const result = safeParseBigNumber(precise);
+      expect(result.toString()).toBe('130.96926000000002');
+    });
+
+    it('avoids floating-point addition errors via BigNumber', () => {
+      const a = safeParseBigNumber('65.48463');
+      const b = safeParseBigNumber('65.48463');
+      expect(a.plus(b).toString()).toBe('130.96926');
+    });
+  });
+});

--- a/app/util/number/bignumber.ts
+++ b/app/util/number/bignumber.ts
@@ -1,0 +1,20 @@
+import BigNumber from 'bignumber.js';
+
+/**
+ * Parses a value to BigNumber, defaulting to 0 for invalid/empty input.
+ * Handles comma-formatted strings (e.g., "1,000.50" → 1000.50).
+ * Uses BigNumber to avoid floating-point precision errors.
+ *
+ * @param value - The value to parse (string or number)
+ * @returns A BigNumber instance, defaulting to 0 if input is invalid/NaN
+ *
+ * @example
+ * safeParseBigNumber('1,000.50') // BigNumber(1000.50)
+ * safeParseBigNumber('') // BigNumber(0)
+ * safeParseBigNumber(undefined) // BigNumber(0)
+ * safeParseBigNumber('abc') // BigNumber(0)
+ */
+export function safeParseBigNumber(value?: string | number): BigNumber {
+  const bn = new BigNumber(String(value ?? '0').replace(/,/g, ''));
+  return bn.isNaN() ? new BigNumber(0) : bn;
+}


### PR DESCRIPTION
…imal precision errors

## **Description**

We got a report of a user trying to unstake and getting the error:

```
View: root
Error: [number] while converting number 130.96926000000002 to token minimal util, too many decimal places 
```

## **Changelog**

CHANGELOG entry: Fixed decimal precision calculation for Tron's staked balance

## **Related issues**

n/a

## **Manual testing steps**

```gherkin
Feature: Tron TRX Unstaking

  Scenario: User unstakes TRX when staked balance has decimal values
    Given the user has TRX staked across Energy and Bandwidth resources with decimal balances
    And the sum of staked balances would produce floating-point precision artifacts (e.g., 65.48463 + 65.48463 = 130.96926000000002)

    When user taps "Unstake" on the Tron staking screen
    Then the unstake flow proceeds without "too many decimal places" error
    And the staked balance is correctly calculated as 130.96926 TRX
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/ad83eaeb-9b35-4f8d-9c95-a5e6210ca898" />

### **After**

n/a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TRON staking/earn calculation paths and changes the shape of `selectTronResourcesBySelectedAccountGroup` from an array to an object, so any missed call sites could break TRON-specific UI/flows; changes are localized and backed by expanded tests.
> 
> **Overview**
> Fixes TRON staking precision bugs by switching staked-balance arithmetic and token minimal-unit conversion to `BigNumber`, preventing floating-point artifacts (e.g. `130.96926000000002`) from causing “too many decimal places” errors.
> 
> Refactors `selectTronResourcesBySelectedAccountGroup` to return a typed `TronResourcesMap` (named fields + precomputed `totalStakedTrx`) and updates TRON UI consumers (`AssetOverview`, `useTokenBalance`, `useTronResources`, Earn/TRON preview) to use the mapped fields instead of scanning arrays. Adds `safeParseBigNumber` and broadens unit tests to cover empty/invalid inputs, APY absence, and precision/rounding edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7004cbe2b37982fb7f2f197c668067be238b37a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->