### PR TITLE
feat(predict): cp-7.65.0 add analytics tracking to deposit flow

### DIFF
--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
@@ -293,7 +293,7 @@ describe('PredictBalance', () => {
       expect(queryByText(/Withdraw/i)).not.toBeOnTheScreen();
     });
 
-    it('calls deposit function when Add Funds button is pressed', () => {
+    it('calls deposit function with analytics properties when Add Funds button is pressed', () => {
       // Arrange
       const mockDeposit = jest.fn();
       mockUsePredictBalance.mockReturnValue({
@@ -318,6 +318,11 @@ describe('PredictBalance', () => {
 
       // Assert
       expect(mockDeposit).toHaveBeenCalledTimes(1);
+      expect(mockDeposit).toHaveBeenCalledWith({
+        analyticsProperties: {
+          entryPoint: 'homepage_balance',
+        },
+      });
     });
 
     it('calls executeGuardedAction when Add Funds button is pressed', () => {

--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
@@ -70,7 +70,11 @@ const PredictBalance: React.FC<PredictBalanceProps> = ({ onLayout }) => {
   const handleAddFunds = useCallback(() => {
     executeGuardedAction(
       () => {
-        deposit();
+        deposit({
+          analyticsProperties: {
+            entryPoint: PredictEventValues.ENTRY_POINT.HOMEPAGE_BALANCE,
+          },
+        });
       },
       { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.DEPOSIT },
     );

--- a/app/components/UI/Predict/constants/eventNames.ts
+++ b/app/components/UI/Predict/constants/eventNames.ts
@@ -86,10 +86,14 @@ export const PredictEventValues = {
     BACKGROUND: 'background',
     TRENDING_SEARCH: 'trending_search',
     TRENDING: 'trending',
+    BUY_PREVIEW: 'buy_preview',
   },
   TRANSACTION_TYPE: {
     MM_PREDICT_BUY: 'mm_predict_buy',
     MM_PREDICT_SELL: 'mm_predict_sell',
+    MM_PREDICT_DEPOSIT: 'mm_predict_deposit',
+    MM_PREDICT_WITHDRAW: 'mm_predict_withdraw',
+    MM_PREDICT_CLAIM: 'mm_predict_claim',
   },
   MARKET_TYPE: {
     BINARY: 'binary',

--- a/app/components/UI/Predict/hooks/usePredictDeposit.ts
+++ b/app/components/UI/Predict/hooks/usePredictDeposit.ts
@@ -112,7 +112,7 @@ export const usePredictDeposit = ({
             hasNoTimeout: false,
             linkButtonOptions: {
               label: strings('predict.deposit.try_again'),
-              onPress: () => deposit(),
+              onPress: () => deposit(params),
             },
           });
         });
@@ -136,7 +136,7 @@ export const usePredictDeposit = ({
           hasNoTimeout: false,
           linkButtonOptions: {
             label: strings('predict.deposit.try_again'),
-            onPress: () => deposit(),
+            onPress: () => deposit(params),
           },
         });
 

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
@@ -21,6 +21,7 @@ import { ensureError, parseErrorMessage } from '../utils/predictErrorHandler';
 import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../constants/errors';
 import { usePredictBalance } from './usePredictBalance';
 import { usePredictDeposit } from './usePredictDeposit';
+import { PredictEventValues } from '../constants/eventNames';
 
 interface UsePredictPlaceOrderOptions {
   /**
@@ -135,7 +136,14 @@ export function usePredictPlaceOrder(
       // Check if user has sufficient balance for the bet amount
       // maxAmountSpent includes the bet amount plus all fees
       if (side === Side.BUY && balance < maxAmountSpent) {
-        await deposit();
+        await deposit({
+          amountUsd: maxAmountSpent,
+          analyticsProperties: {
+            ...orderParams.analyticsProperties,
+            marketId: orderParams.preview.marketId,
+            entryPoint: PredictEventValues.ENTRY_POINT.BUY_PREVIEW,
+          },
+        });
         return;
       }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add analytics event tracking when deposit is triggered from different
entry points (homepage balance, buy preview). The deposit function now
accepts optional analytics parameters including entryPoint and amountUsd.
- Add trackPredictOrderEvent call in usePredictDeposit when analytics
  properties are provided
- Pass HOMEPAGE_BALANCE entry point from PredictBalance component
- Pass BUY_PREVIEW entry point with market context from usePredictPlaceOrder
  when balance is insufficient
- Add new event values: BUY_PREVIEW entry point and transaction types
  for deposit, withdraw, and claim
- Update tests to verify analytics properties are passed correctly

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the deposit initiation path and changes the `deposit` hook API to accept parameters, which could break callers or alter deposit triggering behavior if mis-wired; analytics additions are otherwise low impact.
> 
> **Overview**
> Adds analytics instrumentation to the Predict deposit flow by extending `usePredictDeposit.deposit` to accept optional `{ amountUsd, analyticsProperties }` and emitting `PredictController.trackPredictOrderEvent` with `status: initiated` and `transactionType: mm_predict_deposit` when provided.
> 
> Threads the new analytics context through key entry points: `PredictBalance` passes `entryPoint: homepage_balance` for the Add Funds button, and `usePredictPlaceOrder` triggers a deposit on insufficient BUY balance while passing `amountUsd`, `entryPoint: buy_preview`, and market context (merging any existing `orderParams.analyticsProperties`). Event constants are expanded with `BUY_PREVIEW` and new transaction type values, and tests are updated/added to assert the new analytics payloads and tracking behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d00ac49b7370892b0ca8b6584613661834dfb03a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->