### PR TITLE
feat: Add generic useABTest hook for A/B testing

### DIFF
--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Centralized exports for custom React hooks
+ *
+ * This module provides a single entry point for importing hooks.
+ *
+ * @example
+ * import { useABTest, useFeatureFlagStats } from '../hooks';
+ */
+
+export { useABTest } from './useABTest';
+export type { UseABTestResult } from './useABTest';
+export { useFeatureFlagStats } from './useFeatureFlagStats';

--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -8,5 +8,4 @@
  */
 
 export { useABTest } from './useABTest';
-export type { UseABTestResult } from './useABTest';
 export { useFeatureFlagStats } from './useFeatureFlagStats';

--- a/app/hooks/useABTest.test.ts
+++ b/app/hooks/useABTest.test.ts
@@ -34,8 +34,68 @@ describe('useABTest', () => {
     jest.resetAllMocks();
   });
 
-  describe('with valid flag value matching a variant', () => {
-    it('returns correct variant data when flag matches control variant', () => {
+  describe('with object format { name } from controller', () => {
+    it('returns correct variant data when flag is object with name property', () => {
+      mockUseSelector.mockReturnValue({
+        buttonColorTest: { name: 'control' },
+      });
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.variant).toEqual({ long: 'green', short: 'red' });
+      expect(result.current.variantName).toBe('control');
+      expect(result.current.isActive).toBe(true);
+    });
+
+    it('returns correct variant data for treatment variant in object format', () => {
+      mockUseSelector.mockReturnValue({
+        buttonColorTest: { name: 'monochrome' },
+      });
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.variant).toEqual({ long: 'white', short: 'white' });
+      expect(result.current.variantName).toBe('monochrome');
+      expect(result.current.isActive).toBe(true);
+    });
+
+    it('handles object format with optional value property', () => {
+      mockUseSelector.mockReturnValue({
+        swapsQuoteLayout: { name: 'expanded', value: undefined },
+      });
+
+      const { result } = renderHook(() =>
+        useABTest('swapsQuoteLayout', quoteLayoutVariants),
+      );
+
+      expect(result.current.isActive).toBe(true);
+      expect(result.current.variant).toEqual({
+        showFees: true,
+        layout: 'expanded',
+      });
+    });
+
+    it('falls back to first variant when object name does not match any variant', () => {
+      mockUseSelector.mockReturnValue({
+        buttonColorTest: { name: 'invalid_variant' },
+      });
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.variant).toEqual({ long: 'green', short: 'red' });
+      expect(result.current.variantName).toBe('control');
+      expect(result.current.isActive).toBe(false);
+    });
+  });
+
+  describe('with legacy string format (backward compatibility)', () => {
+    it('returns correct variant data when flag is a string', () => {
       mockUseSelector.mockReturnValue({ buttonColorTest: 'control' });
 
       const { result } = renderHook(() =>

--- a/app/hooks/useABTest.test.ts
+++ b/app/hooks/useABTest.test.ts
@@ -1,0 +1,385 @@
+import { renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import { useABTest } from './useABTest';
+
+// Mock react-redux
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+// Mock the selector module
+jest.mock('../selectors/featureFlagController', () => ({
+  selectRemoteFeatureFlags: jest.fn((state) => state?.featureFlags),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+describe('useABTest', () => {
+  // Test variants configuration
+  const buttonColorVariants = {
+    control: { long: 'green', short: 'red' },
+    monochrome: { long: 'white', short: 'white' },
+  };
+
+  const quoteLayoutVariants = {
+    control: { showFees: false, layout: 'compact' },
+    expanded: { showFees: true, layout: 'expanded' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('with valid flag value matching a variant', () => {
+    it('returns correct variant data when flag matches control variant', () => {
+      mockUseSelector.mockReturnValue({ buttonColorTest: 'control' });
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.variant).toEqual({ long: 'green', short: 'red' });
+      expect(result.current.variantName).toBe('control');
+      expect(result.current.isActive).toBe(true);
+    });
+
+    it('returns correct variant data when flag matches treatment variant', () => {
+      mockUseSelector.mockReturnValue({ buttonColorTest: 'monochrome' });
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.variant).toEqual({ long: 'white', short: 'white' });
+      expect(result.current.variantName).toBe('monochrome');
+      expect(result.current.isActive).toBe(true);
+    });
+
+    it('sets isActive to true when flag value matches a valid variant', () => {
+      mockUseSelector.mockReturnValue({ swapsQuoteLayout: 'expanded' });
+
+      const { result } = renderHook(() =>
+        useABTest('swapsQuoteLayout', quoteLayoutVariants),
+      );
+
+      expect(result.current.isActive).toBe(true);
+      expect(result.current.variant).toEqual({
+        showFees: true,
+        layout: 'expanded',
+      });
+    });
+  });
+
+  describe('with null or undefined flag value', () => {
+    it('falls back to first variant when flag is null', () => {
+      mockUseSelector.mockReturnValue({ buttonColorTest: null });
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.variant).toEqual({ long: 'green', short: 'red' });
+      expect(result.current.variantName).toBe('control');
+      expect(result.current.isActive).toBe(false);
+    });
+
+    it('falls back to first variant when flag is undefined', () => {
+      mockUseSelector.mockReturnValue({ buttonColorTest: undefined });
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.variant).toEqual({ long: 'green', short: 'red' });
+      expect(result.current.variantName).toBe('control');
+      expect(result.current.isActive).toBe(false);
+    });
+
+    it('falls back to first variant when flag key does not exist', () => {
+      mockUseSelector.mockReturnValue({});
+
+      const { result } = renderHook(() =>
+        useABTest('nonExistentFlag', buttonColorVariants),
+      );
+
+      expect(result.current.variant).toEqual({ long: 'green', short: 'red' });
+      expect(result.current.variantName).toBe('control');
+      expect(result.current.isActive).toBe(false);
+    });
+
+    it('sets isActive to false when flag value is not set', () => {
+      mockUseSelector.mockReturnValue({});
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.isActive).toBe(false);
+    });
+  });
+
+  describe('with invalid flag value not matching any variant', () => {
+    it('falls back to first variant when flag value is invalid', () => {
+      mockUseSelector.mockReturnValue({
+        buttonColorTest: 'invalid_variant_name',
+      });
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.variant).toEqual({ long: 'green', short: 'red' });
+      expect(result.current.variantName).toBe('control');
+    });
+
+    it('sets isActive to false when flag value does not match any variant', () => {
+      mockUseSelector.mockReturnValue({ buttonColorTest: 'unknown_variant' });
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.isActive).toBe(false);
+    });
+
+    it('falls back to first variant when flag value is empty string', () => {
+      mockUseSelector.mockReturnValue({ buttonColorTest: '' });
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.variant).toEqual({ long: 'green', short: 'red' });
+      expect(result.current.variantName).toBe('control');
+      expect(result.current.isActive).toBe(false);
+    });
+  });
+
+  describe('with complex variant data objects', () => {
+    it('works with deeply nested variant data', () => {
+      const complexVariants = {
+        control: {
+          ui: { button: { color: 'blue', size: 'medium' } },
+          behavior: { autoSubmit: false },
+        },
+        treatment: {
+          ui: { button: { color: 'green', size: 'large' } },
+          behavior: { autoSubmit: true },
+        },
+      };
+
+      mockUseSelector.mockReturnValue({ complexTest: 'treatment' });
+
+      const { result } = renderHook(() =>
+        useABTest('complexTest', complexVariants),
+      );
+
+      expect(result.current.variant).toEqual({
+        ui: { button: { color: 'green', size: 'large' } },
+        behavior: { autoSubmit: true },
+      });
+      expect(result.current.variantName).toBe('treatment');
+      expect(result.current.isActive).toBe(true);
+    });
+
+    it('works with array data in variants', () => {
+      const arrayVariants = {
+        control: { items: ['a', 'b'], count: 2 },
+        expanded: { items: ['a', 'b', 'c', 'd'], count: 4 },
+      };
+
+      mockUseSelector.mockReturnValue({ arrayTest: 'expanded' });
+
+      const { result } = renderHook(() =>
+        useABTest('arrayTest', arrayVariants),
+      );
+
+      expect(result.current.variant).toEqual({
+        items: ['a', 'b', 'c', 'd'],
+        count: 4,
+      });
+    });
+  });
+
+  describe('with multiple feature flags', () => {
+    it('reads correct flag from multiple flags in state', () => {
+      mockUseSelector.mockReturnValue({
+        buttonColorTest: 'control',
+        swapsQuoteLayout: 'expanded',
+        anotherFlag: 'value',
+      });
+
+      const buttonResult = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      const quoteResult = renderHook(() =>
+        useABTest('swapsQuoteLayout', quoteLayoutVariants),
+      );
+
+      expect(buttonResult.result.current.variantName).toBe('control');
+      expect(buttonResult.result.current.isActive).toBe(true);
+
+      expect(quoteResult.result.current.variantName).toBe('expanded');
+      expect(quoteResult.result.current.isActive).toBe(true);
+    });
+  });
+
+  describe('with three or more variants', () => {
+    it('correctly handles tests with three variants', () => {
+      const threeVariants = {
+        control: { layout: 'default' },
+        treatment_a: { layout: 'compact' },
+        treatment_b: { layout: 'expanded' },
+      };
+
+      mockUseSelector.mockReturnValue({ multiVariantTest: 'treatment_b' });
+
+      const { result } = renderHook(() =>
+        useABTest('multiVariantTest', threeVariants),
+      );
+
+      expect(result.current.variant).toEqual({ layout: 'expanded' });
+      expect(result.current.variantName).toBe('treatment_b');
+      expect(result.current.isActive).toBe(true);
+    });
+
+    it('falls back to first variant for multi-variant test when flag not set', () => {
+      const threeVariants = {
+        control: { layout: 'default' },
+        treatment_a: { layout: 'compact' },
+        treatment_b: { layout: 'expanded' },
+      };
+
+      mockUseSelector.mockReturnValue({});
+
+      const { result } = renderHook(() =>
+        useABTest('multiVariantTest', threeVariants),
+      );
+
+      expect(result.current.variant).toEqual({ layout: 'default' });
+      expect(result.current.variantName).toBe('control');
+      expect(result.current.isActive).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles flags state being null', () => {
+      mockUseSelector.mockReturnValue(null);
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.variant).toEqual({ long: 'green', short: 'red' });
+      expect(result.current.variantName).toBe('control');
+      expect(result.current.isActive).toBe(false);
+    });
+
+    it('handles flags state being undefined', () => {
+      mockUseSelector.mockReturnValue(undefined);
+
+      const { result } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.variant).toEqual({ long: 'green', short: 'red' });
+      expect(result.current.variantName).toBe('control');
+      expect(result.current.isActive).toBe(false);
+    });
+
+    it('works with single variant (edge case)', () => {
+      const singleVariant = {
+        only: { value: 'single' },
+      };
+
+      mockUseSelector.mockReturnValue({});
+
+      const { result } = renderHook(() =>
+        useABTest('singleTest', singleVariant),
+      );
+
+      expect(result.current.variant).toEqual({ value: 'single' });
+      expect(result.current.variantName).toBe('only');
+      expect(result.current.isActive).toBe(false);
+    });
+
+    it('returns consistent variantName as string', () => {
+      mockUseSelector.mockReturnValue({ numericKeyTest: 'variant1' });
+
+      const variants = {
+        variant1: { id: 1 },
+        variant2: { id: 2 },
+      };
+
+      const { result } = renderHook(() =>
+        useABTest('numericKeyTest', variants),
+      );
+
+      expect(typeof result.current.variantName).toBe('string');
+      expect(result.current.variantName).toBe('variant1');
+    });
+  });
+
+  describe('type safety', () => {
+    it('returns correctly typed variant data', () => {
+      interface ButtonColors {
+        long: string;
+        short: string;
+      }
+
+      const typedVariants: Record<string, ButtonColors> = {
+        control: { long: 'green', short: 'red' },
+        monochrome: { long: 'white', short: 'white' },
+      };
+
+      mockUseSelector.mockReturnValue({ typedTest: 'control' });
+
+      const { result } = renderHook(() =>
+        useABTest('typedTest', typedVariants),
+      );
+
+      // TypeScript should infer variant as ButtonColors
+      const variant = result.current.variant as ButtonColors;
+      expect(variant.long).toBe('green');
+      expect(variant.short).toBe('red');
+    });
+  });
+
+  describe('hook stability', () => {
+    it('returns stable results when flag value does not change', () => {
+      mockUseSelector.mockReturnValue({ buttonColorTest: 'control' });
+
+      const { result, rerender } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      const firstResult = result.current;
+      rerender(undefined);
+      const secondResult = result.current;
+
+      expect(firstResult.variantName).toBe(secondResult.variantName);
+      expect(firstResult.isActive).toBe(secondResult.isActive);
+    });
+
+    it('updates when flag value changes', () => {
+      mockUseSelector.mockReturnValue({ buttonColorTest: 'control' });
+
+      const { result, rerender } = renderHook(() =>
+        useABTest('buttonColorTest', buttonColorVariants),
+      );
+
+      expect(result.current.variantName).toBe('control');
+
+      // Simulate flag value change
+      mockUseSelector.mockReturnValue({ buttonColorTest: 'monochrome' });
+      rerender(undefined);
+
+      expect(result.current.variantName).toBe('monochrome');
+    });
+  });
+});

--- a/app/hooks/useABTest.ts
+++ b/app/hooks/useABTest.ts
@@ -1,0 +1,125 @@
+/**
+ * Generic A/B Testing Hook
+ *
+ * Provides a simple, type-safe interface for A/B testing that works with
+ * LaunchDarkly feature flags via the RemoteFeatureFlagController.
+ *
+ * This hook uses a simple API that takes a flag key and variants object directly.
+ * It reads the variant from the feature flags and maps it to the provided variants.
+ *
+ * @example
+ * ```typescript
+ * const { variant, variantName, isActive } = useABTest('buttonColor', {
+ *   control: { color: 'green' },
+ *   treatment: { color: 'blue' },
+ * });
+ *
+ * // Track with single JSON property (no per-test schema changes)
+ * trackEvent('Screen Viewed', {
+ *   screen: 'details',
+ *   ...(isActive && { ab_tests: { button_color: variantName } }),
+ * });
+ * ```
+ */
+
+import { useSelector } from 'react-redux';
+import { selectRemoteFeatureFlags } from '../selectors/featureFlagController';
+
+/**
+ * Return type for the useABTest hook
+ * @template T - The type of the variants object
+ */
+export interface UseABTestResult<T extends Record<string, unknown>> {
+  /** The variant data for the assigned variant */
+  variant: T[keyof T];
+  /** The name of the assigned variant (e.g., 'control', 'treatment') */
+  variantName: string;
+  /** Whether the A/B test is active (flag is set and matches a valid variant) */
+  isActive: boolean;
+}
+
+/**
+ * Generic hook for A/B testing in React components
+ *
+ * Reads the assigned variant from LaunchDarkly via feature flags and returns
+ * the corresponding variant data. LaunchDarkly handles user identification,
+ * variant assignment, and persistence.
+ *
+ * @template T - The shape of the variants object (keys are variant names, values are variant data)
+ * @param flagKey - The feature flag key in LaunchDarkly (camelCase, e.g., 'buttonColorTest')
+ * @param variants - Object mapping variant names to their data
+ * @returns Object containing variant data, variant name, and active state
+ *
+ * @example Basic usage
+ * ```typescript
+ * const { variant, variantName, isActive } = useABTest('swapsQuoteLayout', {
+ *   control: { showFees: false },
+ *   expanded: { showFees: true },
+ * });
+ *
+ * // Use the variant data
+ * if (variant.showFees) {
+ *   // Show expanded quote with fees
+ * }
+ * ```
+ *
+ * @example Tracking A/B test in analytics
+ * ```typescript
+ * const { variantName, isActive } = useABTest('buttonStyle', {
+ *   control: { style: 'default' },
+ *   bold: { style: 'bold' },
+ * });
+ *
+ * trackEvent(
+ *   createEventBuilder(MetaMetricsEvents.BUTTON_CLICKED)
+ *     .addProperties({
+ *       button_id: 'submit',
+ *       ...(isActive && { ab_tests: { button_style: variantName } }),
+ *     })
+ *     .build()
+ * );
+ * ```
+ *
+ * @example Multiple concurrent tests
+ * ```typescript
+ * const buttonTest = useABTest('buttonColorTest', {
+ *   control: { color: 'green' },
+ *   treatment: { color: 'blue' },
+ * });
+ *
+ * const ctaTest = useABTest('ctaTextTest', {
+ *   control: { text: 'Get Started' },
+ *   urgent: { text: 'Start Now!' },
+ * });
+ *
+ * trackEvent('Screen Viewed', {
+ *   ab_tests: {
+ *     ...(buttonTest.isActive && { button_color: buttonTest.variantName }),
+ *     ...(ctaTest.isActive && { cta_text: ctaTest.variantName }),
+ *   },
+ * });
+ * ```
+ */
+export function useABTest<T extends Record<string, unknown>>(
+  flagKey: string,
+  variants: T,
+): UseABTestResult<T> {
+  const flags = useSelector(selectRemoteFeatureFlags);
+  const flagValue = flags?.[flagKey] as string | undefined;
+
+  // Get the first variant name as fallback
+  const variantNames = Object.keys(variants);
+  const fallback = variantNames[0];
+
+  // Determine the variant name: use flag value if it's a valid variant, otherwise fallback
+  const variantName = flagValue && flagValue in variants ? flagValue : fallback;
+
+  // Check if the test is active (flag is set AND matches a valid variant)
+  const isActive = Boolean(flagValue && flagValue in variants);
+
+  return {
+    variant: variants[variantName as keyof T],
+    variantName: String(variantName),
+    isActive,
+  };
+}

--- a/app/hooks/useABTest.ts
+++ b/app/hooks/useABTest.ts
@@ -126,10 +126,10 @@ export function useABTest<T extends ABTestVariants>(
 
   // Determine the variant name: use flag value if it's a valid variant, otherwise fallback to 'control'
   const variantName =
-    flagValue && flagValue in variants ? flagValue : 'control';
+    flagValue && Object.hasOwn(variants, flagValue) ? flagValue : 'control';
 
   // Check if the test is active (flag is set AND matches a valid variant)
-  const isActive = Boolean(flagValue && flagValue in variants);
+  const isActive = Boolean(flagValue && Object.hasOwn(variants, flagValue));
 
   return {
     variant: variants[variantName as keyof T],

--- a/app/hooks/useABTest.ts
+++ b/app/hooks/useABTest.ts
@@ -105,8 +105,15 @@ export function useABTest<T extends Record<string, unknown>>(
   variants: T,
 ): UseABTestResult<T> {
   const flags = useSelector(selectRemoteFeatureFlags);
-  const flagValue = flags?.[flagKey] as string | undefined;
+  const flagData = flags?.[flagKey];
 
+  // Handle both object format { name } from controller and legacy string format
+  // The RemoteFeatureFlagController stores A/B test results as { name: "variant_name" }
+  // after processing array-based flags with scope thresholds
+  const flagValue =
+    typeof flagData === 'object' && flagData !== null && 'name' in flagData
+      ? (flagData as { name: string }).name
+      : (flagData as string | undefined);
   // Get the first variant name as fallback
   const variantNames = Object.keys(variants);
   const fallback = variantNames[0];

--- a/app/hooks/useABTest.ts
+++ b/app/hooks/useABTest.ts
@@ -125,11 +125,16 @@ export function useABTest<T extends ABTestVariants>(
       : (flagData as string | undefined);
 
   // Determine the variant name: use flag value if it's a valid variant, otherwise fallback to 'control'
+  // Use hasOwnProperty to avoid matching prototype methods (e.g. "toString", "constructor")
+  // since flagValue comes from remote feature flags (external data)
+  const hasVariant = (key: string) =>
+    Object.prototype.hasOwnProperty.call(variants, key);
+
   const variantName =
-    flagValue && Object.hasOwn(variants, flagValue) ? flagValue : 'control';
+    flagValue && hasVariant(flagValue) ? flagValue : 'control';
 
   // Check if the test is active (flag is set AND matches a valid variant)
-  const isActive = Boolean(flagValue && Object.hasOwn(variants, flagValue));
+  const isActive = Boolean(flagValue && hasVariant(flagValue));
 
   return {
     variant: variants[variantName as keyof T],

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -88,7 +88,7 @@ function useABTest<T extends Record<string, unknown>>(
 **Parameters:**
 
 - `flagKey` - The feature flag key in LaunchDarkly (camelCase, e.g., `'buttonColorTest'`)
-- `variants` - Object mapping variant names to their data
+- `variants` - Object mapping variant names to their data. **Must include a `control` key** which is used as the fallback when the flag is not set or invalid.
 
 **Returns:**
 
@@ -315,6 +315,9 @@ No `metametricsId` → controller returns array unchanged → no variant selecti
 
 **Q: What does `isActive` mean?**
 `isActive` is `true` when the flag is set AND matches a valid variant. It's `false` when using the fallback (flag not set or invalid).
+
+**Q: Which variant is used as the fallback?**
+The `control` variant is always used as the fallback when the flag is not set, invalid, or doesn't match any defined variant. The `variants` object must include a `control` key (enforced by TypeScript). This ensures users see the default experience when the test is inactive.
 
 ---
 

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -1,0 +1,320 @@
+# A/B Testing Framework
+
+Generic A/B testing for MetaMask Mobile.
+
+**References:**
+
+- [Remote Feature Flags Documentation](https://github.com/MetaMask/contributor-docs/blob/main/docs/remote-feature-flags.md)
+
+---
+
+## How It Works
+
+MetaMask does **NOT use LaunchDarkly's percentage rollout targeting**. Instead, thresholds are defined **inside the variant value**, and the app does its own bucketing:
+
+1. **LD returns array with thresholds in variant** — each element has `scope.value` (0-1)
+2. **App hashes** `SHA256(metametricsId + flagName)` → deterministic value 0-1
+3. **App selects variant** — first element where `userThreshold <= scope.value`
+
+**Flag value structure:**
+
+```json
+[
+  { "name": "control", "scope": { "type": "percentage_rollout", "value": 0.5 }, "value": {...} },
+  { "name": "treatment", "scope": { "type": "percentage_rollout", "value": 1.0 }, "value": {...} }
+]
+```
+
+**Selection logic:** User threshold = 0.45 → 0.45 <= 0.5? YES → `control` selected
+
+> **Key:** Thresholds are IN the variant. App does bucketing via `@metamask/remote-feature-flag-controller`. We do NOT use LD's native percentage rollout targeting.
+
+### How the Controller Detects A/B Test Flags
+
+The `RemoteFeatureFlagController` identifies flags that need bucketing by checking if the value is an **array of objects with a `scope` property**:
+
+```javascript
+// Controller checks: is it an object with a 'scope' property?
+{ name: "control", scope: { value: 0.5 }, value: {...} }  // ✓ Triggers bucketing
+{ enabled: true, minimumVersion: "7.0.0" }                 // ✗ Simple flag, no bucketing
+```
+
+When detected, the controller:
+
+1. Computes `sha256(metametricsId + flagName)` → deterministic threshold (0-1)
+2. Finds first array item where `threshold <= scope.value`
+3. Stores the selected variant's `name` in `state.remoteFeatureFlags`
+
+The `scope.type` field (e.g., `"percentage_rollout"`) is metadata only - the controller just checks for presence of `scope`.
+
+---
+
+## The Hook
+
+The generic `useABTest` hook provides a simple, type-safe interface for A/B testing:
+
+```typescript
+// app/hooks/useABTest.ts
+
+import { useABTest } from '../hooks';
+
+const { variant, variantName, isActive } = useABTest('buttonColorTest', {
+  control: { color: 'green' },
+  treatment: { color: 'blue' },
+});
+```
+
+### API Reference
+
+```typescript
+function useABTest<T extends Record<string, unknown>>(
+  flagKey: string,
+  variants: T,
+): {
+  variant: T[keyof T]; // The variant data for the assigned variant
+  variantName: string; // The name of the assigned variant (e.g., 'control')
+  isActive: boolean; // Whether the A/B test is active
+};
+```
+
+**Parameters:**
+
+- `flagKey` - The feature flag key in LaunchDarkly (camelCase, e.g., `'buttonColorTest'`)
+- `variants` - Object mapping variant names to their data
+
+**Returns:**
+
+- `variant` - The data object for the assigned variant
+- `variantName` - Name of the assigned variant (e.g., `'control'`, `'treatment'`)
+- `isActive` - `true` if the flag is set AND matches a valid variant; `false` otherwise
+
+---
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { useABTest } from '../hooks';
+
+const MyComponent = () => {
+  const { variant, variantName, isActive } = useABTest('buttonColorTest', {
+    control: { color: 'green' },
+    treatment: { color: 'blue' },
+  });
+
+  return (
+    <Button color={variant.color}>
+      Submit
+    </Button>
+  );
+};
+```
+
+### Tracking with Analytics
+
+Track events with a single `ab_tests` JSON property (no per-test schema changes after initial setup):
+
+```typescript
+import { useABTest } from '../hooks';
+import { useAnalytics } from '../components/hooks/useAnalytics';
+import { MetaMetricsEvents } from '../core/Analytics';
+
+const MyComponent = () => {
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const { variant, variantName, isActive } = useABTest('buttonColorTest', {
+    control: { color: 'green' },
+    treatment: { color: 'blue' },
+  });
+
+  const handlePress = () => {
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.SCREEN_VIEWED)
+        .addProperties({
+          screen: 'details',
+          ...(isActive && { ab_tests: { button_color: variantName } }),
+        })
+        .build()
+    );
+  };
+
+  return <Button onPress={handlePress} color={variant.color}>Submit</Button>;
+};
+```
+
+### Multiple Concurrent Tests
+
+```typescript
+const buttonTest = useABTest('buttonColorTest', {
+  control: { color: 'green' },
+  treatment: { color: 'blue' },
+});
+
+const ctaTest = useABTest('ctaTextTest', {
+  control: { text: 'Get Started' },
+  urgent: { text: 'Start Now!' },
+});
+
+trackEvent(
+  createEventBuilder(MetaMetricsEvents.SCREEN_VIEWED)
+    .addProperties({
+      ab_tests: {
+        ...(buttonTest.isActive && { button_color: buttonTest.variantName }),
+        ...(ctaTest.isActive && { cta_text: ctaTest.variantName }),
+      },
+    })
+    .build(),
+);
+```
+
+---
+
+## LaunchDarkly Setup
+
+Thresholds are defined **inside the variation value** as an array. Do NOT use LD's percentage rollout targeting.
+
+### Step 1: Create the Flag
+
+1. LaunchDarkly → Feature Flags → Create Flag
+2. **Name:** `{team}{TestName}` (e.g., `swapsAbtestQuoteLayout`)
+3. **Flag type:** JSON
+4. **Client-side SDK availability:** Check "SDKs using Mobile Key"
+
+### Step 2: Define Variation Value with Thresholds
+
+The variation value is an **array** with cumulative thresholds:
+
+```json
+[
+  {
+    "name": "control",
+    "scope": { "type": "percentage_rollout", "value": 0.5 },
+    "value": { "buttonColor": "green" }
+  },
+  {
+    "name": "treatment",
+    "scope": { "type": "percentage_rollout", "value": 1.0 },
+    "value": { "buttonColor": "blue" }
+  }
+]
+```
+
+**Threshold math:**
+
+- `scope.value: 0.5` → users with hash 0-0.5 (50%)
+- `scope.value: 1.0` → users with hash 0.5-1.0 (remaining 50%)
+
+For 3 variants (33% each): 0.33, 0.66, 1.0
+
+### Step 3: Configure Targeting
+
+- **Default rule:** Serve the variation (single variation with threshold array)
+- **When targeting is OFF:** Serve fallback variation
+
+### Step 4: Enable
+
+Toggle targeting ON. The `RemoteFeatureFlagController` handles bucketing automatically.
+
+---
+
+## Adding a New Test (Summary)
+
+1. **Create LaunchDarkly flag** (JSON type, threshold array in variation)
+2. **Define cumulative thresholds** in `scope.value` (0.5, 1.0 for 50/50)
+3. **Add hook to component:**
+
+```typescript
+const { variant, variantName, isActive } = useABTest('swapsQuoteLayout', {
+  control: { showFees: false },
+  expanded: { showFees: true },
+});
+```
+
+4. **Track events:**
+
+```typescript
+trackEvent(
+  createEventBuilder(MetaMetricsEvents.QUOTE_VIEWED)
+    .addProperties({
+      ...(isActive && { ab_tests: { quote_layout: variantName } }),
+    })
+    .build(),
+);
+```
+
+5. **Build Mixpanel funnel** — Filter by `ab_tests.quote_layout`
+
+---
+
+## Mixpanel Queries
+
+Filter by nested property:
+
+```
+// Funnel step filter
+ab_tests.button_color == "control"
+
+// Breakdown
+ab_tests.button_color
+```
+
+---
+
+## Manual Mixpanel Dashboard Setup
+
+### 1. Create a New Board
+
+- Boards → Create Board → Name: `[Test Name] A/B Analysis`
+
+### 2. Add Funnel Report
+
+- New Report → Funnel
+- Define conversion steps (e.g., Screen Viewed → Button Clicked → Transaction Completed)
+- Filter: `ab_tests.[your_test_name]` is set
+- Breakdown: `ab_tests.[your_test_name]`
+
+### 3. Add Conversion Over Time
+
+- New Report → Insights
+- Metric: Conversion rate from your funnel
+- Breakdown: `ab_tests.[your_test_name]`
+
+### 4. Add Sample Size Tracker
+
+- New Report → Insights → Event: Your entry event
+- Breakdown: `ab_tests.[your_test_name]` → Display as: Total count
+
+### 5. Statistical Significance
+
+- Use Funnel report, compare variants side-by-side
+- Look for 95%+ confidence before calling winner
+
+---
+
+---
+
+## FAQ
+
+**Q: How does bucketing work?**
+`RemoteFeatureFlagController` hashes `SHA256(metametricsId + flagName)` → value 0-1. Selects first variant where `userThreshold <= scope.value`.
+
+**Q: Why don't we use LD's percentage rollout?**
+Thresholds are defined in the variant value itself. App-side controller does bucketing. This gives us control and consistency across platforms.
+
+**Q: Do I need a Segment schema PR for each test?**
+No. The `ab_tests` object accepts any keys. Define once, use forever.
+
+**Q: What if user opts out of MetaMetrics?**
+No `metametricsId` → controller returns array unchanged → no variant selection.
+
+**Q: What does `isActive` mean?**
+`isActive` is `true` when the flag is set AND matches a valid variant. It's `false` when using the fallback (flag not set or invalid).
+
+---
+
+## Related Files
+
+- **Generic Hook:** `app/hooks/useABTest.ts`
+- **Generic Hook Tests:** `app/hooks/useABTest.test.ts`
+- **Hooks Index:** `app/hooks/index.ts`
+- **Feature Flag Selector:** `app/selectors/featureFlagController/index.ts`

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -20,8 +20,14 @@ MetaMask does **NOT use LaunchDarkly's percentage rollout targeting**. Instead, 
 
 ```json
 [
-  { "name": "control", "scope": { "type": "percentage_rollout", "value": 0.5 }, "value": {...} },
-  { "name": "treatment", "scope": { "type": "percentage_rollout", "value": 1.0 }, "value": {...} }
+  {
+    "name": "control",
+    "scope": { "type": "percentage_rollout", "value": 0.5 }
+  },
+  {
+    "name": "treatment",
+    "scope": { "type": "percentage_rollout", "value": 1.0 }
+  }
 ]
 ```
 
@@ -43,9 +49,11 @@ When detected, the controller:
 
 1. Computes `sha256(metametricsId + flagName)` → deterministic threshold (0-1)
 2. Finds first array item where `threshold <= scope.value`
-3. Stores the selected variant's `name` in `state.remoteFeatureFlags`
+3. Stores `{ name, value }` object in `state.remoteFeatureFlags` (value is optional/undefined if not in LD config)
 
 The `scope.type` field (e.g., `"percentage_rollout"`) is metadata only - the controller just checks for presence of `scope`.
+
+The `useABTest` hook reads the `name` property from this stored object and maps it to your locally-defined variant data.
 
 ---
 
@@ -188,13 +196,11 @@ The variation value is an **array** with cumulative thresholds:
 [
   {
     "name": "control",
-    "scope": { "type": "percentage_rollout", "value": 0.5 },
-    "value": { "buttonColor": "green" }
+    "scope": { "type": "percentage_rollout", "value": 0.5 }
   },
   {
     "name": "treatment",
-    "scope": { "type": "percentage_rollout", "value": 1.0 },
-    "value": { "buttonColor": "blue" }
+    "scope": { "type": "percentage_rollout", "value": 1.0 }
   }
 ]
 ```


### PR DESCRIPTION
## **Description**

Adds a `useABTest` hook that provides a simple, type-safe interface for A/B testing using LaunchDarkly feature flags. The hook reads the assigned variant from `RemoteFeatureFlagController` (which handles bucketing via SHA256 hash of `metametricsId + flagName`) and maps it to variant data defined by the caller.

**Why:** We need a standardized, reusable pattern for running A/B tests without requiring per-test boilerplate or Segment schema changes for each experiment.

**What's included:**
- Generic `useABTest` hook with TypeScript support
- Handles both object format `{ name }` from controller and legacy string format
- Comprehensive unit tests (26 test cases)
- Documentation covering LD setup, analytics integration, and bucketing explanation

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A - Infrastructure for future A/B testing

## **Manual testing steps**

1. **Hook returns correct variant when flag is set:** Configure LD to return `{ name: "treatment" }` → hook returns treatment variant data, `isActive` is `true`
2. **Hook falls back to control when flag is not set:** No LD flag configured → hook returns control variant data, `isActive` is `false`
3. **Analytics tracking includes ab_tests property:** With active test, `SWAP_PAGE_VIEWED` event includes `ab_tests: { select_amount_text: "treatment" }`

## **Screenshots/Recordings**

### **Before**

N/A - New feature

### **After**

N/A - No UI changes; hook is internal infrastructure. First experiment (select amount text) requires LD flag to be configured to observe behavior difference.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New hook + docs/tests with no changes to existing runtime flows unless adopted by callers; primary risk is incorrect variant selection/activation logic when teams start using it.
> 
> **Overview**
> Adds a new generic `useABTest` React hook that maps a remote feature-flag value to locally-defined variant data, exposing `{ variant, variantName, isActive }` with a guaranteed `control` fallback and protection against prototype-key matches.
> 
> The hook supports both the controller’s `{ name }` A/B-test object format and a legacy string flag value format, is exported via `app/hooks/index.ts`, and is backed by extensive unit tests plus a new `docs/ab-testing.md` guide covering LaunchDarkly configuration and analytics tracking conventions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 561734abeb70bd7e369d83cd09eaf6529651bf33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->