### PR TITLE
chore: adds call redirect from iab to mockServer

### DIFF
--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -1564,7 +1564,6 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
                         // E2E Testing: Enable native request interception on Android
                         // @ts-expect-error - Custom E2E props not in WebView types
                         e2eMode={isE2E}
-                        // @ts-expect-error - Custom E2E props not in WebView types
                         mockServerUrl={
                           isE2E
                             ? EntryScriptProxyE2E.getMockServerUrl()

--- a/app/core/EntryScriptProxyE2E.ts
+++ b/app/core/EntryScriptProxyE2E.ts
@@ -1,0 +1,263 @@
+import { Platform } from 'react-native';
+import { LaunchArguments } from 'react-native-launch-arguments';
+import {
+  isE2E,
+  FALLBACK_COMMAND_QUEUE_SERVER_PORT,
+  testConfig,
+} from '../util/test/utils';
+import { defaultMockPort } from '../../tests/api-mocking/mock-config/mockUrlCollection.json';
+
+// Fallback port for mock server - same pattern as FixtureServer
+// Android: Uses fallback port (adb reverse maps it to actual port)
+// iOS: Uses actual port from LaunchArguments
+const FALLBACK_MOCKSERVER_PORT = defaultMockPort || 8000;
+
+/**
+ * The E2E proxy script that gets injected into the WebView.
+ * This script patches fetch and XMLHttpRequest to route through the mock server.
+ *
+ * This is embedded directly rather than loaded from a file to avoid
+ * complex build configuration changes.
+ */
+const INPAGE_PROXY_SCRIPT = `
+(function () {
+  'use strict';
+
+  // Check if E2E config is available
+  if (!window.__E2E_MOCK_CONFIG__) {
+    return;
+  }
+
+  var config = window.__E2E_MOCK_CONFIG__;
+  var mockServerPort = config.mockServerPort;
+  var isAndroid = config.isAndroid;
+  var commandQueueServerPort = config.commandQueueServerPort;
+
+  var originalFetch = window.fetch;
+  var OriginalXHR = window.XMLHttpRequest;
+
+  // Try multiple hosts to find available mock server
+  var hosts = ['localhost'];
+  if (isAndroid) {
+    hosts.push('10.0.2.2');
+  }
+
+  var MOCKTTP_URL = '';
+  var isMockServerAvailable = false;
+
+  function isLocalUrl(url) {
+    try {
+      var parsed = new URL(url);
+      return (
+        parsed.hostname === 'localhost' ||
+        parsed.hostname === '127.0.0.1' ||
+        parsed.hostname === '10.0.2.2'
+      );
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function isCommandQueueUrl(url) {
+    try {
+      var parsed = new URL(url);
+      return (
+        isLocalUrl(url) && parsed.port === String(commandQueueServerPort)
+      );
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function isMockServerUrl(url) {
+    return (
+      url.includes('localhost:' + mockServerPort) ||
+      url.includes('10.0.2.2:' + mockServerPort) ||
+      url.includes('/proxy')
+    );
+  }
+
+  (async function init() {
+    for (var i = 0; i < hosts.length; i++) {
+      var host = hosts[i];
+      var testUrl = 'http://' + host + ':' + mockServerPort;
+
+      try {
+        var res = await originalFetch(testUrl + '/health-check');
+        if (res.ok) {
+          MOCKTTP_URL = testUrl;
+          isMockServerAvailable = true;
+          console.log('[E2E WebView] Mock server connected via ' + host);
+          break;
+        }
+      } catch (e) {
+        console.log('[E2E WebView] ' + host + ' health check failed: ' + e.message);
+      }
+    }
+
+    if (!isMockServerAvailable) {
+      console.warn('[E2E WebView] Mock server not available, using original fetch');
+      return;
+    }
+
+    // Patch fetch
+    window.fetch = async function (url, options) {
+      var urlString;
+      if (typeof url === 'string') {
+        urlString = url;
+      } else if (url instanceof URL) {
+        urlString = url.href;
+      } else if (url && typeof url === 'object' && url.url) {
+        urlString = url.url;
+      } else {
+        urlString = String(url);
+      }
+
+      if (isCommandQueueUrl(urlString) || isMockServerUrl(urlString)) {
+        return originalFetch(url, options);
+      }
+
+      if (urlString.startsWith('http://') || urlString.startsWith('https://')) {
+        try {
+          return await originalFetch(
+            MOCKTTP_URL + '/proxy?url=' + encodeURIComponent(urlString),
+            options
+          );
+        } catch (e) {
+          return originalFetch(url, options);
+        }
+      }
+
+      return originalFetch(url, options);
+    };
+
+    // Patch XMLHttpRequest
+    if (OriginalXHR) {
+      window.XMLHttpRequest = function () {
+        var xhr = new OriginalXHR();
+        var originalOpen = xhr.open;
+
+        xhr.open = function (method, url) {
+          var openArgs = Array.prototype.slice.call(arguments, 2);
+
+          try {
+            if (
+              typeof url === 'string' &&
+              (url.startsWith('http://') || url.startsWith('https://'))
+            ) {
+              if (isCommandQueueUrl(url) || isMockServerUrl(url)) {
+                return originalOpen.apply(this, [method, url].concat(openArgs));
+              }
+              url = MOCKTTP_URL + '/proxy?url=' + encodeURIComponent(url);
+            }
+            return originalOpen.apply(this, [method, url].concat(openArgs));
+          } catch (error) {
+            return originalOpen.apply(this, [method, url].concat(openArgs));
+          }
+        };
+
+        return xhr;
+      };
+
+      try {
+        Object.setPrototypeOf(window.XMLHttpRequest, OriginalXHR);
+        Object.assign(window.XMLHttpRequest, OriginalXHR);
+        window.__E2E_XHR_PATCHED = true;
+        console.log('[E2E WebView] Successfully patched XMLHttpRequest');
+      } catch (error) {
+        console.warn('[E2E WebView] Failed to copy XHR properties:', error);
+        window.XMLHttpRequest = OriginalXHR;
+      }
+    }
+
+    console.log('[E2E WebView] Fetch and XHR patching complete');
+  })();
+})();
+`;
+
+interface LaunchArgsType {
+  mockServerPort?: string;
+  commandQueueServerPort?: string;
+}
+
+interface TestConfigType {
+  fixtureServerPort?: number;
+  commandQueueServerPort?: number;
+}
+
+const EntryScriptProxyE2E = {
+  cachedScript: null as string | null,
+  cachedMockServerUrl: null as string | null,
+
+  /**
+   * Get the mock server port based on platform.
+   * Android: Uses fallback port (adb reverse maps to actual)
+   * iOS: Uses actual port from LaunchArguments
+   */
+  getMockServerPort(): number {
+    const raw = LaunchArguments.value() as LaunchArgsType;
+    return Platform.OS === 'android'
+      ? FALLBACK_MOCKSERVER_PORT
+      : Number(raw?.mockServerPort ?? FALLBACK_MOCKSERVER_PORT);
+  },
+
+  /**
+   * Get the mock server URL for native WebView interception.
+   * Returns the URL that the native code should use to proxy requests.
+   */
+  getMockServerUrl(): string | undefined {
+    if (!isE2E) {
+      return undefined;
+    }
+
+    if (this.cachedMockServerUrl) {
+      return this.cachedMockServerUrl;
+    }
+
+    const port = this.getMockServerPort();
+    // Use localhost for both platforms - adb reverse handles Android mapping
+    this.cachedMockServerUrl = `http://localhost:${port}`;
+    return this.cachedMockServerUrl;
+  },
+
+  /**
+   * Get the E2E proxy script with configuration prepended.
+   * Returns empty string if not in E2E mode.
+   */
+  get(): string {
+    // Only return script in E2E mode
+    if (!isE2E) {
+      return '';
+    }
+
+    // Return cached if available
+    if (this.cachedScript) {
+      return this.cachedScript;
+    }
+
+    const mockServerPort = this.getMockServerPort();
+    const commandQueueServerPort =
+      (testConfig as TestConfigType).commandQueueServerPort ??
+      FALLBACK_COMMAND_QUEUE_SERVER_PORT;
+
+    // Create the configuration that will be injected before the script
+    const config = `window.__E2E_MOCK_CONFIG__ = {
+  mockServerPort: ${mockServerPort},
+  isAndroid: ${Platform.OS === 'android'},
+  commandQueueServerPort: ${commandQueueServerPort}
+};`;
+
+    this.cachedScript = config + INPAGE_PROXY_SCRIPT;
+    return this.cachedScript;
+  },
+
+  /**
+   * Clear the cached script and URL (useful for testing)
+   */
+  clearCache(): void {
+    this.cachedScript = null;
+    this.cachedMockServerUrl = null;
+  },
+};
+
+export default EntryScriptProxyE2E;

--- a/tests/api-mocking/MockServerE2E.ts
+++ b/tests/api-mocking/MockServerE2E.ts
@@ -202,7 +202,7 @@ export default class MockServerE2E implements Resource {
       return;
     }
 
-    this._server = getLocal() as InternalMockServer;
+    this._server = getLocal({ cors: true }) as InternalMockServer;
     this._server._liveRequests = [];
     await this._server.start(this._serverPort);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Enable E2E mock server interception for the in-app browser (WebView). Previously, API calls made from websites loaded in the WebView were not being intercepted by the mock server during E2E tests, causing tests to hit live endpoints.

### Problem
The existing mock server implementation patches fetch and XMLHttpRequest in the React Native JavaScript context (shim.js). However, the WebView runs in a separate browser context with its own network stack, so these patches don't affect WebView requests.

### Solution
This PR adds two complementary interception mechanisms for the WebView:
1. JavaScript Injection - Inject a script that patches window.fetch and window.XMLHttpRequest within the WebView context, routing requests through the mock server proxy
2. Native Interception (Android) - Pass e2eMode and mockServerUrl props to the WebView component to enable native-level request interception via shouldInterceptRequest (requires updated @metamask/react-native-webview)

### Changes
`app/core/EntryScriptProxyE2E.ts` (New File)
- Creates the JavaScript injection script that patches fetch/XHR in WebView context
- Mirrors the logic from shim.js for consistency (health check, host fallback, proxy URL format)
- Handles platform-specific port configuration (Android uses fallback + adb reverse, iOS uses LaunchArguments)

`app/components/Views/BrowserTab/BrowserTab.tsx`
- Import isE2E and EntryScriptProxyE2E
- Inject the E2E proxy script before other scripts in E2E mode
- Pass e2eMode and mockServerUrl props to WebView for native interception

`tests/api-mocking/MockServerE2E.ts`
- Enable CORS on the mock server ({ cors: true }) to allow cross-origin requests from WebView
scripts/build.sh


### Example
With this change we can now see live calls being catch on the mock server coming from the IAB.
```
14:55:58.501 detox[25791] i [E2E Framework] [WARN] [MockServer] Request going to live server: https://m.youtube.com/youtubei/v1/guide?prettyPrint=false
14:55:58.968 detox[25791] i [E2E Framework] [WARN] [MockServer] Request going to live server: https://fonts.gstatic.com/s/i/youtube_outline_experimental/alert_bubble/v2/24px.svg
14:55:58.975 detox[25791] i [E2E Framework] [WARN] [MockServer] Request going to live server: https://fonts.gstatic.com/s/i/youtube_outline_experimental/arrow_left/v8/24px.svg

```


### Dependencies
This PR requires an updated version of @metamask/react-native-webview with native E2E interception support. See: https://github.com/MetaMask/react-native-webview-mm/pull/78

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added the ability to intercept calls coming from the inapp browser on E2E

## **Related issues**

Fixes:

## **Manual testing steps**
- Verified WebView requests are routed through mock server proxy
- Verified health check connects successfully with CORS enabled
- Verified non-E2E builds are unaffected

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
