### PR TITLE
refactor: convert promise chains to async/await in AnimatedQRScanner

### DIFF
--- a/app/components/UI/QRHardware/AnimatedQRScanner.tsx
+++ b/app/components/UI/QRHardware/AnimatedQRScanner.tsx
@@ -166,30 +166,31 @@ const AnimatedQRScannerModal = (props: AnimatedQRScannerProps) => {
 
   // Helper to send analytics with device name
   const sendErrorAnalytics = useCallback(
-    (properties: Record<string, unknown>) => {
-      withQrKeyring(({ keyring }) => Promise.resolve(keyring.getName()))
-        .then((deviceName) => {
-          trackEvent(
-            createEventBuilder(MetaMetricsEvents.HARDWARE_WALLET_ERROR)
-              .addProperties({
-                ...properties,
-                device_model: deviceName,
-                device_type: HardwareDeviceTypes.QR,
-              })
-              .build(),
-          );
-        })
-        .catch(() => {
-          trackEvent(
-            createEventBuilder(MetaMetricsEvents.HARDWARE_WALLET_ERROR)
-              .addProperties({
-                ...properties,
-                device_model: 'Unknown',
-                device_type: HardwareDeviceTypes.QR,
-              })
-              .build(),
-          );
-        });
+    async (properties: Record<string, unknown>) => {
+      try {
+        const deviceName = await withQrKeyring(async ({ keyring }) =>
+          keyring.getName(),
+        );
+        trackEvent(
+          createEventBuilder(MetaMetricsEvents.HARDWARE_WALLET_ERROR)
+            .addProperties({
+              ...properties,
+              device_model: deviceName,
+              device_type: HardwareDeviceTypes.QR,
+            })
+            .build(),
+        );
+      } catch (e) {
+        trackEvent(
+          createEventBuilder(MetaMetricsEvents.HARDWARE_WALLET_ERROR)
+            .addProperties({
+              ...properties,
+              device_model: 'Unknown',
+              device_type: HardwareDeviceTypes.QR,
+            })
+            .build(),
+        );
+      }
     },
     [trackEvent, createEventBuilder],
   );


### PR DESCRIPTION
## **Description**

convert promise chains to async/await in AnimatedQRScanner

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-680

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

`~`

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to error-analytics plumbing; behavior should be equivalent but could affect when/if analytics fire if the async keyring lookup throws differently.
> 
> **Overview**
> Refactors `AnimatedQRScanner` error analytics to replace `.then/.catch` promise chaining with `async/await` and a `try/catch` around the QR keyring device-name lookup.
> 
> Analytics events for `MetaMetricsEvents.HARDWARE_WALLET_ERROR` are still emitted with `device_model` set to the resolved keyring name, or `'Unknown'` if lookup fails, with no functional changes outside this error-reporting path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ed261482b08e99602b6e1f01b5a00a965d9c1fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->