### PR TITLE
fix: order book live price header

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
@@ -262,7 +262,7 @@ jest.mock('../../components/PerpsMarketHeader', () => {
 jest.mock(
   '../../../../../component-library/components/BottomSheets/BottomSheet',
   () => {
-    const { View } = jest.requireActual('react-native');
+    const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
     const ReactMock = jest.requireActual('react');
     return {
       __esModule: true,
@@ -273,7 +273,17 @@ jest.mock(
             onClose?: () => void;
           },
           _ref: unknown,
-        ) => <View testID="bottom-sheet">{props.children}</View>,
+        ) => (
+          <View testID="bottom-sheet">
+            {props.children}
+            <TouchableOpacity
+              testID="bottom-sheet-backdrop"
+              onPress={props.onClose}
+            >
+              <Text>Backdrop</Text>
+            </TouchableOpacity>
+          </View>
+        ),
       ),
     };
   },
@@ -302,12 +312,23 @@ jest.mock('../PerpsSelectModifyActionView', () => {
 jest.mock(
   '../../components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip',
   () => {
-    const { View } = jest.requireActual('react-native');
+    const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
     return {
       __esModule: true,
-      default: (props: { testID?: string; isVisible?: boolean }) =>
+      default: (props: {
+        testID?: string;
+        isVisible?: boolean;
+        onClose?: () => void;
+      }) =>
         props.isVisible ? (
-          <View testID={props.testID || 'perps-bottom-sheet-tooltip'} />
+          <View testID={props.testID || 'perps-bottom-sheet-tooltip'}>
+            <TouchableOpacity
+              testID={`${props.testID || 'perps-bottom-sheet-tooltip'}-close`}
+              onPress={props.onClose}
+            >
+              <Text>Close</Text>
+            </TouchableOpacity>
+          </View>
         ) : null,
     };
   },
@@ -1161,6 +1182,258 @@ describe('PerpsOrderBookView', () => {
     it('renders correctly when orderBook is null but no error', () => {
       mockUsePerpsLiveOrderBook.mockReturnValue({
         orderBook: null,
+        isLoading: false,
+        error: null,
+      });
+
+      const { getByTestId } = renderWithProvider(<PerpsOrderBookView />, {
+        state: initialState,
+      });
+
+      expect(
+        getByTestId(PerpsOrderBookViewSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('falls back to static market price when live price is not available', () => {
+      mockUsePerpsLivePrices.mockReturnValue({});
+
+      const { getByTestId } = renderWithProvider(<PerpsOrderBookView />, {
+        state: initialState,
+      });
+
+      expect(
+        getByTestId(PerpsOrderBookViewSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('handles invalid topOfBook values gracefully', () => {
+      mockUsePerpsTopOfBook.mockReturnValue({
+        bestBid: '0',
+        bestAsk: '-1',
+        spread: '0',
+      });
+
+      const { getByTestId } = renderWithProvider(<PerpsOrderBookView />, {
+        state: initialState,
+      });
+
+      expect(
+        getByTestId(PerpsOrderBookViewSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('handles non-finite topOfBook values', () => {
+      mockUsePerpsTopOfBook.mockReturnValue({
+        bestBid: 'NaN',
+        bestAsk: 'Infinity',
+        spread: '0',
+      });
+
+      const { getByTestId } = renderWithProvider(<PerpsOrderBookView />, {
+        state: initialState,
+      });
+
+      expect(
+        getByTestId(PerpsOrderBookViewSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('syncs saved grouping when it loads after mount', async () => {
+      const { usePerpsOrderBookGrouping } = jest.requireMock(
+        '../../hooks/usePerpsOrderBookGrouping',
+      );
+
+      // First render with undefined savedGrouping
+      usePerpsOrderBookGrouping.mockReturnValue({
+        savedGrouping: undefined,
+        saveGrouping: mockSaveGrouping,
+      });
+
+      const { rerender, getByTestId } = renderWithProvider(
+        <PerpsOrderBookView />,
+        {
+          state: initialState,
+        },
+      );
+
+      expect(
+        getByTestId(PerpsOrderBookViewSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
+
+      // Simulate savedGrouping loading
+      usePerpsOrderBookGrouping.mockReturnValue({
+        savedGrouping: 5,
+        saveGrouping: mockSaveGrouping,
+      });
+
+      rerender(<PerpsOrderBookView />);
+
+      expect(
+        getByTestId(PerpsOrderBookViewSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  describe('spread tooltip', () => {
+    it('opens spread tooltip when info button is pressed', async () => {
+      const { getByTestId } = renderWithProvider(<PerpsOrderBookView />, {
+        state: initialState,
+      });
+
+      const spreadInfoButton = getByTestId(
+        PerpsOrderBookViewSelectorsIDs.SPREAD_INFO_BUTTON,
+      );
+
+      fireEvent.press(spreadInfoButton);
+
+      await waitFor(() => {
+        expect(
+          getByTestId(PerpsOrderBookViewSelectorsIDs.BOTTOM_SHEET_TOOLTIP),
+        ).toBeOnTheScreen();
+      });
+    });
+
+    it('closes spread tooltip when onClose is called', async () => {
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <PerpsOrderBookView />,
+        {
+          state: initialState,
+        },
+      );
+
+      // Open tooltip
+      const spreadInfoButton = getByTestId(
+        PerpsOrderBookViewSelectorsIDs.SPREAD_INFO_BUTTON,
+      );
+      fireEvent.press(spreadInfoButton);
+
+      await waitFor(() => {
+        expect(
+          getByTestId(PerpsOrderBookViewSelectorsIDs.BOTTOM_SHEET_TOOLTIP),
+        ).toBeOnTheScreen();
+      });
+
+      // Close the tooltip via the close button in the mock
+      const closeButton = getByTestId(
+        `${PerpsOrderBookViewSelectorsIDs.BOTTOM_SHEET_TOOLTIP}-close`,
+      );
+      fireEvent.press(closeButton);
+
+      await waitFor(() => {
+        expect(
+          queryByTestId(PerpsOrderBookViewSelectorsIDs.BOTTOM_SHEET_TOOLTIP),
+        ).toBeNull();
+      });
+    });
+  });
+
+  describe('depth band sheet close', () => {
+    it('closes depth band sheet via onClose callback', async () => {
+      const { getByTestId, queryByText } = renderWithProvider(
+        <PerpsOrderBookView />,
+        {
+          state: initialState,
+        },
+      );
+
+      // Open the depth band sheet
+      const depthBandButton = getByTestId(
+        PerpsOrderBookViewSelectorsIDs.DEPTH_BAND_BUTTON,
+      );
+      fireEvent.press(depthBandButton);
+
+      await waitFor(() => {
+        expect(queryByText('Depth Band')).toBeOnTheScreen();
+      });
+
+      // Close via backdrop (onClose callback)
+      const backdrop = getByTestId('bottom-sheet-backdrop');
+      fireEvent.press(backdrop);
+
+      await waitFor(() => {
+        expect(queryByText('Depth Band')).toBeNull();
+      });
+    });
+  });
+
+  describe('geo-block modal interactions', () => {
+    it('closes geo-block modal when onClose is called', async () => {
+      const { selectPerpsEligibility } = jest.requireMock(
+        '../../selectors/perpsController',
+      );
+      selectPerpsEligibility.mockReturnValue(false);
+
+      // Ensure no existing position so Long/Short buttons are shown
+      const { useHasExistingPosition } = jest.requireMock(
+        '../../hooks/useHasExistingPosition',
+      );
+      useHasExistingPosition.mockReturnValue({
+        isLoading: false,
+        existingPosition: null,
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <PerpsOrderBookView />,
+        {
+          state: initialState,
+        },
+      );
+
+      // Trigger geo-block modal by pressing Long button when not eligible
+      const longButton = getByTestId(
+        PerpsOrderBookViewSelectorsIDs.LONG_BUTTON,
+      );
+      fireEvent.press(longButton);
+
+      // Verify modal is shown
+      const geoBlockTooltipId = `${PerpsOrderBookViewSelectorsIDs.CONTAINER}-geo-block-tooltip`;
+      expect(queryByTestId(geoBlockTooltipId)).toBeOnTheScreen();
+
+      // Close the modal via the close button
+      const closeButton = getByTestId(`${geoBlockTooltipId}-close`);
+      fireEvent.press(closeButton);
+
+      await waitFor(() => {
+        expect(queryByTestId(geoBlockTooltipId)).toBeNull();
+      });
+    });
+  });
+
+  describe('grouping with no market price', () => {
+    it('returns null grouping when market price is unavailable', () => {
+      const { usePerpsMarkets } = jest.requireMock('../../hooks');
+      usePerpsMarkets.mockReturnValue({
+        markets: [
+          {
+            symbol: 'BTC',
+            price: null,
+            leverage: 50,
+          },
+        ],
+        isLoading: false,
+        error: null,
+      });
+
+      const { getByTestId } = renderWithProvider(<PerpsOrderBookView />, {
+        state: initialState,
+      });
+
+      expect(
+        getByTestId(PerpsOrderBookViewSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('handles invalid market price format', () => {
+      const { usePerpsMarkets } = jest.requireMock('../../hooks');
+      usePerpsMarkets.mockReturnValue({
+        markets: [
+          {
+            symbol: 'BTC',
+            price: 'invalid',
+            leverage: 50,
+          },
+        ],
         isLoading: false,
         error: null,
       });

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
@@ -119,6 +119,19 @@ jest.mock('../../hooks/stream/usePerpsLiveOrderBook', () => ({
   usePerpsLiveOrderBook: (params: unknown) => mockUsePerpsLiveOrderBook(params),
 }));
 
+// Mock usePerpsLivePrices for live price updates in header (TAT-2441)
+const mockUsePerpsLivePrices = jest.fn(() => ({
+  BTC: {
+    price: '50000',
+    percentChange24h: '2.5',
+    symbol: 'BTC',
+  },
+}));
+
+jest.mock('../../hooks/stream/usePerpsLivePrices', () => ({
+  usePerpsLivePrices: (params: unknown) => mockUsePerpsLivePrices(params),
+}));
+
 // Mock usePerpsMeasurement
 jest.mock('../../hooks/usePerpsMeasurement', () => ({
   usePerpsMeasurement: jest.fn(),
@@ -320,6 +333,13 @@ describe('PerpsOrderBookView', () => {
       bestBid: '50000',
       bestAsk: '50001',
       spread: '1.00000',
+    });
+    mockUsePerpsLivePrices.mockReturnValue({
+      BTC: {
+        price: '50000',
+        percentChange24h: '2.5',
+        symbol: 'BTC',
+      },
     });
   });
 
@@ -1066,6 +1086,17 @@ describe('PerpsOrderBookView', () => {
       expect(mockUsePerpsLiveOrderBook).toHaveBeenCalledWith(
         expect.objectContaining({
           symbol: 'BTC',
+        }),
+      );
+    });
+
+    it('subscribes to live prices for header price display (TAT-2441)', () => {
+      renderWithProvider(<PerpsOrderBookView />, { state: initialState });
+
+      expect(mockUsePerpsLivePrices).toHaveBeenCalledWith(
+        expect.objectContaining({
+          symbols: ['BTC'],
+          throttleMs: 1000,
         }),
       );
     });

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
@@ -120,7 +120,10 @@ jest.mock('../../hooks/stream/usePerpsLiveOrderBook', () => ({
 }));
 
 // Mock usePerpsLivePrices for live price updates in header (TAT-2441)
-const mockUsePerpsLivePrices = jest.fn(() => ({
+const mockUsePerpsLivePrices = jest.fn<
+  Record<string, { price: string; percentChange24h: string; symbol: string }>,
+  [unknown]
+>(() => ({
   BTC: {
     price: '50000',
     percentChange24h: '2.5',

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
@@ -1207,6 +1207,42 @@ describe('PerpsOrderBookView', () => {
       ).toBeOnTheScreen();
     });
 
+    it('falls back to static market price when live price is invalid (NaN)', () => {
+      mockUsePerpsLivePrices.mockReturnValue({
+        BTC: {
+          price: 'invalid-price',
+          percentChange24h: '2.5',
+          symbol: 'BTC',
+        },
+      });
+
+      const { getByTestId } = renderWithProvider(<PerpsOrderBookView />, {
+        state: initialState,
+      });
+
+      expect(
+        getByTestId(PerpsOrderBookViewSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('falls back to static market price when live price is zero or negative', () => {
+      mockUsePerpsLivePrices.mockReturnValue({
+        BTC: {
+          price: '0',
+          percentChange24h: '2.5',
+          symbol: 'BTC',
+        },
+      });
+
+      const { getByTestId } = renderWithProvider(<PerpsOrderBookView />, {
+        state: initialState,
+      });
+
+      expect(
+        getByTestId(PerpsOrderBookViewSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
     it('handles invalid topOfBook values gracefully', () => {
       mockUsePerpsTopOfBook.mockReturnValue({
         bestBid: '0',

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
@@ -215,9 +215,13 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
   const currentPrice = useMemo(() => {
     const priceData = livePrices[symbol || ''];
     if (priceData?.price) {
-      return parseFloat(priceData.price);
+      const parsed = parseFloat(priceData.price);
+      // Validate parsed value - fallback to marketPrice if invalid
+      if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+      }
     }
-    // Fallback to static market price if live price not available yet
+    // Fallback to static market price if live price not available or invalid
     return marketPrice ?? 0;
   }, [livePrices, symbol, marketPrice]);
 

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
@@ -66,6 +66,7 @@ import {
 } from '../../hooks';
 import { useHasExistingPosition } from '../../hooks/useHasExistingPosition';
 import { usePerpsLiveOrderBook } from '../../hooks/stream/usePerpsLiveOrderBook';
+import { usePerpsLivePrices } from '../../hooks/stream/usePerpsLivePrices';
 import { usePerpsTopOfBook } from '../../hooks/stream/usePerpsTopOfBook';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
@@ -202,6 +203,23 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
   // Subscribe to top-of-book (best bid/ask) for spread display.
   // This is intentionally independent from order book aggregation/grouping.
   const topOfBook = usePerpsTopOfBook({ symbol: symbol || '' });
+
+  // Subscribe to live price updates for header display (TAT-2441)
+  // This ensures the price in the header updates in real-time
+  const livePrices = usePerpsLivePrices({
+    symbols: symbol ? [symbol] : [],
+    throttleMs: 1000,
+  });
+
+  // Current price for header - use live price with fallback to static market price
+  const currentPrice = useMemo(() => {
+    const priceData = livePrices[symbol || ''];
+    if (priceData?.price) {
+      return parseFloat(priceData.price);
+    }
+    // Fallback to static market price if live price not available yet
+    return marketPrice ?? 0;
+  }, [livePrices, symbol, marketPrice]);
 
   const spreadMetrics = useMemo(() => {
     const bidStr = topOfBook?.bestBid;
@@ -470,7 +488,7 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
           <PerpsMarketHeader
             market={market}
             onBackPress={handleBack}
-            currentPrice={marketPrice ?? 0}
+            currentPrice={currentPrice}
           />
         ) : (
           <View style={styles.header}>
@@ -504,7 +522,7 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
         <PerpsMarketHeader
           market={market}
           onBackPress={handleBack}
-          currentPrice={marketPrice ?? 0}
+          currentPrice={currentPrice}
         />
       )}
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Problem:** The price displayed in the order book page header remained static (e.g., `$107.22`) even when the actual price was changing in the order book and on the market detail page. After a few seconds, there was a significant delta between the header price and the actual price, making the order book confusing and untrustworthy for users.

**Root Cause:** The header price was derived from static market data via `usePerpsMarkets()` which doesn't update in real-time. Meanwhile, the order book itself was correctly subscribed to real-time updates via `usePerpsLiveOrderBook`.

**Solution:** Added subscription to `usePerpsLivePrices` hook in `PerpsOrderBookView` to get real-time price updates for the header display. The implementation uses the live price with a fallback to the static market price if the live data is not yet available.

## **Changelog**

CHANGELOG entry: Fixed order book header price not updating in real-time

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2441

## **Manual testing steps**

```gherkin
Feature: Order book live price header

  Scenario: User views order book and price updates in real-time
    Given user is on the Perps order book view for any asset (e.g., BTC)

    When the market price changes
    Then the price displayed in the header should update in real-time
    And the header price should match the order book mid price
    And there should be no significant delay between header and order book prices
```

## **Screenshots/Recordings**

### **Before**

Price in header stays static at initial value (e.g., $107.22) while order book prices update

### **After**

Price in header now updates in real-time along with the order book data


https://github.com/user-attachments/assets/554df32b-441e-48a7-ab72-5376f3a53baf



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a throttled `usePerpsLivePrices` subscription for the header price; main risk is incorrect fallback/validation causing a wrong displayed price, now covered by tests.
> 
> **Overview**
> Fixes the Perps order book header price staying static by subscribing to `usePerpsLivePrices` and deriving a `currentPrice` that prefers validated live data and falls back to the parsed market price.
> 
> Updates `PerpsOrderBookView` tests to mock live prices and to cover subscription params, price fallback/invalid-data handling, and close interactions for the spread tooltip, depth band sheet, and geo-block modal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81a86524b55f1f6a7e42f5023a68fc4cb250590a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->