### PR TITLE
fix(perps): tx history initial fetch

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
@@ -986,7 +986,7 @@ describe('usePerpsTransactionHistory', () => {
       expect(mockProvider.getFunding).toHaveBeenCalledTimes(1);
     });
 
-    it('handles rapid connection state changes gracefully', async () => {
+    it('fetches once per true-to-false transition during rapid state changes', async () => {
       // Reset mocks to track calls clearly
       mockProvider.getOrderFills.mockClear();
       mockProvider.getOrders.mockClear();

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
@@ -928,4 +928,114 @@ describe('usePerpsTransactionHistory', () => {
       ]);
     });
   });
+
+  describe('connection state transitions', () => {
+    it('triggers fetch when skipInitialFetch transitions from true to false', async () => {
+      // Reset mocks to track calls clearly
+      mockProvider.getOrderFills.mockClear();
+      mockProvider.getOrders.mockClear();
+      mockProvider.getFunding.mockClear();
+
+      // Start with skipInitialFetch: true (simulating not connected state)
+      const { rerender } = renderHook(
+        ({ skipInitialFetch }) =>
+          usePerpsTransactionHistory({ skipInitialFetch }),
+        { initialProps: { skipInitialFetch: true } },
+      );
+
+      // Verify no fetch was made while skipInitialFetch is true
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      expect(mockProvider.getOrderFills).not.toHaveBeenCalled();
+
+      // Clear mocks to track only the new calls
+      mockProvider.getOrderFills.mockClear();
+      mockProvider.getOrders.mockClear();
+      mockProvider.getFunding.mockClear();
+
+      // Transition to skipInitialFetch: false (simulating connection established)
+      rerender({ skipInitialFetch: false });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Verify fetch was triggered after the transition
+      expect(mockProvider.getOrderFills).toHaveBeenCalledTimes(1);
+      expect(mockProvider.getOrders).toHaveBeenCalledTimes(1);
+      expect(mockProvider.getFunding).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not duplicate fetch when skipInitialFetch starts as false', async () => {
+      // Reset mocks to track calls clearly
+      mockProvider.getOrderFills.mockClear();
+      mockProvider.getOrders.mockClear();
+      mockProvider.getFunding.mockClear();
+
+      // Start with skipInitialFetch: false (already connected)
+      renderHook(() => usePerpsTransactionHistory({ skipInitialFetch: false }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Verify fetch was made exactly once (no duplicate)
+      expect(mockProvider.getOrderFills).toHaveBeenCalledTimes(1);
+      expect(mockProvider.getOrders).toHaveBeenCalledTimes(1);
+      expect(mockProvider.getFunding).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles rapid connection state changes gracefully', async () => {
+      // Reset mocks to track calls clearly
+      mockProvider.getOrderFills.mockClear();
+      mockProvider.getOrders.mockClear();
+      mockProvider.getFunding.mockClear();
+
+      // Start with skipInitialFetch: true
+      const { rerender } = renderHook(
+        ({ skipInitialFetch }) =>
+          usePerpsTransactionHistory({ skipInitialFetch }),
+        { initialProps: { skipInitialFetch: true } },
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // No fetch yet
+      expect(mockProvider.getOrderFills).not.toHaveBeenCalled();
+
+      // Transition to connected
+      rerender({ skipInitialFetch: false });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // First fetch
+      expect(mockProvider.getOrderFills).toHaveBeenCalledTimes(1);
+
+      // Clear and transition back to disconnected
+      mockProvider.getOrderFills.mockClear();
+      rerender({ skipInitialFetch: true });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // No additional fetch while disconnected
+      expect(mockProvider.getOrderFills).not.toHaveBeenCalled();
+
+      // Reconnect - should fetch again
+      rerender({ skipInitialFetch: false });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Should fetch on reconnection
+      expect(mockProvider.getOrderFills).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import usePrevious from '../../../hooks/usePrevious';
 import { BigNumber } from 'bignumber.js';
 import Engine from '../../../../core/Engine';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
@@ -59,7 +60,7 @@ export const usePerpsTransactionHistory = ({
   // Track if initial fetch has been done to prevent duplicate fetches
   const initialFetchDone = useRef(false);
   // Track previous skipInitialFetch value to detect connection state transitions
-  const prevSkipInitialFetchRef = useRef(skipInitialFetch);
+  const prevSkipInitialFetch = usePrevious(skipInitialFetch);
   useEffect(() => {
     userHistoryRef.current = userHistory;
   }, [userHistory]);
@@ -171,10 +172,8 @@ export const usePerpsTransactionHistory = ({
 
   useEffect(() => {
     // Detect transition from skipping (not connected) to not skipping (connected)
-    // This handles the case where the component mounts before connection is established
-    const justBecameConnected =
-      prevSkipInitialFetchRef.current && !skipInitialFetch;
-    prevSkipInitialFetchRef.current = skipInitialFetch;
+    // This fixes the case where the component mounts before connection is established
+    const justBecameConnected = prevSkipInitialFetch && !skipInitialFetch;
 
     // Trigger fetch if:
     // 1. Not skipping AND haven't fetched yet (normal initial fetch)
@@ -186,7 +185,7 @@ export const usePerpsTransactionHistory = ({
       initialFetchDone.current = true;
       refetch();
     }
-  }, [skipInitialFetch, refetch]);
+  }, [skipInitialFetch, prevSkipInitialFetch, refetch]);
 
   // Combine loading states
   const combinedIsLoading = useMemo(


### PR DESCRIPTION
## **Description**

Fixes an intermittent bug where the Perps tab in Activity screen sometimes shows as empty when accessed from perps home or perps market detail screens via the "See all" button.

### Root Cause
Race condition in `usePerpsTransactionHistory` hook:
1. User taps "See all" → navigates to Activity screen → Perps tab becomes active
2. `PerpsTransactionsView` mounts with `skipInitialFetch: true` (because WebSocket connection isn't established yet)
3. When connection becomes available, the hook didn't trigger a fetch because the `initialFetchDone` guard prevented it

### Solution
Modified the effect in `usePerpsTransactionHistory` to detect when `skipInitialFetch` transitions from `true` to `false` (i.e., when connection is established) and trigger a fetch regardless of the `initialFetchDone` guard.

## **Changelog**

CHANGELOG entry: Fixed Perps activity tab sometimes showing empty when accessed from perps home or market detail screens

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2335

## **Manual testing steps**

```gherkin
Feature: Perps Activity View

  Scenario: user views perps activity from perps home
    Given user is on the perps home screen
    And user has perps transaction history

    When user taps "See all" in the recent activity section
    Then user should see the Activity screen with Perps tab selected
    And perps transactions should be displayed (not empty)

  Scenario: user views perps activity from market detail
    Given user is on a perps market detail screen
    And user has perps transaction history

    When user taps "See all" in the trades section
    Then user should see the Activity screen with Perps tab selected
    And perps transactions should be displayed (not empty)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Activity tab sometimes shows empty on first load when navigating from perps screens

### **After**

Activity tab reliably shows transaction history when connection is established

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small hook logic change gated on `skipInitialFetch` with added unit tests; main risk is triggering extra network fetches on connection flaps.
> 
> **Overview**
> Fixes an intermittent empty Perps Activity history by making `usePerpsTransactionHistory` trigger its initial `refetch()` when `skipInitialFetch` transitions from `true` to `false` (i.e., connection becomes available), rather than being blocked by the `initialFetchDone` guard.
> 
> Adds focused tests covering connection state transitions to ensure a fetch occurs on true→false changes, does not duplicate on initial `false`, and only re-fetches once per reconnection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89d67fdcbe7c3c24fcb86c664cf74e35540fb03c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->