### PR TITLE
[DRAFT]: `FiatStrategy` PoC implementation

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -1,4 +1,6 @@
 import React, { ReactNode, memo, useCallback, useState } from 'react';
+import { FiatQuoteRow } from '../../rows/fiat-quote-row';
+import { useTransactionPayFiat } from '../../../hooks/pay/useTransactionPayFiat';
 import { PayTokenAmount, PayTokenAmountSkeleton } from '../../pay-token-amount';
 import { PayWithRow, PayWithRowSkeleton } from '../../rows/pay-with-row';
 import { BridgeFeeRow } from '../../rows/bridge-fee-row';
@@ -86,8 +88,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     footerText,
   }) => {
     useClearConfirmationOnBackSwipe();
+    const { isFiatSelected } = useTransactionPayFiat();
     useAutomaticTransactionPayToken({
-      disable: disablePay,
+      disable: disablePay || isFiatSelected,
       preferredToken,
     });
     useTransactionPayMetrics();
@@ -138,7 +141,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             currency={currency}
             hasAlert={Boolean(alertMessage)}
             onPress={handleAmountPress}
-            disabled={!hasTokens}
+            disabled={!hasTokens && !isFiatSelected}
           />
           {overrideContent ? (
             overrideContent(amountHuman)
@@ -147,17 +150,19 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               {disablePay !== true && (
                 <PayTokenAmount
                   amountHuman={amountHuman}
-                  disabled={!hasTokens}
+                  disabled={!hasTokens || isFiatSelected}
                 />
               )}
               {children}
-              {disablePay !== true && hasTokens && <PayWithRow />}
+              {disablePay !== true && (hasTokens || isFiatSelected) && (
+                <PayWithRow />
+              )}
             </>
           )}
         </Box>
         <Box gap={25}>
           <AlertMessage alertMessage={alertMessage} />
-          {isResultReady && (
+          {isResultReady && !isFiatSelected && (
             <Box>
               <BridgeFeeRow />
               <BridgeTimeRow />
@@ -165,6 +170,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               <PercentageRow />
             </Box>
           )}
+          {isFiatSelected && !isKeyboardVisible && <FiatQuoteRow />}
           {footerText && (
             <Text
               variant={TextVariant.BodySM}
@@ -185,7 +191,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               hasMax={hasMax && !isNativePayToken}
             />
           )}
-          {!hasTokens && <BuySection />}
+          {!hasTokens && !isFiatSelected && <BuySection />}
           {!isKeyboardVisible && <ConfirmButton alertTitle={alertTitle} />}
         </Box>
       </Box>

--- a/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.tsx
+++ b/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
+import { useTransactionPayFiat } from '../../hooks/pay/useTransactionPayFiat';
 import Text, {
   TextColor,
   TextVariant,
@@ -25,6 +26,7 @@ export interface PayTokenAmountProps {
 
 export function PayTokenAmount({ amountHuman, disabled }: PayTokenAmountProps) {
   const transaction = useTransactionMetadataRequest();
+  const { isFiatSelected } = useTransactionPayFiat();
   const { chainId } = transaction ?? { chainId: '0x0' };
   const { payToken } = useTransactionPayToken();
   const targetTokenAddress = getTokenAddress(transaction);
@@ -68,6 +70,10 @@ export function PayTokenAmount({ amountHuman, disabled }: PayTokenAmountProps) {
 
     return formatAmount(I18n.locale, payTokenAmount);
   }, [amountHuman, disabled, payToken, fiatRates]);
+
+  if (isFiatSelected) {
+    return null;
+  }
 
   if (disabled) {
     return (

--- a/app/components/Views/confirmations/components/rows/fiat-quote-row/fiat-quote-row.tsx
+++ b/app/components/Views/confirmations/components/rows/fiat-quote-row/fiat-quote-row.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import BigNumber from 'bignumber.js';
+import { View, StyleSheet } from 'react-native';
+import { useSelector } from 'react-redux';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../../component-library/components/Texts/Text';
+import {
+  selectTransactionPayQuotesByTransactionId,
+  selectTransactionPayTotalsByTransactionId,
+} from '../../../../../../selectors/transactionPayController';
+import type { RootState } from '../../../../../../reducers';
+import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 4,
+  },
+});
+
+export function FiatQuoteRow() {
+  const transactionMeta = useTransactionMetadataRequest();
+  const transactionId = transactionMeta?.id ?? '';
+
+  const quotes = useSelector((state: RootState) =>
+    selectTransactionPayQuotesByTransactionId(state, transactionId),
+  );
+
+  const totals = useSelector((state: RootState) =>
+    selectTransactionPayTotalsByTransactionId(state, transactionId),
+  );
+
+  const quote = quotes?.[0];
+
+  if (!quote) {
+    return null;
+  }
+
+  const providerFeeUsd = quote.fees?.provider?.usd ?? '0.00';
+  const estimatedDuration = quote.estimatedDuration ?? 30;
+  const totalUsd = new BigNumber(quote.targetAmount.usd).plus(
+    new BigNumber(quote.fees?.provider?.usd),
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+          Provider fee
+        </Text>
+        <Text variant={TextVariant.BodyMD}>${providerFeeUsd}</Text>
+      </View>
+      <View style={styles.row}>
+        <Text variant={TextVariant.BodyMDBold}>Total</Text>
+        <Text variant={TextVariant.BodyMDBold}>$ {totalUsd.toString()}</Text>
+      </View>
+      <View style={styles.row}>
+        <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          Est. time
+        </Text>
+        <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          ~{estimatedDuration}s
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/app/components/Views/confirmations/components/rows/fiat-quote-row/index.ts
+++ b/app/components/Views/confirmations/components/rows/fiat-quote-row/index.ts
@@ -1,0 +1,1 @@
+export { FiatQuoteRow } from './fiat-quote-row';

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
+import { useTransactionPayFiat } from '../../../hooks/pay/useTransactionPayFiat';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { TokenIcon } from '../../token-icon';
@@ -40,6 +41,7 @@ export function PayWithRow() {
   const { styles } = useStyles(styleSheet, {});
   const { setConfirmationMetric } = useConfirmationMetricEvents();
 
+  const { fiatPayment, isFiatSelected } = useTransactionPayFiat();
   const {
     txParams: { from },
   } = useTransactionMetadataRequest() ?? { txParams: {} };
@@ -60,6 +62,14 @@ export function PayWithRow() {
     () => formatFiat(new BigNumber(payToken?.balanceUsd ?? '0')),
     [formatFiat, payToken?.balanceUsd],
   );
+
+  if (isFiatSelected) {
+    return (
+      <TouchableOpacity onPress={handleClick} style={styles.container}>
+        <Text variant={TextVariant.BodyMD}>{fiatPayment?.methodName}</Text>
+      </TouchableOpacity>
+    );
+  }
 
   if (!payToken) {
     return <PayWithRowSkeleton />;

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTransactionPayFiat } from '../pay/useTransactionPayFiat';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
 import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
@@ -34,7 +35,7 @@ export const useInsufficientBalanceAlert = ({
   const isSimulationEnabled = useSelector(selectUseTransactionSimulations);
   const { hasInsufficientBalance, nativeCurrency } =
     useHasInsufficientBalance();
-
+  const { isFiatSelected } = useTransactionPayFiat();
   const primaryRequiredToken = (requiredTokens ?? []).find(
     (token) => !token.skipIfBalance,
   );
@@ -49,7 +50,8 @@ export const useInsufficientBalanceAlert = ({
     if (
       !transactionMetadata ||
       isTransactionValueUpdating ||
-      (payToken && !isPayTokenTarget)
+      (payToken && !isPayTokenTarget) ||
+      isFiatSelected
     ) {
       return [];
     }
@@ -119,6 +121,7 @@ export const useInsufficientBalanceAlert = ({
     transactionMetadata,
     isTransactionValueUpdating,
     payToken,
+    isFiatSelected,
     isPayTokenTarget,
     isGaslessCheckPending,
     isGaslessSupported,

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTransactionPayFiat } from '../pay/useTransactionPayFiat';
 import { Alert, Severity } from '../../types/alerts';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
@@ -26,7 +27,8 @@ export function useInsufficientPayTokenBalanceAlert({
   const requiredTokens = useTransactionPayRequiredTokens();
   const totals = useTransactionPayTotals();
   const isLoading = useIsTransactionPayLoading();
-  const isSourceGasFeeToken = totals?.fees.isSourceGasFeeToken ?? false;
+  const isSourceGasFeeToken = totals?.fees?.isSourceGasFeeToken ?? false;
+  const { isFiatSelected } = useTransactionPayFiat();
   const isPendingAlert = Boolean(pendingAmountUsd !== undefined);
   const isMax = useTransactionPayIsMaxAmount();
 
@@ -119,6 +121,10 @@ export function useInsufficientPayTokenBalanceAlert({
       isBlocking: true,
     };
 
+    if (isFiatSelected) {
+      return [];
+    }
+
     if (isInsufficientForInput) {
       return [
         {
@@ -160,6 +166,7 @@ export function useInsufficientPayTokenBalanceAlert({
 
     return [];
   }, [
+    isFiatSelected,
     isInsufficientForInput,
     isInsufficientForFees,
     isInsufficientForSourceNetwork,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayData.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayData.ts
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../reducers';
 import {
   selectIsTransactionPayLoadingByTransactionId,
+  selectTransactionFiatPaymentByTransactionId,
   selectTransactionPayIsMaxAmountByTransactionId,
   selectTransactionPayQuotesByTransactionId,
   selectTransactionPaySourceAmountsByTransactionId,
@@ -41,6 +42,10 @@ export function useTransactionPayTotals() {
 
 export function useTransactionPayIsMaxAmount() {
   return useTransactionPayData(selectTransactionPayIsMaxAmountByTransactionId);
+}
+
+export function useTransactionFiatPaymentData() {
+  return useTransactionPayData(selectTransactionFiatPaymentByTransactionId);
 }
 
 function useTransactionPayData<T>(

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayFiat.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { hasTransactionType } from '../../utils/transaction';
+import { useTransactionFiatPaymentData } from './useTransactionPayData';
+
+const IS_FIAT_STRATEGY_ENABLED = process.env.MMPAY_FIAT_STRATEGY === 'true';
+
+export function useTransactionPayFiat() {
+  const transactionMeta = useTransactionMetadataRequest() as TransactionMeta;
+  const fiatPayment = useTransactionFiatPaymentData();
+
+  const isFiatPaymentEnabled =
+    IS_FIAT_STRATEGY_ENABLED &&
+    hasTransactionType(transactionMeta, [TransactionType.predictDeposit]);
+  const isFiatSelected = Boolean(fiatPayment);
+
+  return useMemo(() => {
+    if (!isFiatSelected || !isFiatPaymentEnabled) {
+      return {
+        isFiatPaymentEnabled,
+        isFiatSelected: false,
+        fiatPayment: undefined,
+      };
+    }
+
+    return {
+      isFiatSelected,
+      isFiatPaymentEnabled,
+      fiatPayment,
+    };
+  }, [isFiatPaymentEnabled, isFiatSelected, fiatPayment]);
+}

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -42,6 +42,11 @@ export function useTransactionPayToken(): {
         newPayToken.chainId,
       );
 
+      TransactionPayController.setFiatPayment(
+        transactionId,
+        undefined,
+      );
+
       GasFeeController.fetchGasFeeEstimates({
         networkClientId,
       }).catch(noop);

--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
@@ -2,8 +2,9 @@ import type { ControllerInitFunction } from '../../types';
 import Logger from '../../../../util/Logger';
 import {
   TransactionPayController,
-  TransactionPayControllerMessenger,
   TransactionPayStrategy,
+  type TransactionPayControllerMessenger,
+  type TransactionData,
 } from '@metamask/transaction-pay-controller';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionPayControllerInitMessenger } from '../../messengers/transaction-pay-controller-messenger';
@@ -20,7 +21,8 @@ export const TransactionPayControllerInit: ControllerInitFunction<
     const transactionPayController = new TransactionPayController({
       getDelegationTransaction: ({ transaction }) =>
         getDelegationTransaction(initMessenger, transaction),
-      getStrategy,
+      getStrategy: (transaction, transactionData) =>
+        getStrategy(transaction, transactionData),
       messenger: controllerMessenger,
       state: persistedState.TransactionPayController,
     });
@@ -35,6 +37,15 @@ export const TransactionPayControllerInit: ControllerInitFunction<
   }
 };
 
-function getStrategy(_transaction: TransactionMeta): TransactionPayStrategy {
+function getStrategy(
+  _transaction: TransactionMeta,
+  transactionData?: TransactionData,
+): TransactionPayStrategy {
+  const fiatPayment = transactionData?.fiatPayment;
+
+  if (fiatPayment) {
+    return TransactionPayStrategy.Fiat;
+  }
+
   return TransactionPayStrategy.Relay;
 }

--- a/app/selectors/transactionPayController.ts
+++ b/app/selectors/transactionPayController.ts
@@ -48,6 +48,11 @@ export const selectTransactionPayIsMaxAmountByTransactionId = createSelector(
   (transactionData) => transactionData?.isMaxAmount ?? false,
 );
 
+export const selectTransactionFiatPaymentByTransactionId = createSelector(
+  selectTransactionDataByTransactionId,
+  (transactionData) => transactionData?.fiatPayment,
+);
+
 export const selectTransactionPayTransactionData = createSelector(
   selectTransactionPayControllerState,
   (state) => state.transactionData,

--- a/package.json
+++ b/package.json
@@ -298,7 +298,7 @@
     "@metamask/swaps-controller": "^15.0.0",
     "@metamask/token-search-discovery-controller": "^4.0.0",
     "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.9.0-5c8f871530.patch",
-    "@metamask/transaction-pay-controller": "^11.1.0",
+    "@metamask/transaction-pay-controller": "file:.yalc/@metamask/transaction-pay-controller",
     "@metamask/tron-wallet-snap": "^1.19.2",
     "@metamask/utils": "^11.8.1",
     "@ngraveio/bc-ur": "^1.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7424,60 +7424,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^96.0.0":
-  version: 96.0.0
-  resolution: "@metamask/assets-controllers@npm:96.0.0"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/account-tree-controller": "npm:^4.0.0"
-    "@metamask/accounts-controller": "npm:^35.0.2"
-    "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/contract-metadata": "npm:^2.4.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/core-backend": "npm:^5.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/keyring-controller": "npm:^25.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-account-service": "npm:^5.1.0"
-    "@metamask/network-controller": "npm:^29.0.0"
-    "@metamask/permission-controller": "npm:^12.2.0"
-    "@metamask/phishing-controller": "npm:^16.1.0"
-    "@metamask/polling-controller": "npm:^16.0.2"
-    "@metamask/preferences-controller": "npm:^22.0.0"
-    "@metamask/profile-sync-controller": "npm:^27.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/snaps-controllers": "npm:^17.2.0"
-    "@metamask/snaps-sdk": "npm:^10.3.0"
-    "@metamask/snaps-utils": "npm:^11.7.0"
-    "@metamask/transaction-controller": "npm:^62.9.2"
-    "@metamask/utils": "npm:^11.9.0"
-    "@types/bn.js": "npm:^5.1.5"
-    "@types/uuid": "npm:^8.3.0"
-    async-mutex: "npm:^0.5.0"
-    bitcoin-address-validation: "npm:^2.2.3"
-    bn.js: "npm:^5.2.1"
-    immer: "npm:^9.0.6"
-    lodash: "npm:^4.17.21"
-    multiformats: "npm:^9.9.0"
-    reselect: "npm:^5.1.1"
-    single-call-balance-checker-abi: "npm:^1.0.0"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/providers": ^22.0.0
-    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/c5cf7363972b2f267ba96a925fd74eaee3eebde8bf470af7d4c49589b33b34fc9b8574289e4592cbce13e941201893d2ad20018da0dada8025317db0ce33df0f
-  languageName: node
-  linkType: hard
-
 "@metamask/assets-controllers@npm:^97.0.0":
   version: 97.0.0
   resolution: "@metamask/assets-controllers@npm:97.0.0"
@@ -7589,6 +7535,62 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/assets-controllers@npm:^99.0.0, @metamask/assets-controllers@npm:^99.1.0":
+  version: 99.1.0
+  resolution: "@metamask/assets-controllers@npm:99.1.0"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/abi-utils": "npm:^2.0.3"
+    "@metamask/account-tree-controller": "npm:^4.0.0"
+    "@metamask/accounts-controller": "npm:^35.0.2"
+    "@metamask/approval-controller": "npm:^8.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/contract-metadata": "npm:^2.4.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/core-backend": "npm:^5.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/keyring-api": "npm:^21.0.0"
+    "@metamask/keyring-controller": "npm:^25.1.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-account-service": "npm:^5.1.0"
+    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/network-enablement-controller": "npm:^4.1.0"
+    "@metamask/permission-controller": "npm:^12.2.0"
+    "@metamask/phishing-controller": "npm:^16.1.0"
+    "@metamask/polling-controller": "npm:^16.0.2"
+    "@metamask/preferences-controller": "npm:^22.0.0"
+    "@metamask/profile-sync-controller": "npm:^27.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/snaps-controllers": "npm:^17.2.0"
+    "@metamask/snaps-sdk": "npm:^10.3.0"
+    "@metamask/snaps-utils": "npm:^11.7.0"
+    "@metamask/storage-service": "npm:^0.0.1"
+    "@metamask/transaction-controller": "npm:^62.11.0"
+    "@metamask/utils": "npm:^11.9.0"
+    "@types/bn.js": "npm:^5.1.5"
+    "@types/uuid": "npm:^8.3.0"
+    async-mutex: "npm:^0.5.0"
+    bitcoin-address-validation: "npm:^2.2.3"
+    bn.js: "npm:^5.2.1"
+    immer: "npm:^9.0.6"
+    lodash: "npm:^4.17.21"
+    multiformats: "npm:^9.9.0"
+    reselect: "npm:^5.1.1"
+    single-call-balance-checker-abi: "npm:^1.0.0"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/01e9e33f50d5207817264c969ee37ad534399756d580ff1ebb965018cba0c669a181ba70273ba6901e5c71c2f5acd7506b2ff12432c9b218cfa778e3d12c59b7
+  languageName: node
+  linkType: hard
+
 "@metamask/auth-network-utils@npm:^0.3.0":
   version: 0.3.1
   resolution: "@metamask/auth-network-utils@npm:0.3.1"
@@ -7658,7 +7660,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^64.8.0, @metamask/bridge-controller@npm:^64.8.1, @metamask/bridge-controller@npm:^64.8.2":
+"@metamask/bridge-controller@npm:^64.8.0, @metamask/bridge-controller@npm:^64.8.2":
   version: 64.8.2
   resolution: "@metamask/bridge-controller@npm:64.8.2"
   dependencies:
@@ -7689,7 +7691,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-status-controller@npm:^64.4.4, @metamask/bridge-status-controller@npm:^64.4.5":
+"@metamask/bridge-controller@npm:^65.1.0":
+  version: 65.1.0
+  resolution: "@metamask/bridge-controller@npm:65.1.0"
+  dependencies:
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/constants": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^35.0.2"
+    "@metamask/assets-controllers": "npm:^99.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/gas-fee-controller": "npm:^26.0.2"
+    "@metamask/keyring-api": "npm:^21.0.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-network-controller": "npm:^3.0.2"
+    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/polling-controller": "npm:^16.0.2"
+    "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
+    "@metamask/snaps-controllers": "npm:^17.2.0"
+    "@metamask/transaction-controller": "npm:^62.11.0"
+    "@metamask/utils": "npm:^11.9.0"
+    bignumber.js: "npm:^9.1.2"
+    reselect: "npm:^5.1.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/778c219ecd44f808f936ebb6f5ffe1dd8689e3b160522482d861f7be37d7fed6488561f4d5d4adbcdf63a57f1cedb0f50ff65e06098af5ecf20abfb2ecbbcabb
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-status-controller@npm:^64.4.5":
   version: 64.4.5
   resolution: "@metamask/bridge-status-controller@npm:64.4.5"
   dependencies:
@@ -7707,6 +7740,27 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
     uuid: "npm:^8.3.2"
   checksum: 10/20ab3e69e3ea9c46ca06dfef793710610133f301897a6d0915422a13319a87facd53b8e4f23b7f99acdc2f868954e947529d4e963171ebf6dff31d1558e47cb6
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-status-controller@npm:^65.0.1":
+  version: 65.0.1
+  resolution: "@metamask/bridge-status-controller@npm:65.0.1"
+  dependencies:
+    "@metamask/accounts-controller": "npm:^35.0.2"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/bridge-controller": "npm:^65.1.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/gas-fee-controller": "npm:^26.0.2"
+    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/polling-controller": "npm:^16.0.2"
+    "@metamask/snaps-controllers": "npm:^17.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/transaction-controller": "npm:^62.11.0"
+    "@metamask/utils": "npm:^11.9.0"
+    bignumber.js: "npm:^9.1.2"
+    uuid: "npm:^8.3.2"
+  checksum: 10/aaf19debd3f19ebd1ca7ff1faada30b4aae5dcd18f24d657293295922b4a4f621f6bb095f2135f70430c187c45d83b7463d300ae2b008774f236b2208c004972
   languageName: node
   linkType: hard
 
@@ -9691,6 +9745,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/transaction-controller@npm:^62.11.0, @metamask/transaction-controller@npm:^62.12.0":
+  version: 62.12.0
+  resolution: "@metamask/transaction-controller@npm:62.12.0"
+  dependencies:
+    "@ethereumjs/common": "npm:^4.4.0"
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^35.0.2"
+    "@metamask/approval-controller": "npm:^8.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/core-backend": "npm:^5.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/gas-fee-controller": "npm:^26.0.2"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
+  checksum: 10/949150f95a68186b9c919876c9c70ba2c8e6a072e3bb504624a650b8bd161931126fc50d5112c3d1fd58d541ca762a788116376b6325a19d2ee8e9d9ac0e3a4a
+  languageName: node
+  linkType: hard
+
 "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.9.0-5c8f871530.patch":
   version: 62.9.0
   resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.9.0-5c8f871530.patch::version=62.9.0&hash=d44809"
@@ -9729,29 +9822,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^11.1.0":
-  version: 11.1.0
-  resolution: "@metamask/transaction-pay-controller@npm:11.1.0"
+"@metamask/transaction-pay-controller@file:.yalc/@metamask/transaction-pay-controller::locator=metamask%40workspace%3A.":
+  version: 12.0.2
+  resolution: "@metamask/transaction-pay-controller@file:.yalc/@metamask/transaction-pay-controller#.yalc/@metamask/transaction-pay-controller::hash=daa6c0&locator=metamask%40workspace%3A."
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
-    "@metamask/assets-controllers": "npm:^96.0.0"
+    "@metamask/assets-controllers": "npm:^99.1.0"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/bridge-controller": "npm:^64.8.1"
-    "@metamask/bridge-status-controller": "npm:^64.4.4"
+    "@metamask/bridge-controller": "npm:^65.1.0"
+    "@metamask/bridge-status-controller": "npm:^65.0.1"
     "@metamask/controller-utils": "npm:^11.18.0"
     "@metamask/gas-fee-controller": "npm:^26.0.2"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^29.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
-    "@metamask/transaction-controller": "npm:^62.9.2"
+    "@metamask/transaction-controller": "npm:^62.12.0"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/98385db74a16ed91e21d5e646bf302046b80bbf6f48303f8393b9bf98c42e6f5dac0b5c883abb999be884f2cebf422b15dd34aa04cc7a215ea17a15c10a4e1ad
+  checksum: 10/9330ea0c4c6914b236214f630530dc3406ddfcccb12b9acb56ae5fddfba282f37d885b219e63ce55e069ccdbf5dfd1a44b013db453f07399d2c414036a1eec0b
   languageName: node
   linkType: hard
 
@@ -34774,7 +34867,7 @@ __metadata:
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/token-search-discovery-controller": "npm:^4.0.0"
     "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.9.0-5c8f871530.patch"
-    "@metamask/transaction-pay-controller": "npm:^11.1.0"
+    "@metamask/transaction-pay-controller": "file:.yalc/@metamask/transaction-pay-controller"
     "@metamask/tron-wallet-snap": "npm:^1.19.2"
     "@metamask/utils": "npm:^11.8.1"
     "@ngraveio/bc-ur": "npm:^1.1.6"


### PR DESCRIPTION
- Added fiat selection UI in PayWithModal (a "Pay with cash" section with Transak PoC methods).
- Stored selection by calling `Engine.context.TransactionPayController.setFiatPayment(...)`.
- Added `useTransactionPayFiat()` hook for:
  - feature gate: `process.env.MMPAY_FIAT_STRATEGY === 'true'`
  - scope: `TransactionType.predictDeposit`
  - selection state: `fiatPayment` present
- Updated confirmations UI for fiat mode:
  - `PayWithRow` shows the selected fiat method name when fiat is selected.
  - Token conversion UI is disabled/hidden for fiat mode.
  - Fiat quote row renders from `TransactionPayController` quotes.
- Wired Mobile strategy selection: if `transactionData.fiatPayment` is present, choose `TransactionPayStrategy.Fiat`.