### PR TITLE
fix: display specific geolocation error message for selected rwa token cp-7.64.0

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -88,6 +88,7 @@ import { useIsGasIncludedSTXSendBundleSupported } from '../../hooks/useIsGasIncl
 import { useIsGasIncluded7702Supported } from '../../hooks/useIsGasIncluded7702Supported/index.ts';
 import { useRefreshSmartTransactionsLiveness } from '../../../../hooks/useRefreshSmartTransactionsLiveness';
 import { BridgeViewSelectorsIDs } from './BridgeView.testIds';
+import { useRWAToken } from '../../hooks/useRWAToken.ts';
 
 export interface BridgeRouteParams {
   sourcePage: string;
@@ -125,6 +126,7 @@ const BridgeView = () => {
   const bridgeViewMode = useSelector(selectBridgeViewMode);
   const { quotesLastFetched } = useSelector(selectBridgeControllerState);
   const { handleSwitchTokens } = useSwitchTokens();
+  const { isStockToken } = useRWAToken();
   const selectedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
   );
@@ -420,6 +422,15 @@ const BridgeView = () => {
     isSelectingToken,
     isSubmittingTx,
   ]);
+  const isRWATokenSelected = useMemo(
+    () =>
+      isStockToken(sourceToken as BridgeToken) ||
+      isStockToken(destToken as BridgeToken),
+    [isStockToken, sourceToken, destToken],
+  );
+  const genericErrorMessage = isRWATokenSelected
+    ? strings('bridge.stock_token_error_banner_description')
+    : strings('bridge.error_banner_description');
 
   const renderBottomContent = (submitDisabled: boolean) => {
     if (shouldDisplayKeypad && !isLoading) {
@@ -447,7 +458,7 @@ const BridgeView = () => {
         <Box style={styles.buttonContainer}>
           <BannerAlert
             severity={BannerAlertSeverity.Error}
-            description={strings('bridge.error_banner_description')}
+            description={genericErrorMessage}
             onClose={() => {
               setIsErrorBannerVisible(false);
               setIsInputFocused(true);

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -424,8 +424,8 @@ const BridgeView = () => {
   ]);
   const isRWATokenSelected = useMemo(
     () =>
-      isStockToken(sourceToken as BridgeToken) ||
-      isStockToken(destToken as BridgeToken),
+      (sourceToken && isStockToken(sourceToken as BridgeToken)) ||
+      (destToken && isStockToken(destToken as BridgeToken)),
     [isStockToken, sourceToken, destToken],
   );
   const genericErrorMessage = isRWATokenSelected

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6335,6 +6335,7 @@
     "select_recipient": "Select recipient",
     "external_account": "External account",
     "error_banner_description": "This trade route isn't available right now. Try changing the amount, network, or token and we'll find the best option.",
+    "stock_token_error_banner_description": "This trade route isn't available right now. Try changing the amount, network, or token and we'll find the best option.\n\nPlease note if you are attempting to trade Ondo Tokenised Stocks you may be geo-restricted e.g. via US, EU, UK and BR.",
     "insufficient_funds": "Insufficient funds",
     "insufficient_gas": "Insufficient gas",
     "select_amount": "Select amount",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a specific error message when a RWA token is selected. This messages adds information about unsupported geolocation.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: display specific geolocation error message for selected rwa token

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **After**

#### Regular error message when quotes are empty

<img width="250" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-02-04 at 18 37 26" src="https://github.com/user-attachments/assets/352f7d74-54a6-45c4-bf5e-cb4c2ba008ce" />

--------

#### Custom  error message when quotes are empty and RWA source token is selected

<img width="250" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-02-04 at 18 37 48" src="https://github.com/user-attachments/assets/ce9c07a4-ac70-442c-83dd-0a93f4830eab" />

--------

#### Custom  error message when quotes are empty and RWA destination token is selected

<img width="250" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-02-04 at 18 41 48" src="https://github.com/user-attachments/assets/3bcb9450-b8ff-441a-a4b6-d42a21ab7153" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only copy change gated behind `useRWAToken().isStockToken` with added unit coverage; primary risk is misclassification of tokens leading to showing the wrong banner text.
> 
> **Overview**
> When the Bridge flow has no quotes / quote fetch errors, the error banner now conditionally shows a **stock RWA geolocation restriction** message if either the source or destination token is detected as a stock token via `useRWAToken().isStockToken`.
> 
> Adds the new i18n string `bridge.stock_token_error_banner_description` and updates `BridgeView` tests to mock `useRWAToken` and assert the correct banner copy for RWA vs non-RWA selections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfa79ba174bb6463c02c356ddf2a1520acdd670b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->