### PR TITLE
feat: new token details button layour (#25574)

### DIFF
--- a/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
+++ b/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
@@ -16,7 +16,6 @@ import Routes from '../../../../constants/navigation/Routes';
 import Engine from '../../../../core/Engine';
 import NotificationManager from '../../../../core/NotificationManager';
 import { selectTokenList } from '../../../../selectors/tokenListController';
-import { selectChainId } from '../../../../selectors/networkController';
 import { getDecimalChainId } from '../../../../util/networks';
 import { getDetectedGeolocation } from '../../../../reducers/fiatOrders';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
@@ -75,7 +74,6 @@ const MoreTokenActionsMenu = () => {
   const rampsButtonClickData = useRampsButtonClickData();
   const rampGeodetectedRegion = useSelector(getDetectedGeolocation);
   const tokenList = useSelector(selectTokenList);
-  const chainId = useSelector(selectChainId);
   const explorer = useBlockExplorer(asset.chainId);
 
   const closeBottomSheetAndNavigate = useCallback(
@@ -101,18 +99,6 @@ const MoreTokenActionsMenu = () => {
     [closeBottomSheetAndNavigate, navigation],
   );
 
-  const getChainIdForAsset = useCallback(() => {
-    if (asset.chainId) {
-      if (typeof asset.chainId === 'string' && asset.chainId.startsWith('0x')) {
-        const parsed = parseInt(asset.chainId, 16);
-        return isNaN(parsed) ? getDecimalChainId(chainId) : parsed;
-      }
-      const parsed = parseInt(asset.chainId, 10);
-      return isNaN(parsed) ? getDecimalChainId(chainId) : parsed;
-    }
-    return getDecimalChainId(chainId);
-  }, [asset.chainId, chainId]);
-
   // Fund action handlers (same as FundActionMenu)
   const handleBuyUnified = useCallback(() => {
     closeBottomSheetAndNavigate(() => {
@@ -129,7 +115,7 @@ const MoreTokenActionsMenu = () => {
           .addProperties({
             text: 'Buy',
             location: 'MoreTokenActionsMenu',
-            chain_id_destination: getChainIdForAsset(),
+            chain_id_destination: getDecimalChainId(asset.chainId),
             ramp_type: 'UNIFIED_BUY',
             region: rampGeodetectedRegion,
             ramp_routing: rampsButtonClickData.ramp_routing,
@@ -145,9 +131,9 @@ const MoreTokenActionsMenu = () => {
     onBuy,
     goToBuy,
     asset.address,
+    asset.chainId,
     trackEvent,
     createEventBuilder,
-    getChainIdForAsset,
     rampGeodetectedRegion,
     rampsButtonClickData,
   ]);
@@ -167,7 +153,7 @@ const MoreTokenActionsMenu = () => {
           .addProperties({
             text: 'Buy',
             location: 'MoreTokenActionsMenu',
-            chain_id_destination: getChainIdForAsset(),
+            chain_id_destination: getDecimalChainId(asset.chainId),
             ramp_type: 'BUY',
             region: rampGeodetectedRegion,
             ramp_routing: rampsButtonClickData.ramp_routing,
@@ -188,9 +174,9 @@ const MoreTokenActionsMenu = () => {
     onBuy,
     goToAggregator,
     asset.address,
+    asset.chainId,
     trackEvent,
     createEventBuilder,
-    getChainIdForAsset,
     rampGeodetectedRegion,
     rampsButtonClickData,
   ]);
@@ -251,7 +237,7 @@ const MoreTokenActionsMenu = () => {
                     token_standard: 'ERC20',
                     asset_type: 'token',
                     tokens: [`${tokenSymbol} - ${asset.address}`],
-                    chain_id: getDecimalChainId(chainId),
+                    chain_id: getDecimalChainId(asset.chainId),
                   })
                   .build(),
               );
@@ -270,7 +256,6 @@ const MoreTokenActionsMenu = () => {
     tokenList,
     trackEvent,
     createEventBuilder,
-    chainId,
   ]);
 
   const actionConfigs: ActionConfig[] = useMemo(() => {

--- a/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
+++ b/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
@@ -65,7 +65,7 @@ const MoreTokenActionsMenu = () => {
     isBuyable,
     isNativeCurrency,
     asset,
-    onBuy: customOnBuy,
+    onBuy,
     onReceive,
   } = route.params;
 
@@ -116,14 +116,14 @@ const MoreTokenActionsMenu = () => {
   // Fund action handlers (same as FundActionMenu)
   const handleBuyUnified = useCallback(() => {
     closeBottomSheetAndNavigate(() => {
-      if (customOnBuy) {
-        customOnBuy();
+      if (onBuy) {
+        onBuy();
       } else {
         goToBuy({ assetId: asset.address });
       }
     });
 
-    if (!customOnBuy) {
+    if (!onBuy) {
       trackEvent(
         createEventBuilder(MetaMetricsEvents.RAMPS_BUTTON_CLICKED)
           .addProperties({
@@ -142,7 +142,7 @@ const MoreTokenActionsMenu = () => {
     }
   }, [
     closeBottomSheetAndNavigate,
-    customOnBuy,
+    onBuy,
     goToBuy,
     asset.address,
     trackEvent,
@@ -154,14 +154,14 @@ const MoreTokenActionsMenu = () => {
 
   const handleBuy = useCallback(() => {
     closeBottomSheetAndNavigate(() => {
-      if (customOnBuy) {
-        customOnBuy();
+      if (onBuy) {
+        onBuy();
       } else {
         goToAggregator({ assetId: asset.address });
       }
     });
 
-    if (!customOnBuy) {
+    if (!onBuy) {
       trackEvent(
         createEventBuilder(MetaMetricsEvents.RAMPS_BUTTON_CLICKED)
           .addProperties({
@@ -185,7 +185,7 @@ const MoreTokenActionsMenu = () => {
     }
   }, [
     closeBottomSheetAndNavigate,
-    customOnBuy,
+    onBuy,
     goToAggregator,
     asset.address,
     trackEvent,

--- a/app/components/UI/TokenDetails/components/TokenDetailsActions.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsActions.tsx
@@ -9,7 +9,6 @@ import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { TokenOverviewSelectorsIDs } from '../../AssetOverview/TokenOverview.testIds';
 import { useSelector } from 'react-redux';
 import { selectCanSignTransactions } from '../../../../selectors/accountsController';
-import { selectChainId } from '../../../../selectors/networkController';
 import { getDetectedGeolocation } from '../../../../reducers/fiatOrders';
 import Routes from '../../../../constants/navigation/Routes';
 import { useMetrics } from '../../../hooks/useMetrics';
@@ -94,7 +93,6 @@ export const TokenDetailsActions: React.FC<TokenDetailsActionsProps> = ({
 }) => {
   const { styles } = useStyles(styleSheet, {});
   const canSignTransactions = useSelector(selectCanSignTransactions);
-  const chainId = useSelector(selectChainId);
   const rampGeodetectedRegion = useSelector(getDetectedGeolocation);
   const navigation = useNavigation();
   const { navigate } = navigation;
@@ -128,18 +126,6 @@ export const TokenDetailsActions: React.FC<TokenDetailsActionsProps> = ({
     callback();
   }, []);
 
-  const getChainIdForAsset = useCallback(() => {
-    if (token.chainId) {
-      if (typeof token.chainId === 'string' && token.chainId.startsWith('0x')) {
-        const parsed = parseInt(token.chainId, 16);
-        return isNaN(parsed) ? getDecimalChainId(chainId) : parsed;
-      }
-      const parsed = parseInt(token.chainId, 10);
-      return isNaN(parsed) ? getDecimalChainId(chainId) : parsed;
-    }
-    return getDecimalChainId(chainId);
-  }, [token.chainId, chainId]);
-
   const handleBuyPress = useCallback(() => {
     withNavigationLock(() => {
       if (onBuy) {
@@ -156,7 +142,7 @@ export const TokenDetailsActions: React.FC<TokenDetailsActionsProps> = ({
             .addProperties({
               text: 'Buy',
               location: 'TokenDetailsActions',
-              chain_id_destination: getChainIdForAsset(),
+              chain_id_destination: getDecimalChainId(token.chainId),
               ramp_type: rampUnifiedV1Enabled ? 'UNIFIED_BUY' : 'BUY',
               region: rampGeodetectedRegion,
               ramp_routing: rampsButtonClickData.ramp_routing,
@@ -182,9 +168,9 @@ export const TokenDetailsActions: React.FC<TokenDetailsActionsProps> = ({
     goToBuy,
     goToAggregator,
     token.address,
+    token.chainId,
     trackEvent,
     createEventBuilder,
-    getChainIdForAsset,
     rampGeodetectedRegion,
     rampsButtonClickData,
   ]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been
completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request,
also include relevant motivation and context. Have in mind the following
questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds new button layout for token details v2, hidden behind a feature
flag for now.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the
CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing
description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and
accurately)
-->

CHANGELOG entry: Added new token details button layout behind a feature
flag

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2546

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the
before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="425" height="179" alt="image"
src="https://github.com/user-attachments/assets/906c876d-1469-479b-b3dc-9cd209e5b358"
/>


### **After**

<!-- [screenshots/recordings] -->
<img width="432" height="682" alt="image"
src="https://github.com/user-attachments/assets/bc330805-04eb-4c6e-88c1-f6f7ba947c01"
/>
<img width="420" height="702" alt="image"
src="https://github.com/user-attachments/assets/43c55dff-9526-4104-91ff-597254ced1f4"
/>
<img width="432" height="655" alt="image"
src="https://github.com/user-attachments/assets/5a16cc35-5077-4240-bce2-bdbe419849b7"
/>


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor
Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile
Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format
if applicable
- [X] I've applied the right labels on the PR (see [labeling
guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the
app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described
in the ticket it closes and includes the necessary testing evidence such
as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user navigation flow and analytics/tracing for ramp purchases on token details; regressions could mis-route buy taps or skew metrics depending on the unified-ramps flag.
> 
> **Overview**
> Token Details buy interactions are refactored to **directly route to ramps** (unified `goToBuy` when enabled, otherwise aggregator) from both the main `TokenDetailsActions` button and the `MoreTokenActionsMenu`, instead of relying on the previous intermediate fund-action flow/unified handler split.
> 
> Metrics/tracing are aligned across these entry points: `RAMPS_BUTTON_CLICKED` now uses `asset.chainId`/`token.chainId` via `getDecimalChainId`, sets `ramp_type` based on the unified flag, and only fires `LoadRampExperience` tracing for the non-unified path; the Buy button is also no longer disabled when no custom `onBuy` handler is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 731a86a01f3c84144166780b7989602a4366f907. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
