### PR TITLE
Perps section feature flag

### DIFF
--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -25,7 +25,7 @@ import Routes from '../../../constants/navigation/Routes';
 import ExploreSearchBar from './components/ExploreSearchBar/ExploreSearchBar';
 import QuickActions from './components/QuickActions/QuickActions';
 import SectionHeader from './components/SectionHeader/SectionHeader';
-import { HOME_SECTIONS_ARRAY, SectionId } from './sections.config';
+import { SectionId, useHomeSections } from './sections.config';
 import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
 import BasicFunctionalityEmptyState from '../../UI/BasicFunctionality/BasicFunctionalityEmptyState/BasicFunctionalityEmptyState';
 import TrendingFeedSessionManager from '../../UI/Trending/services/TrendingFeedSessionManager';
@@ -36,15 +36,32 @@ import { TrendingViewSelectorsIDs } from './TrendingView.testIds';
  * Custom hook to track boolean state for each section
  * Returns the Set of sections with that state and callbacks to update them
  */
-const useSectionStateTracker = () => {
+const useSectionStateTracker = (sections: Array<{ id: SectionId }>) => {
   const [activeSections, setActiveSections] = useState<Set<SectionId>>(
     new Set(),
   );
 
+  useEffect(() => {
+    setActiveSections((currentSections) => {
+      const validSections = new Set<SectionId>();
+      sections.forEach((section) => {
+        if (currentSections.has(section.id)) {
+          validSections.add(section.id);
+        }
+      });
+
+      if (validSections.size === currentSections.size) {
+        return currentSections;
+      }
+
+      return validSections;
+    });
+  }, [sections]);
+
   const callbacks = useMemo(() => {
     const result = {} as Record<SectionId, (isActive: boolean) => void>;
 
-    HOME_SECTIONS_ARRAY.forEach((section) => {
+    sections.forEach((section) => {
       result[section.id] = (isActive: boolean) => {
         setActiveSections((currentSections) => {
           const updatedSections = new Set(currentSections);
@@ -61,7 +78,7 @@ const useSectionStateTracker = () => {
     });
 
     return result;
-  }, []);
+  }, [sections]);
 
   return { sectionsWithState: activeSections, callbacks };
 };
@@ -70,6 +87,7 @@ export const ExploreFeed: React.FC = () => {
   const tw = useTailwind();
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
+  const homeSections = useHomeSections();
   const buildPortfolioUrlWithMetrics = useBuildPortfolioUrl();
   const { colors } = useTheme();
   const [refreshing, setRefreshing] = useState(false);
@@ -80,12 +98,12 @@ export const ExploreFeed: React.FC = () => {
 
   // Track which sections have empty data and which are loading
   const { sectionsWithState: emptySections, callbacks: emptyStateCallbacks } =
-    useSectionStateTracker();
+    useSectionStateTracker(homeSections);
 
   const {
     sectionsWithState: loadingSections,
     callbacks: loadingStateCallbacks,
-  } = useSectionStateTracker();
+  } = useSectionStateTracker(homeSections);
 
   const sessionManager = TrendingFeedSessionManager.getInstance();
 
@@ -233,7 +251,7 @@ export const ExploreFeed: React.FC = () => {
         >
           <QuickActions emptySections={emptySections} />
 
-          {HOME_SECTIONS_ARRAY.map((section) => {
+          {homeSections.map((section) => {
             // Hide section visually but keep mounted so it can report when data arrives
             const isHidden = emptySections.has(section.id);
 

--- a/app/components/Views/TrendingView/components/QuickActions/QuickActions.tsx
+++ b/app/components/Views/TrendingView/components/QuickActions/QuickActions.tsx
@@ -10,7 +10,7 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { SECTIONS_ARRAY, SectionId } from '../../sections.config';
+import { SectionId, useSectionsArray } from '../../sections.config';
 import { TrendingViewSelectorsIDs } from '../../TrendingView.testIds';
 
 interface QuickActionsProps {
@@ -26,8 +26,9 @@ interface QuickActionsProps {
 const QuickActions: React.FC<QuickActionsProps> = ({ emptySections }) => {
   const navigation = useNavigation();
   const tw = useTailwind();
+  const sections = useSectionsArray();
 
-  const visibleSections = SECTIONS_ARRAY.filter(
+  const visibleSections = sections.filter(
     (s) => !emptySections.has(s.id),
   );
 


### PR DESCRIPTION
Convert section arrays to hooks that conditionally include the Perps section based on a feature flag.

This simplifies testing by removing the need for Perps provider mocks when the feature is disabled.

---
<a href="https://cursor.com/background-agent?bcId=bc-19b2b818-594d-4402-bbd7-6802150880ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19b2b818-594d-4402-bbd7-6802150880ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

