### PR TITLE
fix(perps): add spotMeta caching to reduce API calls on HIP-3 markets cp-7.63.0 cp-7.64.0

### DIFF
--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -1628,8 +1628,10 @@ export class PerpsController extends BaseController<
           })
           .catch((error) => {
             // Check if user denied/cancelled the transaction
-            const errorMessage =
-              error instanceof Error ? error.message : String(error);
+            const errorMessage = ensureError(
+              error,
+              'PerpsController.initiateDeposit',
+            ).message;
             const userCancelled =
               errorMessage.includes('User denied') ||
               errorMessage.includes('User rejected') ||
@@ -1677,8 +1679,10 @@ export class PerpsController extends BaseController<
       };
     } catch (error) {
       // Check if user denied/cancelled the transaction
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const errorMessage = ensureError(
+        error,
+        'PerpsController.initiateDeposit',
+      ).message;
       const userCancelled =
         errorMessage.includes('User denied') ||
         errorMessage.includes('User rejected') ||
@@ -2143,10 +2147,7 @@ export class PerpsController extends BaseController<
       return {
         success: false,
         isTestnet: this.state.isTestnet,
-        error:
-          error instanceof Error
-            ? error.message
-            : PERPS_ERROR_CODES.UNKNOWN_ERROR,
+        error: ensureError(error, 'PerpsController.toggleTestnet').message,
       };
     } finally {
       this.isReinitializing = false;

--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.test.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.test.ts
@@ -241,9 +241,10 @@ const createMockInfoClient = (overrides: Record<string, unknown> = {}) => ({
   ]),
   spotMeta: jest.fn().mockResolvedValue({
     tokens: [
-      { name: 'USDC', tokenId: '0xdef456' },
-      { name: 'USDT', tokenId: '0x789abc' },
+      { name: 'USDC', tokenId: '0xdef456', index: 0 },
+      { name: 'USDT', tokenId: '0x789abc', index: 1 },
     ],
+    universe: [],
   }),
   ...overrides,
 });
@@ -6397,7 +6398,8 @@ describe('HyperLiquidProvider', () => {
       mockClientService.getInfoClient = jest.fn().mockReturnValue(
         createMockInfoClient({
           spotMeta: jest.fn().mockResolvedValue({
-            tokens: [{ name: 'USDC', tokenId: '0xabc123' }],
+            tokens: [{ name: 'USDC', tokenId: '0xabc123', index: 0 }],
+            universe: [],
           }),
         }),
       );
@@ -6487,7 +6489,8 @@ describe('HyperLiquidProvider', () => {
     it('calls getUsdcTokenId to get correct token', async () => {
       // Arrange
       const mockSpotMeta = jest.fn().mockResolvedValue({
-        tokens: [{ name: 'USDC', tokenId: '0xspecific' }],
+        tokens: [{ name: 'USDC', tokenId: '0xspecific', index: 0 }],
+        universe: [],
       });
       mockClientService.getInfoClient = jest
         .fn()
@@ -6597,9 +6600,10 @@ describe('HyperLiquidProvider', () => {
         // Arrange
         const mockSpotMeta = {
           tokens: [
-            { name: 'USDC', tokenId: '0xdef456' },
-            { name: 'USDT', tokenId: '0x789abc' },
+            { name: 'USDC', tokenId: '0xdef456', index: 0 },
+            { name: 'USDT', tokenId: '0x789abc', index: 1 },
           ],
+          universe: [],
         };
         mockClientService.getInfoClient = jest.fn().mockReturnValue(
           createMockInfoClient({
@@ -6619,7 +6623,8 @@ describe('HyperLiquidProvider', () => {
       it('throws error when USDC token not found in metadata', async () => {
         // Arrange
         const mockSpotMeta = {
-          tokens: [{ name: 'USDT', tokenId: '0x789abc' }],
+          tokens: [{ name: 'USDT', tokenId: '0x789abc', index: 0 }],
+          universe: [],
         };
         mockClientService.getInfoClient = jest.fn().mockReturnValue(
           createMockInfoClient({

--- a/app/components/UI/Perps/providers/PerpsConnectionProvider.tsx
+++ b/app/components/UI/Perps/providers/PerpsConnectionProvider.tsx
@@ -100,7 +100,7 @@ export const PerpsConnectionProvider: React.FC<
     try {
       await PerpsConnectionManager.connect();
     } catch (err) {
-      Logger.error(err as Error, {
+      Logger.error(ensureError(err, 'PerpsConnectionProvider.connect'), {
         message: 'PerpsConnectionProvider: Error during connect',
         context: 'PerpsConnectionProvider.connect',
       });
@@ -128,7 +128,7 @@ export const PerpsConnectionProvider: React.FC<
     try {
       await PerpsConnectionManager.disconnect();
     } catch (err) {
-      Logger.error(err as Error, {
+      Logger.error(ensureError(err, 'PerpsConnectionProvider.disconnect'), {
         message: 'PerpsConnectionProvider: Error during disconnect',
         context: 'PerpsConnectionProvider.disconnect',
       });
@@ -166,10 +166,13 @@ export const PerpsConnectionProvider: React.FC<
         // Use the existing reconnectWithNewContext method from the singleton
         await PerpsConnectionManager.reconnectWithNewContext(options);
       } catch (err) {
-        Logger.error(err as Error, {
-          message: 'PerpsConnectionProvider: Error during reconnect',
-          context: 'PerpsConnectionProvider.reconnectWithNewContext',
-        });
+        Logger.error(
+          ensureError(err, 'PerpsConnectionProvider.reconnectWithNewContext'),
+          {
+            message: 'PerpsConnectionProvider: Error during reconnect',
+            context: 'PerpsConnectionProvider.reconnectWithNewContext',
+          },
+        );
       }
       // Always update state after reconnection attempt
       const state = PerpsConnectionManager.getConnectionState();
@@ -185,11 +188,14 @@ export const PerpsConnectionProvider: React.FC<
       try {
         await PerpsConnectionManager.connect();
       } catch (err) {
-        Logger.error(err as Error, {
-          message: 'PerpsConnectionProvider: Error in lifecycle onConnect',
-          context:
-            'PerpsConnectionProvider.usePerpsConnectionLifecycle.onConnect',
-        });
+        Logger.error(
+          ensureError(err, 'PerpsConnectionProvider.lifecycle.onConnect'),
+          {
+            message: 'PerpsConnectionProvider: Error in lifecycle onConnect',
+            context:
+              'PerpsConnectionProvider.usePerpsConnectionLifecycle.onConnect',
+          },
+        );
       }
       const state = PerpsConnectionManager.getConnectionState();
       setConnectionState(state);
@@ -198,11 +204,14 @@ export const PerpsConnectionProvider: React.FC<
       try {
         await PerpsConnectionManager.disconnect();
       } catch (err) {
-        Logger.error(err as Error, {
-          message: 'PerpsConnectionProvider: Error in lifecycle onDisconnect',
-          context:
-            'PerpsConnectionProvider.usePerpsConnectionLifecycle.onDisconnect',
-        });
+        Logger.error(
+          ensureError(err, 'PerpsConnectionProvider.lifecycle.onDisconnect'),
+          {
+            message: 'PerpsConnectionProvider: Error in lifecycle onDisconnect',
+            context:
+              'PerpsConnectionProvider.usePerpsConnectionLifecycle.onDisconnect',
+          },
+        );
       }
       const state = PerpsConnectionManager.getConnectionState();
       setConnectionState(state);

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -4,6 +4,7 @@ import performance from 'react-native-performance';
 import Engine from '../../../../core/Engine';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import Logger from '../../../../util/Logger';
+import { ensureError } from '../../../../util/errorUtils';
 import {
   trace,
   endTrace,
@@ -410,7 +411,7 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
         this.cleanupPrewarm();
       };
     } catch (error) {
-      Logger.error(error instanceof Error ? error : new Error(String(error)), {
+      Logger.error(ensureError(error, 'PriceStreamChannel.prewarm'), {
         context: 'PriceStreamChannel.prewarm',
       });
       // Return no-op cleanup function
@@ -1181,7 +1182,7 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
       // Don't await - just trigger the fetch and handle errors
       this.fetchMarketData().catch((error) => {
         Logger.error(
-          error instanceof Error ? error : new Error(String(error)),
+          ensureError(error, 'PerpsStreamManager.fetchMarketData.background'),
           'PerpsStreamManager: Failed to fetch market data',
         );
       });
@@ -1238,13 +1239,10 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
         });
       } catch (error) {
         const fetchTime = Date.now() - fetchStartTime;
-        Logger.error(
-          error instanceof Error ? error : new Error(String(error)),
-          {
-            context: 'PerpsStreamManager.fetchMarketData',
-            fetchTimeMs: fetchTime,
-          },
-        );
+        Logger.error(ensureError(error, 'PerpsStreamManager.fetchMarketData'), {
+          context: 'PerpsStreamManager.fetchMarketData',
+          fetchTimeMs: fetchTime,
+        });
         // Keep existing cache if fetch fails
         const existing = this.cache.get('markets');
         if (existing) {

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -559,36 +559,31 @@ class PerpsConnectionManagerClass {
         this.clearConnectionTimeout();
 
         // Capture exception with connection context
-        captureException(
-          error instanceof Error ? error : new Error(String(error)),
-          {
-            tags: {
-              component: 'PerpsConnectionManager',
-              action: 'connection_connection',
-              operation: 'connection_management',
+        captureException(ensureError(error, 'PerpsConnectionManager.connect'), {
+          tags: {
+            component: 'PerpsConnectionManager',
+            action: 'connection_connection',
+            operation: 'connection_management',
+            provider: 'hyperliquid',
+          },
+          extra: {
+            connectionContext: {
               provider: 'hyperliquid',
-            },
-            extra: {
-              connectionContext: {
-                provider: 'hyperliquid',
-                timestamp: new Date().toISOString(),
-                isTestnet:
-                  Engine.context.PerpsController?.getCurrentNetwork?.() ===
-                  'testnet',
-              },
+              timestamp: new Date().toISOString(),
+              isTestnet:
+                Engine.context.PerpsController?.getCurrentNetwork?.() ===
+                'testnet',
             },
           },
-        );
+        });
 
         traceData = {
           success: false,
-          error: error instanceof Error ? error.message : 'Unknown error',
+          error: ensureError(error, 'PerpsConnectionManager.connect').message,
         };
 
         // Set error state for UI
-        this.setError(
-          error instanceof Error ? error : new Error(String(error)),
-        );
+        this.setError(ensureError(error, 'PerpsConnectionManager.connect'));
         DevLogger.log('PerpsConnectionManager: Connection failed', error);
         throw error;
       } finally {
@@ -805,11 +800,11 @@ class PerpsConnectionManagerClass {
 
       traceData = {
         success: false,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        error: ensureError(error, 'PerpsConnectionManager.reconnect').message,
       };
 
       // Set error state for UI - this is critical for reliability
-      this.setError(error instanceof Error ? error : new Error(String(error)));
+      this.setError(ensureError(error, 'PerpsConnectionManager.reconnect'));
       DevLogger.log(
         'PerpsConnectionManager: Reconnection with new context failed',
         error,

--- a/app/components/UI/Perps/types/hyperliquid-types.ts
+++ b/app/components/UI/Perps/types/hyperliquid-types.ts
@@ -16,6 +16,7 @@ import type {
   AllMidsResponse,
   PredictedFundingsResponse,
   OrderParameters,
+  SpotMetaResponse,
 } from '@nktkas/hyperliquid';
 
 // Clearinghouse (Account) Types
@@ -42,4 +43,5 @@ export type {
   AllMidsResponse,
   MetaAndAssetCtxsResponse,
   PredictedFundingsResponse,
+  SpotMetaResponse,
 };

--- a/app/util/errorUtils.test.ts
+++ b/app/util/errorUtils.test.ts
@@ -23,18 +23,18 @@ describe('ensureError', () => {
     expect(result.message).toBe('42');
   });
 
-  it('should convert null to Error with "null" as message', () => {
+  it('should convert null to Error with descriptive message', () => {
     const result = ensureError(null);
 
     expect(result).toBeInstanceOf(Error);
-    expect(result.message).toBe('null');
+    expect(result.message).toBe('Unknown error (no details provided)');
   });
 
-  it('should convert undefined to Error with "undefined" as message', () => {
+  it('should convert undefined to Error with descriptive message', () => {
     const result = ensureError(undefined);
 
     expect(result).toBeInstanceOf(Error);
-    expect(result.message).toBe('undefined');
+    expect(result.message).toBe('Unknown error (no details provided)');
   });
 
   it('should convert object to Error with stringified object as message', () => {

--- a/app/util/errorUtils.test.ts
+++ b/app/util/errorUtils.test.ts
@@ -1,66 +1,68 @@
 import { ensureError } from './errorUtils';
 
 describe('ensureError', () => {
-  it('should return the same Error instance when passed an Error', () => {
+  it('returns the same Error instance when passed an Error', () => {
     const originalError = new Error('Test error');
+
     const result = ensureError(originalError);
 
     expect(result).toBe(originalError);
     expect(result.message).toBe('Test error');
   });
 
-  it('should convert string to Error with the string as message', () => {
+  it('converts string to Error with the string as message', () => {
     const result = ensureError('String error message');
 
     expect(result).toBeInstanceOf(Error);
     expect(result.message).toBe('String error message');
   });
 
-  it('should convert number to Error with number as string message', () => {
+  it('converts number to Error with number as string message', () => {
     const result = ensureError(42);
 
     expect(result).toBeInstanceOf(Error);
     expect(result.message).toBe('42');
   });
 
-  it('should convert null to Error with descriptive message', () => {
+  it('converts null to Error with descriptive message', () => {
     const result = ensureError(null);
 
     expect(result).toBeInstanceOf(Error);
     expect(result.message).toBe('Unknown error (no details provided)');
   });
 
-  it('should convert undefined to Error with descriptive message', () => {
+  it('converts undefined to Error with descriptive message', () => {
     const result = ensureError(undefined);
 
     expect(result).toBeInstanceOf(Error);
     expect(result.message).toBe('Unknown error (no details provided)');
   });
 
-  it('should convert object to Error with stringified object as message', () => {
+  it('converts object to Error with stringified object as message', () => {
     const obj = { code: 'ERROR_CODE', details: 'Some details' };
+
     const result = ensureError(obj);
 
     expect(result).toBeInstanceOf(Error);
     expect(result.message).toBe('[object Object]');
   });
 
-  it('should convert boolean to Error with string representation', () => {
+  it('converts boolean to Error with string representation', () => {
     const result = ensureError(false);
 
     expect(result).toBeInstanceOf(Error);
     expect(result.message).toBe('false');
   });
 
-  it('should preserve Error subclasses', () => {
+  it('preserves Error subclasses', () => {
     class CustomError extends Error {
       constructor(message: string) {
         super(message);
         this.name = 'CustomError';
       }
     }
-
     const customError = new CustomError('Custom error message');
+
     const result = ensureError(customError);
 
     expect(result).toBe(customError);

--- a/app/util/errorUtils.test.ts
+++ b/app/util/errorUtils.test.ts
@@ -38,6 +38,40 @@ describe('ensureError', () => {
     expect(result.message).toBe('Unknown error (no details provided)');
   });
 
+  it('includes context in message when provided with undefined', () => {
+    const result = ensureError(undefined, 'PerpsConnectionProvider.connect');
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe(
+      'Unknown error (no details provided) [PerpsConnectionProvider.connect]',
+    );
+  });
+
+  it('includes context in message when provided with null', () => {
+    const result = ensureError(null, 'PerpsStreamManager.prewarm');
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe(
+      'Unknown error (no details provided) [PerpsStreamManager.prewarm]',
+    );
+  });
+
+  it('does not modify Error instance when context is provided', () => {
+    const originalError = new Error('Original error');
+
+    const result = ensureError(originalError, 'SomeContext');
+
+    expect(result).toBe(originalError);
+    expect(result.message).toBe('Original error');
+  });
+
+  it('does not include context for string errors', () => {
+    const result = ensureError('String error', 'SomeContext');
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('String error');
+  });
+
   it('converts object to Error with stringified object as message', () => {
     const obj = { code: 'ERROR_CODE', details: 'Some details' };
 

--- a/app/util/errorUtils.ts
+++ b/app/util/errorUtils.ts
@@ -6,12 +6,18 @@
 /**
  * Ensures we have a proper Error object for logging.
  * Converts unknown/string errors to proper Error instances.
+ * Handles undefined/null specially for better Sentry context.
  * @param error - The caught error (could be Error, string, or unknown)
  * @returns A proper Error instance
  */
 export function ensureError(error: unknown): Error {
   if (error instanceof Error) {
     return error;
+  }
+  // Handle undefined/null specifically for better error context
+  // e.g. Hyperliquid SDK may reject with undefined when AbortSignal.reason is not set
+  if (error === undefined || error === null) {
+    return new Error('Unknown error (no details provided)');
   }
   return new Error(String(error));
 }

--- a/app/util/errorUtils.ts
+++ b/app/util/errorUtils.ts
@@ -8,16 +8,18 @@
  * Converts unknown/string errors to proper Error instances.
  * Handles undefined/null specially for better Sentry context.
  * @param error - The caught error (could be Error, string, or unknown)
+ * @param context - Optional context string to help identify the source of the error
  * @returns A proper Error instance
  */
-export function ensureError(error: unknown): Error {
+export function ensureError(error: unknown, context?: string): Error {
   if (error instanceof Error) {
     return error;
   }
   // Handle undefined/null specifically for better error context
   // e.g. Hyperliquid SDK may reject with undefined when AbortSignal.reason is not set
   if (error === undefined || error === null) {
-    return new Error('Unknown error (no details provided)');
+    const baseMessage = 'Unknown error (no details provided)';
+    return new Error(context ? `${baseMessage} [${context}]` : baseMessage);
   }
   return new Error(String(error));
 }


### PR DESCRIPTION
## **Description**

**fix(perps): add spotMeta caching to reduce API calls on HIP-3 markets**

This PR adds session-based caching for HyperLiquid's global `spotMeta` endpoint to avoid redundant API calls during HIP-3 operations.

### Context
Following a rate limiting incident where excessive API calls triggered HyperLiquid's rate limits (2000 msg/min), this is a defensive improvement to reduce unnecessary network requests.

### Problem
The `spotMeta` API (which returns token metadata like USDC/USDH indices) was being called multiple times per trading session:
- `getUsdcTokenId()` - called during transfers
- `isUsdhCollateralDex()` - called to check collateral type
- `swapUsdcToUsdh()` - called during HIP-3 USDH swaps

Each call was making a fresh API request, even though the data (token indices) doesn't change during a session.

### Solution
- Added `cachedSpotMeta` property for session-based caching (no TTL - token indices are stable)
- Added `getCachedSpotMeta()` method that returns cached data or fetches once
- Pre-fetch spotMeta in `ensureReadyForTrading()` when HIP-3 is enabled (non-blocking)
- Cache invalidated on `disconnect()` to ensure fresh state on reconnect/account switch

### Design Decisions
- **Global cache** (not per-DEX): `spotMeta` is a global endpoint returning all tokens
- **Session-based** (no TTL): Token indices don't change during a session
- **Graceful fallback**: If pre-fetch fails, methods fetch on-demand
- Follows existing patterns: `getCachedMeta()`, `getCachedPerpDexs()`

## **Changelog**

CHANGELOG entry: Fixed excessive API calls on HIP-3 markets by caching spot metadata

## **Related issues**

Fixes: N/A (Defensive improvement following rate limiting incident)

## **Manual testing steps**

```gherkin
Feature: SpotMeta caching for HIP-3 operations

  Scenario: User places order on HIP-3 DEX (SILVER)
    Given user has connected wallet with USDC balance
    And user is on a HIP-3 enabled DEX (e.g., SILVER)

    When user places an order
    Then order should succeed
    And spotMeta API should only be called once per session (check debug logs)

  Scenario: User disconnects and reconnects
    Given user has placed orders (spotMeta is cached)

    When user disconnects wallet
    And user reconnects wallet
    Then spotMeta cache should be cleared
    And next HIP-3 operation should fetch fresh spotMeta
```

## **Screenshots/Recordings**

N/A - Internal optimization, no UI changes

### **Before**

Multiple `spotMeta` API calls per session (one per HIP-3 operation)

### **After**

Single `spotMeta` API call per session, cached for subsequent operations

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches perps trading setup and HIP-3 collateral/token resolution by introducing session-cached `spotMeta`; incorrect caching or cache invalidation could affect order/transfer flows, though it falls back to on-demand fetch and clears on disconnect.
> 
> **Overview**
> Reduces HyperLiquid rate-limit pressure on HIP-3 flows by adding a **session-level `spotMeta` cache** in `HyperLiquidProvider`, prefetching it during `ensureReadyForTrading()`, reusing it in USDC/USDH collateral checks and swaps, and clearing it on disconnect.
> 
> Standardizes error handling across perps controllers/providers by extending `ensureError` with optional context (including better messages for `null`/`undefined`) and replacing ad-hoc `instanceof Error` checks in connection, streaming, deposit/testnet toggle, and provider operations; updates related tests and types (`SpotMetaResponse`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ee4cb2d286c6aab238fda65b1e1c8d47d0e5283. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->