### PR TITLE
feat: bring back destination asset sync to new swaps asset picker

### DIFF
--- a/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
@@ -30,6 +30,13 @@ jest.mock('./useIsNetworkEnabled', () => ({
   useIsNetworkEnabled: jest.fn(() => true),
 }));
 
+const mockAutoUpdateDestToken = jest.fn();
+jest.mock('./useAutoUpdateDestToken', () => ({
+  useAutoUpdateDestToken: () => ({
+    autoUpdateDestToken: mockAutoUpdateDestToken,
+  }),
+}));
+
 import { useSelector } from 'react-redux';
 import { useIsNetworkEnabled } from './useIsNetworkEnabled';
 const mockUseSelector = useSelector as jest.Mock;
@@ -60,7 +67,7 @@ describe('useTokenSelection', () => {
         .mockReturnValueOnce(mockDestAmount); // selectDestAmount
     });
 
-    it('dispatches setSourceToken when selecting new source token', async () => {
+    it('dispatches setSourceToken and calls autoUpdateDestToken when selecting new source token', async () => {
       const { result } = renderHook(() =>
         useTokenSelection(TokenSelectorType.Source),
       );
@@ -74,6 +81,7 @@ describe('useTokenSelection', () => {
       });
 
       expect(mockDispatch).toHaveBeenCalledWith(setSourceToken(newToken));
+      expect(mockAutoUpdateDestToken).toHaveBeenCalledWith(newToken);
       expect(mockGoBack).toHaveBeenCalled();
     });
 
@@ -88,6 +96,7 @@ describe('useTokenSelection', () => {
 
       expect(mockHandleSwitchTokens).toHaveBeenCalledWith(mockDestAmount);
       expect(mockHandleSwitchTokensInner).toHaveBeenCalled();
+      expect(mockAutoUpdateDestToken).not.toHaveBeenCalled();
       expect(mockGoBack).toHaveBeenCalled();
     });
 
@@ -193,6 +202,7 @@ describe('useTokenSelection', () => {
       });
 
       expect(mockDispatch).toHaveBeenCalledWith(setSourceToken(newToken));
+      expect(mockAutoUpdateDestToken).toHaveBeenCalledWith(newToken);
       expect(mockGoBack).toHaveBeenCalled();
     });
 
@@ -237,6 +247,7 @@ describe('useTokenSelection', () => {
         setSourceToken(sameAddressToken),
       );
       expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(mockAutoUpdateDestToken).toHaveBeenCalledWith(sameAddressToken);
       expect(mockHandleSwitchTokens).not.toHaveBeenCalled();
     });
 
@@ -260,6 +271,7 @@ describe('useTokenSelection', () => {
 
       expect(mockDispatch).toHaveBeenCalledWith(setSourceToken(sameChainToken));
       expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(mockAutoUpdateDestToken).toHaveBeenCalledWith(sameChainToken);
       expect(mockHandleSwitchTokens).not.toHaveBeenCalled();
     });
   });

--- a/app/components/UI/Bridge/hooks/useTokenSelection.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.ts
@@ -12,6 +12,7 @@ import {
 import { BridgeToken, TokenSelectorType } from '../types';
 import { useSwitchTokens } from './useSwitchTokens';
 import { useIsNetworkEnabled } from './useIsNetworkEnabled';
+import { useAutoUpdateDestToken } from './useAutoUpdateDestToken';
 
 /**
  * Hook to manage token selection logic for Bridge token selector
@@ -26,6 +27,7 @@ export const useTokenSelection = (type: TokenSelectorType) => {
   const destAmount = useSelector(selectDestAmount);
   const { handleSwitchTokens } = useSwitchTokens();
   const isDestNetworkEnabled = useIsNetworkEnabled(destToken?.chainId);
+  const { autoUpdateDestToken } = useAutoUpdateDestToken();
 
   const handleTokenPress = useCallback(
     async (token: BridgeToken) => {
@@ -59,6 +61,9 @@ export const useTokenSelection = (type: TokenSelectorType) => {
         dispatch(isSourcePicker ? setSourceToken(token) : setDestToken(token));
         if (!isSourcePicker) {
           dispatch(setIsDestTokenManuallySet(true));
+        } else {
+          // Auto-update dest token when source token changes
+          autoUpdateDestToken(token);
         }
       }
 
@@ -73,6 +78,7 @@ export const useTokenSelection = (type: TokenSelectorType) => {
       navigation,
       handleSwitchTokens,
       isDestNetworkEnabled,
+      autoUpdateDestToken,
     ],
   );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

bring back destination asset sync to new asset picker. Original PR #23822 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: bring back destination asset sync to new swaps asset picker

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3935

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates bridge token-selection behavior to automatically adjust the destination token when the source token changes, which can affect swap/bridge state and user expectations but stays within UI selection logic.
> 
> **Overview**
> Restores destination-asset syncing in the Bridge asset picker by invoking `useAutoUpdateDestToken` whenever a new **source** token is selected (normal selection path), while leaving the swap-on-select-other-token behavior unchanged.
> 
> Updates `useTokenSelection` unit tests to mock `useAutoUpdateDestToken` and assert the auto-update call occurs for source changes and does *not* occur when tokens are swapped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f942d56fef84930cd3acf63d9a22cc5c0b4527. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->