### PR TITLE
feat(card): cp-7.64.0 change CardHome button colors

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -658,7 +658,7 @@ const CardHome = () => {
     if (!isBaanxLoginEnabled) {
       return (
         <Button
-          variant={ButtonVariants.Secondary}
+          variant={ButtonVariants.Primary}
           label={strings('card.card_home.add_funds')}
           size={ButtonSize.Lg}
           onPress={addFundsAction}
@@ -679,7 +679,7 @@ const CardHome = () => {
 
       return (
         <Button
-          variant={ButtonVariants.Secondary}
+          variant={ButtonVariants.Primary}
           label={strings('card.card_home.enable_card_button_label')}
           size={ButtonSize.Lg}
           onPress={openOnboardingDelegationAction}
@@ -692,7 +692,7 @@ const CardHome = () => {
     return (
       <Box twClassName="w-full gap-2 flex-row justify-between items-center">
         <Button
-          variant={ButtonVariants.Secondary}
+          variant={ButtonVariants.Primary}
           style={tw.style(
             'w-1/2',
             !isSwapEnabledForPriorityToken && 'opacity-50',
@@ -705,7 +705,7 @@ const CardHome = () => {
           testID={CardHomeSelectors.ADD_FUNDS_BUTTON}
         />
         <Button
-          variant={ButtonVariants.Secondary}
+          variant={ButtonVariants.Primary}
           style={tw.style('w-1/2')}
           label={strings('card.card_home.change_asset')}
           size={ButtonSize.Lg}
@@ -889,7 +889,7 @@ const CardHome = () => {
         {retries < 3 && !isAuthenticationError(cardError) && (
           <Box twClassName="pt-2">
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariants.Primary}
               label={strings('card.card_home.try_again')}
               size={ButtonSize.Md}
               onPress={() => {

--- a/app/components/UI/Card/Views/CardHome/__snapshots__/CardHome.test.tsx.snap
+++ b/app/components/UI/Card/Views/CardHome/__snapshots__/CardHome.test.tsx.snap
@@ -956,10 +956,8 @@ exports[`CardHome Component renders correctly and matches snapshot 1`] = `
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "stretch",
-                                    "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "transparent",
+                                    "backgroundColor": "#121314",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "height": 48,
                                     "justifyContent": "center",
@@ -974,7 +972,7 @@ exports[`CardHome Component renders correctly and matches snapshot 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "color": "#121314",
+                                      "color": "#ffffff",
                                       "fontFamily": "Geist-Medium",
                                       "fontSize": 16,
                                       "letterSpacing": 0,
@@ -996,10 +994,8 @@ exports[`CardHome Component renders correctly and matches snapshot 1`] = `
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "stretch",
-                                    "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "transparent",
+                                    "backgroundColor": "#121314",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "height": 48,
                                     "justifyContent": "center",
@@ -1014,7 +1010,7 @@ exports[`CardHome Component renders correctly and matches snapshot 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "color": "#121314",
+                                      "color": "#ffffff",
                                       "fontFamily": "Geist-Medium",
                                       "fontSize": 16,
                                       "letterSpacing": 0,
@@ -2301,10 +2297,8 @@ exports[`CardHome Component renders correctly with privacy mode enabled 1`] = `
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "stretch",
-                                    "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "transparent",
+                                    "backgroundColor": "#121314",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "height": 48,
                                     "justifyContent": "center",
@@ -2319,7 +2313,7 @@ exports[`CardHome Component renders correctly with privacy mode enabled 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "color": "#121314",
+                                      "color": "#ffffff",
                                       "fontFamily": "Geist-Medium",
                                       "fontSize": 16,
                                       "letterSpacing": 0,
@@ -2341,10 +2335,8 @@ exports[`CardHome Component renders correctly with privacy mode enabled 1`] = `
                                   {
                                     "alignItems": "center",
                                     "alignSelf": "stretch",
-                                    "backgroundColor": "#3c4d9d0f",
-                                    "borderColor": "transparent",
+                                    "backgroundColor": "#121314",
                                     "borderRadius": 12,
-                                    "borderWidth": 1,
                                     "flexDirection": "row",
                                     "height": 48,
                                     "justifyContent": "center",
@@ -2359,7 +2351,7 @@ exports[`CardHome Component renders correctly with privacy mode enabled 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "color": "#121314",
+                                      "color": "#ffffff",
                                       "fontFamily": "Geist-Medium",
                                       "fontSize": 16,
                                       "letterSpacing": 0,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Change CardHome button colors

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="200" height="900" alt="image" src="https://github.com/user-attachments/assets/31e5700c-2387-4c73-a71a-6576036e2f95" />


### **After**

<!-- [screenshots/recordings] -->

<img width="200" height="900" alt="image" src="https://github.com/user-attachments/assets/64bb8951-f334-406e-a916-d0070723bc28" />


## **Pre-merge author checklist**

- [x]  I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only styling change limited to button variants and snapshot updates, with no impact to card flows, navigation, or data handling.
> 
> **Overview**
> Updates `CardHome` to render its main call-to-action buttons (`Add funds`, `Enable card`, `Change asset`, and the error `Try again`) using `ButtonVariants.Primary` instead of `Secondary`, changing their visual styling.
> 
> Regenerates `CardHome` Jest snapshots to reflect the new button colors (e.g., dark background and white label text).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e6f91e52d4a20758bf1d6e03d4257b6ffa8ce05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->