### PR TITLE
test: Update multichain connection test to dynamically select Dapp URL

### DIFF
--- a/appwright/tests/mm-connect/connection-multichain.spec.js
+++ b/appwright/tests/mm-connect/connection-multichain.spec.js
@@ -11,12 +11,22 @@ import AndroidScreenHelpers from '../../../wdio/screen-objects/Native/Android.js
 import DappConnectionModal from '../../../wdio/screen-objects/Modals/DappConnectionModal.js';
 import AppwrightGestures from '../../../tests/framework/AppwrightGestures.js';
 
-const MULTI_CHAIN_TEST_DAPP_URL = 'http://10.0.2.2:3000/test-dapp-multichain';
+const MULTI_CHAIN_TEST_DAPP_LOCAL_URL =
+  'http://10.0.2.2:3000/test-dapp-multichain';
+const MULTI_CHAIN_TEST_DAPP_PUBLIC_URL =
+  'https://metamask.github.io/test-dapp-multichain/latest/';
 const MULTI_CHAIN_TEST_DAPP_NAME = 'Multichain Test Dapp';
 
 test('@metamask/connect-multichain - Connect to the Multichain Test Dapp', async ({
   device,
-}) => {
+}, testInfo) => {
+  // Determine URL based on device provider from config
+  const isBrowserStack =
+    testInfo.project.use.device.provider === 'browserstack';
+  const MULTI_CHAIN_TEST_DAPP_URL = isBrowserStack
+    ? MULTI_CHAIN_TEST_DAPP_PUBLIC_URL
+    : MULTI_CHAIN_TEST_DAPP_LOCAL_URL;
+
   WalletMainScreen.device = device;
   MultiChainTestDapp.device = device;
   AndroidScreenHelpers.device = device;


### PR DESCRIPTION
This commit modifies the multichain connection test to determine the Dapp URL based on the device provider. It introduces two constants for local and public Dapp URLs and updates the test to use the appropriate URL depending on whether the test is running on BrowserStack or locally. This enhances the flexibility and reliability of the test across different environments.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
