### PR TITLE
fix: MUSD-285 get musd cta displayed for account with no stablecoins clicking on the cta does nothing

### DIFF
--- a/app/components/UI/Earn/components/EarnBalance/EarnBalance.test.tsx
+++ b/app/components/UI/Earn/components/EarnBalance/EarnBalance.test.tsx
@@ -293,6 +293,7 @@ describe('EarnBalance', () => {
 
       mockUseMusdConversionTokens.mockReturnValue({
         isConversionToken: jest.fn().mockReturnValue(true),
+        hasConvertibleTokensByChainId: jest.fn().mockReturnValue(true),
         filterAllowedTokens: jest.fn(),
         tokens: [],
         isMusdSupportedOnChain: jest.fn().mockReturnValue(true),
@@ -322,6 +323,7 @@ describe('EarnBalance', () => {
 
       mockUseMusdConversionTokens.mockReturnValue({
         isConversionToken: jest.fn().mockReturnValue(true),
+        hasConvertibleTokensByChainId: jest.fn().mockReturnValue(true),
         filterAllowedTokens: jest.fn(),
         tokens: [],
         isMusdSupportedOnChain: jest.fn().mockReturnValue(true),

--- a/app/components/UI/Earn/components/EarnLendingBalance/EarnLendingBalance.test.tsx
+++ b/app/components/UI/Earn/components/EarnLendingBalance/EarnLendingBalance.test.tsx
@@ -437,6 +437,7 @@ describe('EarnLendingBalance', () => {
       >
     ).mockReturnValue({
       isConversionToken: jest.fn().mockReturnValue(false),
+      hasConvertibleTokensByChainId: jest.fn().mockReturnValue(false),
       filterAllowedTokens: jest.fn().mockReturnValue([]),
       isMusdSupportedOnChain: jest.fn().mockReturnValue(false),
       tokens: [],
@@ -594,6 +595,7 @@ describe('EarnLendingBalance', () => {
       >
     ).mockReturnValue({
       isConversionToken: jest.fn().mockReturnValue(true),
+      hasConvertibleTokensByChainId: jest.fn().mockReturnValue(false),
       filterAllowedTokens: jest.fn().mockReturnValue([]),
       isMusdSupportedOnChain: jest.fn().mockReturnValue(true),
       tokens: [],
@@ -622,6 +624,7 @@ describe('EarnLendingBalance', () => {
       >
     ).mockReturnValue({
       isConversionToken: jest.fn().mockReturnValue(false),
+      hasConvertibleTokensByChainId: jest.fn().mockReturnValue(false),
       filterAllowedTokens: jest.fn().mockReturnValue([]),
       isMusdSupportedOnChain: jest.fn().mockReturnValue(true),
       tokens: [],
@@ -656,6 +659,7 @@ describe('EarnLendingBalance', () => {
       >
     ).mockReturnValue({
       isConversionToken: jest.fn().mockReturnValue(true),
+      hasConvertibleTokensByChainId: jest.fn().mockReturnValue(false),
       filterAllowedTokens: jest.fn().mockReturnValue([]),
       isMusdSupportedOnChain: jest.fn().mockReturnValue(true),
       tokens: [],
@@ -693,6 +697,7 @@ describe('EarnLendingBalance', () => {
       >
     ).mockReturnValue({
       isConversionToken: jest.fn().mockReturnValue(true),
+      hasConvertibleTokensByChainId: jest.fn().mockReturnValue(false),
       filterAllowedTokens: jest.fn().mockReturnValue([]),
       isMusdSupportedOnChain: jest.fn().mockReturnValue(true),
       tokens: [],
@@ -751,6 +756,7 @@ describe('EarnLendingBalance', () => {
       >
     ).mockReturnValue({
       isConversionToken: jest.fn().mockReturnValue(true),
+      hasConvertibleTokensByChainId: jest.fn().mockReturnValue(false),
       filterAllowedTokens: jest.fn().mockReturnValue([]),
       isMusdSupportedOnChain: jest.fn().mockReturnValue(true),
       tokens: [],

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.test.tsx
@@ -13,7 +13,10 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import MusdConversionAssetListCta from '.';
 import { useMusdConversionFlowData } from '../../../hooks/useMusdConversionFlowData';
 import { useMusdConversion } from '../../../hooks/useMusdConversion';
-import { useMusdCtaVisibility } from '../../../hooks/useMusdCtaVisibility';
+import {
+  BUY_GET_MUSD_CTA_VARIANT,
+  useMusdCtaVisibility,
+} from '../../../hooks/useMusdCtaVisibility';
 import { useRampNavigation } from '../../../../Ramp/hooks/useRampNavigation';
 import {
   MUSD_CONVERSION_APY,
@@ -134,6 +137,7 @@ describe('MusdConversionAssetListCta', () => {
         showNetworkIcon: false,
         selectedChainId: null,
         isEmptyWallet: false,
+        variant: BUY_GET_MUSD_CTA_VARIANT.GET,
       }),
       shouldShowTokenListItemCta: jest.fn(),
       shouldShowAssetOverviewCta: jest.fn(),
@@ -183,7 +187,7 @@ describe('MusdConversionAssetListCta', () => {
   });
 
   describe('CTA button text', () => {
-    it('displays "Buy mUSD" when hook returns isEmptyWallet true', () => {
+    it('displays "Buy mUSD" when CTA variant is BUY', () => {
       (
         useMusdConversionFlowData as jest.MockedFunction<
           typeof useMusdConversionFlowData
@@ -201,6 +205,20 @@ describe('MusdConversionAssetListCta', () => {
         isMusdBuyableOnChain: {},
         isMusdBuyableOnAnyChain: false,
         isMusdBuyable: false,
+      });
+
+      (
+        useMusdCtaVisibility as jest.MockedFunction<typeof useMusdCtaVisibility>
+      ).mockReturnValue({
+        shouldShowBuyGetMusdCta: jest.fn().mockReturnValue({
+          shouldShowCta: true,
+          showNetworkIcon: false,
+          selectedChainId: null,
+          isEmptyWallet: true,
+          variant: BUY_GET_MUSD_CTA_VARIANT.BUY,
+        }),
+        shouldShowTokenListItemCta: jest.fn(),
+        shouldShowAssetOverviewCta: jest.fn(),
       });
 
       const { getByText } = renderWithProvider(<MusdConversionAssetListCta />, {
@@ -227,6 +245,7 @@ describe('MusdConversionAssetListCta', () => {
           showNetworkIcon: false,
           selectedChainId: null,
           isEmptyWallet: false,
+          variant: null,
         }),
         shouldShowTokenListItemCta: jest.fn(),
         shouldShowAssetOverviewCta: jest.fn(),
@@ -265,6 +284,20 @@ describe('MusdConversionAssetListCta', () => {
         isMusdBuyableOnChain: {},
         isMusdBuyableOnAnyChain: false,
         isMusdBuyable: false,
+      });
+
+      (
+        useMusdCtaVisibility as jest.MockedFunction<typeof useMusdCtaVisibility>
+      ).mockReturnValue({
+        shouldShowBuyGetMusdCta: jest.fn().mockReturnValue({
+          shouldShowCta: true,
+          showNetworkIcon: false,
+          selectedChainId: null,
+          isEmptyWallet: true,
+          variant: BUY_GET_MUSD_CTA_VARIANT.BUY,
+        }),
+        shouldShowTokenListItemCta: jest.fn(),
+        shouldShowAssetOverviewCta: jest.fn(),
       });
     });
 
@@ -363,6 +396,8 @@ describe('MusdConversionAssetListCta', () => {
           shouldShowCta: true,
           showNetworkIcon: false,
           selectedChainId: CHAIN_IDS.LINEA_MAINNET,
+          isEmptyWallet: false,
+          variant: BUY_GET_MUSD_CTA_VARIANT.GET,
         }),
         shouldShowTokenListItemCta: jest.fn(),
         shouldShowAssetOverviewCta: jest.fn(),
@@ -418,6 +453,8 @@ describe('MusdConversionAssetListCta', () => {
           shouldShowCta: true,
           showNetworkIcon: false,
           selectedChainId: CHAIN_IDS.LINEA_MAINNET,
+          isEmptyWallet: false,
+          variant: BUY_GET_MUSD_CTA_VARIANT.GET,
         }),
         shouldShowTokenListItemCta: jest.fn(),
         shouldShowAssetOverviewCta: jest.fn(),
@@ -524,6 +561,7 @@ describe('MusdConversionAssetListCta', () => {
           showNetworkIcon: false,
           selectedChainId: null,
           isEmptyWallet: false,
+          variant: null,
         }),
         shouldShowTokenListItemCta: jest.fn(),
         shouldShowAssetOverviewCta: jest.fn(),
@@ -548,6 +586,7 @@ describe('MusdConversionAssetListCta', () => {
           showNetworkIcon: false,
           selectedChainId: null,
           isEmptyWallet: true,
+          variant: BUY_GET_MUSD_CTA_VARIANT.BUY,
         }),
         shouldShowTokenListItemCta: jest.fn(),
         shouldShowAssetOverviewCta: jest.fn(),
@@ -574,6 +613,7 @@ describe('MusdConversionAssetListCta', () => {
           showNetworkIcon: false,
           selectedChainId: null,
           isEmptyWallet: true,
+          variant: BUY_GET_MUSD_CTA_VARIANT.BUY,
         }),
         shouldShowTokenListItemCta: jest.fn(),
         shouldShowAssetOverviewCta: jest.fn(),
@@ -600,6 +640,7 @@ describe('MusdConversionAssetListCta', () => {
           showNetworkIcon: true,
           selectedChainId: CHAIN_IDS.MAINNET,
           isEmptyWallet: true,
+          variant: BUY_GET_MUSD_CTA_VARIANT.BUY,
         }),
         shouldShowTokenListItemCta: jest.fn(),
         shouldShowAssetOverviewCta: jest.fn(),
@@ -624,6 +665,7 @@ describe('MusdConversionAssetListCta', () => {
           showNetworkIcon: true,
           selectedChainId: CHAIN_IDS.LINEA_MAINNET,
           isEmptyWallet: true,
+          variant: BUY_GET_MUSD_CTA_VARIANT.BUY,
         }),
         shouldShowTokenListItemCta: jest.fn(),
         shouldShowAssetOverviewCta: jest.fn(),
@@ -648,6 +690,7 @@ describe('MusdConversionAssetListCta', () => {
           showNetworkIcon: true,
           selectedChainId: CHAIN_IDS.BSC,
           isEmptyWallet: true,
+          variant: BUY_GET_MUSD_CTA_VARIANT.BUY,
         }),
         shouldShowTokenListItemCta: jest.fn(),
         shouldShowAssetOverviewCta: jest.fn(),
@@ -711,8 +754,9 @@ describe('MusdConversionAssetListCta', () => {
         shouldShowBuyGetMusdCta: jest.fn().mockReturnValue({
           shouldShowCta: true,
           showNetworkIcon: false,
-          selectedChainId,
-          isEmptyWallet,
+          selectedChainId: null,
+          isEmptyWallet: true,
+          variant: BUY_GET_MUSD_CTA_VARIANT.BUY,
         }),
         shouldShowTokenListItemCta: jest.fn(),
         shouldShowAssetOverviewCta: jest.fn(),

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.test.tsx
@@ -753,10 +753,12 @@ describe('MusdConversionAssetListCta', () => {
       ).mockReturnValue({
         shouldShowBuyGetMusdCta: jest.fn().mockReturnValue({
           shouldShowCta: true,
-          showNetworkIcon: false,
-          selectedChainId: null,
-          isEmptyWallet: true,
-          variant: BUY_GET_MUSD_CTA_VARIANT.BUY,
+          showNetworkIcon: Boolean(selectedChainId),
+          selectedChainId,
+          isEmptyWallet,
+          variant: isEmptyWallet
+            ? BUY_GET_MUSD_CTA_VARIANT.BUY
+            : BUY_GET_MUSD_CTA_VARIANT.GET,
         }),
         shouldShowTokenListItemCta: jest.fn(),
         shouldShowAssetOverviewCta: jest.fn(),
@@ -818,6 +820,7 @@ describe('MusdConversionAssetListCta', () => {
           redirects_to: EVENT_LOCATIONS.BUY_SCREEN,
           cta_type: MUSD_CTA_TYPES.PRIMARY,
           cta_text: ctaText,
+          cta_click_target: 'cta_button',
           network_chain_id: CHAIN_IDS.MAINNET,
           network_name: 'Ethereum Mainnet',
         });
@@ -837,6 +840,7 @@ describe('MusdConversionAssetListCta', () => {
           redirects_to: EVENT_LOCATIONS.BUY_SCREEN,
           cta_type: MUSD_CTA_TYPES.PRIMARY,
           cta_text: ctaText,
+          cta_click_target: 'cta_button',
           network_chain_id: null,
           network_name: strings('wallet.popular_networks'),
         });
@@ -858,6 +862,7 @@ describe('MusdConversionAssetListCta', () => {
           redirects_to: EVENT_LOCATIONS.BUY_SCREEN,
           cta_type: MUSD_CTA_TYPES.PRIMARY,
           cta_text: ctaText,
+          cta_click_target: 'cta_button',
           network_chain_id: null,
           network_name: strings('wallet.popular_networks'),
         });
@@ -879,6 +884,7 @@ describe('MusdConversionAssetListCta', () => {
           redirects_to: EVENT_LOCATIONS.CUSTOM_AMOUNT_SCREEN,
           cta_type: MUSD_CTA_TYPES.PRIMARY,
           cta_text: strings('earn.musd_conversion.get_musd'),
+          cta_click_target: 'cta_button',
           network_chain_id: null,
           network_name: strings('wallet.popular_networks'),
         });
@@ -898,6 +904,7 @@ describe('MusdConversionAssetListCta', () => {
           redirects_to: EVENT_LOCATIONS.BUY_SCREEN,
           cta_type: MUSD_CTA_TYPES.PRIMARY,
           cta_text: ctaText,
+          cta_click_target: 'cta_text_link',
           network_chain_id: null,
           network_name: strings('wallet.popular_networks'),
         });
@@ -919,6 +926,7 @@ describe('MusdConversionAssetListCta', () => {
           redirects_to: EVENT_LOCATIONS.BUY_SCREEN,
           cta_type: MUSD_CTA_TYPES.PRIMARY,
           cta_text: ctaText,
+          cta_click_target: 'cta_button',
           network_chain_id: null,
           network_name: strings('wallet.popular_networks'),
         });
@@ -940,6 +948,7 @@ describe('MusdConversionAssetListCta', () => {
           redirects_to: EVENT_LOCATIONS.CONVERSION_EDUCATION_SCREEN,
           cta_type: MUSD_CTA_TYPES.PRIMARY,
           cta_text: strings('earn.musd_conversion.get_musd'),
+          cta_click_target: 'cta_button',
           network_chain_id: null,
           network_name: strings('wallet.popular_networks'),
         });
@@ -961,6 +970,7 @@ describe('MusdConversionAssetListCta', () => {
           redirects_to: EVENT_LOCATIONS.CUSTOM_AMOUNT_SCREEN,
           cta_type: MUSD_CTA_TYPES.PRIMARY,
           cta_text: strings('earn.musd_conversion.get_musd'),
+          cta_click_target: 'cta_button',
           network_chain_id: null,
           network_name: strings('wallet.popular_networks'),
         });

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
@@ -40,6 +40,11 @@ import { MetaMetricsEvents, useMetrics } from '../../../../../hooks/useMetrics';
 import { MUSD_EVENTS_CONSTANTS } from '../../../constants/events';
 import { useNetworkName } from '../../../../../Views/confirmations/hooks/useNetworkName';
 
+enum CTA_CLICK_TARGET {
+  CTA_BUTTON = 'cta_button',
+  CTA_TEXT_LINK = 'cta_text_link',
+}
+
 const MusdConversionAssetListCta = () => {
   const { styles } = useStyles(styleSheet, {});
 
@@ -65,7 +70,7 @@ const MusdConversionAssetListCta = () => {
       ? strings('earn.musd_conversion.buy_musd')
       : strings('earn.musd_conversion.get_musd');
 
-  const submitCtaPressedEvent = (source: 'cta_button' | 'cta_text') => {
+  const submitCtaPressedEvent = (source: CTA_CLICK_TARGET) => {
     const { MUSD_CTA_TYPES, EVENT_LOCATIONS } = MUSD_EVENTS_CONSTANTS;
 
     const getRedirectLocation = () => {
@@ -79,7 +84,7 @@ const MusdConversionAssetListCta = () => {
     };
 
     const ctaText =
-      source === 'cta_button'
+      source === CTA_CLICK_TARGET.CTA_BUTTON
         ? buttonText
         : strings('earn.earn_a_percentage_bonus', {
             percentage: MUSD_CONVERSION_APY,
@@ -92,6 +97,7 @@ const MusdConversionAssetListCta = () => {
           redirects_to: getRedirectLocation(),
           cta_type: MUSD_CTA_TYPES.PRIMARY,
           cta_text: ctaText,
+          cta_click_target: source,
           network_chain_id: selectedChainId,
           network_name: networkName ?? strings('wallet.popular_networks'),
         })
@@ -99,7 +105,7 @@ const MusdConversionAssetListCta = () => {
     );
   };
 
-  const handlePress = async (source: 'cta_button' | 'cta_text') => {
+  const handlePress = async (source: CTA_CLICK_TARGET) => {
     submitCtaPressedEvent(source);
 
     if (variant === BUY_GET_MUSD_CTA_VARIANT.BUY) {
@@ -174,7 +180,9 @@ const MusdConversionAssetListCta = () => {
           <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
             MetaMask USD
           </Text>
-          <TouchableOpacity onPress={() => handlePress('cta_text')}>
+          <TouchableOpacity
+            onPress={() => handlePress(CTA_CLICK_TARGET.CTA_TEXT_LINK)}
+          >
             <Text variant={TextVariant.BodySMMedium} color={TextColor.Primary}>
               {strings('earn.earn_a_percentage_bonus', {
                 percentage: MUSD_CONVERSION_APY,
@@ -186,7 +194,7 @@ const MusdConversionAssetListCta = () => {
 
       <Button
         variant={ButtonVariant.Secondary}
-        onPress={() => handlePress('cta_button')}
+        onPress={() => handlePress(CTA_CLICK_TARGET.CTA_BUTTON)}
         size={ButtonSize.Sm}
       >
         <Text variant={TextVariant.BodySMMedium} color={TextColor.Default}>

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
@@ -22,7 +22,10 @@ import { EARN_TEST_IDS } from '../../../constants/testIds';
 import Logger from '../../../../../../util/Logger';
 import { useStyles } from '../../../../../hooks/useStyles';
 import { useMusdConversion } from '../../../hooks/useMusdConversion';
-import { useMusdCtaVisibility } from '../../../hooks/useMusdCtaVisibility';
+import {
+  BUY_GET_MUSD_CTA_VARIANT,
+  useMusdCtaVisibility,
+} from '../../../hooks/useMusdCtaVisibility';
 import { useMusdConversionFlowData } from '../../../hooks/useMusdConversionFlowData';
 import AvatarToken from '../../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
 import { AvatarSize } from '../../../../../../component-library/components/Avatars/Avatar';
@@ -42,11 +45,8 @@ const MusdConversionAssetListCta = () => {
 
   const { goToBuy } = useRampNavigation();
 
-  const {
-    isEmptyWallet,
-    getPaymentTokenForSelectedNetwork,
-    getChainIdForBuyFlow,
-  } = useMusdConversionFlowData();
+  const { getPaymentTokenForSelectedNetwork, getChainIdForBuyFlow } =
+    useMusdConversionFlowData();
 
   const { initiateConversion, hasSeenConversionEducationScreen } =
     useMusdConversion();
@@ -55,20 +55,21 @@ const MusdConversionAssetListCta = () => {
 
   const { trackEvent, createEventBuilder } = useMetrics();
 
-  const { shouldShowCta, showNetworkIcon, selectedChainId } =
+  const { shouldShowCta, showNetworkIcon, selectedChainId, variant } =
     shouldShowBuyGetMusdCta();
 
   const networkName = useNetworkName(selectedChainId ?? undefined);
 
-  const buttonText = isEmptyWallet
-    ? strings('earn.musd_conversion.buy_musd')
-    : strings('earn.musd_conversion.get_musd');
+  const buttonText =
+    variant === BUY_GET_MUSD_CTA_VARIANT.BUY
+      ? strings('earn.musd_conversion.buy_musd')
+      : strings('earn.musd_conversion.get_musd');
 
   const submitCtaPressedEvent = (source: 'cta_button' | 'cta_text') => {
     const { MUSD_CTA_TYPES, EVENT_LOCATIONS } = MUSD_EVENTS_CONSTANTS;
 
     const getRedirectLocation = () => {
-      if (isEmptyWallet) {
+      if (variant === BUY_GET_MUSD_CTA_VARIANT.BUY) {
         return EVENT_LOCATIONS.BUY_SCREEN;
       }
 
@@ -101,7 +102,7 @@ const MusdConversionAssetListCta = () => {
   const handlePress = async (source: 'cta_button' | 'cta_text') => {
     submitCtaPressedEvent(source);
 
-    if (isEmptyWallet) {
+    if (variant === BUY_GET_MUSD_CTA_VARIANT.BUY) {
       const chainId = getChainIdForBuyFlow();
       const rampIntent: RampIntent = {
         assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[chainId],

--- a/app/components/UI/Earn/hooks/useMusdBalance.ts
+++ b/app/components/UI/Earn/hooks/useMusdBalance.ts
@@ -1,16 +1,32 @@
 import { useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
 import { Hex } from '@metamask/utils';
-import { selectContractBalancesPerChainId } from '../../../../selectors/tokenBalancesController';
+import { selectTokensBalances } from '../../../../selectors/tokenBalancesController';
 import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../constants/musd';
 import { toChecksumAddress } from '../../../../util/address';
+import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
+import { EVM_SCOPE } from '../constants/networks';
+import { RootState } from '../../../../reducers';
 
 /**
  * Hook to check if the user has any MUSD token balance across supported chains.
  * @returns Object containing hasAnyMusdBalance boolean and balancesByChain for detailed balance info
  */
 export const useMusdBalance = () => {
-  const balancesPerChainId = useSelector(selectContractBalancesPerChainId);
+  const selectedEvmAddress = useSelector(
+    (state: RootState) =>
+      selectSelectedInternalAccountByScope(state)(EVM_SCOPE)?.address,
+  );
+
+  const tokenBalances = useSelector(selectTokensBalances);
+
+  const balancesPerChainId = useMemo(
+    () =>
+      selectedEvmAddress
+        ? (tokenBalances?.[selectedEvmAddress as Hex] ?? {})
+        : {},
+    [selectedEvmAddress, tokenBalances],
+  );
 
   const { hasMusdBalanceOnAnyChain, balancesByChain } = useMemo(() => {
     const result: Record<Hex, string> = {};

--- a/app/components/UI/Earn/hooks/useMusdConversionTokens.ts
+++ b/app/components/UI/Earn/hooks/useMusdConversionTokens.ts
@@ -13,6 +13,7 @@ import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../constants/musd';
 import { toHex } from '@metamask/controller-utils';
 import { BigNumber } from 'bignumber.js';
 import { Hex } from '@metamask/utils';
+import { safeFormatChainIdToHex } from '../../Card/util/safeFormatChainIdToHex';
 
 /**
  * The source of truth for the tokens that are eligible for mUSD conversion.
@@ -94,17 +95,27 @@ export const useMusdConversionTokens = () => {
 
   const hasConvertibleTokensByChainId = useCallback(
     (chainId: Hex) =>
-      conversionTokens.some((token) => token.chainId === chainId),
+      conversionTokens.some(
+        (token) =>
+          token.chainId && safeFormatChainIdToHex(token.chainId) === chainId,
+      ),
     [conversionTokens],
   );
 
   const isConversionToken = (token?: AssetType | TokenI) => {
     if (!token) return false;
 
+    if (!token.chainId) {
+      return false;
+    }
+
+    const tokenChainId = safeFormatChainIdToHex(token.chainId);
+
     return conversionTokens.some(
       (musdToken) =>
         token.address.toLowerCase() === musdToken.address.toLowerCase() &&
-        token.chainId === musdToken.chainId,
+        musdToken.chainId &&
+        safeFormatChainIdToHex(musdToken.chainId) === tokenChainId,
     );
   };
 

--- a/app/components/UI/Earn/hooks/useMusdConversionTokens.ts
+++ b/app/components/UI/Earn/hooks/useMusdConversionTokens.ts
@@ -12,6 +12,7 @@ import { TokenI } from '../../Tokens/types';
 import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../constants/musd';
 import { toHex } from '@metamask/controller-utils';
 import { BigNumber } from 'bignumber.js';
+import { Hex } from '@metamask/utils';
 
 export const useMusdConversionTokens = () => {
   const musdConversionPaymentTokensAllowlist = useSelector(
@@ -81,6 +82,12 @@ export const useMusdConversionTokens = () => {
     [allTokens, filterAllowedTokens],
   );
 
+  const hasConvertibleTokensByChainId = useCallback(
+    (chainId: Hex) =>
+      conversionTokens.some((token) => token.chainId === chainId),
+    [conversionTokens],
+  );
+
   const isConversionToken = (token?: AssetType | TokenI) => {
     if (!token) return false;
 
@@ -100,6 +107,7 @@ export const useMusdConversionTokens = () => {
     filterAllowedTokens,
     isConversionToken,
     isMusdSupportedOnChain,
+    hasConvertibleTokensByChainId,
     tokens: conversionTokens,
   };
 };

--- a/app/components/UI/Earn/hooks/useMusdConversionTokens.ts
+++ b/app/components/UI/Earn/hooks/useMusdConversionTokens.ts
@@ -14,6 +14,16 @@ import { toHex } from '@metamask/controller-utils';
 import { BigNumber } from 'bignumber.js';
 import { Hex } from '@metamask/utils';
 
+/**
+ * The source of truth for the tokens that are eligible for mUSD conversion.
+ *
+ * @returns Object containing:
+ * - filterAllowedTokens(tokens: AssetType[]): AssetType[] - Filters tokens based on allowlist and blocklist rules.
+ * - isConversionToken(token: AssetType | TokenI): boolean - Checks if a token is eligible for mUSD conversion.
+ * - isMusdSupportedOnChain(chainId: Hex): boolean - Checks if mUSD is supported on a given chain.
+ * - hasConvertibleTokensByChainId(chainId: Hex): boolean - Checks if there are convertible tokens on a given chain.
+ * - tokens: AssetType[] - The tokens that are eligible for mUSD conversion.
+ */
 export const useMusdConversionTokens = () => {
   const musdConversionPaymentTokensAllowlist = useSelector(
     selectMusdConversionPaymentTokensAllowlist,

--- a/app/components/UI/Earn/hooks/useMusdCtaVisibility.test.ts
+++ b/app/components/UI/Earn/hooks/useMusdCtaVisibility.test.ts
@@ -183,6 +183,7 @@ describe('useMusdCtaVisibility', () => {
       filterAllowedTokens: jest.fn(),
       isConversionToken: jest.fn(),
       isMusdSupportedOnChain: jest.fn(),
+      hasConvertibleTokensByChainId: jest.fn().mockReturnValue(false),
     });
     mockUseMusdConversionEligibility.mockReturnValue({
       isEligible: true,
@@ -856,11 +857,14 @@ describe('useMusdCtaVisibility', () => {
               name: 'USDC',
               symbol: 'USDC',
               chainId: CHAIN_IDS.MAINNET,
-            }) as TokenI,
+            }) as AssetType,
           ],
           filterAllowedTokens: jest.fn(),
           isConversionToken: jest.fn().mockReturnValue(true),
           isMusdSupportedOnChain: jest.fn().mockReturnValue(true),
+          hasConvertibleTokensByChainId: jest.fn((chainId: Hex) =>
+            Boolean(chainId === CHAIN_IDS.MAINNET),
+          ),
         });
 
         const { result } = renderHook(() => useMusdCtaVisibility());
@@ -961,6 +965,9 @@ describe('useMusdCtaVisibility', () => {
           filterAllowedTokens: jest.fn(),
           isConversionToken: jest.fn(),
           isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn((chainId: Hex) =>
+            Boolean(chainId === mockConversionToken.chainId),
+          ),
         });
 
         const { result } = renderHook(() => useMusdCtaVisibility());
@@ -983,6 +990,7 @@ describe('useMusdCtaVisibility', () => {
           filterAllowedTokens: jest.fn(),
           isConversionToken: jest.fn(),
           isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn().mockReturnValue(false),
         });
 
         const { result } = renderHook(() => useMusdCtaVisibility());
@@ -1035,6 +1043,9 @@ describe('useMusdCtaVisibility', () => {
         filterAllowedTokens: jest.fn(),
         isConversionToken: jest.fn(),
         isMusdSupportedOnChain: jest.fn(),
+        hasConvertibleTokensByChainId: jest.fn((chainId: Hex) =>
+          Boolean(chainId === conversionToken.chainId),
+        ),
       });
 
       mockMusdConversionCtaTokens = { [CHAIN_IDS.MAINNET]: ['USDC'] };
@@ -1332,6 +1343,9 @@ describe('useMusdCtaVisibility', () => {
         filterAllowedTokens: jest.fn(),
         isConversionToken: jest.fn(),
         isMusdSupportedOnChain: jest.fn(),
+        hasConvertibleTokensByChainId: jest.fn((chainId: Hex) =>
+          Boolean(chainId === conversionToken.chainId),
+        ),
       });
       mockMusdConversionCtaTokens = { [CHAIN_IDS.MAINNET]: ['USDC'] };
     });

--- a/app/components/UI/Earn/hooks/useMusdCtaVisibility.test.ts
+++ b/app/components/UI/Earn/hooks/useMusdCtaVisibility.test.ts
@@ -1,7 +1,10 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { Hex } from '@metamask/utils';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
-import { useMusdCtaVisibility } from './useMusdCtaVisibility';
+import {
+  BUY_GET_MUSD_CTA_VARIANT,
+  useMusdCtaVisibility,
+} from './useMusdCtaVisibility';
 import { useMusdBalance } from './useMusdBalance';
 import { useMusdConversionTokens } from './useMusdConversionTokens';
 import { useMusdConversionEligibility } from './useMusdConversionEligibility';
@@ -578,6 +581,165 @@ describe('useMusdCtaVisibility', () => {
           const { shouldShowCta } = result.current.shouldShowBuyGetMusdCta();
 
           expect(shouldShowCta).toBe(false);
+        });
+      });
+    });
+
+    describe('get mUSD CTA (single selected chain)', () => {
+      const mainnetConversionToken: AssetType = {
+        chainId: CHAIN_IDS.MAINNET,
+        name: 'USD Coin',
+        symbol: 'USDC',
+        decimals: 6,
+        address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        balance: '1000000',
+        balanceFiat: '1.00',
+        aggregators: [],
+        image: '',
+        logo: '',
+        isETH: false,
+      };
+
+      beforeEach(() => {
+        mockUseNetworksByCustomNamespace.mockReturnValue({
+          ...defaultNetworksByNamespace,
+          areAllNetworksSelected: false,
+        });
+
+        mockUseCurrentNetworkInfo.mockReturnValue({
+          ...defaultNetworkInfo,
+          enabledNetworks: [{ chainId: CHAIN_IDS.MAINNET, enabled: true }],
+        });
+
+        // Non-empty wallet ensures we don't accidentally show the BUY CTA
+        mockAccountBalance = {
+          walletId: 'test-wallet',
+          groupId: 'test-group',
+          totalBalanceInUserCurrency: 100,
+          userCurrency: 'USD',
+        };
+      });
+
+      it('returns GET variant with network icon when selected chain has convertible tokens and no mUSD balance on that chain', () => {
+        mockUseMusdConversionTokens.mockReturnValue({
+          tokens: [mainnetConversionToken],
+          filterAllowedTokens: jest.fn(),
+          isConversionToken: jest.fn(),
+          isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn((chainId: Hex) =>
+            Boolean(chainId === CHAIN_IDS.MAINNET),
+          ),
+        });
+
+        mockUseMusdBalance.mockReturnValue({
+          hasMusdBalanceOnAnyChain: false,
+          balancesByChain: {},
+          hasMusdBalanceOnChain: jest.fn().mockReturnValue(false),
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+        const ctaState = result.current.shouldShowBuyGetMusdCta();
+
+        expect(ctaState).toMatchObject({
+          shouldShowCta: true,
+          showNetworkIcon: true,
+          selectedChainId: CHAIN_IDS.MAINNET,
+          isEmptyWallet: false,
+          variant: BUY_GET_MUSD_CTA_VARIANT.GET,
+        });
+      });
+
+      it('hides GET variant when selected chain has no convertible tokens', () => {
+        const lineaOnlyConversionToken: AssetType = {
+          ...mainnetConversionToken,
+          chainId: CHAIN_IDS.LINEA_MAINNET,
+          address: '0x176211869ca2b568f2a7d4ee941e073a821ee1ff',
+        };
+
+        mockUseMusdConversionTokens.mockReturnValue({
+          tokens: [lineaOnlyConversionToken],
+          filterAllowedTokens: jest.fn(),
+          isConversionToken: jest.fn(),
+          isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn((chainId: Hex) =>
+            Boolean(chainId === CHAIN_IDS.LINEA_MAINNET),
+          ),
+        });
+
+        mockUseMusdBalance.mockReturnValue({
+          hasMusdBalanceOnAnyChain: false,
+          balancesByChain: {},
+          hasMusdBalanceOnChain: jest.fn().mockReturnValue(false),
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+        const ctaState = result.current.shouldShowBuyGetMusdCta();
+
+        expect(ctaState).toMatchObject({
+          shouldShowCta: false,
+          showNetworkIcon: false,
+          selectedChainId: null,
+          isEmptyWallet: false,
+          variant: null,
+        });
+      });
+    });
+
+    describe('buy mUSD CTA (single selected chain)', () => {
+      beforeEach(() => {
+        mockUseNetworksByCustomNamespace.mockReturnValue({
+          ...defaultNetworksByNamespace,
+          areAllNetworksSelected: false,
+        });
+
+        mockUseCurrentNetworkInfo.mockReturnValue({
+          ...defaultNetworkInfo,
+          enabledNetworks: [{ chainId: CHAIN_IDS.MAINNET, enabled: true }],
+        });
+
+        // Empty wallet is required for the BUY variant to be considered.
+        mockAccountBalance = {
+          walletId: 'test-wallet',
+          groupId: 'test-group',
+          totalBalanceInUserCurrency: 0,
+          userCurrency: 'USD',
+        };
+      });
+
+      it('hides BUY variant when selected chain is not buyable, even when wallet is empty', () => {
+        // Ensure GET variant cannot be shown (no convertible tokens).
+        mockUseMusdConversionTokens.mockReturnValue({
+          tokens: [],
+          filterAllowedTokens: jest.fn(),
+          isConversionToken: jest.fn(),
+          isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn().mockReturnValue(false),
+        });
+
+        // Selected chain is not buyable on Ramp (no supported token route).
+        mockUseRampTokens.mockReturnValue({
+          ...defaultRampTokens,
+          allTokens: [
+            createMusdRampToken(CHAIN_IDS.MAINNET, false), // not buyable on selected chain
+            createMusdRampToken(CHAIN_IDS.LINEA_MAINNET, true), // buyable elsewhere
+          ],
+        });
+
+        mockUseMusdBalance.mockReturnValue({
+          hasMusdBalanceOnAnyChain: false,
+          balancesByChain: {},
+          hasMusdBalanceOnChain: jest.fn().mockReturnValue(false),
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+        const ctaState = result.current.shouldShowBuyGetMusdCta();
+
+        expect(ctaState).toMatchObject({
+          shouldShowCta: false,
+          showNetworkIcon: false,
+          selectedChainId: null,
+          isEmptyWallet: true,
+          variant: null,
         });
       });
     });

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.test.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.test.tsx
@@ -352,6 +352,7 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
     );
     mockUseMusdConversionTokens.mockReturnValue({
       isConversionToken: jest.fn().mockReturnValue(false),
+      hasConvertibleTokensByChainId: jest.fn().mockReturnValue(false),
       filterAllowedTokens: jest.fn(),
       isMusdSupportedOnChain: jest.fn().mockReturnValue(true),
       tokens: [],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR separates the conditional rendering state of the "Buy mUSD" and "Get mUSD" CTAs within `useMusdCtaVisibility`. The "Get mUSD" wins a tiebreaker if both should be displayed. Also adds a `variant` property to the `shouldShowBuyGetMusdCta` so consumers know which will be rendered.

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: refactored 

## **Related issues**

Fixes: 
- [MUSD-285: Get mUSD CTA  is displayed on an imported account with no stable coin balance on Ethereum Mainnet. Clicking on the CTA does nothing. The account holds stable coin on Linea network](https://consensyssoftware.atlassian.net/browse/MUSD-285)
- [MUSD-284: After switching from a non-EVM network to all networks, the get mUSD CTA is displayed, even if the account holds mUSD on both Ethereum Mainnet and Linea](https://consensyssoftware.atlassian.net/browse/MUSD-284)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CTA decision logic and balance/token selection paths that affect navigation into buy/convert flows; behavior changes are well-covered by tests but could alter CTA visibility across network/account combinations.
> 
> **Overview**
> Fixes the primary mUSD CTA so it resolves to a single **explicit variant** (`BUY` vs `GET`) returned by `useMusdCtaVisibility`, favoring **Get** when both could apply and preventing cases where a CTA is shown but clicking it does nothing.
> 
> Improves chain-awareness across the flow: `useMusdConversionTokens` now exposes `hasConvertibleTokensByChainId` and compares tokens using `safeFormatChainIdToHex`, `useMusdConversionFlowData` selects/returns the payment token chainId safely in hex, and `useMusdBalance` now reads balances from `selectTokensBalances` keyed by the currently selected EVM account. The asset list CTA now uses the new `variant` for label/action and adds `cta_click_target` to MetaMetrics events; tests are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08294e7e178ed682adc7527dbde161ebb7980280. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->