### PR TITLE
fix: add support for CAIP in useRefreshSmartTransactionsLiveness

### DIFF
--- a/app/components/hooks/useRefreshSmartTransactionsLiveness.test.ts
+++ b/app/components/hooks/useRefreshSmartTransactionsLiveness.test.ts
@@ -4,6 +4,7 @@ import { isNonEvmChainId } from '../../core/Multichain/utils';
 import { getAllowedSmartTransactionsChainIds } from '../../constants/smartTransactions';
 import { selectSmartTransactionsOptInStatus } from '../../selectors/preferencesController';
 import { useRefreshSmartTransactionsLiveness } from './useRefreshSmartTransactionsLiveness';
+import { Hex, CaipChainId } from '@metamask/utils';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn((selector) => selector()),
@@ -91,8 +92,17 @@ describe('useRefreshSmartTransactionsLiveness', () => {
     });
   });
 
+  it('fetches liveness for supported EVM chain with CAIP format', () => {
+    renderHook(() => useRefreshSmartTransactionsLiveness('eip155:1'));
+
+    expect(mockFetchLiveness).toHaveBeenCalledTimes(1);
+    expect(mockFetchLiveness).toHaveBeenCalledWith({
+      chainId: '0x1',
+    });
+  });
+
   it('re-fetches when chainId changes to another supported chain', () => {
-    const { rerender } = renderHook<{ chainId: string }, void>(
+    const { rerender } = renderHook<{ chainId: Hex | CaipChainId }, void>(
       ({ chainId }) => useRefreshSmartTransactionsLiveness(chainId),
       { initialProps: { chainId: '0x1' } },
     );

--- a/app/components/hooks/useRefreshSmartTransactionsLiveness.ts
+++ b/app/components/hooks/useRefreshSmartTransactionsLiveness.ts
@@ -4,6 +4,13 @@ import Engine from '../../core/Engine';
 import { getAllowedSmartTransactionsChainIds } from '../../constants/smartTransactions';
 import { isNonEvmChainId } from '../../core/Multichain/utils';
 import { selectSmartTransactionsOptInStatus } from '../../selectors/preferencesController';
+import {
+  isCaipChainId,
+  parseCaipChainId,
+  Hex,
+  CaipChainId,
+} from '@metamask/utils';
+import { toHex } from '@metamask/controller-utils';
 
 /**
  * Hook that fetches smart transactions liveness for a given chain.
@@ -14,7 +21,7 @@ import { selectSmartTransactionsOptInStatus } from '../../selectors/preferencesC
  *
  */
 export function useRefreshSmartTransactionsLiveness(
-  chainId: string | null | undefined,
+  chainId: Hex | CaipChainId | null | undefined,
 ): void {
   const smartTransactionsOptInStatus = useSelector(
     selectSmartTransactionsOptInStatus,
@@ -29,9 +36,13 @@ export function useRefreshSmartTransactionsLiveness(
       return;
     }
 
+    const chainIdHex = isCaipChainId(chainId)
+      ? toHex(parseCaipChainId(chainId).reference)
+      : chainId;
+
     // TODO: will be replaced with feature flags once we have them.
     const allowedChainId = getAllowedSmartTransactionsChainIds().find(
-      (id) => id === chainId,
+      (id) => id === chainIdHex,
     );
 
     if (allowedChainId) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

add support for CAIP in useRefreshSmartTransactionsLiveness

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only normalizes CAIP-formatted EVM chain IDs to hex before checking allowed networks and fetching STX liveness. Main risk is unintended mismatches/parsing issues that could skip liveness refresh in Bridge/confirm flows for some chain IDs.
> 
> **Overview**
> `useRefreshSmartTransactionsLiveness` now accepts both hex and CAIP-formatted chain IDs and normalizes CAIP (e.g., `eip155:1`) to hex before checking `getAllowedSmartTransactionsChainIds()` and calling `SmartTransactionsController.fetchLiveness`.
> 
> Tests were updated to cover CAIP input and to type the hook props as `Hex | CaipChainId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fde1fe4e8c084851d120c5654eee8da3ff4fae79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->