### PR TITLE
feat(predict): add deeplink support for feed tab selection

### DIFF
--- a/app/components/UI/Predict/constants/feedTabs.ts
+++ b/app/components/UI/Predict/constants/feedTabs.ts
@@ -1,15 +1,13 @@
 import type { PredictCategory } from '../types';
 
-export type PredictFeedTabKey = PredictCategory;
+export type PredictTabKey = PredictCategory;
 
-export interface PredictFeedTabConfig {
-  key: PredictFeedTabKey;
+export interface PredictTabConfig {
+  key: PredictTabKey;
   labelKey: string;
 }
 
-export const PREDICT_FEED_DEFAULT_TAB: PredictFeedTabKey = 'trending';
-
-export const PREDICT_FEED_BASE_TABS: readonly PredictFeedTabConfig[] = [
+export const PREDICT_BASE_TABS: readonly PredictTabConfig[] = [
   { key: 'trending', labelKey: 'predict.category.trending' },
   { key: 'new', labelKey: 'predict.category.new' },
   { key: 'sports', labelKey: 'predict.category.sports' },
@@ -17,22 +15,20 @@ export const PREDICT_FEED_BASE_TABS: readonly PredictFeedTabConfig[] = [
   { key: 'politics', labelKey: 'predict.category.politics' },
 ];
 
-export const PREDICT_FEED_HOT_TAB: PredictFeedTabConfig = {
+export const PREDICT_HOT_TAB: PredictTabConfig = {
   key: 'hot',
   labelKey: 'predict.category.hot',
 };
 
-export const PREDICT_FEED_ALL_TABS: readonly PredictFeedTabConfig[] = [
-  ...PREDICT_FEED_BASE_TABS,
-  PREDICT_FEED_HOT_TAB,
+export const PREDICT_ALL_TABS: readonly PredictTabConfig[] = [
+  ...PREDICT_BASE_TABS,
+  PREDICT_HOT_TAB,
 ];
 
-const PREDICT_FEED_TAB_KEYS = PREDICT_FEED_ALL_TABS.map((tab) => tab.key);
-const PREDICT_FEED_TAB_KEYS_SET = new Set<PredictFeedTabKey>(
-  PREDICT_FEED_TAB_KEYS,
-);
+const PREDICT_TAB_KEYS = PREDICT_ALL_TABS.map((tab) => tab.key);
+const PREDICT_TAB_KEYS_SET = new Set<PredictTabKey>(PREDICT_TAB_KEYS);
 
-export const isPredictFeedTabKey = (
+export const isPredictTabKey = (
   value?: string | null,
-): value is PredictFeedTabKey =>
-  Boolean(value && PREDICT_FEED_TAB_KEYS_SET.has(value as PredictFeedTabKey));
+): value is PredictTabKey =>
+  Boolean(value && PREDICT_TAB_KEYS_SET.has(value as PredictTabKey));

--- a/app/components/UI/Predict/constants/feedTabs.ts
+++ b/app/components/UI/Predict/constants/feedTabs.ts
@@ -1,0 +1,38 @@
+import type { PredictCategory } from '../types';
+
+export type PredictFeedTabKey = PredictCategory;
+
+export interface PredictFeedTabConfig {
+  key: PredictFeedTabKey;
+  labelKey: string;
+}
+
+export const PREDICT_FEED_DEFAULT_TAB: PredictFeedTabKey = 'trending';
+
+export const PREDICT_FEED_BASE_TABS: readonly PredictFeedTabConfig[] = [
+  { key: 'trending', labelKey: 'predict.category.trending' },
+  { key: 'new', labelKey: 'predict.category.new' },
+  { key: 'sports', labelKey: 'predict.category.sports' },
+  { key: 'crypto', labelKey: 'predict.category.crypto' },
+  { key: 'politics', labelKey: 'predict.category.politics' },
+];
+
+export const PREDICT_FEED_HOT_TAB: PredictFeedTabConfig = {
+  key: 'hot',
+  labelKey: 'predict.category.hot',
+};
+
+export const PREDICT_FEED_ALL_TABS: readonly PredictFeedTabConfig[] = [
+  ...PREDICT_FEED_BASE_TABS,
+  PREDICT_FEED_HOT_TAB,
+];
+
+const PREDICT_FEED_TAB_KEYS = PREDICT_FEED_ALL_TABS.map((tab) => tab.key);
+const PREDICT_FEED_TAB_KEYS_SET = new Set<PredictFeedTabKey>(
+  PREDICT_FEED_TAB_KEYS,
+);
+
+export const isPredictFeedTabKey = (
+  value?: string | null,
+): value is PredictFeedTabKey =>
+  Boolean(value && PREDICT_FEED_TAB_KEYS_SET.has(value as PredictFeedTabKey));

--- a/app/components/UI/Predict/hooks/index.ts
+++ b/app/components/UI/Predict/hooks/index.ts
@@ -15,3 +15,9 @@ export {
   type UseLivePositionsOptions,
   type UseLivePositionsResult,
 } from './useLivePositions';
+
+export {
+  usePredictTabs,
+  type FeedTab,
+  type UsePredictTabsResponse as UsePredictTabsReturn,
+} from './usePredictTabs';

--- a/app/components/UI/Predict/hooks/index.ts
+++ b/app/components/UI/Predict/hooks/index.ts
@@ -19,5 +19,5 @@ export {
 export {
   usePredictTabs,
   type FeedTab,
-  type UsePredictTabsResponse as UsePredictTabsReturn,
+  type UsePredictTabsResult,
 } from './usePredictTabs';

--- a/app/components/UI/Predict/hooks/useFeedScrollManager.test.ts
+++ b/app/components/UI/Predict/hooks/useFeedScrollManager.test.ts
@@ -46,6 +46,16 @@ describe('useFeedScrollManager', () => {
         : null,
   });
 
+  const createDefaultProps = (overrides = {}) => {
+    const mockSetActiveIndex = jest.fn();
+    return {
+      headerRef: createMockRef(120) as React.RefObject<never>,
+      tabBarRef: createMockRef(48) as React.RefObject<never>,
+      setActiveIndex: mockSetActiveIndex,
+      ...overrides,
+    };
+  };
+
   const originalPlatformOS = Platform.OS;
 
   beforeEach(() => {
@@ -72,152 +82,109 @@ describe('useFeedScrollManager', () => {
 
   describe('initialization', () => {
     it('initializes with default values', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       expect(result.current.headerTranslateY).toBeDefined();
       expect(result.current.headerTranslateY.value).toBe(0);
       expect(result.current.headerHidden).toBe(false);
-      expect(result.current.activeIndex).toBe(0);
     });
 
     it('provides all required properties', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       expect(result.current.headerTranslateY).toBeDefined();
       expect(typeof result.current.headerHidden).toBe('boolean');
       expect(typeof result.current.headerHeight).toBe('number');
       expect(typeof result.current.tabBarHeight).toBe('number');
       expect(typeof result.current.layoutReady).toBe('boolean');
-      expect(typeof result.current.activeIndex).toBe('number');
-      expect(typeof result.current.setActiveIndex).toBe('function');
+      expect(typeof result.current.onTabSwitch).toBe('function');
       expect(result.current.scrollHandler).toBeDefined();
     });
 
     it('initializes layoutReady as false before measurements', () => {
-      const headerRef = createMockRef();
-      const tabBarRef = createMockRef();
+      const props = createDefaultProps({
+        headerRef: createMockRef() as React.RefObject<never>,
+        tabBarRef: createMockRef() as React.RefObject<never>,
+      });
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       expect(result.current.layoutReady).toBe(false);
     });
 
     it('initializes heights as 0 before measurement', () => {
-      const headerRef = createMockRef();
-      const tabBarRef = createMockRef();
+      const props = createDefaultProps({
+        headerRef: createMockRef() as React.RefObject<never>,
+        tabBarRef: createMockRef() as React.RefObject<never>,
+      });
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       expect(result.current.headerHeight).toBe(0);
       expect(result.current.tabBarHeight).toBe(0);
     });
   });
 
-  describe('setActiveIndex', () => {
-    it('updates activeIndex when called', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+  describe('onTabSwitch', () => {
+    it('calls setActiveIndex when onTabSwitch is called', () => {
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       act(() => {
-        result.current.setActiveIndex(2);
+        result.current.onTabSwitch(2);
       });
 
-      expect(result.current.activeIndex).toBe(2);
+      expect(props.setActiveIndex).toHaveBeenCalledWith(2);
     });
 
-    it('updates activeIndex to different values sequentially', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+    it('calls setActiveIndex with different values sequentially', () => {
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       act(() => {
-        result.current.setActiveIndex(1);
+        result.current.onTabSwitch(1);
       });
-      expect(result.current.activeIndex).toBe(1);
+      expect(props.setActiveIndex).toHaveBeenCalledWith(1);
 
       act(() => {
-        result.current.setActiveIndex(4);
+        result.current.onTabSwitch(4);
       });
-      expect(result.current.activeIndex).toBe(4);
+      expect(props.setActiveIndex).toHaveBeenCalledWith(4);
 
       act(() => {
-        result.current.setActiveIndex(0);
+        result.current.onTabSwitch(0);
       });
-      expect(result.current.activeIndex).toBe(0);
+      expect(props.setActiveIndex).toHaveBeenCalledWith(0);
     });
 
-    it('handles rapid index changes', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+    it('handles rapid tab switches', () => {
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       act(() => {
-        result.current.setActiveIndex(1);
-        result.current.setActiveIndex(2);
-        result.current.setActiveIndex(3);
-        result.current.setActiveIndex(4);
+        result.current.onTabSwitch(1);
+        result.current.onTabSwitch(2);
+        result.current.onTabSwitch(3);
+        result.current.onTabSwitch(4);
       });
 
-      expect(result.current.activeIndex).toBe(4);
+      expect(props.setActiveIndex).toHaveBeenCalledTimes(4);
+      expect(props.setActiveIndex).toHaveBeenLastCalledWith(4);
     });
   });
 
   describe('layout measurement', () => {
     it('measures header height after mount', async () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as unknown as React.RefObject<never>,
-          tabBarRef: tabBarRef as unknown as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       act(() => {
         jest.advanceTimersByTime(100);
@@ -229,15 +196,9 @@ describe('useFeedScrollManager', () => {
     });
 
     it('measures tabBar height after mount', async () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as unknown as React.RefObject<never>,
-          tabBarRef: tabBarRef as unknown as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       act(() => {
         jest.advanceTimersByTime(100);
@@ -249,15 +210,9 @@ describe('useFeedScrollManager', () => {
     });
 
     it('sets layoutReady to true after both measurements complete', async () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as unknown as React.RefObject<never>,
-          tabBarRef: tabBarRef as unknown as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       act(() => {
         jest.advanceTimersByTime(100);
@@ -267,75 +222,15 @@ describe('useFeedScrollManager', () => {
         expect(result.current.layoutReady).toBe(true);
       });
     });
-
-    it('retries measurement when initial height is zero', async () => {
-      let callCount = 0;
-      type MeasureCallback = (
-        x: number,
-        y: number,
-        width: number,
-        height: number,
-      ) => void;
-      const headerRef = {
-        current: {
-          measure: jest.fn((callback: MeasureCallback) => {
-            callCount++;
-            const height = callCount > 2 ? 120 : 0;
-            callback(0, 0, 375, height);
-          }),
-        },
-      };
-      const tabBarRef = createMockRef(48);
-
-      renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as unknown as React.RefObject<never>,
-          tabBarRef: tabBarRef as unknown as React.RefObject<never>,
-        }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(200);
-      });
-
-      expect(headerRef.current.measure).toHaveBeenCalled();
-    });
-
-    it('measures on initial mount', async () => {
-      type MeasureCallback = (
-        x: number,
-        y: number,
-        width: number,
-        height: number,
-      ) => void;
-      const measureFn = jest.fn((callback: MeasureCallback) => {
-        callback(0, 0, 375, 120);
-      });
-      const headerRef = { current: { measure: measureFn } };
-      const tabBarRef = createMockRef(48);
-
-      renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as unknown as React.RefObject<never>,
-          tabBarRef: tabBarRef as unknown as React.RefObject<never>,
-        }),
-      );
-
-      expect(measureFn).toHaveBeenCalled();
-    });
   });
 
   describe('null refs handling', () => {
     it('handles null headerRef gracefully', () => {
-      const headerRef = { current: null };
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps({
+        headerRef: { current: null } as React.RefObject<never>,
+      });
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       act(() => {
         jest.advanceTimersByTime(100);
@@ -345,15 +240,11 @@ describe('useFeedScrollManager', () => {
     });
 
     it('handles null tabBarRef gracefully', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = { current: null };
+      const props = createDefaultProps({
+        tabBarRef: { current: null } as React.RefObject<never>,
+      });
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       act(() => {
         jest.advanceTimersByTime(100);
@@ -363,15 +254,12 @@ describe('useFeedScrollManager', () => {
     });
 
     it('handles both refs being null', () => {
-      const headerRef = { current: null };
-      const tabBarRef = { current: null };
+      const props = createDefaultProps({
+        headerRef: { current: null } as React.RefObject<never>,
+        tabBarRef: { current: null } as React.RefObject<never>,
+      });
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       act(() => {
         jest.advanceTimersByTime(100);
@@ -383,15 +271,12 @@ describe('useFeedScrollManager', () => {
     });
 
     it('keeps layoutReady false with zero height measurements', () => {
-      const headerRef = createMockRef(0);
-      const tabBarRef = createMockRef(0);
+      const props = createDefaultProps({
+        headerRef: createMockRef(0) as React.RefObject<never>,
+        tabBarRef: createMockRef(0) as React.RefObject<never>,
+      });
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       act(() => {
         jest.advanceTimersByTime(100);
@@ -402,14 +287,8 @@ describe('useFeedScrollManager', () => {
   });
 
   describe('hook stability', () => {
-    it('returns a callable setActiveIndex function after re-render', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const props = {
-        headerRef: headerRef as React.RefObject<never>,
-        tabBarRef: tabBarRef as React.RefObject<never>,
-      };
+    it('returns a callable onTabSwitch function after re-render', () => {
+      const props = createDefaultProps();
 
       const { result, rerender } = renderHook(
         (p: typeof props) => useFeedScrollManager(p),
@@ -419,68 +298,33 @@ describe('useFeedScrollManager', () => {
       rerender(props);
 
       act(() => {
-        result.current.setActiveIndex(2);
+        result.current.onTabSwitch(2);
       });
 
-      expect(result.current.activeIndex).toBe(2);
-    });
-
-    it('maintains state across re-renders', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const props = {
-        headerRef: headerRef as React.RefObject<never>,
-        tabBarRef: tabBarRef as React.RefObject<never>,
-      };
-
-      const { result, rerender } = renderHook(
-        (p: typeof props) => useFeedScrollManager(p),
-        { initialProps: props },
-      );
-
-      act(() => {
-        result.current.setActiveIndex(3);
-      });
-
-      rerender(props);
-
-      expect(result.current.activeIndex).toBe(3);
+      expect(props.setActiveIndex).toHaveBeenCalledWith(2);
     });
 
     it('provides consistent API across multiple renders', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const props = {
-        headerRef: headerRef as React.RefObject<never>,
-        tabBarRef: tabBarRef as React.RefObject<never>,
-      };
+      const props = createDefaultProps();
 
       const { result, rerender } = renderHook(
         (p: typeof props) => useFeedScrollManager(p),
         { initialProps: props },
       );
 
-      expect(typeof result.current.setActiveIndex).toBe('function');
+      expect(typeof result.current.onTabSwitch).toBe('function');
 
       rerender(props);
 
-      expect(typeof result.current.setActiveIndex).toBe('function');
+      expect(typeof result.current.onTabSwitch).toBe('function');
     });
   });
 
   describe('cleanup', () => {
     it('clears timeout on unmount without errors', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { unmount } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { unmount } = renderHook(() => useFeedScrollManager(props));
 
       unmount();
 
@@ -498,29 +342,17 @@ describe('useFeedScrollManager', () => {
     }
 
     it('returns scroll handler object', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       expect(result.current.scrollHandler).toBeDefined();
     });
 
     it('processes scroll event without throwing', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       const handler = result.current.scrollHandler as unknown as ScrollHandler;
 
@@ -530,15 +362,9 @@ describe('useFeedScrollManager', () => {
     });
 
     it('handles scroll down events', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       const handler = result.current.scrollHandler as unknown as ScrollHandler;
 
@@ -546,62 +372,29 @@ describe('useFeedScrollManager', () => {
       handler.onScroll?.({ contentOffset: { y: 100 } });
       handler.onScroll?.({ contentOffset: { y: 200 } });
       handler.onScroll?.({ contentOffset: { y: 300 } });
-
-      expect(result.current.scrollHandler).toBeDefined();
-    });
-
-    it('handles scroll up events', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      handler.onScroll?.({ contentOffset: { y: 500 } });
-      handler.onScroll?.({ contentOffset: { y: 400 } });
-      handler.onScroll?.({ contentOffset: { y: 300 } });
-      handler.onScroll?.({ contentOffset: { y: 200 } });
 
       expect(result.current.scrollHandler).toBeDefined();
     });
 
     it('handles tab switching by skipping first scroll event', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       act(() => {
-        result.current.setActiveIndex(1);
+        result.current.onTabSwitch(1);
       });
 
       const handler = result.current.scrollHandler as unknown as ScrollHandler;
       handler.onScroll?.({ contentOffset: { y: 100 } });
 
-      expect(result.current.activeIndex).toBe(1);
+      expect(props.setActiveIndex).toHaveBeenCalledWith(1);
     });
 
     it('handles zero delta scroll events', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       const handler = result.current.scrollHandler as unknown as ScrollHandler;
 
@@ -609,271 +402,12 @@ describe('useFeedScrollManager', () => {
       handler.onScroll?.({ contentOffset: { y: 100 } });
 
       expect(result.current.scrollHandler).toBeDefined();
-    });
-
-    it('handles at-top scroll position on iOS', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      handler.onScroll?.({ contentOffset: { y: -10 } });
-      handler.onScroll?.({ contentOffset: { y: -5 } });
-
-      expect(result.current.scrollHandler).toBeDefined();
-    });
-
-    it('handles direction change during scroll', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      handler.onScroll?.({ contentOffset: { y: 0 } });
-      handler.onScroll?.({ contentOffset: { y: 100 } });
-      handler.onScroll?.({ contentOffset: { y: 50 } });
-
-      expect(result.current.scrollHandler).toBeDefined();
-    });
-
-    it('accumulates scroll delta until threshold', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      for (let i = 0; i <= 300; i += 50) {
-        handler.onScroll?.({ contentOffset: { y: i } });
-      }
-
-      expect(result.current.scrollHandler).toBeDefined();
-    });
-
-    it('processes scroll events without errors for extended scrolling', async () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitFor(() => {
-        expect(result.current.layoutReady).toBe(true);
-      });
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      expect(() => {
-        handler.onScroll?.({ contentOffset: { y: 0 } });
-        handler.onScroll?.({ contentOffset: { y: 100 } });
-        handler.onScroll?.({ contentOffset: { y: 200 } });
-        handler.onScroll?.({ contentOffset: { y: 300 } });
-        handler.onScroll?.({ contentOffset: { y: 400 } });
-        handler.onScroll?.({ contentOffset: { y: 500 } });
-      }).not.toThrow();
-    });
-
-    it('processes scroll up events after scroll down without errors', async () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitFor(() => {
-        expect(result.current.layoutReady).toBe(true);
-      });
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      expect(() => {
-        handler.onScroll?.({ contentOffset: { y: 0 } });
-        handler.onScroll?.({ contentOffset: { y: 100 } });
-        handler.onScroll?.({ contentOffset: { y: 200 } });
-        handler.onScroll?.({ contentOffset: { y: 300 } });
-        handler.onScroll?.({ contentOffset: { y: 250 } });
-        handler.onScroll?.({ contentOffset: { y: 150 } });
-        handler.onScroll?.({ contentOffset: { y: 50 } });
-        handler.onScroll?.({ contentOffset: { y: 0 } });
-      }).not.toThrow();
-    });
-
-    it('handles iOS negative contentOffset at top of list', async () => {
-      Platform.OS = 'ios';
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitFor(() => {
-        expect(result.current.layoutReady).toBe(true);
-      });
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      expect(() => {
-        handler.onScroll?.({ contentOffset: { y: 0 } });
-        handler.onScroll?.({ contentOffset: { y: 100 } });
-        handler.onScroll?.({ contentOffset: { y: 200 } });
-        handler.onScroll?.({ contentOffset: { y: 300 } });
-        handler.onScroll?.({ contentOffset: { y: 0 } });
-        handler.onScroll?.({ contentOffset: { y: -10 } });
-        handler.onScroll?.({ contentOffset: { y: -20 } });
-      }).not.toThrow();
-    });
-
-    it('handles Android contentOffset below content inset at top of list', async () => {
-      Platform.OS = 'android';
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitFor(() => {
-        expect(result.current.layoutReady).toBe(true);
-      });
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      expect(() => {
-        handler.onScroll?.({ contentOffset: { y: 200 } });
-        handler.onScroll?.({ contentOffset: { y: 300 } });
-        handler.onScroll?.({ contentOffset: { y: 400 } });
-        handler.onScroll?.({ contentOffset: { y: 500 } });
-        handler.onScroll?.({ contentOffset: { y: 400 } });
-        handler.onScroll?.({ contentOffset: { y: 300 } });
-        handler.onScroll?.({ contentOffset: { y: 150 } });
-        handler.onScroll?.({ contentOffset: { y: 100 } });
-      }).not.toThrow();
-    });
-
-    it('handles Android direction reversal after scrolling down', async () => {
-      Platform.OS = 'android';
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitFor(() => {
-        expect(result.current.layoutReady).toBe(true);
-      });
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      expect(() => {
-        handler.onScroll?.({ contentOffset: { y: 200 } });
-        handler.onScroll?.({ contentOffset: { y: 300 } });
-        handler.onScroll?.({ contentOffset: { y: 400 } });
-        handler.onScroll?.({ contentOffset: { y: 500 } });
-        handler.onScroll?.({ contentOffset: { y: 490 } });
-      }).not.toThrow();
-    });
-
-    it('resets accumulated delta when direction changes', async () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitFor(() => {
-        expect(result.current.layoutReady).toBe(true);
-      });
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      act(() => {
-        handler.onScroll?.({ contentOffset: { y: 0 } });
-        handler.onScroll?.({ contentOffset: { y: 100 } });
-        handler.onScroll?.({ contentOffset: { y: 50 } });
-        handler.onScroll?.({ contentOffset: { y: 100 } });
-        handler.onScroll?.({ contentOffset: { y: 50 } });
-      });
-
-      expect(result.current.headerHidden).toBe(false);
     });
 
     it('does not trigger header change when below threshold', async () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       act(() => {
         jest.advanceTimersByTime(100);
@@ -892,197 +426,33 @@ describe('useFeedScrollManager', () => {
       });
 
       expect(result.current.headerHidden).toBe(false);
-    });
-
-    it('handles scroll events after tab switch without errors', async () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitFor(() => {
-        expect(result.current.layoutReady).toBe(true);
-      });
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      await act(async () => {
-        handler.onScroll?.({ contentOffset: { y: 0 } });
-        handler.onScroll?.({ contentOffset: { y: 100 } });
-        handler.onScroll?.({ contentOffset: { y: 200 } });
-        handler.onScroll?.({ contentOffset: { y: 300 } });
-      });
-
-      await act(async () => {
-        result.current.setActiveIndex(1);
-      });
-
-      expect(() => {
-        handler.onScroll?.({ contentOffset: { y: 500 } });
-        handler.onScroll?.({ contentOffset: { y: 600 } });
-      }).not.toThrow();
-
-      expect(result.current.activeIndex).toBe(1);
-    });
-
-    it('invokes runOnJS during scroll operations', async () => {
-      mockRunOnJS.mockClear();
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitFor(() => {
-        expect(result.current.layoutReady).toBe(true);
-      });
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      await act(async () => {
-        handler.onScroll?.({ contentOffset: { y: 0 } });
-        handler.onScroll?.({ contentOffset: { y: 100 } });
-        handler.onScroll?.({ contentOffset: { y: 200 } });
-        handler.onScroll?.({ contentOffset: { y: 300 } });
-        handler.onScroll?.({ contentOffset: { y: 400 } });
-        handler.onScroll?.({ contentOffset: { y: 500 } });
-      });
-
-      expect(result.current.scrollHandler).toBeDefined();
-    });
-
-    it('handles multiple direction changes without errors', async () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitFor(() => {
-        expect(result.current.layoutReady).toBe(true);
-      });
-
-      const handler = result.current.scrollHandler as unknown as ScrollHandler;
-
-      expect(() => {
-        handler.onScroll?.({ contentOffset: { y: 0 } });
-        handler.onScroll?.({ contentOffset: { y: 100 } });
-        handler.onScroll?.({ contentOffset: { y: 200 } });
-        handler.onScroll?.({ contentOffset: { y: 300 } });
-        handler.onScroll?.({ contentOffset: { y: 250 } });
-        handler.onScroll?.({ contentOffset: { y: 150 } });
-        handler.onScroll?.({ contentOffset: { y: 200 } });
-        handler.onScroll?.({ contentOffset: { y: 350 } });
-        handler.onScroll?.({ contentOffset: { y: 300 } });
-        handler.onScroll?.({ contentOffset: { y: 100 } });
-      }).not.toThrow();
     });
   });
 
   describe('onLayout callbacks', () => {
     it('provides onHeaderLayout callback', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       expect(typeof result.current.onHeaderLayout).toBe('function');
     });
 
     it('provides onTabBarLayout callback', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
+      const props = createDefaultProps();
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       expect(typeof result.current.onTabBarLayout).toBe('function');
     });
 
-    it('onHeaderLayout can be called without error', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      expect(() => {
-        act(() => {
-          result.current.onHeaderLayout({
-            nativeEvent: { layout: { height: 150, width: 375, x: 0, y: 0 } },
-          } as never);
-        });
-      }).not.toThrow();
-    });
-
-    it('onTabBarLayout can be called without error', () => {
-      const headerRef = createMockRef(120);
-      const tabBarRef = createMockRef(48);
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      expect(() => {
-        act(() => {
-          result.current.onTabBarLayout({
-            nativeEvent: { layout: { height: 56, width: 375, x: 0, y: 0 } },
-          } as never);
-        });
-      }).not.toThrow();
-    });
-
     it('updates headerHeight when onHeaderLayout called with value > 0', () => {
-      const headerRef = { current: null };
-      const tabBarRef = { current: null };
+      const props = createDefaultProps({
+        headerRef: { current: null } as React.RefObject<never>,
+        tabBarRef: { current: null } as React.RefObject<never>,
+      });
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       expect(result.current.headerHeight).toBe(0);
 
@@ -1096,15 +466,12 @@ describe('useFeedScrollManager', () => {
     });
 
     it('updates tabBarHeight when onTabBarLayout called with value > 0', () => {
-      const headerRef = { current: null };
-      const tabBarRef = { current: null };
+      const props = createDefaultProps({
+        headerRef: { current: null } as React.RefObject<never>,
+        tabBarRef: { current: null } as React.RefObject<never>,
+      });
 
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
+      const { result } = renderHook(() => useFeedScrollManager(props));
 
       expect(result.current.tabBarHeight).toBe(0);
 
@@ -1115,34 +482,6 @@ describe('useFeedScrollManager', () => {
       });
 
       expect(result.current.tabBarHeight).toBe(56);
-    });
-
-    it('ignores zero height in onHeaderLayout', () => {
-      const headerRef = { current: null };
-      const tabBarRef = { current: null };
-
-      const { result } = renderHook(() =>
-        useFeedScrollManager({
-          headerRef: headerRef as React.RefObject<never>,
-          tabBarRef: tabBarRef as React.RefObject<never>,
-        }),
-      );
-
-      act(() => {
-        result.current.onHeaderLayout({
-          nativeEvent: { layout: { height: 100, width: 375, x: 0, y: 0 } },
-        } as never);
-      });
-
-      expect(result.current.headerHeight).toBe(100);
-
-      act(() => {
-        result.current.onHeaderLayout({
-          nativeEvent: { layout: { height: 0, width: 375, x: 0, y: 0 } },
-        } as never);
-      });
-
-      expect(result.current.headerHeight).toBe(100);
     });
   });
 });

--- a/app/components/UI/Predict/hooks/useFeedScrollManager.ts
+++ b/app/components/UI/Predict/hooks/useFeedScrollManager.ts
@@ -16,7 +16,7 @@ import {
 export interface UseFeedScrollManagerParams {
   headerRef: React.RefObject<View>;
   tabBarRef: React.RefObject<View>;
-  initialIndex?: number;
+  setActiveIndex: (index: number) => void;
 }
 
 export interface UseFeedScrollManagerReturn {
@@ -25,8 +25,7 @@ export interface UseFeedScrollManagerReturn {
   headerHeight: number;
   tabBarHeight: number;
   layoutReady: boolean;
-  activeIndex: number;
-  setActiveIndex: (index: number) => void;
+  onTabSwitch: (index: number) => void;
   scrollHandler: ReturnType<typeof useAnimatedScrollHandler>;
   onHeaderLayout: (event: LayoutChangeEvent) => void;
   onTabBarLayout: (event: LayoutChangeEvent) => void;
@@ -69,34 +68,24 @@ export const SCROLL_THRESHOLD = 250;
 export const useFeedScrollManager = ({
   headerRef,
   tabBarRef,
-  initialIndex,
+  setActiveIndex,
 }: UseFeedScrollManagerParams): UseFeedScrollManagerReturn => {
-  // Header state: 0 = visible, 1 = hidden (binary, not continuous)
   const isHeaderHidden = useSharedValue(0);
-  // Header translateY: 0 = visible, -headerHeight = hidden
   const headerTranslateY = useSharedValue(0);
 
-  // Shared values for worklet access
   const sharedHeaderHeight = useSharedValue(0);
   const sharedTabBarHeight = useSharedValue(0);
   const lastScrollY = useSharedValue(0);
 
-  // Flag to skip direction detection on first scroll after tab switch
   const isTabSwitching = useSharedValue(false);
 
-  // Track accumulated scroll delta for threshold detection
   const accumulatedDelta = useSharedValue(0);
-  const lastDirection = useSharedValue(0); // 1 = down, -1 = up, 0 = none
+  const lastDirection = useSharedValue(0);
 
-  // Layout measurements (JS side)
   const [headerHeight, setHeaderHeight] = useState(0);
   const [tabBarHeight, setTabBarHeight] = useState(0);
   const [layoutReady, setLayoutReady] = useState(false);
 
-  // Tab state
-  const [activeIndex, setActiveIndex] = useState(() => initialIndex ?? 0);
-
-  // React state mirror of isHeaderHidden for reactive UI updates
   const [headerHidden, setHeaderHidden] = useState(false);
 
   useLayoutEffect(() => {
@@ -225,12 +214,12 @@ export const useFeedScrollManager = ({
     },
   });
 
-  const handleSetActiveIndex = useCallback(
+  const onTabSwitch = useCallback(
     (index: number) => {
       isTabSwitching.value = true;
       setActiveIndex(index);
     },
-    [isTabSwitching],
+    [isTabSwitching, setActiveIndex],
   );
 
   return {
@@ -239,8 +228,7 @@ export const useFeedScrollManager = ({
     headerHeight,
     tabBarHeight,
     layoutReady,
-    activeIndex,
-    setActiveIndex: handleSetActiveIndex,
+    onTabSwitch,
     scrollHandler,
     onHeaderLayout,
     onTabBarLayout,

--- a/app/components/UI/Predict/hooks/useFeedScrollManager.ts
+++ b/app/components/UI/Predict/hooks/useFeedScrollManager.ts
@@ -16,6 +16,7 @@ import {
 export interface UseFeedScrollManagerParams {
   headerRef: React.RefObject<View>;
   tabBarRef: React.RefObject<View>;
+  initialIndex?: number;
 }
 
 export interface UseFeedScrollManagerReturn {
@@ -68,6 +69,7 @@ export const SCROLL_THRESHOLD = 250;
 export const useFeedScrollManager = ({
   headerRef,
   tabBarRef,
+  initialIndex,
 }: UseFeedScrollManagerParams): UseFeedScrollManagerReturn => {
   // Header state: 0 = visible, 1 = hidden (binary, not continuous)
   const isHeaderHidden = useSharedValue(0);
@@ -92,7 +94,7 @@ export const useFeedScrollManager = ({
   const [layoutReady, setLayoutReady] = useState(false);
 
   // Tab state
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(() => initialIndex ?? 0);
 
   // React state mirror of isHeaderHidden for reactive UI updates
   const [headerHidden, setHeaderHidden] = useState(false);

--- a/app/components/UI/Predict/hooks/usePredictTabs.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.test.ts
@@ -99,6 +99,41 @@ describe('usePredictTabs', () => {
 
       expect(result.current.activeIndex).toBe(0);
     });
+
+    it('recalculates index when hot tab loads after deeplink', () => {
+      mockRouteParams.tab = 'crypto';
+      mockHotTabFlag.enabled = false;
+
+      const { result, rerender } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(3);
+      expect(result.current.tabs[3].key).toBe('crypto');
+
+      mockHotTabFlag.enabled = true;
+      rerender({});
+
+      expect(result.current.tabs[4].key).toBe('crypto');
+      expect(result.current.activeIndex).toBe(4);
+    });
+
+    it('does not recalculate index after user manually changes tab', () => {
+      mockRouteParams.tab = 'crypto';
+      mockHotTabFlag.enabled = false;
+
+      const { result, rerender } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(3);
+
+      act(() => {
+        result.current.setActiveIndex(0);
+      });
+      expect(result.current.activeIndex).toBe(0);
+
+      mockHotTabFlag.enabled = true;
+      rerender({});
+
+      expect(result.current.activeIndex).toBe(0);
+    });
   });
 
   describe('initialTabKey', () => {

--- a/app/components/UI/Predict/hooks/usePredictTabs.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.test.ts
@@ -116,6 +116,25 @@ describe('usePredictTabs', () => {
       expect(result.current.activeIndex).toBe(4);
     });
 
+    it('recalculates index even after programmatic sync with same value', () => {
+      mockRouteParams.tab = 'crypto';
+      mockHotTabFlag.enabled = false;
+
+      const { result, rerender } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(3);
+
+      act(() => {
+        result.current.setActiveIndex(3);
+      });
+      expect(result.current.activeIndex).toBe(3);
+
+      mockHotTabFlag.enabled = true;
+      rerender({});
+
+      expect(result.current.activeIndex).toBe(4);
+    });
+
     it('does not recalculate index after user manually changes tab', () => {
       mockRouteParams.tab = 'crypto';
       mockHotTabFlag.enabled = false;

--- a/app/components/UI/Predict/hooks/usePredictTabs.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.test.ts
@@ -1,0 +1,149 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { usePredictTabs } from './usePredictTabs';
+
+const mockRouteParams: { tab?: string } = {};
+
+jest.mock('@react-navigation/native', () => ({
+  useRoute: () => ({
+    params: mockRouteParams,
+  }),
+}));
+
+const mockHotTabFlag: { enabled: boolean; queryParams: string | undefined } = {
+  enabled: false,
+  queryParams: undefined,
+};
+
+jest.mock('react-redux', () => ({
+  useSelector: () => mockHotTabFlag,
+}));
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+describe('usePredictTabs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouteParams.tab = undefined;
+    mockHotTabFlag.enabled = false;
+    mockHotTabFlag.queryParams = undefined;
+  });
+
+  describe('tabs array', () => {
+    it('returns base tabs when hot tab is disabled', () => {
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.tabs).toHaveLength(5);
+      expect(result.current.tabs[0].key).toBe('trending');
+    });
+
+    it('includes hot tab at beginning when enabled', () => {
+      mockHotTabFlag.enabled = true;
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.tabs).toHaveLength(6);
+      expect(result.current.tabs[0].key).toBe('hot');
+      expect(result.current.tabs[1].key).toBe('trending');
+    });
+  });
+
+  describe('activeIndex', () => {
+    it('defaults to 0 (trending) when no requested tab', () => {
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(0);
+    });
+
+    it('sets active index to requested tab position', () => {
+      mockRouteParams.tab = 'crypto';
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(3);
+    });
+
+    it('defaults to trending for invalid requested tab', () => {
+      mockRouteParams.tab = 'invalid';
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(0);
+    });
+
+    it('updates when setActiveIndex is called', () => {
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(0);
+
+      act(() => {
+        result.current.setActiveIndex(2);
+      });
+
+      expect(result.current.activeIndex).toBe(2);
+    });
+  });
+
+  describe('initial tab with feature flag loading', () => {
+    it('applies hot tab when flag loads and tab was requested', () => {
+      mockRouteParams.tab = 'hot';
+      mockHotTabFlag.enabled = false;
+
+      const { result, rerender } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(0);
+
+      mockHotTabFlag.enabled = true;
+      rerender({});
+
+      expect(result.current.activeIndex).toBe(0);
+    });
+  });
+
+  describe('initialTabKey', () => {
+    it('returns trending as default', () => {
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.initialTabKey).toBe('trending');
+    });
+
+    it('returns requested tab when valid', () => {
+      mockRouteParams.tab = 'sports';
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.initialTabKey).toBe('sports');
+    });
+
+    it('remains stable across rerenders', () => {
+      mockRouteParams.tab = 'crypto';
+
+      const { result, rerender } = renderHook(() => usePredictTabs());
+
+      const firstKey = result.current.initialTabKey;
+
+      mockRouteParams.tab = 'sports';
+      rerender({});
+
+      expect(result.current.initialTabKey).toBe(firstKey);
+    });
+  });
+
+  describe('hotTabQueryParams', () => {
+    it('returns undefined when hot tab is disabled', () => {
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.hotTabQueryParams).toBeUndefined();
+    });
+
+    it('returns query params when hot tab is enabled', () => {
+      mockHotTabFlag.enabled = true;
+      mockHotTabFlag.queryParams = 'test=value';
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.hotTabQueryParams).toBe('test=value');
+    });
+  });
+});

--- a/app/components/UI/Predict/hooks/usePredictTabs.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.test.ts
@@ -146,4 +146,52 @@ describe('usePredictTabs', () => {
       expect(result.current.hotTabQueryParams).toBe('test=value');
     });
   });
+
+  describe('deeplink navigation while on screen', () => {
+    it('switches to new tab when route params change', () => {
+      mockRouteParams.tab = 'trending';
+
+      const { result, rerender } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(0);
+
+      mockRouteParams.tab = 'crypto';
+      rerender({});
+
+      expect(result.current.activeIndex).toBe(3);
+    });
+
+    it('switches from manually selected tab to deeplink tab', () => {
+      mockRouteParams.tab = undefined;
+
+      const { result, rerender } = renderHook(() => usePredictTabs());
+
+      act(() => {
+        result.current.setActiveIndex(4);
+      });
+      expect(result.current.activeIndex).toBe(4);
+
+      mockRouteParams.tab = 'sports';
+      rerender({});
+
+      expect(result.current.activeIndex).toBe(2);
+    });
+
+    it('does not change tab when route params stay the same', () => {
+      mockRouteParams.tab = 'crypto';
+
+      const { result, rerender } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(3);
+
+      act(() => {
+        result.current.setActiveIndex(0);
+      });
+      expect(result.current.activeIndex).toBe(0);
+
+      rerender({});
+
+      expect(result.current.activeIndex).toBe(0);
+    });
+  });
 });

--- a/app/components/UI/Predict/hooks/usePredictTabs.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.ts
@@ -96,8 +96,12 @@ export const usePredictTabs = (): UsePredictTabsResult => {
   }, [requestedTabKey, tabs]);
 
   const setActiveIndex = useCallback((index: number) => {
-    isFollowingDeeplinkRef.current = false;
-    setActiveIndexState(index);
+    setActiveIndexState((prevIndex) => {
+      if (index !== prevIndex) {
+        isFollowingDeeplinkRef.current = false;
+      }
+      return index;
+    });
   }, []);
 
   return {

--- a/app/components/UI/Predict/hooks/usePredictTabs.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.ts
@@ -4,16 +4,15 @@ import { useRoute, RouteProp } from '@react-navigation/native';
 import { strings } from '../../../../../locales/i18n';
 import { selectPredictHotTabFlag } from '../selectors/featureFlags';
 import {
-  PREDICT_FEED_BASE_TABS,
-  PREDICT_FEED_DEFAULT_TAB,
-  PREDICT_FEED_HOT_TAB,
-  isPredictFeedTabKey,
-  type PredictFeedTabKey,
+  PREDICT_BASE_TABS,
+  PREDICT_HOT_TAB,
+  isPredictTabKey,
+  type PredictTabKey,
 } from '../constants/feedTabs';
 import type { PredictNavigationParamList } from '../types/navigation';
 
 export interface FeedTab {
-  key: PredictFeedTabKey;
+  key: PredictTabKey;
   label: string;
 }
 
@@ -21,7 +20,7 @@ export interface UsePredictTabsResult {
   tabs: FeedTab[];
   activeIndex: number;
   setActiveIndex: (index: number) => void;
-  initialTabKey: PredictFeedTabKey;
+  initialTabKey: PredictTabKey;
   hotTabQueryParams?: string;
 }
 
@@ -31,27 +30,27 @@ export const usePredictTabs = (): UsePredictTabsResult => {
   const hotTabFlag = useSelector(selectPredictHotTabFlag);
 
   const tabs: FeedTab[] = useMemo(() => {
-    const baseTabs: FeedTab[] = PREDICT_FEED_BASE_TABS.map((tab) => ({
+    const baseTabs: FeedTab[] = PREDICT_BASE_TABS.map((tab) => ({
       key: tab.key,
       label: strings(tab.labelKey),
     }));
 
     if (hotTabFlag.enabled) {
       baseTabs.unshift({
-        key: PREDICT_FEED_HOT_TAB.key,
-        label: strings(PREDICT_FEED_HOT_TAB.labelKey),
+        key: PREDICT_HOT_TAB.key,
+        label: strings(PREDICT_HOT_TAB.labelKey),
       });
     }
 
     return baseTabs;
   }, [hotTabFlag.enabled]);
 
-  const requestedTabKey = isPredictFeedTabKey(route.params?.tab)
+  const requestedTabKey = isPredictTabKey(route.params?.tab)
     ? route.params?.tab
     : undefined;
 
-  const initialTabKeyRef = useRef<PredictFeedTabKey>(
-    requestedTabKey ?? PREDICT_FEED_DEFAULT_TAB,
+  const initialTabKeyRef = useRef<PredictTabKey>(
+    requestedTabKey ?? tabs[0].key,
   );
 
   const getInitialIndex = useCallback((tabsArray: FeedTab[]): number => {
@@ -60,14 +59,14 @@ export const usePredictTabs = (): UsePredictTabsResult => {
     if (index >= 0) return index;
 
     const fallbackIndex = tabsArray.findIndex(
-      (tab) => tab.key === PREDICT_FEED_DEFAULT_TAB,
+      (tab) => tab.key === tabsArray[0].key,
     );
     return fallbackIndex >= 0 ? fallbackIndex : 0;
   }, []);
 
   const [activeIndex, setActiveIndex] = useState(() => getInitialIndex(tabs));
 
-  const prevRequestedTabKeyRef = useRef<PredictFeedTabKey | undefined>(
+  const prevRequestedTabKeyRef = useRef<PredictTabKey | undefined>(
     requestedTabKey,
   );
 

--- a/app/components/UI/Predict/hooks/usePredictTabs.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.ts
@@ -17,7 +17,7 @@ export interface FeedTab {
   label: string;
 }
 
-export interface UsePredictTabsResponse {
+export interface UsePredictTabsResult {
   tabs: FeedTab[];
   activeIndex: number;
   setActiveIndex: (index: number) => void;
@@ -25,7 +25,7 @@ export interface UsePredictTabsResponse {
   hotTabQueryParams?: string;
 }
 
-export const usePredictTabs = (): UsePredictTabsResponse => {
+export const usePredictTabs = (): UsePredictTabsResult => {
   const route =
     useRoute<RouteProp<PredictNavigationParamList, 'PredictMarketList'>>();
   const hotTabFlag = useSelector(selectPredictHotTabFlag);

--- a/app/components/UI/Predict/hooks/usePredictTabs.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.ts
@@ -56,12 +56,7 @@ export const usePredictTabs = (): UsePredictTabsResult => {
   const getInitialIndex = useCallback((tabsArray: FeedTab[]): number => {
     const key = initialTabKeyRef.current;
     const index = tabsArray.findIndex((tab) => tab.key === key);
-    if (index >= 0) return index;
-
-    const fallbackIndex = tabsArray.findIndex(
-      (tab) => tab.key === tabsArray[0].key,
-    );
-    return fallbackIndex >= 0 ? fallbackIndex : 0;
+    return Math.max(index, 0);
   }, []);
 
   const [activeIndex, setActiveIndexState] = useState(() =>

--- a/app/components/UI/Predict/hooks/usePredictTabs.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.ts
@@ -1,0 +1,90 @@
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { useRoute, RouteProp } from '@react-navigation/native';
+import { strings } from '../../../../../locales/i18n';
+import { selectPredictHotTabFlag } from '../selectors/featureFlags';
+import {
+  PREDICT_FEED_BASE_TABS,
+  PREDICT_FEED_DEFAULT_TAB,
+  PREDICT_FEED_HOT_TAB,
+  isPredictFeedTabKey,
+  type PredictFeedTabKey,
+} from '../constants/feedTabs';
+import type { PredictNavigationParamList } from '../types/navigation';
+
+export interface FeedTab {
+  key: PredictFeedTabKey;
+  label: string;
+}
+
+export interface UsePredictTabsResponse {
+  tabs: FeedTab[];
+  activeIndex: number;
+  setActiveIndex: (index: number) => void;
+  initialTabKey: PredictFeedTabKey;
+  hotTabQueryParams?: string;
+}
+
+export const usePredictTabs = (): UsePredictTabsResponse => {
+  const route =
+    useRoute<RouteProp<PredictNavigationParamList, 'PredictMarketList'>>();
+  const hotTabFlag = useSelector(selectPredictHotTabFlag);
+
+  const tabs: FeedTab[] = useMemo(() => {
+    const baseTabs: FeedTab[] = PREDICT_FEED_BASE_TABS.map((tab) => ({
+      key: tab.key,
+      label: strings(tab.labelKey),
+    }));
+
+    if (hotTabFlag.enabled) {
+      baseTabs.unshift({
+        key: PREDICT_FEED_HOT_TAB.key,
+        label: strings(PREDICT_FEED_HOT_TAB.labelKey),
+      });
+    }
+
+    return baseTabs;
+  }, [hotTabFlag.enabled]);
+
+  const requestedTabKey = isPredictFeedTabKey(route.params?.tab)
+    ? route.params?.tab
+    : undefined;
+
+  const initialTabKeyRef = useRef<PredictFeedTabKey>(
+    requestedTabKey ?? PREDICT_FEED_DEFAULT_TAB,
+  );
+
+  const getInitialIndex = useCallback((tabsArray: FeedTab[]): number => {
+    const key = initialTabKeyRef.current;
+    const index = tabsArray.findIndex((tab) => tab.key === key);
+    if (index >= 0) return index;
+
+    const fallbackIndex = tabsArray.findIndex(
+      (tab) => tab.key === PREDICT_FEED_DEFAULT_TAB,
+    );
+    return fallbackIndex >= 0 ? fallbackIndex : 0;
+  }, []);
+
+  const [activeIndex, setActiveIndex] = useState(() => getInitialIndex(tabs));
+
+  const hasAppliedRequestedTabRef = useRef(false);
+
+  useEffect(() => {
+    if (!requestedTabKey || hasAppliedRequestedTabRef.current) return;
+
+    const requestedIndex = tabs.findIndex((tab) => tab.key === requestedTabKey);
+
+    if (requestedIndex >= 0) {
+      setActiveIndex(requestedIndex);
+      hasAppliedRequestedTabRef.current = true;
+    }
+  }, [requestedTabKey, tabs]);
+
+  return {
+    tabs,
+    activeIndex,
+    setActiveIndex,
+    initialTabKey: initialTabKeyRef.current,
+    hotTabQueryParams: hotTabFlag.queryParams,
+  };
+};

--- a/app/components/UI/Predict/hooks/usePredictTabs.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.ts
@@ -64,29 +64,46 @@ export const usePredictTabs = (): UsePredictTabsResult => {
     return fallbackIndex >= 0 ? fallbackIndex : 0;
   }, []);
 
-  const [activeIndex, setActiveIndex] = useState(() => getInitialIndex(tabs));
+  const [activeIndex, setActiveIndexState] = useState(() =>
+    getInitialIndex(tabs),
+  );
 
   const prevRequestedTabKeyRef = useRef<PredictTabKey | undefined>(
     requestedTabKey,
   );
+  const isFollowingDeeplinkRef = useRef(Boolean(requestedTabKey));
 
   useEffect(() => {
     if (!requestedTabKey) {
       prevRequestedTabKeyRef.current = undefined;
+      isFollowingDeeplinkRef.current = false;
       return;
     }
 
     const isNewDeeplinkNavigation =
       requestedTabKey !== prevRequestedTabKeyRef.current;
-    if (!isNewDeeplinkNavigation) return;
+
+    if (isNewDeeplinkNavigation) {
+      isFollowingDeeplinkRef.current = true;
+    }
+
+    if (!isFollowingDeeplinkRef.current) {
+      prevRequestedTabKeyRef.current = requestedTabKey;
+      return;
+    }
 
     const requestedIndex = tabs.findIndex((tab) => tab.key === requestedTabKey);
     if (requestedIndex >= 0) {
-      setActiveIndex(requestedIndex);
+      setActiveIndexState(requestedIndex);
     }
 
     prevRequestedTabKeyRef.current = requestedTabKey;
   }, [requestedTabKey, tabs]);
+
+  const setActiveIndex = useCallback((index: number) => {
+    isFollowingDeeplinkRef.current = false;
+    setActiveIndexState(index);
+  }, []);
 
   return {
     tabs,

--- a/app/components/UI/Predict/hooks/usePredictTabs.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.ts
@@ -67,17 +67,26 @@ export const usePredictTabs = (): UsePredictTabsResponse => {
 
   const [activeIndex, setActiveIndex] = useState(() => getInitialIndex(tabs));
 
-  const hasAppliedRequestedTabRef = useRef(false);
+  const prevRequestedTabKeyRef = useRef<PredictFeedTabKey | undefined>(
+    requestedTabKey,
+  );
 
   useEffect(() => {
-    if (!requestedTabKey || hasAppliedRequestedTabRef.current) return;
+    if (!requestedTabKey) {
+      prevRequestedTabKeyRef.current = undefined;
+      return;
+    }
+
+    const isNewDeeplinkNavigation =
+      requestedTabKey !== prevRequestedTabKeyRef.current;
+    if (!isNewDeeplinkNavigation) return;
 
     const requestedIndex = tabs.findIndex((tab) => tab.key === requestedTabKey);
-
     if (requestedIndex >= 0) {
       setActiveIndex(requestedIndex);
-      hasAppliedRequestedTabRef.current = true;
     }
+
+    prevRequestedTabKeyRef.current = requestedTabKey;
   }, [requestedTabKey, tabs]);
 
   return {

--- a/app/components/UI/Predict/types/navigation.ts
+++ b/app/components/UI/Predict/types/navigation.ts
@@ -1,6 +1,7 @@
 import { ParamListBase } from '@react-navigation/native';
 import {
   PredictActivityItem,
+  PredictCategory,
   PredictMarket,
   PredictOutcome,
   PredictOutcomeToken,
@@ -27,6 +28,7 @@ export interface PredictNavigationParamList extends ParamListBase {
   Predict: undefined;
   PredictMarketList: {
     entryPoint?: PredictEntryPoint;
+    tab?: PredictCategory;
   };
   PredictMarketDetails: {
     marketId?: string;

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -242,9 +242,10 @@ describe('PredictFeed', () => {
       headerHeight: 100,
       tabBarHeight: 48,
       layoutReady: true,
-      activeIndex: 0,
-      setActiveIndex: jest.fn(),
+      onTabSwitch: jest.fn(),
       scrollHandler: jest.fn(),
+      onHeaderLayout: jest.fn(),
+      onTabBarLayout: jest.fn(),
     });
     mockUsePredictMarketData.mockReturnValue({
       marketData: [
@@ -480,16 +481,17 @@ describe('PredictFeed', () => {
 
   describe('pager view interactions', () => {
     it('updates active index and tracks analytics when page changes via swipe', () => {
-      const mockSetActiveIndex = jest.fn();
+      const mockOnTabSwitch = jest.fn();
       mockUseFeedScrollManager.mockReturnValue({
         headerTranslateY: { value: 0 },
         headerHidden: false,
         headerHeight: 100,
         tabBarHeight: 48,
         layoutReady: true,
-        activeIndex: 0,
-        setActiveIndex: mockSetActiveIndex,
+        onTabSwitch: mockOnTabSwitch,
         scrollHandler: jest.fn(),
+        onHeaderLayout: jest.fn(),
+        onTabBarLayout: jest.fn(),
       });
 
       const { getByTestId } = render(<PredictFeed />);
@@ -497,7 +499,7 @@ describe('PredictFeed', () => {
 
       fireEvent(page1, 'onTouchEnd');
 
-      expect(mockSetActiveIndex).toHaveBeenCalledWith(1);
+      expect(mockOnTabSwitch).toHaveBeenCalledWith(1);
       expect(mockSessionManager.trackTabChange).toHaveBeenCalledWith('new');
     });
   });
@@ -510,9 +512,10 @@ describe('PredictFeed', () => {
         headerHeight: 100,
         tabBarHeight: 48,
         layoutReady: false,
-        activeIndex: 0,
-        setActiveIndex: jest.fn(),
+        onTabSwitch: jest.fn(),
         scrollHandler: jest.fn(),
+        onHeaderLayout: jest.fn(),
+        onTabBarLayout: jest.fn(),
       });
 
       const { queryByTestId } = render(<PredictFeed />);
@@ -766,16 +769,17 @@ describe('PredictFeed', () => {
         queryParams: 'tag_id=149',
       });
 
-      const mockSetActiveIndex = jest.fn();
+      const mockOnTabSwitch = jest.fn();
       mockUseFeedScrollManager.mockReturnValue({
         headerTranslateY: { value: 0 },
         headerHidden: false,
         headerHeight: 100,
         tabBarHeight: 48,
         layoutReady: true,
-        activeIndex: 1,
-        setActiveIndex: mockSetActiveIndex,
+        onTabSwitch: mockOnTabSwitch,
         scrollHandler: jest.fn(),
+        onHeaderLayout: jest.fn(),
+        onTabBarLayout: jest.fn(),
       });
 
       const { getByTestId } = render(<PredictFeed />);
@@ -783,14 +787,20 @@ describe('PredictFeed', () => {
 
       fireEvent(hotTabPage, 'onTouchEnd');
 
-      expect(mockSetActiveIndex).toHaveBeenCalledWith(0);
+      expect(mockOnTabSwitch).toHaveBeenCalledWith(0);
       expect(mockSessionManager.trackTabChange).toHaveBeenCalledWith('hot');
     });
 
-    it('starts session with hot as initial tab when flag is enabled', () => {
+    it('starts session with hot as initial tab when requested via deeplink', () => {
       mockUseSelector.mockReturnValue({
         enabled: true,
         queryParams: 'tag_id=149',
+      });
+      mockUseRoute.mockReturnValue({
+        params: {
+          entryPoint: 'homepage_new_prediction',
+          tab: 'hot',
+        },
       });
 
       render(<PredictFeed />);

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -611,9 +611,25 @@ const PredictFeed: React.FC = () => {
   const headerRef = useRef<View>(null);
   const tabBarRef = useRef<View>(null);
 
+  const defaultTabKey: FeedTab['key'] = 'trending';
+  const requestedTab = route.params?.tab;
+
   // Capture the initial tab key at mount to avoid re-triggering the analytics
   // session when tabs array changes due to async feature flag loading
-  const initialTabKeyRef = useRef(tabs[0].key);
+  const initialTabKeyRef = useRef<FeedTab['key']>(
+    requestedTab && tabs.some((tab) => tab.key === requestedTab)
+      ? requestedTab
+      : defaultTabKey,
+  );
+
+  const initialTabIndex = useMemo(() => {
+    const key = initialTabKeyRef.current;
+    const index = tabs.findIndex((tab) => tab.key === key);
+    if (index >= 0) return index;
+
+    const fallbackIndex = tabs.findIndex((tab) => tab.key === defaultTabKey);
+    return fallbackIndex >= 0 ? fallbackIndex : 0;
+  }, [tabs, defaultTabKey]);
 
   const [isSearchVisible, setIsSearchVisible] = useState(false);
 
@@ -674,7 +690,11 @@ const PredictFeed: React.FC = () => {
     scrollHandler,
     onHeaderLayout,
     onTabBarLayout,
-  } = useFeedScrollManager({ headerRef, tabBarRef });
+  } = useFeedScrollManager({
+    headerRef,
+    tabBarRef,
+    initialIndex: initialTabIndex,
+  });
 
   const handleTabPress = useCallback(
     (index: number) => {

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -75,6 +75,11 @@ import {
 } from '../../../../../component-library/components-temp/Tabs';
 import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import { selectPredictHotTabFlag } from '../../selectors/featureFlags';
+import {
+  PREDICT_FEED_BASE_TABS,
+  PREDICT_FEED_DEFAULT_TAB,
+  PREDICT_FEED_HOT_TAB,
+} from '../../constants/feedTabs';
 
 interface FeedTab {
   key: PredictCategory;
@@ -586,16 +591,16 @@ const PredictFeed: React.FC = () => {
   const hotTabFlag = useSelector(selectPredictHotTabFlag);
 
   const tabs: FeedTab[] = useMemo(() => {
-    const baseTabs: FeedTab[] = [
-      { key: 'trending', label: strings('predict.category.trending') },
-      { key: 'new', label: strings('predict.category.new') },
-      { key: 'sports', label: strings('predict.category.sports') },
-      { key: 'crypto', label: strings('predict.category.crypto') },
-      { key: 'politics', label: strings('predict.category.politics') },
-    ];
+    const baseTabs: FeedTab[] = PREDICT_FEED_BASE_TABS.map((tab) => ({
+      key: tab.key,
+      label: strings(tab.labelKey),
+    }));
 
     if (hotTabFlag.enabled) {
-      baseTabs.unshift({ key: 'hot', label: strings('predict.category.hot') });
+      baseTabs.unshift({
+        key: PREDICT_FEED_HOT_TAB.key,
+        label: strings(PREDICT_FEED_HOT_TAB.labelKey),
+      });
     }
 
     return baseTabs;
@@ -611,7 +616,7 @@ const PredictFeed: React.FC = () => {
   const headerRef = useRef<View>(null);
   const tabBarRef = useRef<View>(null);
 
-  const defaultTabKey: FeedTab['key'] = 'trending';
+  const defaultTabKey: FeedTab['key'] = PREDICT_FEED_DEFAULT_TAB;
   const requestedTab = route.params?.tab;
 
   // Capture the initial tab key at mount to avoid re-triggering the analytics

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -74,14 +74,6 @@ import {
   TabsBar,
 } from '../../../../../component-library/components-temp/Tabs';
 import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
-import { selectPredictHotTabFlag } from '../../selectors/featureFlags';
-import {
-  PREDICT_FEED_BASE_TABS,
-  PREDICT_FEED_DEFAULT_TAB,
-  PREDICT_FEED_HOT_TAB,
-  isPredictFeedTabKey,
-} from '../../constants/feedTabs';
-import HeaderCenter from '../../../../../component-library/components-temp/HeaderCenter';
 
 type PredictFlashListRef = FlashListRef<PredictMarketType>;
 type PredictFlashListProps = FlashListProps<PredictMarketType> & {

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handlePredictUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handlePredictUrl.test.ts
@@ -191,6 +191,42 @@ describe('handlePredictUrl', () => {
         },
       });
     });
+
+    it('navigates to market list with hot tab parameter', async () => {
+      await handlePredictUrl({ predictPath: '?tab=hot' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+        params: {
+          entryPoint: 'deeplink',
+          tab: 'hot',
+        },
+      });
+    });
+
+    it('normalizes uppercase tab parameter to lowercase', async () => {
+      await handlePredictUrl({ predictPath: '?tab=CRYPTO' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+        params: {
+          entryPoint: 'deeplink',
+          tab: 'crypto',
+        },
+      });
+    });
+
+    it('ignores tab parameter when market parameter is present', async () => {
+      await handlePredictUrl({ predictPath: '?market=123&tab=crypto' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '123',
+          entryPoint: 'deeplink',
+        },
+      });
+    });
   });
 
   describe('error handling', () => {
@@ -270,7 +306,7 @@ describe('handlePredictUrl', () => {
 
       expect(DevLogger.log).toHaveBeenCalledWith(
         '[handlePredictUrl] Parsed navigation parameters:',
-        { market: '23246', utmSource: undefined },
+        { market: '23246', utmSource: undefined, tab: undefined },
       );
     });
 
@@ -556,7 +592,7 @@ describe('handlePredictUrl', () => {
 
       expect(DevLogger.log).toHaveBeenCalledWith(
         '[handlePredictUrl] Parsed navigation parameters:',
-        { market: '23246', utmSource: 'test' },
+        { market: '23246', utmSource: 'test', tab: undefined },
       );
     });
 

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handlePredictUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handlePredictUrl.test.ts
@@ -168,6 +168,29 @@ describe('handlePredictUrl', () => {
         },
       });
     });
+
+    it('navigates to market list with tab parameter when provided', async () => {
+      await handlePredictUrl({ predictPath: '?tab=crypto' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+        params: {
+          entryPoint: 'deeplink',
+          tab: 'crypto',
+        },
+      });
+    });
+
+    it('ignores invalid tab parameter and falls back to default list params', async () => {
+      await handlePredictUrl({ predictPath: '?tab=invalid' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+        params: {
+          entryPoint: 'deeplink',
+        },
+      });
+    });
   });
 
   describe('error handling', () => {

--- a/app/core/DeeplinkManager/handlers/legacy/handlePredictUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handlePredictUrl.ts
@@ -35,8 +35,8 @@ const parsePredictNavigationParams = (
   // Support both 'market' and 'marketId' parameter names
   const marketId = urlParams.get('market') || urlParams.get('marketId');
   const utmSource = urlParams.get('utm_source');
-  const rawTab = urlParams.get('tab')?.toLowerCase();
-  const tab = isPredictFeedTabKey(rawTab) ? rawTab : undefined;
+  const tabParam = urlParams.get('tab')?.toLowerCase();
+  const tab = isPredictFeedTabKey(tabParam) ? tabParam : undefined;
 
   return {
     market: marketId || undefined,

--- a/app/core/DeeplinkManager/handlers/legacy/handlePredictUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handlePredictUrl.ts
@@ -1,6 +1,10 @@
 import NavigationService from '../../../NavigationService';
 import Routes from '../../../../constants/navigation/Routes';
 import DevLogger from '../../../SDKConnect/utils/DevLogger';
+import {
+  isPredictFeedTabKey,
+  type PredictFeedTabKey,
+} from '../../../../components/UI/Predict/constants/feedTabs';
 
 interface HandlePredictUrlParams {
   predictPath: string;
@@ -13,25 +17,8 @@ interface HandlePredictUrlParams {
 interface PredictNavigationParams {
   market?: string; // Market ID
   utmSource?: string; // UTM source for analytics tracking
-  tab?: PredictFeedTab; // Feed tab (when no market param)
+  tab?: PredictFeedTabKey; // Feed tab (when no market param)
 }
-
-type PredictFeedTab =
-  | 'trending'
-  | 'new'
-  | 'sports'
-  | 'crypto'
-  | 'politics'
-  | 'hot';
-
-const PREDICT_FEED_TABS = new Set<PredictFeedTab>([
-  'trending',
-  'new',
-  'sports',
-  'crypto',
-  'politics',
-  'hot',
-]);
 
 /**
  * Parse URL parameters into typed navigation parameters
@@ -49,10 +36,7 @@ const parsePredictNavigationParams = (
   const marketId = urlParams.get('market') || urlParams.get('marketId');
   const utmSource = urlParams.get('utm_source');
   const rawTab = urlParams.get('tab')?.toLowerCase();
-  const tab =
-    rawTab && PREDICT_FEED_TABS.has(rawTab as PredictFeedTab)
-      ? (rawTab as PredictFeedTab)
-      : undefined;
+  const tab = isPredictFeedTabKey(rawTab) ? rawTab : undefined;
 
   return {
     market: marketId || undefined,

--- a/app/core/DeeplinkManager/handlers/legacy/handlePredictUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handlePredictUrl.ts
@@ -2,8 +2,8 @@ import NavigationService from '../../../NavigationService';
 import Routes from '../../../../constants/navigation/Routes';
 import DevLogger from '../../../SDKConnect/utils/DevLogger';
 import {
-  isPredictFeedTabKey,
-  type PredictFeedTabKey,
+  isPredictTabKey,
+  type PredictTabKey,
 } from '../../../../components/UI/Predict/constants/feedTabs';
 
 interface HandlePredictUrlParams {
@@ -17,7 +17,7 @@ interface HandlePredictUrlParams {
 interface PredictNavigationParams {
   market?: string; // Market ID
   utmSource?: string; // UTM source for analytics tracking
-  tab?: PredictFeedTabKey; // Feed tab (when no market param)
+  tab?: PredictTabKey; // Feed tab (when no market param)
 }
 
 /**
@@ -36,7 +36,7 @@ const parsePredictNavigationParams = (
   const marketId = urlParams.get('market') || urlParams.get('marketId');
   const utmSource = urlParams.get('utm_source');
   const tabParam = urlParams.get('tab')?.toLowerCase();
-  const tab = isPredictFeedTabKey(tabParam) ? tabParam : undefined;
+  const tab = isPredictTabKey(tabParam) ? tabParam : undefined;
 
   return {
     market: marketId || undefined,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Add feed tab constants with type-safe configuration (feedTabs.ts)
- Create usePredictTabs hook for tab state management from deeplinks
- Refactor useFeedScrollManager to accept setActiveIndex as prop
- Add isPredictFeedTabKey validator for deeplink parameter validation
- Support tab categories: trending, new, sports, crypto, politics, hot
- Update tests with createDefaultProps helper and onTabSwitch pattern

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-632?atlOrigin=eyJpIjoiMzMyZGZjZmJlODA4NGYxMGEyZWEyNWI1OTk4MTQ3YTUiLCJwIjoiaiJ9

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

https://www.loom.com/share/960027a187a848beb0f8a01cc1f4cf20

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deeplink parsing/navigation and Predict feed tab state initialization/synchronization, which can cause incorrect initial tab selection or analytics/session attribution if regressions occur.
> 
> **Overview**
> Adds deeplink support for opening the Predict feed on a specific category by introducing a typed tab registry (`feedTabs.ts`) and validating/normalizing the `tab` query param in `handlePredictUrl` (ignored when `market` is present, invalid values dropped).
> 
> Refactors `PredictFeed` to use a new `usePredictTabs` hook that derives the tabs array (including feature-flagged `hot`), computes/stabilizes the initial tab for analytics, and keeps the active tab in sync with route param changes; `PagerView` now receives a dynamic `initialPage`. `useFeedScrollManager` is adjusted to no longer own tab state and instead accepts an external `setActiveIndex`, exposing `onTabSwitch` to preserve the “skip first scroll after tab change” behavior.
> 
> Updates navigation types to include `tab` on `PredictMarketList` and revises/adds tests for `usePredictTabs`, deeplink handler tab parsing, and the updated `useFeedScrollManager`/`PredictFeed` APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0777847213ded5b90d6f01bb97dd233df044ffc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->