### PR TITLE
fix: resolve network instability issues causing order and chart failures

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -368,6 +368,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     isLoading: isLoadingHistory,
     hasHistoricalData,
     fetchMoreHistory,
+    retry: retryCandles,
   } = usePerpsLiveCandles({
     coin: market?.symbol || '',
     interval: selectedCandlePeriod,
@@ -547,8 +548,8 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       // Reset chart view to default position
       chartRef.current?.resetToDefault();
 
-      // WebSocket streaming provides real-time data - no manual refresh needed
-      // Just reset the UI state and the chart will update automatically
+      // Retry candle subscription (helps recover from network errors)
+      retryCandles();
     } catch (error) {
       Logger.error(ensureError(error), {
         feature: PERPS_CONSTANTS.FEATURE_NAME,
@@ -557,7 +558,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     } finally {
       setRefreshing(false);
     }
-  }, []);
+  }, [retryCandles]);
 
   // Check if notifications feature is enabled once
   const isNotificationsEnabled = isNotificationsFeatureEnabled();

--- a/app/components/UI/Perps/hooks/stream/usePerpsLiveCandles.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLiveCandles.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { usePerpsStream } from '../../providers/PerpsStreamManager';
 import type { CandleData } from '../../types/perps-types';
 import { CandlePeriod, TimeDuration } from '../../constants/chartConfig';
@@ -38,6 +38,8 @@ export interface UsePerpsLiveCandlesReturn {
   error: Error | null;
   /** Fetch more historical candles before the current oldest candle */
   fetchMoreHistory: () => Promise<void>;
+  /** Retry subscription after error (useful for pull-to-refresh) */
+  retry: () => void;
 }
 
 /**
@@ -72,6 +74,8 @@ export function usePerpsLiveCandles(
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const hasReceivedFirstUpdate = useRef(false);
+  // Retry key - incrementing this triggers a re-subscription
+  const [retryKey, setRetryKey] = useState(0);
 
   useEffect(() => {
     // Reset state immediately when coin or interval changes to prevent stale data
@@ -173,10 +177,18 @@ export function usePerpsLiveCandles(
       setIsLoading(false);
       return;
     }
-  }, [stream, coin, interval, duration, throttleMs]);
+  }, [stream, coin, interval, duration, throttleMs, retryKey]);
 
   const hasHistoricalData =
     candleData !== null && candleData.candles.length > 0;
+
+  /**
+   * Retry subscription after an error
+   * Useful for pull-to-refresh when initial fetch failed
+   */
+  const retry = useCallback(() => {
+    setRetryKey((prev) => prev + 1);
+  }, []);
 
   /**
    * Fetch additional historical candles before the current oldest candle
@@ -221,5 +233,6 @@ export function usePerpsLiveCandles(
     hasHistoricalData,
     error,
     fetchMoreHistory,
+    retry,
   };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes chart and header loading failures on the Perps market detail screen when returning to the app after an idle period or network recovery.

**Changes:**
1. Switch fetchHistoricalCandles to use HTTP client instead of WebSocket
2. Add pull-to-refresh retry mechanism for chart recovery

**Problem**
User scenario:
- User has the detail page open, then backgrounds the app or leaves it idle
- During this time, the WebSocket connection becomes stale (network change, idle timeout, etc.)
- User returns to the app and navigates from the Perps home screen to a different coin's detail page
- The chart and header components hang indefinitely, making the detail page appear broken

**Root cause:**
The WebSocket connection can enter a stale state where it appears connected but is unresponsive. Candle fetch requests through this stale connection hang forever (never resolve or reject), with no timeout or recovery mechanism. Often the user would be able to navigate to the application home screen (perps tab) and re-enter the app, and this would sometime create a fresh connection.

However, this fresh connection wouldn't refresh when navigating directly from PerpsHome to PerpsDetail and this stale hanging behavior was uncovered.

**Solution**
1. Use HTTP for candle fetches (useHttp: true)
    -HTTP is stateless - each request is independent, unaffected by WebSocket connection state
    - Requests fail fast with proper errors instead of hanging indefinitely
    - More reliable when transitioning between network states
    - Add pull-to-refresh retry
2. Added retry() function to usePerpsLiveCandles hook
    - handleRefresh now triggers a fresh chart subscription
    - Provides a recovery path if initial load fails

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/a41e9c37-6d14-455d-a643-710a411f8857

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Perps candle data fetch/subscription flow and adds a new resubscribe pathway, which could impact chart loading/update behavior under normal and flaky networks.
> 
> **Overview**
> Improves Perps market detail chart recovery after idle/network changes by adding a `retry()` resubscribe mechanism to `usePerpsLiveCandles` and wiring pull-to-refresh to trigger it.
> 
> Switches initial historical candle fetching in `HyperLiquidClientService.fetchHistoricalCandles` to use the HTTP `InfoClient` (via `useHttp: true`) to avoid WebSocket stale-connection hangs, and refactors candle subscription setup to separate initial fetch success from WebSocket subscription wiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7dd85a643bd08d36f4ca9f5787a95fc28ff1660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->