### PR TITLE
fix: Fix `mm_pay_quote_requested` in MMPay metrics

### DIFF
--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -249,10 +249,10 @@ describe('useTransactionCustomAmount', () => {
     expect(updateTokenAmountMock).toHaveBeenCalledWith('61.725');
   });
 
-  it('sets quote requested metric when updateTokenAmount is called and hasSourceAmount is true', async () => {
-    useTransactionPayHasSourceAmountMock.mockReturnValue(true);
+  it('sets mm_pay_quote_requested metric only when hasSourceAmount becomes true after updateTokenAmount was called', async () => {
+    useTransactionPayHasSourceAmountMock.mockReturnValue(false);
 
-    const { result } = runHook();
+    const { result, rerender } = runHook();
 
     await act(async () => {
       result.current.updatePendingAmount('123.45');
@@ -262,31 +262,18 @@ describe('useTransactionCustomAmount', () => {
 
     await act(async () => {
       result.current.updateTokenAmount();
+    });
+
+    expect(setConfirmationMetricMock).not.toHaveBeenCalled();
+
+    // Simulate hasSourceAmount becoming true
+    useTransactionPayHasSourceAmountMock.mockReturnValue(true);
+
+    await act(async () => {
+      rerender({});
     });
 
     expect(setConfirmationMetricMock).toHaveBeenCalledWith({
-      properties: {
-        mm_pay_quote_requested: true,
-      },
-    });
-  });
-
-  it('does not set quote requested metric when updateTokenAmount is called and hasSourceAmount is false', async () => {
-    useTransactionPayHasSourceAmountMock.mockReturnValue(false);
-
-    const { result } = runHook();
-
-    await act(async () => {
-      result.current.updatePendingAmount('123.45');
-    });
-
-    setConfirmationMetricMock.mockClear();
-
-    await act(async () => {
-      result.current.updateTokenAmount();
-    });
-
-    expect(setConfirmationMetricMock).not.toHaveBeenCalledWith({
       properties: {
         mm_pay_quote_requested: true,
       },

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -35,6 +35,7 @@ export function useTransactionCustomAmount({
   const totals = useTransactionPayTotals();
   const hasSourceAmount = useTransactionPayHasSourceAmount();
   const { setConfirmationMetric } = useConfirmationMetricEvents();
+  const [isTokenAmountUpdated, setIsTokenAmountUpdated] = useState(false);
 
   const debounceSetAmountDelayed = useMemo(
     () =>
@@ -154,20 +155,19 @@ export function useTransactionCustomAmount({
 
   const updateTokenAmount = useCallback(() => {
     updateTokenAmountCallback(amountHuman);
+    setIsTokenAmountUpdated(true);
+  }, [amountHuman, updateTokenAmountCallback]);
 
-    if (hasSourceAmount) {
+  useEffect(() => {
+    if (isTokenAmountUpdated && hasSourceAmount) {
       setConfirmationMetric({
         properties: {
           mm_pay_quote_requested: true,
         },
       });
+      setIsTokenAmountUpdated(false);
     }
-  }, [
-    amountHuman,
-    hasSourceAmount,
-    setConfirmationMetric,
-    updateTokenAmountCallback,
-  ]);
+  }, [hasSourceAmount, isTokenAmountUpdated, setConfirmationMetric]);
 
   return {
     amountFiat,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an issue where the `updateTokenAmountCallback` effect was not being awaited in `transactionPayData.sourceAmounts`, which was preventing the `mm_pay_quote_requested` metric from being set correctly.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6966

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to confirmation metrics timing in `useTransactionCustomAmount` and updates a unit test to match; no transaction execution logic changes.
> 
> **Overview**
> Adjusts `useTransactionCustomAmount` so `mm_pay_quote_requested` is **not** emitted immediately on `updateTokenAmount()`, but only once `hasSourceAmount` becomes true after a token-amount update (tracked via a new `isTokenAmountUpdated` flag).
> 
> Updates the related hook test to assert the metric fires on a subsequent rerender when `hasSourceAmount` flips from false to true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00513dd1e5ae165410b6360b6fecd6da3366624f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->