### PR TITLE
feat(ramps): migrate ramps region from string to object

### DIFF
--- a/app/store/migrations/116.test.ts
+++ b/app/store/migrations/116.test.ts
@@ -49,7 +49,7 @@ describe(`Migration ${migrationVersion}`, () => {
     expect(result).toStrictEqual(state);
   });
 
-  it('migrates string userRegion to null ResourceState so controller will geolocate', () => {
+  it('migrates string userRegion to null so controller will geolocate', () => {
     const state = {
       engine: {
         backgroundState: {
@@ -63,22 +63,16 @@ describe(`Migration ${migrationVersion}`, () => {
 
     const result = migrate(state) as typeof state;
 
-    expect(
-      result.engine.backgroundState.RampsController.userRegion,
-    ).toStrictEqual({
-      data: null,
-      selected: null,
-      isLoading: false,
-      error: null,
-    });
+    expect(result.engine.backgroundState.RampsController.userRegion).toBeNull();
     expect(
       result.engine.backgroundState.RampsController.providers,
     ).toStrictEqual([]);
   });
 
-  it('leaves userRegion unchanged when already an object (ResourceState)', () => {
+  it('migrates ResourceState userRegion to .data (UserRegion | null)', () => {
+    const existingData = { country: {}, state: null, regionCode: 'us-ca' };
     const existingUserRegion = {
-      data: { country: {}, state: null, regionCode: 'us-ca' },
+      data: existingData,
       selected: null,
       isLoading: false,
       error: null,
@@ -96,7 +90,7 @@ describe(`Migration ${migrationVersion}`, () => {
     const result = migrate(state) as typeof state;
 
     expect(result.engine.backgroundState.RampsController.userRegion).toBe(
-      existingUserRegion,
+      existingData,
     );
   });
 

--- a/app/store/migrations/116.test.ts
+++ b/app/store/migrations/116.test.ts
@@ -1,0 +1,118 @@
+import migrate, { migrationVersion } from './116';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+describe(`Migration ${migrationVersion}`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns state unchanged if state is invalid', () => {
+    const invalidState = null;
+    const result = migrate(invalidState);
+    expect(result).toBe(invalidState);
+  });
+
+  it('returns state unchanged if engine is missing', () => {
+    const invalidState = { foo: 'bar' };
+    const result = migrate(invalidState);
+    expect(result).toStrictEqual(invalidState);
+  });
+
+  it('returns state unchanged if backgroundState is missing', () => {
+    const state = { engine: {} };
+    const result = migrate(state);
+    expect(result).toStrictEqual(state);
+  });
+
+  it('returns state unchanged if RampsController is missing', () => {
+    const state = {
+      engine: {
+        backgroundState: {},
+      },
+    };
+    const result = migrate(state);
+    expect(result).toStrictEqual(state);
+  });
+
+  it('returns state unchanged if RampsController is not an object', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RampsController: 'invalid',
+        },
+      },
+    };
+    const result = migrate(state);
+    expect(result).toStrictEqual(state);
+  });
+
+  it('migrates string userRegion to null ResourceState so controller will geolocate', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RampsController: {
+            userRegion: 'us-ca',
+            providers: [],
+          },
+        },
+      },
+    };
+
+    const result = migrate(state) as typeof state;
+
+    expect(
+      result.engine.backgroundState.RampsController.userRegion,
+    ).toStrictEqual({
+      data: null,
+      selected: null,
+      isLoading: false,
+      error: null,
+    });
+    expect(
+      result.engine.backgroundState.RampsController.providers,
+    ).toStrictEqual([]);
+  });
+
+  it('leaves userRegion unchanged when already an object (ResourceState)', () => {
+    const existingUserRegion = {
+      data: { country: {}, state: null, regionCode: 'us-ca' },
+      selected: null,
+      isLoading: false,
+      error: null,
+    };
+    const state = {
+      engine: {
+        backgroundState: {
+          RampsController: {
+            userRegion: existingUserRegion,
+          },
+        },
+      },
+    };
+
+    const result = migrate(state) as typeof state;
+
+    expect(result.engine.backgroundState.RampsController.userRegion).toBe(
+      existingUserRegion,
+    );
+  });
+
+  it('leaves RampsController unchanged when userRegion is absent', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RampsController: {
+            providers: [],
+          },
+        },
+      },
+    };
+
+    const result = migrate(state) as typeof state;
+
+    expect(result).toStrictEqual(state);
+  });
+});

--- a/app/store/migrations/116.ts
+++ b/app/store/migrations/116.ts
@@ -1,0 +1,49 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { ensureValidState } from './util';
+import { captureException } from '@sentry/react-native';
+
+export const migrationVersion = 116;
+
+const defaultUserRegionResourceState = null;
+
+/**
+ * Migration 116: Migrate RampsController userRegion from legacy string to ResourceState
+ *
+ * The first iteration of RampsController stored userRegion as a string (e.g. "us-ca"). Now it uses objects.
+ * If userRegion is a string, set it to null so the controller will geolocate and set the
+ * correct object on init.
+ *
+ * @param state - The persisted Redux state (with engine.backgroundState inflated)
+ * @returns The migrated Redux state
+ */
+export default function migrate(state: unknown): unknown {
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  try {
+    if (!hasProperty(state.engine.backgroundState, 'RampsController')) {
+      return state;
+    }
+
+    const rampsController = state.engine.backgroundState.RampsController;
+
+    if (!isObject(rampsController)) {
+      return state;
+    }
+
+    if (
+      hasProperty(rampsController, 'userRegion') &&
+      typeof rampsController.userRegion === 'string'
+    ) {
+      rampsController.userRegion = defaultUserRegionResourceState;
+    }
+
+    return state;
+  } catch (error) {
+    captureException(
+      new Error(`Migration ${migrationVersion} failed: ${error}`),
+    );
+    return state;
+  }
+}

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -116,6 +116,7 @@ import migration112 from './112';
 import migration113 from './113';
 import migration114 from './114';
 import migration115 from './115';
+import migration116 from './116';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -251,6 +252,7 @@ export const migrationList: MigrationsList = {
   113: migration113,
   114: migration114,
   115: migration115,
+  116: migration116,
 };
 
 // Enable both synchronous and asynchronous migrations


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The very first iteration of the ramps controller used a string as the user's region (such as `"us-ca"`).  The region is now an object with information about the users region.

This migration will set any legacy users' region to `null` which will ensure the controller resets the region to the correct interface.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a defensive Redux-state migration and unit tests; the main risk is incorrect shaping of persisted `RampsController.userRegion` for legacy users, but it fails closed by returning the original state and capturing exceptions.
> 
> **Overview**
> Adds migration **116** to normalize persisted `engine.backgroundState.RampsController.userRegion` to the current `UserRegion | null` shape.
> 
> Legacy `userRegion` strings are reset to `null` (so the controller geolocates on init), and prior `ResourceState`-shaped values are replaced with their `.data` payload; missing/invalid controller/state shapes are left unchanged and failures are reported to Sentry. Includes Jest coverage for the migration paths and registers the migration in `app/store/migrations/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffe9bacd6a71c6b1167dbfe1e3d94d1ef881c748. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->