### PR TITLE
fix: cherry-pick 429 rate limiting fix with coin naming convention

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -472,7 +472,8 @@ export const PerpsTutorialSelectorsIDs = {
 export const PerpsStopLossPromptSelectorsIDs = {
   CONTAINER: 'perps-stop-loss-prompt-container',
   ADD_MARGIN_BUTTON: 'perps-stop-loss-prompt-add-margin-button',
-  TOGGLE: 'perps-stop-loss-prompt-toggle',
+  SET_STOP_LOSS_BUTTON: 'perps-stop-loss-prompt-set-button',
+  SUCCESS_ICON: 'perps-stop-loss-prompt-success-icon',
   LOADING: 'perps-stop-loss-prompt-loading',
 } as const;
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -252,21 +252,28 @@ jest.mock('../../hooks/usePerpsOpenOrders', () => ({
   usePerpsOpenOrders: () => mockUsePerpsOpenOrdersImpl(),
 }));
 
-const mockUsePerpsOrderFillsImpl = jest.fn<
+const mockUsePerpsLiveFillsImpl = jest.fn<
   ReturnType<
-    typeof import('../../hooks/usePerpsOrderFills').usePerpsOrderFills
+    typeof import('../../hooks/stream/usePerpsLiveFills').usePerpsLiveFills
   >,
   []
 >(() => ({
-  orderFills: [],
-  isLoading: false,
-  error: null,
-  refresh: jest.fn(),
-  isRefreshing: false,
+  fills: [],
+  isInitialLoading: false,
 }));
 
-jest.mock('../../hooks/usePerpsOrderFills', () => ({
-  usePerpsOrderFills: () => mockUsePerpsOrderFillsImpl(),
+jest.mock('../../hooks/stream/usePerpsLiveFills', () => ({
+  usePerpsLiveFills: () => mockUsePerpsLiveFillsImpl(),
+}));
+
+// Mock Engine for REST fallback tests
+const mockGetOrderFills = jest.fn();
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    PerpsController: {
+      getOrderFills: (...args: unknown[]) => mockGetOrderFills(...args),
+    },
+  },
 }));
 
 // Mock for usePerpsMarkets that can be modified per test
@@ -568,6 +575,7 @@ describe('PerpsMarketDetailsView', () => {
       error: null,
       existingPosition: null,
       refreshPosition: jest.fn(),
+      positionOpenedTimestamp: undefined,
     });
 
     // Reset navigation mocks
@@ -600,12 +608,9 @@ describe('PerpsMarketDetailsView', () => {
     };
 
     // Reset order fills mock to default
-    mockUsePerpsOrderFillsImpl.mockReturnValue({
-      orderFills: [],
-      isLoading: false,
-      error: null,
-      refresh: jest.fn(),
-      isRefreshing: false,
+    mockUsePerpsLiveFillsImpl.mockReturnValue({
+      fills: [],
+      isInitialLoading: false,
     });
   });
 
@@ -834,6 +839,7 @@ describe('PerpsMarketDetailsView', () => {
           },
         },
         refreshPosition: jest.fn(),
+        positionOpenedTimestamp: undefined,
       });
 
       const { getByTestId, queryByText, queryByTestId } = renderWithProvider(
@@ -924,6 +930,7 @@ describe('PerpsMarketDetailsView', () => {
         error: null,
         existingPosition: null,
         refreshPosition: mockRefreshPosition, // No-op function for WebSocket positions
+        positionOpenedTimestamp: undefined,
       });
 
       const { getByTestId } = renderWithProvider(
@@ -975,6 +982,7 @@ describe('PerpsMarketDetailsView', () => {
           },
         },
         refreshPosition: mockRefreshPosition,
+        positionOpenedTimestamp: undefined,
       });
 
       const { getByTestId } = renderWithProvider(
@@ -1011,6 +1019,7 @@ describe('PerpsMarketDetailsView', () => {
         error: null,
         existingPosition: null,
         refreshPosition: mockRefreshPosition,
+        positionOpenedTimestamp: undefined,
       });
 
       const { getByTestId } = renderWithProvider(
@@ -1075,6 +1084,7 @@ describe('PerpsMarketDetailsView', () => {
         error: null,
         existingPosition: null,
         refreshPosition: mockRefreshPosition,
+        positionOpenedTimestamp: undefined,
       });
 
       const { getByTestId } = renderWithProvider(
@@ -1692,10 +1702,13 @@ describe('PerpsMarketDetailsView', () => {
     });
   });
 
-  describe('Position opened timestamp calculation', () => {
-    it('computes position opened timestamp from order fills data', () => {
-      // Arrange
-      const timestamp = Date.now();
+  describe('Position opened timestamp', () => {
+    // Note: The timestamp calculation logic has been moved to useHasExistingPosition hook
+    // These tests verify the component correctly uses the hook's positionOpenedTimestamp
+
+    it('uses positionOpenedTimestamp from useHasExistingPosition hook', () => {
+      // Arrange - Hook provides the timestamp
+      const timestamp = Date.now() - 5 * 60 * 1000;
       mockUseHasExistingPosition.mockReturnValue({
         hasPosition: true,
         isLoading: false,
@@ -1718,51 +1731,7 @@ describe('PerpsMarketDetailsView', () => {
           },
         },
         refreshPosition: jest.fn(),
-      });
-
-      mockUsePerpsOrderFillsImpl.mockReturnValue({
-        orderFills: [
-          {
-            orderId: 'order-1',
-            symbol: 'BTC',
-            side: 'buy',
-            direction: 'Open Long',
-            timestamp: timestamp - 2000,
-            size: '0.3',
-            price: '43000',
-            pnl: '0',
-            fee: '0.001',
-            feeToken: 'USDC',
-          },
-          {
-            orderId: 'order-2',
-            symbol: 'BTC',
-            side: 'buy',
-            direction: 'Open Long',
-            timestamp,
-            size: '0.5',
-            price: '44000',
-            pnl: '0',
-            fee: '0.001',
-            feeToken: 'USDC',
-          },
-          {
-            orderId: 'order-3',
-            symbol: 'ETH',
-            side: 'sell',
-            direction: 'Open Short',
-            timestamp: timestamp - 1000,
-            size: '1.0',
-            price: '3000',
-            pnl: '0',
-            fee: '0.001',
-            feeToken: 'USDC',
-          },
-        ],
-        isLoading: false,
-        error: null,
-        refresh: jest.fn(),
-        isRefreshing: false,
+        positionOpenedTimestamp: timestamp, // Hook now provides this
       });
 
       // Act
@@ -1775,11 +1744,53 @@ describe('PerpsMarketDetailsView', () => {
         },
       );
 
-      // Assert
+      // Assert - component renders with position data
       expect(
         getByTestId(PerpsMarketDetailsViewSelectorsIDs.CONTAINER),
       ).toBeTruthy();
-      expect(mockUsePerpsOrderFillsImpl).toHaveBeenCalled();
+    });
+
+    it('handles undefined positionOpenedTimestamp from hook', () => {
+      // Arrange - Hook returns undefined timestamp (e.g., new position)
+      mockUseHasExistingPosition.mockReturnValue({
+        hasPosition: true,
+        isLoading: false,
+        error: null,
+        existingPosition: {
+          symbol: 'BTC',
+          size: '0.5',
+          entryPrice: '44000',
+          positionValue: '22000',
+          unrealizedPnl: '50',
+          marginUsed: '500',
+          leverage: { type: 'isolated', value: 5 },
+          liquidationPrice: '40000',
+          maxLeverage: 20,
+          returnOnEquity: '1.14',
+          cumulativeFunding: {
+            allTime: '0',
+            sinceOpen: '0',
+            sinceChange: '0',
+          },
+        },
+        refreshPosition: jest.fn(),
+        positionOpenedTimestamp: undefined, // No timestamp available yet
+      });
+
+      // Act
+      const { getByTestId } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        {
+          state: initialState,
+        },
+      );
+
+      // Assert - component still renders correctly
+      expect(
+        getByTestId(PerpsMarketDetailsViewSelectorsIDs.CONTAINER),
+      ).toBeTruthy();
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -13,6 +13,12 @@ import React, {
   useState,
 } from 'react';
 import { Linking, RefreshControl, ScrollView, View } from 'react-native';
+import type {
+  Position,
+  PerpsMarketData,
+  PerpsNavigationParamList,
+  TPSLTrackingData,
+} from '../../controllers/types';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
@@ -79,11 +85,6 @@ import {
   PerpsEventValues,
 } from '../../constants/eventNames';
 import { PERPS_CONSTANTS } from '../../constants/perpsConfig';
-import type {
-  PerpsMarketData,
-  PerpsNavigationParamList,
-  TPSLTrackingData,
-} from '../../controllers/types';
 import {
   usePerpsConnection,
   usePerpsNavigation,
@@ -108,7 +109,6 @@ import { usePerpsMarkets } from '../../hooks/usePerpsMarkets';
 import { usePerpsMarketStats } from '../../hooks/usePerpsMarketStats';
 import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
 import { usePerpsOICap } from '../../hooks/usePerpsOICap';
-import { usePerpsOrderFills } from '../../hooks/usePerpsOrderFills';
 import { usePerpsTPSLUpdate } from '../../hooks/usePerpsTPSLUpdate';
 import { useStopLossPrompt } from '../../hooks/useStopLossPrompt';
 import { selectPerpsChartPreferredCandlePeriod } from '../../selectors/chartPreferences';
@@ -198,6 +198,17 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   // Stop loss prompt banner state - for loading/success when setting stop loss via banner
   const [isSettingStopLoss, setIsSettingStopLoss] = useState(false);
   const [isStopLossSuccess, setIsStopLossSuccess] = useState(false);
+  // Preserve banner variant during success fade-out (hook's variant becomes null after SL is set)
+  const preservedBannerVariantRef = useRef<'stop_loss' | 'add_margin' | null>(
+    null,
+  );
+  // Track current market symbol for staleness checks in async callbacks
+  // Using a ref allows reading the CURRENT value at execution time, not closure-captured value
+  const currentMarketSymbolRef = useRef<string | undefined>(market?.symbol);
+  // Track current position for callbacks that are stored (e.g., route params) and called later
+  // This prevents stale closure issues where the captured position is outdated
+  // Initialized to null, will be updated via useEffect when existingPosition is available
+  const currentPositionRef = useRef<Position | null>(null);
 
   const isEligible = useSelector(selectPerpsEligibility);
 
@@ -220,6 +231,11 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   // Reset optimistic state when market changes
   useEffect(() => {
     setOptimisticWatchlist(null);
+  }, [market?.symbol]);
+
+  // Keep current market symbol ref in sync for staleness checks in async callbacks
+  useEffect(() => {
+    currentMarketSymbolRef.current = market?.symbol;
   }, [market?.symbol]);
 
   // Clear optimistic state once Redux has caught up
@@ -377,11 +393,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     // Only zoom when:
     // 1. The interval has changed (user pressed button)
     // 2. New data exists and matches the selected period
-    if (
-      hasIntervalChanged &&
-      candleData &&
-      candleData.interval === selectedCandlePeriod
-    ) {
+    if (hasIntervalChanged && candleData?.interval === selectedCandlePeriod) {
       chartRef.current?.zoomToLatestCandle(visibleCandleCount);
       // Update the ref to track this interval change
       previousIntervalRef.current = selectedCandlePeriod;
@@ -389,32 +401,21 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   }, [candleData, selectedCandlePeriod, visibleCandleCount]);
 
   // Check if user has an existing position for this market
-  const { isLoading: isLoadingPosition, existingPosition } =
-    useHasExistingPosition({
-      asset: market?.symbol || '',
-      loadOnMount: true,
-    });
-
-  // Fetch order fills to get position opened timestamp
-  const { orderFills } = usePerpsOrderFills({
-    skipInitialFetch: false,
+  // Also provides positionOpenedTimestamp for stop loss prompt timing
+  const {
+    isLoading: isLoadingPosition,
+    existingPosition,
+    positionOpenedTimestamp,
+  } = useHasExistingPosition({
+    asset: market?.symbol || '',
+    loadOnMount: true,
   });
 
-  // Get position opened timestamp from fills data
-  const positionOpenedTimestamp = useMemo(() => {
-    if (!existingPosition || !orderFills) return undefined;
-
-    // Find the most recent "Open" fill for this asset
-    const openFill = orderFills
-      .filter((fill) => {
-        const isMatchingAsset = fill.symbol === existingPosition.coin;
-        const isOpenDirection = fill.direction?.startsWith('Open');
-        return isMatchingAsset && isOpenDirection;
-      })
-      .sort((a, b) => b.timestamp - a.timestamp)[0]; // Most recent first
-
-    return openFill?.timestamp;
-  }, [existingPosition, orderFills]);
+  // Keep current position ref in sync for callbacks stored in route params
+  // This must be after useHasExistingPosition since it depends on existingPosition
+  useEffect(() => {
+    currentPositionRef.current = existingPosition;
+  }, [existingPosition]);
 
   // Compute TP/SL lines for the chart based on existing position
   // Use chartCurrentPrice (from candle close) to ensure price line syncs with live candle
@@ -439,12 +440,11 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   // Stop loss prompt banner logic
   // Hook handles visibility orchestration including fade-out animation
   const {
-    variant: bannerVariant,
+    variant: bannerVariantFromHook,
     liquidationDistance,
     suggestedStopLossPrice,
     suggestedStopLossPercent,
     isVisible: isBannerVisible,
-    isDismissing: isBannerDismissing,
     onDismissComplete: handleBannerDismissComplete,
   } = useStopLossPrompt({
     position: existingPosition,
@@ -452,9 +452,24 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     positionOpenedTimestamp,
   });
 
+  // Preserve banner variant when we have a valid one (for use during success fade-out)
+  // The hook's variant becomes null after SL is set, but we need to keep rendering
+  // Use useEffect to avoid ref mutation during render (React best practice)
+  useEffect(() => {
+    if (bannerVariantFromHook && !isStopLossSuccess) {
+      preservedBannerVariantRef.current = bannerVariantFromHook;
+    }
+  }, [bannerVariantFromHook, isStopLossSuccess]);
+
+  // Use preserved variant during success fade-out, otherwise use hook's variant
+  const bannerVariant = isStopLossSuccess
+    ? preservedBannerVariantRef.current
+    : bannerVariantFromHook;
+
   // Reset stop loss success state when market or position changes
   useEffect(() => {
     setIsStopLossSuccess(false);
+    preservedBannerVariantRef.current = null;
   }, [market?.symbol, existingPosition?.coin]);
 
   // Track Perps asset screen load performance with simplified API
@@ -729,12 +744,20 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
         stopLossPrice?: string,
         trackingData?: TPSLTrackingData,
       ) => {
-        await handleUpdateTPSL(
-          existingPosition,
+        // Use ref to get CURRENT position at execution time, not the closure-captured position
+        // This prevents "No position found" errors when the position updates during navigation
+        const currentPosition = currentPositionRef.current;
+        if (!currentPosition) {
+          return { success: false };
+        }
+        // Return value checked for consistency - error toast is shown internally by hook
+        const result = await handleUpdateTPSL(
+          currentPosition,
           takeProfitPrice,
           stopLossPrice,
           trackingData,
         );
+        return result;
       },
     });
   }, [existingPosition, currentPrice, navigation, handleUpdateTPSL]);
@@ -817,6 +840,9 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   const handleSetStopLossFromBanner = useCallback(async () => {
     if (!existingPosition || !suggestedStopLossPrice) return;
 
+    // Capture symbol before async to detect market changes during API call
+    const originalSymbol = existingPosition.symbol;
+
     setIsSettingStopLoss(true);
 
     try {
@@ -828,12 +854,24 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       };
 
       // Set the stop loss using the suggested price (keep existing TP if any)
-      await handleUpdateTPSL(
+      const result = await handleUpdateTPSL(
         existingPosition,
         existingPosition.takeProfitPrice, // Keep existing TP
         suggestedStopLossPrice, // Use suggested SL
         trackingData,
       );
+
+      // Only trigger success state if the update actually succeeded
+      if (!result.success) {
+        // Error toast is already shown by handleUpdateTPSL
+        return;
+      }
+
+      // Staleness check: user may have navigated to a different market during API call
+      // Use ref to get CURRENT market symbol, not the closure-captured value
+      if (originalSymbol !== currentMarketSymbolRef.current) {
+        return;
+      }
 
       // Trigger success state to start fade-out animation
       setIsStopLossSuccess(true);
@@ -1053,8 +1091,8 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
           )}
 
           {/* Stop Loss Prompt Banner - Shows when position needs attention */}
-          {/* Uses hook's isVisible which includes fade-out animation state */}
-          {isBannerVisible && bannerVariant && (
+          {/* Keep mounted while isStopLossSuccess is true to allow fade animation to complete */}
+          {(isBannerVisible || isStopLossSuccess) && bannerVariant && (
             <PerpsStopLossPromptBanner
               variant={bannerVariant}
               liquidationDistance={liquidationDistance ?? 0}
@@ -1063,7 +1101,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
               onSetStopLoss={handleSetStopLossFromBanner}
               onAddMargin={handleAddMarginFromBanner}
               isLoading={isSettingStopLoss}
-              isSuccess={isStopLossSuccess || isBannerDismissing}
+              isSuccess={isStopLossSuccess}
               onFadeOutComplete={handleBannerFadeOutComplete}
               testID={
                 PerpsMarketDetailsViewSelectorsIDs.STOP_LOSS_PROMPT_BANNER

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -841,7 +841,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     if (!existingPosition || !suggestedStopLossPrice) return;
 
     // Capture symbol before async to detect market changes during API call
-    const originalSymbol = existingPosition.symbol;
+    const originalSymbol = existingPosition.coin;
 
     setIsSettingStopLoss(true);
 

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -262,6 +262,11 @@ jest.mock('../../hooks', () => ({
           creationFailed: jest.fn(),
         },
       },
+      positionManagement: {
+        tpsl: {
+          updateTPSLError: jest.fn(),
+        },
+      },
       dataFetching: {
         market: {
           error: {
@@ -1781,6 +1786,11 @@ describe('PerpsOrderView', () => {
               submitted: jest.fn(),
               confirmed: jest.fn(),
               creationFailed: jest.fn(),
+            },
+          },
+          positionManagement: {
+            tpsl: {
+              updateTPSLError: jest.fn(),
             },
           },
           dataFetching: {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -871,11 +871,22 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
         delete orderWithoutTPSL.stopLossPrice;
 
         await executeOrder(orderWithoutTPSL);
-        await updatePositionTPSL({
+        const tpslResult = await updatePositionTPSL({
           coin: orderForm.asset,
           takeProfitPrice: orderForm.takeProfitPrice,
           stopLossPrice: orderForm.stopLossPrice,
         });
+
+        // Show error toast if TP/SL update failed (order succeeded but TP/SL didn't)
+        if (!tpslResult.success) {
+          const errorMessage =
+            tpslResult.error || strings('perps.errors.unknown');
+          showToast(
+            PerpsToastOptions.positionManagement.tpsl.updateTPSLError(
+              errorMessage,
+            ),
+          );
+        }
       } else {
         await executeOrder(orderParams);
       }
@@ -884,26 +895,24 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
       isSubmittingRef.current = false;
     }
   }, [
-    orderValidation.isValid,
-    orderValidation.errors,
+    isButtonColorTestEnabled,
     track,
     orderForm.asset,
     orderForm.direction,
-    orderForm.type,
-    orderForm.leverage,
-    orderForm.limitPrice,
     orderForm.takeProfitPrice,
     orderForm.stopLossPrice,
+    orderForm.type,
+    orderForm.leverage,
     orderForm.amount,
-    positionSize,
-    assetData.price,
+    orderForm.limitPrice,
+    buttonColorVariant,
+    orderValidation.isValid,
+    orderValidation.errors,
+    currentMarketPosition,
     navigation,
     navigationMarketData,
-    currentMarketPosition,
-    executeOrder,
-    showToast,
-    PerpsToastOptions.formValidation.orderForm,
-    updatePositionTPSL,
+    positionSize,
+    assetData.price,
     marginRequired,
     feeResults.totalFee,
     feeResults.metamaskFee,
@@ -911,8 +920,11 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     feeResults.feeDiscountPercentage,
     feeResults.estimatedPoints,
     source,
-    isButtonColorTestEnabled,
-    buttonColorVariant,
+    showToast,
+    PerpsToastOptions.formValidation.orderForm,
+    PerpsToastOptions.positionManagement.tpsl,
+    executeOrder,
+    updatePositionTPSL,
   ]);
 
   // Memoize the tooltip handlers to prevent recreating them on every render

--- a/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx
+++ b/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useRef } from 'react';
-import { View, Switch, ActivityIndicator, Animated } from 'react-native';
+import { View, ActivityIndicator, Animated } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import Text, {
   TextVariant,
@@ -9,6 +9,11 @@ import Button, {
   ButtonVariants,
   ButtonSize,
 } from '../../../../../component-library/components/Buttons/Button';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../../component-library/components/Icons/Icon';
 import { useTheme } from '../../../../../util/theme';
 import { strings } from '../../../../../../locales/i18n';
 import { PerpsStopLossPromptSelectorsIDs } from '../../Perps.testIds';
@@ -19,6 +24,8 @@ import {
 import styleSheet from './PerpsStopLossPromptBanner.styles';
 import type { PerpsStopLossPromptBannerProps } from './PerpsStopLossPromptBanner.types';
 
+/** Delay before fade-out starts, allowing user to see success checkmark */
+const SUCCESS_DISPLAY_DELAY_MS = 2000;
 /** Duration of the fade-out animation in milliseconds */
 const FADE_OUT_DURATION_MS = 300;
 
@@ -70,18 +77,32 @@ const PerpsStopLossPromptBanner: React.FC<PerpsStopLossPromptBannerProps> =
       // Animation value for fade-out effect
       const fadeAnim = useRef(new Animated.Value(1)).current;
 
+      // Reset opacity when isSuccess transitions to false (e.g., market change during animation)
+      // This ensures the banner is visible when shown for a new market
+      useEffect(() => {
+        if (!isSuccess) {
+          fadeAnim.setValue(1);
+        }
+      }, [isSuccess, fadeAnim]);
+
       // Trigger fade-out animation when isSuccess becomes true
+      // Wait for SUCCESS_DISPLAY_DELAY_MS first so user sees success checkmark
       useEffect(() => {
         if (isSuccess) {
-          Animated.timing(fadeAnim, {
-            toValue: 0,
-            duration: FADE_OUT_DURATION_MS,
-            useNativeDriver: true,
-          }).start(() => {
-            // Call callback when animation completes
-            onFadeOutComplete?.();
-          });
+          const delayTimer = setTimeout(() => {
+            Animated.timing(fadeAnim, {
+              toValue: 0,
+              duration: FADE_OUT_DURATION_MS,
+              useNativeDriver: true,
+            }).start(() => {
+              // Call callback when animation completes
+              onFadeOutComplete?.();
+            });
+          }, SUCCESS_DISPLAY_DELAY_MS);
+
+          return () => clearTimeout(delayTimer);
         }
+        return undefined;
       }, [isSuccess, fadeAnim, onFadeOutComplete]);
 
       // Safe press handlers that won't trigger if callback is not provided
@@ -89,15 +110,12 @@ const PerpsStopLossPromptBanner: React.FC<PerpsStopLossPromptBannerProps> =
         onAddMargin?.();
       }, [onAddMargin]);
 
-      // Toggle handler - directly triggers stop loss action
-      const handleToggleChange = useCallback(
-        (value: boolean) => {
-          if (value && !isLoading) {
-            onSetStopLoss?.();
-          }
-        },
-        [isLoading, onSetStopLoss],
-      );
+      // Button press handler - directly triggers stop loss action
+      const handleSetStopLossPress = useCallback(() => {
+        if (!isLoading && !isSuccess) {
+          onSetStopLoss?.();
+        }
+      }, [isLoading, isSuccess, onSetStopLoss]);
 
       // Format the suggested stop loss price for display
       const formattedStopLossPrice = suggestedStopLossPrice
@@ -176,28 +194,32 @@ const PerpsStopLossPromptBanner: React.FC<PerpsStopLossPromptBannerProps> =
                 })}
               </Text>
             </View>
-            <View style={styles.toggleContainer}>
-              {isLoading ? (
-                <ActivityIndicator
-                  size="small"
-                  color={colors.primary.default}
-                  testID={PerpsStopLossPromptSelectorsIDs.LOADING}
-                />
-              ) : (
-                <Switch
-                  value={false}
-                  onValueChange={handleToggleChange}
-                  trackColor={{
-                    true: colors.primary.default,
-                    false: colors.border.muted,
-                  }}
-                  thumbColor={colors.background.default}
-                  ios_backgroundColor={colors.border.muted}
-                  disabled={isLoading || !onSetStopLoss}
-                  testID={PerpsStopLossPromptSelectorsIDs.TOGGLE}
-                />
-              )}
-            </View>
+            <Button
+              variant={ButtonVariants.Primary}
+              size={ButtonSize.Sm}
+              label={
+                isLoading ? (
+                  <ActivityIndicator
+                    size="small"
+                    color={colors.primary.inverse}
+                    testID={PerpsStopLossPromptSelectorsIDs.LOADING}
+                  />
+                ) : isSuccess ? (
+                  <Icon
+                    name={IconName.Check}
+                    size={IconSize.Sm}
+                    color={IconColor.Inverse}
+                    testID={PerpsStopLossPromptSelectorsIDs.SUCCESS_ICON}
+                  />
+                ) : (
+                  strings('perps.stop_loss_prompt.set_button')
+                )
+              }
+              onPress={handleSetStopLossPress}
+              isDisabled={isLoading || isSuccess || !onSetStopLoss}
+              style={styles.button}
+              testID={PerpsStopLossPromptSelectorsIDs.SET_STOP_LOSS_BUTTON}
+            />
           </View>
         </Animated.View>
       );

--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.test.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.test.ts
@@ -364,6 +364,16 @@ describe('HyperLiquidProvider', () => {
       setDexMetaCache: jest.fn(),
       setDexAssetCtxsCache: jest.fn(),
       getDexAssetCtxsCache: jest.fn().mockReturnValue(undefined),
+      // Price cache used by placeOrder, editOrder, closePosition optimizations
+      getCachedPrice: jest.fn().mockImplementation((symbol: string) => {
+        const prices: Record<string, string> = { BTC: '50000', ETH: '3000' };
+        return prices[symbol];
+      }),
+      // Orders cache used by updatePositionTPSL and getOpenOrders
+      isOrdersCacheInitialized: jest.fn().mockReturnValue(false),
+      getCachedOrders: jest.fn().mockReturnValue([]),
+      // Atomic getter - returns null when cache not initialized (prevents race condition)
+      getOrdersCacheIfInitialized: jest.fn().mockReturnValue(null),
     } as Partial<HyperLiquidSubscriptionService> as jest.Mocked<HyperLiquidSubscriptionService>;
 
     // Mock constructors
@@ -704,7 +714,7 @@ describe('HyperLiquidProvider', () => {
       const result = await provider.editOrder(editParams);
 
       expect(result.success).toBe(true);
-      expect(mockClientService.getInfoClient().allMids).toHaveBeenCalled();
+      // Price is fetched from WebSocket cache (getCachedPrice) or REST API (allMids) as fallback
 
       // Verify market orders use FrontendMarket TIF in edit operations
       expect(mockClientService.getExchangeClient().modify).toHaveBeenCalledWith(
@@ -740,7 +750,9 @@ describe('HyperLiquidProvider', () => {
       expect(result.error).toContain('Asset UNKNOWN not found');
     });
 
-    it('should handle editOrder when no price is available', async () => {
+    it('handles editOrder when no price is available', async () => {
+      // Mock both WebSocket cache and REST API to return no price
+      mockSubscriptionService.getCachedPrice.mockReturnValueOnce(undefined);
       (
         mockClientService.getInfoClient().allMids as jest.Mock
       ).mockResolvedValueOnce({}); // Empty price data
@@ -758,14 +770,166 @@ describe('HyperLiquidProvider', () => {
       const result = await provider.editOrder(editParams);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('No price available for BTC');
+      expect(result.error).toContain('Invalid price for BTC');
+    });
+
+    it('falls back to REST API when cached price is zero', async () => {
+      // Mock WebSocket cache to return "0" (invalid price)
+      mockSubscriptionService.getCachedPrice.mockReturnValueOnce('0');
+      // Mock REST API to return valid price
+      (
+        mockClientService.getInfoClient().allMids as jest.Mock
+      ).mockResolvedValueOnce({ BTC: '50000' });
+
+      const editParams = {
+        orderId: '123',
+        newOrder: {
+          symbol: 'BTC',
+          isBuy: true,
+          size: '0.1',
+          orderType: 'market',
+        } as OrderParams,
+      };
+
+      const result = await provider.editOrder(editParams);
+
+      // Should succeed because it fell back to REST API
+      expect(result.success).toBe(true);
+      // Verify REST API was called as fallback
+      expect(mockClientService.getInfoClient().allMids).toHaveBeenCalled();
+    });
+
+    it('falls back to REST API when cached price is NaN', async () => {
+      // Mock WebSocket cache to return invalid string
+      mockSubscriptionService.getCachedPrice.mockReturnValueOnce('invalid');
+      // Mock REST API to return valid price
+      (
+        mockClientService.getInfoClient().allMids as jest.Mock
+      ).mockResolvedValueOnce({ BTC: '50000' });
+
+      const editParams = {
+        orderId: '123',
+        newOrder: {
+          symbol: 'BTC',
+          isBuy: true,
+          size: '0.1',
+          orderType: 'market',
+        } as OrderParams,
+      };
+
+      const result = await provider.editOrder(editParams);
+
+      // Should succeed because it fell back to REST API
+      expect(result.success).toBe(true);
+      // Verify REST API was called as fallback
+      expect(mockClientService.getInfoClient().allMids).toHaveBeenCalled();
+    });
+
+    it('falls back to REST API when cached price is negative', async () => {
+      // Mock WebSocket cache to return negative price (invalid for crypto)
+      mockSubscriptionService.getCachedPrice.mockReturnValueOnce('-100');
+      // Mock REST API to return valid price
+      (
+        mockClientService.getInfoClient().allMids as jest.Mock
+      ).mockResolvedValueOnce({ BTC: '50000' });
+
+      const editParams = {
+        orderId: '123',
+        newOrder: {
+          symbol: 'BTC',
+          isBuy: true,
+          size: '0.1',
+          orderType: 'market',
+        } as OrderParams,
+      };
+
+      const result = await provider.editOrder(editParams);
+
+      // Should succeed because it fell back to REST API
+      expect(result.success).toBe(true);
+      // Verify REST API was called as fallback
+      expect(mockClientService.getInfoClient().allMids).toHaveBeenCalled();
+    });
+
+    it('falls back to REST API when cached price is Infinity', async () => {
+      // Mock WebSocket cache to return Infinity (invalid price)
+      mockSubscriptionService.getCachedPrice.mockReturnValueOnce('Infinity');
+      // Mock REST API to return valid price
+      (
+        mockClientService.getInfoClient().allMids as jest.Mock
+      ).mockResolvedValueOnce({ BTC: '50000' });
+
+      const editParams = {
+        orderId: '123',
+        newOrder: {
+          symbol: 'BTC',
+          isBuy: true,
+          size: '0.1',
+          orderType: 'market',
+        } as OrderParams,
+      };
+
+      const result = await provider.editOrder(editParams);
+
+      // Should succeed because it fell back to REST API
+      expect(result.success).toBe(true);
+      // Verify REST API was called as fallback
+      expect(mockClientService.getInfoClient().allMids).toHaveBeenCalled();
+    });
+
+    it('throws error when REST price is negative', async () => {
+      // Mock WebSocket cache miss
+      mockSubscriptionService.getCachedPrice.mockReturnValueOnce(undefined);
+      // Mock REST API to return negative price
+      (
+        mockClientService.getInfoClient().allMids as jest.Mock
+      ).mockResolvedValueOnce({ BTC: '-50000' });
+
+      const editParams = {
+        orderId: '123',
+        newOrder: {
+          symbol: 'BTC',
+          isBuy: true,
+          size: '0.1',
+          orderType: 'market',
+        } as OrderParams,
+      };
+
+      const result = await provider.editOrder(editParams);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid price for BTC');
+    });
+
+    it('throws error when REST price is Infinity', async () => {
+      // Mock WebSocket cache miss
+      mockSubscriptionService.getCachedPrice.mockReturnValueOnce(undefined);
+      // Mock REST API to return Infinity
+      (
+        mockClientService.getInfoClient().allMids as jest.Mock
+      ).mockResolvedValueOnce({ BTC: 'Infinity' });
+
+      const editParams = {
+        orderId: '123',
+        newOrder: {
+          symbol: 'BTC',
+          isBuy: true,
+          size: '0.1',
+          orderType: 'market',
+        } as OrderParams,
+      };
+
+      const result = await provider.editOrder(editParams);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid price for BTC');
     });
 
     it('should handle editOrder when asset ID is not found', async () => {
       // Create a spy on the coinToAssetId.get method to return undefined for BTC
       // eslint-disable-next-line dot-notation
       const originalGet = provider['coinToAssetId'].get;
-      jest
+      const getSpy = jest
         // eslint-disable-next-line dot-notation
         .spyOn(provider['coinToAssetId'], 'get')
         .mockImplementation((coin) => {
@@ -792,8 +956,8 @@ describe('HyperLiquidProvider', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('Asset ID not found for BTC');
 
-      // Restore the original method
-      jest.restoreAllMocks();
+      // Restore only this specific spy (not all mocks)
+      getSpy.mockRestore();
     });
 
     it('should cancel an order successfully', async () => {
@@ -5333,11 +5497,8 @@ describe('HyperLiquidProvider', () => {
           isTrigger: false,
         },
       ];
-      // Add cache methods to mock
-      mockSubscriptionService.isOrdersCacheInitialized = jest
-        .fn()
-        .mockReturnValue(true);
-      mockSubscriptionService.getCachedOrders = jest
+      // Use the atomic getter mock
+      mockSubscriptionService.getOrdersCacheIfInitialized = jest
         .fn()
         .mockReturnValue(cachedOrders);
 
@@ -5347,6 +5508,98 @@ describe('HyperLiquidProvider', () => {
       // Assert
       expect(result).toEqual(cachedOrders);
       expect(mockClientService.getInfoClient).not.toHaveBeenCalled();
+    });
+
+    it('falls back to REST when atomic cache getter returns null', async () => {
+      // Arrange - atomic getter returns null (cache not initialized or race condition)
+      mockSubscriptionService.getOrdersCacheIfInitialized = jest
+        .fn()
+        .mockReturnValue(null);
+
+      const mockFrontendOpenOrders = jest.fn().mockResolvedValue([
+        {
+          coin: 'ETH',
+          side: 'B',
+          limitPx: '3000',
+          sz: '1.0',
+          oid: 501,
+          timestamp: Date.now(),
+          origSz: '1.0',
+          triggerCondition: '',
+          isTrigger: false,
+          triggerPx: '',
+          children: [],
+          isPositionTpsl: false,
+          reduceOnly: false,
+          orderType: 'Limit',
+          tif: 'Gtc',
+          cloid: null,
+        },
+      ]);
+
+      mockClientService.getInfoClient = jest.fn().mockReturnValue({
+        maxBuilderFee: jest.fn().mockResolvedValue(1),
+        referral: jest.fn().mockResolvedValue({
+          referrerState: { stage: 'ready', data: { code: 'MMCSI' } },
+          referredBy: { code: 'MMCSI' },
+        }),
+        frontendOpenOrders: mockFrontendOpenOrders,
+        clearinghouseState: jest.fn().mockResolvedValue({
+          marginSummary: { totalMarginUsed: '0', accountValue: '1000' },
+          withdrawable: '1000',
+          assetPositions: [],
+          crossMarginSummary: { accountValue: '1000', totalMarginUsed: '0' },
+        }),
+        meta: jest.fn().mockResolvedValue({
+          universe: [{ name: 'ETH', szDecimals: 4, maxLeverage: 25 }],
+        }),
+        perpDexs: jest.fn().mockResolvedValue([null]),
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jest.spyOn(provider as any, 'getValidatedDexs').mockResolvedValue([null]);
+
+      // Act
+      const result = await provider.getOpenOrders();
+
+      // Assert - should fall back to REST API
+      expect(mockFrontendOpenOrders).toHaveBeenCalled();
+      expect(result.length).toBe(1);
+      expect(result[0].orderId).toBe('501');
+    });
+
+    it('returns defensive copy of cached orders (not original array)', async () => {
+      // Arrange - this tests that the atomic getter returns a copy
+      const cachedOrders = [
+        {
+          orderId: '101',
+          symbol: 'ETH',
+          side: 'buy' as const,
+          orderType: 'limit' as const,
+          size: '1.0',
+          originalSize: '1.0',
+          filledSize: '0',
+          remainingSize: '1.0',
+          price: '2900',
+          status: 'open' as const,
+          timestamp: Date.now(),
+          detailedOrderType: 'Limit',
+          reduceOnly: false,
+          isTrigger: false,
+        },
+      ];
+      // Return a new array each time (simulating the defensive copy)
+      mockSubscriptionService.getOrdersCacheIfInitialized = jest
+        .fn()
+        .mockImplementation(() => [...cachedOrders]);
+
+      // Act
+      const result1 = await provider.getOpenOrders();
+      const result2 = await provider.getOpenOrders();
+
+      // Assert - should be equal but not the same reference
+      expect(result1).toEqual(result2);
+      expect(result1).not.toBe(result2); // Different array instances
     });
 
     it('queries only main DEX when no additional DEXs enabled', async () => {
@@ -5404,10 +5657,10 @@ describe('HyperLiquidProvider', () => {
 
     it('queries multiple DEXs when HIP-3 enabled', async () => {
       // Arrange
-      // Ensure cache is disabled for this test
-      mockSubscriptionService.isOrdersCacheInitialized = jest
+      // Ensure cache is disabled for this test (atomic getter returns null)
+      mockSubscriptionService.getOrdersCacheIfInitialized = jest
         .fn()
-        .mockReturnValue(false);
+        .mockReturnValue(null);
 
       const mockFrontendOpenOrders = jest
         .fn()
@@ -6568,6 +6821,236 @@ describe('HyperLiquidProvider', () => {
         // With buffer (1.003) = 4212.6
         expect(result).toBeCloseTo(4212.6, 1);
       });
+    });
+  });
+
+  describe('WebSocket connection state methods', () => {
+    // Import actual enum to ensure type compatibility
+    const { WebSocketConnectionState } = jest.requireActual(
+      '../../services/HyperLiquidClientService',
+    );
+
+    beforeEach(() => {
+      // Add WebSocket methods to mock client service
+      mockClientService.getConnectionState = jest
+        .fn()
+        .mockReturnValue(WebSocketConnectionState.Connected);
+      mockClientService.subscribeToConnectionState = jest
+        .fn()
+        .mockReturnValue(jest.fn());
+      mockClientService.reconnect = jest.fn().mockResolvedValue(undefined);
+    });
+
+    it('getWebSocketConnectionState delegates to clientService', () => {
+      // Arrange
+      mockClientService.getConnectionState.mockReturnValue(
+        WebSocketConnectionState.Connected,
+      );
+
+      // Act
+      const result = provider.getWebSocketConnectionState();
+
+      // Assert
+      expect(result).toBe(WebSocketConnectionState.Connected);
+      expect(mockClientService.getConnectionState).toHaveBeenCalled();
+    });
+
+    it('subscribeToConnectionState delegates to clientService', () => {
+      // Arrange
+      const mockUnsubscribe = jest.fn();
+      mockClientService.subscribeToConnectionState.mockReturnValue(
+        mockUnsubscribe,
+      );
+      const listener = jest.fn();
+
+      // Act
+      const unsubscribe = provider.subscribeToConnectionState(listener);
+
+      // Assert
+      expect(mockClientService.subscribeToConnectionState).toHaveBeenCalledWith(
+        listener,
+      );
+      expect(unsubscribe).toBe(mockUnsubscribe);
+    });
+
+    it('reconnect delegates to clientService', async () => {
+      // Arrange
+      mockClientService.reconnect.mockResolvedValue(undefined);
+
+      // Act
+      await provider.reconnect();
+
+      // Assert
+      expect(mockClientService.reconnect).toHaveBeenCalled();
+    });
+  });
+
+  describe('getOrFetchFills - Cache-First Pattern', () => {
+    const mockFills = [
+      {
+        orderId: '123',
+        symbol: 'BTC',
+        side: 'buy' as const,
+        size: '0.1',
+        price: '50000',
+        fee: '5',
+        feeToken: 'USDC',
+        timestamp: Date.now(),
+        pnl: '100',
+        direction: 'Open Long',
+        success: true,
+      },
+      {
+        orderId: '124',
+        symbol: 'ETH',
+        side: 'sell' as const,
+        size: '1.0',
+        price: '3000',
+        fee: '3',
+        feeToken: 'USDC',
+        timestamp: Date.now() - 1000,
+        pnl: '-50',
+        direction: 'Close Short',
+        success: true,
+      },
+    ];
+
+    it('uses cached fills when cache is initialized', async () => {
+      // Arrange
+      mockSubscriptionService.getFillsCacheIfInitialized = jest
+        .fn()
+        .mockReturnValue(mockFills);
+
+      // Act
+      const result = await provider.getOrFetchFills({});
+
+      // Assert
+      expect(result).toEqual(mockFills);
+      expect(
+        mockSubscriptionService.getFillsCacheIfInitialized,
+      ).toHaveBeenCalled();
+      // Should NOT call REST API
+      expect(mockClientService.getInfoClient).not.toHaveBeenCalled();
+    });
+
+    it('falls back to REST API when cache returns null', async () => {
+      // Arrange - cache not initialized
+      mockSubscriptionService.getFillsCacheIfInitialized = jest
+        .fn()
+        .mockReturnValue(null);
+
+      mockClientService.getInfoClient = jest.fn().mockReturnValue({
+        userFills: jest.fn().mockResolvedValue([
+          {
+            oid: 125,
+            coin: 'BTC',
+            side: 'B',
+            sz: '0.5',
+            px: '49000',
+            fee: '2',
+            feeToken: 'USDC',
+            time: Date.now(),
+            closedPnl: '50',
+            dir: 'Open Long',
+          },
+        ]),
+      });
+
+      // Act
+      const result = await provider.getOrFetchFills({});
+
+      // Assert
+      expect(
+        mockSubscriptionService.getFillsCacheIfInitialized,
+      ).toHaveBeenCalled();
+      expect(mockClientService.getInfoClient).toHaveBeenCalled();
+      expect(result.length).toBe(1);
+      expect(result[0].symbol).toBe('BTC');
+    });
+
+    it('filters cached fills by startTime', async () => {
+      // Arrange
+      const now = Date.now();
+      const fillsWithDifferentTimes = [
+        { ...mockFills[0], timestamp: now },
+        { ...mockFills[1], timestamp: now - 100000 }, // Older fill
+      ];
+      mockSubscriptionService.getFillsCacheIfInitialized = jest
+        .fn()
+        .mockReturnValue(fillsWithDifferentTimes);
+
+      // Act - filter to only include recent fills
+      const result = await provider.getOrFetchFills({ startTime: now - 50000 });
+
+      // Assert - should only include the more recent fill
+      expect(result.length).toBe(1);
+      expect(result[0].timestamp).toBe(now);
+    });
+
+    it('filters cached fills by symbol', async () => {
+      // Arrange
+      mockSubscriptionService.getFillsCacheIfInitialized = jest
+        .fn()
+        .mockReturnValue(mockFills);
+
+      // Act - filter to only BTC fills
+      const result = await provider.getOrFetchFills({ symbol: 'BTC' });
+
+      // Assert - should only include BTC fill
+      expect(result.length).toBe(1);
+      expect(result[0].symbol).toBe('BTC');
+    });
+
+    it('filters cached fills by both startTime and symbol', async () => {
+      // Arrange
+      const now = Date.now();
+      const fillsWithDifferentTimesAndSymbols = [
+        { ...mockFills[0], symbol: 'BTC', timestamp: now },
+        { ...mockFills[0], symbol: 'BTC', timestamp: now - 100000 },
+        { ...mockFills[0], symbol: 'ETH', timestamp: now },
+      ];
+      mockSubscriptionService.getFillsCacheIfInitialized = jest
+        .fn()
+        .mockReturnValue(fillsWithDifferentTimesAndSymbols);
+
+      // Act - filter to recent BTC fills only
+      const result = await provider.getOrFetchFills({
+        startTime: now - 50000,
+        symbol: 'BTC',
+      });
+
+      // Assert - should only include recent BTC fill
+      expect(result.length).toBe(1);
+      expect(result[0].symbol).toBe('BTC');
+      expect(result[0].timestamp).toBe(now);
+    });
+
+    it('returns all fills when no filter params provided', async () => {
+      // Arrange
+      mockSubscriptionService.getFillsCacheIfInitialized = jest
+        .fn()
+        .mockReturnValue(mockFills);
+
+      // Act - no filter params
+      const result = await provider.getOrFetchFills();
+
+      // Assert - should return all fills
+      expect(result).toEqual(mockFills);
+    });
+
+    it('returns empty array when cache is initialized but empty', async () => {
+      // Arrange - cache initialized but no fills
+      mockSubscriptionService.getFillsCacheIfInitialized = jest
+        .fn()
+        .mockReturnValue([]);
+
+      // Act
+      const result = await provider.getOrFetchFills({});
+
+      // Assert
+      expect(result).toEqual([]);
+      // Should NOT call REST API since cache is initialized
+      expect(mockClientService.getInfoClient).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.test.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.test.ts
@@ -784,7 +784,7 @@ describe('HyperLiquidProvider', () => {
       const editParams = {
         orderId: '123',
         newOrder: {
-          symbol: 'BTC',
+          coin: 'BTC',
           isBuy: true,
           size: '0.1',
           orderType: 'market',
@@ -810,7 +810,7 @@ describe('HyperLiquidProvider', () => {
       const editParams = {
         orderId: '123',
         newOrder: {
-          symbol: 'BTC',
+          coin: 'BTC',
           isBuy: true,
           size: '0.1',
           orderType: 'market',
@@ -836,7 +836,7 @@ describe('HyperLiquidProvider', () => {
       const editParams = {
         orderId: '123',
         newOrder: {
-          symbol: 'BTC',
+          coin: 'BTC',
           isBuy: true,
           size: '0.1',
           orderType: 'market',
@@ -862,7 +862,7 @@ describe('HyperLiquidProvider', () => {
       const editParams = {
         orderId: '123',
         newOrder: {
-          symbol: 'BTC',
+          coin: 'BTC',
           isBuy: true,
           size: '0.1',
           orderType: 'market',
@@ -888,7 +888,7 @@ describe('HyperLiquidProvider', () => {
       const editParams = {
         orderId: '123',
         newOrder: {
-          symbol: 'BTC',
+          coin: 'BTC',
           isBuy: true,
           size: '0.1',
           orderType: 'market',
@@ -912,7 +912,7 @@ describe('HyperLiquidProvider', () => {
       const editParams = {
         orderId: '123',
         newOrder: {
-          symbol: 'BTC',
+          coin: 'BTC',
           isBuy: true,
           size: '0.1',
           orderType: 'market',
@@ -6821,67 +6821,6 @@ describe('HyperLiquidProvider', () => {
         // With buffer (1.003) = 4212.6
         expect(result).toBeCloseTo(4212.6, 1);
       });
-    });
-  });
-
-  describe('WebSocket connection state methods', () => {
-    // Import actual enum to ensure type compatibility
-    const { WebSocketConnectionState } = jest.requireActual(
-      '../../services/HyperLiquidClientService',
-    );
-
-    beforeEach(() => {
-      // Add WebSocket methods to mock client service
-      mockClientService.getConnectionState = jest
-        .fn()
-        .mockReturnValue(WebSocketConnectionState.Connected);
-      mockClientService.subscribeToConnectionState = jest
-        .fn()
-        .mockReturnValue(jest.fn());
-      mockClientService.reconnect = jest.fn().mockResolvedValue(undefined);
-    });
-
-    it('getWebSocketConnectionState delegates to clientService', () => {
-      // Arrange
-      mockClientService.getConnectionState.mockReturnValue(
-        WebSocketConnectionState.Connected,
-      );
-
-      // Act
-      const result = provider.getWebSocketConnectionState();
-
-      // Assert
-      expect(result).toBe(WebSocketConnectionState.Connected);
-      expect(mockClientService.getConnectionState).toHaveBeenCalled();
-    });
-
-    it('subscribeToConnectionState delegates to clientService', () => {
-      // Arrange
-      const mockUnsubscribe = jest.fn();
-      mockClientService.subscribeToConnectionState.mockReturnValue(
-        mockUnsubscribe,
-      );
-      const listener = jest.fn();
-
-      // Act
-      const unsubscribe = provider.subscribeToConnectionState(listener);
-
-      // Assert
-      expect(mockClientService.subscribeToConnectionState).toHaveBeenCalledWith(
-        listener,
-      );
-      expect(unsubscribe).toBe(mockUnsubscribe);
-    });
-
-    it('reconnect delegates to clientService', async () => {
-      // Arrange
-      mockClientService.reconnect.mockResolvedValue(undefined);
-
-      // Act
-      await provider.reconnect();
-
-      // Assert
-      expect(mockClientService.reconnect).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
@@ -95,6 +95,7 @@ import type {
   GetMarketsParams,
   GetOrderFillsParams,
   GetOrdersParams,
+  GetOrFetchFillsParams,
   GetPositionsParams,
   GetSupportedPathsParams,
   InitializeResult,
@@ -194,6 +195,11 @@ interface HandleOrderErrorParams {
   coin: string;
   orderType: 'market' | 'limit';
   isBuy: boolean;
+}
+
+interface GetOrFetchPriceParams {
+  symbol: string;
+  dexName: string | null;
 }
 
 /**
@@ -498,6 +504,115 @@ export class HyperLiquidProvider implements IPerpsProvider {
     // The promise is only reset in disconnect() for clean reconnection
     await this.ensureReadyPromise;
     DevLogger.log('[ensureReady] Initialization complete');
+  }
+
+  /**
+   * Get current price for a symbol using WebSocket cache first, REST API fallback
+   * Centralizes the price fetching pattern used across multiple methods
+   * @param params - Parameters for fetching price
+   * @param params.symbol - The symbol to get price for
+   * @param params.dexName - Optional DEX name for REST API fallback
+   * @returns The current price as a number
+   * @throws Error if no price is available
+   */
+  private async getOrFetchPrice(
+    params: GetOrFetchPriceParams,
+  ): Promise<number> {
+    const { symbol, dexName } = params;
+
+    // OPTIMIZATION: Use WebSocket price cache first (0 weight), fall back to REST (2 weight)
+    const cachedPrice = this.subscriptionService.getCachedPrice(symbol);
+
+    if (cachedPrice) {
+      const price = parseFloat(cachedPrice);
+      // Validate cached price: must be positive and finite
+      // Covers zero, negative, NaN, and Infinity in one check
+      if (price <= 0 || !isFinite(price)) {
+        this.deps.debugLogger.log(
+          'WebSocket cached price invalid for getOrFetchPrice, falling back to REST',
+          { symbol, cachedPrice, parsedPrice: price },
+        );
+        // Fall through to REST API fallback
+      } else {
+        this.deps.debugLogger.log('Using WebSocket cached price', {
+          symbol,
+          price,
+        });
+        return price;
+      }
+    }
+
+    // Fallback to REST API if cache miss
+    this.deps.debugLogger.log(
+      'Price cache miss for getOrFetchPrice, falling back to REST allMids',
+      { symbol },
+    );
+    const infoClient = this.clientService.getInfoClient();
+    const mids = await infoClient.allMids(
+      dexName ? { dex: dexName } : undefined,
+    );
+    const price = parseFloat(mids[symbol] || '0');
+
+    // Validate REST price: must be positive and finite
+    if (price <= 0 || !isFinite(price)) {
+      throw new Error(`Invalid price for ${symbol}: ${price}`);
+    }
+
+    return price;
+  }
+
+  /**
+   * Get fills using WebSocket cache first, falling back to REST API
+   * OPTIMIZATION: Uses cached fills when available (0 API weight), only calls REST on cache miss
+   *
+   * Cache limitation: WebSocket cache is limited to ~100 most recent fills.
+   * For historical data (e.g., position-opening fills from months ago), use getOrderFills directly.
+   *
+   * @param params - Optional filter parameters (startTime, symbol)
+   * @returns Array of order fills
+   */
+  public async getOrFetchFills(
+    params?: GetOrFetchFillsParams,
+  ): Promise<OrderFill[]> {
+    // Check WebSocket cache first (0 API weight)
+    const cachedFills = this.subscriptionService.getFillsCacheIfInitialized();
+
+    if (cachedFills !== null) {
+      this.deps.debugLogger.log('Using WebSocket cached fills', {
+        count: cachedFills.length,
+        params,
+      });
+      return this.filterFills(cachedFills, params);
+    }
+
+    // Fallback to REST API when cache not initialized
+    this.deps.debugLogger.log(
+      'Fills cache miss for getOrFetchFills, falling back to REST',
+      { params },
+    );
+    const restFills = await this.getOrderFills(params);
+    // Apply symbol filter to REST results for consistent API behavior
+    // Note: getOrderFills doesn't support symbol filtering natively
+    return this.filterFills(restFills, params);
+  }
+
+  /**
+   * Filter fills array by optional startTime and symbol parameters
+   * @param fills - Array of fills to filter
+   * @param params - Optional filter parameters
+   * @returns Filtered fills array
+   */
+  private filterFills(
+    fills: OrderFill[],
+    params?: { startTime?: number; symbol?: string },
+  ): OrderFill[] {
+    if (!params) return fills;
+
+    return fills.filter((fill) => {
+      if (params.startTime && fill.timestamp < params.startTime) return false;
+      if (params.symbol && fill.symbol !== params.symbol) return false;
+      return true;
+    });
   }
 
   /**
@@ -2276,7 +2391,6 @@ export class HyperLiquidProvider implements IPerpsProvider {
   ): Promise<GetAssetInfoResult> {
     const { coin, dexName } = params;
 
-    const infoClient = this.clientService.getInfoClient();
     const meta = await this.getCachedMeta({ dexName });
 
     const assetInfo = meta.universe.find((asset) => asset.name === coin);
@@ -2286,11 +2400,10 @@ export class HyperLiquidProvider implements IPerpsProvider {
       );
     }
 
-    const mids = await infoClient.allMids({ dex: dexName ?? '' });
-    const currentPrice = parseFloat(mids[coin] || '0');
-    if (currentPrice === 0) {
-      throw new Error(`No price available for ${coin}`);
-    }
+    const currentPrice = await this.getOrFetchPrice({
+      symbol: coin,
+      dexName: dexName ?? null,
+    });
 
     return { assetInfo, currentPrice, meta };
   }
@@ -2758,9 +2871,7 @@ export class HyperLiquidProvider implements IPerpsProvider {
       const { dex: dexName } = parseAssetName(params.newOrder.coin);
 
       // Get asset info and prices (uses cache to avoid redundant API calls)
-      const infoClient = this.clientService.getInfoClient();
       const meta = await this.getCachedMeta({ dexName });
-      const mids = await infoClient.allMids({ dex: dexName ?? '' });
 
       // asset.name format: "BTC" for main DEX, "xyz:XYZ100" for HIP-3
       const assetInfo = meta.universe.find(
@@ -2774,10 +2885,10 @@ export class HyperLiquidProvider implements IPerpsProvider {
         );
       }
 
-      const currentPrice = parseFloat(mids[params.newOrder.coin] || '0');
-      if (currentPrice === 0) {
-        throw new Error(`No price available for ${params.newOrder.coin}`);
-      }
+      const currentPrice = await this.getOrFetchPrice({
+        symbol: params.newOrder.coin,
+        dexName: dexName ?? null,
+      });
 
       // Calculate order parameters using the same logic as placeOrder
       let orderPrice: number;
@@ -3043,9 +3154,8 @@ export class HyperLiquidProvider implements IPerpsProvider {
         };
       }
 
-      // Get exchange client and meta for price/size formatting
+      // Get exchange client for order submission
       const exchangeClient = this.clientService.getExchangeClient();
-      const infoClient = this.clientService.getInfoClient();
 
       // Pre-fetch meta for all unique DEXs to avoid N API calls in loop
       const uniqueDexs = [
@@ -3107,12 +3217,11 @@ export class HyperLiquidProvider implements IPerpsProvider {
           });
         }
 
-        // Get current price for market order slippage
-        const mids = await infoClient.allMids({ dex: dexName ?? '' });
-        const currentPrice = parseFloat(mids[position.coin] || '0');
-        if (currentPrice === 0) {
-          throw new Error(`No price available for ${position.coin}`);
-        }
+        // Get current price for market order slippage (cache-first pattern)
+        const currentPrice = await this.getOrFetchPrice({
+          symbol: position.coin,
+          dexName: dexName ?? null,
+        });
 
         // Calculate order price with slippage
         const slippage =
@@ -3252,28 +3361,45 @@ export class HyperLiquidProvider implements IPerpsProvider {
     try {
       DevLogger.log('Updating position TP/SL:', params);
 
-      const { coin, takeProfitPrice, stopLossPrice } = params;
+      const {
+        coin,
+        takeProfitPrice,
+        stopLossPrice,
+        position: livePosition,
+      } = params;
 
       // Explicitly ensure builder fee approval for trading
       await this.ensureReady();
       await this.ensureBuilderFeeApproval();
 
-      // Get current position to validate it exists
-      // Force fresh API data (not WebSocket cache) since we're about to mutate the position
-      let positions: Position[];
-      try {
-        positions = await this.getPositions({ skipCache: true });
-      } catch (error) {
-        Logger.error(
-          ensureError(error),
-          this.getErrorContext('updatePositionTPSL > getPositions', {
-            coin,
-          }),
-        );
-        throw error;
-      }
+      // Use live position (from WebSocket) if available, otherwise fetch via REST
+      // Preferring WebSocket data avoids rate limiting issues with the REST API
+      let position: Position | undefined = livePosition;
 
-      const position = positions.find((p) => p.coin === coin);
+      if (!position) {
+        // Fallback: fetch positions via REST API (legacy behavior)
+        DevLogger.log(
+          'No live position passed, falling back to REST API fetch',
+        );
+        let positions: Position[];
+        try {
+          positions = await this.getPositions({ skipCache: true });
+        } catch (error) {
+          Logger.error(
+            ensureError(error),
+            this.getErrorContext('updatePositionTPSL > getPositions', {
+              coin,
+            }),
+          );
+          throw error;
+        }
+        position = positions.find((pos) => pos.coin === coin);
+      } else {
+        DevLogger.log('Using live position from WebSocket', {
+          coin: position.coin,
+          size: position.size,
+        });
+      }
 
       if (!position) {
         throw new Error(`No position found for ${coin}`);
@@ -3282,11 +3408,7 @@ export class HyperLiquidProvider implements IPerpsProvider {
       const positionSize = Math.abs(parseFloat(position.size));
       const isLong = parseFloat(position.size) > 0;
 
-      await this.ensureReady();
-
-      // See ensureReady() - builder fee and referral are session-cached
-
-      // Get current price for the asset
+      // Get clients for API calls (ensureReady already called at method start)
       const infoClient = this.clientService.getInfoClient();
       const exchangeClient = this.clientService.getExchangeClient();
       const userAddress = await this.walletService.getUserAddressWithDefault();
@@ -3294,48 +3416,78 @@ export class HyperLiquidProvider implements IPerpsProvider {
       // Extract DEX name for API calls (main DEX = null)
       const { dex: dexName } = parseAssetName(coin);
 
-      // Fetch current price for this asset's DEX
-      const mids = await infoClient.allMids(
-        dexName ? { dex: dexName } : undefined,
-      );
-      const currentPrice = parseFloat(mids[coin] || '0');
-
-      if (currentPrice === 0) {
-        throw new Error(`No price available for ${coin}`);
+      // Cancel existing TP/SL orders for this position
+      // OPTIMIZATION: Use WebSocket cache first (0 weight), fall back to single-DEX REST (20 weight)
+      // Previously: queryUserDataAcrossDexs queried ALL DEXs (20 weight × N DEXs = 40+ weight)
+      const assetId = this.coinToAssetId.get(coin);
+      if (assetId === undefined) {
+        throw new Error(`Asset ID not found for ${coin}`);
       }
 
-      // Cancel existing TP/SL orders for this position across all DEXs
-      DevLogger.log('Fetching open orders to cancel existing TP/SL...');
-      const orderResults = await this.queryUserDataAcrossDexs(
-        { user: userAddress },
-        (p) => infoClient.frontendOpenOrders(p),
-      );
+      let cancelRequests: { a: number; o: number }[] = [];
 
-      // Combine orders from all DEXs
-      const allOrders = orderResults.flatMap((result) => result.data);
+      // Use atomic getter to prevent race condition between check and get
+      const cachedOrders =
+        this.subscriptionService.getOrdersCacheIfInitialized();
 
-      const tpslOrdersToCancel = allOrders.filter(
-        (order) =>
-          order.coin === coin &&
-          order.reduceOnly === true &&
-          order.isPositionTpsl === !!TP_SL_CONFIG.USE_POSITION_BOUND_TPSL &&
-          order.isTrigger === true &&
-          (order.orderType.includes('Take Profit') ||
-            order.orderType.includes('Stop')),
-      );
+      if (cachedOrders !== null) {
+        // WebSocket cache available - use it (no API call, 0 weight)
+        DevLogger.log('Using WebSocket cache for TP/SL orders lookup', {
+          cachedOrdersCount: cachedOrders.length,
+        });
 
-      if (tpslOrdersToCancel.length > 0) {
-        DevLogger.log(
-          `Canceling ${tpslOrdersToCancel.length} existing TP/SL orders for ${coin}`,
+        // Filter using normalized Order type properties
+        // Note: Cached orders don't have isPositionTpsl, but we identify TP/SL orders by:
+        // - isTrigger === true
+        // - reduceOnly === true
+        // - detailedOrderType contains 'Take Profit' or 'Stop'
+        const tpslOrders = cachedOrders.filter(
+          (order) =>
+            order.symbol === coin &&
+            order.reduceOnly === true &&
+            order.isTrigger === true &&
+            order.detailedOrderType &&
+            (order.detailedOrderType.includes('Take Profit') ||
+              order.detailedOrderType.includes('Stop')),
         );
-        const assetId = this.coinToAssetId.get(coin);
-        if (assetId === undefined) {
-          throw new Error(`Asset ID not found for ${coin}`);
-        }
-        const cancelRequests = tpslOrdersToCancel.map((order) => ({
+
+        cancelRequests = tpslOrders.map((order) => ({
+          a: assetId,
+          o: parseInt(order.orderId, 10),
+        }));
+      } else {
+        // Fallback: Query only the specific DEX (20 weight instead of 40+)
+        DevLogger.log(
+          'WebSocket cache not initialized, falling back to single-DEX REST query',
+          { dex: dexName || 'main' },
+        );
+
+        const orders = await infoClient.frontendOpenOrders({
+          user: userAddress,
+          dex: dexName || undefined,
+        });
+
+        // Filter using raw SDK response properties
+        const tpslOrders = orders.filter(
+          (order) =>
+            order.coin === coin &&
+            order.reduceOnly === true &&
+            order.isPositionTpsl === !!TP_SL_CONFIG.USE_POSITION_BOUND_TPSL &&
+            order.isTrigger === true &&
+            (order.orderType.includes('Take Profit') ||
+              order.orderType.includes('Stop')),
+        );
+
+        cancelRequests = tpslOrders.map((order) => ({
           a: assetId,
           o: order.oid,
         }));
+      }
+
+      if (cancelRequests.length > 0) {
+        DevLogger.log(
+          `Canceling ${cancelRequests.length} existing TP/SL orders for ${coin}`,
+        );
 
         const cancelResult = await exchangeClient.cancel({
           cancels: cancelRequests,
@@ -3370,10 +3522,7 @@ export class HyperLiquidProvider implements IPerpsProvider {
         );
       }
 
-      const assetId = this.coinToAssetId.get(coin);
-      if (assetId === undefined) {
-        throw new Error(`Asset ID not found for ${coin}`);
-      }
+      // assetId already validated above when building cancelRequests
 
       // Build orders array for TP/SL
       const orders: SDKOrderParams[] = [];
@@ -4057,15 +4206,16 @@ export class HyperLiquidProvider implements IPerpsProvider {
   async getOpenOrders(params?: GetOrdersParams): Promise<Order[]> {
     try {
       // Try WebSocket cache first (unless explicitly bypassed)
-      if (
-        !params?.skipCache &&
-        this.subscriptionService.isOrdersCacheInitialized()
-      ) {
-        const cachedOrders = this.subscriptionService.getCachedOrders() || [];
-        DevLogger.log('Using cached open orders from WebSocket', {
-          count: cachedOrders.length,
-        });
-        return cachedOrders;
+      // Use atomic getter to prevent race condition between check and get
+      if (!params?.skipCache) {
+        const cachedOrders =
+          this.subscriptionService.getOrdersCacheIfInitialized();
+        if (cachedOrders !== null) {
+          DevLogger.log('Using cached open orders from WebSocket', {
+            count: cachedOrders.length,
+          });
+          return cachedOrders;
+        }
       }
 
       // Fallback to API call

--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
@@ -528,13 +528,13 @@ export class HyperLiquidProvider implements IPerpsProvider {
       // Validate cached price: must be positive and finite
       // Covers zero, negative, NaN, and Infinity in one check
       if (price <= 0 || !isFinite(price)) {
-        this.deps.debugLogger.log(
+        DevLogger.log(
           'WebSocket cached price invalid for getOrFetchPrice, falling back to REST',
           { symbol, cachedPrice, parsedPrice: price },
         );
         // Fall through to REST API fallback
       } else {
-        this.deps.debugLogger.log('Using WebSocket cached price', {
+        DevLogger.log('Using WebSocket cached price', {
           symbol,
           price,
         });
@@ -543,7 +543,7 @@ export class HyperLiquidProvider implements IPerpsProvider {
     }
 
     // Fallback to REST API if cache miss
-    this.deps.debugLogger.log(
+    DevLogger.log(
       'Price cache miss for getOrFetchPrice, falling back to REST allMids',
       { symbol },
     );
@@ -578,7 +578,7 @@ export class HyperLiquidProvider implements IPerpsProvider {
     const cachedFills = this.subscriptionService.getFillsCacheIfInitialized();
 
     if (cachedFills !== null) {
-      this.deps.debugLogger.log('Using WebSocket cached fills', {
+      DevLogger.log('Using WebSocket cached fills', {
         count: cachedFills.length,
         params,
       });
@@ -586,7 +586,7 @@ export class HyperLiquidProvider implements IPerpsProvider {
     }
 
     // Fallback to REST API when cache not initialized
-    this.deps.debugLogger.log(
+    DevLogger.log(
       'Fills cache miss for getOrFetchFills, falling back to REST',
       { params },
     );

--- a/app/components/UI/Perps/hooks/useHasExistingPosition.test.ts
+++ b/app/components/UI/Perps/hooks/useHasExistingPosition.test.ts
@@ -1,16 +1,37 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react-native';
 import { useHasExistingPosition } from './useHasExistingPosition';
-import { usePerpsLivePositions } from './stream';
-import type { Position } from '../controllers/types';
+import { usePerpsLivePositions, usePerpsLiveFills } from './stream';
+import type { Position, OrderFill } from '../controllers/types';
 
-// Mock the usePerpsLivePositions hook
+// Mock the stream hooks
 jest.mock('./stream', () => ({
   usePerpsLivePositions: jest.fn(),
+  usePerpsLiveFills: jest.fn(),
+}));
+
+// Mock Engine for REST fallback - uses getOrderFills directly for historical fills
+// (WebSocket cache is limited to ~100 recent fills, so REST is needed for older positions)
+const mockGetOrderFills = jest.fn();
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    PerpsController: {
+      getOrderFills: (...args: unknown[]) => mockGetOrderFills(...args),
+    },
+  },
+}));
+
+// Mock Logger
+jest.mock('../../../../util/Logger', () => ({
+  log: jest.fn(),
 }));
 
 describe('useHasExistingPosition', () => {
   const mockUsePerpsLivePositions =
     usePerpsLivePositions as jest.MockedFunction<typeof usePerpsLivePositions>;
+  const mockUsePerpsLiveFills = usePerpsLiveFills as jest.MockedFunction<
+    typeof usePerpsLiveFills
+  >;
 
   const mockPositions: Position[] = [
     {
@@ -61,9 +82,16 @@ describe('useHasExistingPosition', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: no fills
+    mockUsePerpsLiveFills.mockReturnValue({
+      fills: [],
+      isInitialLoading: false,
+    });
+    // Default: REST returns empty (via getOrFetchFills cache-first pattern)
+    mockGetOrderFills.mockResolvedValue([]);
   });
 
-  it('should return hasPosition as true when position exists for asset', () => {
+  it('returns hasPosition as true when position exists for asset', () => {
     mockUsePerpsLivePositions.mockReturnValue({
       positions: mockPositions,
       isInitialLoading: false,
@@ -79,7 +107,7 @@ describe('useHasExistingPosition', () => {
     expect(result.current.error).toBe(null);
   });
 
-  it('should return hasPosition as false when no position exists for asset', () => {
+  it('returns hasPosition as false when no position exists for asset', () => {
     mockUsePerpsLivePositions.mockReturnValue({
       positions: mockPositions,
       isInitialLoading: false,
@@ -95,7 +123,7 @@ describe('useHasExistingPosition', () => {
     expect(result.current.error).toBe(null);
   });
 
-  it('should return loading state as false (WebSocket loads from cache)', () => {
+  it('returns loading state as false (WebSocket loads from cache)', () => {
     mockUsePerpsLivePositions.mockReturnValue({
       positions: [],
       isInitialLoading: false,
@@ -111,7 +139,7 @@ describe('useHasExistingPosition', () => {
     expect(result.current.error).toBe(null);
   });
 
-  it('should return error as null (WebSocket handles errors internally)', () => {
+  it('returns error as null (WebSocket handles errors internally)', () => {
     mockUsePerpsLivePositions.mockReturnValue({
       positions: [],
       isInitialLoading: false,
@@ -127,7 +155,7 @@ describe('useHasExistingPosition', () => {
     expect(result.current.error).toBe(null); // Always null with WebSocket
   });
 
-  it('should ignore loadOnMount parameter (WebSocket loads from cache)', () => {
+  it('ignores loadOnMount parameter (WebSocket loads from cache)', () => {
     mockUsePerpsLivePositions.mockReturnValue({
       positions: [],
       isInitialLoading: false,
@@ -141,7 +169,7 @@ describe('useHasExistingPosition', () => {
     expect(result.current.hasPosition).toBe(false);
   });
 
-  it('should handle empty positions array', () => {
+  it('handles empty positions array', () => {
     mockUsePerpsLivePositions.mockReturnValue({
       positions: [],
       isInitialLoading: false,
@@ -155,7 +183,7 @@ describe('useHasExistingPosition', () => {
     expect(result.current.existingPosition).toBe(null);
   });
 
-  it('should update when positions change', () => {
+  it('updates when positions change', () => {
     // Initially no positions
     mockUsePerpsLivePositions.mockReturnValue({
       positions: [],
@@ -179,7 +207,7 @@ describe('useHasExistingPosition', () => {
     expect(result.current.existingPosition).toEqual(mockPositions[0]);
   });
 
-  it('should return a no-op refreshPosition function', async () => {
+  it('returns a no-op refreshPosition function', async () => {
     mockUsePerpsLivePositions.mockReturnValue({
       positions: mockPositions,
       isInitialLoading: false,
@@ -191,5 +219,298 @@ describe('useHasExistingPosition', () => {
 
     // refreshPosition should be a no-op that returns a resolved promise
     await expect(result.current.refreshPosition()).resolves.toBeUndefined();
+  });
+
+  describe('positionOpenedTimestamp', () => {
+    const mockFills: OrderFill[] = [
+      {
+        orderId: 'order-1',
+        symbol: 'BTC',
+        side: 'buy',
+        direction: 'Open Long',
+        timestamp: 1700000000000,
+        size: '0.5',
+        price: '45000',
+        pnl: '0',
+        fee: '0.001',
+        feeToken: 'USDC',
+      },
+      {
+        orderId: 'order-2',
+        symbol: 'ETH',
+        side: 'buy',
+        direction: 'Open Long',
+        timestamp: 1700000001000,
+        size: '1.0',
+        price: '3000',
+        pnl: '0',
+        fee: '0.01',
+        feeToken: 'USDC',
+      },
+    ];
+
+    it('returns positionOpenedTimestamp from WebSocket fills', () => {
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: mockFills,
+        isInitialLoading: false,
+      });
+
+      const { result } = renderHook(() =>
+        useHasExistingPosition({ asset: 'BTC' }),
+      );
+
+      expect(result.current.positionOpenedTimestamp).toBe(1700000000000);
+    });
+
+    it('returns undefined when no matching fill exists in WebSocket', () => {
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: [mockFills[1]], // Only ETH fill
+        isInitialLoading: false,
+      });
+
+      const { result } = renderHook(() =>
+        useHasExistingPosition({ asset: 'BTC' }),
+      );
+
+      // No BTC fill in WebSocket, and REST hasn't returned yet
+      expect(result.current.positionOpenedTimestamp).toBeUndefined();
+    });
+
+    it('returns undefined when no position exists', () => {
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: [],
+        isInitialLoading: false,
+      });
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: mockFills,
+        isInitialLoading: false,
+      });
+
+      const { result } = renderHook(() =>
+        useHasExistingPosition({ asset: 'BTC' }),
+      );
+
+      expect(result.current.positionOpenedTimestamp).toBeUndefined();
+    });
+
+    it('falls back to REST API when WebSocket has no fill', async () => {
+      const restTimestamp = Date.now() - 5 * 60 * 1000;
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: [], // No WebSocket fills
+        isInitialLoading: false,
+      });
+      mockGetOrderFills.mockResolvedValue([
+        {
+          orderId: 'order-rest-1',
+          symbol: 'BTC',
+          side: 'buy',
+          direction: 'Open Long',
+          timestamp: restTimestamp,
+          size: '0.5',
+          price: '45000',
+          pnl: '0',
+          fee: '0.001',
+          feeToken: 'USDC',
+        },
+      ]);
+
+      const { result } = renderHook(() =>
+        useHasExistingPosition({ asset: 'BTC' }),
+      );
+
+      // Wait for REST fallback to complete
+      await waitFor(() => {
+        expect(result.current.positionOpenedTimestamp).toBe(restTimestamp);
+      });
+
+      expect(mockGetOrderFills).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startTime: expect.any(Number),
+        }),
+      );
+    });
+
+    it('prefers WebSocket timestamp over REST', () => {
+      const wsTimestamp = 1700000000000;
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: mockFills, // Has BTC fill with wsTimestamp
+        isInitialLoading: false,
+      });
+
+      const { result } = renderHook(() =>
+        useHasExistingPosition({ asset: 'BTC' }),
+      );
+
+      // Should use WebSocket timestamp, not trigger REST fallback
+      expect(result.current.positionOpenedTimestamp).toBe(wsTimestamp);
+      expect(mockGetOrderFills).not.toHaveBeenCalled();
+    });
+
+    it('clears stale timestamp when switching positions', async () => {
+      const btcTimestamp = Date.now() - 10 * 60 * 1000;
+      const ethTimestamp = Date.now() - 5 * 60 * 1000;
+
+      // Start with BTC position, REST returns BTC fill
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: [mockPositions[0]], // BTC only
+        isInitialLoading: false,
+      });
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: [],
+        isInitialLoading: false,
+      });
+      mockGetOrderFills.mockResolvedValueOnce([
+        {
+          orderId: 'order-btc-1',
+          symbol: 'BTC',
+          side: 'buy',
+          direction: 'Open Long',
+          timestamp: btcTimestamp,
+          size: '0.5',
+          price: '45000',
+          pnl: '0',
+          fee: '0.001',
+          feeToken: 'USDC',
+        },
+      ]);
+
+      const { result, rerender } = renderHook(
+        ({ asset }) => useHasExistingPosition({ asset }),
+        { initialProps: { asset: 'BTC' } },
+      );
+
+      // Wait for BTC timestamp
+      await waitFor(() => {
+        expect(result.current.positionOpenedTimestamp).toBe(btcTimestamp);
+      });
+
+      // Switch to ETH position
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: [mockPositions[1]], // ETH only
+        isInitialLoading: false,
+      });
+      mockGetOrderFills.mockResolvedValueOnce([
+        {
+          orderId: 'order-eth-1',
+          symbol: 'ETH',
+          side: 'buy',
+          direction: 'Open Long',
+          timestamp: ethTimestamp,
+          size: '1.0',
+          price: '3000',
+          pnl: '0',
+          fee: '0.01',
+          feeToken: 'USDC',
+        },
+      ]);
+
+      rerender({ asset: 'ETH' });
+
+      // BTC timestamp should be cleared, then ETH timestamp should be set
+      await waitFor(() => {
+        expect(result.current.positionOpenedTimestamp).toBe(ethTimestamp);
+      });
+    });
+
+    it('fetches fresh timestamp when same symbol position is closed and reopened', async () => {
+      const oldTimestamp = Date.now() - 60 * 60 * 1000; // 1 hour ago (old position)
+      const newTimestamp = Date.now() - 5 * 60 * 1000; // 5 minutes ago (new position)
+
+      // Start with BTC position
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: [mockPositions[0]], // BTC
+        isInitialLoading: false,
+      });
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: [], // No WebSocket fills
+        isInitialLoading: false,
+      });
+
+      // First REST fetch returns old timestamp
+      mockGetOrderFills.mockResolvedValueOnce([
+        {
+          orderId: 'order-btc-old',
+          symbol: 'BTC',
+          side: 'buy',
+          direction: 'Open Long',
+          timestamp: oldTimestamp,
+          size: '0.5',
+          price: '45000',
+          pnl: '0',
+          fee: '0.001',
+          feeToken: 'USDC',
+        },
+      ]);
+
+      const { result, rerender } = renderHook(
+        ({ asset }) => useHasExistingPosition({ asset }),
+        { initialProps: { asset: 'BTC' } },
+      );
+
+      // Wait for old timestamp to be set
+      await waitFor(() => {
+        expect(result.current.positionOpenedTimestamp).toBe(oldTimestamp);
+      });
+      expect(mockGetOrderFills).toHaveBeenCalledTimes(1);
+
+      // Close position (set positions to empty)
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: [],
+        isInitialLoading: false,
+      });
+      rerender({ asset: 'BTC' });
+
+      // Timestamp should be cleared
+      expect(result.current.positionOpenedTimestamp).toBeUndefined();
+      expect(result.current.hasPosition).toBe(false);
+
+      // Reopen position with same symbol (BTC)
+      mockUsePerpsLivePositions.mockReturnValue({
+        positions: [mockPositions[0]], // BTC again
+        isInitialLoading: false,
+      });
+
+      // Second REST fetch returns new timestamp
+      mockGetOrderFills.mockResolvedValueOnce([
+        {
+          orderId: 'order-btc-new',
+          symbol: 'BTC',
+          side: 'buy',
+          direction: 'Open Long',
+          timestamp: newTimestamp,
+          size: '0.3',
+          price: '50000',
+          pnl: '0',
+          fee: '0.001',
+          feeToken: 'USDC',
+        },
+      ]);
+
+      rerender({ asset: 'BTC' });
+
+      // Should fetch fresh timestamp for the reopened position
+      await waitFor(() => {
+        expect(result.current.positionOpenedTimestamp).toBe(newTimestamp);
+      });
+
+      // REST should have been called twice (once for old, once for new position)
+      expect(mockGetOrderFills).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/app/components/UI/Perps/hooks/useHasExistingPosition.ts
+++ b/app/components/UI/Perps/hooks/useHasExistingPosition.ts
@@ -68,7 +68,7 @@ export function useHasExistingPosition(
     // Find the most recent "Open" fill for this position's symbol
     const openFill = orderFills
       .filter((fill) => {
-        const isMatchingAsset = fill.symbol === existingPosition.symbol;
+        const isMatchingAsset = fill.symbol === existingPosition.coin;
         const isOpenDirection = fill.direction?.startsWith('Open');
         return isMatchingAsset && isOpenDirection;
       })
@@ -96,7 +96,7 @@ export function useHasExistingPosition(
 
     // Check if this is a new symbol (different from what we last fetched)
     const isNewSymbol =
-      restFetchedForSymbolRef.current !== existingPosition.symbol;
+      restFetchedForSymbolRef.current !== existingPosition.coin;
 
     // Skip if we've already fetched for this position symbol
     if (!isNewSymbol) {
@@ -108,7 +108,7 @@ export function useHasExistingPosition(
     setRestPositionTimestamp(undefined);
 
     // Mark that we're fetching for this symbol to prevent duplicate calls
-    restFetchedForSymbolRef.current = existingPosition.symbol;
+    restFetchedForSymbolRef.current = existingPosition.coin;
 
     // Track if this effect is still current to prevent stale updates
     // This prevents race conditions when users rapidly switch markets
@@ -116,7 +116,7 @@ export function useHasExistingPosition(
 
     const fetchHistoricalFills = async () => {
       // Capture symbol at fetch start for validation and logging
-      const symbolAtFetchStart = existingPosition.symbol;
+      const symbolAtFetchStart = existingPosition.coin;
 
       try {
         // Fetch fills from the last 90 days to find position-opening fill
@@ -124,7 +124,7 @@ export function useHasExistingPosition(
         // because WebSocket cache is limited to ~100 recent fills and won't contain
         // position-opening fills for older positions. The REST API is needed for
         // historical data that predates the WebSocket connection.
-        const startTime = Date.now() - PERPS_CONSTANTS.FillsLookbackMs;
+        const startTime = Date.now() - PERPS_CONSTANTS.FILLS_LOOKBACK_MS;
         const controller = Engine.context.PerpsController;
         const fills = await controller.getOrderFills({ startTime });
 

--- a/app/components/UI/Perps/hooks/useHasExistingPosition.ts
+++ b/app/components/UI/Perps/hooks/useHasExistingPosition.ts
@@ -1,6 +1,9 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Position } from '../controllers/types';
-import { usePerpsLivePositions } from './stream';
+import { usePerpsLivePositions, usePerpsLiveFills } from './stream';
+import Engine from '../../../../core/Engine';
+import Logger from '../../../../util/Logger';
+import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 
 interface UseHasExistingPositionParams {
   /** Asset symbol to check for existing position */
@@ -20,6 +23,8 @@ interface UseHasExistingPositionReturn {
   existingPosition: Position | null;
   /** Function to refresh positions data - no-op for WebSocket */
   refreshPosition: () => Promise<void>;
+  /** Timestamp when the position was opened (from order fills) */
+  positionOpenedTimestamp: number | undefined;
 }
 
 /**
@@ -37,22 +42,136 @@ export function useHasExistingPosition(
   // Get real-time positions via WebSocket
   const { positions, isInitialLoading } = usePerpsLivePositions();
 
+  // Get real-time fills via WebSocket for position opened timestamp
+  const { fills: orderFills } = usePerpsLiveFills();
+
+  // State for REST-fetched position opened timestamp (fallback when WebSocket doesn't have the fill)
+  const [restPositionTimestamp, setRestPositionTimestamp] = useState<
+    number | undefined
+  >(undefined);
+  // Track which position symbol we've already fetched REST data for to avoid duplicate calls
+  const restFetchedForSymbolRef = useRef<string | null>(null);
+
   // Check if user has an existing position for this asset
   const existingPosition = useMemo(
     () => (positions || []).find((position) => position.coin === asset) || null,
     [positions, asset],
   );
 
-  const hasPosition = useMemo(
-    () => existingPosition !== null,
-    [existingPosition],
-  );
+  const hasPosition = existingPosition !== null;
 
-  // No-op refresh function for compatibility
-  // Positions update automatically via WebSocket
-  // WebSocket positions update automatically, no manual refresh needed
+  // Get position opened timestamp from WebSocket fills data
+  // This is used by useStopLossPrompt to bypass client-side debounce timers
+  const wsPositionOpenedTimestamp = useMemo(() => {
+    if (!existingPosition || !orderFills) return undefined;
+
+    // Find the most recent "Open" fill for this position's symbol
+    const openFill = orderFills
+      .filter((fill) => {
+        const isMatchingAsset = fill.symbol === existingPosition.symbol;
+        const isOpenDirection = fill.direction?.startsWith('Open');
+        return isMatchingAsset && isOpenDirection;
+      })
+      .sort((a, b) => b.timestamp - a.timestamp)[0];
+
+    return openFill?.timestamp;
+  }, [existingPosition, orderFills]);
+
+  // Clear cached timestamp data when position is closed
+  // This ensures reopening the same symbol gets a fresh timestamp
+  useEffect(() => {
+    if (!existingPosition) {
+      restFetchedForSymbolRef.current = null;
+      setRestPositionTimestamp(undefined);
+    }
+  }, [existingPosition]);
+
+  // Fallback: Fetch historical fills via REST when WebSocket doesn't have the position-opening fill
+  // This handles older positions where the "Open" fill is no longer in the WebSocket snapshot
+  useEffect(() => {
+    // Skip if no position or if WebSocket already has the timestamp
+    if (!existingPosition || wsPositionOpenedTimestamp) {
+      return;
+    }
+
+    // Check if this is a new symbol (different from what we last fetched)
+    const isNewSymbol =
+      restFetchedForSymbolRef.current !== existingPosition.symbol;
+
+    // Skip if we've already fetched for this position symbol
+    if (!isNewSymbol) {
+      return;
+    }
+
+    // IMPORTANT: Clear stale timestamp BEFORE updating ref to prevent race condition
+    // This ensures the old position's timestamp doesn't leak to the new position
+    setRestPositionTimestamp(undefined);
+
+    // Mark that we're fetching for this symbol to prevent duplicate calls
+    restFetchedForSymbolRef.current = existingPosition.symbol;
+
+    // Track if this effect is still current to prevent stale updates
+    // This prevents race conditions when users rapidly switch markets
+    let isCurrent = true;
+
+    const fetchHistoricalFills = async () => {
+      // Capture symbol at fetch start for validation and logging
+      const symbolAtFetchStart = existingPosition.symbol;
+
+      try {
+        // Fetch fills from the last 90 days to find position-opening fill
+        // Note: We use getOrderFills (REST) directly here instead of getOrFetchFills
+        // because WebSocket cache is limited to ~100 recent fills and won't contain
+        // position-opening fills for older positions. The REST API is needed for
+        // historical data that predates the WebSocket connection.
+        const startTime = Date.now() - PERPS_CONSTANTS.FillsLookbackMs;
+        const controller = Engine.context.PerpsController;
+        const fills = await controller.getOrderFills({ startTime });
+
+        if (!fills || fills.length === 0) {
+          return;
+        }
+
+        // Find the most recent "Open" fill for this position's symbol
+        const openFill = fills
+          .filter((fill) => {
+            // Use captured symbol to ensure consistency
+            const isMatchingAsset = fill.symbol === symbolAtFetchStart;
+            const isOpenDirection = fill.direction?.startsWith('Open');
+            return isMatchingAsset && isOpenDirection;
+          })
+          .sort((a, b) => b.timestamp - a.timestamp)[0];
+
+        // Only set state if this effect is still current (not cleaned up due to market switch)
+        if (openFill?.timestamp && isCurrent) {
+          setRestPositionTimestamp(openFill.timestamp);
+        }
+      } catch (error) {
+        // Don't log for cancelled operations
+        if (!isCurrent) return;
+
+        // Non-critical error - fall back to debounce timer if REST fails
+        Logger.log('Failed to fetch historical fills for position timestamp', {
+          error,
+          symbol: symbolAtFetchStart,
+        });
+      }
+    };
+
+    fetchHistoricalFills();
+
+    // Cleanup: mark this effect as no longer current when market changes
+    return () => {
+      isCurrent = false;
+    };
+  }, [existingPosition, wsPositionOpenedTimestamp]);
+
+  // Combine WebSocket and REST timestamps - prefer WebSocket (faster), fall back to REST
+  const positionOpenedTimestamp =
+    wsPositionOpenedTimestamp ?? restPositionTimestamp;
+
+  // No-op refresh function for compatibility - positions update automatically via WebSocket
   const refreshPosition = useCallback(async () => undefined, []);
-  // WebSocket positions update automatically, no manual refresh needed
 
   return {
     hasPosition,
@@ -60,5 +179,6 @@ export function useHasExistingPosition(
     error: null, // WebSocket subscriptions handle errors internally
     existingPosition,
     refreshPosition,
+    positionOpenedTimestamp,
   };
 }

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
@@ -169,6 +169,8 @@ describe('usePerpsTPSLUpdate', () => {
       coin: 'ETH',
       takeProfitPrice,
       stopLossPrice,
+      trackingData: undefined,
+      position,
     });
   });
 
@@ -251,6 +253,8 @@ describe('usePerpsTPSLUpdate', () => {
       coin: 'ETH',
       takeProfitPrice: undefined,
       stopLossPrice: undefined,
+      trackingData: undefined,
+      position,
     });
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -30,7 +30,7 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
       takeProfitPrice: string | undefined,
       stopLossPrice: string | undefined,
       trackingData?: TPSLTrackingData,
-    ) => {
+    ): Promise<{ success: boolean }> => {
       setIsUpdating(true);
       DevLogger.log('usePerpsTPSLUpdate: Setting isUpdating to true');
 
@@ -40,6 +40,7 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
           takeProfitPrice,
           stopLossPrice,
           trackingData,
+          position, // Pass live WebSocket position to avoid REST API fetch (prevents rate limiting)
         });
 
         if (result.success) {
@@ -59,20 +60,23 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
 
           // Call success callback if provided
           options?.onSuccess?.();
-        } else {
-          DevLogger.log('Failed to update position TP/SL:', result.error);
 
-          const errorMessage = result.error || strings('perps.errors.unknown');
-
-          showToast(
-            PerpsToastOptions.positionManagement.tpsl.updateTPSLError(
-              errorMessage,
-            ),
-          );
-
-          // Call error callback if provided
-          options?.onError?.(errorMessage);
+          return { success: true };
         }
+        DevLogger.log('Failed to update position TP/SL:', result.error);
+
+        const errorMessage = result.error || strings('perps.errors.unknown');
+
+        showToast(
+          PerpsToastOptions.positionManagement.tpsl.updateTPSLError(
+            errorMessage,
+          ),
+        );
+
+        // Call error callback if provided
+        options?.onError?.(errorMessage);
+
+        return { success: false };
       } catch (error) {
         DevLogger.log('Error updating position TP/SL:', error);
 
@@ -112,6 +116,8 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
 
         // Call error callback if provided
         options?.onError?.(errorMessage);
+
+        return { success: false };
       } finally {
         DevLogger.log('usePerpsTPSLUpdate: Setting isUpdating to false');
         setIsUpdating(false);

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.test.ts
@@ -3329,6 +3329,60 @@ describe('HyperLiquidSubscriptionService', () => {
 
       expect(result).toBeNull();
     });
+
+    it('getOrdersCacheIfInitialized returns null when cache not initialized', () => {
+      const result = service.getOrdersCacheIfInitialized();
+
+      expect(result).toBeNull();
+    });
+
+    it('getOrdersCacheIfInitialized returns empty array when initialized but no orders', async () => {
+      // First subscribe to trigger initialization
+      const callback = jest.fn();
+      service.subscribeToOrders({ callback });
+
+      // Manually set the cache as initialized with empty data
+      // We need to simulate WebSocket message to trigger initialization
+      // For unit test, we verify the method exists and returns correct type
+      const result = service.getOrdersCacheIfInitialized();
+
+      // Before any WebSocket data, should return null
+      expect(result).toBeNull();
+    });
+
+    it('getOrdersCacheIfInitialized returns defensive copy of orders', async () => {
+      // This test verifies the atomic getter returns a copy, not the original
+      // We test indirectly by verifying the method signature and behavior
+      const result1 = service.getOrdersCacheIfInitialized();
+      const result2 = service.getOrdersCacheIfInitialized();
+
+      // Both should be null before initialization
+      expect(result1).toBeNull();
+      expect(result2).toBeNull();
+    });
+
+    it('returns null for cached fills before initialization', () => {
+      const result = service.getCachedFills();
+
+      expect(result).toBeNull();
+    });
+
+    it('getFillsCacheIfInitialized returns null when cache not initialized', () => {
+      const result = service.getFillsCacheIfInitialized();
+
+      expect(result).toBeNull();
+    });
+
+    it('getFillsCacheIfInitialized returns defensive copy of fills', () => {
+      // This test verifies the atomic getter returns a copy, not the original
+      // We test indirectly by verifying the method signature and behavior
+      const result1 = service.getFillsCacheIfInitialized();
+      const result2 = service.getFillsCacheIfInitialized();
+
+      // Both should be null before initialization
+      expect(result1).toBeNull();
+      expect(result2).toBeNull();
+    });
   });
 
   describe('OI Cap Subscriptions', () => {

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -140,6 +140,10 @@ export class HyperLiquidSubscriptionService {
   // Global price data cache
   private cachedPriceData: Map<string, PriceUpdate> | null = null;
 
+  // Fills cache for cache-first pattern (similar to price caching)
+  private cachedFills: OrderFill[] | null = null;
+  private fillsCacheInitialized = false;
+
   // HIP-3: assetCtxs subscriptions for multi-DEX market data
   private readonly assetCtxsSubscriptions = new Map<string, ISubscription>(); // Key: dex name ('' for main)
   private readonly dexAssetCtxsCache = new Map<
@@ -1750,6 +1754,22 @@ export class HyperLiquidSubscriptionService {
             : undefined,
         }));
 
+        // Cache fills for cache-first pattern (similar to price caching)
+        // This allows getOrFetchFills() to return cached data without REST API calls
+        if (data.isSnapshot) {
+          // Snapshot: replace cache with initial historical data, sorted newest first
+          this.cachedFills = [...orderFills]
+            .sort((a, b) => b.timestamp - a.timestamp)
+            .slice(0, 100);
+          this.fillsCacheInitialized = true;
+        } else {
+          // Streaming: prepend new fills to existing (newest first)
+          this.cachedFills = [...orderFills, ...(this.cachedFills || [])].slice(
+            0,
+            100,
+          );
+        }
+
         // Distribute to all callbacks for this accountId
         const subscribers = this.orderFillSubscribers.get(normalizedAccountId);
         if (subscribers) {
@@ -1861,6 +1881,50 @@ export class HyperLiquidSubscriptionService {
    */
   public getCachedOrders(): Order[] | null {
     return this.cachedOrders;
+  }
+
+  /**
+   * Atomically get cached orders if initialized
+   * Prevents race condition between checking initialization and getting data
+   * @returns Cached orders array if initialized, null otherwise
+   */
+  public getOrdersCacheIfInitialized(): Order[] | null {
+    if (!this.ordersCacheInitialized) {
+      return null;
+    }
+    return this.cachedOrders ? [...this.cachedOrders] : [];
+  }
+
+  /**
+   * Get cached price for a symbol from WebSocket allMids subscription
+   * OPTIMIZATION: Use this instead of REST infoClient.allMids() to avoid rate limiting
+   * @param symbol - Asset symbol (e.g., 'BTC', 'ETH', 'xyz:TSLA')
+   * @returns Price string, or undefined if not cached
+   */
+  public getCachedPrice(symbol: string): string | undefined {
+    return this.cachedPriceData?.get(symbol)?.price;
+  }
+
+  /**
+   * Get cached fills from WebSocket userFills subscription
+   * OPTIMIZATION: Use this instead of REST userFills() to avoid rate limiting
+   * @returns Copy of cached fills array, or null if not cached
+   */
+  public getCachedFills(): OrderFill[] | null {
+    return this.cachedFills ? [...this.cachedFills] : null;
+  }
+
+  /**
+   * Get cached fills only if the cache has been initialized from WebSocket
+   * OPTIMIZATION: Distinguishes between "not initialized" (null) and "initialized but empty" ([])
+   * - Returns null if cache hasn't received WebSocket snapshot yet (caller should use REST)
+   * - Returns empty array [] if cache is initialized but user has no fills (caller can skip REST)
+   * - Returns fills array if cache has data
+   * @returns Fills array or empty array if initialized, null if not yet initialized
+   */
+  public getFillsCacheIfInitialized(): OrderFill[] | null {
+    if (!this.fillsCacheInitialized) return null;
+    return this.cachedFills ? [...this.cachedFills] : [];
   }
 
   /**
@@ -2756,8 +2820,10 @@ export class HyperLiquidSubscriptionService {
     this.cachedPositions = null;
     this.cachedOrders = null;
     this.cachedAccount = null;
+    this.cachedFills = null;
     this.ordersCacheInitialized = false; // Reset cache initialization flag
     this.positionsCacheInitialized = false; // Reset cache initialization flag
+    this.fillsCacheInitialized = false; // Reset fills cache initialization flag
     this.marketDataCache.clear();
     this.orderBookCache.clear();
     this.symbolSubscriberCounts.clear();


### PR DESCRIPTION
## **Description**

Cherry-pick of commit 425beaead7 (Nick's 429 rate limiting fix) to release/7.62.2 branch.

This hotfix addresses HyperLiquid WebSocket rate limiting issues (429 errors) that occur during rapid market switching or TP/SL updates. The fix introduces cache-first patterns to reduce API weight and avoid hitting rate limits.

**Key changes:**
- Add optional `position` parameter to `updatePositionTPSL` to skip REST API fetch when WebSocket data is available
- Implement `getOrFetchPrice` helper for WebSocket-first price retrieval (0 weight vs 20 weight)
- Add atomic cache getter `getOrdersCacheIfInitialized()` to prevent race conditions
- Add `getOrFetchFills` for cache-first fills retrieval
- Move `positionOpenedTimestamp` calculation into `useHasExistingPosition` hook
- Add `currentPositionRef` sync in PerpsMarketDetailsView to prevent stale closure issues

**Conflict resolution notes:**
The main branch uses `symbol` naming convention while release/7.62.2 uses `coin`. All conflicts were resolved by keeping the `coin` naming convention while adopting the cache-first optimization patterns.

## **Changelog**

CHANGELOG entry: Fixed rate limiting issues (429 errors) when rapidly switching markets or updating TP/SL orders

## **Related issues**

Fixes: Rate limiting issues on HyperLiquid API during rapid market navigation

## **Manual testing steps**

```gherkin
Feature: Rate limiting prevention for Perps

  Scenario: User rapidly switches between markets
    Given user has the Perps feature enabled
    And user is viewing a market details page

    When user rapidly navigates between different markets (BTC -> ETH -> SOL -> BTC)
    Then no 429 rate limit errors should appear
    And market data should load correctly for each market

  Scenario: User updates TP/SL via stop loss prompt banner
    Given user has an open position without stop loss
    And the stop loss prompt banner is visible

    When user taps "Set Stop Loss" on the banner
    Then the stop loss should be set successfully
    And no rate limit errors should occur

  Scenario: User edits existing TP/SL on a position
    Given user has an open position with TP/SL set

    When user navigates to modify TP/SL
    And user updates the stop loss price
    Then the update should succeed without 429 errors
```

## **Screenshots/Recordings**

### **Before**

N/A - Bug fix for rate limiting, no visual changes

### **After**

N/A - Bug fix for rate limiting, no visual changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches perps trading/provider logic (`updatePositionTPSL`, order/price/fill retrieval) and async UI state around stop-loss actions, so regressions could impact TP/SL updates or stale-data handling, but changes are bounded and add explicit fallbacks/tests.
> 
> **Overview**
> **Goal:** reduce HyperLiquid REST API weight (and 429s) during rapid market switching and TP/SL operations by preferring WebSocket caches.
> 
> Adds cache-first primitives in `HyperLiquidSubscriptionService` (fills cache + atomic `getOrdersCacheIfInitialized`) and `HyperLiquidProvider` (`getOrFetchPrice`, `getOrFetchFills`), and refactors provider call sites to use these helpers with stricter invalid-price validation and single-DEX REST fallbacks.
> 
> Updates TP/SL flow to pass live WebSocket `position` into `updatePositionTPSL` (avoiding a REST positions fetch), uses cached orders to cancel existing TP/SL when available, and surfaces partial-failure feedback in `PerpsOrderView` when order succeeds but TP/SL update fails.
> 
> Moves `positionOpenedTimestamp` derivation into `useHasExistingPosition` (WebSocket fills first, REST historical fallback), and hardens `PerpsMarketDetailsView` stop-loss banner interactions against stale closures/market switches; the banner UI switches from a `Switch` to a "Set" button with a delayed success checkmark + fade-out. Tests and test IDs are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0edee81a893f625bba8ca5d960f534326bdca43f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->