### PR TITLE
fix: resolve SonarCloud maintenance issues in TrendingView

### DIFF
--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -47,6 +47,21 @@ function applySectionState(
   return next;
 }
 
+function buildSectionCallbacks(
+  sections: { id: SectionId }[],
+  setActiveSections: React.Dispatch<React.SetStateAction<Set<SectionId>>>,
+): Record<SectionId, (isActive: boolean) => void> {
+  const result = {} as Record<SectionId, (isActive: boolean) => void>;
+  sections.forEach((section) => {
+    result[section.id] = (isActive: boolean) => {
+      setActiveSections((current) =>
+        applySectionState(current, section.id, isActive),
+      );
+    };
+  });
+  return result;
+}
+
 const useSectionStateTracker = (
   sections: { id: SectionId }[],
 ): {
@@ -56,21 +71,10 @@ const useSectionStateTracker = (
   const [activeSections, setActiveSections] = useState<Set<SectionId>>(
     new Set(),
   );
-
-  const callbacks = useMemo(() => {
-    const result = {} as Record<SectionId, (isActive: boolean) => void>;
-
-    sections.forEach((section) => {
-      result[section.id] = (isActive: boolean) => {
-        setActiveSections((current) =>
-          applySectionState(current, section.id, isActive),
-        );
-      };
-    });
-
-    return result;
-  }, [sections]);
-
+  const callbacks = useMemo(
+    () => buildSectionCallbacks(sections, setActiveSections),
+    [sections],
+  );
   return { sectionsWithState: activeSections, callbacks };
 };
 

--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -36,6 +36,17 @@ import { TrendingViewSelectorsIDs } from './TrendingView.testIds';
  * Custom hook to track boolean state for each section
  * Returns the Set of sections with that state and callbacks to update them
  */
+function applySectionState(
+  current: Set<SectionId>,
+  sectionId: SectionId,
+  isActive: boolean,
+): Set<SectionId> {
+  const next = new Set(current);
+  if (isActive) next.add(sectionId);
+  else next.delete(sectionId);
+  return next;
+}
+
 const useSectionStateTracker = (
   sections: { id: SectionId }[],
 ): {
@@ -51,17 +62,9 @@ const useSectionStateTracker = (
 
     sections.forEach((section) => {
       result[section.id] = (isActive: boolean) => {
-        setActiveSections((currentSections) => {
-          const updatedSections = new Set(currentSections);
-
-          if (isActive) {
-            updatedSections.add(section.id);
-          } else {
-            updatedSections.delete(section.id);
-          }
-
-          return updatedSections;
-        });
+        setActiveSections((current) =>
+          applySectionState(current, section.id, isActive),
+        );
       };
     });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes SonarCloud maintenance issues in `TrendingView.tsx`:

### 1. typescript:S2004 – Nesting too deep
The `useSectionStateTracker` hook had **5 levels of nesting** inside the `useMemo` callback (useMemo → forEach → callback → setState updater → if/else), above the 4-level limit.

**Change:** Extracted the “compute next Set” logic into a top-level helper `applySectionState(current, sectionId, isActive)`. The `useMemo` now only builds the callbacks and calls that helper, so nesting stays at 4 levels. Behavior is unchanged.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change to `TrendingView` state callback construction; low risk aside from potential subtle closure/state update regressions.
> 
> **Overview**
> Refactors `useSectionStateTracker` in `TrendingView.tsx` to reduce nesting by extracting Set update logic into `applySectionState` and callback construction into `buildSectionCallbacks`.
> 
> The hook now memoizes a call to `buildSectionCallbacks` rather than inlining a deeply nested `useMemo` implementation; intended behavior for tracking section empty/loading state remains the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7f29384005733dfe6d0ac0bcb218dd2f15c4f4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->