### PR TITLE
fix: subtitle in token details

### DIFF
--- a/app/components/UI/AssetOverview/Price/Price.test.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.test.tsx
@@ -75,12 +75,13 @@ describe('Price Component', () => {
         },
       };
 
-      const { getAllByText } = render(<Price {...props} />);
+      const { getByText } = render(<Price {...props} />);
 
-      // Name and symbol are rendered separately
-      // When name and symbol are the same, we expect to find both text nodes
-      const elements = getAllByText(mockProps.asset.name);
-      expect(elements.length).toBeGreaterThanOrEqual(1);
+      // Name and symbol are rendered together when ticker is not provided
+      // Format: "name (symbol)"
+      expect(
+        getByText(`${mockProps.asset.name} (${mockProps.asset.symbol})`),
+      ).toBeTruthy();
     });
 
     it('renders header correctly when name not provided and symbol is provided', () => {
@@ -101,9 +102,11 @@ describe('Price Component', () => {
     it('renders header correctly when name and ticker are provided', () => {
       const { getByText } = render(<Price {...mockProps} />);
 
-      // Name and ticker are rendered separately
-      expect(getByText(mockProps.asset.name)).toBeTruthy();
-      expect(getByText(mockProps.asset.ticker as string)).toBeTruthy();
+      // Name and ticker are rendered together
+      // Format: "name (ticker)"
+      expect(
+        getByText(`${mockProps.asset.name} (${mockProps.asset.ticker})`),
+      ).toBeTruthy();
     });
   });
 

--- a/app/components/UI/AssetOverview/Price/Price.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.tsx
@@ -96,23 +96,32 @@ const Price = ({
     <>
       <View style={styles.wrapper}>
         {asset.name ? (
-          <View>
-            <Text
-              variant={TextVariant.BodyMDMedium}
-              color={TextColor.Alternative}
-            >
-              {asset.name}
-            </Text>
-            <View style={styles.assetWrapper}>
+          stockTokenBadge ? (
+            <View>
               <Text
                 variant={TextVariant.BodyMDMedium}
                 color={TextColor.Alternative}
               >
-                {ticker}
+                {asset.name}
               </Text>
-              {stockTokenBadge}
+              <View style={styles.assetWrapper}>
+                <Text
+                  variant={TextVariant.BodyMDMedium}
+                  color={TextColor.Alternative}
+                >
+                  {ticker}
+                </Text>
+                {stockTokenBadge}
+              </View>
             </View>
-          </View>
+          ) : (
+            <Text
+              variant={TextVariant.BodyMDMedium}
+              color={TextColor.Alternative}
+            >
+              {asset.name} ({ticker})
+            </Text>
+          )
         ) : (
           <View style={styles.assetWrapper}>
             <Text variant={TextVariant.BodyMDMedium}>{ticker}</Text>

--- a/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
+++ b/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
@@ -17,45 +17,23 @@ exports[`AssetOverview should render native balances when non evm network is sel
         }
       }
     >
-      <View>
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#686e7d",
-              "fontFamily": "Geist-Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#686e7d",
+            "fontFamily": "Geist-Medium",
+            "fontSize": 16,
+            "letterSpacing": 0,
+            "lineHeight": 24,
           }
-        >
-          Ethereum
-        </Text>
-        <View
-          style={
-            {
-              "flexDirection": "row",
-              "justifyContent": "flex-start",
-            }
-          }
-        >
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#686e7d",
-                "fontFamily": "Geist-Medium",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            ETH
-          </Text>
-        </View>
-      </View>
+        }
+      >
+        Ethereum
+         (
+        ETH
+        )
+      </Text>
       <Text
         accessibilityRole="text"
         style={


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This bug was introduced after RWA tokens were introduced in this [PR](https://github.com/MetaMask/metamask-mobile/pull/24740)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove subtitle in token details

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/25478 & https://consensyssoftware.atlassian.net/browse/ASSETS-2586

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300" height="929" alt="image" src="https://github.com/user-attachments/assets/f87cd576-ec56-4226-9f8d-5c5174e9870c" />

<img width="300" height="955" alt="image" src="https://github.com/user-attachments/assets/c36f2ec5-e310-44a8-a2a7-5abb1884127d" />

<!-- [screenshots/recordings] -->

### **After**
<img width="300" height="948" alt="image" src="https://github.com/user-attachments/assets/3f86daf4-2375-461b-94cf-168693119370" />

<img width="300" height="916" alt="image" src="https://github.com/user-attachments/assets/fa39987f-885d-474e-853f-e4f4149f73e6" />
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only formatting change in the asset header plus test/snapshot updates; low risk aside from potential minor layout regressions for edge-case token names.
> 
> **Overview**
> Fixes the token details subtitle rendering in `AssetOverview` by **combining the asset name and ticker/symbol into a single text node** (`name (ticker)`), while preserving the special two-line layout when a stock/RWA badge is shown.
> 
> Updates `Price` header unit tests and the `AssetOverview` snapshot to match the new subtitle format, including cases where `ticker` is missing (falls back to `symbol`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0f9bfe26a3dc18620ce0e48896eb1b5777351a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->