### PR TITLE
fix: background color for Perps deposit cp-7.64.0

### DIFF
--- a/app/components/UI/Perps/routes/index.tsx
+++ b/app/components/UI/Perps/routes/index.tsx
@@ -36,7 +36,6 @@ import ActivityView from '../../../Views/ActivityView';
 import PerpsStreamBridge from '../components/PerpsStreamBridge';
 import { HIP3DebugView } from '../Debug';
 import PerpsCrossMarginWarningBottomSheet from '../components/PerpsCrossMarginWarningBottomSheet';
-import { useTheme } from '../../../../util/theme';
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { CONFIRMATION_HEADER_CONFIG } from '../constants/perpsConfig';
 
@@ -66,22 +65,13 @@ const PerpsConfirmScreen = (
     route: RouteProp<PerpsNavigationParamList, 'RedesignedConfirmations'>;
   },
 ) => {
-  const theme = useTheme();
   const params =
     useRoute<RouteProp<PerpsNavigationParamList, 'RedesignedConfirmations'>>();
   const showPerpsHeader =
     params?.params?.showPerpsHeader ??
     CONFIRMATION_HEADER_CONFIG.DefaultShowPerpsHeader;
 
-  return (
-    <Confirm
-      {...props}
-      disableSafeArea={!showPerpsHeader}
-      fullscreenStyle={{
-        backgroundColor: theme.colors.background.default,
-      }}
-    />
-  );
+  return <Confirm {...props} disableSafeArea={!showPerpsHeader} />;
 };
 
 const PerpsModalStack = () => {


### PR DESCRIPTION
## **Description**
Fixes background color for Perps deposit. It was set to white, now it's set back to gray.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes background color for Perps deposit

## **Related issues**

Fixes: 

## **Manual testing steps**
1. Go to Perps deposit, background is gray now, as it was before


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**



### **After**



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI change limited to Perps confirmation screen styling; minimal behavioral risk beyond potential visual regressions.
> 
> **Overview**
> Perps confirmations no longer pass a theme-derived `fullscreenStyle` background override into `Confirm`; they now rely on `Confirm`’s default container styling.
> 
> The Perps route wrapper still conditionally disables safe-area insets based on `showPerpsHeader`, but drops the `useTheme` dependency that was forcing a white/incorrect background.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 239fb4b2ffd0643612bdf3b6b9ec57d36161c083. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->