### PR TITLE
fix(ramp): localize hardcoded 'Change' text in PaymentMethodSelector

### DIFF
--- a/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelector.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelector.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import { View, StyleSheet } from 'react-native';
 import Box from './Box';
+import { strings } from '../../../../../../locales/i18n';
 import { useTheme } from '../../../../../util/theme';
 import { Colors } from '../../../../../util/theme/models';
 import ListItem from '../../../../../component-library/components/List/ListItem';
@@ -79,7 +80,11 @@ const PaymentMethodSelector: React.FC<IProps> = ({
             <Text variant={TextVariant.BodyLGMedium}>{name}</Text>
           )}
         </ListItemColumn>
-        {!loading && <DownChevronText text="Change" />}
+        {!loading && (
+          <DownChevronText
+            text={strings('fiat_on_ramp_aggregator.payment_method.change')}
+          />
+        )}
       </ListItem>
       <View style={styles.divider} />
       <View style={styles.iconContainer}>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4848,6 +4848,7 @@
       "lowest_sell_limit": "lowest sell limit",
       "medium_sell_limit": "medium sell limit",
       "highest_sell_limit": "highest sell limit",
+      "change": "Change",
       "continue_to_amount": "Continue to amount",
       "no_payment_methods_title": "No payment methods in {{regionName}}",
       "no_cash_destinations_title": "No cash destinations in {{regionName}}",


### PR DESCRIPTION
## **Description**

The "Change" text in the PaymentMethodSelector component on the Buy screen was hardcoded in English. This PR adds proper localization support by:

1. Adding a new i18n key `fiat_on_ramp_aggregator.payment_method.change` in `en.json`
2. Updating `PaymentMethodSelector.tsx` to use the `strings()` function instead of the hardcoded text

This allows the text to be translated into other languages.

## **Changelog**

CHANGELOG entry: Fixed missing localization for "Change" text on the Buy screen

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3255

## **Manual testing steps**

```gherkin
Feature: Localized Change text on Buy screen

  Scenario: User sees localized Change text
    Given the user has the app set to a non-English locale
    And the user navigates to the Buy screen

    When user views the payment method selector
    Then the "Change" text should be displayed in the user's locale (once translations are added)
```

## **Screenshots/Recordings**

### **Before**

Hardcoded "Change" text in English regardless of locale.

### **After**

"Change" text now uses i18n `strings()` function and can be translated.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: replaces a hardcoded string with an i18n lookup and adds the corresponding English translation key.
> 
> **Overview**
> Removes the hardcoded "Change" label in `PaymentMethodSelector` and sources it from `strings('fiat_on_ramp_aggregator.payment_method.change')` instead.
> 
> Adds the new `fiat_on_ramp_aggregator.payment_method.change` entry to `en.json` to support localization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbd27045dc459c001dc12d1258317295bc43ff22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->