### PR TITLE
fix: exclude gas fees from swap quotes insufficientBal calculation

### DIFF
--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -44,10 +44,14 @@ export const useBridgeQuoteRequest = () => {
     chainId: sourceToken?.chainId,
   });
 
+  // Use simple balance check (ignoring gas fees) for quote requests to avoid circular dependencies.
+  // The full balance check with gas fees is used separately for UI display in the BridgeView.
+  // This prevents the infinite loop: quote request → gas data changes → insufficientBal changes → new quote request
   const insufficientBal = useIsInsufficientBalance({
     amount: sourceAmount,
     token: sourceToken,
     latestAtomicBalance: latestSourceBalance?.atomicBalance,
+    ignoreGasFees: true,
   });
 
   const { gasIncluded, gasIncluded7702 } = useSelector(

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -45,7 +45,8 @@ export const useBridgeQuoteRequest = () => {
   });
 
   // Use simple balance check (ignoring gas fees) for quote requests to avoid circular dependencies.
-  // The full balance check with gas fees is used separately for UI display in the BridgeView.
+  // The full balance check with gas fees is used separately within the BridgeView to block user from executing
+  // the swap in insufficient balance.
   // This prevents the infinite loop: quote request → gas data changes → insufficientBal changes → new quote request
   const insufficientBal = useIsInsufficientBalance({
     amount: sourceAmount,

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
@@ -555,6 +555,7 @@ describe('useBridgeQuoteRequest', () => {
         amount: '5.5',
         token: testState.bridge.sourceToken,
         latestAtomicBalance: BigNumber.from('10000000000000000000'),
+        ignoreGasFees: true,
       });
     });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Prevents infinite quote loading on some chains like tron

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: exclude gas fees from swap quotes insufficientBal calculation

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3933

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes balance/insufficient-funds logic used in quote requests; while scoped and guarded by a flag, it can affect when quotes are requested/filtered and should be validated across native-token and gasless/sponsored scenarios.
> 
> **Overview**
> Prevents infinite bridge/swap quote loading by decoupling the quote-request `insufficientBal` computation from gas-fee data.
> 
> `useIsInsufficientBalance` now accepts `ignoreGasFees`; when enabled (used by `useBridgeQuoteRequest`), it skips reading gas-related fields from the recommended quote and performs a token-only balance check, while leaving the UI path to continue using full gas-aware validation. Tests were updated to assert the new `ignoreGasFees: true` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c15084feb999aa0de4f237a982a4d4d7cf3372b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->