### PR TITLE
fix: Multiple cleanups perps market search

### DIFF
--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { Linking } from 'react-native';
 import PerpsHomeView from './PerpsHomeView';
 import { PerpsEventValues } from '../../constants/eventNames';
 import { selectPerpsFeedbackEnabledFlag } from '../../selectors/featureFlags';
@@ -555,9 +554,10 @@ describe('PerpsHomeView', () => {
     // Act - Press search toggle
     fireEvent.press(getByTestId('perps-home-search-toggle'));
 
-    // Assert - Should navigate to MarketListView with search enabled
+    // Assert - Should navigate to MarketListView with search enabled and 'all' category
     expect(mockNavigateToMarketList).toHaveBeenCalledWith({
       defaultSearchVisible: true,
+      defaultMarketTypeFilter: 'all',
       source: PerpsEventValues.SOURCE.HOMESCREEN_TAB,
       fromHome: true,
       button_clicked: 'magnifying_glass',
@@ -805,14 +805,6 @@ describe('PerpsHomeView', () => {
   });
 
   describe('Feedback Feature', () => {
-    beforeEach(() => {
-      jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
-    });
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
     it('does not show feedback button when feature flag is disabled', () => {
       // Arrange - Feature flag disabled (default)
       mockUseSelector.mockReturnValue(false);
@@ -840,7 +832,7 @@ describe('PerpsHomeView', () => {
       expect(getByTestId('perps-home-feedback-button')).toBeTruthy();
     });
 
-    it('opens survey URL in external browser when feedback button is pressed', () => {
+    it('opens survey URL in in-app browser when feedback button is pressed', () => {
       // Arrange - Enable feedback feature flag
       mockUseSelector.mockImplementation((selector: unknown) => {
         if (selector === selectPerpsFeedbackEnabledFlag) {
@@ -854,10 +846,14 @@ describe('PerpsHomeView', () => {
       // Act
       fireEvent.press(getByTestId('perps-home-feedback-button'));
 
-      // Assert
-      expect(Linking.openURL).toHaveBeenCalledWith(
-        'https://survey.alchemer.com/s3/8649911/MetaMask-Perps-Trading-Feedback',
-      );
+      // Assert - Should navigate to in-app browser (same pattern as Contact Support)
+      expect(mockNavigate).toHaveBeenCalledWith('Webview', {
+        screen: 'SimpleWebview',
+        params: {
+          url: 'https://survey.alchemer.com/s3/8649911/MetaMask-Perps-Trading-Feedback',
+          title: 'perps.feedback.title',
+        },
+      });
     });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -231,9 +231,11 @@ const PerpsHomeView = () => {
         })
         .build(),
     );
-    // Navigate to MarketListView with search enabled
+    // Navigate to MarketListView with search enabled and 'all' category
+    // When user closes search, they should see all markets (not a specific category)
     perpsNavigation.navigateToMarketList({
       defaultSearchVisible: true,
+      defaultMarketTypeFilter: 'all',
       source: PerpsEventValues.SOURCE.HOMESCREEN_TAB,
       fromHome: true,
       button_clicked: PerpsEventValues.BUTTON_CLICKED.MAGNIFYING_GLASS,

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   useMemo,
 } from 'react';
-import { View, ScrollView, Modal, Linking } from 'react-native';
+import { View, ScrollView, Modal } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
   SafeAreaView,
@@ -44,9 +44,7 @@ import {
   LEARN_MORE_CONFIG,
   SUPPORT_CONFIG,
   FEEDBACK_CONFIG,
-  PERPS_CONSTANTS,
 } from '../../constants/perpsConfig';
-import { ensureError } from '../../../../../util/errorUtils';
 import { selectPerpsFeedbackEnabledFlag } from '../../selectors/featureFlags';
 import PerpsMarketBalanceActions from '../../components/PerpsMarketBalanceActions';
 import PerpsCard from '../../components/PerpsCard';
@@ -59,7 +57,6 @@ import HeaderCenter from '../../../../../component-library/components-temp/Heade
 import type { PerpsNavigationParamList } from '../../types/navigation';
 import { useMetrics, MetaMetricsEvents } from '../../../../hooks/useMetrics';
 import styleSheet from './PerpsHomeView.styles';
-import Logger from '../../../../../util/Logger';
 import { TraceName } from '../../../../../util/trace';
 import {
   PerpsEventProperties,
@@ -302,14 +299,15 @@ const PerpsHomeView = () => {
         })
         .build(),
     );
-    // Open survey in external browser
-    Linking.openURL(FEEDBACK_CONFIG.Url).catch((error: unknown) => {
-      Logger.error(ensureError(error), {
-        feature: PERPS_CONSTANTS.FeatureName,
-        message: 'Failed to open feedback survey URL',
-      });
+    // Open survey in in-app browser (same pattern as Contact Support)
+    navigation.navigate(Routes.WEBVIEW.MAIN, {
+      screen: Routes.WEBVIEW.SIMPLE,
+      params: {
+        url: FEEDBACK_CONFIG.Url,
+        title: strings(FEEDBACK_CONFIG.TitleKey),
+      },
     });
-  }, [trackEvent, createEventBuilder]);
+  }, [trackEvent, createEventBuilder, navigation]);
 
   const navigationItems: NavigationItem[] = useMemo(() => {
     const items: NavigationItem[] = [

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -186,8 +186,9 @@ const PerpsMarketListView = ({
     toggleSearchVisibility();
 
     if (isSearchVisible) {
-      // When disabling search, clear the query
+      // When disabling search, clear the query and reset category filter
       clearSearch();
+      setMarketTypeFilter(defaultMarketTypeFilter);
     } else {
       // When enabling search, track the event
       track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
@@ -195,7 +196,14 @@ const PerpsMarketListView = ({
           PerpsEventValues.INTERACTION_TYPE.SEARCH_CLICKED,
       });
     }
-  }, [isSearchVisible, toggleSearchVisibility, clearSearch, track]);
+  }, [
+    isSearchVisible,
+    toggleSearchVisibility,
+    clearSearch,
+    track,
+    setMarketTypeFilter,
+    defaultMarketTypeFilter,
+  ]);
 
   // Performance tracking: Measure screen load time until market data is displayed
   usePerpsMeasurement({

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -79,6 +79,9 @@ const PerpsMarketListView = ({
   const fadeAnimation = useRef(new Animated.Value(0)).current;
   const [isSortFieldSheetVisible, setIsSortFieldSheetVisible] = useState(false);
 
+  // Store the market type filter before entering search, so we can restore it when exiting
+  const preSearchFilterRef = useRef<MarketTypeFilter>(defaultMarketTypeFilter);
+
   // Use the combined market list view hook for all business logic
   const {
     markets: filteredMarkets,
@@ -186,13 +189,13 @@ const PerpsMarketListView = ({
     toggleSearchVisibility();
 
     if (isSearchVisible) {
-      // When disabling search, clear the query and reset category filter to the default
-      // This preserves context: navigating via "See all crypto" keeps crypto selected,
-      // while navigating via search icon from home resets to 'all'
+      // When disabling search, clear the query and restore the filter to what it was before search
       clearSearch();
-      setMarketTypeFilter(defaultMarketTypeFilter);
+      setMarketTypeFilter(preSearchFilterRef.current);
     } else {
-      // When enabling search, track the event
+      // When enabling search, store the current filter so we can restore it when exiting
+      preSearchFilterRef.current = marketTypeFilter;
+      // Track the event
       track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
         [PerpsEventProperties.INTERACTION_TYPE]:
           PerpsEventValues.INTERACTION_TYPE.SEARCH_CLICKED,
@@ -204,7 +207,7 @@ const PerpsMarketListView = ({
     clearSearch,
     track,
     setMarketTypeFilter,
-    defaultMarketTypeFilter,
+    marketTypeFilter,
   ]);
 
   // Performance tracking: Measure screen load time until market data is displayed

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -186,9 +186,11 @@ const PerpsMarketListView = ({
     toggleSearchVisibility();
 
     if (isSearchVisible) {
-      // When disabling search, clear the query and reset category filter to show all markets
+      // When disabling search, clear the query and reset category filter to the default
+      // This preserves context: navigating via "See all crypto" keeps crypto selected,
+      // while navigating via search icon from home resets to 'all'
       clearSearch();
-      setMarketTypeFilter('all');
+      setMarketTypeFilter(defaultMarketTypeFilter);
     } else {
       // When enabling search, track the event
       track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
@@ -202,6 +204,7 @@ const PerpsMarketListView = ({
     clearSearch,
     track,
     setMarketTypeFilter,
+    defaultMarketTypeFilter,
   ]);
 
   // Performance tracking: Measure screen load time until market data is displayed

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -186,9 +186,9 @@ const PerpsMarketListView = ({
     toggleSearchVisibility();
 
     if (isSearchVisible) {
-      // When disabling search, clear the query and reset category filter
+      // When disabling search, clear the query and reset category filter to show all markets
       clearSearch();
-      setMarketTypeFilter(defaultMarketTypeFilter);
+      setMarketTypeFilter('all');
     } else {
       // When enabling search, track the event
       track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
@@ -202,7 +202,6 @@ const PerpsMarketListView = ({
     clearSearch,
     track,
     setMarketTypeFilter,
-    defaultMarketTypeFilter,
   ]);
 
   // Performance tracking: Measure screen load time until market data is displayed

--- a/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.test.tsx
@@ -184,7 +184,7 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
       ).toBeOnTheScreen();
     });
 
-    it('shows direction indicator only on priceChange option when selected', () => {
+    it('shows direction indicator on priceChange option when selected', () => {
       render(
         <PerpsMarketSortFieldBottomSheet
           isVisible
@@ -205,7 +205,7 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
       ).toBeOnTheScreen();
     });
 
-    it('shows checkmark for non-priceChange options when selected', () => {
+    it('shows direction indicator for all options when selected', () => {
       render(
         <PerpsMarketSortFieldBottomSheet
           isVisible
@@ -217,15 +217,13 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
         />,
       );
 
-      // Should show checkmark for volume
+      // Should show direction indicator for volume (all options now support direction toggle)
       expect(
-        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
       ).toBeOnTheScreen();
-
-      // Should not show direction indicator
       expect(
-        screen.queryByTestId('sort-field-sheet-direction-indicator'),
-      ).not.toBeOnTheScreen();
+        screen.getByTestId('sort-field-sheet-direction-text'),
+      ).toHaveTextContent('High to low');
     });
 
     it('renders apply button', () => {
@@ -259,9 +257,9 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
         />,
       );
 
-      // Initially volume is selected (has checkmark)
+      // Initially volume is selected (has direction indicator)
       expect(
-        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
       ).toBeOnTheScreen();
 
       // Press priceChange option
@@ -309,7 +307,7 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
       expect(mockOnOptionSelect).not.toHaveBeenCalled();
     });
 
-    it('does not toggle direction for non-priceChange options when pressed again', () => {
+    it('toggles direction for all options when pressed again', () => {
       render(
         <PerpsMarketSortFieldBottomSheet
           isVisible
@@ -321,21 +319,24 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
         />,
       );
 
-      // Volume should have checkmark
+      // Volume should have direction indicator showing "High to low"
       expect(
-        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
       ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('sort-field-sheet-direction-text'),
+      ).toHaveTextContent('High to low');
 
-      // Press volume again (same option)
+      // Press volume again (same option) to toggle direction
       fireEvent.press(screen.getByTestId('sort-field-sheet-option-volume'));
 
-      // Should still show checkmark, not direction indicator
+      // Should now show "Low to high" (direction toggled)
       expect(
-        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
       ).toBeOnTheScreen();
       expect(
-        screen.queryByTestId('sort-field-sheet-direction-indicator'),
-      ).not.toBeOnTheScreen();
+        screen.getByTestId('sort-field-sheet-direction-text'),
+      ).toHaveTextContent('Low to high');
 
       // onOptionSelect should NOT be called until Apply is pressed
       expect(mockOnOptionSelect).not.toHaveBeenCalled();
@@ -463,10 +464,13 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
         />,
       );
 
-      // Initially volume is selected
+      // Initially volume is selected with "High to low"
       expect(
-        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
       ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('sort-field-sheet-direction-text'),
+      ).toHaveTextContent('High to low');
 
       // Change props to priceChange with asc direction
       rerender(
@@ -480,14 +484,13 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
         />,
       );
 
-      // Now priceChange should have direction indicator
+      // Now priceChange should have direction indicator showing "Low to high"
       expect(
         screen.getByTestId('sort-field-sheet-direction-indicator'),
       ).toBeOnTheScreen();
-      // Volume checkmark should be gone
       expect(
-        screen.queryByTestId('sort-field-sheet-checkmark-volume'),
-      ).not.toBeOnTheScreen();
+        screen.getByTestId('sort-field-sheet-direction-text'),
+      ).toHaveTextContent('Low to high');
     });
 
     it('resets uncommitted changes when reopening the sheet', () => {
@@ -502,10 +505,13 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
         />,
       );
 
-      // Initially volume is selected
+      // Initially volume is selected with "High to low"
       expect(
-        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
       ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('sort-field-sheet-direction-text'),
+      ).toHaveTextContent('High to low');
 
       // User makes changes without applying - select priceChange
       fireEvent.press(
@@ -541,13 +547,13 @@ describe('PerpsMarketSortFieldBottomSheet', () => {
         />,
       );
 
-      // Local state should be reset to volume (uncommitted changes discarded)
+      // Local state should be reset to volume with "High to low" (uncommitted changes discarded)
       expect(
-        screen.getByTestId('sort-field-sheet-checkmark-volume'),
+        screen.getByTestId('sort-field-sheet-direction-indicator'),
       ).toBeOnTheScreen();
       expect(
-        screen.queryByTestId('sort-field-sheet-direction-indicator'),
-      ).not.toBeOnTheScreen();
+        screen.getByTestId('sort-field-sheet-direction-text'),
+      ).toHaveTextContent('High to low');
     });
   });
 });

--- a/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.tsx
@@ -81,12 +81,12 @@ const PerpsMarketSortFieldBottomSheet: React.FC<
   }, [isVisible]);
 
   /**
-   * Handle option press - either select new option or toggle direction (only for priceChange)
+   * Handle option press - either select new option or toggle direction
    */
   const handleOptionPress = useCallback(
     (optionId: SortOptionId) => {
-      // If clicking the same option AND it's priceChange, toggle sort direction
-      if (selectedOption === optionId && optionId === 'priceChange') {
+      // If clicking the same option, toggle sort direction
+      if (selectedOption === optionId) {
         const newDirection = sortDirection === 'asc' ? 'desc' : 'asc';
         setSortDirection(newDirection);
       } else {
@@ -143,7 +143,7 @@ const PerpsMarketSortFieldBottomSheet: React.FC<
               <Text variant={TextVariant.BodyMD}>
                 {strings(option.labelKey)}
               </Text>
-              {isSelected && option.id === 'priceChange' && (
+              {isSelected && (
                 <View
                   style={styles.arrowContainer}
                   testID={testID ? `${testID}-direction-indicator` : undefined}
@@ -167,15 +167,6 @@ const PerpsMarketSortFieldBottomSheet: React.FC<
                     color={IconColor.Alternative}
                   />
                 </View>
-              )}
-              {isSelected && option.id !== 'priceChange' && (
-                <Icon
-                  name={IconName.Check}
-                  size={IconSize.Md}
-                  testID={
-                    testID ? `${testID}-checkmark-${option.id}` : undefined
-                  }
-                />
               )}
             </TouchableOpacity>
           );

--- a/app/components/UI/Perps/constants/perpsConfig.ts
+++ b/app/components/UI/Perps/constants/perpsConfig.ts
@@ -439,8 +439,7 @@ export const MARKET_SORTING_CONFIG = {
   ] as const,
 
   // Sort options for the bottom sheet
-  // Only Price Change can be toggled for direction (similar to trending tokens pattern)
-  // Other options (volume, open interest, funding rate) use descending sort only
+  // All options support direction toggle (high-to-low / low-to-high)
   SortOptions: [
     {
       id: 'volume',


### PR DESCRIPTION
## **Description**

This PR addresses three issues introduced during the badge refactor of the perps market list search:

1. Consistent browser behavior for links: "Give us feedback" now opens in the in-app browser (same as "Contact Support") instead of the external browser for consistent UX.
2. Search filter state reset: When closing search on the market list view, the category filter now resets to 'all' (showing all markets) instead of persisting the previously selected category.
3. Sort direction toggle for all options: All sort options (Volume, Open Interest, Funding Rate) now support high-to-low / low-to-high toggling, not just Price Change.

## **Changelog**

CHANGELOG entry: Fixed perps market list search to reset category filters when closing search and enabled sort direction toggle for all sort options

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Perps Market List Search Fixes

  Scenario: Give Feedback opens in-app browser
    Given user is on the Perps Home screen
    When user taps "Give us feedback" button
    Then the feedback survey opens in the in-app browser (not external browser)

  Scenario: Search toggle resets category filter
    Given user is on the Perps Market List view
    And user has selected "Crypto" category badge
    When user taps search icon to open search
    And user taps the back/close button to exit search
    Then no category badge should be selected
    And all markets should be displayed

  Scenario: Sort options support high/low toggle
    Given user is on the Perps Market List view
    When user opens the sort options bottom sheet
    And user selects "Volume" sort option
    Then user sees "High to low" indicator with arrow
    When user taps "Volume" again
    Then the direction toggles to "Low to high" with up arrow
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/ad10c1d6-20fd-4c09-b36b-60d841027ce5

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Perps market list state management and sort-direction semantics, plus switches feedback links to an in-app webview, which could affect user navigation flow and ordering expectations but not funds/auth logic.
> 
> **Overview**
> **Perps market search UX is made more consistent.** Home search navigation now always opens `PerpsMarketListView` with `defaultMarketTypeFilter: 'all'`.
> 
> **Market list search now preserves/recovers category selection.** `PerpsMarketListView` stores the current `marketTypeFilter` when entering search and restores it (and clears the query) when exiting search.
> 
> **Sort bottom sheet now supports direction toggling for every field.** `PerpsMarketSortFieldBottomSheet` toggles asc/desc when re-selecting *any* option and always shows the direction indicator (removing the non-`priceChange` checkmark behavior); related tests/config comments were updated.
> 
> **Feedback link behavior is standardized.** `PerpsHomeView` opens the feedback survey via the in-app `Routes.WEBVIEW.SIMPLE` flow instead of `Linking.openURL`, with tests updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7373c6960b99e6744b1affa009230757e1791cc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->