### PR TITLE
chore: disallow hiding of mUSD

### DIFF
--- a/app/components/UI/Earn/constants/musd.test.ts
+++ b/app/components/UI/Earn/constants/musd.test.ts
@@ -1,0 +1,46 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { isMusdToken, MUSD_TOKEN_ADDRESS_BY_CHAIN } from './musd';
+
+describe('isMusdToken', () => {
+  const MUSD_ADDRESS = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET];
+
+  it('returns true for mUSD token address in lowercase', () => {
+    const result = isMusdToken(MUSD_ADDRESS);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true for mUSD token address in uppercase', () => {
+    const result = isMusdToken(MUSD_ADDRESS.toUpperCase());
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true for mUSD token address with mixed case', () => {
+    const mixedCaseAddress = '0xAcA92E438df0B2401fF60dA7E4337B687a2435DA';
+
+    const result = isMusdToken(mixedCaseAddress);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false for non-mUSD token address', () => {
+    const otherAddress = '0x1234567890123456789012345678901234567890';
+
+    const result = isMusdToken(otherAddress);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false for undefined address', () => {
+    const result = isMusdToken(undefined);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false for empty string address', () => {
+    const result = isMusdToken('');
+
+    expect(result).toBe(false);
+  });
+});

--- a/app/components/UI/Earn/constants/musd.ts
+++ b/app/components/UI/Earn/constants/musd.ts
@@ -22,6 +22,16 @@ export const MUSD_TOKEN_ADDRESS_BY_CHAIN: Record<Hex, Hex> = {
 };
 
 /**
+ * Check if the given token address is mUSD.
+ * mUSD has the same address on all supported chains.
+ */
+export const isMusdToken = (address?: string): boolean => {
+  if (!address) return false;
+  const musdAddress = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET];
+  return address.toLowerCase() === musdAddress.toLowerCase();
+};
+
+/**
  * Chains where mUSD CTA should show (buy routes available).
  * BSC is excluded as buy routes are not yet available.
  */

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.test.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.test.tsx
@@ -1082,4 +1082,76 @@ describe('TokenListItem - Component Rendering Tests for Coverage', () => {
       expect(queryByText('+1.23%')).toBeNull();
     });
   });
+
+  describe('mUSD Token Long Press', () => {
+    const musdAddress = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+    const musdAsset = {
+      ...defaultAsset,
+      address: musdAddress,
+      symbol: 'mUSD',
+      name: 'MetaMask USD',
+      isNative: false,
+    };
+
+    const musdAssetKey: FlashListAssetKey = {
+      address: musdAddress,
+      chainId: '0x1',
+      isStaked: false,
+    };
+
+    it('does not call showRemoveMenu on long press for mUSD token', () => {
+      prepareMocks({
+        asset: musdAsset,
+      });
+
+      const mockShowRemoveMenu = jest.fn();
+      const { getByText } = renderWithProvider(
+        <TokenListItem
+          assetKey={musdAssetKey}
+          showRemoveMenu={mockShowRemoveMenu}
+          setShowScamWarningModal={jest.fn()}
+          shouldShowTokenListItemCta={mockShouldShowTokenListItemCta}
+          privacyMode={false}
+        />,
+      );
+
+      const tokenElement = getByText('MetaMask USD');
+      fireEvent(tokenElement, 'longPress');
+
+      expect(mockShowRemoveMenu).not.toHaveBeenCalled();
+    });
+
+    it('calls showRemoveMenu on long press for non-mUSD token', () => {
+      prepareMocks({
+        asset: defaultAsset,
+      });
+
+      const mockShowRemoveMenu = jest.fn();
+      const assetKey: FlashListAssetKey = {
+        address: '0x456',
+        chainId: '0x1',
+        isStaked: false,
+      };
+
+      const { getByText } = renderWithProvider(
+        <TokenListItem
+          assetKey={assetKey}
+          showRemoveMenu={mockShowRemoveMenu}
+          setShowScamWarningModal={jest.fn()}
+          shouldShowTokenListItemCta={mockShouldShowTokenListItemCta}
+          privacyMode={false}
+        />,
+      );
+
+      const tokenElement = getByText('Test Token');
+      fireEvent(tokenElement, 'longPress');
+
+      expect(mockShowRemoveMenu).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: '0x456',
+          symbol: 'TEST',
+        }),
+      );
+    });
+  });
 });

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
@@ -50,7 +50,7 @@ import { toHex } from '@metamask/controller-utils';
 import Logger from '../../../../../util/Logger';
 import { useNetworkName } from '../../../../Views/confirmations/hooks/useNetworkName';
 import { MUSD_EVENTS_CONSTANTS } from '../../../Earn/constants/events';
-import { MUSD_CONVERSION_APY } from '../../../Earn/constants/musd';
+import { MUSD_CONVERSION_APY, isMusdToken } from '../../../Earn/constants/musd';
 import {
   useMerklRewards,
   isEligibleForMerklRewards,
@@ -379,7 +379,9 @@ export const TokenListItem = React.memo(
     return (
       <AssetElement
         onPress={onItemPress}
-        onLongPress={asset.isNative ? null : showRemoveMenu}
+        onLongPress={
+          asset.isNative || isMusdToken(asset.address) ? null : showRemoveMenu
+        }
         asset={asset}
         balance={asset.balanceFiat}
         secondaryBalance={secondaryBalanceDisplay.text}

--- a/app/components/Views/AssetDetails/AssetsDetails.test.tsx
+++ b/app/components/Views/AssetDetails/AssetsDetails.test.tsx
@@ -316,6 +316,29 @@ describe('AssetDetails', () => {
     runAfterInteractionsSpy.mockRestore();
   });
 
+  it('hides the Hide token button for mUSD tokens', () => {
+    const musdAddress = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+
+    const { queryByText } = render(
+      <Provider store={mockStore(initialState)}>
+        <AssetDetails
+          route={{
+            params: {
+              address: musdAddress,
+              chainId: CHAIN_IDS.MAINNET,
+              asset: {
+                ...mockAsset,
+                address: musdAddress,
+              } as unknown as TokenI,
+            },
+          }}
+        />
+      </Provider>,
+    );
+
+    expect(queryByText('Hide token')).toBeNull();
+  });
+
   it('renders warning banner if balance is undefined', () => {
     const mockEmptyState = {
       ...initialState,

--- a/app/components/Views/AssetDetails/index.tsx
+++ b/app/components/Views/AssetDetails/index.tsx
@@ -58,6 +58,7 @@ import { Colors } from '../../../util/theme/models';
 import { Hex } from '@metamask/utils';
 import { selectLastSelectedEvmAccount } from '../../../selectors/accountsController';
 import { TokenI } from '../../UI/Tokens/types';
+import { isMusdToken } from '../../UI/Earn/constants/musd';
 import { areAddressesEqual } from '../../../util/address';
 // Perps Discovery Banner imports
 import { selectPerpsEnabledFlag } from '../../UI/Perps';
@@ -465,7 +466,7 @@ const AssetDetails = (props: InnerProps) => {
             {renderSectionDescription(aggregators.join(', '))}
           </>
         )}
-        {renderHideButton()}
+        {!isMusdToken(address) && renderHideButton()}
       </ScrollView>
     </View>
   );

--- a/app/components/Views/AssetOptions/AssetOptions.test.tsx
+++ b/app/components/Views/AssetOptions/AssetOptions.test.tsx
@@ -625,6 +625,40 @@ describe('AssetOptions Component', () => {
 
       expect(queryByText('Remove token')).not.toBeOnTheScreen();
     });
+
+    it('hides Remove token option for mUSD token', () => {
+      const musdAddress = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+
+      (useSelector as jest.Mock).mockImplementation((selector) => {
+        if (selector === selectAssetsBySelectedAccountGroup)
+          return {
+            '0x1': [
+              {
+                assetId: musdAddress,
+                chainId: '0x1',
+              },
+            ],
+          };
+        if (selector.name === 'selectEvmChainId') return '0x1';
+        if (selector.name === 'selectTokenList') return {};
+        return {};
+      });
+
+      const { queryByText } = render(
+        <AssetOptions
+          route={{
+            params: {
+              address: musdAddress,
+              chainId: '0x1',
+              isNativeCurrency: false,
+              asset: mockAsset as unknown as TokenI,
+            },
+          }}
+        />,
+      );
+
+      expect(queryByText('Remove token')).not.toBeOnTheScreen();
+    });
   });
 
   describe('Token removal', () => {

--- a/app/components/Views/AssetOptions/AssetOptions.tsx
+++ b/app/components/Views/AssetOptions/AssetOptions.tsx
@@ -36,6 +36,7 @@ import BottomSheet, {
   BottomSheetRef,
 } from '../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../component-library/components/BottomSheets/BottomSheetHeader';
+import { isMusdToken } from '../../UI/Earn/constants/musd';
 
 // Wrapped SOL token address on Solana
 const WRAPPED_SOL_ADDRESS = 'So11111111111111111111111111111111111111111';
@@ -308,6 +309,7 @@ const AssetOptions = (props: Props) => {
         icon: IconName.DocumentCode,
       });
     !isNativeToken &&
+      !isMusdToken(address) &&
       tokenExistsInState &&
       options.push({
         label: strings('asset_details.options.remove_token'),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR stops allowing the hiding of mUSD if the user has the token in their token list. It blocks it in the three places that a user can hide their token

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updates to disable hiding of mUSD token similar to network tokens but does not display by default

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-276

## **Manual testing steps**

```gherkin
Feature: Disallow hiding mUSD token

  Scenario: User cannot hide mUSD from token list via long press
    Given user has mUSD token in their wallet
    
    When user long-presses on mUSD token in the token list
    Then no hide/remove menu appears

  Scenario: User cannot hide mUSD from asset options menu
    Given user is viewing mUSD token details
    
    When user opens the asset options menu (3-dot menu)
    Then "Remove Token" option is not displayed

  Scenario: User cannot hide mUSD from asset details page
    Given user is viewing mUSD asset details page
    
    When user scrolls to the bottom of the page
    Then "Hide Token" button is not displayed

  Scenario: User can still hide other ERC-20 tokens
    Given user has a non-native, non-mUSD token in their wallet
    
    When user long-presses on that token
    Then hide/remove menu appears as expected
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/1301055c-7b0c-439f-aab6-1377c6488b8a

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/UX guardrail change gated by a simple address check; low risk aside from potentially mis-identifying mUSD if the address list changes or differs by chain in the future.
> 
> **Overview**
> Prevents users from hiding/removing the `mUSD` token by disabling the removal affordances across the UI.
> 
> Adds a shared `isMusdToken` helper (case-insensitive address match) and uses it to: (1) suppress the long-press remove menu in `TokenListItem`, (2) hide the **Hide token** CTA in `AssetDetails`, and (3) omit the **Remove token** option in `AssetOptions`. Updates and adds tests to cover the new `mUSD` detection and the blocked removal flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50fddefe17813f6de640115ef40320f44673a28a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->