### PR TITLE
feat: set preferred ramp provider based on orders

### DIFF
--- a/app/components/UI/Ramp/hooks/useRampsProviders.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsProviders.test.ts
@@ -6,7 +6,7 @@ import { useRampsProviders } from './useRampsProviders';
 import { type Provider as RampProvider } from '@metamask/ramps-controller';
 import Engine from '../../../../core/Engine';
 import { determinePreferredProvider } from '../utils/determinePreferredProvider';
-import { getOrders } from '../../../../reducers/fiatOrders';
+import { getOrders, type FiatOrder } from '../../../../reducers/fiatOrders';
 
 jest.mock('../../../../core/Engine', () => ({
   context: {
@@ -20,7 +20,7 @@ jest.mock('../utils/determinePreferredProvider', () => ({
   determinePreferredProvider: jest.fn(),
 }));
 
-const emptyOrders: unknown[] = [];
+const emptyOrders: FiatOrder[] = [];
 jest.mock('../../../../reducers/fiatOrders', () => ({
   ...jest.requireActual('../../../../reducers/fiatOrders'),
   getOrders: jest.fn((_state: unknown) => emptyOrders),

--- a/app/components/UI/Ramp/hooks/useRampsProviders.ts
+++ b/app/components/UI/Ramp/hooks/useRampsProviders.ts
@@ -1,8 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { selectProviders } from '../../../../selectors/rampsController';
 import { type Provider } from '@metamask/ramps-controller';
 import Engine from '../../../../core/Engine';
+import { determinePreferredProvider } from '../utils/determinePreferredProvider';
+import { getOrders } from '../../../../reducers/fiatOrders';
 
 /**
  * Result returned by the useRampsProviders hook.
@@ -45,11 +47,19 @@ export function useRampsProviders(): UseRampsProvidersResult {
     error,
   } = useSelector(selectProviders);
 
+  const orders = useSelector(getOrders);
+
   const setSelectedProvider = useCallback(
     (provider: Provider | null) =>
       Engine.context.RampsController.setSelectedProvider(provider?.id ?? null),
     [],
   );
+
+  useEffect(() => {
+    if (providers.length > 0 && !selectedProvider) {
+      setSelectedProvider(determinePreferredProvider(orders, providers));
+    }
+  }, [providers, selectedProvider, setSelectedProvider, orders]);
 
   return {
     providers,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a useEffect in `useRampsProviders` to set the preferred ramp provider.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new side-effecting selection logic tied to Redux state, which can change default provider behavior and potentially trigger unintended provider switches if selectors/effect dependencies behave unexpectedly.
> 
> **Overview**
> Automatically sets a *preferred* on-ramp provider in `useRampsProviders` when providers are loaded and no provider is currently selected, using `getOrders` plus `determinePreferredProvider` to pick based on prior order history.
> 
> Extends `useRampsProviders` tests to mock orders/preference logic and assert that the effect selects the computed provider only when appropriate (providers present + no existing selection), and does nothing when providers are empty or a selection already exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14114a8ff105b2630312e790966dc9dc89ced0e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>14114a8</u></sup><!-- /BUGBOT_STATUS -->