### PR TITLE
fix(rewards): end of season scrollable rewards

### DIFF
--- a/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.tsx
+++ b/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
+import { FlatList } from 'react-native';
 import {
   Box,
   BoxFlexDirection,
@@ -144,7 +145,10 @@ const PreviousSeasonUnlockedRewards = () => {
   }
 
   return (
-    <Box flexDirection={BoxFlexDirection.Column} twClassName="flex-col mt-2">
+    <Box
+      flexDirection={BoxFlexDirection.Column}
+      twClassName="flex-col mt-2 max-h-[72.5%]"
+    >
       <Box flexDirection={BoxFlexDirection.Column} twClassName="gap-4">
         <Text
           variant={TextVariant.HeadingMd}
@@ -170,8 +174,14 @@ const PreviousSeasonUnlockedRewards = () => {
                 flexDirection={BoxFlexDirection.Column}
                 twClassName="gap-4 w-full"
               >
-                <Box twClassName="flex-col">
-                  {endOfSeasonRewards?.map((unlockedReward: RewardDto) => {
+                <FlatList
+                  data={endOfSeasonRewards}
+                  keyExtractor={(item) => item.id}
+                  showsVerticalScrollIndicator={false}
+                  nestedScrollEnabled
+                  style={tw.style('w-full')}
+                  contentContainerStyle={tw.style('gap-4 pb-20')}
+                  renderItem={({ item: unlockedReward, index }) => {
                     const seasonReward = seasonTiers
                       ?.flatMap((tier) => tier.rewards)
                       ?.find(
@@ -190,28 +200,31 @@ const PreviousSeasonUnlockedRewards = () => {
                         | undefined
                     )?.url;
 
+                    const isLast = index === endOfSeasonRewards.length - 1;
+
                     return (
-                      <RewardItem
-                        key={unlockedReward.id}
-                        reward={unlockedReward}
-                        seasonReward={seasonReward}
-                        isLast={unlockedReward === endOfSeasonRewards.at(-1)}
-                        isEndOfSeasonReward
-                        endOfSeasonClaimedDescription={
-                          claimIsRedeem
-                            ? strings(
-                                'rewards.end_of_season_rewards.arriving_soon',
-                              )
-                            : undefined
-                        }
-                        compact
-                        // Can't do anything if we don't have reward url allocated yet
-                        isLocked={!rewardUrl && !claimIsRedeem}
-                        onPress={handleEndOfSeasonClaim}
-                      />
+                      <Box twClassName={isLast ? 'mb-12' : undefined}>
+                        <RewardItem
+                          reward={unlockedReward}
+                          seasonReward={seasonReward}
+                          isLast={isLast}
+                          isEndOfSeasonReward
+                          endOfSeasonClaimedDescription={
+                            claimIsRedeem
+                              ? strings(
+                                  'rewards.end_of_season_rewards.arriving_soon',
+                                )
+                              : undefined
+                          }
+                          compact
+                          // Can't do anything if we don't have reward url allocated yet
+                          isLocked={!rewardUrl && !claimIsRedeem}
+                          onPress={handleEndOfSeasonClaim}
+                        />
+                      </Box>
                     );
-                  })}
-                </Box>
+                  }}
+                />
               </Box>
             ) : (
               <>

--- a/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.tsx
+++ b/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.tsx
@@ -180,7 +180,7 @@ const PreviousSeasonUnlockedRewards = () => {
                   showsVerticalScrollIndicator={false}
                   nestedScrollEnabled
                   style={tw.style('w-full')}
-                  contentContainerStyle={tw.style('gap-4 pb-20')}
+                  contentContainerStyle={tw.style('gap-4 pb-60')}
                   renderItem={({ item: unlockedReward, index }) => {
                     const seasonReward = seasonTiers
                       ?.flatMap((tier) => tier.rewards)


### PR DESCRIPTION
## **Description**

This PR fixes the issue in the end of season summary where users couldn't scroll down properly if they had a small resolution and/or a more reward rows rendered.

## **Changelog**

CHANGELOG entry: fix rewards end of season scroll issue

## **Screenshots/Recordings**

### **After**

![scroll-eos-rewards](https://github.com/user-attachments/assets/325a19e3-b3a4-41a3-b050-16b665027845)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout change confined to end-of-season rewards rendering; main risk is unintended spacing/scroll behavior differences on some devices.
> 
> **Overview**
> Fixes end-of-season (previous season) rewards overflow/scroll issues by **constraining the container height** and rendering rewards via a `FlatList` (with nested scrolling and extra bottom padding) instead of mapping inline.
> 
> Updates tests to cover OTHERSIDE rewards without a claim URL (locked state + navigation payload) and to assert the correct “no rewards earned” message when `currentTier.pointsNeeded` is `0` and unlocked rewards are empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8731b83625d7c00d3dfb0014413eea69cb78ec2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->