### PR TITLE
fix: do not render keyboard when quote reloads after slippage change

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
@@ -214,6 +214,52 @@ describeForPlatforms('BridgeView', () => {
     expect(await findByText(expected)).toBeOnTheScreen();
   });
 
+  it('hides keypad when refreshing quote with input unfocused', () => {
+    const now = Date.now();
+    const previousQuote = { ...mockQuoteWithMetadata };
+
+    const { queryByTestId } = renderBridgeView({
+      deterministicFiat: true,
+      overrides: {
+        bridge: {
+          sourceAmount: '1',
+          sourceToken: {
+            address: '0x0000000000000000000000000000000000000000',
+            chainId: '0x1',
+            decimals: 18,
+            symbol: 'ETH',
+            name: 'Ether',
+          },
+          destToken: {
+            address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+            chainId: '0x1',
+            decimals: 6,
+            symbol: 'USDC',
+            name: 'USD Coin',
+          },
+        },
+        engine: {
+          backgroundState: {
+            BridgeController: {
+              quotes: [previousQuote as unknown as Record<string, unknown>],
+              recommendedQuote: previousQuote as unknown as Record<
+                string,
+                unknown
+              >,
+              quotesLastFetched: now - 1000,
+              quotesLoadingStatus: 'LOADING',
+              quoteFetchError: null,
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>,
+    });
+
+    // Keypad should NOT be visible when refreshing quote with valid inputs and unfocused input
+    // This simulates the scenario after user changes slippage - quote is loading but input is not focused
+    expect(queryByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON)).toBeNull();
+  });
+
   it('navigates to dest token selector on press', async () => {
     const TokenSelectorProbe: React.FC<{
       route?: { params?: { type?: string } };

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -257,8 +257,12 @@ const BridgeView = () => {
   const isError = isNoQuotesAvailable || quoteFetchError;
 
   // Primary condition for keypad visibility - when input is focused or we don't have valid inputs
+  // Also hide the keypad when a new quote is loading and input field is not focused like after
+  // user changing the slippage value.
   const shouldDisplayKeypad =
-    isInputFocused || !hasValidBridgeInputs || (!activeQuote && !isError);
+    isInputFocused ||
+    !hasValidBridgeInputs ||
+    (!activeQuote && !isError && !isLoading);
   // Hide quote whenever the keypad is displayed
   const shouldDisplayQuoteDetails = activeQuote && !shouldDisplayKeypad;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Do not render keyboard when quote reloads after slippage change

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: do not render keyboard when quote reloads after slippage change

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3932

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/f37ca261-31ca-4c7d-9a18-8e68acb2f113


<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
