### PR TITLE
fix(perps): clear confirmation on order view unmount cp-7.64.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -208,7 +208,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     () => () => {
       onReject(undefined, true);
     },
-    [onReject],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
   );
 
   // Disable automatic token selection - we want to show "Perps balance" by default

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -58,7 +58,6 @@ import { useAddToken } from '../../../../Views/confirmations/hooks/tokens/useAdd
 import { useAutomaticTransactionPayToken } from '../../../../Views/confirmations/hooks/pay/useAutomaticTransactionPayToken';
 import { useTransactionPayMetrics } from '../../../../Views/confirmations/hooks/pay/useTransactionPayMetrics';
 import { useTransactionMetadataRequest } from '../../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
-import useClearConfirmationOnBackSwipe from '../../../../Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe';
 import AddRewardsAccount from '../../../Rewards/components/AddRewardsAccount/AddRewardsAccount';
 import RewardsAnimations, {
   RewardAnimationState,
@@ -147,6 +146,7 @@ import { useTransactionConfirm } from '../../../../Views/confirmations/hooks/tra
 import { useTransactionCustomAmount } from '../../../../Views/confirmations/hooks/transactions/useTransactionCustomAmount';
 import { useUpdateTokenAmount } from '../../../../Views/confirmations/hooks/transactions/useUpdateTokenAmount';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
+import { useConfirmActions } from '../../../../Views/confirmations/hooks/useConfirmActions';
 
 // Navigation params interface
 interface OrderRouteParams {
@@ -202,7 +202,14 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     tokenAddress: ARBITRUM_USDC.address,
   });
 
-  useClearConfirmationOnBackSwipe();
+  // Clear confirmation when leaving the order view
+  const { onReject } = useConfirmActions();
+  useEffect(
+    () => () => {
+      onReject(undefined, true);
+    },
+    [onReject],
+  );
 
   // Disable automatic token selection - we want to show "Perps balance" by default
   // User can explicitly select a token from the modal


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Clear transaction confirmation when user leaves the perps order screen

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/25439
 
## **Manual testing steps**

- Go to Perps
- Start a new order
- Go back to home page
- Start Send flow
- Select any token from any EVM network (on non-EVM networks the error does not trigger, but the flow is broken)
- Input amount
- Select recipient
- NO error should be shown

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
no visible change

### **After**

<!-- [screenshots/recordings] -->
no visible change

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared confirmation state by force-rejecting on unmount; a mistake here could prematurely dismiss legitimate confirmations or change navigation/UX around confirmations.
> 
> **Overview**
> Clears any active confirmations when the Perps order screen is left by replacing `useClearConfirmationOnBackSwipe()` with an explicit unmount cleanup that calls `useConfirmActions().onReject(undefined, true)`.
> 
> This prevents stale confirmation state from leaking into other flows (e.g., Send) after backing out of Perps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 616455e2bbcc75fac19f7d8978b03dc2bae638ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->