### PR TITLE
Feature flag cache duration

### DIFF
--- a/.yarn/patches/@metamask-remote-feature-flag-controller-npm-4.0.0-59b92a524c.patch
+++ b/.yarn/patches/@metamask-remote-feature-flag-controller-npm-4.0.0-59b92a524c.patch
@@ -1,0 +1,132 @@
+diff --git a/dist/remote-feature-flag-controller.cjs b/dist/remote-feature-flag-controller.cjs
+index 387c6cf7aabcca8d604a92048f46a23914290f11..d7c63005ae1f688a64dd479f449ce8778c111270 100644
+--- a/dist/remote-feature-flag-controller.cjs
++++ b/dist/remote-feature-flag-controller.cjs
+@@ -51,6 +51,12 @@ const remoteFeatureFlagControllerMetadata = {
+         includeInDebugSnapshot: false,
+         usedInUi: false,
+     },
++    cachedClientVersion: {
++        includeInStateLogs: true,
++        persist: true,
++        includeInDebugSnapshot: true,
++        usedInUi: false,
++    },
+ };
+ /**
+  * Returns the default state for the RemoteFeatureFlagController.
+@@ -63,6 +69,7 @@ function getDefaultRemoteFeatureFlagControllerState() {
+         localOverrides: {},
+         rawRemoteFeatureFlags: {},
+         cacheTimestamp: 0,
++        cachedClientVersion: undefined,
+     };
+ }
+ exports.getDefaultRemoteFeatureFlagControllerState = getDefaultRemoteFeatureFlagControllerState;
+@@ -193,6 +200,12 @@ class RemoteFeatureFlagController extends base_controller_1.BaseController {
+ }
+ exports.RemoteFeatureFlagController = RemoteFeatureFlagController;
+ _RemoteFeatureFlagController_fetchInterval = new WeakMap(), _RemoteFeatureFlagController_disabled = new WeakMap(), _RemoteFeatureFlagController_clientConfigApiService = new WeakMap(), _RemoteFeatureFlagController_inProgressFlagUpdate = new WeakMap(), _RemoteFeatureFlagController_getMetaMetricsId = new WeakMap(), _RemoteFeatureFlagController_clientVersion = new WeakMap(), _RemoteFeatureFlagController_instances = new WeakSet(), _RemoteFeatureFlagController_isCacheExpired = function _RemoteFeatureFlagController_isCacheExpired() {
++    // Invalidate cache if clientVersion changed (e.g., after app upgrade)
++    const currentClientVersion = __classPrivateFieldGet(this, _RemoteFeatureFlagController_clientVersion, "f");
++    const cachedClientVersion = this.state.cachedClientVersion;
++    if (cachedClientVersion !== undefined && cachedClientVersion !== currentClientVersion) {
++        return true;
++    }
+     return Date.now() - this.state.cacheTimestamp > __classPrivateFieldGet(this, _RemoteFeatureFlagController_fetchInterval, "f");
+ }, _RemoteFeatureFlagController_updateCache = 
+ /**
+@@ -220,6 +233,7 @@ async function _RemoteFeatureFlagController_updateCache(remoteFeatureFlags) {
+         }
+     }
+     // Single state update with all changes batched together
++    const currentClientVersion = __classPrivateFieldGet(this, _RemoteFeatureFlagController_clientVersion, "f");
+     this.update(() => {
+         return {
+             ...this.state,
+@@ -227,6 +241,7 @@ async function _RemoteFeatureFlagController_updateCache(remoteFeatureFlags) {
+             rawRemoteFeatureFlags: remoteFeatureFlags,
+             cacheTimestamp: Date.now(),
+             thresholdCache: updatedThresholdCache,
++            cachedClientVersion: currentClientVersion,
+         };
+     });
+ }, _RemoteFeatureFlagController_processVersionBasedFlag = function _RemoteFeatureFlagController_processVersionBasedFlag(flagValue) {
+diff --git a/dist/remote-feature-flag-controller.d.cts b/dist/remote-feature-flag-controller.d.cts
+index 41005bb7b753b130766909d949d00d92c19b4b0c..fbe7764b7d159a6e7c88357c5f2667628a49d4ea 100644
+--- a/dist/remote-feature-flag-controller.d.cts
++++ b/dist/remote-feature-flag-controller.d.cts
+@@ -12,6 +12,7 @@ export type RemoteFeatureFlagControllerState = {
+     rawRemoteFeatureFlags?: FeatureFlags;
+     cacheTimestamp: number;
+     thresholdCache?: Record<string, number>;
++    cachedClientVersion?: string;
+ };
+ /**
+  * The action to retrieve the state of the {@link RemoteFeatureFlagController}.
+diff --git a/dist/remote-feature-flag-controller.d.mts b/dist/remote-feature-flag-controller.d.mts
+index a67a1daa804cc89b1d69b2b0dda699f01eb02bc2..7d5c054f74556b2ddb49f73181bb421ebfebef1c 100644
+--- a/dist/remote-feature-flag-controller.d.mts
++++ b/dist/remote-feature-flag-controller.d.mts
+@@ -12,6 +12,7 @@ export type RemoteFeatureFlagControllerState = {
+     rawRemoteFeatureFlags?: FeatureFlags;
+     cacheTimestamp: number;
+     thresholdCache?: Record<string, number>;
++    cachedClientVersion?: string;
+ };
+ /**
+  * The action to retrieve the state of the {@link RemoteFeatureFlagController}.
+diff --git a/dist/remote-feature-flag-controller.mjs b/dist/remote-feature-flag-controller.mjs
+index be983f82f494531626d2fab65ddcd9c6a9068952..ffdbdb49c1a611dbcefa213ff596ede3da31f759 100644
+--- a/dist/remote-feature-flag-controller.mjs
++++ b/dist/remote-feature-flag-controller.mjs
+@@ -48,6 +48,12 @@ const remoteFeatureFlagControllerMetadata = {
+         includeInDebugSnapshot: false,
+         usedInUi: false,
+     },
++    cachedClientVersion: {
++        includeInStateLogs: true,
++        persist: true,
++        includeInDebugSnapshot: true,
++        usedInUi: false,
++    },
+ };
+ /**
+  * Returns the default state for the RemoteFeatureFlagController.
+@@ -60,6 +66,7 @@ export function getDefaultRemoteFeatureFlagControllerState() {
+         localOverrides: {},
+         rawRemoteFeatureFlags: {},
+         cacheTimestamp: 0,
++        cachedClientVersion: undefined,
+     };
+ }
+ /**
+@@ -188,6 +195,12 @@ export class RemoteFeatureFlagController extends BaseController {
+     }
+ }
+ _RemoteFeatureFlagController_fetchInterval = new WeakMap(), _RemoteFeatureFlagController_disabled = new WeakMap(), _RemoteFeatureFlagController_clientConfigApiService = new WeakMap(), _RemoteFeatureFlagController_inProgressFlagUpdate = new WeakMap(), _RemoteFeatureFlagController_getMetaMetricsId = new WeakMap(), _RemoteFeatureFlagController_clientVersion = new WeakMap(), _RemoteFeatureFlagController_instances = new WeakSet(), _RemoteFeatureFlagController_isCacheExpired = function _RemoteFeatureFlagController_isCacheExpired() {
++    // Invalidate cache if clientVersion changed (e.g., after app upgrade)
++    const currentClientVersion = __classPrivateFieldGet(this, _RemoteFeatureFlagController_clientVersion, "f");
++    const cachedClientVersion = this.state.cachedClientVersion;
++    if (cachedClientVersion !== undefined && cachedClientVersion !== currentClientVersion) {
++        return true;
++    }
+     return Date.now() - this.state.cacheTimestamp > __classPrivateFieldGet(this, _RemoteFeatureFlagController_fetchInterval, "f");
+ }, _RemoteFeatureFlagController_updateCache = 
+ /**
+@@ -215,6 +228,7 @@ async function _RemoteFeatureFlagController_updateCache(remoteFeatureFlags) {
+         }
+     }
+     // Single state update with all changes batched together
++    const currentClientVersion = __classPrivateFieldGet(this, _RemoteFeatureFlagController_clientVersion, "f");
+     this.update(() => {
+         return {
+             ...this.state,
+@@ -222,6 +236,7 @@ async function _RemoteFeatureFlagController_updateCache(remoteFeatureFlags) {
+             rawRemoteFeatureFlags: remoteFeatureFlags,
+             cacheTimestamp: Date.now(),
+             thresholdCache: updatedThresholdCache,
++            cachedClientVersion: currentClientVersion,
+         };
+     });
+ }, _RemoteFeatureFlagController_processVersionBasedFlag = function _RemoteFeatureFlagController_processVersionBasedFlag(flagValue) {

--- a/package.json
+++ b/package.json
@@ -184,7 +184,8 @@
     "@playwright/test": "^1.57.0",
     "@metamask/transaction-controller@npm:^61.0.0": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.9.0-5c8f871530.patch",
     "@metamask/transaction-controller@npm:^62.9.2": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.9.0-5c8f871530.patch",
-    "@metamask/transaction-controller@npm:^62.11.0": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.9.0-5c8f871530.patch"
+    "@metamask/transaction-controller@npm:^62.11.0": "patch:@metamask/transaction-controller@npm%3A62.9.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.9.0-5c8f871530.patch",
+    "@metamask/remote-feature-flag-controller@npm:^4.0.0": "patch:@metamask/remote-feature-flag-controller@npm%3A4.0.0#~/.yarn/patches/@metamask-remote-feature-flag-controller-npm-4.0.0-59b92a524c.patch"
   },
   "dependencies": {
     "@config-plugins/detox": "^9.0.0",
@@ -275,7 +276,7 @@
     "@metamask/react-native-payments": "^2.0.0",
     "@metamask/react-native-search-api": "1.0.1",
     "@metamask/react-native-webview": "patch:@metamask/react-native-webview@npm%3A14.5.0#~/.yarn/patches/@metamask-react-native-webview-npm-14.5.0-b34fed6d50.patch",
-    "@metamask/remote-feature-flag-controller": "^4.0.0",
+    "@metamask/remote-feature-flag-controller": "patch:@metamask/remote-feature-flag-controller@npm%3A4.0.0#~/.yarn/patches/@metamask-remote-feature-flag-controller-npm-4.0.0-59b92a524c.patch",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/sample-controllers": "^3.0.0",
     "@metamask/scure-bip39": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9217,7 +9217,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/remote-feature-flag-controller@npm:^4.0.0":
+"@metamask/remote-feature-flag-controller@npm:4.0.0":
   version: 4.0.0
   resolution: "@metamask/remote-feature-flag-controller@npm:4.0.0"
   dependencies:
@@ -9227,6 +9227,19 @@ __metadata:
     "@metamask/utils": "npm:^11.9.0"
     uuid: "npm:^8.3.2"
   checksum: 10/5cb0e380d9b68666564f8e34add9a3c4cab1907bc3e0abddf37d1c06a6311f07cc6718baf4091aeab44c2d2cde378bb072e07a713546be3d5c9358fda5d75ab8
+  languageName: node
+  linkType: hard
+
+"@metamask/remote-feature-flag-controller@patch:@metamask/remote-feature-flag-controller@npm%3A4.0.0#~/.yarn/patches/@metamask-remote-feature-flag-controller-npm-4.0.0-59b92a524c.patch":
+  version: 4.0.0
+  resolution: "@metamask/remote-feature-flag-controller@patch:@metamask/remote-feature-flag-controller@npm%3A4.0.0#~/.yarn/patches/@metamask-remote-feature-flag-controller-npm-4.0.0-59b92a524c.patch::version=4.0.0&hash=f45413"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.17.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/utils": "npm:^11.9.0"
+    uuid: "npm:^8.3.2"
+  checksum: 10/401291cb6e6b17f331cd691b5e66112307e309a32bb8d331a9ad2eff02b4db67c996e0ea30991e20c21e89c7789b821815eb7e0efbb5090ecf1ced808118603c
   languageName: node
   linkType: hard
 
@@ -34790,7 +34803,7 @@ __metadata:
     "@metamask/react-native-payments": "npm:^2.0.0"
     "@metamask/react-native-search-api": "npm:1.0.1"
     "@metamask/react-native-webview": "patch:@metamask/react-native-webview@npm%3A14.5.0#~/.yarn/patches/@metamask-react-native-webview-npm-14.5.0-b34fed6d50.patch"
-    "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
+    "@metamask/remote-feature-flag-controller": "patch:@metamask/remote-feature-flag-controller@npm%3A4.0.0#~/.yarn/patches/@metamask-remote-feature-flag-controller-npm-4.0.0-59b92a524c.patch"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/sample-controllers": "npm:^3.0.0"
     "@metamask/scure-bip39": "npm:^2.1.0"


### PR DESCRIPTION
Add a yarn patch to `@metamask/remote-feature-flag-controller` to invalidate the feature flag cache when the client version changes.

This fixes a bug where users upgrading the app would not immediately see new version-gated feature flags. The controller previously processed version-based flags at fetch time using the old client version and then cached them. After an upgrade, the cache remained valid for up to 15 minutes, preventing a re-fetch with the new client version and thus hiding new features. The patch forces a cache refresh upon client version change.

---
<a href="https://cursor.com/background-agent?bcId=bc-3102d06e-b960-4688-a110-c0a08e1bd9e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3102d06e-b960-4688-a110-c0a08e1bd9e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

