### PR TITLE
Perps section conditional rendering

### DIFF
--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -25,7 +25,7 @@ import Routes from '../../../constants/navigation/Routes';
 import ExploreSearchBar from './components/ExploreSearchBar/ExploreSearchBar';
 import QuickActions from './components/QuickActions/QuickActions';
 import SectionHeader from './components/SectionHeader/SectionHeader';
-import { HOME_SECTIONS_ARRAY, SectionId } from './sections.config';
+import { SectionId, useHomeSectionsArray } from './sections.config';
 import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
 import BasicFunctionalityEmptyState from '../../UI/BasicFunctionality/BasicFunctionalityEmptyState/BasicFunctionalityEmptyState';
 import TrendingFeedSessionManager from '../../UI/Trending/services/TrendingFeedSessionManager';
@@ -36,7 +36,7 @@ import { TrendingViewSelectorsIDs } from './TrendingView.testIds';
  * Custom hook to track boolean state for each section
  * Returns the Set of sections with that state and callbacks to update them
  */
-const useSectionStateTracker = () => {
+const useSectionStateTracker = (sections: Array<{ id: SectionId }>) => {
   const [activeSections, setActiveSections] = useState<Set<SectionId>>(
     new Set(),
   );
@@ -44,7 +44,7 @@ const useSectionStateTracker = () => {
   const callbacks = useMemo(() => {
     const result = {} as Record<SectionId, (isActive: boolean) => void>;
 
-    HOME_SECTIONS_ARRAY.forEach((section) => {
+    sections.forEach((section) => {
       result[section.id] = (isActive: boolean) => {
         setActiveSections((currentSections) => {
           const updatedSections = new Set(currentSections);
@@ -61,7 +61,7 @@ const useSectionStateTracker = () => {
     });
 
     return result;
-  }, []);
+  }, [sections]);
 
   return { sectionsWithState: activeSections, callbacks };
 };
@@ -78,14 +78,16 @@ export const ExploreFeed: React.FC = () => {
     silentRefresh: true,
   });
 
+  const homeSections = useHomeSectionsArray();
+
   // Track which sections have empty data and which are loading
   const { sectionsWithState: emptySections, callbacks: emptyStateCallbacks } =
-    useSectionStateTracker();
+    useSectionStateTracker(homeSections);
 
   const {
     sectionsWithState: loadingSections,
     callbacks: loadingStateCallbacks,
-  } = useSectionStateTracker();
+  } = useSectionStateTracker(homeSections);
 
   const sessionManager = TrendingFeedSessionManager.getInstance();
 
@@ -233,7 +235,7 @@ export const ExploreFeed: React.FC = () => {
         >
           <QuickActions emptySections={emptySections} />
 
-          {HOME_SECTIONS_ARRAY.map((section) => {
+          {homeSections.map((section) => {
             // Hide section visually but keep mounted so it can report when data arrives
             const isHidden = emptySections.has(section.id);
 

--- a/app/components/Views/TrendingView/components/QuickActions/QuickActions.tsx
+++ b/app/components/Views/TrendingView/components/QuickActions/QuickActions.tsx
@@ -10,7 +10,7 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { SECTIONS_ARRAY, SectionId } from '../../sections.config';
+import { SectionId, useSectionsArray } from '../../sections.config';
 import { TrendingViewSelectorsIDs } from '../../TrendingView.testIds';
 
 interface QuickActionsProps {
@@ -26,8 +26,9 @@ interface QuickActionsProps {
 const QuickActions: React.FC<QuickActionsProps> = ({ emptySections }) => {
   const navigation = useNavigation();
   const tw = useTailwind();
+  const sectionsArray = useSectionsArray();
 
-  const visibleSections = SECTIONS_ARRAY.filter(
+  const visibleSections = sectionsArray.filter(
     (s) => !emptySections.has(s.id),
   );
 

--- a/app/components/Views/TrendingView/hooks/useExploreSearch.test.ts
+++ b/app/components/Views/TrendingView/hooks/useExploreSearch.test.ts
@@ -1,6 +1,12 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import { useExploreSearch } from './useExploreSearch';
-import { SECTIONS_ARRAY } from '../sections.config';
+import { useSectionsArray } from '../sections.config';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
 
 const mockTrendingTokens = [
   { assetId: '1', symbol: 'BTC', name: 'Bitcoin' },
@@ -92,8 +98,13 @@ jest.mock('../../../UI/Sites/hooks/useSiteData/useSitesData', () => ({
 }));
 
 describe('useExploreSearch', () => {
+  const mockUseSelector = useSelector as jest.MockedFunction<
+    typeof useSelector
+  >;
+
   beforeEach(() => {
     jest.useFakeTimers();
+    mockUseSelector.mockReturnValue(true);
 
     // Reset to default values
     mockTrendingData = mockTrendingTokens;
@@ -216,8 +227,9 @@ describe('useExploreSearch', () => {
 
   it('processes all sections defined in config', () => {
     const { result } = renderHook(() => useExploreSearch(''));
+    const { result: sectionsResult } = renderHook(() => useSectionsArray());
 
-    SECTIONS_ARRAY.forEach((section) => {
+    sectionsResult.current.forEach((section) => {
       expect(result.current.data[section.id]).toBeDefined();
       expect(result.current.isLoading[section.id]).toBeDefined();
     });
@@ -225,9 +237,10 @@ describe('useExploreSearch', () => {
 
   it('returns default sectionsOrder when no options provided', () => {
     const { result } = renderHook(() => useExploreSearch(''));
+    const { result: sectionsResult } = renderHook(() => useSectionsArray());
 
     expect(result.current.sectionsOrder).toEqual(
-      SECTIONS_ARRAY.map((s) => s.id),
+      sectionsResult.current.map((s) => s.id),
     );
   });
 

--- a/app/components/Views/TrendingView/sections.config.tsx
+++ b/app/components/Views/TrendingView/sections.config.tsx
@@ -22,6 +22,7 @@ import SiteRowItemWrapper from '../../UI/Sites/components/SiteRowItemWrapper/Sit
 import SiteSkeleton from '../../UI/Sites/components/SiteSkeleton/SiteSkeleton';
 import { useSitesData } from '../../UI/Sites/hooks/useSiteData/useSitesData';
 import { useTrendingSearch } from '../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
+import { useSelector } from 'react-redux';
 import {
   TimeOption,
   PriceChangeOption,
@@ -31,6 +32,7 @@ import { filterMarketsByQuery } from '../../UI/Perps/utils/marketUtils';
 import PredictMarketRowItem from '../../UI/Predict/components/PredictMarketRowItem';
 import SectionCard from './components/Sections/SectionTypes/SectionCard';
 import SectionCarrousel from './components/Sections/SectionTypes/SectionCarrousel';
+import { selectPerpsEnabledFlag } from '../../UI/Perps';
 
 export type SectionId = 'predictions' | 'tokens' | 'perps' | 'sites';
 
@@ -120,7 +122,7 @@ const PREDICTIONS_FUSE_OPTIONS: FuseOptions<PredictMarketType> = {
  *
  * To add a new section (EVERYTHING IN THIS FILE):
  * 1. Add the section ID to the SectionId type above
- * 2. Add the config to SECTIONS_CONFIG, HOME_SECTIONS_ARRAY, and SECTIONS_ARRAY below
+ * 2. Add the config to SECTIONS_CONFIG, useHomeSectionsArray, and useSectionsArray below
  * 3. Add the hook to useSectionsData below
  *
  * The section will automatically appear in:
@@ -309,21 +311,37 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
   },
 };
 
+type SectionsArray = (SectionConfig & { id: SectionId })[];
+
 // Sorted by order on the main screen
-export const HOME_SECTIONS_ARRAY: (SectionConfig & { id: SectionId })[] = [
-  SECTIONS_CONFIG.predictions,
-  SECTIONS_CONFIG.tokens,
-  SECTIONS_CONFIG.perps,
-  SECTIONS_CONFIG.sites,
-];
+export const useHomeSectionsArray = (): SectionsArray => {
+  const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
+
+  return useMemo(
+    () => [
+      SECTIONS_CONFIG.predictions,
+      SECTIONS_CONFIG.tokens,
+      ...(isPerpsEnabled ? [SECTIONS_CONFIG.perps] : []),
+      SECTIONS_CONFIG.sites,
+    ],
+    [isPerpsEnabled],
+  );
+};
 
 // Sorted by order on the QuickAction buttons and SearchResults
-export const SECTIONS_ARRAY: (SectionConfig & { id: SectionId })[] = [
-  SECTIONS_CONFIG.tokens,
-  SECTIONS_CONFIG.perps,
-  SECTIONS_CONFIG.predictions,
-  SECTIONS_CONFIG.sites,
-];
+export const useSectionsArray = (): SectionsArray => {
+  const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
+
+  return useMemo(
+    () => [
+      SECTIONS_CONFIG.tokens,
+      ...(isPerpsEnabled ? [SECTIONS_CONFIG.perps] : []),
+      SECTIONS_CONFIG.predictions,
+      SECTIONS_CONFIG.sites,
+    ],
+    [isPerpsEnabled],
+  );
+};
 
 /**
  * Centralized hook that fetches data for all sections.


### PR DESCRIPTION
Convert TrendingView section arrays into hooks to conditionally render the Perps section based on a feature flag, simplifying E2E tests.

This change resolves an E2E testing issue where the TrendingView's Perps section required extensive mocking, even when the perps feature was intended to be disabled. By making the Perps section conditional on `selectPerpsEnabledFlag` via new hooks, tests can now simply disable the flag to prevent the section from rendering, removing the need for mocks.

---
<a href="https://cursor.com/background-agent?bcId=bc-81588ea8-1dcb-4cb6-afd5-04e0dafb6d3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81588ea8-1dcb-4cb6-afd5-04e0dafb6d3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

