### PR TITLE
chore: moves quarantine specs to tests; deprecates e2e/specs

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -17,7 +17,7 @@ Use the rules in the [unit testing guidelines](rules/unit-testing-guidelines.mdc
 ### 2. Initial Setup - E2E Tests
 
 - **ALWAYS** load and reference [e2e-testing-guidelines](rules/e2e-testing-guidelines.mdc)
-- Verify test file naming pattern: `e2e/specs/**/*.spec.{js,ts}`
+- Verify test file naming pattern: `tests/(smoke|regression)/**/*.spec.{js,ts}`
 - Check for proper imports and framework utilities from `tests/framework/index.ts`
 
 Use the rules in the [e2e-testing-guidelines](rules/e2e-testing-guidelines.mdc) to enforce the test quality and bug detection.

--- a/.cursor/rules/e2e-testing-guidelines.mdc
+++ b/.cursor/rules/e2e-testing-guidelines.mdc
@@ -26,14 +26,15 @@ alwaysApply: true
 ## Test Organization - MANDATORY
 
 - Organize tests into folders based on features and scenarios
+- Use the a directory that suits the test type (regression|smoke) based on the tag used
 - Each feature team should own one or more folders of tests
 - Follow the same organization pattern as the extension team for consistency
 - Place tests in logical feature directories:
   ```
-  e2e/specs/<feature-name>/<e2e-test-name.spec.ts>
-  e2e/specs/tokens/import/import-erc1155.spec.ts
-  e2e/specs/settings/clear-activity.spec.ts
-  e2e/specs/ppom/ppom-blockaid-alert-erc20-approval.spec.ts
+  tests/smoke/<feature-name>/<e2e-test-name.spec.ts>
+  tests/smoke/tokens/import/import-erc1155.spec.ts
+  tests/regression/wallet/settings/clear-activity.spec.ts
+  tests/regression/ppom/ppom-blockaid-alert-erc20-approval.spec.ts
   ```
 
 ## Framework Architecture

--- a/.github/scripts/e2e-extract-test-results.mjs
+++ b/.github/scripts/e2e-extract-test-results.mjs
@@ -48,7 +48,7 @@ async function parseXml(content) {
  * jest-junit outputs XML with structure:
  * <testsuites>
  *   <testsuite name="TestSuite" tests="N" failures="N" ...>
- *     <testcase name="test name" classname="e2e/specs/path/to/file.spec.ts" time="N">
+ *     <testcase name="test name" classname="tests/smoke/path/to/file.spec.ts" time="N">
  *       <failure>...</failure>  <!-- only if failed -->
  *     </testcase>
  *   </testsuite>

--- a/.github/scripts/e2e-split-tags-shards.mjs
+++ b/.github/scripts/e2e-split-tags-shards.mjs
@@ -11,10 +11,7 @@ import { extractTestResults } from './e2e-extract-test-results.mjs';
 
 const env = {
   TEST_SUITE_TAG: process.env.TEST_SUITE_TAG,
-  // Starting at the root drastically affects the performance of the script. 
-  // This will be reverted as soon as all specs are migrated to the new folder 
-  // structure.
-  BASE_DIR: process.env.BASE_DIR || './',
+  BASE_DIR: process.env.BASE_DIR || './tests/',
   METAMASK_BUILD_TYPE: process.env.METAMASK_BUILD_TYPE || 'main',
   PLATFORM: process.env.PLATFORM || 'ios',
   SPLIT_NUMBER: Number(process.env.SPLIT_NUMBER || '1'),

--- a/docs/readme/e2e-testing.md
+++ b/docs/readme/e2e-testing.md
@@ -149,15 +149,15 @@ source .e2e.env && yarn test:e2e:android:debug:run
 **Run Specific Test Folder**
 
 ```bash
-source .e2e.env && yarn test:e2e:ios:debug:run e2e/specs/your-folder
-source .e2e.env && yarn test:e2e:android:debug:run e2e/specs/your-folder
+source .e2e.env && yarn test:e2e:ios:debug:run tests/smoke/your-folder
+source .e2e.env && yarn test:e2e:android:debug:run tests/smoke/your-folder
 ```
 
 **Run Specific Test File**
 
 ```bash
-source .e2e.env && yarn test:e2e:ios:debug:run e2e/specs/onboarding/create-wallet.spec.js
-source .e2e.env && yarn test:e2e:android:debug:run e2e/specs/onboarding/create-wallet.spec.js
+source .e2e.env && yarn test:e2e:ios:debug:run tests/smoke/onboarding/create-wallet.spec.js
+source .e2e.env && yarn test:e2e:android:debug:run tests/smoke/onboarding/create-wallet.spec.js
 ```
 
 **Run Tests by Tag**
@@ -206,8 +206,8 @@ yarn test:e2e:android:flask:run
 # These commands are hardcoded to build for `flask` build type and `e2e` environment based on the .detoxrc.js file
 
 # Run specific Flask test
-yarn test:e2e:ios:flask:run e2e/specs/snaps/test-snap-jsx.spec.ts
-yarn test:e2e:android:flask:run e2e/specs/snaps/test-snap-jsx.spec.ts
+yarn test:e2e:ios:flask:run test/smoke/snaps/test-snap-jsx.spec.ts
+yarn test:e2e:android:flask:run tests/smoke/snaps/test-snap-jsx.spec.ts
 ```
 
 ### Flask Configuration Details
@@ -670,7 +670,7 @@ Our CI/CD process is automated through various Bitrise pipelines, each designed 
 - **Example**:
 
   ```
-  FAIL e2e/specs/swaps/swap-action-smoke.spec.js (232.814 s)
+  FAIL tets/smoke/swaps/swap-action-smoke.spec.js (232.814 s)
     SmokeSwaps Swap from Actions
       ✓ should Swap .05 'ETH' to 'USDT' (90488 ms)
       ✕ should Swap 100 'USDT' to 'ETH' (50549 ms)

--- a/docs/readme/e2e-testing.md
+++ b/docs/readme/e2e-testing.md
@@ -670,7 +670,7 @@ Our CI/CD process is automated through various Bitrise pipelines, each designed 
 - **Example**:
 
   ```
-  FAIL tets/smoke/swaps/swap-action-smoke.spec.js (232.814 s)
+  FAIL tests/smoke/swaps/swap-action-smoke.spec.js (232.814 s)
     SmokeSwaps Swap from Actions
       ✓ should Swap .05 'ETH' to 'USDT' (90488 ms)
       ✕ should Swap 100 'USDT' to 'ETH' (50549 ms)

--- a/e2e/jest.e2e.config.js
+++ b/e2e/jest.e2e.config.js
@@ -7,10 +7,7 @@ require('dotenv').config({ path: '.e2e.env' });
 
 module.exports = {
   rootDir: '..',
-  testMatch: [
-    '<rootDir>/e2e/specs/**/*.spec.{js,ts}',
-    '<rootDir>/tests/**/*.spec.{js,ts}',
-  ],
+  testMatch: ['<rootDir>/tests/**/*.spec.{js,ts}'],
   testTimeout: 300000,
   maxWorkers: 1,
   clearMocks: true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -52,6 +52,7 @@ const config = {
   ],
   testPathIgnorePatterns: [
     '.*/tests/(smoke|regression)/.*\\.spec\\.(ts|js)$',
+    '.*/e2e/.*\\.spec\\.(ts|js)$',
     '.*/e2e/pages/',
     '.*/e2e/selectors/',
   ],

--- a/jest.config.js
+++ b/jest.config.js
@@ -51,7 +51,7 @@ const config = {
     '<rootDir>/app/features/SampleFeature/e2e/',
   ],
   testPathIgnorePatterns: [
-    '.*/e2e/specs/.*\\.spec\\.(ts|js)$',
+    '.*/tests/(smoke|regression)/.*\\.spec\\.(ts|js)$',
     '.*/e2e/pages/',
     '.*/e2e/selectors/',
   ],

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "build:ios:qa": "./scripts/build.sh ios QA",
     "build:attribution": "./scripts/generate-attributions.sh",
     "test": "yarn test:unit",
-    "test:unit": "jest ./app/ ./locales/ ./tests/**/*.test.ts .github/**/*.test.ts --testPathIgnorePatterns='.*/e2e/specs/.*\\.spec\\.(ts|tsx|js)$|.*\\.view(\\..*)?\\.test\\.(ts|tsx|js|jsx)$'",
+    "test:unit": "jest ./app/ ./locales/ ./tests/**/*.test.ts .github/**/*.test.ts --testPathIgnorePatterns='.*/tests/(smoke|regression)/.*\\.spec\\.(ts|tsx|js)$|.*\\.view(\\..*)?\\.test\\.(ts|tsx|js|jsx)$'",
     "test:view": "jest -c jest.config.view.js --runInBand --no-watchman --verbose --testPathPattern='.*\\.view(\\..*)?\\.test\\.(ts|tsx|js|jsx)$'",
     "test:unit:update": "time jest -u ./app/",
     "test:api-specs": "detox reset-lock-file && detox test -c ios.sim.apiSpecs",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "build:ios:qa": "./scripts/build.sh ios QA",
     "build:attribution": "./scripts/generate-attributions.sh",
     "test": "yarn test:unit",
-    "test:unit": "jest ./app/ ./locales/ ./tests/**/*.test.ts .github/**/*.test.ts --testPathIgnorePatterns='.*/tests/(smoke|regression)/.*\\.spec\\.(ts|tsx|js)$|.*\\.view(\\..*)?\\.test\\.(ts|tsx|js|jsx)$'",
+    "test:unit": "jest ./app/ ./locales/ ./tests/**/*.test.ts .github/**/*.test.ts --testPathIgnorePatterns='.*/tests/(smoke|regression)/.*\\.spec\\.(ts|tsx|js)$|.*/e2e/.*\\.spec\\.(ts|tsx|js)$|.*\\.view(\\..*)?\\.test\\.(ts|tsx|js|jsx)$'",
     "test:view": "jest -c jest.config.view.js --runInBand --no-watchman --verbose --testPathPattern='.*\\.view(\\..*)?\\.test\\.(ts|tsx|js|jsx)$'",
     "test:unit:update": "time jest -u ./app/",
     "test:api-specs": "detox reset-lock-file && detox test -c ios.sim.apiSpecs",

--- a/scripts/run-e2e-tags.sh
+++ b/scripts/run-e2e-tags.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # Constants
-BASE_DIR="./e2e/specs"
+BASE_DIR="./tests/smoke"
 # TEST_SUITE_TAG=".*SmokeEarn.*"
 
 echo "Searching for tests with pattern: $TEST_SUITE_TAG"

--- a/tests/docs/README.md
+++ b/tests/docs/README.md
@@ -11,7 +11,8 @@
 
 ## E2E Framework Structure
 
-- **Testing Scenarios (`e2e/specs/`)** - Test files organized by feature
+- **Regression Testing Scenarios (`e2e/regression/`)** - Regression Test files organized by feature
+- **Snoke Testing Scenarios (`e2e/smoke/`)** - Smoke Test files organized by feature
 - **TypeScript Framework (`tests/framework/`)**: Modern testing framework with type safety
 - **Legacy JavaScript (`e2e/utils/`)**: Deprecated utilities being migrated
 - **Page Objects (`e2e/pages/`)**: Page Object Model implementation
@@ -30,7 +31,8 @@
 **Key E2E Directories:**
 
 - `tests/framework/` - TypeScript framework foundation (USE THIS)
-- `e2e/specs/` - Test files organized by feature
+- `tests/smoke/` - Smoke Test files organized by feature
+- `tests/regression/` - Regression Test files organized by feature
 - `e2e/pages/` - Page Object classes following POM pattern
 - `e2e/selectors/` - Element selectors (avoid direct use in tests)
 - `tests/api-mocking/` - API mocking utilities and responses

--- a/tests/regression/multichain/permissions/accounts/permission-system-delete-wallet.failing.ts
+++ b/tests/regression/multichain/permissions/accounts/permission-system-delete-wallet.failing.ts
@@ -1,27 +1,30 @@
-import TestHelpers from '../../helpers';
-import { RegressionNetworkAbstractions } from '../../tags';
-import OnboardingView from '../../pages/Onboarding/OnboardingView';
-import ProtectYourWalletView from '../../pages/Onboarding/ProtectYourWalletView';
-import CreatePasswordView from '../../pages/Onboarding/CreatePasswordView';
-import WalletView from '../../pages/wallet/WalletView';
-import Browser from '../../pages/Browser/BrowserView';
-import SettingsView from '../../pages/Settings/SettingsView';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
-import SkipAccountSecurityModal from '../../pages/Onboarding/SkipAccountSecurityModal';
-import ConnectedAccountsModal from '../../pages/Browser/ConnectedAccountsModal';
-import DeleteWalletModal from '../../pages/Settings/SecurityAndPrivacy/DeleteWalletModal';
-import LoginView from '../../pages/wallet/LoginView';
-import NetworkListModal from '../../pages/Network/NetworkListModal';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import MetaMetricsOptIn from '../../pages/Onboarding/MetaMetricsOptInView';
-import ProtectYourWalletModal from '../../pages/Onboarding/ProtectYourWalletModal';
-import OnboardingSuccessView from '../../pages/Onboarding/OnboardingSuccessView';
-import Assertions from '../../../tests/framework/Assertions';
-import ToastModal from '../../pages/wallet/ToastModal';
-import OnboardingSheet from '../../pages/Onboarding/OnboardingSheet';
-import { DappVariants } from '../../../tests/framework/Constants';
+import TestHelpers from '../../../../../e2e/helpers';
+import { RegressionNetworkAbstractions } from '../../../../../e2e/tags';
+import OnboardingView from '../../../../../e2e/pages/Onboarding/OnboardingView';
+import ProtectYourWalletView from '../../../../../e2e/pages/Onboarding/ProtectYourWalletView';
+import CreatePasswordView from '../../../../../e2e/pages/Onboarding/CreatePasswordView';
+import WalletView from '../../../../../e2e/pages/wallet/WalletView';
+import Browser from '../../../../../e2e/pages/Browser/BrowserView';
+import SettingsView from '../../../../../e2e/pages/Settings/SettingsView';
+import TabBarComponent from '../../../../../e2e/pages/wallet/TabBarComponent';
+import SkipAccountSecurityModal from '../../../../../e2e/pages/Onboarding/SkipAccountSecurityModal';
+import ConnectedAccountsModal from '../../../../../e2e/pages/Browser/ConnectedAccountsModal';
+import DeleteWalletModal from '../../../../../e2e/pages/Settings/SecurityAndPrivacy/DeleteWalletModal';
+import LoginView from '../../../../../e2e/pages/wallet/LoginView';
+import NetworkListModal from '../../../../../e2e/pages/Network/NetworkListModal';
+import {
+  loginToApp,
+  navigateToBrowserView,
+} from '../../../../../e2e/viewHelper';
+import FixtureBuilder from '../../../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../../../framework/fixtures/FixtureHelper';
+import MetaMetricsOptIn from '../../../../../e2e/pages/Onboarding/MetaMetricsOptInView';
+import ProtectYourWalletModal from '../../../../../e2e/pages/Onboarding/ProtectYourWalletModal';
+import OnboardingSuccessView from '../../../../../e2e/pages/Onboarding/OnboardingSuccessView';
+import Assertions from '../../../../framework/Assertions';
+import ToastModal from '../../../../../e2e/pages/wallet/ToastModal';
+import OnboardingSheet from '../../../../../e2e/pages/Onboarding/OnboardingSheet';
+import { DappVariants } from '../../../../framework/Constants';
 
 const SEEDLESS_ONBOARDING_ENABLED =
   process.env.SEEDLESS_ONBOARDING_ENABLED === 'true';

--- a/tests/regression/multichain/permissions/accounts/permission-system-removing-imported-account.failing.ts
+++ b/tests/regression/multichain/permissions/accounts/permission-system-removing-imported-account.failing.ts
@@ -1,25 +1,25 @@
-import TestHelpers from '../../helpers';
-import { RegressionNetworkAbstractions } from '../../tags';
-import WalletView from '../../pages/wallet/WalletView';
-import ImportAccountView from '../../pages/importAccount/ImportAccountView';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
+import TestHelpers from '../../../../../e2e/helpers';
+import { RegressionNetworkAbstractions } from '../../../../../e2e/tags';
+import WalletView from '../../../../../e2e/pages/wallet/WalletView';
+import ImportAccountView from '../../../../../e2e/pages/importAccount/ImportAccountView';
+import TabBarComponent from '../../../../../e2e/pages/wallet/TabBarComponent';
 
-import Browser from '../../pages/Browser/BrowserView';
-import AccountListBottomSheet from '../../pages/wallet/AccountListBottomSheet';
+import Browser from '../../../../../e2e/pages/Browser/BrowserView';
+import AccountListBottomSheet from '../../../../../e2e/pages/wallet/AccountListBottomSheet';
 
-import ConnectBottomSheet from '../../pages/Browser/ConnectBottomSheet';
-import ConnectedAccountsModal from '../../pages/Browser/ConnectedAccountsModal';
-import NetworkListModal from '../../pages/Network/NetworkListModal';
-import NetworkEducationModal from '../../pages/Network/NetworkEducationModal';
+import ConnectBottomSheet from '../../../../../e2e/pages/Browser/ConnectBottomSheet';
+import ConnectedAccountsModal from '../../../../../e2e/pages/Browser/ConnectedAccountsModal';
+import NetworkListModal from '../../../../../e2e/pages/Network/NetworkListModal';
+import NetworkEducationModal from '../../../../../e2e/pages/Network/NetworkEducationModal';
 
-import Accounts from '../../../wdio/helpers/Accounts';
+import Accounts from '../../../../../wdio/helpers/Accounts';
 import {
   importWalletWithRecoveryPhrase,
   navigateToBrowserView,
-} from '../../viewHelper';
-import AddAccountBottomSheet from '../../pages/wallet/AddAccountBottomSheet';
-import Assertions from '../../../tests/framework/Assertions';
-import SuccessImportAccountView from '../../pages/importAccount/SuccessImportAccountView';
+} from '../../../../../e2e/viewHelper';
+import AddAccountBottomSheet from '../../../../../e2e/pages/wallet/AddAccountBottomSheet';
+import Assertions from '../../../../framework/Assertions';
+import SuccessImportAccountView from '../../../../../e2e/pages/importAccount/SuccessImportAccountView';
 
 const SEPOLIA = 'Sepolia';
 

--- a/tests/regression/multichain/permissions/chains/multiple-dapps.failing.ts
+++ b/tests/regression/multichain/permissions/chains/multiple-dapps.failing.ts
@@ -1,20 +1,23 @@
-import TestHelpers from '../../../../../helpers';
-import { RegressionNetworkExpansion } from '../../../../../tags';
-import Browser from '../../../../../pages/Browser/BrowserView';
-import TabBarComponent from '../../../../../pages/wallet/TabBarComponent';
-import NetworkListModal from '../../../../../pages/Network/NetworkListModal';
-import ConnectedAccountsModal from '../../../../../pages/Browser/ConnectedAccountsModal';
-import FixtureBuilder from '../../../../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../../../../tests/framework/fixtures/FixtureHelper';
-import { loginToApp, navigateToBrowserView } from '../../../../../viewHelper';
-import Assertions from '../../../../../../tests/framework/Assertions';
-import WalletView from '../../../../../pages/wallet/WalletView';
-import NetworkNonPemittedBottomSheet from '../../../../../pages/Network/NetworkNonPemittedBottomSheet';
-import NetworkConnectMultiSelector from '../../../../../pages/Browser/NetworkConnectMultiSelector';
-import NetworkEducationModal from '../../../../../pages/Network/NetworkEducationModal';
-import PermissionSummaryBottomSheet from '../../../../../pages/Browser/PermissionSummaryBottomSheet';
-import { DappVariants } from '../../../../../../tests/framework/Constants';
-import TestDApp from '../../../../../pages/Browser/TestDApp';
+import TestHelpers from '../../../../../e2e/helpers';
+import { RegressionNetworkExpansion } from '../../../../../e2e/tags';
+import Browser from '../../../../../e2e/pages/Browser/BrowserView';
+import TabBarComponent from '../../../../../e2e/pages/wallet/TabBarComponent';
+import NetworkListModal from '../../../../../e2e/pages/Network/NetworkListModal';
+import ConnectedAccountsModal from '../../../../../e2e/pages/Browser/ConnectedAccountsModal';
+import FixtureBuilder from '../../../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../../../framework/fixtures/FixtureHelper';
+import {
+  loginToApp,
+  navigateToBrowserView,
+} from '../../../../../e2e/viewHelper';
+import Assertions from '../../../../framework/Assertions';
+import WalletView from '../../../../../e2e/pages/wallet/WalletView';
+import NetworkNonPemittedBottomSheet from '../../../../../e2e/pages/Network/NetworkNonPemittedBottomSheet';
+import NetworkConnectMultiSelector from '../../../../../e2e/pages/Browser/NetworkConnectMultiSelector';
+import NetworkEducationModal from '../../../../../e2e/pages/Network/NetworkEducationModal';
+import PermissionSummaryBottomSheet from '../../../../../e2e/pages/Browser/PermissionSummaryBottomSheet';
+import { DappVariants } from '../../../../framework/Constants';
+import TestDApp from '../../../../../e2e/pages/Browser/TestDApp';
 
 /*
 Test Steps:

--- a/tests/regression/ramps/deeplink-to-sell-flow.failing.ts
+++ b/tests/regression/ramps/deeplink-to-sell-flow.failing.ts
@@ -1,16 +1,16 @@
-import { loginToApp } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import TestHelpers from '../../helpers';
-import SellGetStartedView from '../../pages/Ramps/SellGetStartedView';
-import { RegressionTrade } from '../../tags';
-import BuildQuoteView from '../../pages/Ramps/BuildQuoteView';
-import Assertions from '../../../tests/framework/Assertions';
-import NetworkApprovalBottomSheet from '../../pages/Network/NetworkApprovalBottomSheet';
-import NetworkAddedBottomSheet from '../../pages/Network/NetworkAddedBottomSheet';
-import NetworkEducationModal from '../../pages/Network/NetworkEducationModal';
-import NetworkListModal from '../../pages/Network/NetworkListModal';
-import { PopularNetworksList } from '../../../tests/resources/networks.e2e';
+import { loginToApp } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestHelpers from '../../../e2e/helpers';
+import SellGetStartedView from '../../../e2e/pages/Ramps/SellGetStartedView';
+import { RegressionTrade } from '../../../e2e/tags';
+import BuildQuoteView from '../../../e2e/pages/Ramps/BuildQuoteView';
+import Assertions from '../../framework/Assertions';
+import NetworkApprovalBottomSheet from '../../../e2e/pages/Network/NetworkApprovalBottomSheet';
+import NetworkAddedBottomSheet from '../../../e2e/pages/Network/NetworkAddedBottomSheet';
+import NetworkEducationModal from '../../../e2e/pages/Network/NetworkEducationModal';
+import NetworkListModal from '../../../e2e/pages/Network/NetworkListModal';
+import { PopularNetworksList } from '../../resources/networks.e2e';
 
 // This test was migrated to the new framework but should be reworked to use withFixtures properly
 describe(RegressionTrade('Sell Crypto Deeplinks'), () => {

--- a/tests/regression/swap/swap-action-regression.failing.ts
+++ b/tests/regression/swap/swap-action-regression.failing.ts
@@ -1,18 +1,18 @@
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { LocalNode, LocalNodeType } from '../../../tests/framework/types';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
-import WalletView from '../../pages/wallet/WalletView';
-import { RegressionTrade } from '../../tags';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { LocalNode, LocalNodeType } from '../../framework/types';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import TabBarComponent from '../../../e2e/pages/wallet/TabBarComponent';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import { RegressionTrade } from '../../../e2e/tags';
 import {
   submitSwapUnifiedUI,
   checkSwapActivity,
-} from '../../../tests/helpers/swap/swap-unified-ui';
-import { loginToApp } from '../../viewHelper';
-import { prepareSwapsTestEnvironment } from '../../../tests/helpers/swap/prepareSwapsTestEnvironment';
-import { testSpecificMock } from '../../../tests/helpers/swap/swap-mocks';
-import { AnvilPort } from '../../../tests/framework/fixtures/FixtureUtils';
-import { AnvilManager } from '../../../tests/seeder/anvil-manager';
+} from '../../helpers/swap/swap-unified-ui';
+import { loginToApp } from '../../../e2e/viewHelper';
+import { prepareSwapsTestEnvironment } from '../../helpers/swap/prepareSwapsTestEnvironment';
+import { testSpecificMock } from '../../helpers/swap/swap-mocks';
+import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
+import { AnvilManager } from '../../seeder/anvil-manager';
 
 describe(RegressionTrade('Multiple Swaps from Actions'), (): void => {
   beforeEach(async (): Promise<void> => {

--- a/tests/regression/wallet/deeplinks.failing.ts
+++ b/tests/regression/wallet/deeplinks.failing.ts
@@ -1,21 +1,21 @@
-import TestHelpers from '../../helpers';
-import { RegressionWalletPlatform } from '../../tags';
-import ConnectBottomSheet from '../../pages/Browser/ConnectBottomSheet';
-import NetworkApprovalBottomSheet from '../../pages/Network/NetworkApprovalBottomSheet';
-import NetworkAddedBottomSheet from '../../pages/Network/NetworkAddedBottomSheet';
-import Browser from '../../pages/Browser/BrowserView';
-import NetworkView from '../../pages/Settings/NetworksView';
-import SettingsView from '../../pages/Settings/SettingsView';
-import LoginView from '../../pages/wallet/LoginView';
-import TransactionConfirmationView from '../../pages/Send/TransactionConfirmView';
-import SecurityAndPrivacy from '../../pages/Settings/SecurityAndPrivacy/SecurityAndPrivacyView';
-import CommonView from '../../pages/CommonView';
-import WalletView from '../../pages/wallet/WalletView';
-import { importWalletWithRecoveryPhrase } from '../../viewHelper';
+import TestHelpers from '../../../e2e/helpers';
+import { RegressionWalletPlatform } from '../../../e2e/tags';
+import ConnectBottomSheet from '../../../e2e/pages/Browser/ConnectBottomSheet';
+import NetworkApprovalBottomSheet from '../../../e2e/pages/Network/NetworkApprovalBottomSheet';
+import NetworkAddedBottomSheet from '../../../e2e/pages/Network/NetworkAddedBottomSheet';
+import Browser from '../../../e2e/pages/Browser/BrowserView';
+import NetworkView from '../../../e2e/pages/Settings/NetworksView';
+import SettingsView from '../../../e2e/pages/Settings/SettingsView';
+import LoginView from '../../../e2e/pages/wallet/LoginView';
+import TransactionConfirmationView from '../../../e2e/pages/Send/TransactionConfirmView';
+import SecurityAndPrivacy from '../../../e2e/pages/Settings/SecurityAndPrivacy/SecurityAndPrivacyView';
+import CommonView from '../../../e2e/pages/CommonView';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import { importWalletWithRecoveryPhrase } from '../../../e2e/viewHelper';
 import Accounts from '../../../wdio/helpers/Accounts';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
-import Assertions from '../../../tests/framework/Assertions';
-import { PopularNetworksList } from '../../../tests/resources/networks.e2e';
+import TabBarComponent from '../../../e2e/pages/wallet/TabBarComponent';
+import Assertions from '../../framework/Assertions';
+import { PopularNetworksList } from '../../resources/networks.e2e';
 
 //const BINANCE_RPC_URL = 'https://bsc-dataseed1.binance.org';
 

--- a/tests/regression/wallet/start-exploring.failing.ts
+++ b/tests/regression/wallet/start-exploring.failing.ts
@@ -1,13 +1,13 @@
-import { RegressionWalletPlatform } from '../../tags';
-import TestHelpers from '../../helpers';
-import OnboardingView from '../../pages/Onboarding/OnboardingView';
-import OnboardingCarouselView from '../../pages/Onboarding/OnboardingCarouselView';
-import ProtectYourWalletView from '../../pages/Onboarding/ProtectYourWalletView';
-import CreatePasswordView from '../../pages/Onboarding/CreatePasswordView';
-import OnboardingSuccessView from '../../pages/Onboarding/OnboardingSuccessView';
-import SkipAccountSecurityModal from '../../pages/Onboarding/SkipAccountSecurityModal';
-import { acceptTermOfUse } from '../../viewHelper';
-import Assertions from '../../../tests/framework/Assertions';
+import { RegressionWalletPlatform } from '../../../e2e/tags';
+import TestHelpers from '../../../e2e/helpers';
+import OnboardingView from '../../../e2e/pages/Onboarding/OnboardingView';
+import OnboardingCarouselView from '../../../e2e/pages/Onboarding/OnboardingCarouselView';
+import ProtectYourWalletView from '../../../e2e/pages/Onboarding/ProtectYourWalletView';
+import CreatePasswordView from '../../../e2e/pages/Onboarding/CreatePasswordView';
+import OnboardingSuccessView from '../../../e2e/pages/Onboarding/OnboardingSuccessView';
+import SkipAccountSecurityModal from '../../../e2e/pages/Onboarding/SkipAccountSecurityModal';
+import { acceptTermOfUse } from '../../../e2e/viewHelper';
+import Assertions from '../../framework/Assertions';
 
 const PASSWORD = '12345678';
 

--- a/tests/regression/wallet/token-details.failing.ts
+++ b/tests/regression/wallet/token-details.failing.ts
@@ -1,13 +1,13 @@
-import { RegressionTrade } from '../../tags';
-import WalletView from '../../pages/wallet/WalletView';
-import TokenOverview from '../../pages/wallet/TokenOverview';
+import { RegressionTrade } from '../../../e2e/tags';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import TokenOverview from '../../../e2e/pages/wallet/TokenOverview';
 import {
   importWalletWithRecoveryPhrase,
   switchToSepoliaNetwork,
-} from '../../viewHelper';
-import Assertions from '../../../tests/framework/Assertions';
-import CommonView from '../../pages/CommonView';
-import TestHelpers from '../../helpers';
+} from '../../../e2e/viewHelper';
+import Assertions from '../../framework/Assertions';
+import CommonView from '../../../e2e/pages/CommonView';
+import TestHelpers from '../../../e2e/helpers';
 
 // This test was migrated to the new framework but should be reworked to use withFixtures properly
 describe(RegressionTrade('Token Chart Tests'), () => {

--- a/tests/smoke/accounts/create-wallet-account.failing.ts
+++ b/tests/smoke/accounts/create-wallet-account.failing.ts
@@ -1,12 +1,12 @@
-import { SmokeAccounts } from '../../tags.js';
-import WalletView from '../../pages/wallet/WalletView.js';
-import AccountListBottomSheet from '../../pages/wallet/AccountListBottomSheet.js';
-import Assertions from '../../../tests/framework/Assertions.js';
-import { withMultichainAccountDetailsV2EnabledFixtures } from '../../../tests/helpers/multichain-accounts/common.js';
-import AccountDetails from '../../pages/MultichainAccounts/AccountDetails.js';
-import AddressList from '../../pages/MultichainAccounts/AddressList.js';
-import { defaultGanacheOptions } from '../../../tests/framework/Constants.js';
-import { completeSrpQuiz } from '../../../tests/flows/accounts.flow.js';
+import { SmokeAccounts } from '../../../e2e/tags.js';
+import WalletView from '../../../e2e/pages/wallet/WalletView.js';
+import AccountListBottomSheet from '../../../e2e/pages/wallet/AccountListBottomSheet.js';
+import Assertions from '../../framework/Assertions.js';
+import { withMultichainAccountDetailsV2EnabledFixtures } from '../../helpers/multichain-accounts/common.js';
+import AccountDetails from '../../../e2e/pages/MultichainAccounts/AccountDetails.js';
+import AddressList from '../../../e2e/pages/MultichainAccounts/AddressList.js';
+import { defaultGanacheOptions } from '../../framework/Constants.js';
+import { completeSrpQuiz } from '../../flows/accounts.flow.js';
 
 // Quarantining, See open ticket here: https://github.com/MetaMask/metamask-mobile/issues/21429
 describe(SmokeAccounts('Create wallet accounts'), () => {

--- a/tests/smoke/multichain/permissions/accounts/permission-system-remove.failing.ts
+++ b/tests/smoke/multichain/permissions/accounts/permission-system-remove.failing.ts
@@ -1,24 +1,27 @@
-import TestHelpers from '../../helpers';
-import { SmokeNetworkAbstractions } from '../../tags';
-import Browser from '../../pages/Browser/BrowserView';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
+import TestHelpers from '../../../../../e2e/helpers';
+import { SmokeNetworkAbstractions } from '../../../../../e2e/tags';
+import Browser from '../../../../../e2e/pages/Browser/BrowserView';
+import TabBarComponent from '../../../../../e2e/pages/wallet/TabBarComponent';
 
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import Assertions from '../../../tests/framework/Assertions';
+import FixtureBuilder from '../../../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../../../framework/fixtures/FixtureHelper';
+import {
+  loginToApp,
+  navigateToBrowserView,
+} from '../../../../../e2e/viewHelper';
+import Assertions from '../../../../framework/Assertions';
 
-import { PopularNetworksList } from '../../../tests/resources/networks.e2e';
+import { PopularNetworksList } from '../../../../resources/networks.e2e';
 
-import WalletView from '../../pages/wallet/WalletView';
-import NetworkListModal from '../../pages/Network/NetworkListModal';
-import TestDApp from '../../pages/Browser/TestDApp';
-import ConnectBottomSheet from '../../pages/Browser/ConnectBottomSheet';
-import PermissionSummaryBottomSheet from '../../pages/Browser/PermissionSummaryBottomSheet';
-import NetworkConnectMultiSelector from '../../pages/Browser/NetworkConnectMultiSelector';
-import NetworkNonPemittedBottomSheet from '../../pages/Network/NetworkNonPemittedBottomSheet';
-import ConnectedAccountsModal from '../../pages/Browser/ConnectedAccountsModal';
-import { DappVariants } from '../../../tests/framework/Constants';
+import WalletView from '../../../../../e2e/pages/wallet/WalletView';
+import NetworkListModal from '../../../../../e2e/pages/Network/NetworkListModal';
+import TestDApp from '../../../../../e2e/pages/Browser/TestDApp';
+import ConnectBottomSheet from '../../../../../e2e/pages/Browser/ConnectBottomSheet';
+import PermissionSummaryBottomSheet from '../../../../../e2e/pages/Browser/PermissionSummaryBottomSheet';
+import NetworkConnectMultiSelector from '../../../../../e2e/pages/Browser/NetworkConnectMultiSelector';
+import NetworkNonPemittedBottomSheet from '../../../../../e2e/pages/Network/NetworkNonPemittedBottomSheet';
+import ConnectedAccountsModal from '../../../../../e2e/pages/Browser/ConnectedAccountsModal';
+import { DappVariants } from '../../../../framework/Constants';
 
 // This test was migrated to the new framework but should be reworked to use withFixtures properly
 describe(SmokeNetworkAbstractions('Chain Permission Management'), () => {

--- a/tests/smoke/multichain/permissions/accounts/permission-system-update-permissions.failing.ts
+++ b/tests/smoke/multichain/permissions/accounts/permission-system-update-permissions.failing.ts
@@ -1,21 +1,24 @@
-import { SmokeNetworkAbstractions } from '../../tags';
-import Browser from '../../pages/Browser/BrowserView';
-import ConnectedAccountsModal from '../../pages/Browser/ConnectedAccountsModal';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import Assertions from '../../../tests/framework/Assertions';
-import NetworkConnectMultiSelector from '../../pages/Browser/NetworkConnectMultiSelector';
-import NetworkNonPemittedBottomSheet from '../../pages/Network/NetworkNonPemittedBottomSheet';
-import { CustomNetworks } from '../../../tests/resources/networks.e2e';
-import PermissionSummaryBottomSheet from '../../pages/Browser/PermissionSummaryBottomSheet';
-import { NetworkNonPemittedBottomSheetSelectorsText } from '../../../app/components/Views/NetworkConnect/NetworkNonPemittedBottomSheet.testIds';
-import NetworkListModal from '../../pages/Network/NetworkListModal';
-import ToastModal from '../../pages/wallet/ToastModal';
-import AccountListBottomSheet from '../../pages/wallet/AccountListBottomSheet';
-import AddNewAccountSheet from '../../pages/wallet/AddNewAccountSheet';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { DappVariants } from '../../../tests/framework/Constants';
-import { logger } from '../../../tests/framework/logger';
+import { SmokeNetworkAbstractions } from '../../../../../e2e/tags';
+import Browser from '../../../../../e2e/pages/Browser/BrowserView';
+import ConnectedAccountsModal from '../../../../../e2e/pages/Browser/ConnectedAccountsModal';
+import {
+  loginToApp,
+  navigateToBrowserView,
+} from '../../../../../e2e/viewHelper';
+import Assertions from '../../../../framework/Assertions';
+import NetworkConnectMultiSelector from '../../../../../e2e/pages/Browser/NetworkConnectMultiSelector';
+import NetworkNonPemittedBottomSheet from '../../../../../e2e/pages/Network/NetworkNonPemittedBottomSheet';
+import { CustomNetworks } from '../../../../resources/networks.e2e';
+import PermissionSummaryBottomSheet from '../../../../../e2e/pages/Browser/PermissionSummaryBottomSheet';
+import { NetworkNonPemittedBottomSheetSelectorsText } from '../../../../../app/components/Views/NetworkConnect/NetworkNonPemittedBottomSheet.testIds';
+import NetworkListModal from '../../../../../e2e/pages/Network/NetworkListModal';
+import ToastModal from '../../../../../e2e/pages/wallet/ToastModal';
+import AccountListBottomSheet from '../../../../../e2e/pages/wallet/AccountListBottomSheet';
+import AddNewAccountSheet from '../../../../../e2e/pages/wallet/AddNewAccountSheet';
+import FixtureBuilder from '../../../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../../../framework/fixtures/FixtureHelper';
+import { DappVariants } from '../../../../framework/Constants';
+import { logger } from '../../../../framework/logger';
 
 const accountOneText = 'Account 1';
 const accountTwoText = 'Account 2';

--- a/tests/smoke/multichain/permissions/chains/permission-system-add-non-permitted.failing.js
+++ b/tests/smoke/multichain/permissions/chains/permission-system-add-non-permitted.failing.js
@@ -1,23 +1,26 @@
 import {
   RegressionNetworkExpansion,
   SmokeNetworkExpansion,
-} from '../../../../../tags';
-import { loginToApp, navigateToBrowserView } from '../../../../../viewHelper';
-import Assertions from '../../../../../../tests/framework/Assertions';
-import TestHelpers from '../../../../../helpers';
-import FixtureBuilder from '../../../../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../../../../tests/framework/fixtures/FixtureHelper';
-import { CustomNetworks } from '../../../../../../tests/resources/networks.e2e';
-import Browser from '../../../../../pages/Browser/BrowserView';
-import TabBarComponent from '../../../../../pages/wallet/TabBarComponent';
-import { NetworkNonPemittedBottomSheetSelectorsText } from '../../../../../../app/components/Views/NetworkConnect/NetworkNonPemittedBottomSheet.testIds';
-import ConnectedAccountsModal from '../../../../../pages/Browser/ConnectedAccountsModal';
-import NetworkConnectMultiSelector from '../../../../../pages/Browser/NetworkConnectMultiSelector';
-import { DappVariants } from '../../../../../../tests/framework/Constants';
-import WalletView from '../../../../../pages/wallet/WalletView';
-import NetworkListModal from '../../../../../pages/Network/NetworkListModal';
-import TestDApp from '../../../../../pages/Browser/TestDApp';
-import ConnectBottomSheet from '../../../../../pages/Browser/ConnectBottomSheet';
+} from '../../../../../e2e/tags';
+import {
+  loginToApp,
+  navigateToBrowserView,
+} from '../../../../../e2e/viewHelper';
+import Assertions from '../../../../framework/Assertions';
+import TestHelpers from '../../../../../e2e/helpers';
+import FixtureBuilder from '../../../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../../../framework/fixtures/FixtureHelper';
+import { CustomNetworks } from '../../../../resources/networks.e2e';
+import Browser from '../../../../../e2e/pages/Browser/BrowserView';
+import TabBarComponent from '../../../../../e2e/pages/wallet/TabBarComponent';
+import { NetworkNonPemittedBottomSheetSelectorsText } from '../../../../../app/components/Views/NetworkConnect/NetworkNonPemittedBottomSheet.testIds';
+import ConnectedAccountsModal from '../../../../../e2e/pages/Browser/ConnectedAccountsModal';
+import NetworkConnectMultiSelector from '../../../../../e2e/pages/Browser/NetworkConnectMultiSelector';
+import { DappVariants } from '../../../../framework/Constants';
+import WalletView from '../../../../../e2e/pages/wallet/WalletView';
+import NetworkListModal from '../../../../../e2e/pages/Network/NetworkListModal';
+import TestDApp from '../../../../../e2e/pages/Browser/TestDApp';
+import ConnectBottomSheet from '../../../../../e2e/pages/Browser/ConnectBottomSheet';
 
 const SEPOLIA = CustomNetworks.Sepolia.providerConfig.nickname;
 const ETHEREUM_MAIN_NET_NETWORK_NAME =

--- a/tests/smoke/multichain/solana-send-flow.failing.ts
+++ b/tests/smoke/multichain/solana-send-flow.failing.ts
@@ -1,15 +1,15 @@
-import { SmokeNetworkExpansion } from '../../tags';
-import { importWalletWithRecoveryPhrase } from '../../viewHelper';
-import Assertions from '../../../tests/framework/Assertions';
-import TestHelpers from '../../helpers';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
-import WalletView from '../../pages/wallet/WalletView';
-import ActivitiesView from '../../pages/Transactions/ActivitiesView';
-import SnapSendActionSheet from '../../pages/wallet/SendActionBottomSheet';
-import NetworkEducationModal from '../../pages/Network/NetworkEducationModal';
-import AccountListBottomSheet from '../../pages/wallet/AccountListBottomSheet';
-import AddAccountBottomSheet from '../../pages/wallet/AddAccountBottomSheet';
-import AddNewHdAccountComponent from '../../pages/wallet/MultiSrp/AddAccountToSrp/AddNewHdAccountComponent';
+import { SmokeNetworkExpansion } from '../../../e2e/tags';
+import { importWalletWithRecoveryPhrase } from '../../../e2e/viewHelper';
+import Assertions from '../../framework/Assertions';
+import TestHelpers from '../../../e2e/helpers';
+import TabBarComponent from '../../../e2e/pages/wallet/TabBarComponent';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import ActivitiesView from '../../../e2e/pages/Transactions/ActivitiesView';
+import SnapSendActionSheet from '../../../e2e/pages/wallet/SendActionBottomSheet';
+import NetworkEducationModal from '../../../e2e/pages/Network/NetworkEducationModal';
+import AccountListBottomSheet from '../../../e2e/pages/wallet/AccountListBottomSheet';
+import AddAccountBottomSheet from '../../../e2e/pages/wallet/AddAccountBottomSheet';
+import AddNewHdAccountComponent from '../../../e2e/pages/wallet/MultiSrp/AddAccountToSrp/AddNewHdAccountComponent';
 
 // Test constants
 const INVALID_ADDRESS = 'invalid address';

--- a/tests/smoke/multichain/solana-wallet-standard/wallet-invokeMethod.failing.ts
+++ b/tests/smoke/multichain/solana-wallet-standard/wallet-invokeMethod.failing.ts
@@ -2,21 +2,21 @@
  * E2E tests for Solana methods using Multichain API
  */
 import { SolScope } from '@metamask/keyring-api';
-import TestHelpers from '../../helpers';
-import { SmokeMultiChainAPI } from '../../tags';
-import Browser from '../../pages/Browser/BrowserView';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { loginToApp, navigateToBrowserView } from '../../viewHelper';
-import Assertions from '../../../tests/framework/Assertions';
-import MultichainTestDApp from '../../pages/Browser/MultichainTestDApp';
-import AddNewHdAccountComponent from '../../pages/wallet/MultiSrp/AddAccountToSrp/AddNewHdAccountComponent';
-import Gestures from '../../../tests/framework/Gestures';
-import Matchers from '../../../tests/framework/Matchers';
-import WalletView from '../../pages/wallet/WalletView';
-import AccountListBottomSheet from '../../pages/wallet/AccountListBottomSheet';
-import AddAccountBottomSheet from '../../pages/wallet/AddAccountBottomSheet';
-import { DappVariants } from '../../../tests/framework/Constants';
+import TestHelpers from '../../../../e2e/helpers';
+import { SmokeMultiChainAPI } from '../../../../e2e/tags';
+import Browser from '../../../../e2e/pages/Browser/BrowserView';
+import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
+import { loginToApp, navigateToBrowserView } from '../../../../e2e/viewHelper';
+import Assertions from '../../../framework/Assertions';
+import MultichainTestDApp from '../../../../e2e/pages/Browser/MultichainTestDApp';
+import AddNewHdAccountComponent from '../../../../e2e/pages/wallet/MultiSrp/AddAccountToSrp/AddNewHdAccountComponent';
+import Gestures from '../../../framework/Gestures';
+import Matchers from '../../../framework/Matchers';
+import WalletView from '../../../../e2e/pages/wallet/WalletView';
+import AccountListBottomSheet from '../../../../e2e/pages/wallet/AccountListBottomSheet';
+import AddAccountBottomSheet from '../../../../e2e/pages/wallet/AddAccountBottomSheet';
+import { DappVariants } from '../../../framework/Constants';
 
 const SOLANA_MAINNET_CHAIN_ID = SolScope.Mainnet;
 

--- a/tests/smoke/multichain/wallet-invokeMethod.failing.ts
+++ b/tests/smoke/multichain/wallet-invokeMethod.failing.ts
@@ -18,23 +18,23 @@
  * 2. Result elements are created in the DOM
  * 3. Results appear in the expected format (truncated vs non-truncated)
  */
-import { SmokeMultiChainAPI } from '../../../tags';
-import FixtureBuilder from '../../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../../tests/framework/fixtures/FixtureHelper';
-import MultichainTestDApp from '../../../pages/Browser/MultichainTestDApp';
-import { BrowserViewSelectorsIDs } from '../../../../app/components/Views/BrowserTab/BrowserView.testIds';
-import MultichainUtilities from '../../../utils/MultichainUtilities';
-import Assertions from '../../../../tests/framework/Assertions';
-import { MULTICHAIN_TEST_TIMEOUTS } from '../../../selectors/Browser/MultichainTestDapp.selectors';
+import { SmokeMultiChainAPI } from '../../../e2e/tags';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import MultichainTestDApp from '../../../e2e/pages/Browser/MultichainTestDApp';
+import { BrowserViewSelectorsIDs } from '../../../app/components/Views/BrowserTab/BrowserView.testIds';
+import MultichainUtilities from '../../../e2e/utils/MultichainUtilities';
+import Assertions from '../../framework/Assertions';
+import { MULTICHAIN_TEST_TIMEOUTS } from '../../../e2e/selectors/Browser/MultichainTestDapp.selectors';
 import { waitFor } from 'detox';
-import FooterActions from '../../../pages/Browser/Confirmations/FooterActions';
+import FooterActions from '../../../e2e/pages/Browser/Confirmations/FooterActions';
 import { isHexString } from '@metamask/utils';
-import { DappVariants } from '../../../../tests/framework/Constants';
-import { LocalNodeType } from '../../../../tests/framework';
-import { AnvilNodeOptions } from '../../../../tests/framework/types';
+import { DappVariants } from '../../framework/Constants';
+import { LocalNodeType } from '../../framework';
+import { AnvilNodeOptions } from '../../framework/types';
 import { Mockttp } from 'mockttp';
-import { setupRemoteFeatureFlagsMock } from '../../../../tests/api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureEip7702 } from '../../../../tests/api-mocking/mock-responses/feature-flags-mocks';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
+import { remoteFeatureEip7702 } from '../../api-mocking/mock-responses/feature-flags-mocks';
 
 const ANVIL_NODE_OPTIONS_WITH_GATOR = [
   {

--- a/tests/smoke/multichain/wallet-notify.failing.ts
+++ b/tests/smoke/multichain/wallet-notify.failing.ts
@@ -27,13 +27,13 @@
  * 4. Infer state by checking presence/absence of specific elements
  * 5. Check for state changes (empty → has notifications) to prove functionality
  */
-import { SmokeMultiChainAPI } from '../../tags';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import MultichainTestDApp from '../../pages/Browser/MultichainTestDApp';
-import MultichainUtilities from '../../utils/MultichainUtilities';
-import Assertions from '../../../tests/framework/Assertions';
-import { DappVariants } from '../../../tests/framework/Constants';
+import { SmokeMultiChainAPI } from '../../../e2e/tags';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import MultichainTestDApp from '../../../e2e/pages/Browser/MultichainTestDApp';
+import MultichainUtilities from '../../../e2e/utils/MultichainUtilities';
+import Assertions from '../../framework/Assertions';
+import { DappVariants } from '../../framework/Constants';
 
 describe(SmokeMultiChainAPI('wallet_notify'), () => {
   beforeEach(() => {

--- a/tests/smoke/ramps/deeplink-to-buy-flow-with-unsupported-network.failing.ts
+++ b/tests/smoke/ramps/deeplink-to-buy-flow-with-unsupported-network.failing.ts
@@ -1,16 +1,16 @@
-import TestHelpers from '../../helpers';
-import { loginToApp } from '../../viewHelper';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { SmokeTrade } from '../../tags';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import SellGetStartedView from '../../pages/Ramps/SellGetStartedView';
-import BuyGetStartedView from '../../pages/Ramps/BuyGetStartedView';
-import Assertions from '../../../tests/framework/Assertions';
-import NetworkAddedBottomSheet from '../../pages/Network/NetworkAddedBottomSheet';
-import NetworkApprovalBottomSheet from '../../pages/Network/NetworkApprovalBottomSheet';
-import NetworkEducationModal from '../../pages/Network/NetworkEducationModal';
-import NetworkListModal from '../../pages/Network/NetworkListModal';
-import { PopularNetworksList } from '../../../tests/resources/networks.e2e';
+import TestHelpers from '../../../e2e/helpers';
+import { loginToApp } from '../../../e2e/viewHelper';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { SmokeTrade } from '../../../e2e/tags';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import SellGetStartedView from '../../../e2e/pages/Ramps/SellGetStartedView';
+import BuyGetStartedView from '../../../e2e/pages/Ramps/BuyGetStartedView';
+import Assertions from '../../framework/Assertions';
+import NetworkAddedBottomSheet from '../../../e2e/pages/Network/NetworkAddedBottomSheet';
+import NetworkApprovalBottomSheet from '../../../e2e/pages/Network/NetworkApprovalBottomSheet';
+import NetworkEducationModal from '../../../e2e/pages/Network/NetworkEducationModal';
+import NetworkListModal from '../../../e2e/pages/Network/NetworkListModal';
+import { PopularNetworksList } from '../../resources/networks.e2e';
 
 // This test was migrated to the new framework but should be reworked to use withFixtures properly
 describe(SmokeTrade('Buy Crypto Deeplinks'), () => {

--- a/tests/smoke/ramps/deeplink-to-buy-flow.failing.ts
+++ b/tests/smoke/ramps/deeplink-to-buy-flow.failing.ts
@@ -1,15 +1,15 @@
-import TestHelpers from '../../helpers';
-import { loginToApp } from '../../viewHelper';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { SmokeRamps } from '../../tags';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import SellGetStartedView from '../../pages/Ramps/SellGetStartedView';
-import BuyGetStartedView from '../../pages/Ramps/BuyGetStartedView';
-import BuildQuoteView from '../../pages/Ramps/BuildQuoteView';
-import TokenSelectBottomSheet from '../../pages/Ramps/TokenSelectBottomSheet';
-import Assertions from '../../../tests/framework/Assertions';
-import { PopularNetworksList } from '../../../tests/resources/networks.e2e';
-import NetworkEducationModal from '../../pages/Network/NetworkEducationModal';
+import TestHelpers from '../../../e2e/helpers';
+import { loginToApp } from '../../../e2e/viewHelper';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { SmokeRamps } from '../../../e2e/tags';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import SellGetStartedView from '../../../e2e/pages/Ramps/SellGetStartedView';
+import BuyGetStartedView from '../../../e2e/pages/Ramps/BuyGetStartedView';
+import BuildQuoteView from '../../../e2e/pages/Ramps/BuildQuoteView';
+import TokenSelectBottomSheet from '../../../e2e/pages/Ramps/TokenSelectBottomSheet';
+import Assertions from '../../framework/Assertions';
+import { PopularNetworksList } from '../../resources/networks.e2e';
+import NetworkEducationModal from '../../../e2e/pages/Network/NetworkEducationModal';
 
 // This test was migrated to the new framework but should be reworked to use withFixtures properly
 describe(SmokeRamps('Buy Crypto Deeplinks'), () => {

--- a/tests/smoke/ramps/offramp-cashout.failing.ts
+++ b/tests/smoke/ramps/offramp-cashout.failing.ts
@@ -1,25 +1,22 @@
-import { loginToApp } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { SmokeTrade } from '../../tags';
-import BuildQuoteView from '../../pages/Ramps/BuildQuoteView';
-import Assertions from '../../../tests/framework/Assertions';
-import WalletView from '../../pages/wallet/WalletView';
-import FundActionMenu from '../../pages/UI/FundActionMenu';
-import SelectPaymentMethodView from '../../pages/Ramps/SelectPaymentMethodView';
-import SellGetStartedView from '../../pages/Ramps/SellGetStartedView';
+import { loginToApp } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { SmokeTrade } from '../../../e2e/tags';
+import BuildQuoteView from '../../../e2e/pages/Ramps/BuildQuoteView';
+import Assertions from '../../framework/Assertions';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import FundActionMenu from '../../../e2e/pages/UI/FundActionMenu';
+import SelectPaymentMethodView from '../../../e2e/pages/Ramps/SelectPaymentMethodView';
+import SellGetStartedView from '../../../e2e/pages/Ramps/SellGetStartedView';
 import {
   EventPayload,
   findEvent,
   getEventsPayloads,
-} from '../../../tests/helpers/analytics/helpers';
-import SoftAssert from '../../../tests/framework/SoftAssert';
-import {
-  RampsRegions,
-  RampsRegionsEnum,
-} from '../../../tests/framework/Constants';
+} from '../../helpers/analytics/helpers';
+import SoftAssert from '../../framework/SoftAssert';
+import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
 import { Mockttp } from 'mockttp';
-import { setupRegionAwareOnRampMocks } from '../../../tests/api-mocking/mock-responses/ramps/ramps-region-aware-mock-setup';
+import { setupRegionAwareOnRampMocks } from '../../api-mocking/mock-responses/ramps/ramps-region-aware-mock-setup';
 
 const PaymentMethods = {
   SEPA_BANK_TRANSFER: 'SEPA Bank Transfer',

--- a/tests/smoke/ramps/offramp.failing.ts
+++ b/tests/smoke/ramps/offramp.failing.ts
@@ -1,25 +1,22 @@
-import { loginToApp } from '../../viewHelper';
-import TabBarComponent from '../../pages/wallet/TabBarComponent';
-import WalletView from '../../pages/wallet/WalletView';
-import FundActionMenu from '../../pages/UI/FundActionMenu';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { CustomNetworks } from '../../../tests/resources/networks.e2e';
-import { SmokeTrade } from '../../tags';
-import Assertions from '../../../tests/framework/Assertions';
-import SellGetStartedView from '../../pages/Ramps/SellGetStartedView';
-import BuildQuoteView from '../../pages/Ramps/BuildQuoteView';
-import QuotesView from '../../pages/Ramps/QuotesView';
+import { loginToApp } from '../../../e2e/viewHelper';
+import TabBarComponent from '../../../e2e/pages/wallet/TabBarComponent';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import FundActionMenu from '../../../e2e/pages/UI/FundActionMenu';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { CustomNetworks } from '../../resources/networks.e2e';
+import { SmokeTrade } from '../../../e2e/tags';
+import Assertions from '../../framework/Assertions';
+import SellGetStartedView from '../../../e2e/pages/Ramps/SellGetStartedView';
+import BuildQuoteView from '../../../e2e/pages/Ramps/BuildQuoteView';
+import QuotesView from '../../../e2e/pages/Ramps/QuotesView';
 import {
   EventPayload,
   getEventsPayloads,
-} from '../../../tests/helpers/analytics/helpers';
-import SoftAssert from '../../../tests/framework/SoftAssert';
-import {
-  RampsRegions,
-  RampsRegionsEnum,
-} from '../../../tests/framework/Constants';
-import TestHelpers from '../../helpers';
+} from '../../helpers/analytics/helpers';
+import SoftAssert from '../../framework/SoftAssert';
+import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
+import TestHelpers from '../../../e2e/helpers';
 
 describe(SmokeTrade('Off-Ramp'), () => {
   let shouldCheckProviderSelectedEvents = true;

--- a/tests/smoke/ramps/onramp-limits.failing.ts
+++ b/tests/smoke/ramps/onramp-limits.failing.ts
@@ -1,17 +1,14 @@
-import { loginToApp } from '../../viewHelper';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { SmokeTrade } from '../../tags';
-import BuildQuoteView from '../../pages/Ramps/BuildQuoteView';
-import Assertions from '../../../tests/framework/Assertions';
-import WalletView from '../../pages/wallet/WalletView';
-import FundActionMenu from '../../pages/UI/FundActionMenu';
-import BuyGetStartedView from '../../pages/Ramps/BuyGetStartedView';
-import {
-  RampsRegions,
-  RampsRegionsEnum,
-} from '../../../tests/framework/Constants';
-import { setupRegionAwareOnRampMocks } from '../../../tests/api-mocking/mock-responses/ramps/ramps-region-aware-mock-setup';
+import { loginToApp } from '../../../e2e/viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { SmokeTrade } from '../../../e2e/tags';
+import BuildQuoteView from '../../../e2e/pages/Ramps/BuildQuoteView';
+import Assertions from '../../framework/Assertions';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import FundActionMenu from '../../../e2e/pages/UI/FundActionMenu';
+import BuyGetStartedView from '../../../e2e/pages/Ramps/BuyGetStartedView';
+import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
+import { setupRegionAwareOnRampMocks } from '../../api-mocking/mock-responses/ramps/ramps-region-aware-mock-setup';
 import { Mockttp } from 'mockttp';
 
 /**

--- a/tests/smoke/ramps/onramp.failing.ts
+++ b/tests/smoke/ramps/onramp.failing.ts
@@ -1,25 +1,22 @@
-import { loginToApp } from '../../viewHelper';
-import WalletView from '../../pages/wallet/WalletView';
-import FundActionMenu from '../../pages/UI/FundActionMenu';
-import FixtureBuilder from '../../../tests/framework/fixtures/FixtureBuilder';
-import { withFixtures } from '../../../tests/framework/fixtures/FixtureHelper';
-import { CustomNetworks } from '../../../tests/resources/networks.e2e';
-import { SmokeTrade } from '../../tags';
-import Assertions from '../../../tests/framework/Assertions';
-import BuildQuoteView from '../../pages/Ramps/BuildQuoteView';
-import BuyGetStartedView from '../../pages/Ramps/BuyGetStartedView';
-import QuotesView from '../../pages/Ramps/QuotesView';
-import SoftAssert from '../../../tests/framework/SoftAssert';
+import { loginToApp } from '../../../e2e/viewHelper';
+import WalletView from '../../../e2e/pages/wallet/WalletView';
+import FundActionMenu from '../../../e2e/pages/UI/FundActionMenu';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { CustomNetworks } from '../../resources/networks.e2e';
+import { SmokeTrade } from '../../../e2e/tags';
+import Assertions from '../../framework/Assertions';
+import BuildQuoteView from '../../../e2e/pages/Ramps/BuildQuoteView';
+import BuyGetStartedView from '../../../e2e/pages/Ramps/BuyGetStartedView';
+import QuotesView from '../../../e2e/pages/Ramps/QuotesView';
+import SoftAssert from '../../framework/SoftAssert';
 import {
   EventPayload,
   getEventsPayloads,
-} from '../../../tests/helpers/analytics/helpers';
-import {
-  RampsRegions,
-  RampsRegionsEnum,
-} from '../../../tests/framework/Constants';
+} from '../../helpers/analytics/helpers';
+import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
 import { Mockttp } from 'mockttp';
-import { setupRegionAwareOnRampMocks } from '../../../tests/api-mocking/mock-responses/ramps/ramps-region-aware-mock-setup';
+import { setupRegionAwareOnRampMocks } from '../../api-mocking/mock-responses/ramps/ramps-region-aware-mock-setup';
 
 const eventsToCheck: EventPayload[] = [];
 

--- a/tests/smoke/wallet/browser/browser-tests.failing.ts
+++ b/tests/smoke/wallet/browser/browser-tests.failing.ts
@@ -1,21 +1,21 @@
-import { SmokeWalletPlatform } from '../../../tags.js';
-import { loginToApp, navigateToBrowserView } from '../../../viewHelper.ts';
-import FixtureBuilder from '../../../../tests/framework/fixtures/FixtureBuilder.ts';
-import { withFixtures } from '../../../../tests/framework/fixtures/FixtureHelper.ts';
-import ExternalSites from '../../../../tests/resources/externalsites.json';
-import Browser from '../../../pages/Browser/BrowserView.ts';
-import EnsWebsite from '../../../pages/Browser/ExternalWebsites/EnsWebsite.ts';
-import Assertions from '../../../../tests/framework/Assertions.ts';
-import ConnectBottomSheet from '../../../pages/Browser/ConnectBottomSheet.ts';
-import RedirectWebsite from '../../../pages/Browser/ExternalWebsites/RedirectWebsite.ts';
-import UniswapWebsite from '../../../pages/Browser/ExternalWebsites/UniswapWebsite.ts';
-import OpenseaWebsite from '../../../pages/Browser/ExternalWebsites/OpenseaWebsite.ts';
-import PancakeSwapWebsite from '../../../pages/Browser/ExternalWebsites/PancakeSwapWebsite.ts';
-import DownloadFile from '../../../pages/Browser/DownloadFile.ts';
-import DownloadFileWebsite from '../../../pages/Browser/ExternalWebsites/DownloadFileWebsite.ts';
-import TestHelpers from '../../../helpers.js';
-import CameraWebsite from '../../../pages/Browser/ExternalWebsites/Security/CameraWebsite.ts';
-import HistoryDisclosureWebsite from '../../../pages/Browser/ExternalWebsites/Security/HistoryDisclosureWebsite.ts';
+import { SmokeWalletPlatform } from '../../../../e2e/tags.js';
+import { loginToApp, navigateToBrowserView } from '../../../../e2e/viewHelper';
+import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
+import ExternalSites from '../../../resources/externalsites.json';
+import Browser from '../../../../e2e/pages/Browser/BrowserView';
+import EnsWebsite from '../../../../e2e/pages/Browser/ExternalWebsites/EnsWebsite';
+import Assertions from '../../../framework/Assertions';
+import ConnectBottomSheet from '../../../../e2e/pages/Browser/ConnectBottomSheet';
+import RedirectWebsite from '../../../../e2e/pages/Browser/ExternalWebsites/RedirectWebsite';
+import UniswapWebsite from '../../../../e2e/pages/Browser/ExternalWebsites/UniswapWebsite';
+import OpenseaWebsite from '../../../../e2e/pages/Browser/ExternalWebsites/OpenseaWebsite';
+import PancakeSwapWebsite from '../../../../e2e/pages/Browser/ExternalWebsites/PancakeSwapWebsite';
+import DownloadFile from '../../../../e2e/pages/Browser/DownloadFile';
+import DownloadFileWebsite from '../../../../e2e/pages/Browser/ExternalWebsites/DownloadFileWebsite';
+import TestHelpers from '../../../../e2e/helpers.js';
+import CameraWebsite from '../../../../e2e/pages/Browser/ExternalWebsites/Security/CameraWebsite';
+import HistoryDisclosureWebsite from '../../../../e2e/pages/Browser/ExternalWebsites/Security/HistoryDisclosureWebsite';
 
 const getOriginFromURL = (url: string): string => {
   try {

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/prompt.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/prompt.ts
@@ -42,7 +42,7 @@ Critical files (marked in file list) typically warrant wide testing. Use tools t
 For E2E test infrastructure related changes, consider running the necessary tests or all of them in case the changes are wide-ranging.
 Balance thoroughness with efficiency, and be conservative in your risk assessment. When in doubt, err on the side of running more test tags to ensure adequate coverage.
 Do not exceed the maximum number of analysis iterations which is ${LLM_CONFIG.maxIterations}, i.e. try to decide before the maximum number of iterations is reached.
-FlaskBuildTests is for MetaMask Snaps functionality. Select this tag when changes affect e2e/specs/snaps/ directory, snap-related app code (snap permissions, snap state, snap UI, browser), or Flask build configuration.`;
+FlaskBuildTests is for MetaMask Snaps functionality. Select this tag when changes affect tests/smoke/snaps/ directory, snap-related app code (snap permissions, snap state, snap UI, browser), or Flask build configuration.`;
 
   const performanceGuidanceSection = `PERFORMANCE TEST GUIDANCE:
 Performance tests measure app responsiveness and render times. Select performance tests when changes could impact:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Following https://github.com/MetaMask/metamask-mobile/pull/24313 we're looking to centralize all tools and test resources in one place.
This PR also:
- moves the quarantined specs to `/tests`. These quarantine files are now in their respective folder (smoke and regression) instead of using a dedicated quarantine folder.
- updates BUGBOT.md to review the proper location for e2e tests
- jest configs for both E2E and unit tests 
- updates documentation to reflect the complete migration of all spec files to `/tests`
- reverts back the search of e2e specs in CI. It is now scoped to `tests` since all specs have been migrated.

Previous related PRs:
- https://github.com/MetaMask/metamask-mobile/pull/24988
- https://github.com/MetaMask/metamask-mobile/pull/24313
- https://github.com/MetaMask/metamask-mobile/pull/25031
- https://github.com/MetaMask/metamask-mobile/pull/25095
- https://github.com/MetaMask/metamask-mobile/pull/25167
- https://github.com/MetaMask/metamask-mobile/pull/25198
- https://github.com/MetaMask/metamask-mobile/pull/25219
- https://github.com/MetaMask/metamask-mobile/pull/25263
- https://github.com/MetaMask/metamask-mobile/pull/25279
- https://github.com/MetaMask/metamask-mobile/pull/25520
- https://github.com/MetaMask/metamask-mobile/pull/25533
- https://github.com/MetaMask/metamask-mobile/pull/25598
- https://github.com/MetaMask/metamask-mobile/pull/25636
- https://github.com/MetaMask/metamask-mobile/pull/25638
- https://github.com/MetaMask/metamask-mobile/pull/25698



<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1235

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI/Jest test discovery and sharding logic, so misconfigured paths could cause E2E suites to be skipped or incorrectly partitioned; changes are largely mechanical path updates.
> 
> **Overview**
> Shifts Detox E2E spec discovery to `tests/` (smoke/regression) and deprecates `e2e/specs`, updating Jest configs, unit-test ignore patterns, CI sharding/tag selection scripts, and result parsing assumptions accordingly.
> 
> Updates documentation and AI review guidance to reference the new `tests/(smoke|regression)` layout, and rewrites quarantined smoke/regression spec files’ imports to point at shared `e2e/` page objects/helpers while using `tests/framework` + `tests/resources` from their new locations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76eeb92054580f5d185dbd6d4196ca53dc1873b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->