### PR TITLE
feat(perps): extract empty balance UI into PerpsEmptyBalance component and redesign it

### DIFF
--- a/app/components/UI/Perps/components/PerpsEmptyBalance/PerpsEmptyBalance.styles.ts
+++ b/app/components/UI/Perps/components/PerpsEmptyBalance/PerpsEmptyBalance.styles.ts
@@ -1,0 +1,11 @@
+import { StyleSheet } from 'react-native';
+import type { Theme } from '../../../../../util/theme/models';
+
+const styleSheet = (_params: { theme: Theme }) =>
+  StyleSheet.create({
+    balanceText: {
+      fontWeight: '500',
+    },
+  });
+
+export default styleSheet;

--- a/app/components/UI/Perps/components/PerpsEmptyBalance/PerpsEmptyBalance.test.tsx
+++ b/app/components/UI/Perps/components/PerpsEmptyBalance/PerpsEmptyBalance.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import PerpsEmptyBalance from './PerpsEmptyBalance';
+import { PerpsMarketBalanceActionsSelectorsIDs } from '../../Perps.testIds';
+
+jest.mock('../../../../../component-library/hooks', () => ({
+  useStyles: jest.fn(() => ({
+    styles: {
+      balanceText: { fontWeight: '500' },
+    },
+  })),
+}));
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => {
+    const mockStrings: Record<string, string> = {
+      'perps.add_funds': 'Add funds',
+    };
+    return mockStrings[key] ?? key;
+  }),
+}));
+
+describe('PerpsEmptyBalance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders $0.00 balance text', () => {
+      const onAddFunds = jest.fn();
+
+      const { getByText } = render(
+        <PerpsEmptyBalance onAddFunds={onAddFunds} />,
+      );
+
+      expect(getByText('$0.00')).toBeTruthy();
+    });
+
+    it('renders balance value with correct testID', () => {
+      const onAddFunds = jest.fn();
+
+      const { getByTestId } = render(
+        <PerpsEmptyBalance onAddFunds={onAddFunds} />,
+      );
+
+      expect(
+        getByTestId(PerpsMarketBalanceActionsSelectorsIDs.BALANCE_VALUE),
+      ).toBeTruthy();
+    });
+
+    it('renders Add funds button', () => {
+      const onAddFunds = jest.fn();
+
+      const { getByText } = render(
+        <PerpsEmptyBalance onAddFunds={onAddFunds} />,
+      );
+
+      expect(getByText('Add funds')).toBeTruthy();
+    });
+
+    it('renders Add funds button with correct testID', () => {
+      const onAddFunds = jest.fn();
+
+      const { getByTestId } = render(
+        <PerpsEmptyBalance onAddFunds={onAddFunds} />,
+      );
+
+      expect(
+        getByTestId(PerpsMarketBalanceActionsSelectorsIDs.ADD_FUNDS_BUTTON),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('onAddFunds callback', () => {
+    it('calls onAddFunds when Add funds button is pressed', () => {
+      const onAddFunds = jest.fn();
+
+      const { getByTestId } = render(
+        <PerpsEmptyBalance onAddFunds={onAddFunds} />,
+      );
+
+      fireEvent.press(
+        getByTestId(PerpsMarketBalanceActionsSelectorsIDs.ADD_FUNDS_BUTTON),
+      );
+
+      expect(onAddFunds).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onAddFunds each time Add funds button is pressed', () => {
+      const onAddFunds = jest.fn();
+
+      const { getByTestId } = render(
+        <PerpsEmptyBalance onAddFunds={onAddFunds} />,
+      );
+
+      const addFundsButton = getByTestId(
+        PerpsMarketBalanceActionsSelectorsIDs.ADD_FUNDS_BUTTON,
+      );
+
+      fireEvent.press(addFundsButton);
+      fireEvent.press(addFundsButton);
+
+      expect(onAddFunds).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/app/components/UI/Perps/components/PerpsEmptyBalance/PerpsEmptyBalance.tsx
+++ b/app/components/UI/Perps/components/PerpsEmptyBalance/PerpsEmptyBalance.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Image } from 'react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import { strings } from '../../../../../locales/i18n';
+import { LEARN_MORE_CONFIG } from '../../constants/perpsConfig';
+import { PerpsMarketBalanceActionsSelectorsIDs } from '../../Perps.testIds';
+import PerpsEmptyStateIcon from '../../../../../images/perps-home-empty-state.png';
+
+export interface PerpsEmptyBalanceProps {
+  onAddFunds: () => void;
+  onLearnMore: () => void;
+}
+
+const PerpsEmptyBalance: React.FC<PerpsEmptyBalanceProps> = ({
+  onAddFunds,
+  onLearnMore,
+}) => {
+  const tw = useTailwind();
+
+  return (
+    <Box twClassName="p-6">
+      <Box twClassName="items-center mb-6">
+        <Image
+          source={PerpsEmptyStateIcon}
+          style={tw.style('w-24 h-24 mb-4')}
+          resizeMode="contain"
+        />
+        <Text
+          variant={TextVariant.HeadingMD}
+          color={TextColor.Default}
+          style={tw.style('mb-2 text-center')}
+          testID={PerpsMarketBalanceActionsSelectorsIDs.EMPTY_STATE_TITLE}
+        >
+          {strings('perps.trade_perps')}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMD}
+          color={TextColor.Alternative}
+          style={tw.style('text-center')}
+          testID={PerpsMarketBalanceActionsSelectorsIDs.EMPTY_STATE_DESCRIPTION}
+        >
+          {strings('perps.trade_perps_description')}
+        </Text>
+      </Box>
+      <Button
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Lg}
+        onPress={onAddFunds}
+        isFullWidth
+        testID={PerpsMarketBalanceActionsSelectorsIDs.ADD_FUNDS_BUTTON}
+        style={tw.style('mb-3')}
+      >
+        {strings('perps.add_funds')}
+      </Button>
+      <Button
+        variant={ButtonVariant.Secondary}
+        size={ButtonSize.Lg}
+        onPress={onLearnMore}
+        isFullWidth
+        testID={PerpsMarketBalanceActionsSelectorsIDs.LEARN_MORE_BUTTON}
+      >
+        {strings(LEARN_MORE_CONFIG.TitleKey)}
+      </Button>
+    </Box>
+  );
+};
+
+export default PerpsEmptyBalance;

--- a/app/components/UI/Perps/components/PerpsEmptyBalance/PerpsEmptyBalance.tsx
+++ b/app/components/UI/Perps/components/PerpsEmptyBalance/PerpsEmptyBalance.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Image } from 'react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
   Button,
   ButtonSize,
   ButtonVariant,
@@ -11,66 +12,45 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import { strings } from '../../../../../locales/i18n';
-import { LEARN_MORE_CONFIG } from '../../constants/perpsConfig';
+import { useStyles } from '../../../../../component-library/hooks';
+import { strings } from '../../../../../../locales/i18n';
 import { PerpsMarketBalanceActionsSelectorsIDs } from '../../Perps.testIds';
-import PerpsEmptyStateIcon from '../../../../../images/perps-home-empty-state.png';
+import styleSheet from './PerpsEmptyBalance.styles';
 
 export interface PerpsEmptyBalanceProps {
   onAddFunds: () => void;
-  onLearnMore: () => void;
 }
 
 const PerpsEmptyBalance: React.FC<PerpsEmptyBalanceProps> = ({
   onAddFunds,
-  onLearnMore,
 }) => {
-  const tw = useTailwind();
+  const { styles } = useStyles(styleSheet, {});
 
   return (
-    <Box twClassName="p-6">
-      <Box twClassName="items-center mb-6">
-        <Image
-          source={PerpsEmptyStateIcon}
-          style={tw.style('w-24 h-24 mb-4')}
-          resizeMode="contain"
-        />
+    <Box twClassName="px-4 py-4">
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        twClassName="gap-3"
+      >
         <Text
-          variant={TextVariant.HeadingMD}
+          variant={TextVariant.DisplayLG}
           color={TextColor.Default}
-          style={tw.style('mb-2 text-center')}
-          testID={PerpsMarketBalanceActionsSelectorsIDs.EMPTY_STATE_TITLE}
+          style={styles.balanceText}
+          testID={PerpsMarketBalanceActionsSelectorsIDs.BALANCE_VALUE}
         >
-          {strings('perps.trade_perps')}
+          $0.00
         </Text>
-        <Text
-          variant={TextVariant.BodyMD}
-          color={TextColor.Alternative}
-          style={tw.style('text-center')}
-          testID={PerpsMarketBalanceActionsSelectorsIDs.EMPTY_STATE_DESCRIPTION}
+        <Button
+          variant={ButtonVariant.Secondary}
+          size={ButtonSize.Lg}
+          onPress={onAddFunds}
+          testID={PerpsMarketBalanceActionsSelectorsIDs.ADD_FUNDS_BUTTON}
         >
-          {strings('perps.trade_perps_description')}
-        </Text>
+          {strings('perps.add_funds')}
+        </Button>
       </Box>
-      <Button
-        variant={ButtonVariant.Primary}
-        size={ButtonSize.Lg}
-        onPress={onAddFunds}
-        isFullWidth
-        testID={PerpsMarketBalanceActionsSelectorsIDs.ADD_FUNDS_BUTTON}
-        style={tw.style('mb-3')}
-      >
-        {strings('perps.add_funds')}
-      </Button>
-      <Button
-        variant={ButtonVariant.Secondary}
-        size={ButtonSize.Lg}
-        onPress={onLearnMore}
-        isFullWidth
-        testID={PerpsMarketBalanceActionsSelectorsIDs.LEARN_MORE_BUTTON}
-      >
-        {strings(LEARN_MORE_CONFIG.TitleKey)}
-      </Button>
     </Box>
   );
 };

--- a/app/components/UI/Perps/components/PerpsEmptyBalance/index.ts
+++ b/app/components/UI/Perps/components/PerpsEmptyBalance/index.ts
@@ -1,0 +1,2 @@
+export { default } from './PerpsEmptyBalance';
+export type { PerpsEmptyBalanceProps } from './PerpsEmptyBalance';

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
@@ -150,6 +150,9 @@ jest.mock('@metamask/design-system-react-native', () => {
     BoxAlignItems: {
       Center: 'center',
     },
+    BoxJustifyContent: {
+      Between: 'space-between',
+    },
     ButtonSize: {
       Sm: 'sm',
       Md: 'md',
@@ -607,20 +610,21 @@ describe('PerpsMarketBalanceActions', () => {
       });
 
       // Act
-      const { getByText, getByTestId, queryByTestId } = renderWithProvider(
+      const { getByText, getByTestId } = renderWithProvider(
         <PerpsMarketBalanceActions />,
         { state: createMockState() },
         false, // Disable NavigationContainer
       );
 
-      // Assert - Should show empty state UI instead of balance display
+      // Assert - Should show empty state UI: $0.00 balance and Add Funds button
       expect(
-        getByTestId(PerpsMarketBalanceActionsSelectorsIDs.EMPTY_STATE_TITLE),
+        getByTestId(PerpsMarketBalanceActionsSelectorsIDs.BALANCE_VALUE),
+      ).toBeOnTheScreen();
+      expect(getByText('$0.00')).toBeOnTheScreen();
+      expect(
+        getByTestId(PerpsMarketBalanceActionsSelectorsIDs.ADD_FUNDS_BUTTON),
       ).toBeOnTheScreen();
       expect(getByText('perps.add_funds')).toBeOnTheScreen();
-      expect(
-        queryByTestId(PerpsMarketBalanceActionsSelectorsIDs.BALANCE_VALUE),
-      ).toBeNull();
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
@@ -1,12 +1,5 @@
-import React, {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  useMemo,
-} from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { Animated, Modal, View } from 'react-native';
-import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
@@ -21,7 +14,6 @@ import Text, {
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
 import { strings } from '../../../../../../locales/i18n';
-import Routes from '../../../../../constants/navigation/Routes';
 import { useColorPulseAnimation, useBalanceComparison } from '../../hooks';
 import { usePerpsHomeActions } from '../../hooks/usePerpsHomeActions';
 import PerpsBottomSheetTooltip from '../PerpsBottomSheetTooltip';
@@ -30,7 +22,6 @@ import {
   formatPerpsFiat,
   PRICE_RANGES_MINIMAL_VIEW,
 } from '../../utils/formatUtils';
-import type { PerpsNavigationParamList } from '../../controllers/types';
 import { PerpsMarketBalanceActionsSelectorsIDs } from '../../Perps.testIds';
 import { BigNumber } from 'bignumber.js';
 import { INITIAL_AMOUNT_UI_PROGRESS } from '../../constants/hyperLiquidConfig';
@@ -71,7 +62,6 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
   showActionButtons = true,
 }) => {
   const tw = useTailwind();
-  const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
   const { isDepositInProgress } = usePerpsDepositProgress();
 
   // Get withdrawal requests filtered by current account using memoized selector
@@ -187,12 +177,6 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
 
   const availableBalance = perpsAccount?.availableBalance || '0';
 
-  const handleLearnMore = useCallback(() => {
-    navigation.navigate(Routes.PERPS.TUTORIAL, {
-      source: PerpsEventValues.SOURCE.PERPS_HOME,
-    });
-  }, [navigation]);
-
   // Show skeleton while loading initial account data
   if (isInitialLoading) {
     return <PerpsMarketBalanceActionsSkeleton />;
@@ -207,8 +191,7 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
     <>
       <Box
         testID={PerpsMarketBalanceActionsSelectorsIDs.CONTAINER}
-        twClassName={isBalanceEmpty ? 'mx-4 mt-4 mb-4 rounded-xl' : 'mb-4'}
-        style={isBalanceEmpty ? tw.style('bg-background-section') : undefined}
+        twClassName={isBalanceEmpty ? 'mt-4 mb-4 rounded-xl' : 'mb-4'}
       >
         <PerpsProgressBar
           progressAmount={INITIAL_AMOUNT_UI_PROGRESS}
@@ -246,10 +229,7 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
         )}
         {/* Balance Section */}
         {isBalanceEmpty ? (
-          <PerpsEmptyBalance
-            onAddFunds={handleAddFunds}
-            onLearnMore={handleLearnMore}
-          />
+          <PerpsEmptyBalance onAddFunds={handleAddFunds} />
         ) : (
           <Box twClassName="px-4 pt-4 pb-4">
             <Animated.View style={[getBalanceAnimatedStyle]}>

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
@@ -5,7 +5,7 @@ import React, {
   useState,
   useMemo,
 } from 'react';
-import { Animated, Image, Modal, View } from 'react-native';
+import { Animated, Modal, View } from 'react-native';
 import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -22,7 +22,6 @@ import Text, {
 } from '../../../../../component-library/components/Texts/Text';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
-import { LEARN_MORE_CONFIG } from '../../constants/perpsConfig';
 import { useColorPulseAnimation, useBalanceComparison } from '../../hooks';
 import { usePerpsHomeActions } from '../../hooks/usePerpsHomeActions';
 import PerpsBottomSheetTooltip from '../PerpsBottomSheetTooltip';
@@ -38,8 +37,8 @@ import { INITIAL_AMOUNT_UI_PROGRESS } from '../../constants/hyperLiquidConfig';
 import { usePerpsDepositProgress } from '../../hooks/usePerpsDepositProgress';
 import { usePerpsTransactionState } from '../../hooks/usePerpsTransactionState';
 import { convertPerpsAmountToUSD } from '../../utils/amountConversion';
-import PerpsEmptyStateIcon from '../../../../../images/perps-home-empty-state.png';
 import { Skeleton } from '../../../../../component-library/components/Skeleton';
+import PerpsEmptyBalance from '../PerpsEmptyBalance';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import { PerpsProgressBar } from '../PerpsProgressBar';
 import { selectWithdrawalRequestsBySelectedAccount } from '../../../../../selectors/perps';
@@ -247,52 +246,10 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
         )}
         {/* Balance Section */}
         {isBalanceEmpty ? (
-          <Box twClassName="p-6">
-            <Box twClassName="items-center mb-6">
-              <Image
-                source={PerpsEmptyStateIcon}
-                style={tw.style('w-24 h-24 mb-4')}
-                resizeMode="contain"
-              />
-              <Text
-                variant={TextVariant.HeadingMD}
-                color={TextColor.Default}
-                style={tw.style('mb-2 text-center')}
-                testID={PerpsMarketBalanceActionsSelectorsIDs.EMPTY_STATE_TITLE}
-              >
-                {strings('perps.trade_perps')}
-              </Text>
-              <Text
-                variant={TextVariant.BodyMD}
-                color={TextColor.Alternative}
-                style={tw.style('text-center')}
-                testID={
-                  PerpsMarketBalanceActionsSelectorsIDs.EMPTY_STATE_DESCRIPTION
-                }
-              >
-                {strings('perps.trade_perps_description')}
-              </Text>
-            </Box>
-            <Button
-              variant={ButtonVariant.Primary}
-              size={ButtonSize.Lg}
-              onPress={handleAddFunds}
-              isFullWidth
-              testID={PerpsMarketBalanceActionsSelectorsIDs.ADD_FUNDS_BUTTON}
-              style={tw.style('mb-3')}
-            >
-              {strings('perps.add_funds')}
-            </Button>
-            <Button
-              variant={ButtonVariant.Secondary}
-              size={ButtonSize.Lg}
-              onPress={handleLearnMore}
-              isFullWidth
-              testID={PerpsMarketBalanceActionsSelectorsIDs.LEARN_MORE_BUTTON}
-            >
-              {strings(LEARN_MORE_CONFIG.TitleKey)}
-            </Button>
-          </Box>
+          <PerpsEmptyBalance
+            onAddFunds={handleAddFunds}
+            onLearnMore={handleLearnMore}
+          />
         ) : (
           <Box twClassName="px-4 pt-4 pb-4">
             <Animated.View style={[getBalanceAnimatedStyle]}>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The empty-state UI for the Perps balance section (icon, title, description, buttons) was inlined inside `PerpsMarketBalanceActions`. This PR extracts it into a dedicated `PerpsEmptyBalance` component and simplifies the empty state to show only:
- **$0.00** with Amount Display Lg styling (40px, font-weight 500, line-height 50px) and a stylesheet for `fontWeight: '500'`.
- **Add funds** button (design-system Secondary) in a horizontal layout with the balance.


## **Changelog**



CHANGELOG entry: Added new design of the perps empty state


## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1030

## **Manual testing steps**

```gherkin
Feature: Perps empty balance

  Scenario: user sees empty balance state on Perps home
    Given the user has a Perps account with zero balance

    When the user opens the Perps home screen

    Then the balance area shows "$0.00" with large display styling
    And an "Add funds" button is shown on the right
    And tapping "Add funds" opens the add funds flow
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="1206" height="2622" alt="simulator_screenshot_7F84C4ED-5E78-466E-82F4-E3BEC34D4A03" src="https://github.com/user-attachments/assets/10a31aca-c41e-4213-adbb-ed6fcf457646" />

### **After**

<!-- [screenshots/recordings] -->
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-03 at 16 18 17" src="https://github.com/user-attachments/assets/89de4b0f-cee2-4ad3-b208-0cd5b23518f9" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that changes the Perps empty-balance presentation and associated test expectations; main risk is visual/layout regressions or stale testIDs around the removed empty-state content.
> 
> **Overview**
> Refactors the Perps balance empty state by extracting it into a new `PerpsEmptyBalance` component and simplifying the UI to a horizontal row showing **`$0.00`** and a **Secondary** “Add funds” button.
> 
> Updates `PerpsMarketBalanceActions` to render this new component when balance is zero (removing the previous icon/title/description and “Learn more” button), and adjusts unit tests/mocks to assert the new empty-state elements and testIDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9da14971c83023ec34b15df8ceeda0f2546267a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->