### PR TITLE
feat(predict): add version gating to market highlights and filter closed markets

### DIFF
--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -24,6 +24,7 @@ export const DEFAULT_LIVE_SPORTS_FLAG: PredictLiveSportsFlag = {
 export const DEFAULT_MARKET_HIGHLIGHTS_FLAG: PredictMarketHighlightsFlag = {
   enabled: false,
   highlights: [],
+  minimumVersion: '7.64.0',
 };
 
 export const DEFAULT_HOT_TAB_FLAG: PredictHotTabFlag = {

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -58,6 +58,7 @@ const DEFAULT_REMOTE_FEATURE_FLAG_STATE = {
     },
     predictMarketHighlights: {
       enabled: false,
+      minimumVersion: '0.0.0',
       highlights: [],
     },
   },
@@ -69,6 +70,11 @@ const DEFAULT_NETWORK_CLIENT = {
     checkForLatestBlock: jest.fn().mockResolvedValue(undefined),
   },
 };
+
+// Mock react-native-device-info for version gating
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('99.0.0'),
+}));
 
 // Mock DevLogger (default export)
 jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
@@ -1803,11 +1809,16 @@ describe('PredictController', () => {
       title: `Market ${id}`,
       category,
       outcomes: ['YES', 'NO'],
+      status: 'open',
     });
 
     const createFlagState = (flag: {
       enabled: boolean;
-      highlights: { category: string; markets: string[] }[];
+      minimumVersion?: string;
+      highlights: {
+        category: string;
+        markets: string[];
+      }[];
     }) => ({
       remoteFeatureFlags: {
         predictFeeCollection: {
@@ -1821,7 +1832,10 @@ describe('PredictController', () => {
           enabled: false,
           leagues: [],
         },
-        predictMarketHighlights: flag,
+        predictMarketHighlights: {
+          ...flag,
+          minimumVersion: flag.minimumVersion ?? '0.0.0',
+        },
       },
       cacheTimestamp: Date.now(),
     });
@@ -2319,6 +2333,137 @@ describe('PredictController', () => {
                   {
                     category: 'trending',
                     markets: ['highlight-1', 'highlight-2'],
+                  },
+                ],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('filters out closed highlighted markets', async () => {
+      const regularMarkets = [createMockMarket('regular-1')];
+      const closedHighlightedMarket = {
+        ...createMockMarket('highlight-1'),
+        status: 'closed',
+      };
+      const openHighlightedMarket = {
+        ...createMockMarket('highlight-2'),
+        status: 'open',
+      };
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue(
+            regularMarkets as any,
+          );
+          mockPolymarketProvider.getMarketsByIds.mockResolvedValue([
+            closedHighlightedMarket,
+            openHighlightedMarket,
+          ] as any);
+
+          const result = await controller.getMarkets({
+            providerId: 'polymarket',
+            category: 'trending',
+            offset: 0,
+          });
+
+          expect(result).toHaveLength(2);
+          expect(result[0].id).toBe('highlight-2');
+          expect(result[1].id).toBe('regular-1');
+          expect(result.find((m) => m.id === 'highlight-1')).toBeUndefined();
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                highlights: [
+                  {
+                    category: 'trending',
+                    markets: ['highlight-1', 'highlight-2'],
+                  },
+                ],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('filters out resolved highlighted markets', async () => {
+      const regularMarkets = [createMockMarket('regular-1')];
+      const resolvedHighlightedMarket = {
+        ...createMockMarket('highlight-1'),
+        status: 'resolved',
+      };
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue(
+            regularMarkets as any,
+          );
+          mockPolymarketProvider.getMarketsByIds.mockResolvedValue([
+            resolvedHighlightedMarket,
+          ] as any);
+
+          const result = await controller.getMarkets({
+            providerId: 'polymarket',
+            category: 'trending',
+            offset: 0,
+          });
+
+          expect(result).toHaveLength(1);
+          expect(result[0].id).toBe('regular-1');
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                highlights: [
+                  {
+                    category: 'trending',
+                    markets: ['highlight-1'],
+                  },
+                ],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('skips highlights when version requirement not met', async () => {
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue(
+            regularMarkets as any,
+          );
+
+          const result = await controller.getMarkets({
+            providerId: 'polymarket',
+            category: 'trending',
+            offset: 0,
+          });
+
+          expect(result).toHaveLength(1);
+          expect(result[0].id).toBe('regular-1');
+          expect(mockPolymarketProvider.getMarketsByIds).not.toHaveBeenCalled();
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                minimumVersion: '999.0.0',
+                highlights: [
+                  {
+                    category: 'trending',
+                    markets: ['highlight-1'],
                   },
                 ],
               }),

--- a/app/components/UI/Predict/mocks/remoteFeatureFlagMocks.ts
+++ b/app/components/UI/Predict/mocks/remoteFeatureFlagMocks.ts
@@ -15,6 +15,7 @@ export const mockedPredictFeatureFlagsEnabledState: Record<
 
 export const mockPredictMarketHighlightsFlag: PredictMarketHighlightsFlag = {
   enabled: true,
+  minimumVersion: '0.0.0',
   highlights: [
     {
       category: 'trending',

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -19,8 +19,7 @@ export interface PredictMarketHighlight {
   markets: string[];
 }
 
-export interface PredictMarketHighlightsFlag {
-  enabled: boolean;
+export interface PredictMarketHighlightsFlag extends VersionGatedFeatureFlag {
   highlights: PredictMarketHighlight[];
 }
 


### PR DESCRIPTION
## **Description**

Enhances the `PredictMarketHighlightsFlag` feature with version gating and closed market filtering:

1. **Version Gating**: `PredictMarketHighlightsFlag` now extends `VersionGatedFeatureFlag`, adding `minimumVersion` support. Highlights are only fetched when the user's app version meets the minimum requirement (7.64.0).

2. **Closed Market Filtering**: Highlighted markets that are closed or resolved are now filtered out, ensuring only open markets are displayed at the top of category lists.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A - Internal improvement

## **Manual testing steps**

```gherkin
Feature: Predict Market Highlights

  Scenario: User views category with highlighted markets
    Given the user is on the Predict tab
    And the remote feature flag has highlights configured for a category
    And the user's app version meets the minimum version requirement

    When user navigates to that category
    Then highlighted markets appear at the top of the list
    And only open markets are shown in the highlights

  Scenario: Highlights filtered when version requirement not met
    Given the user is on the Predict tab
    And the remote feature flag has minimumVersion set to a higher version

    When user navigates to a category with highlights
    Then no highlighted markets are prepended
    And only regular market list is shown

  Scenario: Closed markets are not highlighted
    Given a highlighted market has been closed or resolved

    When user navigates to that category
    Then that market is not shown in the highlights section
```

## **Screenshots/Recordings**

N/A - Backend logic change, no UI changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.