### PR TITLE
Explore feature upgrade bug

### DIFF
--- a/app/store/migrations/115.test.ts
+++ b/app/store/migrations/115.test.ts
@@ -1,0 +1,194 @@
+import migrate, { migrationVersion } from './115';
+import { captureException } from '@sentry/react-native';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+const mockCaptureException = captureException as jest.MockedFunction<
+  typeof captureException
+>;
+
+const createValidState = (
+  remoteFeatureFlagControllerState: Record<string, unknown> = {},
+) => ({
+  engine: {
+    backgroundState: {
+      RemoteFeatureFlagController: {
+        cacheTimestamp: 1234567890000,
+        remoteFeatureFlags: {},
+        rawRemoteFeatureFlags: {},
+        localOverrides: {},
+        ...remoteFeatureFlagControllerState,
+      },
+    },
+  },
+});
+
+describe(`Migration ${migrationVersion}`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns state unchanged if state is invalid', async () => {
+    const invalidState = null;
+    const result = await migrate(invalidState);
+    expect(result).toBe(invalidState);
+  });
+
+  it('returns state unchanged if engine is missing', async () => {
+    const invalidState = { foo: 'bar' };
+    const result = await migrate(invalidState);
+    expect(result).toStrictEqual(invalidState);
+  });
+
+  it('returns state unchanged if RemoteFeatureFlagController is missing', async () => {
+    const state = {
+      engine: {
+        backgroundState: {},
+      },
+    };
+    const result = await migrate(state);
+    expect(result).toStrictEqual(state);
+    // Should not capture exception - this is expected for old versions
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('returns state unchanged and captures exception if RemoteFeatureFlagController is not an object', async () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: 'invalid-string',
+        },
+      },
+    };
+    const result = await migrate(state);
+    expect(result).toStrictEqual(state);
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          "Invalid RemoteFeatureFlagController state: 'string'",
+        ),
+      }),
+    );
+  });
+
+  it('resets cacheTimestamp to 0', async () => {
+    const originalTimestamp = 1234567890000;
+    const state = createValidState({
+      cacheTimestamp: originalTimestamp,
+    });
+
+    const result = await migrate(state);
+
+    expect(
+      (result as typeof state).engine.backgroundState
+        .RemoteFeatureFlagController.cacheTimestamp,
+    ).toBe(0);
+  });
+
+  it('preserves other RemoteFeatureFlagController state properties', async () => {
+    const remoteFeatureFlags = {
+      trendingTokens: { enabled: true, minimumVersion: '7.64.0' },
+      someOtherFlag: true,
+    };
+    const rawRemoteFeatureFlags = { raw: 'data' };
+    const localOverrides = { overrideFlag: true };
+
+    const state = createValidState({
+      cacheTimestamp: 1234567890000,
+      remoteFeatureFlags,
+      rawRemoteFeatureFlags,
+      localOverrides,
+    });
+
+    const result = await migrate(state);
+
+    const resultController = (result as typeof state).engine.backgroundState
+      .RemoteFeatureFlagController;
+    expect(resultController.cacheTimestamp).toBe(0);
+    expect(resultController.remoteFeatureFlags).toStrictEqual(
+      remoteFeatureFlags,
+    );
+    expect(resultController.rawRemoteFeatureFlags).toStrictEqual(
+      rawRemoteFeatureFlags,
+    );
+    expect(resultController.localOverrides).toStrictEqual(localOverrides);
+  });
+
+  it('handles missing cacheTimestamp gracefully', async () => {
+    const state = createValidState({
+      cacheTimestamp: undefined,
+    });
+
+    const result = await migrate(state);
+
+    // Should set it to 0 even if it was undefined
+    expect(
+      (result as typeof state).engine.backgroundState
+        .RemoteFeatureFlagController.cacheTimestamp,
+    ).toBe(0);
+  });
+
+  it('handles cacheTimestamp of 0 (already reset)', async () => {
+    const state = createValidState({
+      cacheTimestamp: 0,
+    });
+
+    const result = await migrate(state);
+
+    expect(
+      (result as typeof state).engine.backgroundState
+        .RemoteFeatureFlagController.cacheTimestamp,
+    ).toBe(0);
+  });
+
+  it('handles empty RemoteFeatureFlagController object', async () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {} as { cacheTimestamp?: number },
+        },
+      },
+    };
+
+    const result = await migrate(state);
+
+    expect(
+      (result as typeof state).engine.backgroundState
+        .RemoteFeatureFlagController.cacheTimestamp,
+    ).toBe(0);
+  });
+
+  it('does not modify other backgroundState controllers', async () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            cacheTimestamp: 1234567890000,
+            remoteFeatureFlags: {},
+          },
+          NetworkController: {
+            providerConfig: { chainId: '0x1' },
+          },
+          PreferencesController: {
+            selectedAddress: '0x123',
+          },
+        },
+      },
+    };
+
+    const result = await migrate(state);
+
+    expect(
+      (result as typeof state).engine.backgroundState.NetworkController,
+    ).toStrictEqual({
+      providerConfig: { chainId: '0x1' },
+    });
+    expect(
+      (result as typeof state).engine.backgroundState.PreferencesController,
+    ).toStrictEqual({
+      selectedAddress: '0x123',
+    });
+  });
+});

--- a/app/store/migrations/115.ts
+++ b/app/store/migrations/115.ts
@@ -1,0 +1,76 @@
+import { captureException } from '@sentry/react-native';
+import { hasProperty, isObject } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+
+import { ensureValidState } from './util';
+
+export const migrationVersion = 115;
+
+interface RemoteFeatureFlagControllerState {
+  cacheTimestamp?: number;
+  remoteFeatureFlags?: Record<string, unknown>;
+  rawRemoteFeatureFlags?: Record<string, unknown>;
+  localOverrides?: Record<string, unknown>;
+}
+
+/**
+ * This migration resets the RemoteFeatureFlagController's cacheTimestamp to 0
+ * to force a fresh fetch of feature flags on app upgrade.
+ *
+ * Background:
+ * When upgrading from older versions (7.62.2/7.63.0) to newer versions (7.64.0),
+ * the persisted RemoteFeatureFlagController state may have stale feature flags.
+ * The controller checks cacheTimestamp to determine if it should fetch new flags.
+ * If the cache is still valid (within fetchInterval), it won't fetch new flags.
+ * This causes new features (like the Explore tab) to not appear after upgrade.
+ *
+ * The fix:
+ * Reset cacheTimestamp to 0 to force the controller to fetch fresh flags.
+ * This ensures users get the latest feature flags after upgrading.
+ *
+ * @param state - MetaMask mobile state
+ * @returns Updated MetaMask mobile state with reset cacheTimestamp
+ */
+export default async function migrate(stateAsync: unknown): Promise<unknown> {
+  const state = cloneDeep(await stateAsync);
+
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  try {
+    if (
+      !hasProperty(state.engine.backgroundState, 'RemoteFeatureFlagController')
+    ) {
+      // RemoteFeatureFlagController doesn't exist in persisted state
+      // This is expected for very old versions - nothing to migrate
+      return state;
+    }
+
+    const remoteFeatureFlagControllerState = state.engine.backgroundState
+      .RemoteFeatureFlagController as
+      | RemoteFeatureFlagControllerState
+      | undefined;
+
+    if (!isObject(remoteFeatureFlagControllerState)) {
+      captureException(
+        new Error(
+          `Migration ${migrationVersion}: Invalid RemoteFeatureFlagController state: '${typeof remoteFeatureFlagControllerState}'`,
+        ),
+      );
+      return state;
+    }
+
+    // Reset cacheTimestamp to 0 to force a fresh fetch of feature flags
+    // This ensures the controller will fetch new flags on next initialization
+    remoteFeatureFlagControllerState.cacheTimestamp = 0;
+
+    return state;
+  } catch (error) {
+    captureException(
+      new Error(`Migration ${migrationVersion}: ${String(error)}`),
+    );
+    // Return state unchanged on error - the feature flags will eventually refresh
+    return state;
+  }
+}

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -115,6 +115,7 @@ import migration111 from './111';
 import migration112 from './112';
 import migration113 from './113';
 import migration114 from './114';
+import migration115 from './115';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -249,6 +250,7 @@ export const migrationList: MigrationsList = {
   112: migration112,
   113: migration113,
   114: migration114,
+  115: migration115,
 };
 
 // Enable both synchronous and asynchronous migrations


### PR DESCRIPTION
Add migration 115 to reset `RemoteFeatureFlagController`'s `cacheTimestamp` to ensure new feature flags (like the Explore tab) are fetched on app upgrade.

When upgrading from older versions (7.62.2/7.63.0) to 7.64.0, the persisted `RemoteFeatureFlagController` state can have stale feature flags. The controller uses `cacheTimestamp` to decide if it should fetch new flags. If the cache is still valid, new flags aren't fetched, leading to features like the Explore tab not appearing. Resetting `cacheTimestamp` to 0 forces a fresh fetch.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9a58570-2d35-4b7b-b603-2c2f5e31290a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9a58570-2d35-4b7b-b603-2c2f5e31290a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

