### PR TITLE
feat(perps): introduce myx protocol support behind feature flag

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -178,6 +178,7 @@ export MM_PERPS_BLOCKED_REGIONS="US,CA-ON,GB,BE"
 export MM_PERPS_GTM_MODAL_ENABLED="true"
 export MM_PERPS_ORDER_BOOK_ENABLED="true"
 export MM_PERPS_FEEDBACK_ENABLED="true"
+export MM_PERPS_MYX_PROVIDER_ENABLED="true"
 # HIP-3 Feature Flags (remote override with local fallback)
 export MM_PERPS_HIP3_ENABLED="true"
 export MM_PERPS_HIP3_ALLOWLIST_MARKETS=""  # Allowlist: Empty = enable all markets. Examples: "xyz:XYZ100,xyz:TSLA" or "xyz:*,abc:TSLA"

--- a/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch
+++ b/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch
@@ -126,7 +126,7 @@ index 638c5df..f5b8ff4 100644
          const sessionData = await getSessionDetails(sessionId);
          const sessionDetails = sessionData?.automation_session;
          const videoURL = sessionDetails?.video_url;
-@@ -241,7 +248,10 @@ class BrowserStackDeviceProvider {
+@@ -241,7 +248,13 @@ class BrowserStackDeviceProvider {
              capabilities: {
                  "bstack:options": {
                      debug: true,
@@ -135,9 +135,12 @@ index 638c5df..f5b8ff4 100644
 +                    selfHeal: true,
 +                    appProfiling: true,
                      networkLogs: true,
++                    networkLogsOptions:{
++                        captureContent: true,
++                    },
                      appiumVersion: "2.6.0",
                      enableCameraImageInjection: this.project.use.device?.enableCameraImageInjection,
-@@ -250,10 +260,10 @@ class BrowserStackDeviceProvider {
+@@ -250,10 +261,10 @@ class BrowserStackDeviceProvider {
                      osVersion: this.project.use.device.osVersion,
                      platformName: platformName,
                      deviceOrientation: this.project.use.device?.orientation,

--- a/app/components/Base/RemoteImage/index.test.tsx
+++ b/app/components/Base/RemoteImage/index.test.tsx
@@ -307,6 +307,22 @@ describe('RemoteImage', () => {
   });
 
   describe('IPFS URL Resolution', () => {
+    it('returns null while resolving IPFS URL', () => {
+      const ipfsUri = 'ipfs://QmeE94srcYV9WwJb1p42eM4zncdLUai2N9zmMxxukoEQ23';
+      // Mock as a promise that doesn't resolve immediately
+      mockGetFormattedIpfsUrl.mockImplementation(
+        () =>
+          new Promise(() => {
+            // Intentionally never resolves to test loading state
+          }),
+      );
+
+      const { toJSON } = render(<RemoteImage source={{ uri: ipfsUri }} />);
+
+      // Component should return null while IPFS URL is being resolved
+      expect(toJSON()).toBeNull();
+    });
+
     it('resolves IPFS URL successfully', async () => {
       const ipfsUri = 'ipfs://QmeE94srcYV9WwJb1p42eM4zncdLUai2N9zmMxxukoEQ23';
       const resolvedUrl =

--- a/app/components/Base/RemoteImage/index.tsx
+++ b/app/components/Base/RemoteImage/index.tsx
@@ -51,7 +51,7 @@ const RemoteImage: React.FC<RemoteImageProps> = (props) => {
   const [error, setError] = useState<string | undefined>(undefined);
   const source = resolveAssetSource(props.source);
   const ipfsGateway = useIpfsGateway();
-  const [resolvedIpfsUrl, setResolvedIpfsUrl] = useState<string | false>(false);
+  const [resolvedIpfsUrl, setResolvedIpfsUrl] = useState<string | false>();
 
   const uri =
     resolvedIpfsUrl ||
@@ -140,6 +140,10 @@ const RemoteImage: React.FC<RemoteImageProps> = (props) => {
 
   if (error && props.address) {
     return <Identicon address={props.address} customStyle={props.style} />;
+  }
+
+  if (resolvedIpfsUrl === undefined && !uri) {
+    return null;
   }
 
   const defaultImage = (

--- a/app/components/UI/AssetOverview/Price/Price.test.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.test.tsx
@@ -75,12 +75,13 @@ describe('Price Component', () => {
         },
       };
 
-      const { getAllByText } = render(<Price {...props} />);
+      const { getByText } = render(<Price {...props} />);
 
-      // Name and symbol are rendered separately
-      // When name and symbol are the same, we expect to find both text nodes
-      const elements = getAllByText(mockProps.asset.name);
-      expect(elements.length).toBeGreaterThanOrEqual(1);
+      // Name and symbol are rendered together when ticker is not provided
+      // Format: "name (symbol)"
+      expect(
+        getByText(`${mockProps.asset.name} (${mockProps.asset.symbol})`),
+      ).toBeTruthy();
     });
 
     it('renders header correctly when name not provided and symbol is provided', () => {
@@ -101,9 +102,11 @@ describe('Price Component', () => {
     it('renders header correctly when name and ticker are provided', () => {
       const { getByText } = render(<Price {...mockProps} />);
 
-      // Name and ticker are rendered separately
-      expect(getByText(mockProps.asset.name)).toBeTruthy();
-      expect(getByText(mockProps.asset.ticker as string)).toBeTruthy();
+      // Name and ticker are rendered together
+      // Format: "name (ticker)"
+      expect(
+        getByText(`${mockProps.asset.name} (${mockProps.asset.ticker})`),
+      ).toBeTruthy();
     });
   });
 

--- a/app/components/UI/AssetOverview/Price/Price.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.tsx
@@ -96,23 +96,32 @@ const Price = ({
     <>
       <View style={styles.wrapper}>
         {asset.name ? (
-          <View>
-            <Text
-              variant={TextVariant.BodyMDMedium}
-              color={TextColor.Alternative}
-            >
-              {asset.name}
-            </Text>
-            <View style={styles.assetWrapper}>
+          stockTokenBadge ? (
+            <View>
               <Text
                 variant={TextVariant.BodyMDMedium}
                 color={TextColor.Alternative}
               >
-                {ticker}
+                {asset.name}
               </Text>
-              {stockTokenBadge}
+              <View style={styles.assetWrapper}>
+                <Text
+                  variant={TextVariant.BodyMDMedium}
+                  color={TextColor.Alternative}
+                >
+                  {ticker}
+                </Text>
+                {stockTokenBadge}
+              </View>
             </View>
-          </View>
+          ) : (
+            <Text
+              variant={TextVariant.BodyMDMedium}
+              color={TextColor.Alternative}
+            >
+              {asset.name} ({ticker})
+            </Text>
+          )
         ) : (
           <View style={styles.assetWrapper}>
             <Text variant={TextVariant.BodyMDMedium}>{ticker}</Text>

--- a/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
+++ b/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
@@ -17,45 +17,23 @@ exports[`AssetOverview should render native balances when non evm network is sel
         }
       }
     >
-      <View>
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#686e7d",
-              "fontFamily": "Geist-Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#686e7d",
+            "fontFamily": "Geist-Medium",
+            "fontSize": 16,
+            "letterSpacing": 0,
+            "lineHeight": 24,
           }
-        >
-          Ethereum
-        </Text>
-        <View
-          style={
-            {
-              "flexDirection": "row",
-              "justifyContent": "flex-start",
-            }
-          }
-        >
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#686e7d",
-                "fontFamily": "Geist-Medium",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            ETH
-          </Text>
-        </View>
-      </View>
+        }
+      >
+        Ethereum
+         (
+        ETH
+        )
+      </Text>
       <Text
         accessibilityRole="text"
         style={

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklClaim.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklClaim.ts
@@ -111,7 +111,7 @@ export const useMerklClaim = (asset: TokenI) => {
         deviceConfirmedOn: WalletDevice.MM_MOBILE,
         networkClientId,
         origin: MERKL_CLAIM_ORIGIN,
-        type: TransactionType.contractInteraction,
+        type: TransactionType.musdClaim,
       });
 
       // transactionMeta can be undefined if user cancels before tx is created

--- a/app/components/UI/Earn/constants/musd.ts
+++ b/app/components/UI/Earn/constants/musd.ts
@@ -13,12 +13,23 @@ export const MUSD_TOKEN = {
   imageSource: MusdIcon,
 } as const;
 
+/**
+ * mUSD token decimals (derived from MUSD_TOKEN for single source of truth)
+ */
+export const MUSD_DECIMALS = MUSD_TOKEN.decimals;
+
 export const MUSD_CONVERSION_DEFAULT_CHAIN_ID = CHAIN_IDS.MAINNET;
 
+/**
+ * mUSD token address (same on all supported chains)
+ */
+export const MUSD_TOKEN_ADDRESS: Hex =
+  '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+
 export const MUSD_TOKEN_ADDRESS_BY_CHAIN: Record<Hex, Hex> = {
-  [CHAIN_IDS.MAINNET]: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
-  [CHAIN_IDS.LINEA_MAINNET]: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
-  [CHAIN_IDS.BSC]: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+  [CHAIN_IDS.MAINNET]: MUSD_TOKEN_ADDRESS,
+  [CHAIN_IDS.LINEA_MAINNET]: MUSD_TOKEN_ADDRESS,
+  [CHAIN_IDS.BSC]: MUSD_TOKEN_ADDRESS,
 };
 
 /**

--- a/app/components/UI/Earn/utils/musd.test.ts
+++ b/app/components/UI/Earn/utils/musd.test.ts
@@ -1,0 +1,209 @@
+import { TransactionType } from '@metamask/transaction-controller';
+import { BigNumber } from 'bignumber.js';
+import { Hex } from '@metamask/utils';
+import { isMusdClaimForCurrentView, convertMusdClaimAmount } from './musd';
+import { MUSD_TOKEN_ADDRESS } from '../constants/musd';
+
+const LINEA_CHAIN_ID = '0xe708' as Hex;
+const MAINNET_CHAIN_ID = '0x1' as Hex;
+const SELECTED_ADDRESS = '0x1234567890123456789012345678901234567890';
+const OTHER_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+describe('musd utils', () => {
+  describe('isMusdClaimForCurrentView', () => {
+    const baseTx = {
+      type: TransactionType.musdClaim,
+      status: 'confirmed',
+      chainId: LINEA_CHAIN_ID,
+      txParams: {
+        from: SELECTED_ADDRESS,
+      },
+    };
+
+    it('returns true when viewing mUSD by address with matching chainId and account', () => {
+      const result = isMusdClaimForCurrentView({
+        tx: baseTx,
+        navAddress: MUSD_TOKEN_ADDRESS,
+        navSymbol: 'musd',
+        chainId: LINEA_CHAIN_ID,
+        selectedAddress: SELECTED_ADDRESS,
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns true when viewing mUSD by symbol (case-insensitive)', () => {
+      const result = isMusdClaimForCurrentView({
+        tx: baseTx,
+        navAddress: '0xsomeotheraddress',
+        navSymbol: 'musd',
+        chainId: LINEA_CHAIN_ID,
+        selectedAddress: SELECTED_ADDRESS,
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns false when viewing a different token', () => {
+      const result = isMusdClaimForCurrentView({
+        tx: baseTx,
+        navAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        navSymbol: 'usdc',
+        chainId: LINEA_CHAIN_ID,
+        selectedAddress: SELECTED_ADDRESS,
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false for unapproved transactions', () => {
+      const result = isMusdClaimForCurrentView({
+        tx: { ...baseTx, status: 'unapproved' },
+        navAddress: MUSD_TOKEN_ADDRESS,
+        navSymbol: 'musd',
+        chainId: LINEA_CHAIN_ID,
+        selectedAddress: SELECTED_ADDRESS,
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when chainId does not match', () => {
+      const result = isMusdClaimForCurrentView({
+        tx: baseTx,
+        navAddress: MUSD_TOKEN_ADDRESS,
+        navSymbol: 'musd',
+        chainId: MAINNET_CHAIN_ID,
+        selectedAddress: SELECTED_ADDRESS,
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false for non-musdClaim transaction types', () => {
+      const result = isMusdClaimForCurrentView({
+        tx: { ...baseTx, type: TransactionType.contractInteraction },
+        navAddress: MUSD_TOKEN_ADDRESS,
+        navSymbol: 'musd',
+        chainId: LINEA_CHAIN_ID,
+        selectedAddress: SELECTED_ADDRESS,
+      });
+      expect(result).toBe(false);
+    });
+
+    it('handles checksummed address comparison', () => {
+      const result = isMusdClaimForCurrentView({
+        tx: baseTx,
+        navAddress: '0xAcA92E438df0B2401fF60dA7E4337B687a2435DA', // checksummed
+        navSymbol: 'other',
+        chainId: LINEA_CHAIN_ID,
+        selectedAddress: SELECTED_ADDRESS,
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns false when transaction is from a different account', () => {
+      const result = isMusdClaimForCurrentView({
+        tx: {
+          ...baseTx,
+          txParams: { from: OTHER_ADDRESS },
+        },
+        navAddress: MUSD_TOKEN_ADDRESS,
+        navSymbol: 'musd',
+        chainId: LINEA_CHAIN_ID,
+        selectedAddress: SELECTED_ADDRESS,
+      });
+      expect(result).toBe(false);
+    });
+
+    it('handles checksummed from address comparison', () => {
+      const result = isMusdClaimForCurrentView({
+        tx: {
+          ...baseTx,
+          txParams: { from: '0x1234567890123456789012345678901234567890' },
+        },
+        navAddress: MUSD_TOKEN_ADDRESS,
+        navSymbol: 'musd',
+        chainId: LINEA_CHAIN_ID,
+        selectedAddress: '0x1234567890123456789012345678901234567890',
+      });
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('convertMusdClaimAmount', () => {
+    // 100 mUSD in raw units (6 decimals)
+    const claimAmountRaw = '100000000';
+
+    it('converts to user currency when rates are available', () => {
+      // ETH = $2000 USD, ETH = €1800 EUR
+      // So €1 = $2000/1800 = $1.11 USD
+      // 100 mUSD ≈ $100 USD ≈ €90 EUR
+      const result = convertMusdClaimAmount({
+        claimAmountRaw,
+        conversionRate: 1800, // ETH to EUR
+        usdConversionRate: 2000, // ETH to USD
+      });
+
+      expect(result.claimAmountDecimal.toNumber()).toBe(100);
+      expect(result.fiatValue.toNumber()).toBe(90); // 100 * (1800/2000)
+      expect(result.isConverted).toBe(true);
+    });
+
+    it('falls back to USD when conversionRate is 0', () => {
+      const result = convertMusdClaimAmount({
+        claimAmountRaw,
+        conversionRate: 0,
+        usdConversionRate: 2000,
+      });
+
+      expect(result.claimAmountDecimal.toNumber()).toBe(100);
+      expect(result.fiatValue.toNumber()).toBe(100); // 1:1 with USD
+      expect(result.isConverted).toBe(false);
+    });
+
+    it('falls back to USD when usdConversionRate is 0', () => {
+      const result = convertMusdClaimAmount({
+        claimAmountRaw,
+        conversionRate: 1800,
+        usdConversionRate: 0,
+      });
+
+      expect(result.claimAmountDecimal.toNumber()).toBe(100);
+      expect(result.fiatValue.toNumber()).toBe(100);
+      expect(result.isConverted).toBe(false);
+    });
+
+    it('accepts BigNumber for conversionRate', () => {
+      const result = convertMusdClaimAmount({
+        claimAmountRaw,
+        conversionRate: new BigNumber(1800),
+        usdConversionRate: 2000,
+      });
+
+      expect(result.fiatValue.toNumber()).toBe(90);
+      expect(result.isConverted).toBe(true);
+    });
+
+    it('handles small claim amounts correctly', () => {
+      // 0.01 mUSD
+      const result = convertMusdClaimAmount({
+        claimAmountRaw: '10000',
+        conversionRate: 2000,
+        usdConversionRate: 2000,
+      });
+
+      expect(result.claimAmountDecimal.toNumber()).toBe(0.01);
+      expect(result.fiatValue.toNumber()).toBe(0.01);
+      expect(result.isConverted).toBe(true);
+    });
+
+    it('handles large claim amounts correctly', () => {
+      // 1,000,000 mUSD
+      const result = convertMusdClaimAmount({
+        claimAmountRaw: '1000000000000',
+        conversionRate: 1800,
+        usdConversionRate: 2000,
+      });
+
+      expect(result.claimAmountDecimal.toNumber()).toBe(1000000);
+      expect(result.fiatValue.toNumber()).toBe(900000);
+      expect(result.isConverted).toBe(true);
+    });
+  });
+});

--- a/app/components/UI/Earn/utils/musd.ts
+++ b/app/components/UI/Earn/utils/musd.ts
@@ -1,0 +1,155 @@
+/**
+ * mUSD utility functions for Earn namespace
+ */
+
+import { Interface } from '@ethersproject/abi';
+import { TransactionType } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+import { BigNumber } from 'bignumber.js';
+import { areAddressesEqual } from '../../../../util/address';
+import { calcTokenAmount } from '../../../../util/transactions';
+import {
+  MUSD_DECIMALS,
+  MUSD_TOKEN,
+  MUSD_TOKEN_ADDRESS,
+} from '../constants/musd';
+import { DISTRIBUTOR_CLAIM_ABI } from '../components/MerklRewards/constants';
+
+/**
+ * Parameters for checking if a transaction is a mUSD claim for the current view.
+ */
+export interface IsMusdClaimForCurrentViewParams {
+  /** Transaction to check */
+  tx: {
+    type?: TransactionType;
+    status?: string;
+    chainId?: Hex;
+    txParams?: {
+      from?: string;
+    };
+  };
+  /** Token address being viewed (should be lowercased or checksummed) */
+  navAddress: string;
+  /** Token symbol being viewed (should be lowercased) */
+  navSymbol: string;
+  /** Current chain ID */
+  chainId: Hex;
+  /** Currently selected account address */
+  selectedAddress: string;
+}
+
+/**
+ * Check if transaction is a Merkl mUSD yield claim that should be shown in current view.
+ * These transactions interact with the Merkl distributor contract (not the mUSD token directly),
+ * so they won't be caught by standard token transfer detection and need special handling.
+ *
+ * @param params - The parameters for the check
+ * @returns true if the transaction should be shown in the current mUSD view
+ */
+export function isMusdClaimForCurrentView({
+  tx,
+  navAddress,
+  navSymbol,
+  chainId,
+  selectedAddress,
+}: IsMusdClaimForCurrentViewParams): boolean {
+  const isMusdView =
+    areAddressesEqual(navAddress, MUSD_TOKEN_ADDRESS) ||
+    navSymbol === MUSD_TOKEN.symbol.toLowerCase();
+  const isFromSelectedAccount = areAddressesEqual(
+    tx.txParams?.from ?? '',
+    selectedAddress,
+  );
+  return (
+    tx.type === TransactionType.musdClaim &&
+    tx.status !== 'unapproved' &&
+    isMusdView &&
+    chainId === tx.chainId &&
+    isFromSelectedAccount
+  );
+}
+
+/**
+ * Parameters for converting mUSD claim amount to user's currency.
+ */
+export interface ConvertMusdClaimParams {
+  /** Raw claim amount from decodeMerklClaimAmount (wei string) */
+  claimAmountRaw: string;
+  /** Native-to-user-currency conversion rate (e.g., ETH to EUR) */
+  conversionRate: BigNumber | number;
+  /** Native-to-USD conversion rate (e.g., ETH to USD) */
+  usdConversionRate: number;
+}
+
+/**
+ * Result of mUSD claim amount conversion.
+ */
+export interface ConvertMusdClaimResult {
+  /** Claim amount in mUSD decimals (not fiat converted) */
+  claimAmountDecimal: BigNumber;
+  /** Fiat value in user's currency (or USD if rates unavailable) */
+  fiatValue: BigNumber;
+  /** Whether the fiat value was converted to user's currency (false = USD fallback) */
+  isConverted: boolean;
+}
+
+/**
+ * Convert raw mUSD claim amount to display values.
+ * mUSD is a stablecoin pegged to USD (1 mUSD ≈ $1).
+ * Converts to user's currency using: USD * (nativeToUserCurrency / nativeToUSD)
+ *
+ * @param params - Conversion parameters
+ * @returns Converted amounts and conversion status
+ */
+export function convertMusdClaimAmount({
+  claimAmountRaw,
+  conversionRate,
+  usdConversionRate,
+}: ConvertMusdClaimParams): ConvertMusdClaimResult {
+  const claimAmountDecimal = calcTokenAmount(claimAmountRaw, MUSD_DECIMALS);
+  const conversionRateBN =
+    conversionRate instanceof BigNumber
+      ? conversionRate
+      : new BigNumber(conversionRate);
+
+  if (usdConversionRate > 0 && conversionRateBN.isGreaterThan(0)) {
+    const usdToUserCurrencyRate = conversionRateBN.dividedBy(usdConversionRate);
+    const fiatValue = claimAmountDecimal.times(usdToUserCurrencyRate);
+    return { claimAmountDecimal, fiatValue, isConverted: true };
+  }
+
+  // Fallback: no conversion rates available, use 1:1 with USD
+  return {
+    claimAmountDecimal,
+    fiatValue: claimAmountDecimal,
+    isConverted: false,
+  };
+}
+
+/**
+ * Decode the claim amount from a Merkl claim transaction data.
+ * The claim function signature is: claim(address[] users, address[] tokens, uint256[] amounts, bytes32[][] proofs)
+ *
+ * @param data - The transaction data hex string
+ * @returns The first claim amount as a string (raw value, not adjusted for decimals), or null if decoding fails
+ */
+export function decodeMerklClaimAmount(
+  data: string | undefined,
+): string | null {
+  if (!data || typeof data !== 'string') {
+    return null;
+  }
+
+  try {
+    const contractInterface = new Interface(DISTRIBUTOR_CLAIM_ABI);
+    const decoded = contractInterface.decodeFunctionData('claim', data);
+    // amounts is the 3rd parameter (index 2)
+    const amounts = decoded[2];
+    if (!amounts || amounts.length === 0) {
+      return null;
+    }
+    return amounts[0].toString();
+  } catch {
+    return null;
+  }
+}

--- a/app/components/UI/PaymentRequest/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/PaymentRequest/__snapshots__/index.test.tsx.snap
@@ -287,69 +287,7 @@ exports[`PaymentRequest renders correctly 1`] = `
                       "marginRight": 12,
                     }
                   }
-                >
-                  <View
-                    useNativeDriver={true}
-                  >
-                    <View
-                      fadeIn={true}
-                      source={
-                        {
-                          "uri": "",
-                        }
-                      }
-                      style={
-                        [
-                          {
-                            "borderRadius": 12,
-                            "height": 24,
-                            "width": 24,
-                          },
-                          undefined,
-                          {
-                            "borderRadius": 25,
-                            "height": 50,
-                            "width": 50,
-                          },
-                          undefined,
-                          {
-                            "height": 50,
-                            "width": 50,
-                          },
-                        ]
-                      }
-                    />
-                    <View
-                      collapsable={false}
-                      style={
-                        {
-                          "bottom": 0,
-                          "left": 0,
-                          "opacity": 1,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          [
-                            {
-                              "borderRadius": 25,
-                              "height": 50,
-                              "width": 50,
-                            },
-                            {
-                              "backgroundColor": "#eee",
-                            },
-                            undefined,
-                          ]
-                        }
-                      />
-                    </View>
-                  </View>
-                </View>
+                />
                 <View
                   style={
                     {
@@ -821,69 +759,7 @@ exports[`PaymentRequest renders correctly with network picker when feature flag 
                       "marginRight": 12,
                     }
                   }
-                >
-                  <View
-                    useNativeDriver={true}
-                  >
-                    <View
-                      fadeIn={true}
-                      source={
-                        {
-                          "uri": "",
-                        }
-                      }
-                      style={
-                        [
-                          {
-                            "borderRadius": 12,
-                            "height": 24,
-                            "width": 24,
-                          },
-                          undefined,
-                          {
-                            "borderRadius": 25,
-                            "height": 50,
-                            "width": 50,
-                          },
-                          undefined,
-                          {
-                            "height": 50,
-                            "width": 50,
-                          },
-                        ]
-                      }
-                    />
-                    <View
-                      collapsable={false}
-                      style={
-                        {
-                          "bottom": 0,
-                          "left": 0,
-                          "opacity": 1,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          [
-                            {
-                              "borderRadius": 25,
-                              "height": 50,
-                              "width": 50,
-                            },
-                            {
-                              "backgroundColor": "#eee",
-                            },
-                            undefined,
-                          ]
-                        }
-                      />
-                    </View>
-                  </View>
-                </View>
+                />
                 <View
                   style={
                     {

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -22,7 +22,6 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
-  IconName,
 } from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import { TextColor } from '../../../../../component-library/components/Texts/Text';
@@ -53,7 +52,7 @@ import PerpsMarketTypeSection from '../../components/PerpsMarketTypeSection';
 import PerpsRecentActivityList from '../../components/PerpsRecentActivityList/PerpsRecentActivityList';
 import PerpsHomeSection from '../../components/PerpsHomeSection';
 import PerpsRowSkeleton from '../../components/PerpsRowSkeleton';
-import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
+import PerpsHomeHeader from '../../components/PerpsHomeHeader';
 import type { PerpsNavigationParamList } from '../../types/navigation';
 import { useMetrics, MetaMetricsEvents } from '../../../../hooks/useMetrics';
 import styleSheet from './PerpsHomeView.styles';
@@ -414,17 +413,9 @@ const PerpsHomeView = () => {
   return (
     <SafeAreaView style={styles.container}>
       {/* Header */}
-      <HeaderCompactStandard
-        title={strings('perps.title')}
+      <PerpsHomeHeader
         onBack={handleBackPress}
-        backButtonProps={{ testID: 'back-button' }}
-        endButtonIconProps={[
-          {
-            iconName: IconName.Search,
-            onPress: handleSearchToggle,
-            testID: 'perps-home-search-toggle',
-          },
-        ]}
+        onSearchToggle={handleSearchToggle}
         testID="perps-home"
       />
 

--- a/app/components/UI/Perps/Views/PerpsSelectProviderView/PerpsSelectProviderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsSelectProviderView/PerpsSelectProviderView.tsx
@@ -1,0 +1,52 @@
+import React, { useCallback } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import Logger from '../../../../../util/Logger';
+import { usePerpsProvider } from '../../hooks/usePerpsProvider';
+import PerpsProviderSelectorSheet from '../../components/PerpsProviderSelector/PerpsProviderSelectorSheet';
+import type { PerpsProviderType } from '../../controllers/types';
+
+/**
+ * PerpsSelectProviderView
+ *
+ * Navigation-based wrapper for the provider selector bottom sheet.
+ * This ensures the sheet renders at full-screen level rather than
+ * being constrained by parent container bounds.
+ */
+const PerpsSelectProviderView: React.FC = () => {
+  const navigation = useNavigation();
+  const { activeProvider, switchProvider } = usePerpsProvider();
+
+  const handleClose = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const handleProviderSelect = useCallback(
+    async (providerId: PerpsProviderType) => {
+      try {
+        await switchProvider(providerId);
+      } catch (error) {
+        Logger.error(error as Error, {
+          message: `Failed to switch perps provider to ${providerId}`,
+        });
+      }
+      // Navigation is handled by handleClose when bottom sheet closes
+    },
+    [switchProvider],
+  );
+
+  // Determine selected provider, defaulting to hyperliquid for aggregated mode
+  const selectedProvider =
+    activeProvider !== 'aggregated' ? activeProvider : 'hyperliquid';
+
+  return (
+    <PerpsProviderSelectorSheet
+      isVisible
+      onClose={handleClose}
+      selectedProvider={selectedProvider}
+      onProviderSelect={handleProviderSelect}
+      testID="perps-select-provider-sheet"
+    />
+  );
+};
+
+export default PerpsSelectProviderView;

--- a/app/components/UI/Perps/Views/PerpsSelectProviderView/index.ts
+++ b/app/components/UI/Perps/Views/PerpsSelectProviderView/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PerpsSelectProviderView';

--- a/app/components/UI/Perps/components/PerpsHomeHeader/PerpsHomeHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsHomeHeader/PerpsHomeHeader.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { View, TouchableOpacity, TextInput, Pressable } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
 import { useStyles } from '../../../../../component-library/hooks';
 import {
   Box,
@@ -21,6 +22,8 @@ import { strings } from '../../../../../../locales/i18n';
 import { useTheme } from '../../../../../util/theme';
 import type { PerpsHomeHeaderProps } from './PerpsHomeHeader.types';
 import styleSheet from './PerpsHomeHeader.styles';
+import { selectPerpsMYXProviderEnabledFlag } from '../../selectors/featureFlags';
+import { PerpsProviderSelectorBadge } from '../PerpsProviderSelector';
 
 /**
  * PerpsHomeHeader Component
@@ -65,6 +68,7 @@ const PerpsHomeHeader: React.FC<PerpsHomeHeaderProps> = ({
   const tw = useTailwind();
   const { colors } = useTheme();
   const navigation = useNavigation();
+  const isMYXProviderEnabled = useSelector(selectPerpsMYXProviderEnabledFlag);
 
   // Default back handler
   const defaultHandleBack = useCallback(() => {
@@ -137,15 +141,25 @@ const PerpsHomeHeader: React.FC<PerpsHomeHeaderProps> = ({
             <Icon name={IconName.ArrowLeft} size={IconSize.Md} />
           </TouchableOpacity>
 
-          {/* Title */}
+          {/* Title with optional provider badge */}
           <View style={styles.headerTitleContainer}>
-            <Text
-              variant={TextVariant.HeadingLG}
-              color={TextColor.Default}
-              style={styles.headerTitle}
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
             >
-              {title || strings('perps.title')}
-            </Text>
+              <Text
+                variant={TextVariant.HeadingLG}
+                color={TextColor.Default}
+                style={styles.headerTitle}
+              >
+                {title || strings('perps.title')}
+              </Text>
+              {isMYXProviderEnabled && (
+                <PerpsProviderSelectorBadge
+                  testID={testID ? `${testID}-provider-badge` : undefined}
+                />
+              )}
+            </Box>
           </View>
 
           {/* Search Toggle Button */}

--- a/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelector.styles.ts
+++ b/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelector.styles.ts
@@ -1,0 +1,57 @@
+import { StyleSheet } from 'react-native';
+import type { Theme } from '../../../../../util/theme/models';
+
+/**
+ * Styles for PerpsProviderSelector components
+ */
+export const styleSheet = (params: { theme: Theme }) => {
+  const { theme } = params;
+
+  return StyleSheet.create({
+    // Badge styles
+    badgeContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: 8,
+      paddingVertical: 4,
+      borderRadius: 16,
+      backgroundColor: theme.colors.background.alternative,
+      marginLeft: 8,
+    },
+    badgeText: {
+      marginRight: 4,
+    },
+
+    // Bottom sheet styles
+    optionsList: {
+      paddingHorizontal: 16,
+      paddingBottom: 16,
+    },
+    optionRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingVertical: 16,
+      paddingHorizontal: 16,
+      marginVertical: 4,
+      borderRadius: 12,
+      backgroundColor: theme.colors.background.default,
+    },
+    optionRowSelected: {
+      backgroundColor: theme.colors.primary.muted,
+      borderWidth: 1,
+      borderColor: theme.colors.primary.default,
+    },
+    optionContent: {
+      flex: 1,
+    },
+    optionName: {
+      marginBottom: 2,
+    },
+    checkIcon: {
+      marginLeft: 8,
+    },
+  });
+};
+
+export default styleSheet;

--- a/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelector.types.ts
+++ b/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelector.types.ts
@@ -1,0 +1,70 @@
+import type { PerpsProviderType } from '../../controllers/types';
+
+/**
+ * Props for PerpsProviderSelectorBadge component
+ */
+export interface PerpsProviderSelectorBadgeProps {
+  /**
+   * Test ID for testing purposes
+   */
+  testID?: string;
+}
+
+/**
+ * Props for PerpsProviderSelectorSheet component
+ */
+export interface PerpsProviderSelectorSheetProps {
+  /**
+   * Whether the bottom sheet is visible
+   */
+  isVisible: boolean;
+
+  /**
+   * Callback when the sheet is closed
+   */
+  onClose: () => void;
+
+  /**
+   * Currently selected provider
+   */
+  selectedProvider?: PerpsProviderType;
+
+  /**
+   * Callback when a provider is selected
+   */
+  onProviderSelect: (providerId: PerpsProviderType) => void;
+
+  /**
+   * Test ID for testing purposes
+   */
+  testID?: string;
+}
+
+/**
+ * Provider display info for UI
+ */
+export interface ProviderDisplayInfo {
+  id: PerpsProviderType;
+  name: string;
+  description: string;
+  iconName?: string;
+}
+
+/**
+ * Provider display configuration
+ */
+export const PROVIDER_DISPLAY_INFO: Record<
+  PerpsProviderType,
+  ProviderDisplayInfo
+> = {
+  hyperliquid: {
+    id: 'hyperliquid',
+    name: 'HyperLiquid',
+    description: 'High-performance L1 perps',
+  },
+  myx: {
+    id: 'myx',
+    name: 'MYX',
+    description: 'BNB Chain perps (Beta)',
+  },
+};

--- a/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorBadge.tsx
+++ b/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorBadge.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback } from 'react';
+import { TouchableOpacity } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useStyles } from '../../../../../component-library/hooks';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../../component-library/components/Icons/Icon';
+import Routes from '../../../../../constants/navigation/Routes';
+import { usePerpsProvider } from '../../hooks/usePerpsProvider';
+import {
+  PROVIDER_DISPLAY_INFO,
+  type PerpsProviderSelectorBadgeProps,
+} from './PerpsProviderSelector.types';
+import { styleSheet } from './PerpsProviderSelector.styles';
+
+/**
+ * PerpsProviderSelectorBadge Component
+ *
+ * A compact badge that shows the current provider and opens selection sheet.
+ * Only visible when multiple providers are available.
+ *
+ * @example
+ * ```tsx
+ * <PerpsProviderSelectorBadge testID="provider-badge" />
+ * ```
+ */
+const PerpsProviderSelectorBadge: React.FC<PerpsProviderSelectorBadgeProps> = ({
+  testID,
+}) => {
+  const { styles } = useStyles(styleSheet, {});
+  const navigation = useNavigation();
+  const { activeProvider, isMultiProviderEnabled } = usePerpsProvider();
+
+  const handlePress = useCallback(() => {
+    navigation.navigate(
+      Routes.PERPS.MODALS.ROOT as never,
+      {
+        screen: Routes.PERPS.MODALS.SELECT_PROVIDER,
+      } as never,
+    );
+  }, [navigation]);
+
+  // Don't render if only one provider available
+  if (!isMultiProviderEnabled) {
+    return null;
+  }
+
+  // Get display info for current provider
+  const currentProvider =
+    activeProvider && activeProvider !== 'aggregated'
+      ? PROVIDER_DISPLAY_INFO[activeProvider]
+      : PROVIDER_DISPLAY_INFO.hyperliquid;
+
+  return (
+    <TouchableOpacity
+      style={styles.badgeContainer}
+      onPress={handlePress}
+      testID={testID}
+      accessibilityRole="button"
+      accessibilityLabel={`Current provider: ${currentProvider.name}. Tap to change.`}
+    >
+      <Text
+        variant={TextVariant.BodySM}
+        color={TextColor.Alternative}
+        style={styles.badgeText}
+      >
+        {currentProvider.name}
+      </Text>
+      <Icon
+        name={IconName.ArrowDown}
+        size={IconSize.Xs}
+        color={IconColor.Alternative}
+      />
+    </TouchableOpacity>
+  );
+};
+
+export default PerpsProviderSelectorBadge;

--- a/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorSheet.tsx
@@ -1,0 +1,135 @@
+import React, { useRef, useEffect, useCallback } from 'react';
+import { TouchableOpacity, View } from 'react-native';
+import { useStyles } from '../../../../../component-library/hooks';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../../component-library/components/Icons/Icon';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import { strings } from '../../../../../../locales/i18n';
+import { usePerpsProvider } from '../../hooks/usePerpsProvider';
+import {
+  PROVIDER_DISPLAY_INFO,
+  type PerpsProviderSelectorSheetProps,
+} from './PerpsProviderSelector.types';
+import { styleSheet } from './PerpsProviderSelector.styles';
+import type { PerpsProviderType } from '../../controllers/types';
+
+/**
+ * PerpsProviderSelectorSheet Component
+ *
+ * Bottom sheet for selecting between available perps providers.
+ *
+ * @example
+ * ```tsx
+ * <PerpsProviderSelectorSheet
+ *   isVisible={showSheet}
+ *   onClose={() => setShowSheet(false)}
+ *   selectedProvider="hyperliquid"
+ *   onProviderSelect={handleProviderSelect}
+ * />
+ * ```
+ */
+const PerpsProviderSelectorSheet: React.FC<PerpsProviderSelectorSheetProps> = ({
+  isVisible,
+  onClose,
+  selectedProvider,
+  onProviderSelect,
+  testID,
+}) => {
+  const { styles } = useStyles(styleSheet, {});
+  const bottomSheetRef = useRef<BottomSheetRef>(null);
+  const { availableProviders } = usePerpsProvider();
+
+  useEffect(() => {
+    const sheet = bottomSheetRef.current;
+    if (isVisible) {
+      sheet?.onOpenBottomSheet();
+    } else {
+      sheet?.onCloseBottomSheet();
+    }
+
+    return () => {
+      sheet?.onCloseBottomSheet();
+    };
+  }, [isVisible]);
+
+  const handleProviderPress = useCallback(
+    (providerId: PerpsProviderType) => {
+      onProviderSelect(providerId);
+      // Just close the sheet - the BottomSheet's onClose prop handles navigation
+      bottomSheetRef.current?.onCloseBottomSheet();
+    },
+    [onProviderSelect],
+  );
+
+  if (!isVisible) return null;
+
+  return (
+    <BottomSheet
+      ref={bottomSheetRef}
+      shouldNavigateBack={false}
+      onClose={onClose}
+      isFullscreen={false}
+      testID={testID}
+    >
+      <BottomSheetHeader onClose={onClose}>
+        <Text variant={TextVariant.HeadingMD}>
+          {strings('perps.provider_selector.title')}
+        </Text>
+      </BottomSheetHeader>
+      <View style={styles.optionsList}>
+        {availableProviders.map((providerId) => {
+          const providerInfo = PROVIDER_DISPLAY_INFO[providerId];
+          const isSelected = selectedProvider === providerId;
+
+          return (
+            <TouchableOpacity
+              key={providerId}
+              style={[styles.optionRow, isSelected && styles.optionRowSelected]}
+              activeOpacity={0.7}
+              onPress={() => handleProviderPress(providerId)}
+              testID={testID ? `${testID}-option-${providerId}` : undefined}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: isSelected }}
+            >
+              <View style={styles.optionContent}>
+                <Text
+                  variant={TextVariant.BodyMDMedium}
+                  style={styles.optionName}
+                >
+                  {providerInfo.name}
+                </Text>
+                <Text
+                  variant={TextVariant.BodySM}
+                  color={TextColor.Alternative}
+                >
+                  {providerInfo.description}
+                </Text>
+              </View>
+              {isSelected && (
+                <Icon
+                  name={IconName.Check}
+                  size={IconSize.Md}
+                  color={IconColor.Primary}
+                  style={styles.checkIcon}
+                  testID={testID ? `${testID}-check-${providerId}` : undefined}
+                />
+              )}
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </BottomSheet>
+  );
+};
+
+export default PerpsProviderSelectorSheet;

--- a/app/components/UI/Perps/components/PerpsProviderSelector/index.ts
+++ b/app/components/UI/Perps/components/PerpsProviderSelector/index.ts
@@ -1,0 +1,8 @@
+export { default as PerpsProviderSelectorBadge } from './PerpsProviderSelectorBadge';
+export { default as PerpsProviderSelectorSheet } from './PerpsProviderSelectorSheet';
+export type {
+  PerpsProviderSelectorBadgeProps,
+  PerpsProviderSelectorSheetProps,
+  ProviderDisplayInfo,
+} from './PerpsProviderSelector.types';
+export { PROVIDER_DISPLAY_INFO } from './PerpsProviderSelector.types';

--- a/app/components/UI/Perps/constants/myxConfig.ts
+++ b/app/components/UI/Perps/constants/myxConfig.ts
@@ -1,0 +1,219 @@
+/**
+ * MYX Protocol Configuration Constants
+ *
+ * Stage 1 configuration for market display and price fetching.
+ * Based on MYX SDK patterns but simplified for read-only operations.
+ */
+
+import BigNumber from 'bignumber.js';
+import type { CaipChainId } from '@metamask/utils';
+import type {
+  MYXNetwork,
+  MYXEndpoints,
+  MYXAssetConfigs,
+} from '../types/myx-types';
+
+// ============================================================================
+// Network Constants
+// ============================================================================
+
+/**
+ * BNB Chain IDs - MYX's primary network
+ */
+export const BNB_MAINNET_CHAIN_ID = '56' as const;
+export const BNB_TESTNET_CHAIN_ID = '97' as const;
+export const BNB_MAINNET_CAIP_CHAIN_ID =
+  `eip155:${BNB_MAINNET_CHAIN_ID}` as CaipChainId;
+export const BNB_TESTNET_CAIP_CHAIN_ID =
+  `eip155:${BNB_TESTNET_CHAIN_ID}` as CaipChainId;
+
+/**
+ * Get numeric chain ID for MYX network
+ */
+export function getMYXChainId(network: MYXNetwork): number {
+  return network === 'testnet'
+    ? parseInt(BNB_TESTNET_CHAIN_ID, 10)
+    : parseInt(BNB_MAINNET_CHAIN_ID, 10);
+}
+
+// ============================================================================
+// API Endpoints
+// ============================================================================
+
+/**
+ * MYX REST and WebSocket endpoints
+ */
+export const MYX_ENDPOINTS: MYXEndpoints = {
+  mainnet: {
+    http: 'https://api.myx.finance',
+    ws: 'wss://ws.myx.finance',
+  },
+  testnet: {
+    http: 'https://api-beta.myx.finance',
+    ws: 'wss://ws-beta.myx.finance',
+  },
+};
+
+/**
+ * Get HTTP endpoint for network
+ */
+export function getMYXHttpEndpoint(network: MYXNetwork): string {
+  return MYX_ENDPOINTS[network].http;
+}
+
+// ============================================================================
+// Decimal Constants
+// ============================================================================
+
+/**
+ * MYX uses 30 decimals for price representation
+ * This is consistent with the SDK's internal format
+ */
+export const MYX_PRICE_DECIMALS = 30;
+
+/**
+ * MYX uses 18 decimals for position sizes
+ */
+export const MYX_SIZE_DECIMALS = 18;
+
+/**
+ * MYX uses 18 decimals for collateral amounts (USDT on BNB)
+ */
+export const MYX_COLLATERAL_DECIMALS = 18;
+
+// ============================================================================
+// Token Addresses
+// ============================================================================
+
+/**
+ * USDT token address on BNB testnet
+ */
+export const USDT_BNB_TESTNET =
+  '0x337610d27c682e347c9cd60bd4b3b107c9d34ddd' as const;
+
+/**
+ * USDT token address on BNB mainnet
+ */
+export const USDT_BNB_MAINNET =
+  '0x55d398326f99059ff775485246999027b3197955' as const;
+
+/**
+ * USDT configuration by network
+ */
+export const MYX_ASSET_CONFIGS: MYXAssetConfigs = {
+  USDT: {
+    mainnet: {
+      chainId: BNB_MAINNET_CAIP_CHAIN_ID,
+      tokenAddress: USDT_BNB_MAINNET,
+    },
+    testnet: {
+      chainId: BNB_TESTNET_CAIP_CHAIN_ID,
+      tokenAddress: USDT_BNB_TESTNET,
+    },
+  },
+};
+
+// ============================================================================
+// Decimal Conversion Helpers
+// ============================================================================
+
+/**
+ * Convert MYX SDK price (30 decimals) to standard number
+ * @param myxPrice - Price string in 30-decimal format from SDK
+ * @returns Standard decimal number
+ */
+export function fromMYXPrice(myxPrice: string): number {
+  if (!myxPrice || myxPrice === '0') return 0;
+
+  try {
+    const bn = new BigNumber(myxPrice);
+    const divisor = new BigNumber(10).pow(MYX_PRICE_DECIMALS);
+    return bn.dividedBy(divisor).toNumber();
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Convert standard number to MYX SDK price format (30 decimals)
+ * @param price - Standard decimal number
+ * @returns Price string in 30-decimal format for SDK
+ */
+export function toMYXPrice(price: number | string): string {
+  try {
+    const bn = new BigNumber(price);
+    const multiplier = new BigNumber(10).pow(MYX_PRICE_DECIMALS);
+    return bn.multipliedBy(multiplier).toFixed(0);
+  } catch {
+    return '0';
+  }
+}
+
+/**
+ * Convert MYX SDK size (18 decimals) to standard number
+ * @param myxSize - Size string in 18-decimal format from SDK
+ * @returns Standard decimal number
+ */
+export function fromMYXSize(myxSize: string): number {
+  if (!myxSize || myxSize === '0') return 0;
+
+  try {
+    const bn = new BigNumber(myxSize);
+    const divisor = new BigNumber(10).pow(MYX_SIZE_DECIMALS);
+    return bn.dividedBy(divisor).toNumber();
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Convert standard number to MYX SDK size format (18 decimals)
+ * @param size - Standard decimal number
+ * @returns Size string in 18-decimal format for SDK
+ */
+export function toMYXSize(size: number | string): string {
+  try {
+    const bn = new BigNumber(size);
+    const multiplier = new BigNumber(10).pow(MYX_SIZE_DECIMALS);
+    return bn.multipliedBy(multiplier).toFixed(0);
+  } catch {
+    return '0';
+  }
+}
+
+/**
+ * Convert MYX SDK collateral (18 decimals) to standard number
+ * @param myxCollateral - Collateral string in 18-decimal format from SDK
+ * @returns Standard decimal number
+ */
+export function fromMYXCollateral(myxCollateral: string): number {
+  if (!myxCollateral || myxCollateral === '0') return 0;
+
+  try {
+    const bn = new BigNumber(myxCollateral);
+    const divisor = new BigNumber(10).pow(MYX_COLLATERAL_DECIMALS);
+    return bn.dividedBy(divisor).toNumber();
+  } catch {
+    return 0;
+  }
+}
+
+// ============================================================================
+// REST API Configuration
+// ============================================================================
+
+/**
+ * Price polling interval in milliseconds
+ * Using 5 seconds as a fallback for unreliable WebSocket
+ */
+export const MYX_PRICE_POLLING_INTERVAL_MS = 5000;
+
+/**
+ * HTTP request timeout in milliseconds
+ */
+export const MYX_HTTP_TIMEOUT_MS = 10000;
+
+/**
+ * Maximum retries for failed API requests
+ */
+export const MYX_MAX_RETRIES = 3;

--- a/app/components/UI/Perps/constants/perpsConfig.ts
+++ b/app/components/UI/Perps/constants/perpsConfig.ts
@@ -579,3 +579,16 @@ export const STOP_LOSS_PROMPT_CONFIG = {
   // When suggesting a stop loss, calculate price at this ROE from entry
   SuggestedStopLossRoe: -50,
 } as const;
+
+/**
+ * Provider configuration
+ * Controls which perpetual DEX providers are available
+ *
+ * Note: MYX provider enablement is now controlled via LaunchDarkly feature flag
+ * (perpsMyxProviderEnabled) and MM_PERPS_MYX_PROVIDER_ENABLED environment variable.
+ * See selectPerpsMYXProviderEnabledFlag selector for details.
+ */
+export const PROVIDER_CONFIG = {
+  /** Force MYX to testnet only (mainnet credentials not yet available) */
+  MYX_TESTNET_ONLY: true,
+} as const;

--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
@@ -132,6 +132,7 @@ import type {
   ToggleTestnetResult,
   TransferBetweenDexsParams,
   TransferBetweenDexsResult,
+  UpdateMarginParams,
   UpdatePositionTPSLParams,
   UserHistoryItem,
   WithdrawParams,
@@ -4249,6 +4250,7 @@ export class HyperLiquidProvider implements PerpsProvider {
    * @param params - Margin adjustment parameters
    * @param params.symbol - Asset symbol (e.g., 'BTC', 'ETH')
    * @param params.amount - Amount to adjust as string (positive = add, negative = remove)
+   * @param params.providerId - Optional provider identifier (ignored, always uses HyperLiquid)
    * @returns Promise resolving to margin adjustment result
    *
    * Note: HyperLiquid uses micro-units (multiply by 1e6) for the ntli parameter.
@@ -4257,10 +4259,7 @@ export class HyperLiquidProvider implements PerpsProvider {
    * - isBuy: Position direction (true for long, false for short)
    * - ntli: Amount in micro-units (amount * 1e6)
    */
-  async updateMargin(params: {
-    symbol: string;
-    amount: string;
-  }): Promise<MarginResult> {
+  async updateMargin(params: UpdateMarginParams): Promise<MarginResult> {
     try {
       this.deps.debugLogger.log('Updating position margin:', params);
 

--- a/app/components/UI/Perps/controllers/providers/MYXProvider.ts
+++ b/app/components/UI/Perps/controllers/providers/MYXProvider.ts
@@ -1,0 +1,726 @@
+/**
+ * MYXProvider
+ *
+ * Stage 1 provider implementation for MYX protocol.
+ * Implements the PerpsProvider interface with read-only operations.
+ * Trading functionality will be added in Stage 3.
+ *
+ * Key differences from HyperLiquid:
+ * - Uses USDT collateral on BNB chain (vs USDC on Arbitrum)
+ * - Multi-Pool Model: multiple pools can exist per symbol
+ * - Uses REST polling for prices (WebSocket deferred to Stage 3)
+ */
+
+import type { CaipAccountId } from '@metamask/utils';
+import { ensureError } from '../../../../../util/errorUtils';
+import { MYXClientService } from '../../services/MYXClientService';
+import {
+  adaptMarketFromMYX,
+  adaptMarketDataFromMYX,
+  adaptPriceFromMYX,
+  filterMYXExclusiveMarkets,
+  buildPoolSymbolMap,
+} from '../../utils/myxAdapter';
+import type { MYXPoolSymbol, MYXTicker } from '../../types/myx-types';
+import { PERPS_CONSTANTS } from '../../constants/perpsConfig';
+import type {
+  AccountState,
+  AssetRoute,
+  BatchCancelOrdersParams,
+  CancelOrderParams,
+  CancelOrderResult,
+  CancelOrdersResult,
+  ClosePositionParams,
+  ClosePositionsParams,
+  ClosePositionsResult,
+  DepositParams,
+  DisconnectResult,
+  EditOrderParams,
+  FeeCalculationParams,
+  FeeCalculationResult,
+  Funding,
+  GetAccountStateParams,
+  GetFundingParams,
+  GetHistoricalPortfolioParams,
+  GetMarketsParams,
+  GetOrderFillsParams,
+  GetOrdersParams,
+  GetOrFetchFillsParams,
+  GetPositionsParams,
+  GetSupportedPathsParams,
+  HistoricalPortfolioResult,
+  InitializeResult,
+  LiquidationPriceParams,
+  LiveDataConfig,
+  MaintenanceMarginParams,
+  MarginResult,
+  MarketInfo,
+  Order,
+  OrderFill,
+  OrderParams,
+  OrderResult,
+  PerpsPlatformDependencies,
+  PerpsMarketData,
+  PerpsProvider,
+  Position,
+  PriceUpdate,
+  ReadyToTradeResult,
+  SubscribeAccountParams,
+  SubscribeCandlesParams,
+  SubscribeOICapsParams,
+  SubscribeOrderBookParams,
+  SubscribeOrderFillsParams,
+  SubscribeOrdersParams,
+  SubscribePositionsParams,
+  SubscribePricesParams,
+  ToggleTestnetResult,
+  UpdatePositionTPSLParams,
+  UserHistoryItem,
+  WithdrawParams,
+  WithdrawResult,
+} from '../types';
+import type { RawHyperLiquidLedgerUpdate } from '../../utils/hyperLiquidAdapter';
+import { WebSocketConnectionState } from '../../services/HyperLiquidClientService';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const MYX_NOT_SUPPORTED_ERROR = 'MYX trading not yet supported';
+const MYX_BLOCK_EXPLORER_URL = 'https://bscscan.com';
+const MYX_TESTNET_EXPLORER_URL = 'https://testnet.bscscan.com';
+
+// ============================================================================
+// MYXProvider
+// ============================================================================
+
+/**
+ * MYX provider implementation
+ *
+ * Stage 1: Read-only operations (markets, prices)
+ * Trading operations return errors until Stage 3.
+ */
+export class MYXProvider implements PerpsProvider {
+  readonly protocolId = 'myx';
+
+  // Platform dependencies
+  private readonly deps: PerpsPlatformDependencies;
+
+  // Client service
+  private clientService: MYXClientService;
+
+  // Configuration
+  private isTestnet: boolean;
+
+  // Cache for pools
+  private poolsCache: MYXPoolSymbol[] = [];
+  private poolsCacheTimestamp = 0;
+  private readonly POOLS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+  private poolSymbolMap: Map<string, string> = new Map();
+
+  // Ticker cache for price data
+  private tickersCache: Map<string, MYXTicker> = new Map();
+
+  // Price subscription callback
+  private priceCallback?: (updates: PriceUpdate[]) => void;
+
+  // Track initialization state
+  private isInitialized = false;
+
+  constructor(options: {
+    isTestnet?: boolean;
+    platformDependencies: PerpsPlatformDependencies;
+  }) {
+    this.deps = options.platformDependencies;
+    this.isTestnet = options.isTestnet ?? true; // Force testnet in Stage 1
+
+    // Initialize client service
+    this.clientService = new MYXClientService(this.deps, {
+      isTestnet: this.isTestnet,
+    });
+
+    this.deps.debugLogger.log('[MYXProvider] Constructor complete', {
+      protocolId: this.protocolId,
+      isTestnet: this.isTestnet,
+    });
+  }
+
+  // ============================================================================
+  // Error Context Helper
+  // ============================================================================
+
+  private getErrorContext(
+    method: string,
+    extra?: Record<string, unknown>,
+  ): {
+    tags?: Record<string, string | number>;
+    context?: { name: string; data: Record<string, unknown> };
+  } {
+    return {
+      tags: {
+        feature: PERPS_CONSTANTS.FeatureName,
+        provider: 'MYXProvider',
+        network: this.isTestnet ? 'testnet' : 'mainnet',
+      },
+      context: {
+        name: `MYXProvider.${method}`,
+        data: {
+          isTestnet: this.isTestnet,
+          ...extra,
+        },
+      },
+    };
+  }
+
+  // ============================================================================
+  // Initialization & Lifecycle
+  // ============================================================================
+
+  async initialize(): Promise<InitializeResult> {
+    try {
+      this.deps.debugLogger.log('[MYXProvider] Initializing...');
+
+      // Fetch initial markets
+      const pools = await this.clientService.getMarkets();
+
+      // Filter to MYX-exclusive markets
+      this.poolsCache = filterMYXExclusiveMarkets(pools);
+      this.poolSymbolMap = buildPoolSymbolMap(this.poolsCache);
+
+      this.isInitialized = true;
+
+      this.deps.debugLogger.log('[MYXProvider] Initialized successfully', {
+        totalPools: pools.length,
+        exclusivePools: this.poolsCache.length,
+      });
+
+      return { success: true };
+    } catch (error) {
+      const err = ensureError(error);
+      this.deps.logger.error(err, this.getErrorContext('initialize'));
+      return { success: false, error: err.message };
+    }
+  }
+
+  async disconnect(): Promise<DisconnectResult> {
+    try {
+      this.deps.debugLogger.log('[MYXProvider] Disconnecting...');
+
+      this.clientService.disconnect();
+      this.isInitialized = false;
+      this.poolsCache = [];
+      this.poolsCacheTimestamp = 0;
+      this.poolSymbolMap.clear();
+      this.tickersCache.clear();
+      this.priceCallback = undefined;
+
+      return { success: true };
+    } catch (error) {
+      const err = ensureError(error);
+      this.deps.logger.error(err, this.getErrorContext('disconnect'));
+      return { success: false, error: err.message };
+    }
+  }
+
+  async ping(timeoutMs?: number): Promise<void> {
+    await this.clientService.ping(timeoutMs);
+  }
+
+  async toggleTestnet(): Promise<ToggleTestnetResult> {
+    // Stage 1: Testnet only
+    return {
+      success: false,
+      isTestnet: this.isTestnet,
+      error: 'MYX mainnet not yet available',
+    };
+  }
+
+  async isReadyToTrade(): Promise<ReadyToTradeResult> {
+    // Stage 1: Trading not supported
+    return {
+      ready: false,
+      error: 'MYX trading not yet supported',
+      walletConnected: false,
+      networkSupported: this.isTestnet,
+    };
+  }
+
+  // ============================================================================
+  // Market Data Operations (Stage 1 - Fully Implemented)
+  // ============================================================================
+
+  async getMarkets(_params?: GetMarketsParams): Promise<MarketInfo[]> {
+    try {
+      const now = Date.now();
+      const cacheValid =
+        this.poolsCache.length > 0 &&
+        now - this.poolsCacheTimestamp < this.POOLS_CACHE_TTL_MS;
+
+      // Return cached pools if available and not expired
+      if (cacheValid) {
+        return this.poolsCache.map((pool) => adaptMarketFromMYX(pool));
+      }
+
+      // Fetch fresh data
+      const pools = await this.clientService.getMarkets();
+      this.poolsCache = filterMYXExclusiveMarkets(pools);
+      this.poolsCacheTimestamp = now;
+      this.poolSymbolMap = buildPoolSymbolMap(this.poolsCache);
+
+      return this.poolsCache.map((pool) => adaptMarketFromMYX(pool));
+    } catch (error) {
+      const err = ensureError(error);
+      this.deps.logger.error(err, this.getErrorContext('getMarkets'));
+      throw err;
+    }
+  }
+
+  async getMarketDataWithPrices(): Promise<PerpsMarketData[]> {
+    try {
+      // Ensure we have markets
+      if (this.poolsCache.length === 0) {
+        await this.getMarkets();
+      }
+
+      // Fetch tickers for all pools
+      const poolIds = this.poolsCache.map((pool) => pool.poolId);
+      const tickers = await this.clientService.getTickers(poolIds);
+
+      // Build ticker map
+      const tickerMap = new Map<string, MYXTicker>();
+      for (const ticker of tickers) {
+        tickerMap.set(ticker.poolId, ticker);
+        this.tickersCache.set(ticker.poolId, ticker);
+      }
+
+      // Transform to PerpsMarketData
+      return this.poolsCache.map((pool) => {
+        const ticker = tickerMap.get(pool.poolId);
+        return adaptMarketDataFromMYX(pool, ticker);
+      });
+    } catch (error) {
+      const err = ensureError(error);
+      this.deps.logger.error(
+        err,
+        this.getErrorContext('getMarketDataWithPrices'),
+      );
+      throw err;
+    }
+  }
+
+  // ============================================================================
+  // Price Subscriptions (Stage 1 - REST Polling)
+  // ============================================================================
+
+  subscribeToPrices(params: SubscribePricesParams): () => void {
+    const { symbols, callback, includeOrderBook } = params;
+
+    this.deps.debugLogger.log('[MYXProvider] Setting up price subscription', {
+      symbols: symbols.length,
+      includeOrderBook,
+    });
+
+    // Map symbols to pool IDs
+    const poolIds: string[] = [];
+    for (const pool of this.poolsCache) {
+      const symbol = pool.baseSymbol || pool.poolId;
+      if (symbols.includes(symbol)) {
+        poolIds.push(pool.poolId);
+      }
+    }
+
+    if (poolIds.length === 0) {
+      this.deps.debugLogger.log('[MYXProvider] No matching pools for symbols', {
+        symbols,
+      });
+      return () => {
+        /* noop */
+      }; // No-op unsubscribe
+    }
+
+    // Store callback for internal use
+    this.priceCallback = callback;
+
+    // Start price polling
+    this.clientService.startPricePolling(poolIds, (tickers) => {
+      // Convert tickers to PriceUpdate format
+      const updates: PriceUpdate[] = tickers.map((ticker) => {
+        const symbol = this.poolSymbolMap.get(ticker.poolId) || ticker.poolId;
+        const { price, change24h } = this.getAdaptedPrice(ticker);
+
+        return {
+          symbol,
+          price,
+          timestamp: Date.now(),
+          percentChange24h: change24h.toFixed(2),
+          providerId: 'myx',
+        };
+      });
+
+      callback(updates);
+    });
+
+    // Return unsubscribe function
+    return () => {
+      this.deps.debugLogger.log('[MYXProvider] Unsubscribing from prices');
+      this.clientService.stopPricePolling();
+      this.priceCallback = undefined;
+    };
+  }
+
+  private getAdaptedPrice(ticker: MYXTicker): {
+    price: string;
+    change24h: number;
+  } {
+    return adaptPriceFromMYX(ticker);
+  }
+
+  // ============================================================================
+  // Asset Routes (Stage 1 - Stubbed)
+  // ============================================================================
+
+  getDepositRoutes(_params?: GetSupportedPathsParams): AssetRoute[] {
+    // Stage 1: No deposit support
+    return [];
+  }
+
+  getWithdrawalRoutes(_params?: GetSupportedPathsParams): AssetRoute[] {
+    // Stage 1: No withdrawal support
+    return [];
+  }
+
+  // ============================================================================
+  // Trading Operations (Stage 1 - All Stubbed)
+  // ============================================================================
+
+  async placeOrder(_params: OrderParams): Promise<OrderResult> {
+    return {
+      success: false,
+      error: MYX_NOT_SUPPORTED_ERROR,
+    };
+  }
+
+  async editOrder(_params: EditOrderParams): Promise<OrderResult> {
+    return {
+      success: false,
+      error: MYX_NOT_SUPPORTED_ERROR,
+    };
+  }
+
+  async cancelOrder(_params: CancelOrderParams): Promise<CancelOrderResult> {
+    return {
+      success: false,
+      error: MYX_NOT_SUPPORTED_ERROR,
+    };
+  }
+
+  async cancelOrders(
+    _params: BatchCancelOrdersParams,
+  ): Promise<CancelOrdersResult> {
+    return {
+      success: false,
+      successCount: 0,
+      failureCount: 0,
+      results: [],
+    };
+  }
+
+  async closePosition(_params: ClosePositionParams): Promise<OrderResult> {
+    return {
+      success: false,
+      error: MYX_NOT_SUPPORTED_ERROR,
+    };
+  }
+
+  async closePositions(
+    _params: ClosePositionsParams,
+  ): Promise<ClosePositionsResult> {
+    return {
+      success: false,
+      successCount: 0,
+      failureCount: 0,
+      results: [],
+    };
+  }
+
+  async updatePositionTPSL(
+    _params: UpdatePositionTPSLParams,
+  ): Promise<OrderResult> {
+    return {
+      success: false,
+      error: MYX_NOT_SUPPORTED_ERROR,
+    };
+  }
+
+  async updateMargin(_params: {
+    symbol: string;
+    amount: string;
+    isAdd: boolean;
+  }): Promise<MarginResult> {
+    return {
+      success: false,
+      error: MYX_NOT_SUPPORTED_ERROR,
+    };
+  }
+
+  async withdraw(_params: WithdrawParams): Promise<WithdrawResult> {
+    return {
+      success: false,
+      error: MYX_NOT_SUPPORTED_ERROR,
+    };
+  }
+
+  // ============================================================================
+  // Account Operations (Stage 1 - Empty Returns)
+  // ============================================================================
+
+  async getPositions(_params?: GetPositionsParams): Promise<Position[]> {
+    // Stage 1: No position tracking
+    return [];
+  }
+
+  async getAccountState(
+    _params?: GetAccountStateParams,
+  ): Promise<AccountState> {
+    // Stage 1: Empty account state
+    return {
+      availableBalance: '0',
+      totalBalance: '0',
+      marginUsed: '0',
+      unrealizedPnl: '0',
+      returnOnEquity: '0',
+    };
+  }
+
+  async getOrders(_params?: GetOrdersParams): Promise<Order[]> {
+    // Stage 1: No order tracking
+    return [];
+  }
+
+  async getOpenOrders(_params?: GetOrdersParams): Promise<Order[]> {
+    // Stage 1: No order tracking
+    return [];
+  }
+
+  async getOrderFills(_params?: GetOrderFillsParams): Promise<OrderFill[]> {
+    // Stage 1: No fill tracking
+    return [];
+  }
+
+  async getOrFetchFills(_params?: GetOrFetchFillsParams): Promise<OrderFill[]> {
+    // Stage 1: No fill tracking
+    return [];
+  }
+
+  async getFunding(_params?: GetFundingParams): Promise<Funding[]> {
+    // Stage 1: No funding tracking
+    return [];
+  }
+
+  async getHistoricalPortfolio(
+    _params?: GetHistoricalPortfolioParams,
+  ): Promise<HistoricalPortfolioResult> {
+    return {
+      accountValue1dAgo: '0',
+      timestamp: Date.now(),
+    };
+  }
+
+  async getUserNonFundingLedgerUpdates(_params?: {
+    accountId?: string;
+    startTime?: number;
+    endTime?: number;
+  }): Promise<RawHyperLiquidLedgerUpdate[]> {
+    return [];
+  }
+
+  async getUserHistory(_params?: {
+    accountId?: CaipAccountId;
+    startTime?: number;
+    endTime?: number;
+  }): Promise<UserHistoryItem[]> {
+    return [];
+  }
+
+  // ============================================================================
+  // Validation Operations (Stage 1 - All Invalid)
+  // ============================================================================
+
+  async validateDeposit(
+    _params: DepositParams,
+  ): Promise<{ isValid: boolean; error?: string }> {
+    return { isValid: false, error: MYX_NOT_SUPPORTED_ERROR };
+  }
+
+  async validateOrder(
+    _params: OrderParams,
+  ): Promise<{ isValid: boolean; error?: string }> {
+    return { isValid: false, error: MYX_NOT_SUPPORTED_ERROR };
+  }
+
+  async validateClosePosition(
+    _params: ClosePositionParams,
+  ): Promise<{ isValid: boolean; error?: string }> {
+    return { isValid: false, error: MYX_NOT_SUPPORTED_ERROR };
+  }
+
+  async validateWithdrawal(
+    _params: WithdrawParams,
+  ): Promise<{ isValid: boolean; error?: string }> {
+    return { isValid: false, error: MYX_NOT_SUPPORTED_ERROR };
+  }
+
+  // ============================================================================
+  // Protocol Calculations (Stage 1 - Default Values)
+  // ============================================================================
+
+  async calculateLiquidationPrice(
+    _params: LiquidationPriceParams,
+  ): Promise<string> {
+    return '0';
+  }
+
+  async calculateMaintenanceMargin(
+    _params: MaintenanceMarginParams,
+  ): Promise<number> {
+    return 0;
+  }
+
+  async getMaxLeverage(_asset: string): Promise<number> {
+    return 100; // MYX default max leverage
+  }
+
+  async calculateFees(
+    _params: FeeCalculationParams,
+  ): Promise<FeeCalculationResult> {
+    // MYX fee structure (placeholder values)
+    return {
+      feeRate: 0.0005, // 0.05% total fee rate
+      protocolFeeRate: 0.0005, // Protocol taker fee
+    };
+  }
+
+  // ============================================================================
+  // Subscriptions (Stage 1 - No-op)
+  // ============================================================================
+
+  subscribeToPositions(params: SubscribePositionsParams): () => void {
+    // Stage 1: No position tracking - immediately call back with empty array
+    // to signal loading is complete (no data to show)
+    setTimeout(() => params.callback([]), 0);
+    return () => {
+      /* noop */
+    };
+  }
+
+  subscribeToOrderFills(params: SubscribeOrderFillsParams): () => void {
+    // Stage 1: No fill tracking - immediately call back with empty array
+    setTimeout(() => params.callback([]), 0);
+    return () => {
+      /* noop */
+    };
+  }
+
+  subscribeToOrders(params: SubscribeOrdersParams): () => void {
+    // Stage 1: No order tracking - immediately call back with empty array
+    setTimeout(() => params.callback([]), 0);
+    return () => {
+      /* noop */
+    };
+  }
+
+  subscribeToAccount(params: SubscribeAccountParams): () => void {
+    // Stage 1: Empty account state - immediately call back
+    setTimeout(
+      () =>
+        params.callback({
+          availableBalance: '0',
+          totalBalance: '0',
+          marginUsed: '0',
+          unrealizedPnl: '0',
+          returnOnEquity: '0',
+        }),
+      0,
+    );
+    return () => {
+      /* noop */
+    };
+  }
+
+  subscribeToOICaps(_params: SubscribeOICapsParams): () => void {
+    return () => {
+      /* noop */
+    };
+  }
+
+  subscribeToCandles(_params: SubscribeCandlesParams): () => void {
+    return () => {
+      /* noop */
+    };
+  }
+
+  subscribeToOrderBook(_params: SubscribeOrderBookParams): () => void {
+    return () => {
+      /* noop */
+    };
+  }
+
+  setLiveDataConfig(_config: Partial<LiveDataConfig>): void {
+    // Stage 1: No-op
+  }
+
+  // ============================================================================
+  // Connection State (Stage 1 - REST Only)
+  // ============================================================================
+
+  getWebSocketConnectionState(): WebSocketConnectionState {
+    // Stage 1: No WebSocket, report as connected (REST is always available)
+    return WebSocketConnectionState.Connected;
+  }
+
+  subscribeToConnectionState(
+    _listener: (
+      state: WebSocketConnectionState,
+      reconnectionAttempt: number,
+    ) => void,
+  ): () => void {
+    // Stage 1: No WebSocket, no connection state changes
+    return () => {
+      /* noop */
+    };
+  }
+
+  async reconnect(): Promise<void> {
+    // Stage 1: No WebSocket to reconnect
+    this.deps.debugLogger.log('[MYXProvider] reconnect() is no-op in Stage 1');
+  }
+
+  // ============================================================================
+  // Block Explorer
+  // ============================================================================
+
+  getBlockExplorerUrl(address?: string): string {
+    const baseUrl = this.isTestnet
+      ? MYX_TESTNET_EXPLORER_URL
+      : MYX_BLOCK_EXPLORER_URL;
+
+    return address ? `${baseUrl}/address/${address}` : baseUrl;
+  }
+
+  // ============================================================================
+  // Fee Discount (Stage 1 - No-op)
+  // ============================================================================
+
+  setUserFeeDiscount(_discountBips: number | undefined): void {
+    // Stage 1: No fee discount support
+  }
+
+  // ============================================================================
+  // HIP-3 Operations (N/A for MYX)
+  // ============================================================================
+
+  async getAvailableDexs(): Promise<string[]> {
+    // MYX doesn't have HIP-3 equivalent
+    return [];
+  }
+}

--- a/app/components/UI/Perps/controllers/services/EligibilityService.test.ts
+++ b/app/components/UI/Perps/controllers/services/EligibilityService.test.ts
@@ -186,7 +186,9 @@ describe('EligibilityService', () => {
         text: async () => 'FR',
       });
 
-      const result = await service.checkEligibility(['US', 'CN']);
+      const result = await service.checkEligibility({
+        blockedRegions: ['US', 'CN'],
+      });
 
       expect(result).toBe(true);
     });
@@ -196,7 +198,9 @@ describe('EligibilityService', () => {
         text: async () => 'US',
       });
 
-      const result = await service.checkEligibility(['US', 'CN']);
+      const result = await service.checkEligibility({
+        blockedRegions: ['US', 'CN'],
+      });
 
       expect(result).toBe(false);
     });
@@ -206,7 +210,9 @@ describe('EligibilityService', () => {
         text: async () => 'CN',
       });
 
-      const result = await service.checkEligibility(['US', 'CN', 'KP', 'IR']);
+      const result = await service.checkEligibility({
+        blockedRegions: ['US', 'CN', 'KP', 'IR'],
+      });
 
       expect(result).toBe(false);
     });
@@ -216,7 +222,7 @@ describe('EligibilityService', () => {
         text: async () => 'US',
       });
 
-      const result = await service.checkEligibility([]);
+      const result = await service.checkEligibility({ blockedRegions: [] });
 
       expect(result).toBe(true);
     });
@@ -224,7 +230,9 @@ describe('EligibilityService', () => {
     it('returns true when location is UNKNOWN (defaults to eligible)', async () => {
       (successfulFetch as jest.Mock).mockRejectedValue(new Error('API error'));
 
-      const result = await service.checkEligibility(['US', 'CN']);
+      const result = await service.checkEligibility({
+        blockedRegions: ['US', 'CN'],
+      });
 
       expect(result).toBe(true);
     });
@@ -234,7 +242,9 @@ describe('EligibilityService', () => {
         text: async () => 'US-NY',
       });
 
-      const resultWithUS = await service.checkEligibility(['US']);
+      const resultWithUS = await service.checkEligibility({
+        blockedRegions: ['US'],
+      });
 
       expect(resultWithUS).toBe(false);
     });
@@ -244,7 +254,7 @@ describe('EligibilityService', () => {
         text: async () => 'us',
       });
 
-      const result = await service.checkEligibility(['US']);
+      const result = await service.checkEligibility({ blockedRegions: ['US'] });
 
       expect(result).toBe(false);
     });
@@ -254,8 +264,12 @@ describe('EligibilityService', () => {
         text: async () => 'FR',
       });
 
-      const result1 = await service.checkEligibility(['US']);
-      const result2 = await service.checkEligibility(['US']);
+      const result1 = await service.checkEligibility({
+        blockedRegions: ['US'],
+      });
+      const result2 = await service.checkEligibility({
+        blockedRegions: ['US'],
+      });
 
       expect(result1).toBe(true);
       expect(result2).toBe(true);
@@ -267,7 +281,9 @@ describe('EligibilityService', () => {
         new Error('Network failure'),
       );
 
-      const result = await service.checkEligibility(['US', 'CN']);
+      const result = await service.checkEligibility({
+        blockedRegions: ['US', 'CN'],
+      });
 
       expect(result).toBe(true);
     });
@@ -278,9 +294,9 @@ describe('EligibilityService', () => {
       });
 
       const [result1, result2, result3] = await Promise.all([
-        service.checkEligibility(['US']),
-        service.checkEligibility(['CN']),
-        service.checkEligibility(['UK']),
+        service.checkEligibility({ blockedRegions: ['US'] }),
+        service.checkEligibility({ blockedRegions: ['CN'] }),
+        service.checkEligibility({ blockedRegions: ['UK'] }),
       ]);
 
       expect(result1).toBe(true);

--- a/app/components/UI/Perps/controllers/services/EligibilityService.ts
+++ b/app/components/UI/Perps/controllers/services/EligibilityService.ts
@@ -1,7 +1,10 @@
 import { successfulFetch } from '@metamask/controller-utils';
 import { getEnvironment } from '../utils';
 import { ensureError } from '../../../../../util/errorUtils';
-import type { PerpsPlatformDependencies } from '../types';
+import type {
+  PerpsPlatformDependencies,
+  CheckEligibilityParams,
+} from '../types';
 
 // Geo-blocking API URLs
 const ON_RAMP_GEO_BLOCKING_URLS = {
@@ -132,10 +135,11 @@ export class EligibilityService {
 
   /**
    * Check if user is eligible based on geo-blocked regions
-   * @param blockedRegions - List of blocked region codes (e.g., ['US', 'CN'])
+   * @param options.blockedRegions - List of blocked region codes (e.g., ['US', 'CN'])
    * @returns true if eligible (not in blocked region), false otherwise
    */
-  async checkEligibility(blockedRegions: string[]): Promise<boolean> {
+  async checkEligibility(options: CheckEligibilityParams): Promise<boolean> {
+    const { blockedRegions } = options;
     try {
       this.deps.debugLogger.log('EligibilityService: Checking eligibility', {
         blockedRegionsCount: blockedRegions.length,

--- a/app/components/UI/Perps/controllers/services/MarketDataService.test.ts
+++ b/app/components/UI/Perps/controllers/services/MarketDataService.test.ts
@@ -895,7 +895,12 @@ describe('MarketDataService', () => {
       expect(result).toEqual(mockCandleData);
       expect(
         hyperLiquidProvider.clientService.fetchHistoricalCandles,
-      ).toHaveBeenCalledWith('BTC', '1h', 100, undefined);
+      ).toHaveBeenCalledWith({
+        symbol: 'BTC',
+        interval: '1h',
+        limit: 100,
+        endTime: undefined,
+      });
       expect(mockDeps.tracer.trace).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'Perps Fetch Historical Candles' }),
       );

--- a/app/components/UI/Perps/controllers/services/MarketDataService.ts
+++ b/app/components/UI/Perps/controllers/services/MarketDataService.ts
@@ -674,12 +674,12 @@ export class MarketDataService {
       // Check if provider supports historical candles via clientService
       const hyperLiquidProvider = provider as {
         clientService?: {
-          fetchHistoricalCandles?: (
-            symbol: string,
-            interval: CandlePeriod,
-            limit: number,
-            endTime?: number,
-          ) => Promise<CandleData>;
+          fetchHistoricalCandles?: (options: {
+            symbol: string;
+            interval: CandlePeriod;
+            limit?: number;
+            endTime?: number;
+          }) => Promise<CandleData>;
         };
       };
       if (!hyperLiquidProvider.clientService?.fetchHistoricalCandles) {
@@ -687,12 +687,12 @@ export class MarketDataService {
       }
 
       const result =
-        await hyperLiquidProvider.clientService.fetchHistoricalCandles(
+        await hyperLiquidProvider.clientService.fetchHistoricalCandles({
           symbol,
           interval,
           limit,
           endTime,
-        );
+        });
 
       traceData = { success: true };
       return result;

--- a/app/components/UI/Perps/controllers/types/index.ts
+++ b/app/components/UI/Perps/controllers/types/index.ts
@@ -617,6 +617,10 @@ export interface OrderFill {
 }
 
 // Parameter interfaces - all fully optional for better UX
+export interface CheckEligibilityParams {
+  blockedRegions: string[]; // List of blocked region codes (e.g., ['US', 'CN'])
+}
+
 export interface GetPositionsParams {
   accountId?: CaipAccountId; // Optional: defaults to selected account
   includeHistory?: boolean; // Optional: include historical positions

--- a/app/components/UI/Perps/hooks/index.ts
+++ b/app/components/UI/Perps/hooks/index.ts
@@ -1,6 +1,7 @@
 // Core hooks (direct controller access)
 export { usePerpsMarkets } from './usePerpsMarkets';
 export { usePerpsNetwork } from './usePerpsNetwork';
+export { usePerpsProvider } from './usePerpsProvider';
 export { usePerpsNetworkConfig } from './usePerpsNetworkConfig';
 export { usePerpsNetworkManagement } from './usePerpsNetworkManagement';
 export { usePerpsTrading } from './usePerpsTrading';

--- a/app/components/UI/Perps/hooks/usePerpsProvider.ts
+++ b/app/components/UI/Perps/hooks/usePerpsProvider.ts
@@ -1,0 +1,97 @@
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import Engine from '../../../../core/Engine';
+import { selectPerpsProvider } from '../selectors/perpsController';
+import { selectPerpsMYXProviderEnabledFlag } from '../selectors/featureFlags';
+import type {
+  PerpsProviderType,
+  PerpsActiveProviderMode,
+  SwitchProviderResult,
+} from '../controllers/types';
+
+/**
+ * Hook for managing perps provider selection
+ *
+ * Provides:
+ * - Current active provider
+ * - Available providers based on feature flags
+ * - Method to switch between providers
+ */
+export function usePerpsProvider() {
+  const activeProvider = useSelector(selectPerpsProvider);
+  const isMYXProviderEnabled = useSelector(selectPerpsMYXProviderEnabledFlag);
+
+  /**
+   * Get list of available providers based on feature flags
+   */
+  const availableProviders = useMemo((): PerpsProviderType[] => {
+    const providers: PerpsProviderType[] = ['hyperliquid'];
+
+    if (isMYXProviderEnabled) {
+      providers.push('myx');
+    }
+
+    return providers;
+  }, [isMYXProviderEnabled]);
+
+  /**
+   * Switch to a different provider
+   */
+  const switchProvider = useCallback(
+    async (
+      providerId: PerpsActiveProviderMode,
+    ): Promise<SwitchProviderResult> => {
+      const controller = Engine.context.PerpsController;
+      return controller.switchProvider(providerId);
+    },
+    [],
+  );
+
+  /**
+   * Check if a specific provider is available
+   */
+  const isProviderAvailable = useCallback(
+    (providerId: PerpsProviderType): boolean =>
+      availableProviders.includes(providerId),
+    [availableProviders],
+  );
+
+  /**
+   * Check if the current provider is MYX
+   */
+  const isMYXProvider = useMemo(
+    () => activeProvider === 'myx',
+    [activeProvider],
+  );
+
+  /**
+   * Check if the current provider is HyperLiquid
+   */
+  const isHyperLiquidProvider = useMemo(
+    () => activeProvider === 'hyperliquid',
+    [activeProvider],
+  );
+
+  /**
+   * Check if multi-provider mode is enabled (more than one provider available)
+   */
+  const isMultiProviderEnabled = useMemo(
+    () => availableProviders.length > 1,
+    [availableProviders],
+  );
+
+  return {
+    // Current state
+    activeProvider,
+    availableProviders,
+
+    // Actions
+    switchProvider,
+
+    // Helpers
+    isProviderAvailable,
+    isMYXProvider,
+    isHyperLiquidProvider,
+    isMultiProviderEnabled,
+  };
+}

--- a/app/components/UI/Perps/mocks/remoteFeatureFlagMocks.ts
+++ b/app/components/UI/Perps/mocks/remoteFeatureFlagMocks.ts
@@ -13,4 +13,5 @@ export const mockedPerpsFeatureFlagsEnabledState: Record<
   perpsPerpTradingServiceInterruptionBannerEnabled: mockEnabledPerpsLDFlag,
   perpsOrderBookEnabled: mockEnabledPerpsLDFlag,
   perpsFeedbackEnabled: mockEnabledPerpsLDFlag,
+  perpsMyxProviderEnabled: mockEnabledPerpsLDFlag,
 };

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
@@ -873,12 +873,12 @@ describe('CandleStreamChannel', () => {
         TimeDuration.OneDay,
       );
 
-      expect(mockFetchHistoricalCandles).toHaveBeenCalledWith(
-        'BTC',
-        CandlePeriod.OneHour,
-        50,
-        expect.any(Number),
-      );
+      expect(mockFetchHistoricalCandles).toHaveBeenCalledWith({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        limit: 50,
+        endTime: expect.any(Number),
+      });
 
       expect(subscriber).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
@@ -359,12 +359,12 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
 
       // Fetch historical candles via controller
       const newCandleData =
-        await Engine.context.PerpsController.fetchHistoricalCandles(
+        await Engine.context.PerpsController.fetchHistoricalCandles({
           symbol,
           interval,
           limit,
           endTime,
-        );
+        });
 
       if (!newCandleData || newCandleData.candles.length === 0) {
         DevLogger.log(

--- a/app/components/UI/Perps/routes/index.tsx
+++ b/app/components/UI/Perps/routes/index.tsx
@@ -36,6 +36,7 @@ import ActivityView from '../../../Views/ActivityView';
 import PerpsStreamBridge from '../components/PerpsStreamBridge';
 import { HIP3DebugView } from '../Debug';
 import PerpsCrossMarginWarningBottomSheet from '../components/PerpsCrossMarginWarningBottomSheet';
+import PerpsSelectProviderView from '../Views/PerpsSelectProviderView';
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { CONFIRMATION_HEADER_CONFIG } from '../constants/perpsConfig';
 
@@ -134,6 +135,14 @@ const PerpsModalStack = () => {
             component={PerpsCrossMarginWarningBottomSheet}
             options={{
               title: strings('perps.crossMargin.title'),
+            }}
+          />
+          <ModalStack.Screen
+            name={Routes.PERPS.MODALS.SELECT_PROVIDER}
+            component={PerpsSelectProviderView}
+            options={{
+              title: strings('perps.provider_selector.title'),
+              cardStyle: { backgroundColor: 'transparent' },
             }}
           />
           {/* Action Selection Modals */}
@@ -393,6 +402,8 @@ const PerpsScreenStack = () => {
                 backgroundColor: 'transparent',
               },
               animationEnabled: false,
+              // Keep previous screen rendered for transparent overlay
+              detachPreviousScreen: false,
             }}
           />
 

--- a/app/components/UI/Perps/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Perps/selectors/featureFlags/index.test.ts
@@ -8,6 +8,7 @@ import {
   selectPerpsFeedbackEnabledFlag,
   selectPerpsTradeWithAnyTokenEnabledFlag,
   selectPerpsRewardsReferralCodeEnabledFlag,
+  selectPerpsMYXProviderEnabledFlag,
 } from '.';
 import mockedEngine from '../../../../../core/__mocks__/MockedEngine';
 import {
@@ -1521,6 +1522,215 @@ describe('Perps Feature Flag Selectors', () => {
         };
 
         const result = selectPerpsTradeWithAnyTokenEnabledFlag(
+          stateWithUndefinedController,
+        );
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('selectPerpsMYXProviderEnabledFlag', () => {
+    // Helper to create fresh state objects to avoid reselect caching issues
+    const createEmptyFlagsState = () => ({
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {},
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    });
+
+    describe('default behavior (disabled by default)', () => {
+      it('returns false when remote flag is not set and local env var is not set', () => {
+        delete process.env.MM_PERPS_MYX_PROVIDER_ENABLED;
+        const result = selectPerpsMYXProviderEnabledFlag(
+          createEmptyFlagsState(),
+        );
+        expect(result).toBe(false);
+      });
+
+      it('returns true when local env var is explicitly true', () => {
+        process.env.MM_PERPS_MYX_PROVIDER_ENABLED = 'true';
+        const result = selectPerpsMYXProviderEnabledFlag(
+          createEmptyFlagsState(),
+        );
+        expect(result).toBe(true);
+      });
+
+      it('returns false when local env var is explicitly false', () => {
+        process.env.MM_PERPS_MYX_PROVIDER_ENABLED = 'false';
+        const result = selectPerpsMYXProviderEnabledFlag(
+          createEmptyFlagsState(),
+        );
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('hybrid flag behavior', () => {
+      it('uses remote flag when valid and enabled', () => {
+        mockHasMinimumRequiredVersion.mockReturnValue(true);
+        process.env.MM_PERPS_MYX_PROVIDER_ENABLED = 'false';
+
+        const stateWithEnabledRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  perpsMyxProviderEnabled: {
+                    enabled: true,
+                    minimumVersion: '1.0.0',
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPerpsMYXProviderEnabledFlag(
+          stateWithEnabledRemoteFlag,
+        );
+        expect(result).toBe(true);
+      });
+
+      it('uses remote flag when valid but disabled', () => {
+        mockHasMinimumRequiredVersion.mockReturnValue(true);
+        process.env.MM_PERPS_MYX_PROVIDER_ENABLED = 'true';
+
+        const stateWithDisabledRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  perpsMyxProviderEnabled: {
+                    enabled: false,
+                    minimumVersion: '1.0.0',
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPerpsMYXProviderEnabledFlag(
+          stateWithDisabledRemoteFlag,
+        );
+        expect(result).toBe(false);
+      });
+
+      it('uses remote flag (false) when enabled but version check fails', () => {
+        mockHasMinimumRequiredVersion.mockReturnValue(false);
+        process.env.MM_PERPS_MYX_PROVIDER_ENABLED = 'true';
+
+        const stateWithVersionCheckFailure = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  perpsMyxProviderEnabled: {
+                    enabled: true,
+                    minimumVersion: '99.0.0',
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPerpsMYXProviderEnabledFlag(
+          stateWithVersionCheckFailure,
+        );
+        expect(result).toBe(false);
+      });
+
+      it('falls back to local flag (false by default) when remote flag is invalid', () => {
+        delete process.env.MM_PERPS_MYX_PROVIDER_ENABLED;
+
+        const stateWithInvalidRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  perpsMyxProviderEnabled: {
+                    enabled: 'invalid',
+                    minimumVersion: 123,
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPerpsMYXProviderEnabledFlag(
+          stateWithInvalidRemoteFlag,
+        );
+        expect(result).toBe(false);
+      });
+
+      it('falls back to local flag (true) when remote flag is invalid and env is true', () => {
+        process.env.MM_PERPS_MYX_PROVIDER_ENABLED = 'true';
+
+        const stateWithInvalidRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  perpsMyxProviderEnabled: {
+                    enabled: 'invalid',
+                    minimumVersion: 123,
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPerpsMYXProviderEnabledFlag(
+          stateWithInvalidRemoteFlag,
+        );
+        expect(result).toBe(true);
+      });
+
+      it('falls back to local flag (false) when remote flag is null and env is false', () => {
+        process.env.MM_PERPS_MYX_PROVIDER_ENABLED = 'false';
+
+        const stateWithNullRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  perpsMyxProviderEnabled: null,
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPerpsMYXProviderEnabledFlag(
+          stateWithNullRemoteFlag,
+        );
+        expect(result).toBe(false);
+      });
+
+      it('falls back to local flag when RemoteFeatureFlagController is undefined', () => {
+        delete process.env.MM_PERPS_MYX_PROVIDER_ENABLED;
+
+        const stateWithUndefinedController = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: undefined,
+            },
+          },
+        };
+
+        const result = selectPerpsMYXProviderEnabledFlag(
           stateWithUndefinedController,
         );
         expect(result).toBe(false);

--- a/app/components/UI/Perps/selectors/featureFlags/index.ts
+++ b/app/components/UI/Perps/selectors/featureFlags/index.ts
@@ -207,3 +207,21 @@ export const selectPerpsRewardsReferralCodeEnabledFlag = createSelector(
     return validatedVersionGatedFeatureFlag(versionGatedFlag) ?? false;
   },
 );
+
+/**
+ * Selector for MYX Provider enabled flag
+ * Controls whether MYX is available as a provider option
+ *
+ * @returns boolean - true if MYX provider should be available, false otherwise
+ */
+export const selectPerpsMYXProviderEnabledFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    // Default to false (disabled by default for gradual rollout)
+    const localFlag = process.env.MM_PERPS_MYX_PROVIDER_ENABLED === 'true';
+    const remoteFlag =
+      remoteFeatureFlags?.perpsMyxProviderEnabled as unknown as VersionGatedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
+  },
+);

--- a/app/components/UI/Perps/services/HyperLiquidClientService.test.ts
+++ b/app/components/UI/Perps/services/HyperLiquidClientService.test.ts
@@ -527,11 +527,11 @@ describe('HyperLiquidClientService', () => {
         .mockResolvedValue(mockResponse);
 
       // Act
-      const result = await service.fetchHistoricalCandles(
-        'BTC',
-        '1h' as ValidCandleInterval,
-        100,
-      );
+      const result = await service.fetchHistoricalCandles({
+        symbol: 'BTC',
+        interval: '1h' as ValidCandleInterval,
+        limit: 100,
+      });
 
       // Assert
       expect(result).toEqual({
@@ -573,11 +573,11 @@ describe('HyperLiquidClientService', () => {
         .mockResolvedValue(mockResponse);
 
       // Act
-      const result = await service.fetchHistoricalCandles(
-        'BTC',
-        '1h' as ValidCandleInterval,
-        100,
-      );
+      const result = await service.fetchHistoricalCandles({
+        symbol: 'BTC',
+        interval: '1h' as ValidCandleInterval,
+        limit: 100,
+      });
 
       // Assert
       expect(result).toEqual({
@@ -596,7 +596,11 @@ describe('HyperLiquidClientService', () => {
 
       // Act & Assert
       await expect(
-        service.fetchHistoricalCandles('BTC', '1h' as ValidCandleInterval, 100),
+        service.fetchHistoricalCandles({
+          symbol: 'BTC',
+          interval: '1h' as ValidCandleInterval,
+          limit: 100,
+        }),
       ).rejects.toThrow(errorMessage);
     });
 
@@ -613,11 +617,11 @@ describe('HyperLiquidClientService', () => {
         .mockResolvedValue(mockResponse);
 
       // Act
-      await service.fetchHistoricalCandles(
-        'ETH',
-        '5m' as ValidCandleInterval,
-        50,
-      );
+      await service.fetchHistoricalCandles({
+        symbol: 'ETH',
+        interval: '5m' as ValidCandleInterval,
+        limit: 50,
+      });
 
       // Assert
       expect(mockInfoClientWs.candleSnapshot).toHaveBeenCalledWith({
@@ -652,7 +656,11 @@ describe('HyperLiquidClientService', () => {
           .mockResolvedValue(mockResponse);
 
         // Act
-        await service.fetchHistoricalCandles('BTC', interval, 10);
+        await service.fetchHistoricalCandles({
+          symbol: 'BTC',
+          interval,
+          limit: 10,
+        });
 
         // Assert
         const callArgs = mockInfoClientWs.candleSnapshot.mock.calls[0][0];
@@ -675,11 +683,11 @@ describe('HyperLiquidClientService', () => {
         .mockResolvedValue(mockResponse);
 
       // Act
-      await testnetService.fetchHistoricalCandles(
-        'BTC',
-        '1h' as ValidCandleInterval,
-        100,
-      );
+      await testnetService.fetchHistoricalCandles({
+        symbol: 'BTC',
+        interval: '1h' as ValidCandleInterval,
+        limit: 100,
+      });
 
       // Assert
       expect(mockInfoClientWs.candleSnapshot).toHaveBeenCalled();
@@ -692,11 +700,11 @@ describe('HyperLiquidClientService', () => {
 
       // Act & Assert
       await expect(
-        uninitializedService.fetchHistoricalCandles(
-          'BTC',
-          '1h' as ValidCandleInterval,
-          100,
-        ),
+        uninitializedService.fetchHistoricalCandles({
+          symbol: 'BTC',
+          interval: '1h' as ValidCandleInterval,
+          limit: 100,
+        }),
       ).rejects.toThrow('CLIENT_NOT_INITIALIZED');
     });
   });
@@ -1671,7 +1679,9 @@ describe('HyperLiquidClientService', () => {
 
       // Use expect().rejects pattern with async timer advancement
       // The promise and timer advancement need to happen concurrently
-      const promiseResult = service.ensureTransportReady(50).catch((e) => e);
+      const promiseResult = service
+        .ensureTransportReady({ timeoutMs: 50 })
+        .catch((e) => e);
 
       // Advance timers to trigger the timeout
       await jest.advanceTimersByTimeAsync(100);

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -2804,7 +2804,7 @@ export class HyperLiquidSubscriptionService {
     // This prevents race conditions where subscriptions are attempted while
     // the WebSocket is still in CONNECTING state
     try {
-      await this.clientService.ensureTransportReady(5000);
+      await this.clientService.ensureTransportReady({ timeoutMs: 5000 });
     } catch (error) {
       this.deps.debugLogger.log(
         'Transport not ready during subscription restore, will retry on next reconnect',

--- a/app/components/UI/Perps/services/MYXClientService.ts
+++ b/app/components/UI/Perps/services/MYXClientService.ts
@@ -1,0 +1,346 @@
+/**
+ * MYXClientService
+ *
+ * Stage 1 service for fetching MYX market data using the @myx-trade/sdk.
+ * Handles market listing, ticker fetching, and price polling.
+ *
+ * Uses MyxClient SDK for API calls.
+ * Trading functionality will be added in Stage 3.
+ */
+
+import { MyxClient } from '@myx-trade/sdk';
+import { ensureError } from '../../../../util/errorUtils';
+import type { PerpsPlatformDependencies } from '../controllers/types';
+import type { MYXPoolSymbol, MYXTicker } from '../types/myx-types';
+import { MYX_PRICE_POLLING_INTERVAL_MS } from '../constants/myxConfig';
+import { PERPS_CONSTANTS } from '../constants/perpsConfig';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * MYX Client Configuration
+ */
+export interface MYXClientConfig {
+  isTestnet: boolean;
+}
+
+/**
+ * Price polling callback type
+ */
+export type PricePollingCallback = (tickers: MYXTicker[]) => void;
+
+// ============================================================================
+// MYXClientService
+// ============================================================================
+
+/**
+ * Service for managing MYX SDK client interactions
+ * Stage 1: Read-only operations (markets, prices)
+ */
+export class MYXClientService {
+  // SDK Client
+  private myxClient: MyxClient;
+
+  // Configuration
+  private readonly isTestnet: boolean;
+  private readonly chainId: number;
+
+  // Price polling (sequential using setTimeout to prevent request pileup)
+  private pricePollingTimeout?: ReturnType<typeof setTimeout>;
+  private pollingSymbols: string[] = [];
+  private pollingCallback?: PricePollingCallback;
+
+  // Caches
+  private marketsCache: MYXPoolSymbol[] = [];
+  private marketsCacheTimestamp = 0;
+  private readonly MARKETS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+  // Platform dependencies
+  private readonly deps: PerpsPlatformDependencies;
+
+  constructor(
+    deps: PerpsPlatformDependencies,
+    options: { isTestnet?: boolean } = {},
+  ) {
+    this.deps = deps;
+
+    // Stage 1: Force testnet - mainnet credentials not available
+    this.isTestnet = options.isTestnet ?? true;
+    this.chainId = this.isTestnet ? 97 : 56; // BNB testnet/mainnet
+
+    // Initialize MyxClient
+    this.myxClient = new MyxClient({
+      chainId: this.chainId,
+      brokerAddress: '0x0000000000000000000000000000000000000000', // Not needed for read-only
+      isTestnet: this.isTestnet,
+      isBetaMode: this.isTestnet, // Use beta API for testnet
+    });
+
+    this.deps.debugLogger.log('[MYXClientService] Initialized with SDK', {
+      isTestnet: this.isTestnet,
+      chainId: this.chainId,
+    });
+  }
+
+  // ============================================================================
+  // Error Context Helper
+  // ============================================================================
+
+  private getErrorContext(
+    method: string,
+    extra?: Record<string, unknown>,
+  ): {
+    tags?: Record<string, string | number>;
+    context?: { name: string; data: Record<string, unknown> };
+  } {
+    return {
+      tags: {
+        feature: PERPS_CONSTANTS.FeatureName,
+        service: 'MYXClientService',
+        network: this.isTestnet ? 'testnet' : 'mainnet',
+      },
+      context: {
+        name: `MYXClientService.${method}`,
+        data: {
+          chainId: this.chainId,
+          ...extra,
+        },
+      },
+    };
+  }
+
+  // ============================================================================
+  // Market Operations
+  // ============================================================================
+
+  /**
+   * Get all available markets/pools
+   * Uses SDK markets.getPoolSymbolAll()
+   */
+  async getMarkets(): Promise<MYXPoolSymbol[]> {
+    // Return cache if valid
+    const now = Date.now();
+    if (
+      this.marketsCache.length > 0 &&
+      now - this.marketsCacheTimestamp < this.MARKETS_CACHE_TTL_MS
+    ) {
+      return this.marketsCache;
+    }
+
+    try {
+      this.deps.debugLogger.log('[MYXClientService] Fetching markets via SDK');
+
+      const pools = await this.myxClient.markets.getPoolSymbolAll();
+
+      // Update cache
+      this.marketsCache = pools || [];
+      this.marketsCacheTimestamp = now;
+
+      this.deps.debugLogger.log('[MYXClientService] Markets fetched', {
+        count: this.marketsCache.length,
+      });
+
+      return this.marketsCache;
+    } catch (error) {
+      const err = ensureError(error);
+      this.deps.logger.error(err, this.getErrorContext('getMarkets'));
+
+      // Return stale cache if available
+      if (this.marketsCache.length > 0) {
+        this.deps.debugLogger.log(
+          '[MYXClientService] Returning stale cache after error',
+        );
+        return this.marketsCache;
+      }
+
+      throw err;
+    }
+  }
+
+  /**
+   * Get tickers for specific symbols/pools
+   * Uses SDK markets.getTickerList()
+   */
+  async getTickers(poolIds: string[]): Promise<MYXTicker[]> {
+    if (poolIds.length === 0) {
+      return [];
+    }
+
+    try {
+      this.deps.debugLogger.log('[MYXClientService] Fetching tickers via SDK', {
+        poolIds: poolIds.length,
+      });
+
+      const tickers = await this.myxClient.markets.getTickerList({
+        chainId: this.chainId,
+        poolIds,
+      });
+
+      return tickers || [];
+    } catch (error) {
+      const err = ensureError(error);
+      this.deps.logger.error(
+        err,
+        this.getErrorContext('getTickers', { poolIds }),
+      );
+      throw err;
+    }
+  }
+
+  /**
+   * Get all tickers (for all available markets)
+   */
+  async getAllTickers(): Promise<MYXTicker[]> {
+    try {
+      this.deps.debugLogger.log(
+        '[MYXClientService] Fetching all tickers via SDK',
+      );
+
+      // Get all pools first, then fetch tickers for them
+      const pools = await this.getMarkets();
+      const poolIds = pools.map((p) => p.poolId);
+
+      if (poolIds.length === 0) {
+        return [];
+      }
+
+      return this.getTickers(poolIds);
+    } catch (error) {
+      const err = ensureError(error);
+      this.deps.logger.error(err, this.getErrorContext('getAllTickers'));
+      throw err;
+    }
+  }
+
+  // ============================================================================
+  // Price Polling
+  // ============================================================================
+
+  /**
+   * Start polling for price updates.
+   * Uses sequential setTimeout to prevent request pileup — the next poll
+   * is only scheduled after the current one completes (or fails).
+   */
+  startPricePolling(poolIds: string[], callback: PricePollingCallback): void {
+    // Stop existing polling
+    this.stopPricePolling();
+
+    this.pollingSymbols = poolIds;
+    this.pollingCallback = callback;
+
+    // Start sequential polling
+    this.scheduleNextPoll();
+
+    this.deps.debugLogger.log('[MYXClientService] Started price polling', {
+      symbols: poolIds.length,
+      intervalMs: MYX_PRICE_POLLING_INTERVAL_MS,
+    });
+  }
+
+  /**
+   * Stop price polling
+   */
+  stopPricePolling(): void {
+    if (this.pricePollingTimeout) {
+      clearTimeout(this.pricePollingTimeout);
+      this.pricePollingTimeout = undefined;
+    }
+    this.pollingSymbols = [];
+    this.pollingCallback = undefined;
+
+    this.deps.debugLogger.log('[MYXClientService] Stopped price polling');
+  }
+
+  /**
+   * Execute a single price poll, then schedule the next one.
+   * Sequential pattern ensures no request pileup if polls take longer than the interval.
+   */
+  private async pollPrices(): Promise<void> {
+    if (!this.pollingCallback || this.pollingSymbols.length === 0) {
+      return;
+    }
+
+    try {
+      const tickers = await this.getTickers(this.pollingSymbols);
+      this.pollingCallback(tickers);
+    } catch (error) {
+      const err = ensureError(error);
+      this.deps.debugLogger.log('[MYXClientService] Price poll failed', {
+        error: err.message,
+      });
+      // Don't propagate error - polling continues
+    } finally {
+      this.scheduleNextPoll();
+    }
+  }
+
+  /**
+   * Schedule the next poll after the configured interval
+   */
+  private scheduleNextPoll(): void {
+    // Only schedule if polling is still active
+    if (!this.pollingCallback || this.pollingSymbols.length === 0) {
+      return;
+    }
+
+    this.pricePollingTimeout = setTimeout(() => {
+      this.pollPrices();
+    }, MYX_PRICE_POLLING_INTERVAL_MS);
+  }
+
+  // ============================================================================
+  // Health Check
+  // ============================================================================
+
+  /**
+   * Health check — attempts a lightweight REST call (getTickerList with empty poolIds)
+   * to verify the MYX API is reachable.
+   */
+  async ping(timeoutMs = 5000): Promise<void> {
+    this.deps.debugLogger.log('[MYXClientService] Ping - checking REST health');
+
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('MYX ping timeout')), timeoutMs),
+    );
+
+    try {
+      await Promise.race([
+        this.myxClient.markets.getTickerList({
+          chainId: this.chainId,
+          poolIds: [],
+        }),
+        timeoutPromise,
+      ]);
+    } catch (error) {
+      const err = ensureError(error);
+      this.deps.debugLogger.log('[MYXClientService] Ping failed', {
+        error: err.message,
+      });
+      throw err;
+    }
+  }
+
+  // ============================================================================
+  // Lifecycle
+  // ============================================================================
+
+  /**
+   * Disconnect and cleanup
+   */
+  disconnect(): void {
+    this.stopPricePolling();
+    this.marketsCache = [];
+    this.marketsCacheTimestamp = 0;
+
+    this.deps.debugLogger.log('[MYXClientService] Disconnected');
+  }
+
+  /**
+   * Get current network mode
+   */
+  getIsTestnet(): boolean {
+    return this.isTestnet;
+  }
+}

--- a/app/components/UI/Perps/types/myx-types.ts
+++ b/app/components/UI/Perps/types/myx-types.ts
@@ -1,0 +1,93 @@
+/**
+ * MYX Protocol Type Definitions
+ *
+ * Minimal types needed for Stage 1 (market display and price fetching).
+ * Only defines what's needed - SDK types are re-exported with MYX prefix.
+ */
+
+import type { CaipChainId } from '@metamask/utils';
+
+// ============================================================================
+// Re-export SDK Types with MYX prefix for consistency
+// ============================================================================
+
+export type { PoolSymbolAllResponse as MYXPoolSymbol } from '@myx-trade/sdk';
+export type { TickerDataItem as MYXTicker } from '@myx-trade/sdk';
+
+// ============================================================================
+// Network Configuration Types
+// ============================================================================
+
+/**
+ * MYX Network type - mainnet or testnet
+ */
+export type MYXNetwork = 'mainnet' | 'testnet';
+
+/**
+ * MYX Endpoint configuration for a single network
+ */
+export interface MYXEndpointConfig {
+  http: string;
+  ws: string;
+}
+
+/**
+ * MYX Endpoints for all networks
+ */
+export interface MYXEndpoints {
+  mainnet: MYXEndpointConfig;
+  testnet: MYXEndpointConfig;
+}
+
+/**
+ * MYX Asset network configuration (token addresses per network)
+ */
+export interface MYXAssetNetworkConfig {
+  chainId: CaipChainId;
+  tokenAddress: string;
+}
+
+/**
+ * MYX Asset configurations by network
+ */
+export interface MYXAssetConfigs {
+  USDT: {
+    mainnet: MYXAssetNetworkConfig;
+    testnet: MYXAssetNetworkConfig;
+  };
+}
+
+// ============================================================================
+// Market Overlap Configuration
+// ============================================================================
+
+/**
+ * Markets that overlap with HyperLiquid
+ * These are excluded from MYX display in v1.0 to avoid confusion
+ * In Stage 7, we'll implement market collision handling
+ */
+export const MYX_HL_OVERLAPPING_MARKETS = [
+  'BTC',
+  'ETH',
+  'BNB',
+  'PUMP',
+  'WLFI',
+] as const;
+
+export type MYXOverlappingMarket = (typeof MYX_HL_OVERLAPPING_MARKETS)[number];
+
+// ============================================================================
+// Client Service Types
+// ============================================================================
+
+/**
+ * Price callback for REST polling
+ */
+export type MYXPriceCallback = (
+  tickers: { symbol: string; price: string; change24h: number }[],
+) => void;
+
+/**
+ * Error callback for client operations
+ */
+export type MYXErrorCallback = (error: Error) => void;

--- a/app/components/UI/Perps/utils/myxAdapter.ts
+++ b/app/components/UI/Perps/utils/myxAdapter.ts
@@ -1,0 +1,297 @@
+/**
+ * MYX SDK Adapter Utilities
+ *
+ * Stage 1 adapters for transforming between MetaMask Perps API types and MYX SDK types.
+ * Only includes adapters needed for market display and price fetching.
+ *
+ * Key differences from HyperLiquid:
+ * - Prices use 30 decimals
+ * - Sizes use 18 decimals (vs HyperLiquid's szDecimals per asset)
+ * - Multiple pools can exist per symbol (MPM model)
+ * - USDT collateral (vs USDC)
+ */
+
+import type { MarketInfo, PerpsMarketData } from '../controllers/types';
+import {
+  MYX_HL_OVERLAPPING_MARKETS,
+  type MYXPoolSymbol,
+  type MYXTicker,
+} from '../types/myx-types';
+import { fromMYXPrice } from '../constants/myxConfig';
+
+// ============================================================================
+// Market Transformation
+// ============================================================================
+
+/**
+ * Transform MYX Pool/Market info to MetaMask Perps API MarketInfo format
+ *
+ * @param pool - Pool symbol data from MYX SDK (PoolSymbolAllResponse)
+ * @returns MetaMask Perps API market info object
+ */
+export function adaptMarketFromMYX(pool: MYXPoolSymbol): MarketInfo {
+  // Extract base symbol from pool data
+  const symbol = pool.baseSymbol || extractSymbolFromPoolId(pool.poolId);
+
+  // MYX uses fixed 18 decimals for sizes
+  const szDecimals = 18;
+
+  // Default max leverage - MYX supports up to 100x on most markets
+  // Will be refined when pool level config is fetched
+  const maxLeverage = 100;
+
+  return {
+    name: symbol,
+    szDecimals,
+    maxLeverage,
+    marginTableId: 0, // MYX doesn't use margin tables like HyperLiquid
+    minimumOrderSize: 10, // MYX minimum order size is $10
+    providerId: 'myx',
+  };
+}
+
+/**
+ * Convert MYX ticker data to price and change values
+ *
+ * @param ticker - Ticker data from MYX SDK
+ * @returns Object with price string and 24h change percentage
+ */
+export function adaptPriceFromMYX(ticker: MYXTicker): {
+  price: string;
+  change24h: number;
+} {
+  // MYX ticker prices are in 30-decimal format
+  const priceNum = fromMYXPrice(ticker.price);
+
+  // Change is provided as a percentage string (e.g., "2.5" means 2.5%)
+  const change24h = ticker.change ? parseFloat(ticker.change) : 0;
+
+  return {
+    price: priceNum.toString(),
+    change24h,
+  };
+}
+
+/**
+ * Transform MYX pool and ticker to PerpsMarketData for UI display
+ *
+ * @param pool - Pool symbol data from MYX SDK
+ * @param ticker - Optional ticker data for price info
+ * @returns Formatted market data for UI display
+ */
+export function adaptMarketDataFromMYX(
+  pool: MYXPoolSymbol,
+  ticker?: MYXTicker,
+): PerpsMarketData {
+  const symbol = pool.baseSymbol || extractSymbolFromPoolId(pool.poolId);
+
+  // Get price data from ticker if available
+  let price = '0';
+  let change24h = 0;
+  let volume = '0';
+
+  if (ticker) {
+    const priceData = adaptPriceFromMYX(ticker);
+    price = priceData.price;
+    change24h = priceData.change24h;
+    // Volume is already in USD (not 30-decimal format)
+    volume = ticker.volume || '0';
+  }
+
+  // Format price for display
+  const priceNum = parseFloat(price);
+  const formattedPrice = formatPrice(priceNum);
+
+  // Format 24h change
+  const change24hAbs = Math.abs(change24h);
+  const changeSign = change24h >= 0 ? '+' : '-';
+  const formattedChange = `${changeSign}$${formatPriceChange(
+    priceNum,
+    change24h,
+  )}`;
+  const formattedChangePercent = `${changeSign}${change24hAbs.toFixed(2)}%`;
+
+  // Format volume
+  const formattedVolume = formatVolume(parseFloat(volume));
+
+  return {
+    symbol,
+    name: getTokenName(symbol),
+    maxLeverage: '100x', // MYX default
+    price: formattedPrice,
+    change24h: formattedChange,
+    change24hPercent: formattedChangePercent,
+    volume: formattedVolume,
+    providerId: 'myx',
+  };
+}
+
+// ============================================================================
+// Market Filtering
+// ============================================================================
+
+/**
+ * Filter MYX markets to only include MYX-exclusive markets
+ * Removes markets that overlap with HyperLiquid
+ *
+ * @param pools - Array of MYX pool symbols
+ * @returns Filtered array with only MYX-exclusive markets
+ */
+export function filterMYXExclusiveMarkets(
+  pools: MYXPoolSymbol[],
+): MYXPoolSymbol[] {
+  return pools.filter((pool) => {
+    const symbol = pool.baseSymbol || extractSymbolFromPoolId(pool.poolId);
+    // Exclude markets that overlap with HyperLiquid
+    return !MYX_HL_OVERLAPPING_MARKETS.includes(
+      symbol as (typeof MYX_HL_OVERLAPPING_MARKETS)[number],
+    );
+  });
+}
+
+/**
+ * Check if a symbol overlaps with HyperLiquid markets
+ *
+ * @param symbol - Market symbol to check
+ * @returns true if the symbol is available on both MYX and HyperLiquid
+ */
+export function isOverlappingMarket(symbol: string): boolean {
+  return MYX_HL_OVERLAPPING_MARKETS.includes(
+    symbol as (typeof MYX_HL_OVERLAPPING_MARKETS)[number],
+  );
+}
+
+// ============================================================================
+// Pool ID Utilities
+// ============================================================================
+
+/**
+ * Build a map of poolId to symbol for quick lookup
+ *
+ * @param pools - Array of MYX pool symbols
+ * @returns Map of poolId to symbol
+ */
+export function buildPoolSymbolMap(
+  pools: MYXPoolSymbol[],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const pool of pools) {
+    const symbol = pool.baseSymbol || extractSymbolFromPoolId(pool.poolId);
+    map.set(pool.poolId, symbol);
+  }
+  return map;
+}
+
+/**
+ * Build a map of symbol to poolIds (for multi-pool support)
+ *
+ * @param pools - Array of MYX pool symbols
+ * @returns Map of symbol to array of poolIds
+ */
+export function buildSymbolPoolsMap(
+  pools: MYXPoolSymbol[],
+): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const pool of pools) {
+    const symbol = pool.baseSymbol || extractSymbolFromPoolId(pool.poolId);
+    const existing = map.get(symbol) || [];
+    existing.push(pool.poolId);
+    map.set(symbol, existing);
+  }
+  return map;
+}
+
+/**
+ * Extract symbol from pool ID
+ * Pool IDs typically contain the symbol as a suffix or can be parsed
+ *
+ * @param poolId - MYX pool ID string
+ * @returns Extracted symbol or poolId as fallback
+ */
+export function extractSymbolFromPoolId(poolId: string): string {
+  // Pool IDs in MYX typically look like "0x..." hex addresses
+  // The actual symbol comes from the pool's baseSymbol field
+  // This is a fallback when baseSymbol is not available
+  return poolId;
+}
+
+// ============================================================================
+// Formatting Helpers
+// ============================================================================
+
+/**
+ * Format price for display
+ */
+function formatPrice(price: number): string {
+  if (price === 0) return '$0.00';
+
+  if (price >= 1000) {
+    return `$${price.toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })}`;
+  } else if (price >= 1) {
+    return `$${price.toFixed(2)}`;
+  } else if (price >= 0.01) {
+    return `$${price.toFixed(4)}`;
+  }
+  return `$${price.toFixed(6)}`;
+}
+
+/**
+ * Calculate and format the absolute price change based on percentage
+ */
+function formatPriceChange(
+  currentPrice: number,
+  changePercent: number,
+): string {
+  const priceChange = Math.abs(currentPrice * (changePercent / 100));
+
+  if (priceChange >= 1000) {
+    return priceChange.toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+  } else if (priceChange >= 1) {
+    return priceChange.toFixed(2);
+  } else if (priceChange >= 0.01) {
+    return priceChange.toFixed(4);
+  }
+  return priceChange.toFixed(6);
+}
+
+/**
+ * Format volume for display (e.g., $1.2M, $500K)
+ */
+function formatVolume(volume: number): string {
+  if (volume === 0) return '$0';
+
+  if (volume >= 1_000_000_000) {
+    return `$${(volume / 1_000_000_000).toFixed(1)}B`;
+  } else if (volume >= 1_000_000) {
+    return `$${(volume / 1_000_000).toFixed(1)}M`;
+  } else if (volume >= 1_000) {
+    return `$${(volume / 1_000).toFixed(1)}K`;
+  }
+  return `$${volume.toFixed(0)}`;
+}
+
+/**
+ * Get full token name from symbol
+ * Returns the symbol as name if not found (MYX-specific tokens)
+ */
+function getTokenName(symbol: string): string {
+  const tokenNames: Record<string, string> = {
+    BTC: 'Bitcoin',
+    ETH: 'Ethereum',
+    BNB: 'BNB',
+    MYX: 'MYX Protocol',
+    RHEA: 'Rhea Finance',
+    PARTI: 'Particle Network',
+    SKYAI: 'SkyAI',
+    PUMP: 'PumpFun',
+    WLFI: 'World Liberty Financial',
+  };
+
+  return tokenNames[symbol] || symbol;
+}

--- a/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
@@ -23,6 +23,7 @@ import {
   selectTransactions,
 } from '../../../../selectors/transactionController';
 import { TOKEN_CATEGORY_HASH } from '../../../UI/TransactionElement/utils';
+import { isMusdClaimForCurrentView } from '../../Earn/utils/musd';
 import { isNonEvmChainId } from '../../../../core/Multichain/utils';
 import {
   selectSelectedInternalAccount,
@@ -268,6 +269,19 @@ export const useTokenTransactions = (
     ///: END:ONLY_INCLUDE_IF
   ]);
 
+  // Wrapper for shared mUSD claim detection utility
+  const checkIsMusdClaimForCurrentView = useCallback(
+    (tx: Transaction): boolean =>
+      isMusdClaimForCurrentView({
+        tx,
+        navAddress,
+        navSymbol,
+        chainId,
+        selectedAddress: selectedAddress ?? '',
+      }),
+    [chainId, navAddress, navSymbol, selectedAddress],
+  );
+
   // ETH filter - for native token transactions
   const ethFilter = useCallback(
     (tx: Transaction) => {
@@ -278,6 +292,10 @@ export const useTokenTransactions = (
         transferInformation,
         type,
       } = tx;
+
+      if (checkIsMusdClaimForCurrentView(tx)) {
+        return true;
+      }
 
       if (
         (areAddressesEqual(from ?? '', selectedAddress ?? '') ||
@@ -301,7 +319,7 @@ export const useTokenTransactions = (
       }
       return false;
     },
-    [chainId, selectedAddress, tokens],
+    [chainId, checkIsMusdClaimForCurrentView, selectedAddress, tokens],
   );
 
   // Non-ETH filter - for token transactions
@@ -313,6 +331,10 @@ export const useTokenTransactions = (
         isTransfer,
         transferInformation,
       } = tx;
+
+      if (checkIsMusdClaimForCurrentView(tx)) {
+        return true;
+      }
 
       if (
         (areAddressesEqual(from ?? '', selectedAddress ?? '') ||
@@ -342,7 +364,13 @@ export const useTokenTransactions = (
       }
       return false;
     },
-    [chainId, navAddress, selectedAddress, swapsTransactions],
+    [
+      chainId,
+      checkIsMusdClaimForCurrentView,
+      navAddress,
+      selectedAddress,
+      swapsTransactions,
+    ],
   );
 
   // Determine which filter to use

--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -57,7 +57,10 @@ import {
   getFontFamily,
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
-import { selectConversionRateByChainId } from '../../../selectors/currencyRateController';
+import {
+  selectConversionRateByChainId,
+  selectCurrencyRates,
+} from '../../../selectors/currencyRateController';
 import { selectContractExchangeRatesByChainId } from '../../../selectors/tokenRatesController';
 import { selectTokensByChainIdAndAddress } from '../../../selectors/tokensController';
 import Routes from '../../../constants/navigation/Routes';
@@ -156,6 +159,7 @@ const transactionIconSwapFailed = require('../../../images/transaction-icons/swa
 /* eslint-enable import/no-commonjs */
 
 const NEW_TRANSACTION_DETAILS_TYPES = [
+  TransactionType.musdClaim,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
@@ -307,9 +311,14 @@ class TransactionElement extends PureComponent {
           this.props.bridgeTxHistoryData?.bridgeTxHistoryItem,
       });
     } else if (hasTransactionType(tx, NEW_TRANSACTION_DETAILS_TYPES)) {
-      this.props.navigation.navigate(Routes.TRANSACTION_DETAILS, {
-        transactionId: tx.id,
-      });
+      // Navigate to TRANSACTIONS_VIEW first to ensure correct navigation context,
+      // then navigate to TRANSACTION_DETAILS (pattern from usePerpsToasts)
+      this.props.navigation.navigate(Routes.TRANSACTIONS_VIEW);
+      setTimeout(() => {
+        this.props.navigation.navigate(Routes.TRANSACTION_DETAILS, {
+          transactionId: tx.id,
+        });
+      }, 100);
     } else {
       const { transactionElement, transactionDetails } = this.state;
       this.props.navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
@@ -798,6 +807,7 @@ const mapStateToProps = (state, ownProps) => ({
   swapsTokens: swapsControllerTokens(state),
   ticker: selectTickerByChainId(state, ownProps.txChainId),
   conversionRate: selectConversionRateByChainId(state, ownProps.txChainId),
+  currencyRates: selectCurrencyRates(state),
   contractExchangeRates: selectContractExchangeRatesByChainId(
     state,
     ownProps.txChainId,

--- a/app/components/UI/TransactionElement/index.test.tsx
+++ b/app/components/UI/TransactionElement/index.test.tsx
@@ -77,6 +77,11 @@ const store = mockStore(initialState);
 describe('TransactionElement', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('renders correctly', () => {
@@ -139,7 +144,12 @@ describe('TransactionElement', () => {
       // Press the transaction element
       fireEvent.press(getByText('Test Action'));
 
-      // Verify navigation to unified TransactionDetails screen
+      // First, navigation goes to TRANSACTIONS_VIEW to ensure correct context
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
+
+      // Then after timeout, navigates to TRANSACTION_DETAILS
+      jest.advanceTimersByTime(100);
+
       expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTION_DETAILS, {
         transactionId: musdConversionTx.id,
       });

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -35,6 +35,10 @@ import { calculateTotalGas, renderGwei } from './utils-gas';
 import { getTokenTransferData } from '../../Views/confirmations/utils/transaction-pay';
 import { hasTransactionType } from '../../Views/confirmations/utils/transaction';
 import { BigNumber } from 'bignumber.js';
+import {
+  convertMusdClaimAmount,
+  decodeMerklClaimAmount,
+} from '../Earn/utils/musd';
 
 const POSITIVE_TRANSFER_TRANSACTION_TYPES = [
   TransactionType.musdConversion,
@@ -819,6 +823,96 @@ function decodeConfirmTx(args) {
 }
 
 /**
+ * Decode musdClaim transaction for display in activity list
+ */
+function decodeMusdClaimTx(args) {
+  const {
+    tx: {
+      txParams,
+      txParams: { from, gas, data },
+      hash,
+    },
+    txChainId,
+    conversionRate,
+    currencyRates,
+    currentCurrency,
+    primaryCurrency,
+    ticker,
+  } = args;
+
+  const totalGas = calculateTotalGas(txParams);
+  const renderFrom = renderFullAddress(from);
+
+  // Decode the claim amount from transaction data
+  const claimAmountRaw = decodeMerklClaimAmount(data);
+
+  // Calculate display values
+  let renderClaimAmount = strings('transaction.value_not_available');
+  let renderClaimFiat;
+
+  if (claimAmountRaw) {
+    const nativeCurrency = ticker || 'ETH';
+    const usdConversionRate =
+      currencyRates?.[nativeCurrency]?.usdConversionRate ?? 0;
+
+    const { claimAmountDecimal, fiatValue, isConverted } =
+      convertMusdClaimAmount({
+        claimAmountRaw,
+        conversionRate,
+        usdConversionRate,
+      });
+
+    renderClaimAmount = `${claimAmountDecimal.toFixed(2)} mUSD`;
+    renderClaimFiat = addCurrencySymbol(
+      parseFloat(fiatValue.toFixed(2)),
+      isConverted ? currentCurrency : 'usd',
+    );
+  }
+
+  const transactionElement = {
+    renderFrom,
+    actionKey: strings('transactions.claim'),
+    value: renderClaimAmount,
+    fiatValue: renderClaimFiat,
+    transactionType: TRANSACTION_TYPES.RECEIVED_TOKEN,
+  };
+
+  let transactionDetails = {
+    renderFrom,
+    hash,
+    renderValue: renderClaimAmount,
+    renderGas: parseInt(gas, 16).toString(),
+    renderGasPrice: renderGwei(txParams),
+    renderTotalGas: `${renderFromWei(totalGas)} ${ticker}`,
+    txChainId,
+  };
+
+  if (primaryCurrency === 'ETH') {
+    transactionDetails = {
+      ...transactionDetails,
+      summaryAmount: renderClaimAmount,
+      summaryFee: `${renderFromWei(totalGas)} ${ticker}`,
+      summarySecondaryTotalAmount: weiToFiat(
+        totalGas,
+        conversionRate,
+        currentCurrency,
+      ),
+      summaryTotalAmount: renderClaimAmount,
+    };
+  } else {
+    transactionDetails = {
+      ...transactionDetails,
+      summaryAmount: renderClaimFiat || renderClaimAmount,
+      summaryFee: weiToFiat(totalGas, conversionRate, currentCurrency),
+      summarySecondaryTotalAmount: renderClaimAmount,
+      summaryTotalAmount: renderClaimFiat || renderClaimAmount,
+    };
+  }
+
+  return [transactionElement, transactionDetails];
+}
+
+/**
  * Parse transaction with wallet information to render
  *
  * @param {*} args - Should contain tx, selectedAddress, ticker, conversionRate,
@@ -881,6 +975,12 @@ export default async function decodeTransaction(args) {
         break;
       case strings('transactions.contract_deploy'):
         [transactionElement, transactionDetails] = decodeDeploymentTx({
+          ...args,
+          actionKey,
+        });
+        break;
+      case TransactionType.musdClaim:
+        [transactionElement, transactionDetails] = decodeMusdClaimTx({
           ...args,
           actionKey,
         });

--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -76,6 +76,8 @@ import {
 } from '../../../selectors/transactionController';
 import { TOKEN_CATEGORY_HASH } from '../../UI/TransactionElement/utils';
 import { isNonEvmChainId } from '../../../core/Multichain/utils';
+import { TransactionType } from '@metamask/transaction-controller';
+import { isMusdClaimForCurrentView } from '../../UI/Earn/utils/musd';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../selectors/multichain';
 ///: END:ONLY_INCLUDE_IF
@@ -359,6 +361,18 @@ class Asset extends PureComponent {
   didTxStatusesChange = (newTxsPending) =>
     this.txsPending.length !== newTxsPending.length;
 
+  // Wrapper for shared mUSD claim detection utility
+  checkIsMusdClaimForCurrentView = (tx) => {
+    const { chainId } = this.props;
+    return isMusdClaimForCurrentView({
+      tx,
+      navAddress: this.navAddress,
+      navSymbol: this.navSymbol?.toLowerCase() ?? '',
+      chainId,
+      selectedAddress: this.selectedAddress,
+    });
+  };
+
   ethFilter = (tx) => {
     const { networkId } = store.getState().inpageProvider;
     const { chainId } = this.props;
@@ -368,6 +382,10 @@ class Asset extends PureComponent {
       transferInformation,
       type,
     } = tx;
+
+    if (this.checkIsMusdClaimForCurrentView(tx)) {
+      return true;
+    }
 
     if (
       (areAddressesEqual(from, this.selectedAddress) ||
@@ -398,6 +416,11 @@ class Asset extends PureComponent {
       isTransfer,
       transferInformation,
     } = tx;
+
+    if (this.checkIsMusdClaimForCurrentView(tx)) {
+      return true;
+    }
+
     if (
       (areAddressesEqual(from, this.selectedAddress) ||
         areAddressesEqual(to, this.selectedAddress)) &&

--- a/app/components/Views/Onboarding/index.test.tsx
+++ b/app/components/Views/Onboarding/index.test.tsx
@@ -62,6 +62,9 @@ import { fetch as netInfoFetch } from '@react-native-community/netinfo';
 
 const mockNetInfoFetch = netInfoFetch as jest.Mock;
 
+// Helper to flush all pending promises
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
 const mockInitialState = {
   engine: {
     backgroundState: {
@@ -154,8 +157,8 @@ jest.mock('../../../util/analytics/analytics', () => ({
   analytics: {
     isEnabled: jest.fn(() => false),
     trackEvent: jest.fn(),
-    optIn: jest.fn(),
-    optOut: jest.fn(),
+    optIn: jest.fn().mockResolvedValue(undefined),
+    optOut: jest.fn().mockResolvedValue(undefined),
     getAnalyticsId: jest.fn().mockResolvedValue('test-analytics-id'),
     identify: jest.fn(),
     trackView: jest.fn(),
@@ -195,6 +198,29 @@ interface MetricsProps {
 import { analytics } from '../../../util/analytics/analytics';
 
 const mockAnalytics = analytics as jest.Mocked<typeof analytics>;
+
+// Mock useAnalytics hook to use our mocked analytics
+jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockAnalytics.trackEvent,
+    enable: async (enable?: boolean) => {
+      if (enable === false) {
+        await mockAnalytics.optOut();
+      } else {
+        await mockAnalytics.optIn();
+      }
+    },
+    addTraitsToUser: mockAnalytics.identify,
+    createDataDeletionTask: jest.fn(),
+    checkDataDeleteStatus: jest.fn(),
+    getDeleteRegulationCreationDate: jest.fn(),
+    getDeleteRegulationId: jest.fn(),
+    isDataRecorded: jest.fn(),
+    isEnabled: mockAnalytics.isEnabled,
+    getAnalyticsId: mockAnalytics.getAnalyticsId,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
 
 jest.mock(
   '../../hooks/useMetrics/withMetricsAwareness',
@@ -595,21 +621,23 @@ describe('Onboarding', () => {
 
       await act(async () => {
         fireEvent.press(importSeedButton);
+        await flushPromises();
+        await flushPromises();
       });
 
-      await act(async () => {
-        await Promise.resolve();
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          Routes.ONBOARDING.IMPORT_FROM_SECRET_RECOVERY_PHRASE,
+          expect.objectContaining({
+            [PREVIOUS_SCREEN]: ONBOARDING,
+            onboardingTraceCtx: expect.any(Object),
+          }),
+        );
       });
 
-      expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.ONBOARDING.IMPORT_FROM_SECRET_RECOVERY_PHRASE,
-        expect.objectContaining({
-          [PREVIOUS_SCREEN]: ONBOARDING,
-          onboardingTraceCtx: expect.any(Object),
-        }),
-      );
-
-      expect(mockAnalytics.optOut).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockAnalytics.optOut).toHaveBeenCalled();
+      });
     });
   });
 
@@ -1500,17 +1528,21 @@ describe('Onboarding', () => {
       mockNavigate.mockClear();
       await act(async () => {
         await googleOAuthFunction(true);
+        await flushPromises();
+        await flushPromises();
       });
 
       // Verify fallback was attempted
       expect(mockOAuthService.handleOAuthLogin).toHaveBeenCalledTimes(2);
 
       // Verify error is handled via ErrorBoundary flow (triggers trackEvent with Error Screen Viewed)
-      expect(mockAnalytics.trackEvent).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          name: 'Error Screen Viewed',
-        }),
-      );
+      await waitFor(() => {
+        expect(mockAnalytics.trackEvent).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            name: 'Error Screen Viewed',
+          }),
+        );
+      });
 
       Platform.OS = 'ios';
     });
@@ -1548,9 +1580,13 @@ describe('Onboarding', () => {
 
       await act(async () => {
         await googleOAuthFunction(true);
+        await flushPromises();
+        await flushPromises();
       });
 
-      expect(mockAnalytics.optIn).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockAnalytics.optIn).toHaveBeenCalled();
+      });
     });
   });
 
@@ -2007,13 +2043,17 @@ describe('Onboarding', () => {
 
       await act(async () => {
         await appleOAuthFunction(false);
+        await flushPromises();
+        await flushPromises();
       });
 
-      expect(mockAnalytics.trackEvent).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          name: 'Error Screen Viewed',
-        }),
-      );
+      await waitFor(() => {
+        expect(mockAnalytics.trackEvent).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            name: 'Error Screen Viewed',
+          }),
+        );
+      });
     });
 
     it('does not trigger ErrorBoundary for OAuth login failures when analytics enabled', async () => {
@@ -2049,11 +2089,13 @@ describe('Onboarding', () => {
         await appleOAuthFunction(false);
       });
 
-      expect(mockAnalytics.trackEvent).not.toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          name: 'Error Screen Viewed',
-        }),
-      );
+      await waitFor(() => {
+        expect(mockAnalytics.trackEvent).not.toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            name: 'Error Screen Viewed',
+          }),
+        );
+      });
     });
   });
 });

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -87,7 +87,7 @@ import { OAuthError, OAuthErrorType } from '../../../core/OAuthService/error';
 import { createLoginHandler } from '../../../core/OAuthService/OAuthLoginHandlers';
 import { AuthConnection } from '../../../core/OAuthService/OAuthInterface';
 import { SEEDLESS_ONBOARDING_ENABLED } from '../../../core/OAuthService/OAuthLoginHandlers/constants';
-import { useMetrics } from '../../hooks/useMetrics';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { setupSentry } from '../../../util/sentry/utils';
 import ErrorBoundary from '../ErrorBoundary';
 import FastOnboarding from './FastOnboarding';
@@ -126,7 +126,7 @@ const Onboarding = () => {
   const route =
     useRoute<RouteProp<{ params: OnboardingRouteParams }, 'params'>>();
   const dispatch = useDispatch();
-  const metrics = useMetrics();
+  const metrics = useAnalytics();
 
   const passwordSet = useSelector((state: RootState) => state.user.passwordSet);
   const existingUserProp = useSelector(selectExistingUser);

--- a/app/components/Views/confirmations/components/UI/nft/nft.tsx
+++ b/app/components/Views/confirmations/components/UI/nft/nft.tsx
@@ -75,7 +75,7 @@ export function Nft({ asset, onPress }: NftProps) {
             color={TextColor.TextAlternative}
             numberOfLines={1}
           >
-            {asset.standard === 'ERC1155' && `(${asset.balance}) `}
+            {asset.standard === 'ERC1155' && `(${asset.balance || 0}) `}
             {asset.standard === 'ERC721' ? `#${asset.tokenId}` : asset.name}
           </Text>
         </Box>

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Interface } from '@ethersproject/abi';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import {
@@ -9,6 +10,7 @@ import { TransactionDetailsHero } from './transaction-details-hero';
 import { merge } from 'lodash';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
+import { DISTRIBUTOR_CLAIM_ABI } from '../../../../../UI/Earn/components/MerklRewards/constants';
 
 jest.mock('../../../hooks/activity/useTransactionDetails');
 jest.mock('../../../hooks/tokens/useTokenWithBalance');
@@ -164,5 +166,47 @@ describe('TransactionDetailsHero', () => {
     const { getByText } = render();
 
     expect(getByText('$100')).toBeDefined();
+  });
+
+  it('renders claim amount for musdClaim with valid claim data', () => {
+    const USER_ADDRESS = '0x1234567890123456789012345678901234567890';
+    const TOKEN_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+    const claimAmount = '75500000'; // 75.5 mUSD (6 decimals)
+
+    const contractInterface = new Interface(DISTRIBUTOR_CLAIM_ABI);
+    const claimData = contractInterface.encodeFunctionData('claim', [
+      [USER_ADDRESS],
+      [TOKEN_ADDRESS],
+      [claimAmount],
+      [[]],
+    ]);
+
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        ...TRANSACTION_META_MOCK,
+        type: TransactionType.musdClaim,
+        txParams: {
+          data: claimData,
+        },
+      } as unknown as TransactionMeta,
+    });
+
+    const { getByText } = render();
+    expect(getByText('$75.50')).toBeDefined();
+  });
+
+  it('renders nothing for musdClaim without valid claim data', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        ...TRANSACTION_META_MOCK,
+        type: TransactionType.musdClaim,
+        txParams: {
+          data: '0x123', // Invalid claim data
+        },
+      } as unknown as TransactionMeta,
+    });
+
+    const { queryByTestId } = render();
+    expect(queryByTestId('transaction-details-hero')).toBeNull();
   });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { Box } from '../../../../../UI/Box/Box';
 import Text, {
   TextVariant,
@@ -19,8 +20,20 @@ import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/us
 import { PERPS_CURRENCY } from '../../../constants/perps';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { BigNumber } from 'bignumber.js';
+import { MERKL_CLAIM_CHAIN_ID } from '../../../../../UI/Earn/components/MerklRewards/constants';
+import {
+  convertMusdClaimAmount,
+  decodeMerklClaimAmount,
+} from '../../../../../UI/Earn/utils/musd';
+import {
+  selectConversionRateByChainId,
+  selectCurrencyRates,
+} from '../../../../../../selectors/currencyRateController';
+import { RootState } from '../../../../../../reducers';
+import useNetworkInfo from '../../../hooks/useNetworkInfo';
 
 const SUPPORTED_TYPES = [
+  TransactionType.musdClaim,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.predictDeposit,
@@ -28,9 +41,12 @@ const SUPPORTED_TYPES = [
 ];
 
 export function TransactionDetailsHero() {
-  const formatFiat = useFiatFormatter({ currency: PERPS_CURRENCY });
+  const formatFiatPerps = useFiatFormatter({ currency: PERPS_CURRENCY });
+  const formatFiatUser = useFiatFormatter();
   const { styles } = useStyles(styleSheet, {});
   const decodedAmount = useDecodedAmount();
+  const { amount: claimAmount, isConverted: isClaimConverted } =
+    useClaimAmount();
   const targetFiat = useTargetFiat();
   const { transactionMeta } = useTransactionDetails();
 
@@ -38,12 +54,13 @@ export function TransactionDetailsHero() {
     return null;
   }
 
-  const amount = targetFiat ?? decodedAmount;
+  const amount = targetFiat ?? claimAmount ?? decodedAmount;
 
   if (!amount) {
     return null;
   }
 
+  const formatFiat = isClaimConverted ? formatFiatUser : formatFiatPerps;
   const formattedAmount = formatFiat(amount);
 
   return (
@@ -90,4 +107,41 @@ function useDecodedAmount() {
   }
 
   return calcTokenAmount(amount, decimals);
+}
+
+/**
+ * Hook to decode the claim amount from a Merkl claim transaction
+ * and convert it to the user's selected currency.
+ */
+function useClaimAmount(): { amount: BigNumber | null; isConverted: boolean } {
+  const { transactionMeta } = useTransactionDetails();
+  const { networkNativeCurrency } = useNetworkInfo(MERKL_CLAIM_CHAIN_ID);
+
+  const conversionRate = new BigNumber(
+    useSelector((state: RootState) =>
+      selectConversionRateByChainId(state, MERKL_CLAIM_CHAIN_ID),
+    ) ?? 0,
+  );
+  const currencyRates = useSelector(selectCurrencyRates);
+  const usdConversionRate =
+    currencyRates?.[networkNativeCurrency as string]?.usdConversionRate ?? 0;
+
+  if (!hasTransactionType(transactionMeta, [TransactionType.musdClaim])) {
+    return { amount: null, isConverted: false };
+  }
+
+  const { data } = transactionMeta.txParams ?? {};
+  const claimAmountRaw = decodeMerklClaimAmount(data as string);
+
+  if (!claimAmountRaw) {
+    return { amount: null, isConverted: false };
+  }
+
+  const { fiatValue, isConverted } = convertMusdClaimAmount({
+    claimAmountRaw,
+    conversionRate,
+    usdConversionRate,
+  });
+
+  return { amount: fiatValue, isConverted };
 }

--- a/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
@@ -6,17 +6,18 @@ import { strings } from '../../../../../../../locales/i18n';
 import { TransactionType } from '@metamask/transaction-controller';
 import { hasTransactionType } from '../../../utils/transaction';
 import { useFeeCalculations } from '../../../hooks/gas/useFeeCalculations';
-import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { BigNumber } from 'bignumber.js';
 import { TransactionDetailsSelectorIDs } from '../TransactionDetailsModal.testIds';
+import { usePayFiatFormatter } from '../../../hooks/pay/usePayFiatFormatter';
 
 const FALLBACK_TYPES = [
   TransactionType.predictClaim,
   TransactionType.predictWithdraw,
+  TransactionType.musdClaim,
 ];
 
 export function TransactionDetailsNetworkFeeRow() {
-  const formatFiat = useFiatFormatter({ currency: 'usd' });
+  const formatFiat = usePayFiatFormatter();
   const { transactionMeta } = useTransactionDetails();
   const { estimatedFeeFiatPrecise } = useFeeCalculations(transactionMeta);
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -330,6 +330,8 @@ function getLineTitle({
       return strings('transaction_details.summary_title.swap');
     case TransactionType.swapApproval:
       return strings('transaction_details.summary_title.swap_approval');
+    case TransactionType.musdClaim:
+      return strings('transaction_details.summary_title.musd_claim');
     default:
       return strings('transaction_details.summary_title.default');
   }
@@ -409,6 +411,7 @@ function useBridgeReceiveData(
 
   if (
     hasTransactionType(parentTransaction, [
+      TransactionType.musdClaim,
       TransactionType.perpsDeposit,
       TransactionType.predictDeposit,
     ])

--- a/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
@@ -14,8 +14,21 @@ jest.mock('../../../hooks/useTokenAmount');
 const PAY_TOTAL = '123.45';
 const TOKEN_TOTAL = '234.56';
 
+const MOCK_STATE = {
+  engine: {
+    backgroundState: {
+      CurrencyRateController: {
+        currentCurrency: 'usd',
+        currencyRates: {},
+      },
+    },
+  },
+};
+
 function render() {
-  return renderWithProvider(<TransactionDetailsTotalRow />, {});
+  return renderWithProvider(<TransactionDetailsTotalRow />, {
+    state: MOCK_STATE,
+  });
 }
 
 describe('TransactionDetailsTotalRow', () => {
@@ -34,7 +47,7 @@ describe('TransactionDetailsTotalRow', () => {
     });
 
     useTokenAmountMock.mockReturnValue({
-      amount: TOKEN_TOTAL,
+      amountUnformatted: TOKEN_TOTAL,
     } as ReturnType<typeof useTokenAmount>);
   });
 
@@ -66,5 +79,24 @@ describe('TransactionDetailsTotalRow', () => {
     const { toJSON } = render();
 
     expect(toJSON()).toBeNull();
+  });
+
+  it('renders total from fiat amount for musdClaim with user currency', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        metamaskPay: {},
+        type: TransactionType.musdClaim,
+      } as unknown as TransactionMeta,
+    });
+
+    useTokenAmountMock.mockReturnValue({
+      amountUnformatted: '100', // Token amount (mUSD)
+      fiatUnformatted: '123.45', // Converted to user's currency
+    } as ReturnType<typeof useTokenAmount>);
+
+    const { getByText } = render();
+
+    // Uses fiatUnformatted and user's currency formatter
+    expect(getByText('$123.45')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
@@ -6,21 +6,37 @@ import { strings } from '../../../../../../../locales/i18n';
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { TransactionType } from '@metamask/transaction-controller';
 import { hasTransactionType } from '../../../utils/transaction';
-import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { BigNumber } from 'bignumber.js';
 import { TransactionDetailsSelectorIDs } from '../TransactionDetailsModal.testIds';
+import { usePayFiatFormatter } from '../../../hooks/pay/usePayFiatFormatter';
+import { USER_CURRENCY_TYPES } from '../../../constants/confirmations';
 
-const FALLBACK_TYPES = [TransactionType.predictWithdraw];
+const FALLBACK_TYPES = [
+  TransactionType.musdClaim,
+  TransactionType.predictWithdraw,
+];
+
+const RECEIVE_TYPES = [
+  TransactionType.musdClaim,
+  TransactionType.predictClaim,
+  TransactionType.predictWithdraw,
+];
 
 export function TransactionDetailsTotalRow() {
-  const formatFiat = useFiatFormatter({ currency: 'usd' });
+  const formatFiat = usePayFiatFormatter();
   const { transactionMeta } = useTransactionDetails();
-  const { amount } = useTokenAmount({ transactionMeta }) ?? {};
+  const { amountUnformatted, fiatUnformatted } =
+    useTokenAmount({ transactionMeta }) ?? {};
 
   const { metamaskPay } = transactionMeta;
   const { totalFiat: payTotal } = metamaskPay || {};
 
-  const total = payTotal ?? amount;
+  const useUserCurrency = hasTransactionType(
+    transactionMeta,
+    USER_CURRENCY_TYPES,
+  );
+  const total =
+    payTotal ?? (useUserCurrency ? fiatUnformatted : amountUnformatted);
 
   const totalFormatted = useMemo(
     () => formatFiat(new BigNumber(total ?? '0')),
@@ -31,10 +47,7 @@ export function TransactionDetailsTotalRow() {
     return null;
   }
 
-  const label = hasTransactionType(transactionMeta, [
-    TransactionType.predictClaim,
-    TransactionType.predictWithdraw,
-  ])
+  const label = hasTransactionType(transactionMeta, RECEIVE_TYPES)
     ? strings('transaction_details.label.received_total')
     : strings('transaction_details.label.total');
 

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
@@ -122,6 +122,20 @@ describe('TransactionDetails', () => {
       expect(mockTransactionDetailsRetry).toHaveBeenCalledTimes(1);
     });
 
+    it('renders summary section exactly once for musdClaim transactions', () => {
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.musdClaim,
+        } as unknown as TransactionMeta,
+      });
+
+      render();
+
+      expect(mockTransactionDetailsSummary).toHaveBeenCalledTimes(1);
+      expect(mockTransactionDetailsRetry).toHaveBeenCalledTimes(1);
+    });
+
     it('renders summary section exactly once for predictDeposit nested transactions', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
@@ -168,6 +182,23 @@ describe('TransactionDetails', () => {
       expect(mockSetOptions).toHaveBeenCalledWith(
         expect.objectContaining({
           title: strings('transaction_details.title.perps_deposit'),
+        }),
+      );
+    });
+
+    it('returns musd_claim title for musdClaim type', () => {
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.musdClaim,
+        } as unknown as TransactionMeta,
+      });
+
+      render();
+
+      expect(mockSetOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: strings('transaction_details.title.musd_claim'),
         }),
       );
     });
@@ -247,14 +278,15 @@ describe('TransactionDetails', () => {
   describe('SUMMARY_SECTION_TYPES', () => {
     it.each([
       TransactionType.musdConversion,
+      TransactionType.musdClaim,
       TransactionType.perpsDeposit,
       TransactionType.predictDeposit,
     ])('includes %s', (type) => {
       expect(SUMMARY_SECTION_TYPES).toContain(type);
     });
 
-    it('contains exactly 3 transaction types', () => {
-      expect(SUMMARY_SECTION_TYPES).toHaveLength(3);
+    it('contains exactly 4 transaction types', () => {
+      expect(SUMMARY_SECTION_TYPES).toHaveLength(4);
     });
   });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -26,6 +26,7 @@ import { TransactionDetailsRetry } from '../transaction-details-retry';
 import { TransactionDetailsAccountRow } from '../transaction-details-account-row';
 
 export const SUMMARY_SECTION_TYPES = [
+  TransactionType.musdClaim,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.predictDeposit,
@@ -91,6 +92,8 @@ function getTitle(transactionMeta: TransactionMeta) {
   switch (transactionMeta.type) {
     case TransactionType.musdConversion:
       return strings('transaction_details.title.musd_conversion');
+    case TransactionType.musdClaim:
+      return strings('transaction_details.title.musd_claim');
     case TransactionType.perpsDeposit:
       return strings('transaction_details.title.perps_deposit');
     default:

--- a/app/components/Views/confirmations/constants/confirmations.ts
+++ b/app/components/Views/confirmations/constants/confirmations.ts
@@ -13,6 +13,7 @@ export const REDESIGNED_TRANSACTION_TYPES = [
   TransactionType.batch,
   TransactionType.contractInteraction,
   TransactionType.deployContract,
+  TransactionType.musdClaim,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
@@ -45,6 +46,7 @@ export const TRANSFER_TRANSACTION_TYPES = [
 ];
 
 export const FULL_SCREEN_CONFIRMATIONS = [
+  TransactionType.musdClaim,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
@@ -70,3 +72,9 @@ export const EARN_CONTRACT_INTERACTION_TYPES = [
  * Used when pay token selection is constrained to a single network (e.g. Perps).
  */
 export const HIDE_NETWORK_FILTER_TYPES = [TransactionType.perpsDepositAndOrder];
+
+/**
+ * Transaction types that use user's currency instead of USD for display.
+ * mUSD is a stablecoin pegged to USD, so we convert to user's local currency.
+ */
+export const USER_CURRENCY_TYPES = [TransactionType.musdClaim];

--- a/app/components/Views/confirmations/hooks/pay/usePayFiatFormatter.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayFiatFormatter.ts
@@ -1,0 +1,25 @@
+import { useTransactionDetails } from '../activity/useTransactionDetails';
+import { hasTransactionType } from '../../utils/transaction';
+import { USER_CURRENCY_TYPES } from '../../constants/confirmations';
+import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
+
+/**
+ * Hook that returns the appropriate fiat formatter based on transaction type.
+ *
+ * For transaction types in USER_CURRENCY_TYPES (e.g., musdClaim), uses the user's
+ * selected currency. For all other types, uses USD.
+ *
+ * @returns A fiat formatter function
+ */
+export function usePayFiatFormatter() {
+  const formatFiatUsd = useFiatFormatter({ currency: 'usd' });
+  const formatFiatUser = useFiatFormatter();
+  const { transactionMeta } = useTransactionDetails();
+
+  const useUserCurrency = hasTransactionType(
+    transactionMeta,
+    USER_CURRENCY_TYPES,
+  );
+
+  return useUserCurrency ? formatFiatUser : formatFiatUsd;
+}

--- a/app/components/Views/confirmations/hooks/send/useNfts.ts
+++ b/app/components/Views/confirmations/hooks/send/useNfts.ts
@@ -10,6 +10,9 @@ import { selectAllNfts } from '../../../../../selectors/nftController';
 import { getNetworkBadgeSource } from '../../utils/network';
 import { Nft } from '../../types/token';
 import { useSendScope } from './useSendScope';
+import { getFormattedIpfsUrl } from '@metamask/assets-controllers';
+import useIpfsGateway from '../../../../hooks/useIpfsGateway';
+import Logger from '../../../../../util/Logger';
 
 export function useEVMNfts(): Nft[] {
   const { NftController, AssetsContractController, NetworkController } =
@@ -19,6 +22,7 @@ export function useEVMNfts(): Nft[] {
   const allNFTS = useSelector(selectAllNfts);
   const [transformedNfts, setTransformedNfts] = useState<Nft[]>([]);
   const { isSolanaOnly } = useSendScope();
+  const ipfsGateway = useIpfsGateway();
 
   const evmAccount = selectedAccountGroup?.accounts
     .map((accountId) => internalAccountsById[accountId])
@@ -58,6 +62,7 @@ export function useEVMNfts(): Nft[] {
 
       for (const nft of rawNfts) {
         const transformed = await transformNft(
+          ipfsGateway,
           nft,
           evmAccount.address,
           AssetsContractController,
@@ -73,6 +78,7 @@ export function useEVMNfts(): Nft[] {
 
     processNfts();
   }, [
+    ipfsGateway,
     evmAccount,
     allNFTS,
     NftController,
@@ -87,18 +93,32 @@ export function useEVMNfts(): Nft[] {
   return transformedNfts;
 }
 
-function getValidImageUrl(
+async function getValidImageUrl(
+  ipfsGateway: string,
   imageUrls: (string | undefined)[],
-): string | undefined {
+): Promise<string | undefined> {
   for (const url of imageUrls) {
-    if (url && !url.startsWith('ipfs:')) {
-      return url;
+    if (url) {
+      if (!url.startsWith('ipfs:')) {
+        return url;
+      }
+
+      try {
+        const ipfsUrl = await getFormattedIpfsUrl(ipfsGateway, url, false);
+        if (!ipfsUrl) {
+          continue;
+        }
+        return ipfsUrl;
+      } catch {
+        Logger.log(`Failed to resolve IPFS URL for ${url}`);
+      }
     }
   }
   return undefined;
 }
 
 async function transformNft(
+  ipfsGateway: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   nft: any,
   userAddress: string,
@@ -121,7 +141,7 @@ async function transformNft(
 
   if (standard === 'ERC721') {
     name = nft.name || undefined;
-    image = getValidImageUrl([
+    image = await getValidImageUrl(ipfsGateway, [
       nft.image,
       nft.imageUrl,
       collection?.imageUrl,
@@ -129,7 +149,7 @@ async function transformNft(
     ]);
   } else if (standard === 'ERC1155') {
     name = nft.name || undefined;
-    image = getValidImageUrl([
+    image = await getValidImageUrl(ipfsGateway, [
       nft.image,
       nft.imageOriginal,
       collection?.imageUrl,

--- a/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@metamask/transaction-controller';
 import { merge } from 'lodash';
 import { waitFor } from '@testing-library/react-native';
+import { Interface } from '@ethersproject/abi';
 import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
 import {
   stakingDepositConfirmationState,
@@ -17,6 +18,7 @@ import {
   tokensControllerMock,
 } from '../__mocks__/controllers/other-controllers-mock';
 import { updateEditableParams } from '../../../../util/transaction-controller';
+import { DISTRIBUTOR_CLAIM_ABI } from '../../../UI/Earn/components/MerklRewards/constants';
 
 jest.mock('../../../../util/transaction-controller');
 
@@ -477,6 +479,142 @@ describe('Edge cases', () => {
 
     await waitFor(() => {
       expect(result.current.fiatUnformatted).toBe('0.359625');
+    });
+  });
+});
+
+describe('musdClaim transactions', () => {
+  const USER_ADDRESS = '0x1234567890123456789012345678901234567890';
+  const TOKEN_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+  // Helper to encode valid claim data
+  const encodeClaimData = (amount: string): string => {
+    const contractInterface = new Interface(DISTRIBUTOR_CLAIM_ABI);
+    return contractInterface.encodeFunctionData('claim', [
+      [USER_ADDRESS],
+      [TOKEN_ADDRESS],
+      [amount],
+      [[]],
+    ]);
+  };
+
+  const createMusdClaimState = (claimData: string) =>
+    merge({}, transferConfirmationState, {
+      engine: {
+        backgroundState: {
+          TransactionController: {
+            transactions: [
+              {
+                type: TransactionType.musdClaim,
+                txParams: {
+                  data: claimData,
+                  from: USER_ADDRESS,
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+  it('decodes and returns correct amount for musdClaim transaction', async () => {
+    const claimAmount = '50000000'; // 50 mUSD (6 decimals)
+    const claimData = encodeClaimData(claimAmount);
+
+    const { result } = renderHookWithProvider(() => useTokenAmount(), {
+      state: createMusdClaimState(claimData),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          amount: '50',
+          amountPrecise: '50',
+          amountUnformatted: '50',
+          fiat: '$50',
+          fiatUnformatted: '50',
+          isNative: false,
+          usdValue: '50.00',
+        }),
+      );
+    });
+  });
+
+  it('handles fractional mUSD amounts correctly', async () => {
+    const claimAmount = '12345000'; // 12.345 mUSD (6 decimals)
+    const claimData = encodeClaimData(claimAmount);
+
+    const { result } = renderHookWithProvider(() => useTokenAmount(), {
+      state: createMusdClaimState(claimData),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          amount: '12.35',
+          amountPrecise: '12.345',
+          amountUnformatted: '12.345',
+          fiat: '$12.35',
+          fiatUnformatted: '12.345',
+          isNative: false,
+          usdValue: '12.35',
+        }),
+      );
+    });
+  });
+
+  it('handles very small mUSD amounts', async () => {
+    const claimAmount = '100'; // 0.0001 mUSD (6 decimals)
+    const claimData = encodeClaimData(claimAmount);
+
+    const { result } = renderHookWithProvider(() => useTokenAmount(), {
+      state: createMusdClaimState(claimData),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          amount: '0.0001',
+          amountPrecise: '0.0001',
+          fiat: '<$0.01',
+          isNative: false,
+          usdValue: '0.00',
+        }),
+      );
+    });
+  });
+
+  it('handles large mUSD amounts', async () => {
+    const claimAmount = '100000000000'; // 100,000 mUSD (6 decimals)
+    const claimData = encodeClaimData(claimAmount);
+
+    const { result } = renderHookWithProvider(() => useTokenAmount(), {
+      state: createMusdClaimState(claimData),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          amount: '100,000',
+          amountUnformatted: '100000',
+          fiat: '$100,000',
+          isNative: false,
+          usdValue: '100000.00',
+        }),
+      );
+    });
+  });
+
+  it('returns default values when claim data is invalid', async () => {
+    const invalidClaimData = '0x123456'; // Invalid data
+
+    const { result } = renderHookWithProvider(() => useTokenAmount(), {
+      state: createMusdClaimState(invalidClaimData),
+    });
+
+    await waitFor(() => {
+      // When decoding fails, it falls through to default case
+      expect(result.current.amount).toBeDefined();
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/useTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.ts
@@ -36,6 +36,10 @@ import { useCallback, useMemo } from 'react';
 import { updateEditableParams } from '../../../../util/transaction-controller';
 import { selectTokensByChainIdAndAddress } from '../../../../selectors/tokensController';
 import { getTokenTransferData } from '../utils/transaction-pay';
+import {
+  convertMusdClaimAmount,
+  decodeMerklClaimAmount,
+} from '../../../UI/Earn/utils/musd';
 
 interface TokenAmountProps {
   /**
@@ -214,6 +218,32 @@ export const useTokenAmount = ({
       usdValue = usdConversionRateFromCurrencyRates
         ? usdAmount.toFixed(2)
         : null;
+      break;
+    }
+    case TransactionType.musdClaim: {
+      const claimAmountRaw = decodeMerklClaimAmount(txParams?.data as string);
+      if (claimAmountRaw) {
+        const { claimAmountDecimal, fiatValue } = convertMusdClaimAmount({
+          claimAmountRaw,
+          conversionRate: nativeConversionRate,
+          usdConversionRate,
+        });
+
+        return {
+          amount: formatAmount(I18n.locale, claimAmountDecimal),
+          amountNative: undefined,
+          amountPrecise: formatAmountMaxPrecision(
+            I18n.locale,
+            claimAmountDecimal,
+          ),
+          amountUnformatted: claimAmountDecimal.toString(),
+          fiat: fiatFormatter(fiatValue),
+          fiatUnformatted: fiatValue.toString(),
+          isNative: false,
+          updateTokenAmount,
+          usdValue: claimAmountDecimal.toFixed(2),
+        };
+      }
       break;
     }
     default: {

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -289,6 +289,7 @@ const Routes = {
       CANCEL_ALL_ORDERS: 'PerpsCancelAllOrders',
       TOOLTIP: 'PerpsTooltip',
       CROSS_MARGIN_WARNING: 'PerpsCrossMarginWarning',
+      SELECT_PROVIDER: 'PerpsSelectProvider',
     },
     POSITION_TRANSACTION: 'PerpsPositionTransaction',
     ORDER_TRANSACTION: 'PerpsOrderTransaction',

--- a/app/core/Engine/controllers/nft-controller-init.test.ts
+++ b/app/core/Engine/controllers/nft-controller-init.test.ts
@@ -41,6 +41,7 @@ describe('NftControllerInit', () => {
       messenger: expect.any(Object),
       state: undefined,
       useIpfsSubdomains: false,
+      ipfsGateway: 'dweb.link',
     });
   });
 });

--- a/app/core/Engine/controllers/nft-controller-init.ts
+++ b/app/core/Engine/controllers/nft-controller-init.ts
@@ -20,6 +20,7 @@ export const nftControllerInit: ControllerInitFunction<
     state: persistedState.NftController,
     useIpfsSubdomains: false,
     displayNftMedia: persistedState.PreferencesController?.displayNftMedia,
+    ipfsGateway: 'dweb.link',
   });
 
   return {

--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -22,12 +22,13 @@ import { endTrace, trace, TraceName } from '../util/trace';
 import { hasTransactionType } from '../components/Views/confirmations/utils/transaction';
 
 export const SKIP_NOTIFICATION_TRANSACTION_TYPES = [
+  TransactionType.musdClaim,
+  TransactionType.musdConversion,
   TransactionType.perpsDeposit,
+  TransactionType.perpsDepositAndOrder,
   TransactionType.predictDeposit,
   TransactionType.predictClaim,
   TransactionType.predictWithdraw,
-  TransactionType.musdConversion,
-  TransactionType.perpsDepositAndOrder,
 ];
 
 export const IN_PROGRESS_SKIP_STATUS = [

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -570,6 +570,7 @@ export async function getTransactionActionKey(transaction, chainId) {
       TransactionType.lendingWithdraw,
       TransactionType.perpsDeposit,
       TransactionType.musdConversion,
+      TransactionType.musdClaim,
     ].includes(type)
   ) {
     return type;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1885,6 +1885,9 @@
       "time": "Time",
       "apply": "Apply"
     },
+    "provider_selector": {
+      "title": "Select Provider"
+    },
     "market_type": {
       "filter_by": "Filter by"
     },
@@ -3811,6 +3814,7 @@
     "tx_review_predict_claim": "Claimed wins",
     "tx_review_predict_withdraw": "Predictions withdraw",
     "tx_review_musd_conversion": "mUSD conversion",
+    "claim": "Claim",
     "sent_ether": "Sent ETH",
     "self_sent_ether": "Sent yourself ETH",
     "received_ether": "Received ETH",
@@ -7584,6 +7588,7 @@
   "transaction_details": {
     "title": {
       "musd_conversion": "Converted to mUSD",
+      "musd_claim": "Claimed mUSD",
       "perps_deposit": "Funded perps account",
       "predict_claim": "Claimed winnings",
       "predict_deposit": "Funded Predict account",
@@ -7608,6 +7613,7 @@
       "bridge_receive_loading": "Bridge receive",
       "default": "Transaction",
       "musd_convert_send": "Sent {{sourceSymbol}} from {{sourceChain}}",
+      "musd_claim": "Claim mUSD",
       "perps_deposit": "Add funds",
       "predict_deposit": "Add funds",
       "swap": "Swap tokens",

--- a/package.json
+++ b/package.json
@@ -179,12 +179,11 @@
     "@ethereumjs/util@npm:^9.0.2": "patch:@ethereumjs/util@npm%3A9.1.0#~/.yarn/patches/@ethereumjs-util-npm-9.1.0-7e85509408.patch",
     "@metamask/key-tree@npm:^10.1.1": "patch:@metamask/key-tree@npm%3A10.1.1#~/.yarn/patches/@metamask-key-tree-npm-10.1.1-0bfab435ac.patch",
     "@metamask/key-tree@npm:^10.0.2": "patch:@metamask/key-tree@npm%3A10.1.1#~/.yarn/patches/@metamask-key-tree-npm-10.1.1-0bfab435ac.patch",
-    "@metamask/transaction-controller@npm:^62.9.0": "patch:@metamask/transaction-controller@npm%3A62.10.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.10.0-e1d24e7db5.patch",
+    "@metamask/transaction-controller@npm:^62.9.0": "^62.12.0",
     "qs": "6.14.1",
     "@playwright/test": "^1.57.0",
     "@metamask/transaction-controller@npm:^61.0.0": "patch:@metamask/transaction-controller@npm%3A62.10.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.10.0-e1d24e7db5.patch",
-    "@metamask/transaction-controller@npm:^62.9.2": "patch:@metamask/transaction-controller@npm%3A62.10.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.10.0-e1d24e7db5.patch",
-    "@metamask/transaction-controller@npm:^62.14.0": "patch:@metamask/transaction-controller@npm%3A62.10.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.10.0-e1d24e7db5.patch"
+    "@metamask/transaction-controller@npm:^62.9.2": "^62.14.0"
   },
   "dependencies": {
     "@config-plugins/detox": "^9.0.0",
@@ -302,6 +301,7 @@
     "@metamask/transaction-pay-controller": "^12.1.0",
     "@metamask/tron-wallet-snap": "^1.19.2",
     "@metamask/utils": "^11.8.1",
+    "@myx-trade/sdk": "^0.1.265",
     "@ngraveio/bc-ur": "^1.1.6",
     "@nktkas/hyperliquid": "^0.30.2",
     "@noble/curves": "1.9.6",

--- a/scripts/aggregate-performance-reports.mjs
+++ b/scripts/aggregate-performance-reports.mjs
@@ -163,6 +163,9 @@ function processTestReport(testReport) {
     // Include profiling data if available
     profilingData: testReport.profilingData || null,
     profilingSummary: testReport.profilingSummary || null,
+    // BrowserStack network logs (HAR) per test
+    apiCalls: testReport.apiCalls ?? null,
+    apiCallsError: testReport.apiCallsError ?? null,
     // Include quality gates if available
     qualityGates: testReport.qualityGates || null,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adraffy/ens-normalize@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@adraffy/ens-normalize@npm:1.10.1"
+  checksum: 10/4cb938c4abb88a346d50cb0ea44243ab3574330c81d4f5aaaf9dfee584b96189d0faa404de0fcbef5a1b73909ea4ebc3e63d84bd23f9949e5c8d4085207a5091
+  languageName: node
+  linkType: hard
+
 "@adraffy/ens-normalize@npm:^1.10.1, @adraffy/ens-normalize@npm:^1.11.0":
   version: 1.11.0
   resolution: "@adraffy/ens-normalize@npm:1.11.0"
@@ -3277,6 +3284,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/providers@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/providers@npm:5.8.0"
+  dependencies:
+    "@ethersproject/abstract-provider": "npm:^5.8.0"
+    "@ethersproject/abstract-signer": "npm:^5.8.0"
+    "@ethersproject/address": "npm:^5.8.0"
+    "@ethersproject/base64": "npm:^5.8.0"
+    "@ethersproject/basex": "npm:^5.8.0"
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/constants": "npm:^5.8.0"
+    "@ethersproject/hash": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/networks": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    "@ethersproject/random": "npm:^5.8.0"
+    "@ethersproject/rlp": "npm:^5.8.0"
+    "@ethersproject/sha2": "npm:^5.8.0"
+    "@ethersproject/strings": "npm:^5.8.0"
+    "@ethersproject/transactions": "npm:^5.8.0"
+    "@ethersproject/web": "npm:^5.8.0"
+    bech32: "npm:1.1.4"
+    ws: "npm:8.18.0"
+  checksum: 10/7d40fc0abb78fc9e69b71cb560beb2a93cf1da2cf978a061031a34c0ed76c2f5936ed8c0bdb9aa1307fe5308d0159e429b83b779dbd550639a886a88d6d17817
+  languageName: node
+  linkType: hard
+
 "@ethersproject/random@npm:5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/random@npm:5.7.0"
@@ -6301,6 +6336,247 @@ __metadata:
   version: 0.34.4
   resolution: "@img/sharp-win32-x64@npm:0.34.4"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@inquirer/ansi@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@inquirer/ansi@npm:2.0.3"
+  checksum: 10/846bf48acc4a89e62c2be49af74c014311e5a575a46875fe3066c28ac241671132fb16518e859bd63db6a2be326a6a7160c9a79f60013b1a2c6a1c1d620a98ac
+  languageName: node
+  linkType: hard
+
+"@inquirer/checkbox@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@inquirer/checkbox@npm:5.0.4"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.3"
+    "@inquirer/core": "npm:^11.1.1"
+    "@inquirer/figures": "npm:^2.0.3"
+    "@inquirer/type": "npm:^4.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/43ce1c429bdba2ec88c978a7a32068d7802775b67b9971dedbb3ef374f1a66e918a5999a02dfb244fd5f0e80728a623b3332051f3fce4c569367100ec583b79e
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^6.0.4":
+  version: 6.0.4
+  resolution: "@inquirer/confirm@npm:6.0.4"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.1"
+    "@inquirer/type": "npm:^4.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/ff3c544ebb8ec45f77641c37565f838cf9502c5af9ace7b789c57897829f700e0ac3a4a2b2a700ba563942b20f1878dfa39bf656f8f92a19860d5541ddc04238
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "@inquirer/core@npm:11.1.1"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.3"
+    "@inquirer/figures": "npm:^2.0.3"
+    "@inquirer/type": "npm:^4.0.3"
+    cli-width: "npm:^4.1.0"
+    mute-stream: "npm:^3.0.0"
+    signal-exit: "npm:^4.1.0"
+    wrap-ansi: "npm:^9.0.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/a4f084fe7f536240f48175baf4dcf761651810b0547c5661dd92032b37139c14ff9da2c6b2dc3245f99a68d42c70d0bf0e9f240dda2cd64d8085cd5511d63882
+  languageName: node
+  linkType: hard
+
+"@inquirer/editor@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@inquirer/editor@npm:5.0.4"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.1"
+    "@inquirer/external-editor": "npm:^2.0.3"
+    "@inquirer/type": "npm:^4.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/c339613eb46359c4cb07ed53f41bb96e6d6872b92e2de26471a11742a7ce11da41e92eccabe3dcfae94f50ed2e9489111e2da6a4f83a3e2e766c0751d7b17fdc
+  languageName: node
+  linkType: hard
+
+"@inquirer/expand@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@inquirer/expand@npm:5.0.4"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.1"
+    "@inquirer/type": "npm:^4.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/5487b02d0175ebf30ed8ea4e21075a9e3bb54c724abf5e5c2ce601f1b5bf1ccf05c447d1bbaecda146bc79c8504f204ddfd048a9333f11274d04cabd5fd01443
+  languageName: node
+  linkType: hard
+
+"@inquirer/external-editor@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@inquirer/external-editor@npm:2.0.3"
+  dependencies:
+    chardet: "npm:^2.1.1"
+    iconv-lite: "npm:^0.7.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/cd055ef96c04d0af0a06c5beb1d26e08a2a83f1785851ec1e60c52eb619bf19bc90232c367f98bf9e61ae77555bddfce98b0daeae5be1e1cbf746375ab48a56f
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@inquirer/figures@npm:2.0.3"
+  checksum: 10/d1496081e28e8fb5f50790fdbf7fb5f437933de557092a3eaac7f290190f9597ff9d75693bbb6d94e3da71b4dae567f2e88d3c54557b280b7b832219ff26e072
+  languageName: node
+  linkType: hard
+
+"@inquirer/input@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@inquirer/input@npm:5.0.4"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.1"
+    "@inquirer/type": "npm:^4.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/bf57758c632ec05bd9018da97a78a8d9d7ffa92200a54b380c39eee442d53c98fdf278597395a32b665851ef0572337402a0ba9180889ded049437a01810946f
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@inquirer/number@npm:4.0.4"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.1"
+    "@inquirer/type": "npm:^4.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/63af377551ccced477ffd71527d5e88927b79ab0171bdbfa13ab011beff10b6df1799caef2f3d91ccdf894a9f5532851a5c62b62f576e7f7ad1ccfcd31d19f3f
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@inquirer/password@npm:5.0.4"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.3"
+    "@inquirer/core": "npm:^11.1.1"
+    "@inquirer/type": "npm:^4.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/1d38173b1cf457679f0ff3f6bcaa1d1ebb9b3669cee391fcedad1892520c2922438dd88e3f499911dce55cbb6557606954bf9c0080bb4c29f39bb96214c64ba0
+  languageName: node
+  linkType: hard
+
+"@inquirer/prompts@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "@inquirer/prompts@npm:8.2.0"
+  dependencies:
+    "@inquirer/checkbox": "npm:^5.0.4"
+    "@inquirer/confirm": "npm:^6.0.4"
+    "@inquirer/editor": "npm:^5.0.4"
+    "@inquirer/expand": "npm:^5.0.4"
+    "@inquirer/input": "npm:^5.0.4"
+    "@inquirer/number": "npm:^4.0.4"
+    "@inquirer/password": "npm:^5.0.4"
+    "@inquirer/rawlist": "npm:^5.2.0"
+    "@inquirer/search": "npm:^4.1.0"
+    "@inquirer/select": "npm:^5.0.4"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/4677fdf41b7aee3043d9428bfb148958992204176c70dee09fb60953b0bea296828d451ff1aadbd688f87fa3b2851cecadd0fce8df9c027613f5f8c393e0cb33
+  languageName: node
+  linkType: hard
+
+"@inquirer/rawlist@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@inquirer/rawlist@npm:5.2.0"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.1"
+    "@inquirer/type": "npm:^4.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/b5fe38ab047047eba4f9a2d2697570e67cf43b7b6a43cb0e0399613510e273a79585c334887b17be5717f51823ed09bd2b4a752da49ed47d906b1bfedba94a5b
+  languageName: node
+  linkType: hard
+
+"@inquirer/search@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@inquirer/search@npm:4.1.0"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.1"
+    "@inquirer/figures": "npm:^2.0.3"
+    "@inquirer/type": "npm:^4.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/71829d5bd946c3545ecde4ec18fa1ecdcd5f1acebf0c5c69dc226bb633a5e0e0754c2d182e3e78a51be4dfed5a763cbe38d23ee0d13e74519eb307cee03052f5
+  languageName: node
+  linkType: hard
+
+"@inquirer/select@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@inquirer/select@npm:5.0.4"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.3"
+    "@inquirer/core": "npm:^11.1.1"
+    "@inquirer/figures": "npm:^2.0.3"
+    "@inquirer/type": "npm:^4.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/06027a2c035774d1299b4a33d4829bc8a53db07da4c6d369a2a7a5b007fe42c32d629cda1eaa3b676a01f6a66227010fbb79558e57749d85539f9eb5ba36ed7f
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "@inquirer/type@npm:4.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/93166fc35dbb597067341c125090a51b1c8d0d57308ec14ad601727513d0aefa33643cff28aa52e7e6796a866bb2f60b4e49820774970110fe8454a276ac7c4c
   languageName: node
   linkType: hard
 
@@ -9688,7 +9964,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^62.11.0, @metamask/transaction-controller@npm:^62.13.0":
+"@metamask/transaction-controller@npm:^62.11.0, @metamask/transaction-controller@npm:^62.13.0, @metamask/transaction-controller@npm:^62.14.0":
   version: 62.14.0
   resolution: "@metamask/transaction-controller@npm:62.14.0"
   dependencies:
@@ -9890,6 +10166,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@myx-trade/sdk@npm:^0.1.265":
+  version: 0.1.265
+  resolution: "@myx-trade/sdk@npm:0.1.265"
+  dependencies:
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/providers": "npm:^5.8.0"
+    "@types/ws": "npm:^8.18.1"
+    crypto-js: "npm:^4.2.0"
+    dayjs: "npm:^1.11.13"
+    ethers: "npm:^6.15.0"
+    ethers-decode-error: "npm:^2.1.3"
+    inquirer: "npm:^13.2.0"
+    lodash-es: "npm:^4.17.21"
+    mitt: "npm:^3.0.1"
+    reconnecting-websocket: "npm:^4.4.0"
+    viem: "npm:^2.36.0"
+    wretch: "npm:^2.11.0"
+    ws: "npm:^8.18.3"
+  checksum: 10/0390eafdb6607e0f344747f0b959173117b2ab6e87e0ed2da6052645ea7977e46fc2cb69457653c20e32f3bac5a897a60e1626b56163a452dd9be3688cb24477
+  languageName: node
+  linkType: hard
+
 "@native-html/css-processor@npm:1.11.0":
   version: 1.11.0
   resolution: "@native-html/css-processor@npm:1.11.0"
@@ -9981,6 +10279,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@noble/curves@npm:1.2.0"
+  dependencies:
+    "@noble/hashes": "npm:1.3.2"
+  checksum: 10/94e02e9571a9fd42a3263362451849d2f54405cb3ce9fa7c45bc6b9b36dcd7d1d20e2e1e14cfded24937a13d82f1e60eefc4d7a14982ce0bc219a9fc0f51d1f9
+  languageName: node
+  linkType: hard
+
 "@noble/curves@npm:1.4.2":
   version: 1.4.2
   resolution: "@noble/curves@npm:1.4.2"
@@ -10059,6 +10366,13 @@ __metadata:
   dependencies:
     "@noble/hashes": "npm:2.0.1"
   checksum: 10/e826af523f40a671601a6d07f98df16c3afe1cbd0349c3ba4d7b31f6dba7dc743822719f260bd291716b6b42b8dc327f94a76b4852359aa85f79df461eb22bfc
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@noble/hashes@npm:1.3.2"
+  checksum: 10/685f59d2d44d88e738114b71011d343a9f7dce9dfb0a121f1489132f9247baa60bc985e5ec6f3213d114fbd1e1168e7294644e46cbd0ce2eba37994f28eeb51b
   languageName: node
   linkType: hard
 
@@ -18333,6 +18647,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:22.7.5":
+  version: 22.7.5
+  resolution: "@types/node@npm:22.7.5"
+  dependencies:
+    undici-types: "npm:~6.19.2"
+  checksum: 10/e8ba102f8c1aa7623787d625389be68d64e54fcbb76d41f6c2c64e8cf4c9f4a2370e7ef5e5f1732f3c57529d3d26afdcb2edc0101c5e413a79081449825c57ac
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^12.12.54":
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
@@ -18783,7 +19106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:*, @types/ws@npm:^8.2.2, @types/ws@npm:^8.5.3":
+"@types/ws@npm:*, @types/ws@npm:^8.18.1, @types/ws@npm:^8.2.2, @types/ws@npm:^8.5.3":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
   dependencies:
@@ -20435,7 +20758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abitype@npm:^1.0.6, abitype@npm:^1.0.8, abitype@npm:^1.0.9":
+"abitype@npm:1.2.3, abitype@npm:^1.0.6, abitype@npm:^1.0.8, abitype@npm:^1.0.9, abitype@npm:^1.2.3":
   version: 1.2.3
   resolution: "abitype@npm:1.2.3"
   peerDependencies:
@@ -20567,6 +20890,13 @@ __metadata:
   version: 3.0.0
   resolution: "aes-js@npm:3.0.0"
   checksum: 10/1b3772e5ba74abdccb6c6b99bf7f50b49057b38c0db1612b46c7024414f16e65ba7f1643b2d6e38490b1870bdf3ba1b87b35e2c831fd3fdaeff015f08aad19d1
+  languageName: node
+  linkType: hard
+
+"aes-js@npm:4.0.0-beta.5":
+  version: 4.0.0-beta.5
+  resolution: "aes-js@npm:4.0.0-beta.5"
+  checksum: 10/8f745da2e8fb38e91297a8ec13c2febe3219f8383303cd4ed4660ca67190242ccfd5fdc2f0d1642fd1ea934818fb871cd4cc28d3f28e812e3dc6c3d0f1f97c24
   languageName: node
   linkType: hard
 
@@ -21441,7 +21771,7 @@ __metadata:
 
 "appwright@patch:appwright@npm%3A0.1.45#~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch::version=0.1.45&hash=3beae4":
   version: 0.1.45
-  resolution: "appwright@patch:appwright@npm%3A0.1.45#~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch::version=0.1.45&hash=3beae4"
+  resolution: "appwright@patch:appwright@npm%3A0.1.45#~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch::version=0.1.45&hash=fe2da7"
   dependencies:
     "@empiricalrun/llm": "npm:^0.9.25"
     "@ffmpeg-installer/ffmpeg": "npm:^1.1.0"
@@ -21457,13 +21787,13 @@ __metadata:
     webdriver: "npm:^8.36.1"
   bin:
     appwright: dist/bin/index.js
-  checksum: 10/a7b98dc4bcdc19660a976927d6b508779b40ac22b786f90e96559ee8a3fa9df331ff85f8a0bdf28c16ea729011b38a95409b9f07e88e0695fff982735518c71b
+  checksum: 10/b6fc9278b1b25eb775e5bfdeec63533764bf38e2d3304396d783a6c75f1d7beed6411b35cfddfa812c2b02204d5a5a596bf2a9f619f45436722c8a48b95eddf3
   languageName: node
   linkType: hard
 
 "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=3beae4#~/.yarn/patches/appwright-patch-685d6e06a0.patch":
   version: 0.1.45
-  resolution: "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=3beae4#~/.yarn/patches/appwright-patch-685d6e06a0.patch::version=0.1.45&hash=2d02ee"
+  resolution: "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=fe2da7#~/.yarn/patches/appwright-patch-685d6e06a0.patch::version=0.1.45&hash=2d02ee"
   dependencies:
     "@empiricalrun/llm": "npm:^0.9.25"
     "@ffmpeg-installer/ffmpeg": "npm:^1.1.0"
@@ -21479,7 +21809,7 @@ __metadata:
     webdriver: "npm:^8.36.1"
   bin:
     appwright: dist/bin/index.js
-  checksum: 10/1ccf9e933937b35aaf15c152353596070dcd7175a5670def418ef0b3a124b750bc23ea4eed16ced52e2e5d631a9833a35be75553618b5ee8b0b88d17c4c9ba37
+  checksum: 10/6dcd6c9f0fdb7bf2f2a8e8d27137036e1cf3de94d864a23da630a6459aeeb7284652a7ff833a5a16b7f76b116cb76a315553aae7098c973adba88ac71c5f7768
   languageName: node
   linkType: hard
 
@@ -23761,6 +24091,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chardet@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "chardet@npm:2.1.1"
+  checksum: 10/d56913b65e45c5c86f331988e2ef6264c131bfeadaae098ee719bf6610546c77740e37221ffec802dde56b5e4466613a4c754786f4da6b5f6c5477243454d324
+  languageName: node
+  linkType: hard
+
 "charenc@npm:0.0.2":
   version: 0.0.2
   resolution: "charenc@npm:0.0.2"
@@ -24038,6 +24375,13 @@ __metadata:
     slice-ansi: "npm:^5.0.0"
     string-width: "npm:^7.0.0"
   checksum: 10/d5149175fd25ca985731bdeec46a55ec237475cf74c1a5e103baea696aceb45e372ac4acbaabf1316f06bd62e348123060f8191ffadfeedebd2a70a2a7fb199d
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cli-width@npm:4.1.0"
+  checksum: 10/b58876fbf0310a8a35c79b72ecfcf579b354e18ad04e6b20588724ea2b522799a758507a37dfe132fafaf93a9922cafd9514d9e1598e6b2cd46694853aed099f
   languageName: node
   linkType: hard
 
@@ -27859,6 +28203,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ethers-decode-error@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "ethers-decode-error@npm:2.1.3"
+  peerDependencies:
+    ethers: ^6.0.0
+  checksum: 10/c4af3dadb94f68a4839254fe7acc6a2e156f5070ede8e2c2e4d2aadff06ae5a6f0ca4ab8c269ae144b15488db7ff568199af9d53735c2f3c1594f35b273c4196
+  languageName: node
+  linkType: hard
+
 "ethers@npm:^5.0.14":
   version: 5.7.2
   resolution: "ethers@npm:5.7.2"
@@ -27894,6 +28247,21 @@ __metadata:
     "@ethersproject/web": "npm:5.7.1"
     "@ethersproject/wordlists": "npm:5.7.0"
   checksum: 10/227dfa88a2547c799c0c3c9e92e5e246dd11342f4b495198b3ae7c942d5bf81d3970fcef3fbac974a9125d62939b2d94f3c0458464e702209b839a8e6e615028
+  languageName: node
+  linkType: hard
+
+"ethers@npm:^6.15.0":
+  version: 6.16.0
+  resolution: "ethers@npm:6.16.0"
+  dependencies:
+    "@adraffy/ens-normalize": "npm:1.10.1"
+    "@noble/curves": "npm:1.2.0"
+    "@noble/hashes": "npm:1.3.2"
+    "@types/node": "npm:22.7.5"
+    aes-js: "npm:4.0.0-beta.5"
+    tslib: "npm:2.7.0"
+    ws: "npm:8.17.1"
+  checksum: 10/7e980f0a77963fbe14321a3b9746c3ca3cad44932e28bb3506406a66c4b4d9dc1e60ed68d9d784224e9f2582a53d6a0a2e55a7c9559659681f4ad1f70e00e325
   languageName: node
   linkType: hard
 
@@ -31142,6 +31510,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iconv-lite@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "iconv-lite@npm:0.7.2"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10/24c937b532f868e938386b62410b303b7c767ce3d08dc2829cbe59464d5a26ef86ae5ad1af6b34eec43ddfea39e7d101638644b0178d67262fa87015d59f983a
+  languageName: node
+  linkType: hard
+
 "icss-utils@npm:^5.0.0, icss-utils@npm:^5.1.0":
   version: 5.1.0
   resolution: "icss-utils@npm:5.1.0"
@@ -31345,6 +31722,26 @@ __metadata:
   version: 6.0.0
   resolution: "ini@npm:6.0.0"
   checksum: 10/e87d8cde86d091ddb104580d42dfdc8306593627269990ca0f5176ccc60c936268bad56856398fef924cdf0af33b1a9c21e84f85914820037e003ee45443cc85
+  languageName: node
+  linkType: hard
+
+"inquirer@npm:^13.2.0":
+  version: 13.2.2
+  resolution: "inquirer@npm:13.2.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.3"
+    "@inquirer/core": "npm:^11.1.1"
+    "@inquirer/prompts": "npm:^8.2.0"
+    "@inquirer/type": "npm:^4.0.3"
+    mute-stream: "npm:^3.0.0"
+    run-async: "npm:^4.0.6"
+    rxjs: "npm:^7.8.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/6daf275730ce4bf872d94d404a8a61020cc586391db4f32a9dae644b922a03eda9af56134f9c52cbabae024c59859404292000225bfb1cd747e68aa2cee542d6
   languageName: node
   linkType: hard
 
@@ -34821,6 +35218,7 @@ __metadata:
     "@metamask/transaction-pay-controller": "npm:^12.1.0"
     "@metamask/tron-wallet-snap": "npm:^1.19.2"
     "@metamask/utils": "npm:^11.8.1"
+    "@myx-trade/sdk": "npm:^0.1.265"
     "@ngraveio/bc-ur": "npm:^1.1.6"
     "@nktkas/hyperliquid": "npm:^0.30.2"
     "@noble/curves": "npm:1.9.6"
@@ -36173,6 +36571,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mute-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mute-stream@npm:3.0.0"
+  checksum: 10/bee5db5c996a4585dbffc49e51fea10f3582d7f65441db9bc63126f16269541713c6ccb5a6fe37e08f627967b6eb28dd6b35e54a8dce53cf3837d7e010917b43
+  languageName: node
+  linkType: hard
+
 "mv@npm:2.1.1, mv@npm:~2":
   version: 2.1.1
   resolution: "mv@npm:2.1.1"
@@ -37326,6 +37731,27 @@ __metadata:
     os-homedir: "npm:^1.0.0"
     os-tmpdir: "npm:^1.0.0"
   checksum: 10/779d261920f2a13e5e18cf02446484f12747d3f2ff82280912f52b213162d43d312647a40c332373cbccd5e3fb8126915d3bfea8dde4827f70f82da76e52d359
+  languageName: node
+  linkType: hard
+
+"ox@npm:0.11.3":
+  version: 0.11.3
+  resolution: "ox@npm:0.11.3"
+  dependencies:
+    "@adraffy/ens-normalize": "npm:^1.11.0"
+    "@noble/ciphers": "npm:^1.3.0"
+    "@noble/curves": "npm:1.9.1"
+    "@noble/hashes": "npm:^1.8.0"
+    "@scure/bip32": "npm:^1.7.0"
+    "@scure/bip39": "npm:^1.6.0"
+    abitype: "npm:^1.2.3"
+    eventemitter3: "npm:5.0.1"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/6eaf0e0ea812b3673228b323c90a7ab04513a2a495e483419333bda6eae802ad7afd17ab869e417036d85683eda2e2f2a811c2e2d26fd09fc6aa9729b4e063a6
   languageName: node
   linkType: hard
 
@@ -40733,6 +41159,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"reconnecting-websocket@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "reconnecting-websocket@npm:4.4.0"
+  checksum: 10/542b09b4604c4050833017e9602867d2dd76631de1790d46238e5a5857a41183e09faf38d373406e4ed7fef8614b43bf43c89aac677104997ccbbf6fa071338c
+  languageName: node
+  linkType: hard
+
 "redent@npm:^3.0.0":
   version: 3.0.0
   resolution: "redent@npm:3.0.0"
@@ -41539,6 +41972,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"run-async@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "run-async@npm:4.0.6"
+  checksum: 10/d23929e36d0422b871a8964d5cfcb1b88295950ea5f72e1dfed458d4c3f3a33a7395e08167d8a4446f2110cfaac7d7653d9c804d2becab8afa8a63e16b97da81
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -41563,6 +42003,15 @@ __metadata:
   dependencies:
     tslib: "npm:^1.9.0"
   checksum: 10/c8263ebb20da80dd7a91c452b9e96a178331f402344bbb40bc772b56340fcd48d13d1f545a1e3d8e464893008c5e306cc42a1552afe0d562b1a6d4e1e6262b03
+  languageName: node
+  linkType: hard
+
+"rxjs@npm:^7.8.2":
+  version: 7.8.2
+  resolution: "rxjs@npm:7.8.2"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 10/03dff09191356b2b87d94fbc1e97c4e9eb3c09d4452399dddd451b09c2f1ba8d56925a40af114282d7bc0c6fe7514a2236ca09f903cf70e4bbf156650dddb49d
   languageName: node
   linkType: hard
 
@@ -44367,6 +44816,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:2.7.0":
+  version: 2.7.0
+  resolution: "tslib@npm:2.7.0"
+  checksum: 10/9a5b47ddac65874fa011c20ff76db69f97cf90c78cff5934799ab8894a5342db2d17b4e7613a087046bc1d133d21547ddff87ac558abeec31ffa929c88b7fce6
+  languageName: node
+  linkType: hard
+
 "tslib@npm:2.8.1, tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.5.0, tslib@npm:^2.5.3, tslib@npm:^2.6.2, tslib@npm:^2.8.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
@@ -44833,6 +45289,13 @@ __metadata:
   version: 5.26.5
   resolution: "undici-types@npm:5.26.5"
   checksum: 10/0097779d94bc0fd26f0418b3a05472410408877279141ded2bd449167be1aed7ea5b76f756562cb3586a07f251b90799bab22d9019ceba49c037c76445f7cddd
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.19.2":
+  version: 6.19.8
+  resolution: "undici-types@npm:6.19.8"
+  checksum: 10/cf0b48ed4fc99baf56584afa91aaffa5010c268b8842f62e02f752df209e3dea138b372a60a963b3b2576ed932f32329ce7ddb9cb5f27a6c83040d8cd74b7a70
   languageName: node
   linkType: hard
 
@@ -45700,6 +46163,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"viem@npm:^2.36.0":
+  version: 2.45.1
+  resolution: "viem@npm:2.45.1"
+  dependencies:
+    "@noble/curves": "npm:1.9.1"
+    "@noble/hashes": "npm:1.8.0"
+    "@scure/bip32": "npm:1.7.0"
+    "@scure/bip39": "npm:1.6.0"
+    abitype: "npm:1.2.3"
+    isows: "npm:1.0.7"
+    ox: "npm:0.11.3"
+    ws: "npm:8.18.3"
+  peerDependencies:
+    typescript: ">=5.0.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/88838ca073a0de832b35aa97ef8202d33566cec67680b5e8951a41c94ba4be5b360f9a6991fb21a16ab744b6e80bd5b4bd8983b8de387ed56e131038d7dca47e
+  languageName: node
+  linkType: hard
+
 "vite-plugin-node-polyfills@npm:^0.22.0":
   version: 0.22.0
   resolution: "vite-plugin-node-polyfills@npm:0.22.0"
@@ -46379,10 +46863,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^9.0.2":
+  version: 9.0.2
+  resolution: "wrap-ansi@npm:9.0.2"
+  dependencies:
+    ansi-styles: "npm:^6.2.1"
+    string-width: "npm:^7.0.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10/f3907e1ea9717404ca53a338fa5a017c2121550c3a5305180e2bc08c03e21aa45068df55b0d7676bf57be1880ba51a84458c17241ebedea485fafa9ef16b4024
+  languageName: node
+  linkType: hard
+
 "wrappy@npm:1":
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 10/159da4805f7e84a3d003d8841557196034155008f817172d4e986bd591f74aa82aa7db55929a54222309e01079a65a92a9e6414da5a6aa4b01ee44a511ac3ee5
+  languageName: node
+  linkType: hard
+
+"wretch@npm:^2.11.0":
+  version: 2.11.1
+  resolution: "wretch@npm:2.11.1"
+  checksum: 10/36fbe1889bbfbbe6174be7fde5c2897e4414f911aed15e337b1f4b18b294f0aba49c99415e7d5c3ceced2e93d4214c9c96a239c2d519a7f5332f1aa2237639ee
   languageName: node
   linkType: hard
 
@@ -46429,7 +46931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:*, ws@npm:^8.0.0, ws@npm:^8.12.1, ws@npm:^8.13.0, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.5.0, ws@npm:^8.8.0":
+"ws@npm:*, ws@npm:8.18.3, ws@npm:^8.0.0, ws@npm:^8.12.1, ws@npm:^8.13.0, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.5.0, ws@npm:^8.8.0":
   version: 8.18.3
   resolution: "ws@npm:8.18.3"
   peerDependencies:
@@ -46456,6 +46958,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/1769532b6fdab9ff659f0b17810e7501831d34ecca23fd179ee64091dd93a51f42c59f6c7bb4c7a384b6c229aca8076fb312aa35626257c18081511ef62a161d
+  languageName: node
+  linkType: hard
+
+"ws@npm:8.17.1, ws@npm:~8.17.1":
+  version: 8.17.1
+  resolution: "ws@npm:8.17.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/4264ae92c0b3e59c7e309001e93079b26937aab181835fb7af79f906b22cd33b6196d96556dafb4e985742dd401e99139572242e9847661fdbc96556b9e6902d
   languageName: node
   linkType: hard
 
@@ -46513,9 +47030,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:~8.17.1":
-  version: 8.17.1
-  resolution: "ws@npm:8.17.1"
+"ws@npm:^8.18.3":
+  version: 8.19.0
+  resolution: "ws@npm:8.19.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -46524,7 +47041,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/4264ae92c0b3e59c7e309001e93079b26937aab181835fb7af79f906b22cd33b6196d96556dafb4e985742dd401e99139572242e9847661fdbc96556b9e6902d
+  checksum: 10/26e4901e93abaf73af9f26a93707c95b4845e91a7a347ec8c569e6e9be7f9df066f6c2b817b2d685544e208207898a750b78461e6e8d810c11a370771450c31b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

This PR adds the first stage of MYX protocol integration for perpetual trading. MYX is a decentralized perpetuals exchange on BNB Chain that will complement our existing HyperLiquid integration, allowing users to access MYX-exclusive markets.

**Why this change?**
- Expand perps trading options with MYX protocol support
- Enable access to MYX-exclusive markets (tokens not available on HyperLiquid)
- Prepare infrastructure for multi-provider perps trading

**What's included (Stage 1 - Read-Only)?**
- MYXProvider implementation with market data operations
- SDK integration (`@myx-trade/sdk` v0.1.265)
- Provider selector UI for switching between HyperLiquid and MYX
- Type adapters for MYX ↔ MetaMask perps data transformation
- Feature flag control (`perpsMYXProviderEnabled`)

**Stage 1 Limitations (by design):**
- Read-only operations only (markets, prices)
- No trading functionality (returns "not supported" errors)
- REST polling for prices instead of WebSocket subscriptions
- Positions/orders show empty state (auth not implemented)

Trading functionality will be added in Stage 3 once the MYX SDK WebSocket authentication issues are resolved.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of MYX integration epic - Stage 1 implementation

## **Manual testing steps**

```gherkin
Feature: MYX Provider Stage 1

  Scenario: User views MYX markets
    Given user has perps feature enabled
    And perpsMYXProviderEnabled feature flag is true

    When user navigates to Perps home screen
    Then user sees provider selector badge in header
    And user can tap badge to open provider selection sheet

  Scenario: User switches to MYX provider
    Given user is on Perps home screen with HyperLiquid selected

    When user taps provider badge
    And user selects "MYX" from the provider list
    Then provider switches to MYX
    And MYX markets are displayed (BCXY, KNT, etc.)
    And prices update via REST polling
    And positions/orders sections show empty state

  Scenario: MYX markets display correctly
    Given user has MYX provider selected

    When markets load
    Then market cards show symbol, price, 24h change
    And volume shows actual value or $0 (not $---)
    And leverage badge shows 100x
```

## **Screenshots/Recordings**

### **Before**

N/A - New feature

### **After**

<!-- Add screenshots showing:
1. Provider selector badge in header
2. Provider selection bottom sheet
3. MYX markets list with prices
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## **Technical Details**

### Files Added (Core Implementation)

| File | Purpose | Lines |
|------|---------|-------|
| `controllers/providers/MYXProvider.ts` | PerpsProvider interface implementation | 717 |
| `services/MYXClientService.ts` | SDK client wrapper using MyxClient | 314 |
| `utils/myxAdapter.ts` | Type transformations MYX ↔ MetaMask | 297 |
| `constants/myxConfig.ts` | Configuration and conversion utilities | 219 |
| `types/myx-types.ts` | MYX-specific TypeScript types | 93 |
| `hooks/usePerpsProvider.ts` | Provider selection hook | 105 |

### Files Added (UI Components)

| File | Purpose |
|------|---------|
| `PerpsProviderSelectorBadge.tsx` | Header badge showing current provider |
| `PerpsProviderSelectorSheet.tsx` | Bottom sheet for provider selection |
| `PerpsSelectProviderView.tsx` | Full-screen provider selection view |

### Key Implementation Notes

1. **SDK Usage**: Uses `MyxClient.markets.getPoolSymbolAll()` and `getTickerList()` for data fetching
2. **Price Updates**: REST polling every 5 seconds (WebSocket deferred to Stage 3)
3. **Empty States**: Subscription callbacks immediately return empty arrays to prevent infinite loading
4. **Feature Flag**: Controlled by `perpsMYXProviderEnabled` remote feature flag

### Documentation Added

- `docs/perps/myx/MYX_IMPLEMENTATION_SUMMARY.md` - Full implementation overview
- `docs/perps/myx/MYX_SDK_SUBSCRIPTION_AUTH_BUG.md` - Known SDK auth issues
- `docs/perps/myx/MYX_POC_IMPLEMENTATION_GUIDE.md` - Re-implementation guide
- Additional API and SDK reference docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new perps provider selection/runtime reinitialization path and new transaction type handling, which can impact perps state consistency and activity rendering; most changes are gated by feature flags and covered by updated tests.
> 
> **Overview**
> **Perps:** Introduces a new MYX provider path behind `perpsMyxProviderEnabled` / `MM_PERPS_MYX_PROVIDER_ENABLED`, including `MYXProvider` + `MYXClientService` (SDK-backed market/ticker fetching with REST polling), MYX config/adapters/types, cache invalidation when switching providers, and a new header badge + modal bottom-sheet flow to select the active provider.
> 
> **Perps controller/service API changes:** Adds a version-gated feature-flag check inside `PerpsController`, makes provider switching do a full disconnect/reinit with rollback on failure, and refactors historical candle fetching and eligibility checks to take option objects (updating dependent services/tests).
> 
> **Earn/Activity:** Reclassifies Merkl claims as `TransactionType.musdClaim`, adds shared mUSD utilities (claim detection, amount decoding, fiat conversion), and wires them into token transaction filtering, activity list decoding, transaction-details hero/summary, and network-fee formatting.
> 
> **Misc/test infra:** Tweaks `RemoteImage` to return `null` while IPFS URL resolution is pending (with tests/snapshot updates), adjusts AssetOverview price header rendering, improves onboarding analytics tests by awaiting async opt-in/out, and updates the BrowserStack appwright patch (optional video download disable + capability tweaks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 727148c9b6acc331f4246329417454ca28180ac5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->