### PR TITLE
fix: allow max balance after inputting non-max balance in swaps

### DIFF
--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import Engine from '../../../../../core/Engine';
 import {
   formatAddressToCaipReference,
@@ -43,6 +43,7 @@ export const useBridgeQuoteRequest = () => {
     decimals: sourceToken?.decimals,
     chainId: sourceToken?.chainId,
   });
+
   const insufficientBal = useIsInsufficientBalance({
     amount: sourceAmount,
     token: sourceToken,
@@ -52,13 +53,6 @@ export const useBridgeQuoteRequest = () => {
   const { gasIncluded, gasIncluded7702 } = useSelector(
     selectGasIncludedQuoteParams,
   );
-
-  // Prevents infinite requests when user select max balance on
-  // source token input.
-  const insufficientBalRef = useRef(insufficientBal);
-  useEffect(() => {
-    insufficientBalRef.current = insufficientBal;
-  }, [insufficientBal]);
 
   /**
    * Updates quote parameters in the bridge controller
@@ -93,7 +87,7 @@ export const useBridgeQuoteRequest = () => {
       destWalletAddress: destAddress ?? walletAddress,
       gasIncluded,
       gasIncluded7702,
-      insufficientBal: insufficientBalRef.current,
+      insufficientBal,
     };
 
     await Engine.context.BridgeController.updateBridgeQuoteRequestParams(
@@ -111,6 +105,7 @@ export const useBridgeQuoteRequest = () => {
     context,
     gasIncluded,
     gasIncluded7702,
+    insufficientBal,
   ]);
 
   // Create a stable debounced function that persists across renders

--- a/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { selectMinSolBalance } from '../../../../../selectors/bridgeController';
 import { parseUnits } from 'ethers/lib/utils';
@@ -50,84 +51,99 @@ const useIsInsufficientBalance = ({
   const quotes = useSelector(selectBridgeQuotes);
   const minSolBalance = useSelector(selectMinSolBalance);
 
+  // Extract only the required data from quote to prevent
+  // uneccessary rerenders that can use infinite loops.
   const bestQuote = quotes?.recommendedQuote;
-  const { gasIncluded, gasIncluded7702, gasSponsored } = bestQuote?.quote ?? {};
-  const isGasless = gasIncluded7702 || gasIncluded;
+  const gasIncluded = bestQuote?.quote?.gasIncluded;
+  const gasIncluded7702 = bestQuote?.quote?.gasIncluded7702;
+  const gasSponsored = bestQuote?.quote?.gasSponsored;
+  const gasAmount = bestQuote?.gasFee?.effective?.amount;
 
-  const isValidAmount =
-    amount !== undefined && amount !== '.' && token?.decimals;
+  return useMemo(() => {
+    const isValidAmount =
+      amount !== undefined && amount !== '.' && token?.decimals;
 
-  // If we don't have valid inputs yet, return false (no error)
-  if (!isValidAmount || !token) {
-    return false;
-  }
-
-  // If we don't have balance data yet (e.g., during token switching),
-  // return true to prevent invalid swaps until balance is loaded
-  if (!latestAtomicBalance) {
-    return true;
-  }
-
-  // Normalize amount to token decimals and handle excess decimals
-  let inputAmount: BigNumber;
-  try {
-    const normalizedAmount = normalizeAmount(amount, token.decimals);
-    inputAmount = parseAmount(normalizedAmount, token.decimals);
-  } catch {
-    // If we can't parse the amount, treat it as invalid (insufficient balance)
-    return true;
-  }
-
-  const isNativeToken = token.chainId && isNativeAddress(token.address);
-  const isSOL = isNativeToken && isSolanaChainId(token.chainId);
-
-  // Calculate gas fees if needed for native token source
-  // For ERC-20 tokens (USDC, DAI, etc.), gas is checked separately in useHasSufficientGas
-  // For native tokens (ETH, MATIC, etc.), gas comes from the SAME balance we're spending,
-  // so we need to ensure: balance >= sourceAmount + gasAmount
-  // NOTE: If gas is sponsored/included, we skip adding gas to the calculation but still check token balance
-  let atomicGasFee = BigNumber.from(0);
-  if (isNativeToken && !isGasless && !gasSponsored) {
-    const gasAmount = bestQuote?.gasFee?.effective?.amount;
-    const effectiveGasFee = isNumberValue(gasAmount)
-      ? // we guard against null and undefined values of gasAmount when checked isNumberValue
-        new BigNumberJS(gasAmount as string | number).toFixed()
-      : null;
-
-    if (effectiveGasFee) {
-      atomicGasFee = parseAmount(effectiveGasFee, token.decimals);
+    // If we don't have valid inputs yet, return false (no error)
+    if (!isValidAmount || !token) {
+      return false;
     }
-  }
 
-  let isInsufficientBalance = false;
+    // If we don't have balance data yet (e.g., during token switching),
+    // return true to prevent invalid swaps until balance is loaded
+    if (!latestAtomicBalance) {
+      return true;
+    }
 
-  if (isSOL) {
-    // SOL: check if balance - inputAmount >= minSolBalance (rent exemption)
-    const minSolBalanceLamports = parseUnits(minSolBalance, token.decimals);
-    const remainingBalance = latestAtomicBalance.sub(inputAmount);
-    isInsufficientBalance =
-      isInsufficientBalance || remainingBalance.lt(minSolBalanceLamports);
-  } else if (
-    isNativeToken &&
-    !isGasless &&
-    !gasSponsored &&
-    atomicGasFee.gt(0)
-  ) {
-    // Native tokens (ETH, MATIC, etc.): check balance >= sourceAmount + gasAmount
-    // Example: User has 1 ETH, wants to send 1 ETH, needs 0.01 ETH gas = insufficient
-    const totalRequired = inputAmount.add(atomicGasFee);
-    isInsufficientBalance =
-      isInsufficientBalance || totalRequired.gt(latestAtomicBalance);
-  } else {
-    // All other cases: ERC-20 tokens, gasless transactions, or gas-sponsored transactions
-    // Check balance >= sourceAmount only (gas is either not needed or checked separately)
-    // Example: User has 100 USDC, wants to send 50 USDC = sufficient
-    // Example: User has 0.0004 BTC, wants to send 0.0114 BTC (gasless) = insufficient
-    isInsufficientBalance =
-      isInsufficientBalance || inputAmount.gt(latestAtomicBalance);
-  }
+    // Normalize amount to token decimals and handle excess decimals
+    let inputAmount: BigNumber;
+    try {
+      const normalizedAmount = normalizeAmount(amount, token.decimals);
+      inputAmount = parseAmount(normalizedAmount, token.decimals);
+    } catch {
+      // If we can't parse the amount, treat it as invalid (insufficient balance)
+      return true;
+    }
 
-  return Boolean(isInsufficientBalance);
+    const isNativeToken = token.chainId && isNativeAddress(token.address);
+    const isSOL = isNativeToken && isSolanaChainId(token.chainId);
+    const isGasless = gasIncluded7702 || gasIncluded;
+
+    // Calculate gas fees if needed for native token source
+    // For ERC-20 tokens (USDC, DAI, etc.), gas is checked separately in useHasSufficientGas
+    // For native tokens (ETH, MATIC, etc.), gas comes from the SAME balance we're spending,
+    // so we need to ensure: balance >= sourceAmount + gasAmount
+    // NOTE: If gas is sponsored/included, we skip adding gas to the calculation but still check token balance
+    let atomicGasFee = BigNumber.from(0);
+    if (isNativeToken && !isGasless && !gasSponsored) {
+      const effectiveGasFee = isNumberValue(gasAmount)
+        ? // we guard against null and undefined values of gasAmount when checked isNumberValue
+          new BigNumberJS(gasAmount as string | number).toFixed()
+        : null;
+
+      if (effectiveGasFee) {
+        atomicGasFee = parseAmount(effectiveGasFee, token.decimals);
+      }
+    }
+
+    let isInsufficientBalance = false;
+
+    if (isSOL) {
+      // SOL: check if balance - inputAmount >= minSolBalance (rent exemption)
+      const minSolBalanceLamports = parseUnits(minSolBalance, token.decimals);
+      const remainingBalance = latestAtomicBalance.sub(inputAmount);
+      isInsufficientBalance =
+        isInsufficientBalance || remainingBalance.lt(minSolBalanceLamports);
+    } else if (
+      isNativeToken &&
+      !isGasless &&
+      !gasSponsored &&
+      atomicGasFee.gt(0)
+    ) {
+      // Native tokens (ETH, MATIC, etc.): check balance >= sourceAmount + gasAmount
+      // Example: User has 1 ETH, wants to send 1 ETH, needs 0.01 ETH gas = insufficient
+      const totalRequired = inputAmount.add(atomicGasFee);
+      isInsufficientBalance =
+        isInsufficientBalance || totalRequired.gt(latestAtomicBalance);
+    } else {
+      // All other cases: ERC-20 tokens, gasless transactions, or gas-sponsored transactions
+      // Check balance >= sourceAmount only (gas is either not needed or checked separately)
+      // Example: User has 100 USDC, wants to send 50 USDC = sufficient
+      // Example: User has 0.0004 BTC, wants to send 0.0114 BTC (gasless) = insufficient
+      isInsufficientBalance =
+        isInsufficientBalance || inputAmount.gt(latestAtomicBalance);
+    }
+
+    return Boolean(isInsufficientBalance);
+  }, [
+    amount,
+    token,
+    latestAtomicBalance,
+    gasIncluded,
+    gasIncluded7702,
+    gasSponsored,
+    gasAmount,
+    minSolBalance,
+  ]);
 };
 
 export default useIsInsufficientBalance;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

It was discovered that when a user pressed the Max button after receiving a quote for a non-max amount, they would encounter an "insufficient funds" error. This issue occurred because the quote parameters were not updated after an insufficient balance was detected; the values were wrapped in a ref, which prevented infinite requests in certain scenarios. However, the root cause was in the useInsufficientBalance hook, which recalculated the condition every time the quotes object changed. To resolve both the insufficient funds error and the risk of infinite requests, we now return a memoized version of the condition that only depends on specific quote values.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixes an issue preventing insufficient funds error when pressing max balance after inputting non-max balance in swaps

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3925

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/1dba469b-4672-46a1-9911-da92d36be1bb



<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/9fcfcf9a-7bb9-4cbb-a20a-68c77bbbe800



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches swap/bridge quote parameter updates and insufficient-balance calculation; regressions could cause incorrect quote requests or false insufficient-funds gating, but changes are localized to UI hooks.
> 
> **Overview**
> Fixes a quoting edge case where pressing *Max* after receiving a non-max quote could get stuck showing **insufficient funds**.
> 
> `useBridgeQuoteRequest` now sends the live `insufficientBal` value (and re-runs when it changes) instead of freezing it in a ref. To avoid the prior infinite-request risk, `useIsInsufficientBalance` memoizes its result and only depends on specific fields from the recommended quote (gas flags/amount) rather than the whole quotes object.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 504317ae324e3752eab41e322b25007360a5f016. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->