### PR TITLE
test: remove redundant BIP-44 mock

### DIFF
--- a/e2e/specs/multichain/connections/multiple-provider-connections-regression.spec.ts
+++ b/e2e/specs/multichain/connections/multiple-provider-connections-regression.spec.ts
@@ -17,8 +17,6 @@ import ConnectedAccountsModal from '../../../pages/Browser/ConnectedAccountsModa
 import NetworkConnectMultiSelector from '../../../pages/Browser/NetworkConnectMultiSelector';
 import Assertions from '../../../../tests/framework/Assertions';
 import { NetworkNonPemittedBottomSheetSelectorsText } from '../../../../app/components/Views/NetworkConnect/NetworkNonPemittedBottomSheet.testIds';
-import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../../../tests/api-mocking/mock-responses/feature-flags-mocks';
-import { setupRemoteFeatureFlagsMock } from '../../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
 
 describe(
   RegressionNetworkExpansion('Multiple Provider Connections [Regression]'),
@@ -77,12 +75,6 @@ describe(
             },
           ],
           restartDevice: true,
-          testSpecificMock: async (mockServer) => {
-            await setupRemoteFeatureFlagsMock(
-              mockServer,
-              remoteFeatureMultichainAccountsAccountDetailsV2(true),
-            );
-          },
         },
         async () => {
           await loginToApp();
@@ -119,12 +111,6 @@ describe(
             },
           ],
           restartDevice: true,
-          testSpecificMock: async (mockServer) => {
-            await setupRemoteFeatureFlagsMock(
-              mockServer,
-              remoteFeatureMultichainAccountsAccountDetailsV2(true),
-            );
-          },
         },
         async () => {
           await loginToApp();

--- a/e2e/specs/multichain/connections/multiple-provider-connections.spec.ts
+++ b/e2e/specs/multichain/connections/multiple-provider-connections.spec.ts
@@ -19,8 +19,6 @@ import {
 import { DappVariants } from '../../../../tests/framework/Constants';
 import { createLogger } from '../../../../tests/framework/logger';
 import { requestPermissions } from './helpers';
-import { setupRemoteFeatureFlagsMock } from '../../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../../../tests/api-mocking/mock-responses/feature-flags-mocks';
 
 const logger = createLogger({
   name: 'multiple-provider-connections.spec.ts',
@@ -64,12 +62,6 @@ describe(SmokeNetworkExpansion('Multiple Standard Dapp Connections'), () => {
           })
           .build(),
         restartDevice: true,
-        testSpecificMock: async (mockServer) => {
-          await setupRemoteFeatureFlagsMock(
-            mockServer,
-            remoteFeatureMultichainAccountsAccountDetailsV2(true),
-          );
-        },
       },
       async () => {
         await loginToApp();
@@ -103,12 +95,6 @@ describe(SmokeNetworkExpansion('Multiple Standard Dapp Connections'), () => {
           },
         ],
         restartDevice: true,
-        testSpecificMock: async (mockServer) => {
-          await setupRemoteFeatureFlagsMock(
-            mockServer,
-            remoteFeatureMultichainAccountsAccountDetailsV2(true),
-          );
-        },
       },
       async () => {
         await loginToApp();
@@ -152,12 +138,6 @@ describe(SmokeNetworkExpansion('Multiple Standard Dapp Connections'), () => {
           },
         ],
         restartDevice: true,
-        testSpecificMock: async (mockServer) => {
-          await setupRemoteFeatureFlagsMock(
-            mockServer,
-            remoteFeatureMultichainAccountsAccountDetailsV2(true),
-          );
-        },
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/multichain/solana-wallet-standard/connect.spec.ts
+++ b/e2e/specs/multichain/solana-wallet-standard/connect.spec.ts
@@ -14,8 +14,6 @@ import { Utilities } from '../../../../tests/framework';
 import { loginToApp, navigateToBrowserView } from '../../../viewHelper';
 import { withFixtures } from '../../../../tests/framework/fixtures/FixtureHelper';
 import FixtureBuilder from '../../../../tests/framework/fixtures/FixtureBuilder';
-import { setupRemoteFeatureFlagsMock } from '../../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../../../tests/api-mocking/mock-responses/feature-flags-mocks';
 import { DappVariants } from '../../../../tests/framework/Constants';
 
 describe(SmokeNetworkExpansion('Solana Wallet Standard E2E - Connect'), () => {
@@ -33,11 +31,6 @@ describe(SmokeNetworkExpansion('Solana Wallet Standard E2E - Connect'), () => {
             dappVariant: DappVariants.SOLANA_TEST_DAPP,
           },
         ],
-        testSpecificMock: async (mockServer) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureMultichainAccountsAccountDetailsV2(true),
-          });
-        },
       },
       async () => {
         await loginToApp();
@@ -76,11 +69,6 @@ describe(SmokeNetworkExpansion('Solana Wallet Standard E2E - Connect'), () => {
             dappVariant: DappVariants.SOLANA_TEST_DAPP,
           },
         ],
-        testSpecificMock: async (mockServer) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureMultichainAccountsAccountDetailsV2(true),
-          });
-        },
       },
       async () => {
         await loginToApp();
@@ -114,11 +102,6 @@ describe(SmokeNetworkExpansion('Solana Wallet Standard E2E - Connect'), () => {
             dappVariant: DappVariants.SOLANA_TEST_DAPP,
           },
         ],
-        testSpecificMock: async (mockServer) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureMultichainAccountsAccountDetailsV2(true),
-          });
-        },
       },
       async () => {
         await loginToApp();
@@ -151,11 +134,6 @@ describe(SmokeNetworkExpansion('Solana Wallet Standard E2E - Connect'), () => {
             dappVariant: DappVariants.SOLANA_TEST_DAPP,
           },
         ],
-        testSpecificMock: async (mockServer) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureMultichainAccountsAccountDetailsV2(true),
-          });
-        },
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/multichain/solana-wallet-standard/signMessage.spec.ts
+++ b/e2e/specs/multichain/solana-wallet-standard/signMessage.spec.ts
@@ -4,8 +4,6 @@ import { connectSolanaTestDapp, navigateToSolanaTestDApp } from './testHelpers';
 import Assertions from '../../../../tests/framework/Assertions';
 import { logger } from '../../../../tests/framework/logger';
 import { loginToApp } from '../../../viewHelper';
-import { setupRemoteFeatureFlagsMock } from '../../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../../../tests/api-mocking/mock-responses/feature-flags-mocks';
 import { DappVariants } from '../../../../tests/framework/Constants';
 import FixtureBuilder from '../../../../tests/framework/fixtures/FixtureBuilder';
 import { withFixtures } from '../../../../tests/framework/fixtures/FixtureHelper';
@@ -27,11 +25,6 @@ describe(
               dappVariant: DappVariants.SOLANA_TEST_DAPP,
             },
           ],
-          testSpecificMock: async (mockServer) => {
-            await setupRemoteFeatureFlagsMock(mockServer, {
-              ...remoteFeatureMultichainAccountsAccountDetailsV2(true),
-            });
-          },
         },
         async () => {
           await loginToApp();

--- a/e2e/specs/multichain/solana-wallet-standard/transferSol.spec.ts
+++ b/e2e/specs/multichain/solana-wallet-standard/transferSol.spec.ts
@@ -2,8 +2,6 @@ import { SmokeNetworkExpansion } from '../../../tags';
 import SolanaTestDApp from '../../../pages/Browser/SolanaTestDApp';
 import { connectSolanaTestDapp, navigateToSolanaTestDApp } from './testHelpers';
 import { loginToApp } from '../../../viewHelper';
-import { setupRemoteFeatureFlagsMock } from '../../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../../../tests/api-mocking/mock-responses/feature-flags-mocks';
 import { DappVariants } from '../../../../tests/framework/Constants';
 import FixtureBuilder from '../../../../tests/framework/fixtures/FixtureBuilder';
 import { withFixtures } from '../../../../tests/framework/fixtures/FixtureHelper';
@@ -26,11 +24,6 @@ describe(
               dappVariant: DappVariants.SOLANA_TEST_DAPP,
             },
           ],
-          testSpecificMock: async (mockServer) => {
-            await setupRemoteFeatureFlagsMock(mockServer, {
-              ...remoteFeatureMultichainAccountsAccountDetailsV2(true),
-            });
-          },
         },
         async () => {
           await loginToApp();
@@ -59,11 +52,6 @@ describe(
               dappVariant: DappVariants.SOLANA_TEST_DAPP,
             },
           ],
-          testSpecificMock: async (mockServer) => {
-            await setupRemoteFeatureFlagsMock(mockServer, {
-              ...remoteFeatureMultichainAccountsAccountDetailsV2(true),
-            });
-          },
         },
         async () => {
           await loginToApp();

--- a/e2e/specs/snaps/test-snap-multichain-provider.spec.ts
+++ b/e2e/specs/snaps/test-snap-multichain-provider.spec.ts
@@ -8,10 +8,7 @@ import ConnectBottomSheet from '../../pages/Browser/ConnectBottomSheet';
 import RequestTypes from '../../pages/Browser/Confirmations/RequestTypes';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
-import {
-  confirmationFeatureFlags,
-  remoteFeatureMultichainAccountsAccountDetailsV2,
-} from '../../../tests/api-mocking/mock-responses/feature-flags-mocks';
+import { confirmationFeatureFlags } from '../../../tests/api-mocking/mock-responses/feature-flags-mocks';
 import { mockGenesisBlocks } from './mocks';
 
 jest.setTimeout(150_000);
@@ -26,11 +23,7 @@ describe(FlaskBuildTests('Multichain Provider Snap Tests'), () => {
         testSpecificMock: async (mockServer: Mockttp) => {
           await setupRemoteFeatureFlagsMock(
             mockServer,
-            Object.assign(
-              {},
-              ...confirmationFeatureFlags,
-              remoteFeatureMultichainAccountsAccountDetailsV2(true),
-            ),
+            Object.assign({}, ...confirmationFeatureFlags),
           );
           await mockGenesisBlocks(mockServer);
         },

--- a/tests/regression/assets/multichain/asset-list.spec.ts
+++ b/tests/regression/assets/multichain/asset-list.spec.ts
@@ -7,10 +7,7 @@ import Assertions from '../../../framework/Assertions';
 import TokenOverview from '../../../../e2e/pages/wallet/TokenOverview';
 import NetworkManager from '../../../../e2e/pages/wallet/NetworkManager';
 import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import {
-  remoteFeatureFlagTronAccounts,
-  remoteFeatureMultichainAccountsAccountDetailsV2,
-} from '../../../api-mocking/mock-responses/feature-flags-mocks.ts';
+import { remoteFeatureFlagTronAccounts } from '../../../api-mocking/mock-responses/feature-flags-mocks.ts';
 
 const ETHEREUM_NAME = 'Ethereum';
 const AVAX_NAME = 'AVAX';
@@ -104,7 +101,6 @@ describe(RegressionAssets('Asset list - '), () => {
         testSpecificMock: async (mockServer) => {
           await setupRemoteFeatureFlagsMock(mockServer, {
             ...remoteFeatureFlagTronAccounts(true),
-            ...remoteFeatureMultichainAccountsAccountDetailsV2(true),
           });
         },
       },
@@ -134,11 +130,6 @@ describe(RegressionAssets('Asset list - '), () => {
       {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
-        testSpecificMock: async (mockServer) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureMultichainAccountsAccountDetailsV2(true),
-          });
-        },
       },
       async () => {
         await loginToApp();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.  
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Several E2E tests are still using the `remoteFeatureMultichainAccountsAccountDetailsV2` util to mock the remote feature flag value. This PR removes the usage of this method with the value `true` since this is already the default behaviour covered by the default fixture.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: null

## **Manual testing steps**

Not applicable

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

Not applicable

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes remove explicit enabling of `enableMultichainAccountsState2`; risk is low but could cause E2E flakes if the default feature-flag behavior changes in the test harness.
> 
> **Overview**
> Removes explicit mocking of the `remoteFeatureMultichainAccountsAccountDetailsV2(true)` remote feature flag across multiple multichain E2E/regression specs, relying on the default-enabled behavior instead.
> 
> Cleans up related imports and `testSpecificMock` blocks (including the multichain provider snap test and multichain asset-list regression), simplifying fixture setup while preserving the existing test flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63da2a2f354342190c98490e5b8735063284abd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->