### PR TITLE
fix: cp-7.64.0 when switching the network filter from a non-EVM network to "Popular networks" EVM tokens aren't displayed

### DIFF
--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -1,4 +1,8 @@
-import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
+import {
+  AccountGroupId,
+  AccountGroupType,
+  AccountWalletType,
+} from '@metamask/account-api';
 import {
   EthAccountType,
   SolAccountType,
@@ -733,18 +737,23 @@ describe('selectAsset', () => {
     });
   });
 
-  it('scopes native and staked lookups to selected account', () => {
-    const stateWithSecondEvm = mockState();
-    const account1Id =
-      stateWithSecondEvm.engine.backgroundState.AccountsController
-        .internalAccounts.selectedAccount;
+  it('scopes native and staked lookups to selected account group', () => {
+    const baseState = mockState();
 
+    // Account 1 info (already exists in mockState)
+    const account1Id = 'd7f11451-9d79-4df4-a012-afd253443639';
+    const group1Id = 'entropy:01K1TJY9QPSCKNBSVGZNG510GJ/0';
+
+    // Create second account group with different EVM account
     const account2Id = '11111111-1111-1111-1111-111111111111';
     const account2Address = '0x1111111111111111111111111111111111111111';
     const account2AddressLowercased = account2Address.toLowerCase();
+    const group2Id = 'entropy:01K1TJY9QPSCKNBSVGZNG510GJ/1';
+    const walletId = 'entropy:01K1TJY9QPSCKNBSVGZNG510GJ';
 
-    const withSelectedAccount = (
+    const withSelectedGroup = (
       state: RootState,
+      selectedGroup: AccountGroupId,
       selectedAccount: string,
     ): RootState => ({
       ...state,
@@ -752,6 +761,13 @@ describe('selectAsset', () => {
         ...state.engine,
         backgroundState: {
           ...state.engine.backgroundState,
+          AccountTreeController: {
+            ...state.engine.backgroundState.AccountTreeController,
+            accountTree: {
+              ...state.engine.backgroundState.AccountTreeController.accountTree,
+              selectedAccountGroup: selectedGroup,
+            },
+          },
           AccountsController: {
             ...state.engine.backgroundState.AccountsController,
             internalAccounts: {
@@ -764,8 +780,8 @@ describe('selectAsset', () => {
       },
     });
 
-    // Add second EVM internal account into the same selected account group
-    stateWithSecondEvm.engine.backgroundState.AccountsController.internalAccounts.accounts[
+    // Add second EVM account to AccountsController
+    baseState.engine.backgroundState.AccountsController.internalAccounts.accounts[
       account2Id
     ] = {
       id: account2Id,
@@ -783,73 +799,75 @@ describe('selectAsset', () => {
       },
     };
 
-    const groupId = 'entropy:01K1TJY9QPSCKNBSVGZNG510GJ/0';
-    const walletId = 'entropy:01K1TJY9QPSCKNBSVGZNG510GJ';
-    stateWithSecondEvm.engine.backgroundState.AccountTreeController.accountTree.wallets[
+    // Create second account group with the second EVM account
+    baseState.engine.backgroundState.AccountTreeController.accountTree.wallets[
       walletId
-    ].groups[groupId].accounts = [
-      ...stateWithSecondEvm.engine.backgroundState.AccountTreeController
-        .accountTree.wallets[walletId].groups[groupId].accounts,
-      account2Id,
-    ];
+    ].groups[group2Id] = {
+      id: group2Id,
+      type: AccountGroupType.MultichainAccount,
+      accounts: [account2Id],
+      metadata: {
+        name: 'Account Group 2',
+        pinned: false,
+        hidden: false,
+        entropy: {
+          groupIndex: 1,
+        },
+      },
+    };
 
-    // Provide AccountTracker balances for second address on mainnet
-    stateWithSecondEvm.engine.backgroundState.AccountTrackerController.accountsByChainId[
+    // Provide AccountTracker balances for second account on mainnet
+    baseState.engine.backgroundState.AccountTrackerController.accountsByChainId[
       '0x1'
     ][account2AddressLowercased] = {
       balance: '0x0DE0B6B3A7640000', // 1 ETH
       stakedBalance: '0x1BC16D674EC80000', // 2 ETH
     };
 
-    // Provide empty token lists/balances for second address to keep asset building stable
-    stateWithSecondEvm.engine.backgroundState.TokensController.allTokens['0x1'][
+    // Provide empty token lists/balances for second address
+    baseState.engine.backgroundState.TokensController.allTokens['0x1'][
       account2AddressLowercased
     ] = [];
-    stateWithSecondEvm.engine.backgroundState.TokensController.allTokens['0xa'][
+    baseState.engine.backgroundState.TokensController.allTokens['0xa'][
       account2AddressLowercased
     ] = [];
     (
-      stateWithSecondEvm.engine.backgroundState.TokenBalancesController
+      baseState.engine.backgroundState.TokenBalancesController
         .tokenBalances as Record<string, unknown>
     )[account2AddressLowercased] = {};
 
-    // Sanity check: original account still resolves correctly
-    const stateForAccount1 = withSelectedAccount(
-      stateWithSecondEvm,
-      account1Id,
-    );
+    // Test Group 1: should return account 1 balances
+    const stateForGroup1 = withSelectedGroup(baseState, group1Id, account1Id);
 
-    const stakedForAccount1 = selectAsset(stateForAccount1, {
+    const stakedForGroup1 = selectAsset(stateForGroup1, {
       address: '0x0000000000000000000000000000000000000000',
       chainId: '0x1',
       isStaked: true,
     });
-    expect(stakedForAccount1?.balance).toBe('100');
+    expect(stakedForGroup1?.balance).toBe('100');
+    expect(stakedForGroup1?.balanceFiat).toBe('$240,000.00');
 
-    // Switch selected account → balances should follow
-    const stateForAccount2 = withSelectedAccount(
-      stateWithSecondEvm,
-      account2Id,
-    );
+    // Test Group 2: should return account 2 balances
+    const stateForGroup2 = withSelectedGroup(baseState, group2Id, account2Id);
 
-    const nativeForAccount2 = selectAsset(stateForAccount2, {
+    const nativeForGroup2 = selectAsset(stateForGroup2, {
       address: '0x0000000000000000000000000000000000000000',
       chainId: '0x1',
       isStaked: false,
     });
-    expect(nativeForAccount2).toMatchObject({
+    expect(nativeForGroup2).toMatchObject({
       name: 'Ethereum',
       balance: '1',
       balanceFiat: '$2,400.00',
       isStaked: false,
     });
 
-    const stakedForAccount2 = selectAsset(stateForAccount2, {
+    const stakedForGroup2 = selectAsset(stateForGroup2, {
       address: '0x0000000000000000000000000000000000000000',
       chainId: '0x1',
       isStaked: true,
     });
-    expect(stakedForAccount2).toMatchObject({
+    expect(stakedForGroup2).toMatchObject({
       name: 'Staked Ethereum',
       balance: '2',
       balanceFiat: '$4,800.00',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Bug: When I switch the network filter from a non-EVM network to "Popular networks" my EVM tokens aren't displayed.

Solution: I have idnetified that this bug was introduced by [this](https://github.com/MetaMask/metamask-mobile/pull/25468) PR and needs to be backported cause the bug was also backported [here](https://github.com/MetaMask/metamask-mobile/pull/25580)

The issue is that the wrong selector `selectSelectedInternalAccountId` was being used instead of `selectSelectedInternalAccountByScope`

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix when switching the network filter from a non-EVM network to "Popular networks" EVM tokens aren't displayed

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2597 & https://github.com/MetaMask/metamask-mobile/issues/25632

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/bcffcb65-3227-467d-9255-55d2177f2416


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/b0e5a877-b7ae-4078-a0fa-d4000a9525f6


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core asset-selection logic used to render token/native/staked balances across networks; a mistake could hide or mis-associate assets when switching networks/account groups.
> 
> **Overview**
> Fixes an asset lookup bug where switching from a non-EVM network filter back to EVM (“Popular networks”) could return the wrong/missing EVM token entries.
> 
> `selectAsset` now scopes native/staked and token lookups to the *selected account group’s* account for the requested chain via `selectSelectedInternalAccountByScope`, normalizing chain IDs to CAIP with `isCaipChainId`/`toEvmCaipChainId` instead of relying on `selectSelectedInternalAccountId`.
> 
> Updates `assets-list.test.ts` to validate scoping by account group (adding a second group/account and asserting balances switch correctly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c68b7c9e977378969c7df1ead2060064046c993. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->