### PR TITLE
fix: nft images not loading (flaky) cp-7.64.0

### DIFF
--- a/app/components/Base/RemoteImage/index.test.tsx
+++ b/app/components/Base/RemoteImage/index.test.tsx
@@ -307,6 +307,22 @@ describe('RemoteImage', () => {
   });
 
   describe('IPFS URL Resolution', () => {
+    it('returns null while resolving IPFS URL', () => {
+      const ipfsUri = 'ipfs://QmeE94srcYV9WwJb1p42eM4zncdLUai2N9zmMxxukoEQ23';
+      // Mock as a promise that doesn't resolve immediately
+      mockGetFormattedIpfsUrl.mockImplementation(
+        () =>
+          new Promise(() => {
+            // Intentionally never resolves to test loading state
+          }),
+      );
+
+      const { toJSON } = render(<RemoteImage source={{ uri: ipfsUri }} />);
+
+      // Component should return null while IPFS URL is being resolved
+      expect(toJSON()).toBeNull();
+    });
+
     it('resolves IPFS URL successfully', async () => {
       const ipfsUri = 'ipfs://QmeE94srcYV9WwJb1p42eM4zncdLUai2N9zmMxxukoEQ23';
       const resolvedUrl =

--- a/app/components/Base/RemoteImage/index.tsx
+++ b/app/components/Base/RemoteImage/index.tsx
@@ -51,7 +51,7 @@ const RemoteImage: React.FC<RemoteImageProps> = (props) => {
   const [error, setError] = useState<string | undefined>(undefined);
   const source = resolveAssetSource(props.source);
   const ipfsGateway = useIpfsGateway();
-  const [resolvedIpfsUrl, setResolvedIpfsUrl] = useState<string | false>(false);
+  const [resolvedIpfsUrl, setResolvedIpfsUrl] = useState<string | false>();
 
   const uri =
     resolvedIpfsUrl ||
@@ -140,6 +140,10 @@ const RemoteImage: React.FC<RemoteImageProps> = (props) => {
 
   if (error && props.address) {
     return <Identicon address={props.address} customStyle={props.style} />;
+  }
+
+  if (resolvedIpfsUrl === undefined && !uri) {
+    return null;
   }
 
   const defaultImage = (

--- a/app/components/UI/PaymentRequest/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/PaymentRequest/__snapshots__/index.test.tsx.snap
@@ -287,69 +287,7 @@ exports[`PaymentRequest renders correctly 1`] = `
                       "marginRight": 12,
                     }
                   }
-                >
-                  <View
-                    useNativeDriver={true}
-                  >
-                    <View
-                      fadeIn={true}
-                      source={
-                        {
-                          "uri": "",
-                        }
-                      }
-                      style={
-                        [
-                          {
-                            "borderRadius": 12,
-                            "height": 24,
-                            "width": 24,
-                          },
-                          undefined,
-                          {
-                            "borderRadius": 25,
-                            "height": 50,
-                            "width": 50,
-                          },
-                          undefined,
-                          {
-                            "height": 50,
-                            "width": 50,
-                          },
-                        ]
-                      }
-                    />
-                    <View
-                      collapsable={false}
-                      style={
-                        {
-                          "bottom": 0,
-                          "left": 0,
-                          "opacity": 1,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          [
-                            {
-                              "borderRadius": 25,
-                              "height": 50,
-                              "width": 50,
-                            },
-                            {
-                              "backgroundColor": "#eee",
-                            },
-                            undefined,
-                          ]
-                        }
-                      />
-                    </View>
-                  </View>
-                </View>
+                />
                 <View
                   style={
                     {
@@ -821,69 +759,7 @@ exports[`PaymentRequest renders correctly with network picker when feature flag 
                       "marginRight": 12,
                     }
                   }
-                >
-                  <View
-                    useNativeDriver={true}
-                  >
-                    <View
-                      fadeIn={true}
-                      source={
-                        {
-                          "uri": "",
-                        }
-                      }
-                      style={
-                        [
-                          {
-                            "borderRadius": 12,
-                            "height": 24,
-                            "width": 24,
-                          },
-                          undefined,
-                          {
-                            "borderRadius": 25,
-                            "height": 50,
-                            "width": 50,
-                          },
-                          undefined,
-                          {
-                            "height": 50,
-                            "width": 50,
-                          },
-                        ]
-                      }
-                    />
-                    <View
-                      collapsable={false}
-                      style={
-                        {
-                          "bottom": 0,
-                          "left": 0,
-                          "opacity": 1,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          [
-                            {
-                              "borderRadius": 25,
-                              "height": 50,
-                              "width": 50,
-                            },
-                            {
-                              "backgroundColor": "#eee",
-                            },
-                            undefined,
-                          ]
-                        }
-                      />
-                    </View>
-                  </View>
-                </View>
+                />
                 <View
                   style={
                     {

--- a/app/components/Views/confirmations/components/UI/nft/nft.tsx
+++ b/app/components/Views/confirmations/components/UI/nft/nft.tsx
@@ -75,7 +75,7 @@ export function Nft({ asset, onPress }: NftProps) {
             color={TextColor.TextAlternative}
             numberOfLines={1}
           >
-            {asset.standard === 'ERC1155' && `(${asset.balance}) `}
+            {asset.standard === 'ERC1155' && `(${asset.balance || 0}) `}
             {asset.standard === 'ERC721' ? `#${asset.tokenId}` : asset.name}
           </Text>
         </Box>

--- a/app/components/Views/confirmations/hooks/send/useNfts.ts
+++ b/app/components/Views/confirmations/hooks/send/useNfts.ts
@@ -12,6 +12,7 @@ import { Nft } from '../../types/token';
 import { useSendScope } from './useSendScope';
 import { getFormattedIpfsUrl } from '@metamask/assets-controllers';
 import useIpfsGateway from '../../../../hooks/useIpfsGateway';
+import Logger from '../../../../../util/Logger';
 
 export function useEVMNfts(): Nft[] {
   const { NftController, AssetsContractController, NetworkController } =
@@ -101,7 +102,16 @@ async function getValidImageUrl(
       if (!url.startsWith('ipfs:')) {
         return url;
       }
-      return (await getFormattedIpfsUrl(ipfsGateway, url, false)) || undefined;
+
+      try {
+        const ipfsUrl = await getFormattedIpfsUrl(ipfsGateway, url, false);
+        if (!ipfsUrl) {
+          continue;
+        }
+        return ipfsUrl;
+      } catch {
+        Logger.log(`Failed to resolve IPFS URL for ${url}`);
+      }
     }
   }
   return undefined;

--- a/app/core/Engine/controllers/nft-controller-init.test.ts
+++ b/app/core/Engine/controllers/nft-controller-init.test.ts
@@ -41,6 +41,7 @@ describe('NftControllerInit', () => {
       messenger: expect.any(Object),
       state: undefined,
       useIpfsSubdomains: false,
+      ipfsGateway: 'dweb.link',
     });
   });
 });

--- a/app/core/Engine/controllers/nft-controller-init.ts
+++ b/app/core/Engine/controllers/nft-controller-init.ts
@@ -20,6 +20,7 @@ export const nftControllerInit: ControllerInitFunction<
     state: persistedState.NftController,
     useIpfsSubdomains: false,
     displayNftMedia: persistedState.PreferencesController?.displayNftMedia,
+    ipfsGateway: 'dweb.link',
   });
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Seeing a bug with NFT import on mobile for a custom network. On extension, the image for this NFT shows up just fine after import. On mobile, the image is blank. Multiple users have reported this.

Mobile:
<img width="300" height="2400" alt="image" src="https://github.com/user-attachments/assets/ab29a8f7-5c1f-4070-bf79-940f105b8caf" />

Extension:
<img width="300" height="492" alt="image" src="https://github.com/user-attachments/assets/ec722a68-67e3-483a-b6a7-6f7eb08709c6" />

Solution:
@sahar-fehri spotted that the difference between Extension and Mobile was the IPFS gateway, following that piece of information we identified where to change the ipfs url so that we only had to modify the cleint (mobile) and not core.

Furthermore, after fixing that issue, we spotted some kind of flakiness where images were sometimes displayed and other times werent. This was due to the image being null while decoding the IPFS url which triggered expo-image calling `onError` and therefore not loading the image

Finally, I also found an existing bug on @MetaMask/confirmations where IPFS images are not resolved

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: nft images not loading for ApexYugalabs + flakiness

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2610

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/a379d20a-0ac2-45e8-89c5-8779517d3891


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes NFT/IPFS image resolution and controller init parameters; while localized, it affects how NFT media URLs are derived and rendered across key user flows.
> 
> **Overview**
> Fixes flaky/blank NFT images by **avoiding rendering `expo-image` with an empty URI while an `ipfs://` URL is still resolving**: `RemoteImage` now returns `null` during the initial IPFS resolution state, with a new unit test covering the loading case and updated snapshots where the image subtree is absent until resolved.
> 
> Adds IPFS resolution to confirmations’ `useEVMNfts` transformation: image selection now asynchronously converts `ipfs://` candidates via `getFormattedIpfsUrl` using the app’s configured gateway, falling back to the next URL when resolution returns `''`/`null` or throws (with logging). Tests were updated/added to cover these fallback cases and to de-flake the send amount NFT image assertion by waiting for resolution.
> 
> Initializes `NftController` with an explicit `ipfsGateway: 'dweb.link'` and updates the init test accordingly, and fixes ERC1155 NFT list rendering to show `(0)` when balance is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3c533b7be7bea0e777b6bfe497b661aa52d269c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->