### PR TITLE
test: Check genesis hash in Snaps Ethereum provider E2E

### DIFF
--- a/e2e/selectors/Browser/TestSnaps.selectors.ts
+++ b/e2e/selectors/Browser/TestSnaps.selectors.ts
@@ -71,6 +71,7 @@ export const TestSnapViewSelectorWebIDS = {
   showPreinstalledDialogButton: 'showPreinstalledDialog',
   getWebSocketState: 'getWebSocketState',
   getChainIdButton: 'sendEthprovider',
+  getGenesisHashButton: 'sendGenesisBlockEthProvider',
   getAccountsButton: 'sendEthproviderAccounts',
   personalSignButton: 'signPersonalSignMessage',
   sendWasmMessageButton: 'sendWasmMessage',

--- a/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
+++ b/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
@@ -88,14 +88,14 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
 
         await TestSnaps.selectInDropdown('networkDropDown', 'Linea');
         await TestSnaps.tapButton('getGenesisHashButton');
-        await TestSnaps.checkResultSpan(
+        await TestSnaps.checkResultSpanIncludes(
           'ethereumProviderResultSpan',
           '"0xb6762a65689107b2326364aefc18f94cda413209fab35c00d4af51eaa20ffbc6"',
         );
 
         await TestSnaps.selectInDropdown('networkDropDown', 'Sepolia');
         await TestSnaps.tapButton('getGenesisHashButton');
-        await TestSnaps.checkResultSpan(
+        await TestSnaps.checkResultSpanIncludes(
           'ethereumProviderResultSpan',
           '"0x25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9"',
         );

--- a/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
+++ b/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
@@ -12,6 +12,7 @@ import {
   confirmationFeatureFlags,
   remoteFeatureMultichainAccountsAccountDetailsV2,
 } from '../../../tests/api-mocking/mock-responses/feature-flags-mocks';
+import { mockGenesisBlocks } from './mocks';
 
 jest.setTimeout(150_000);
 
@@ -27,6 +28,8 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
             ...Object.assign({}, ...confirmationFeatureFlags),
             ...remoteFeatureMultichainAccountsAccountDetailsV2(false),
           });
+
+          await mockGenesisBlocks(mockServer);
         },
       },
       async () => {
@@ -77,21 +80,24 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
 
         // Check other networks.
         await TestSnaps.selectInDropdown('networkDropDown', 'Ethereum');
-        await TestSnaps.tapButton('getChainIdButton');
-        await TestSnaps.checkResultSpan('ethereumProviderResultSpan', '"0x1"');
+        await TestSnaps.tapButton('getGenesisHashButton');
+        await TestSnaps.checkResultSpanIncludes(
+          'ethereumProviderResultSpan',
+          '"0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"',
+        );
 
         await TestSnaps.selectInDropdown('networkDropDown', 'Linea');
-        await TestSnaps.tapButton('getChainIdButton');
+        await TestSnaps.tapButton('getGenesisHashButton');
         await TestSnaps.checkResultSpan(
           'ethereumProviderResultSpan',
-          '"0xe708"',
+          '"0xb6762a65689107b2326364aefc18f94cda413209fab35c00d4af51eaa20ffbc6"',
         );
 
         await TestSnaps.selectInDropdown('networkDropDown', 'Sepolia');
-        await TestSnaps.tapButton('getChainIdButton');
+        await TestSnaps.tapButton('getGenesisHashButton');
         await TestSnaps.checkResultSpan(
           'ethereumProviderResultSpan',
-          '"0xaa36a7"',
+          '"0x25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9"',
         );
       },
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Mirror [extension E2E test](https://github.com/MetaMask/metamask-extension/blob/main/test/e2e/snaps/test-snap-ethereum-provider.spec.ts#L75-L96) by checking against genesis hashes instead of chain IDs when validating that the Snap can switch the network correctly.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to E2E test assertions/selectors and add deterministic RPC mocking; no production logic is modified.
> 
> **Overview**
> Updates the `test-snap-ethereum-provider` E2E to validate network switching by requesting the genesis block and asserting its hash for Ethereum, Linea, and Sepolia (using `checkResultSpanIncludes`) rather than asserting `chainId`.
> 
> Adds a new `getGenesisHashButton` selector and wires in `mockGenesisBlocks` during fixture setup so tests don’t depend on live RPC responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a155d8808f3524134ce386f42dc133185cab5f37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->