### PR TITLE
feat: MUSD-280 Make mUSD Conversion Primary CTA text clickable

### DIFF
--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
 import styleSheet from './MusdConversionAssetListCta.styles';
 import Text, {
   TextVariant,
@@ -12,7 +12,6 @@ import {
 } from '@metamask/design-system-react-native';
 import {
   MUSD_CONVERSION_APY,
-  MUSD_CONVERSION_DEFAULT_CHAIN_ID,
   MUSD_TOKEN,
   MUSD_TOKEN_ASSET_ID_BY_CHAIN,
 } from '../../../constants/musd';
@@ -59,15 +58,13 @@ const MusdConversionAssetListCta = () => {
   const { shouldShowCta, showNetworkIcon, selectedChainId } =
     shouldShowBuyGetMusdCta();
 
-  const networkName = useNetworkName(
-    selectedChainId ?? MUSD_CONVERSION_DEFAULT_CHAIN_ID,
-  );
+  const networkName = useNetworkName(selectedChainId ?? undefined);
 
-  const ctaText = isEmptyWallet
+  const buttonText = isEmptyWallet
     ? strings('earn.musd_conversion.buy_musd')
     : strings('earn.musd_conversion.get_musd');
 
-  const submitCtaPressedEvent = () => {
+  const submitCtaPressedEvent = (source: 'cta_button' | 'cta_text') => {
     const { MUSD_CTA_TYPES, EVENT_LOCATIONS } = MUSD_EVENTS_CONSTANTS;
 
     const getRedirectLocation = () => {
@@ -80,6 +77,13 @@ const MusdConversionAssetListCta = () => {
         : EVENT_LOCATIONS.CONVERSION_EDUCATION_SCREEN;
     };
 
+    const ctaText =
+      source === 'cta_button'
+        ? buttonText
+        : strings('earn.earn_a_percentage_bonus', {
+            percentage: MUSD_CONVERSION_APY,
+          });
+
     trackEvent(
       createEventBuilder(MetaMetricsEvents.MUSD_CONVERSION_CTA_CLICKED)
         .addProperties({
@@ -87,15 +91,15 @@ const MusdConversionAssetListCta = () => {
           redirects_to: getRedirectLocation(),
           cta_type: MUSD_CTA_TYPES.PRIMARY,
           cta_text: ctaText,
-          network_chain_id: selectedChainId || MUSD_CONVERSION_DEFAULT_CHAIN_ID,
-          network_name: networkName,
+          network_chain_id: selectedChainId,
+          network_name: networkName ?? strings('wallet.popular_networks'),
         })
         .build(),
     );
   };
 
-  const handlePress = async () => {
-    submitCtaPressedEvent();
+  const handlePress = async (source: 'cta_button' | 'cta_text') => {
+    submitCtaPressedEvent(source);
 
     if (isEmptyWallet) {
       const chainId = getChainIdForBuyFlow();
@@ -169,21 +173,23 @@ const MusdConversionAssetListCta = () => {
           <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
             MetaMask USD
           </Text>
-          <Text variant={TextVariant.BodySMMedium} color={TextColor.Primary}>
-            {strings('earn.earn_a_percentage_bonus', {
-              percentage: MUSD_CONVERSION_APY,
-            })}
-          </Text>
+          <TouchableOpacity onPress={() => handlePress('cta_text')}>
+            <Text variant={TextVariant.BodySMMedium} color={TextColor.Primary}>
+              {strings('earn.earn_a_percentage_bonus', {
+                percentage: MUSD_CONVERSION_APY,
+              })}
+            </Text>
+          </TouchableOpacity>
         </View>
       </View>
 
       <Button
         variant={ButtonVariant.Secondary}
-        onPress={handlePress}
+        onPress={() => handlePress('cta_button')}
         size={ButtonSize.Sm}
       >
         <Text variant={TextVariant.BodySMMedium} color={TextColor.Default}>
-          {ctaText}
+          {buttonText}
         </Text>
       </Button>
     </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR makes the "Earn a 3% bonus" text in the mUSD conversion CTA clickable.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updates the "Earn a 3% bonus" text in the mUSD conversion CTA to be clickable.

## **Related issues**

Fixes: [MUSD-280: mUSD Conversion Primary CTA isn't clickable](https://consensyssoftware.atlassian.net/browse/MUSD-280)

## **Manual testing steps**

```gherkin
Feature: mUSD conversion CTA link text

  Scenario: user taps the bonus text CTA
    Given user is viewing the mUSD conversion CTA on the token list

    When user taps the "Earn a <percentage>% bonus" text
    Then the conversion CTA action is initiated
    And an analytics event is tracked with cta_text set to the bonus text
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
N/A - Text isn't clickable

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/dc1246c9-0659-4562-93bd-f5854c50395a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI interaction and analytics payload changes scoped to the mUSD conversion CTA; no auth/security or persistent data changes, but tracking fields and click targets could regress if event expectations are wrong.
> 
> **Overview**
> Makes the mUSD conversion promo line ("Earn a X% bonus") tappable by wrapping it in a `TouchableOpacity` and routing it through the same CTA handler as the button.
> 
> Updates MetaMetrics tracking to distinguish *button vs text* clicks (`cta_text` now reflects the actual pressed element), and changes network analytics fields to use `selectedChainId`/`useNetworkName` when available with a fallback to `wallet.popular_networks`.
> 
> Expands/rewrites unit tests to cover clicking the bonus text, the new event properties (`cta_text`, `redirects_to`, `network_name` fallback), and `useNetworkName` behavior when no chain is selected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ddd5fdbf1f7c5e3c1b0e488d685d7d53b8f1fb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>1ddd5fd</u></sup><!-- /BUGBOT_STATUS -->