### PR TITLE
chore: Remove appTriggeredAuth and update unit tests

### DIFF
--- a/app/constants/error.ts
+++ b/app/constants/error.ts
@@ -25,7 +25,6 @@ export const SYMBOL_ERROR = 'symbolError';
 export const AUTHENTICATION_APP_TRIGGERED_AUTH_NO_CREDENTIALS =
   'Password does not exist when calling SecureKeychain.getGenericPassword';
 export const AUTHENTICATION_FAILED_WALLET_CREATION = 'Failed wallet creation';
-export const AUTHENTICATION_FAILED_TO_LOGIN = 'Failed to login';
 export const AUTHENTICATION_RESET_PASSWORD_FAILED_MESSAGE =
   'Authentication.resetPassword failed when calling SecureKeychain.resetGenericPassword with:';
 export const AUTHENTICATION_RESET_PASSWORD_FAILED =

--- a/app/constants/error.ts
+++ b/app/constants/error.ts
@@ -24,8 +24,6 @@ export const SYMBOL_ERROR = 'symbolError';
 // Authentication errors
 export const AUTHENTICATION_APP_TRIGGERED_AUTH_NO_CREDENTIALS =
   'Password does not exist when calling SecureKeychain.getGenericPassword';
-export const AUTHENTICATION_APP_TRIGGERED_AUTH_ERROR =
-  'Authentication.appTriggeredAuth failed to login';
 export const AUTHENTICATION_FAILED_WALLET_CREATION = 'Failed wallet creation';
 export const AUTHENTICATION_FAILED_TO_LOGIN = 'Failed to login';
 export const AUTHENTICATION_RESET_PASSWORD_FAILED_MESSAGE =

--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -15,7 +15,6 @@ import SecureKeychain from '../SecureKeychain';
 import ReduxService, { ReduxStore } from '../redux';
 import AuthenticationError from './AuthenticationError';
 import {
-  AUTHENTICATION_APP_TRIGGERED_AUTH_ERROR,
   AUTHENTICATION_APP_TRIGGERED_AUTH_NO_CREDENTIALS,
   AUTHENTICATION_FAILED_TO_LOGIN,
   AUTHENTICATION_FAILED_WALLET_CREATION,
@@ -1119,6 +1118,18 @@ describe('Authentication', () => {
       });
 
       it('does not break authentication flow when discovery fails', async () => {
+        jest.spyOn(ReduxService, 'store', 'get').mockReturnValue({
+          dispatch: mockDispatch,
+          getState: () => ({
+            user: { existingUser: true },
+          }),
+        } as unknown as ReduxStore);
+
+        // Mock MetaMetrics.getInstance to return true for isEnabled
+        jest
+          .spyOn(MetaMetrics, 'getInstance')
+          .mockReturnValue({ isEnabled: () => true } as MetaMetrics);
+
         // Set up pending discovery that will be checked on unlock
         await StorageWrapper.setItem(SOLANA_DISCOVERY_PENDING, 'true');
 
@@ -1128,7 +1139,7 @@ describe('Authentication', () => {
           .mockReturnValue(mockCredentials);
 
         // App unlock should succeed even if retry fails
-        await expect(Authentication.appTriggeredAuth()).resolves.not.toThrow();
+        await expect(Authentication.unlockWallet()).resolves.not.toThrow();
       });
 
       it('sets SOLANA_DISCOVERY_PENDING when discovery fails in createWalletVaultAndKeychain', async () => {
@@ -1180,6 +1191,20 @@ describe('Authentication', () => {
         let mockAttemptMultichainAccountWalletDiscovery: jest.SpyInstance;
 
         beforeEach(() => {
+          // Mock Redux store with user state for unlockWallet tests
+          jest.spyOn(ReduxService, 'store', 'get').mockReturnValue({
+            dispatch: mockDispatch,
+            getState: () => ({
+              user: { existingUser: true },
+              security: { allowLoginWithRememberMe: true },
+            }),
+          } as unknown as ReduxStore);
+
+          // Mock MetaMetrics.getInstance to return true for isEnabled
+          jest
+            .spyOn(MetaMetrics, 'getInstance')
+            .mockReturnValue({ isEnabled: () => true } as MetaMetrics);
+
           // Spy on the private method
           mockAttemptAccountDiscovery = jest
             .spyOn(
@@ -1213,7 +1238,7 @@ describe('Authentication', () => {
             .fn()
             .mockReturnValue(mockCredentials);
 
-          await Authentication.appTriggeredAuth();
+          await Authentication.unlockWallet();
 
           expect(mockAttemptAccountDiscovery).toHaveBeenCalled();
         });
@@ -1226,7 +1251,7 @@ describe('Authentication', () => {
             .fn()
             .mockReturnValue(mockCredentials);
 
-          await Authentication.appTriggeredAuth();
+          await Authentication.unlockWallet();
 
           expect(mockAttemptAccountDiscovery).not.toHaveBeenCalled();
         });
@@ -1239,7 +1264,7 @@ describe('Authentication', () => {
             .fn()
             .mockReturnValue(mockCredentials);
 
-          await Authentication.appTriggeredAuth();
+          await Authentication.unlockWallet();
 
           expect(mockAttemptAccountDiscovery).not.toHaveBeenCalled();
         });
@@ -1266,7 +1291,7 @@ describe('Authentication', () => {
             .mockReturnValue(mockCredentials);
 
           await expect(
-            Authentication.appTriggeredAuth(),
+            Authentication.unlockWallet(),
           ).resolves.not.toThrow();
 
           expect(console.warn).toHaveBeenCalledWith(
@@ -1295,7 +1320,7 @@ describe('Authentication', () => {
 
           // Does not throw and completes authentication
           await expect(
-            Authentication.appTriggeredAuth(),
+            Authentication.unlockWallet(),
           ).resolves.not.toThrow();
 
           expect(mockAttemptAccountDiscovery).toHaveBeenCalled();
@@ -1304,40 +1329,6 @@ describe('Authentication', () => {
             'solana',
             expect.any(Error),
           );
-        });
-
-        it('throws AuthenticationError when appTriggeredAuth fails', async () => {
-          const mockDispatch = jest.fn();
-          jest.spyOn(ReduxService, 'store', 'get').mockReturnValue({
-            dispatch: mockDispatch,
-            getState: () => ({ security: { allowLoginWithRememberMe: true } }),
-          } as unknown as ReduxStore);
-
-          const Engine = jest.requireMock('../Engine');
-
-          Engine.context.KeyringController.setLocked.mockResolvedValue(
-            undefined,
-          );
-
-          // Mock getGenericPassword to return null to trigger error
-          SecureKeychain.getGenericPassword = jest.fn().mockReturnValue(null);
-
-          try {
-            await Authentication.appTriggeredAuth();
-            throw new Error('Expected an error to be thrown');
-          } catch (error) {
-            expect(mockDispatch).toHaveBeenCalledWith(logOut());
-            expect(error).toBeInstanceOf(AuthenticationError);
-            expect((error as AuthenticationError).customErrorMessage).toBe(
-              AUTHENTICATION_APP_TRIGGERED_AUTH_ERROR,
-            );
-            expect((error as AuthenticationError).message).toBe(
-              AUTHENTICATION_APP_TRIGGERED_AUTH_NO_CREDENTIALS,
-            );
-            await Promise.resolve();
-            jest.runAllTimers();
-            expect(mockDispatch).toHaveBeenCalledWith(logOut());
-          }
         });
 
         it('throws AuthenticationError when userEntryAuth fails', async () => {
@@ -1453,7 +1444,7 @@ describe('Authentication', () => {
             .fn()
             .mockReturnValue(mockCredentials);
 
-          await Authentication.appTriggeredAuth();
+          await Authentication.unlockWallet();
 
           // Wait for the asynchronous call to `postLoginAsyncOperations`.
           await Promise.resolve();
@@ -1478,7 +1469,7 @@ describe('Authentication', () => {
             .fn()
             .mockReturnValue(mockCredentials);
 
-          await Authentication.appTriggeredAuth();
+          await Authentication.unlockWallet();
 
           // Wait for the asynchronous call to `postLoginAsyncOperations`.
           await Promise.resolve();

--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -1290,9 +1290,7 @@ describe('Authentication', () => {
             .fn()
             .mockReturnValue(mockCredentials);
 
-          await expect(
-            Authentication.unlockWallet(),
-          ).resolves.not.toThrow();
+          await expect(Authentication.unlockWallet()).resolves.not.toThrow();
 
           expect(console.warn).toHaveBeenCalledWith(
             'Failed to check/retry discovery:',
@@ -1319,9 +1317,7 @@ describe('Authentication', () => {
             .mockReturnValue(mockCredentials);
 
           // Does not throw and completes authentication
-          await expect(
-            Authentication.unlockWallet(),
-          ).resolves.not.toThrow();
+          await expect(Authentication.unlockWallet()).resolves.not.toThrow();
 
           expect(mockAttemptAccountDiscovery).toHaveBeenCalled();
           expect(console.warn).toHaveBeenCalledWith(
@@ -1330,7 +1326,7 @@ describe('Authentication', () => {
             expect.any(Error),
           );
         });
-        
+
         it('throws AuthenticationError when newWalletAndRestore fails', async () => {
           const mockDispatch = jest.fn();
           jest.spyOn(ReduxService, 'store', 'get').mockReturnValue({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

These changes removes two fully deprecated auth methods: `appTriggeredAuth` and `userEntryAuth`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-308

## **Manual testing steps**

None

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication code by removing two legacy login paths; risk is mainly around any remaining call sites/tests relying on the removed APIs or subtle differences now routed through `unlockWallet`.
> 
> **Overview**
> Removes the deprecated `Authentication.appTriggeredAuth` and `Authentication.userEntryAuth` flows from `Authentication.ts`, including their custom error constants and the vault-corruption analytics hook used in `appTriggeredAuth`.
> 
> Updates `Authentication.test.ts` to exercise equivalent scenarios via `unlockWallet` (including seedless rehydrate and pending discovery retry cases), adjusts mocks/state setup, and drops unit tests that asserted the old error behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b316f533dd604e37aa58f8012ecb615f1419829. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->