### PR TITLE
feat: Auto-select preferred provider in useRampsProviders

### DIFF
--- a/app/components/UI/Ramp/hooks/useRampsProviders.ts
+++ b/app/components/UI/Ramp/hooks/useRampsProviders.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import {
   selectProviders,
@@ -11,6 +11,8 @@ import {
   type Provider,
 } from '@metamask/ramps-controller';
 import Engine from '../../../../core/Engine';
+import { determinePreferredProvider } from '../utils/determinePreferredProvider';
+import { getOrders } from '../../../../reducers/fiatOrders';
 
 /**
  * Result returned by the useRampsProviders hook.
@@ -59,6 +61,7 @@ export function useRampsProviders(
   const providers = useSelector(selectProviders);
   const selectedProvider = useSelector(selectSelectedProvider);
   const userRegion = useSelector(selectUserRegion);
+  const orders = useSelector(getOrders);
 
   const regionCode = useMemo(
     () => region ?? userRegion?.regionCode ?? '',
@@ -81,6 +84,12 @@ export function useRampsProviders(
       ) => void
     )(provider?.id ?? null);
   }, []);
+
+  useEffect(() => {
+    if (!selectedProvider && providers.length > 0) {
+      setSelectedProvider(determinePreferredProvider(orders, providers));
+    }
+  }, [providers, orders, selectedProvider, setSelectedProvider]);
 
   return {
     providers,


### PR DESCRIPTION
## Summary
- Automatically selects the preferred provider when no provider is currently selected and providers are available
- Improves UX by preselecting the most appropriate provider based on the user's order history
- Uses the existing `determinePreferredProvider` utility to intelligently choose the best provider

## Technical changes
- Added `useEffect` hook to `useRampsProviders` that runs when providers list or orders change
- Imports `getOrders` selector to access user's fiat order history
- Imports `determinePreferredProvider` utility for provider selection logic
- Added `useEffect` to React imports

## Test plan
- [ ] Verify that when opening the ramps flow with no selected provider, a provider is automatically selected
- [ ] Verify that the auto-selection respects user's order history
- [ ] Verify that manual provider selection still works as expected
- [ ] Verify that the hook doesn't interfere when a provider is already selected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes selection side effects in a shared hook and could unintentionally override/oscillate provider selection as providers/orders load, affecting ramp UX across flows.
> 
> **Overview**
> **Auto-selects a ramp provider by default.** `useRampsProviders` now pulls fiat order history via `getOrders` and, when no provider is selected and providers are available, runs an effect to set the selection using `determinePreferredProvider`.
> 
> This introduces a new automatic side effect in the hook, aiming to preselect the most relevant provider based on past completed orders (with fallbacks) instead of leaving selection empty until the user picks one.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cf962c60a9424b3709a3ba46be9736fd0668814. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->