### PR TITLE
fix: strengthen explore portfolio site condition

### DIFF
--- a/app/components/UI/Sites/hooks/useSiteData/useSitesData.ts
+++ b/app/components/UI/Sites/hooks/useSiteData/useSitesData.ts
@@ -30,6 +30,7 @@ interface UseSitesDataResult {
 
 const PORTFOLIO_API_BASE_URL = 'https://portfolio.api.cx.metamask.io/';
 const DEFAULT_SITES_LIMIT = 200;
+const PORTFOLIO_HOSTNAME = 'portfolio.metamask.io';
 
 /**
  * Hardcoded Portfolio site entry to ensure it's always included
@@ -38,8 +39,8 @@ const DEFAULT_SITES_LIMIT = 200;
 const PORTFOLIO_SITE: SiteData = {
   id: 'metamask-portfolio',
   name: 'MetaMask Portfolio',
-  url: 'https://portfolio.metamask.io',
-  displayUrl: 'portfolio.metamask.io',
+  url: `https://${PORTFOLIO_HOSTNAME}`,
+  displayUrl: PORTFOLIO_HOSTNAME,
   logoUrl:
     'https://raw.githubusercontent.com/MetaMask/metamask-mobile/main/logo.png',
   featured: true,
@@ -58,6 +59,19 @@ const extractDisplayUrl = (url: string): string => {
   }
 };
 
+const isPortfolioSiteUrl = (url: string): boolean => {
+  try {
+    const trimmedUrl = url.trim();
+    const normalizedUrl =
+      trimmedUrl.startsWith('http://') || trimmedUrl.startsWith('https://')
+        ? trimmedUrl
+        : `https://${trimmedUrl}`;
+    return new URL(normalizedUrl).hostname === PORTFOLIO_HOSTNAME;
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Helper function to merge Portfolio site with API sites,
  * ensuring Portfolio is always included at the beginning
@@ -65,9 +79,7 @@ const extractDisplayUrl = (url: string): string => {
 const mergePortfolioSite = (sites: SiteData[]): SiteData[] => {
   // Check if Portfolio is already in the list (by URL match)
   const portfolioExists = sites.some(
-    (site) =>
-      site.url.includes('portfolio.metamask.io') ||
-      site.id === PORTFOLIO_SITE.id,
+    (site) => isPortfolioSiteUrl(site.url) || site.id === PORTFOLIO_SITE.id,
   );
 
   if (portfolioExists) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Replaced URL substring check with hostname comparison for portfolio site identification to fix a security vulnerability.

This should be pretty safe since we own the underlying data, but still good practice to use stricter url condition.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: strengthen explore portfolio site condition

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/security/code-scanning/134

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<a href="https://cursor.com/background-agent?bcId=bc-6ac797b6-6854-4d64-89f8-a169dec92a38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ac797b6-6854-4d64-89f8-a169dec92a38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to Portfolio site detection logic; the main risk is accidentally missing/duplicating the Portfolio entry if URL parsing/normalization behaves unexpectedly for edge-case inputs.
> 
> **Overview**
> Strengthens how the Explore sites list detects whether MetaMask Portfolio is already present by replacing a `url.includes('portfolio.metamask.io')` substring check with strict hostname parsing/comparison.
> 
> Adds `PORTFOLIO_HOSTNAME` and a new `isPortfolioSiteUrl()` normalizer (handles missing schemes/whitespace) and uses it in `mergePortfolioSite` to avoid false matches that could let non-Portfolio URLs bypass or trigger the Portfolio entry logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3214479b364cdb6c8e1bde8e04859f1bc58a6b8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->