### PR TITLE
fix(perps): add spotMeta caching to reduce API calls on HIP-3 markets

### DIFF
--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.test.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.test.ts
@@ -241,9 +241,10 @@ const createMockInfoClient = (overrides: Record<string, unknown> = {}) => ({
   ]),
   spotMeta: jest.fn().mockResolvedValue({
     tokens: [
-      { name: 'USDC', tokenId: '0xdef456' },
-      { name: 'USDT', tokenId: '0x789abc' },
+      { name: 'USDC', tokenId: '0xdef456', index: 0 },
+      { name: 'USDT', tokenId: '0x789abc', index: 1 },
     ],
+    universe: [],
   }),
   ...overrides,
 });
@@ -6397,7 +6398,8 @@ describe('HyperLiquidProvider', () => {
       mockClientService.getInfoClient = jest.fn().mockReturnValue(
         createMockInfoClient({
           spotMeta: jest.fn().mockResolvedValue({
-            tokens: [{ name: 'USDC', tokenId: '0xabc123' }],
+            tokens: [{ name: 'USDC', tokenId: '0xabc123', index: 0 }],
+            universe: [],
           }),
         }),
       );
@@ -6487,7 +6489,8 @@ describe('HyperLiquidProvider', () => {
     it('calls getUsdcTokenId to get correct token', async () => {
       // Arrange
       const mockSpotMeta = jest.fn().mockResolvedValue({
-        tokens: [{ name: 'USDC', tokenId: '0xspecific' }],
+        tokens: [{ name: 'USDC', tokenId: '0xspecific', index: 0 }],
+        universe: [],
       });
       mockClientService.getInfoClient = jest
         .fn()
@@ -6597,9 +6600,10 @@ describe('HyperLiquidProvider', () => {
         // Arrange
         const mockSpotMeta = {
           tokens: [
-            { name: 'USDC', tokenId: '0xdef456' },
-            { name: 'USDT', tokenId: '0x789abc' },
+            { name: 'USDC', tokenId: '0xdef456', index: 0 },
+            { name: 'USDT', tokenId: '0x789abc', index: 1 },
           ],
+          universe: [],
         };
         mockClientService.getInfoClient = jest.fn().mockReturnValue(
           createMockInfoClient({
@@ -6619,7 +6623,8 @@ describe('HyperLiquidProvider', () => {
       it('throws error when USDC token not found in metadata', async () => {
         // Arrange
         const mockSpotMeta = {
-          tokens: [{ name: 'USDT', tokenId: '0x789abc' }],
+          tokens: [{ name: 'USDT', tokenId: '0x789abc', index: 0 }],
+          universe: [],
         };
         mockClientService.getInfoClient = jest.fn().mockReturnValue(
           createMockInfoClient({

--- a/app/components/UI/Perps/types/hyperliquid-types.ts
+++ b/app/components/UI/Perps/types/hyperliquid-types.ts
@@ -16,6 +16,7 @@ import type {
   AllMidsResponse,
   PredictedFundingsResponse,
   OrderParameters,
+  SpotMetaResponse,
 } from '@nktkas/hyperliquid';
 
 // Clearinghouse (Account) Types
@@ -42,4 +43,5 @@ export type {
   AllMidsResponse,
   MetaAndAssetCtxsResponse,
   PredictedFundingsResponse,
+  SpotMetaResponse,
 };

--- a/app/util/errorUtils.test.ts
+++ b/app/util/errorUtils.test.ts
@@ -23,18 +23,18 @@ describe('ensureError', () => {
     expect(result.message).toBe('42');
   });
 
-  it('should convert null to Error with "null" as message', () => {
+  it('should convert null to Error with descriptive message', () => {
     const result = ensureError(null);
 
     expect(result).toBeInstanceOf(Error);
-    expect(result.message).toBe('null');
+    expect(result.message).toBe('Unknown error (no details provided)');
   });
 
-  it('should convert undefined to Error with "undefined" as message', () => {
+  it('should convert undefined to Error with descriptive message', () => {
     const result = ensureError(undefined);
 
     expect(result).toBeInstanceOf(Error);
-    expect(result.message).toBe('undefined');
+    expect(result.message).toBe('Unknown error (no details provided)');
   });
 
   it('should convert object to Error with stringified object as message', () => {

--- a/app/util/errorUtils.ts
+++ b/app/util/errorUtils.ts
@@ -6,12 +6,18 @@
 /**
  * Ensures we have a proper Error object for logging.
  * Converts unknown/string errors to proper Error instances.
+ * Handles undefined/null specially for better Sentry context.
  * @param error - The caught error (could be Error, string, or unknown)
  * @returns A proper Error instance
  */
 export function ensureError(error: unknown): Error {
   if (error instanceof Error) {
     return error;
+  }
+  // Handle undefined/null specifically for better error context
+  // e.g. Hyperliquid SDK may reject with undefined when AbortSignal.reason is not set
+  if (error === undefined || error === null) {
+    return new Error('Unknown error (no details provided)');
   }
   return new Error(String(error));
 }

--- a/docs/perps/perps-reconnection-incident-postmortem.md
+++ b/docs/perps/perps-reconnection-incident-postmortem.md
@@ -1,0 +1,138 @@
+# Perps Rate Limiting & HIP-3 Reconnection Incident - Postmortem
+
+**Incident Period:** Jan 27 - Jan 31, 2026
+**Affected Versions:** 7.62.0, 7.62.1, 7.63.0
+**Impact:** Trade success rate dropped to 65% (from ~95%), Position close success rate dropped to 54%
+**Root Cause:** WebSocket rate limiting due to excessive API calls
+**Resolution:** Root cause **was already fixed in main** before the incident was identified. Hotfixed to 7.62.2, cherry-picked to 7.63.0.
+
+---
+
+## Executive Summary
+
+In Dec 2025, we switched to WebSocket transport for better performance. However, HyperLiquid has strict rate limits (2000 msg/min), and several operations bypassed caching. Under heavy usage, this triggered rate limit errors.
+
+**Key symptoms:**
+
+- Orders fail with "Unknown error" messages
+- HIP-3 assets (SILVER) fail more than crypto assets after network reconnection
+- App restart fixes the issue
+
+---
+
+## Root Cause
+
+Trading methods (`updatePositionTPSL`, `closePosition`, etc.) used `skipCache: true`, forcing fresh API calls on every operation instead of using cached WebSocket data. Under heavy usage, this exceeded HyperLiquid's rate limit.
+
+---
+
+## Why This Took Time to Diagnose
+
+### Ongoing WebSocket Challenges Since HIP-3
+
+WebSocket performance issues have been a recurring challenge since introducing HIP-3 support. Multiple symptoms were reported—slow price updates, order failures after network changes, inconsistent behavior between crypto and HIP-3 assets—but diagnosing the root cause was difficult without proper tooling.
+
+### Debugging Blind: WebSocket Visibility Challenge
+
+WebSocket debugging in React Native has been historically difficult:
+
+- **Metro/Hermes limitation**: WebSocket traffic doesn't appear in the standard debugger
+- **Log loss on reconnection**: When testing network reconnection scenarios (airplane mode → background → restore), bringing the app back to foreground loses all previous logs
+- **Production-only visibility**: Issues only became visible after 7.62.0 was published to production
+
+We made iterative fixes throughout December and January based on symptoms, but couldn't confirm root causes until this week.
+
+### How We Finally Solved It
+
+**1. MITM Proxy Interception (PR #25155)**
+
+- Intercept all WebSocket frames between the app and HyperLiquid
+- See exact message sequences during reconnection
+- Debug without losing context when app goes to background
+- See: [perps-websocket-monitoring.md](./perps-websocket-monitoring.md)
+
+**2. In-App Debug Page**
+
+- Redirects console logs to an in-app UI
+- Allows viewing logs even when Metro is disconnected (airplane mode)
+- Preserves log history across app background/foreground cycles
+
+This infrastructure finally gave us the visibility needed to diagnose WebSocket issues. The fixes were already in main (from iterative work since Dec 2025), but we only confirmed the production issue and validated the fixes once we had proper WebSocket observability this week.
+
+---
+
+## Resolution Status
+
+| Branch            | Status                                 |
+| ----------------- | -------------------------------------- |
+| **main / 7.64.0** | All fixes included                     |
+| **7.63.0**        | Needs cherry-pick of #25472 and #25022 |
+| **7.62.2**        | Rate limit fixes included, rolling out |
+
+---
+
+## Fixes Applied
+
+1. **WebSocket Reconnection** (#25022) - Added reconnection detection and user notification
+2. **Cache-First Pattern** (#25234, #25438) - Trading methods now use cached data instead of forcing API calls
+
+---
+
+## Defensive Improvement: `spotMeta` Caching (#25490)
+
+HIP-3 orders call `spotMeta()` to check collateral type. This call is currently **not cached**, adding an extra API call per HIP-3 order.
+
+While not the root cause of this incident, caching `spotMeta` is a defensive improvement that:
+
+- Reduces unnecessary API calls
+- Prevents potential rate limiting during heavy HIP-3 trading
+- Improves resilience after network reconnection
+
+**Status:** Being revisited to cache `spotMeta` in `ensureReadyForTrading()` for consistency with other cached metadata.
+
+---
+
+## Sentry Errors
+
+### METAMASK-MOBILE-5DKA / METAMASK-MOBILE-5DC2
+
+These errors show as `undefined` in Sentry with no useful context.
+
+**Root cause:** The HyperLiquid SDK rejects promises with `undefined` when an AbortSignal fires without an explicit reason set. Our error handler converts this to `Error("undefined")`.
+
+**Key insight:** These errors only appear on **7.62.x** versions, **not on 7.64.0 (main)**. This confirms they are symptoms of the rate limiting issue that was already fixed in main, not a separate bug.
+
+| Issue | First Seen | Affected Versions      | On 7.64? |
+| ----- | ---------- | ---------------------- | -------- |
+| 5DKA  | Jan 29     | 7.62.0, 7.62.1         | No       |
+| 5DC2  | Jan 26     | 7.62.0, 7.62.1, 7.62.2 | No       |
+
+---
+
+## Timeline
+
+| Date      | Event                                                                |
+| --------- | -------------------------------------------------------------------- |
+| Dec 2025  | Switched to WebSocket transport, began iterative fixes               |
+| Jan 26    | Reconnection fix merged to main                                      |
+| Jan 27    | 7.62.0 released, issues reported                                     |
+| Jan 29-30 | Rate limit fixes merged to main                                      |
+| Jan 30    | Incident identified, 65% success rate                                |
+| Jan 31    | HIP-3 specific issue identified, MITM debugging confirmed root cause |
+| Feb 1     | 7.62.2 rolling out with fixes                                        |
+
+---
+
+## Lessons Learned
+
+1. **Prefer aggressive caching** - The original tradeoff was to fetch fresh data before orders to ensure accuracy, but rate limits make aggressive caching the better approach. Trust cached WebSocket data for trading operations.
+2. **Test network recovery** - Airplane mode → background → restore is a critical path
+3. **WebSocket debugging needs tooling** - Standard React Native debugging is insufficient for WebSocket issues
+4. **MITM interception is essential** - Implement early for any WebSocket-heavy feature
+
+---
+
+## Technical Details
+
+For implementation details and code references, see:
+**[Technical Deep Dive](./perps-reconnection-technical-deep-dive.md)**

--- a/docs/perps/perps-reconnection-technical-deep-dive.md
+++ b/docs/perps/perps-reconnection-technical-deep-dive.md
@@ -1,0 +1,152 @@
+# Perps Reconnection Incident - Technical Deep Dive
+
+For the high-level postmortem, see [perps-reconnection-incident-postmortem.md](./perps-reconnection-incident-postmortem.md).
+
+---
+
+## Architecture Overview
+
+| Component                      | File                                           | Responsibility                              |
+| ------------------------------ | ---------------------------------------------- | ------------------------------------------- |
+| HyperLiquidProvider            | `controllers/providers/HyperLiquidProvider.ts` | Trading logic, caching, order placement     |
+| HyperLiquidClientService       | `services/HyperLiquidClientService.ts`         | WebSocket connection, reconnection handling |
+| HyperLiquidSubscriptionService | `services/HyperLiquidSubscriptionService.ts`   | Price/position subscriptions                |
+
+### Caching Architecture
+
+| Cache             | Location            | Populated By          | Cleared On Disconnect | Cleared On WS Reconnect |
+| ----------------- | ------------------- | --------------------- | --------------------- | ----------------------- |
+| `cachedMetaByDex` | Provider            | `buildAssetMapping()` | YES                   | NO                      |
+| `dexMetaCache`    | SubscriptionService | `setDexMetaCache()`   | NO                    | NO                      |
+| `spotMeta`        | **NOT CACHED**      | -                     | -                     | -                       |
+
+---
+
+## Root Cause: `skipCache: true` in Trading Methods
+
+Trading methods forced fresh API calls instead of using cached WebSocket data:
+
+- `updatePositionTPSL()`
+- `closePosition()`
+- `closePositions()`
+- `updateMargin()`
+
+**Fix (PRs #25234, #25438):** Added cache-first helpers and removed `skipCache: true`.
+
+---
+
+## Defensive Improvement: `spotMeta` Caching
+
+HIP-3 orders call `spotMeta()` to check collateral type. This is **not the root cause** but adds an extra API call per HIP-3 order, creating potential for rate limiting.
+
+### Call Flow
+
+```
+placeOrder()
+  → handleHip3PreOrder()
+    → isUsdhCollateralDex()
+      → infoClient.spotMeta()  ← Extra API call (not cached)
+```
+
+### Recommended Fix
+
+Cache `spotMeta` in `ensureReadyForTrading()`:
+
+1. Add property: `private cachedSpotMeta: SpotMeta | null = null;`
+
+2. In `ensureReadyForTrading()`:
+
+   ```typescript
+   if (this.hip3Enabled && !this.cachedSpotMeta) {
+     const infoClient = this.clientService.getInfoClient();
+     this.cachedSpotMeta = await infoClient.spotMeta();
+   }
+   ```
+
+3. Update `isUsdhCollateralDex()` to use cache instead of fetching
+
+4. Clear in `disconnect()`: `this.cachedSpotMeta = null;`
+
+---
+
+## Reconnection vs Disconnect Asymmetry
+
+| Aspect            | `disconnect()` | WebSocket Reconnection |
+| ----------------- | -------------- | ---------------------- |
+| When called       | Account switch | Network drop/restore   |
+| `cachedMetaByDex` | CLEARED        | NOT cleared            |
+| `cachedSpotMeta`  | Should clear   | NOT cleared            |
+| InfoClient        | N/A            | RECREATED              |
+
+WebSocket reconnection leaves Provider caches intact while recreating the underlying clients. This is intentional for stable data like `cachedMetaByDex`.
+
+---
+
+## Sentry Errors: METAMASK-MOBILE-5DKA / METAMASK-MOBILE-5DC2
+
+### Symptom
+
+These errors appear as `undefined` in Sentry with no useful stack trace or context.
+
+### Root Cause
+
+The HyperLiquid SDK (`@nktkas/hyperliquid`) rejects promises with `undefined` when an AbortSignal fires without an explicit reason:
+
+```javascript
+// In SDK's websocket/_postRequest.js
+if (signal?.aborted) return Promise.reject(signal.reason); // reason is undefined!
+```
+
+This happens when:
+
+- Request times out
+- WebSocket terminates
+- User cancellation without explicit reason
+
+Our `ensureError()` utility converts `undefined` to `Error("undefined")`, losing all context.
+
+### Relationship to Incident
+
+These errors are a **symptom** of rate limiting, not a separate bug. When rate limits are hit, WebSocket requests fail and the SDK rejects with undefined.
+
+### Optional Improvement
+
+Update `app/util/errorUtils.ts` to provide better messaging:
+
+```typescript
+export function ensureError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  if (error === undefined || error === null) {
+    return new Error('Unknown error (no details provided)');
+  }
+  return new Error(String(error));
+}
+```
+
+---
+
+## Testing
+
+### Network Recovery Test
+
+1. Open perps, open/close SILVER position (success)
+2. Toggle airplane mode on, put app in background ~20 sec
+3. Open app, toggle airplane mode off
+4. Try SILVER position - **should succeed with fix**
+
+### Verification
+
+- [ ] HIP-3 orders work after network recovery
+- [ ] Crypto orders work after network recovery
+- [ ] No 429 errors in logs during rapid trading
+
+---
+
+## Lessons Learned
+
+1. **Prefer aggressive caching** - The original tradeoff was to fetch fresh data before orders to ensure accuracy, but rate limits make aggressive caching the better approach. Trust cached WebSocket data for trading operations.
+2. **Test network recovery** - Airplane mode → background → restore is a critical test path
+3. **WebSocket debugging needs tooling** - Standard React Native debugging (Metro/Hermes) doesn't show WebSocket traffic. Use MITM proxy interception or in-app debug logging.
+4. **Understand cache lifecycle** - Know which caches are cleared on disconnect vs WebSocket reconnection


### PR DESCRIPTION
## **Description**

**fix(perps): add spotMeta caching to reduce API calls on HIP-3 markets**

This PR adds session-based caching for HyperLiquid's global `spotMeta` endpoint to avoid redundant API calls during HIP-3 operations.

### Context
Following the [rate limiting incident](docs/perps/perps-reconnection-incident-postmortem.md) where excessive API calls triggered HyperLiquid's rate limits (2000 msg/min), this is a defensive improvement to reduce unnecessary network requests.

### Problem
The `spotMeta` API (which returns token metadata like USDC/USDH indices) was being called multiple times per trading session:
- `getUsdcTokenId()` - called during transfers
- `isUsdhCollateralDex()` - called to check collateral type
- `swapUsdcToUsdh()` - called during HIP-3 USDH swaps

Each call was making a fresh API request, even though the data (token indices) doesn't change during a session.

### Solution
- Added `cachedSpotMeta` property for session-based caching (no TTL - token indices are stable)
- Added `getCachedSpotMeta()` method that returns cached data or fetches once
- Pre-fetch spotMeta in `ensureReadyForTrading()` when HIP-3 is enabled (non-blocking)
- Cache invalidated on `disconnect()` to ensure fresh state on reconnect/account switch

### Design Decisions
- **Global cache** (not per-DEX): `spotMeta` is a global endpoint returning all tokens
- **Session-based** (no TTL): Token indices don't change during a session
- **Graceful fallback**: If pre-fetch fails, methods fetch on-demand
- Follows existing patterns: `getCachedMeta()`, `getCachedPerpDexs()`

## **Changelog**

CHANGELOG entry: Fixed excessive API calls on HIP-3 markets by caching spot metadata

## **Related issues**

Fixes: add spotMeta caching to reduce API calls on HIP-3 markets

## **Manual testing steps**

```gherkin
Feature: SpotMeta caching for HIP-3 operations

  Scenario: User places order on HIP-3 DEX (SILVER)
    Given user has connected wallet with USDC balance
    And user is on a HIP-3 enabled DEX (e.g., SILVER)

    When user places an order
    Then order should succeed
    And spotMeta API should only be called once per session (check debug logs)

  Scenario: User disconnects and reconnects
    Given user has placed orders (spotMeta is cached)

    When user disconnects wallet
    And user reconnects wallet
    Then spotMeta cache should be cleared
    And next HIP-3 operation should fetch fresh spotMeta
```

## **Screenshots/Recordings**

N/A - Internal optimization, no UI changes

### **Before**

Multiple `spotMeta` API calls per session (one per HIP-3 operation)

### **After**

Single `spotMeta` API call per session, cached for subsequent operations

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches perps trading setup and HIP-3 order/transfer paths by introducing session caching and prefetching of `spotMeta`; bugs here could affect order placement after reconnect or when token metadata is unexpectedly stale.
> 
> **Overview**
> Reduces HyperLiquid API traffic during HIP-3 trading by introducing a session cache for `spotMeta` (via `getCachedSpotMeta()`), prefetching it in `ensureReadyForTrading()`, and reusing it in `getUsdcTokenId()`, `isUsdhCollateralDex()`, and `swapUsdcToUsdh()`; the cache is cleared on `disconnect()`.
> 
> Improves error reporting by updating `ensureError()` to convert `null`/`undefined` into a consistent descriptive `Error`, and updates provider tests/mocks to match the `SpotMetaResponse` shape (token `index` and `universe`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7d00a0b43ef6501910b2bedc3fc10b589a75f95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->