### PR TITLE
chore: moves snaps specs to tests

### DIFF
--- a/tests/smoke/snaps/mocks.ts
+++ b/tests/smoke/snaps/mocks.ts
@@ -1,5 +1,5 @@
 import { Mockttp } from 'mockttp';
-import { setupMockPostRequest } from '../../../tests/api-mocking/helpers/mockHelpers';
+import { setupMockPostRequest } from '../../api-mocking/helpers/mockHelpers';
 
 /**
  * Mock real genesis blocks for the chains to not require hitting the network.

--- a/tests/smoke/snaps/test-snap-background-events.spec.ts
+++ b/tests/smoke/snaps/test-snap-background-events.spec.ts
@@ -1,12 +1,12 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import Assertions from '../../../tests/framework/Assertions';
-import Matchers from '../../../tests/framework/Matchers';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import Assertions from '../../framework/Assertions';
+import Matchers from '../../framework/Matchers';
 import { BrowserViewSelectorsIDs } from '../../../app/components/Views/BrowserTab/BrowserView.testIds';
-import { TestSnapResultSelectorWebIDS } from '../../selectors/Browser/TestSnaps.selectors.ts';
+import { TestSnapResultSelectorWebIDS } from '../../../e2e/selectors/Browser/TestSnaps.selectors';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-bip-32.spec.ts
+++ b/tests/smoke/snaps/test-snap-bip-32.spec.ts
@@ -1,9 +1,9 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import Assertions from '../../../tests/framework/Assertions';
-import TestSnaps from '../../pages/Browser/TestSnaps';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import Assertions from '../../framework/Assertions';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-bip-44.spec.ts
+++ b/tests/smoke/snaps/test-snap-bip-44.spec.ts
@@ -1,9 +1,9 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import Assertions from '../../../tests/framework/Assertions';
-import TestSnaps from '../../pages/Browser/TestSnaps';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import Assertions from '../../framework/Assertions';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-client-status.spec.ts
+++ b/tests/smoke/snaps/test-snap-client-status.spec.ts
@@ -1,8 +1,8 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
 import sdkPackageJson from '@metamask/snaps-sdk/package.json';
 import packageJson from '../../../package.json';
 

--- a/tests/smoke/snaps/test-snap-cronjob.spec.ts
+++ b/tests/smoke/snaps/test-snap-cronjob.spec.ts
@@ -1,9 +1,9 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import { Assertions } from '../../../tests/framework';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import { Assertions } from '../../framework';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-dialog.spec.ts
+++ b/tests/smoke/snaps/test-snap-dialog.spec.ts
@@ -1,11 +1,11 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import Assertions from '../../../tests/framework/Assertions';
-import Gestures from '../../../tests/framework/Gestures';
-import { Matchers } from '../../../tests/framework';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import Assertions from '../../framework/Assertions';
+import Gestures from '../../framework/Gestures';
+import { Matchers } from '../../framework';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-ethereum-provider.spec.ts
+++ b/tests/smoke/snaps/test-snap-ethereum-provider.spec.ts
@@ -1,17 +1,17 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import Assertions from '../../../tests/framework/Assertions';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import ConnectBottomSheet from '../../pages/Browser/ConnectBottomSheet';
-import RequestTypes from '../../pages/Browser/Confirmations/RequestTypes';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import Assertions from '../../framework/Assertions';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import ConnectBottomSheet from '../../../e2e/pages/Browser/ConnectBottomSheet';
+import RequestTypes from '../../../e2e/pages/Browser/Confirmations/RequestTypes';
 import { Mockttp } from 'mockttp';
-import { setupRemoteFeatureFlagsMock } from '../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
 import {
   confirmationFeatureFlags,
   remoteFeatureMultichainAccountsAccountDetailsV2,
-} from '../../../tests/api-mocking/mock-responses/feature-flags-mocks';
+} from '../../api-mocking/mock-responses/feature-flags-mocks';
 import { mockGenesisBlocks } from './mocks';
 
 jest.setTimeout(150_000);

--- a/tests/smoke/snaps/test-snap-get-entropy.spec.ts
+++ b/tests/smoke/snaps/test-snap-get-entropy.spec.ts
@@ -1,9 +1,9 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import Assertions from '../../../tests/framework/Assertions.ts';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import Assertions from '../../framework/Assertions';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-get-file.spec.ts
+++ b/tests/smoke/snaps/test-snap-get-file.spec.ts
@@ -1,8 +1,8 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-get-preferences.spec.ts
+++ b/tests/smoke/snaps/test-snap-get-preferences.spec.ts
@@ -1,8 +1,8 @@
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-image.spec.ts
+++ b/tests/smoke/snaps/test-snap-image.spec.ts
@@ -1,9 +1,9 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import { Assertions, Matchers } from '../../../tests/framework';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import { Assertions, Matchers } from '../../framework';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-installed.spec.ts
+++ b/tests/smoke/snaps/test-snap-installed.spec.ts
@@ -1,9 +1,9 @@
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { FlaskBuildTests } from '../../tags';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { FlaskBuildTests } from '../../../e2e/tags';
 
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-interactive-ui.spec.ts
+++ b/tests/smoke/snaps/test-snap-interactive-ui.spec.ts
@@ -1,10 +1,10 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import { Assertions } from '../../../tests/framework';
-import Matchers from '../../../tests/framework/Matchers';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import { Assertions } from '../../framework';
+import Matchers from '../../framework/Matchers';
 import { DateTime } from 'luxon';
 
 jest.setTimeout(150_000);

--- a/tests/smoke/snaps/test-snap-jsx.spec.ts
+++ b/tests/smoke/snaps/test-snap-jsx.spec.ts
@@ -1,9 +1,9 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import { Assertions, Gestures, Matchers } from '../../../tests/framework';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import { Assertions, Gestures, Matchers } from '../../framework';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-lifecycle.spec.ts
+++ b/tests/smoke/snaps/test-snap-lifecycle.spec.ts
@@ -1,9 +1,9 @@
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import { FlaskBuildTests } from '../../tags';
-import Assertions from '../../../tests/framework/Assertions';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import Assertions from '../../framework/Assertions';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-manage-state.spec.ts
+++ b/tests/smoke/snaps/test-snap-manage-state.spec.ts
@@ -1,8 +1,8 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-management.spec.ts
+++ b/tests/smoke/snaps/test-snap-management.spec.ts
@@ -1,13 +1,13 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import SettingsView from '../../pages/Settings/SettingsView';
-import SnapSettingsView from '../../pages/Settings/SnapSettingsView';
-import { Assertions } from '../../../tests/framework';
-import BrowserView from '../../pages/Browser/BrowserView';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TabBarComponent from '../../../e2e/pages/wallet/TabBarComponent';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import SettingsView from '../../../e2e/pages/Settings/SettingsView';
+import SnapSettingsView from '../../../e2e/pages/Settings/SnapSettingsView';
+import { Assertions } from '../../framework';
+import BrowserView from '../../../e2e/pages/Browser/BrowserView';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-multichain-provider.spec.ts
+++ b/tests/smoke/snaps/test-snap-multichain-provider.spec.ts
@@ -1,14 +1,14 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import Assertions from '../../../tests/framework/Assertions';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import ConnectBottomSheet from '../../pages/Browser/ConnectBottomSheet';
-import RequestTypes from '../../pages/Browser/Confirmations/RequestTypes';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import Assertions from '../../framework/Assertions';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import ConnectBottomSheet from '../../../e2e/pages/Browser/ConnectBottomSheet';
+import RequestTypes from '../../../e2e/pages/Browser/Confirmations/RequestTypes';
 import { Mockttp } from 'mockttp';
-import { setupRemoteFeatureFlagsMock } from '../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
-import { confirmationFeatureFlags } from '../../../tests/api-mocking/mock-responses/feature-flags-mocks';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
+import { confirmationFeatureFlags } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import { mockGenesisBlocks } from './mocks';
 
 jest.setTimeout(150_000);

--- a/tests/smoke/snaps/test-snap-network-access.spec.ts
+++ b/tests/smoke/snaps/test-snap-network-access.spec.ts
@@ -1,11 +1,11 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import { getAnvilPortForTest } from '../../../tests/framework/fixtures/FixtureUtils';
-import { LocalNodeType } from '../../../tests/framework';
-import { defaultOptions } from '../../../tests/seeder/anvil-manager';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import { getAnvilPortForTest } from '../../framework/fixtures/FixtureUtils';
+import { LocalNodeType } from '../../framework';
+import { defaultOptions } from '../../seeder/anvil-manager';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-preinstalled.spec.ts
+++ b/tests/smoke/snaps/test-snap-preinstalled.spec.ts
@@ -1,11 +1,11 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import Assertions from '../../../tests/framework/Assertions';
-import { getEventsPayloads } from '../../../tests/helpers/analytics/helpers';
-import TestHelpers from '../../helpers';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import Assertions from '../../framework/Assertions';
+import { getEventsPayloads } from '../../helpers/analytics/helpers';
+import TestHelpers from '../../../e2e/helpers';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-rpc.spec.ts
+++ b/tests/smoke/snaps/test-snap-rpc.spec.ts
@@ -1,8 +1,8 @@
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-uilinks.spec.ts
+++ b/tests/smoke/snaps/test-snap-uilinks.spec.ts
@@ -1,9 +1,9 @@
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import { Assertions, Matchers } from '../../../tests/framework';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import { Assertions, Matchers } from '../../framework';
 
 jest.setTimeout(150_000);
 

--- a/tests/smoke/snaps/test-snap-wasm.spec.ts
+++ b/tests/smoke/snaps/test-snap-wasm.spec.ts
@@ -1,8 +1,8 @@
-import { FlaskBuildTests } from '../../tags';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestSnaps from '../../pages/Browser/TestSnaps';
+import { FlaskBuildTests } from '../../../e2e/tags';
+import { loginToApp, navigateToBrowserView } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../../e2e/pages/Browser/TestSnaps';
 
 jest.setTimeout(150_000);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Following https://github.com/MetaMask/metamask-mobile/pull/24313 we're looking to centralize all tools and test resources in one place.
This PR moves spec files for `Snaps` to `/tests`.

Previous related PRs:
- https://github.com/MetaMask/metamask-mobile/pull/24988
- https://github.com/MetaMask/metamask-mobile/pull/24313
- https://github.com/MetaMask/metamask-mobile/pull/25031
- https://github.com/MetaMask/metamask-mobile/pull/25095
- https://github.com/MetaMask/metamask-mobile/pull/25167
- https://github.com/MetaMask/metamask-mobile/pull/25198
- https://github.com/MetaMask/metamask-mobile/pull/25219
- https://github.com/MetaMask/metamask-mobile/pull/25263
- https://github.com/MetaMask/metamask-mobile/pull/25279
- https://github.com/MetaMask/metamask-mobile/pull/25520
- https://github.com/MetaMask/metamask-mobile/pull/25533
- https://github.com/MetaMask/metamask-mobile/pull/25598
- https://github.com/MetaMask/metamask-mobile/pull/25636
- https://github.com/MetaMask/metamask-mobile/pull/25638



<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1235

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely test-only changes that primarily update module paths; risk is limited to potential breakage of the smoke test runner due to incorrect import resolution.
> 
> **Overview**
> Refactors the Snaps smoke test suite under `tests/smoke/snaps` to align with the new centralized testing layout by **updating imports** from the old `tests/` locations to `e2e/` pages/helpers and local `tests/` framework/fixtures.
> 
> Updates related mocks and helpers (e.g., `mockGenesisBlocks`, remote feature flag mocks) to reference the relocated `api-mocking` utilities, without changing test logic or assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91a67a8d2acf25b5b84385d1c90d265e96d5f525. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->