### PR TITLE
fix: Refactor pending withdraw/deposit tracking to fifo queue design

### DIFF
--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -184,6 +184,7 @@ export type PerpsControllerState = {
   lastDepositResult: LastTransactionResult | null;
 
   // Simple withdrawal state (transient, for UI feedback)
+  // Note: withdrawInProgress is now derived from withdrawalRequests having pending/bridging entries
   withdrawInProgress: boolean;
   lastWithdrawResult: LastTransactionResult | null;
 
@@ -1872,6 +1873,88 @@ export class PerpsController extends BaseController<
         });
       }
     });
+  }
+
+  /**
+   * Complete a specific withdrawal detected via transaction history polling (FIFO queue).
+   * Called when a completed withdrawal appears in the transaction history matching a pending request.
+   *
+   * Key design: The hook polls getUserHistory (same API the transaction history UI uses).
+   * Uses FIFO matching: oldest pending withdrawal is matched with first completed withdrawal
+   * in history that happened after its submission time.
+   *
+   * @param withdrawalRequestId - The ID of the pending withdrawal request to mark as complete
+   * @param completedWithdrawal - The completed withdrawal data from the history API
+   */
+  completeWithdrawalFromHistory(
+    withdrawalRequestId: string,
+    completedWithdrawal: {
+      txHash: string;
+      amount: string;
+      timestamp: number;
+      asset?: string;
+    },
+  ): void {
+    this.update((state) => {
+      // Find and remove the specific withdrawal request
+      const requestIndex = state.withdrawalRequests.findIndex(
+        (req) => req.id === withdrawalRequestId,
+      );
+
+      if (requestIndex !== -1) {
+        // Remove this specific request from the queue
+        state.withdrawalRequests.splice(requestIndex, 1);
+      }
+
+      // Update lastWithdrawResult with the completed withdrawal
+      state.lastWithdrawResult = {
+        success: true,
+        txHash: completedWithdrawal.txHash,
+        amount: completedWithdrawal.amount,
+        asset: completedWithdrawal.asset || USDC_SYMBOL,
+        timestamp: completedWithdrawal.timestamp,
+        error: '',
+      };
+
+      // Check if there are still pending withdrawals in the queue
+      const hasPendingWithdrawals = state.withdrawalRequests.some(
+        (req) => req.status === 'pending' || req.status === 'bridging',
+      );
+
+      // Only set withdrawInProgress to false if queue is empty
+      state.withdrawInProgress = hasPendingWithdrawals;
+
+      // Clear withdrawal progress only if no more pending withdrawals
+      if (!hasPendingWithdrawals) {
+        state.withdrawalProgress = {
+          progress: 0,
+          lastUpdated: Date.now(),
+          activeWithdrawalId: null,
+        };
+      }
+
+      state.lastUpdateTimestamp = Date.now();
+    });
+
+    this.debugLog(
+      'PerpsController: Completed withdrawal from transaction history (FIFO)',
+      {
+        withdrawalRequestId,
+        txHash: completedWithdrawal.txHash,
+        amount: completedWithdrawal.amount,
+      },
+    );
+
+    // Track the completion
+    this.getMetrics().trackPerpsEvent(
+      PerpsAnalyticsEvent.WithdrawalTransaction,
+      {
+        [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.COMPLETED,
+        [PERPS_EVENT_PROPERTY.WITHDRAWAL_AMOUNT]: Number.parseFloat(
+          completedWithdrawal.amount,
+        ),
+      },
+    );
   }
 
   /**

--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -1906,15 +1906,13 @@ export class PerpsController extends BaseController<
         state.withdrawalRequests.splice(requestIndex, 1);
       }
 
-      // Update lastWithdrawResult with the completed withdrawal
-      state.lastWithdrawResult = {
-        success: true,
-        txHash: completedWithdrawal.txHash,
-        amount: completedWithdrawal.amount,
-        asset: completedWithdrawal.asset || USDC_SYMBOL,
-        timestamp: completedWithdrawal.timestamp,
-        error: '',
-      };
+      // Note: We do NOT update lastWithdrawResult here.
+      // The "confirmed" toast is shown once when the withdrawal is submitted
+      // (in AccountService). We only need to track the timestamp for FIFO matching.
+      // Update the timestamp to prevent double-matching in FIFO logic.
+      if (state.lastWithdrawResult) {
+        state.lastWithdrawResult.timestamp = completedWithdrawal.timestamp;
+      }
 
       // Check if there are still pending withdrawals in the queue
       const hasPendingWithdrawals = state.withdrawalRequests.some(

--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -2011,13 +2011,8 @@ export class PerpsController extends BaseController<
       },
     );
 
-    // Track the completion
-    this.getMetrics().trackPerpsEvent(PerpsAnalyticsEvent.DepositTransaction, {
-      [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.COMPLETED,
-      [PERPS_EVENT_PROPERTY.DEPOSIT_AMOUNT]: Number.parseFloat(
-        completedDeposit.amount,
-      ),
-    });
+    // TODO: Add analytics tracking for deposit completion when PerpsAnalyticsEvent.DepositTransaction is defined
+    // Similar to WithdrawalTransaction tracking
   }
 
   /**

--- a/app/components/UI/Perps/controllers/services/AccountService.ts
+++ b/app/components/UI/Perps/controllers/services/AccountService.ts
@@ -160,15 +160,6 @@ export class AccountService {
           context.stateManager.update((state) => {
             state.lastError = null;
             state.lastUpdateTimestamp = Date.now();
-            state.withdrawInProgress = false;
-            state.lastWithdrawResult = {
-              success: true,
-              txHash: result.txHash || '',
-              amount: params.amount,
-              asset: USDC_SYMBOL,
-              timestamp: Date.now(),
-              error: '',
-            };
 
             // Update the withdrawal request by request ID
             if (state.withdrawalRequests.length > 0) {
@@ -177,10 +168,12 @@ export class AccountService {
               );
               if (requestToUpdate) {
                 if (result.txHash) {
+                  // Withdrawal is fully completed (has txHash)
                   requestToUpdate.status = 'completed' as TransactionStatus;
                   requestToUpdate.success = true;
                   requestToUpdate.txHash = result.txHash;
                 } else {
+                  // Withdrawal is bridging (no txHash yet)
                   requestToUpdate.status = 'bridging' as TransactionStatus;
                   requestToUpdate.success = true;
                 }
@@ -189,6 +182,25 @@ export class AccountService {
                 }
               }
             }
+
+            // Only clear withdrawInProgress if we have a txHash (fully completed)
+            // If bridging (no txHash), keep withdrawInProgress = true so the UI
+            // continues showing the progress indicator until we detect completion
+            // in the transaction history
+            if (result.txHash) {
+              state.withdrawInProgress = false;
+              state.lastWithdrawResult = {
+                success: true,
+                txHash: result.txHash,
+                amount: params.amount,
+                asset: USDC_SYMBOL,
+                timestamp: Date.now(),
+                error: '',
+              };
+            }
+            // If no txHash (bridging), keep withdrawInProgress = true
+            // useWithdrawalRequests will poll getUserHistory and call
+            // completeWithdrawalFromHistory when the transaction appears
           });
         }
 

--- a/app/components/UI/Perps/controllers/services/AccountService.ts
+++ b/app/components/UI/Perps/controllers/services/AccountService.ts
@@ -183,20 +183,23 @@ export class AccountService {
               }
             }
 
+            // Set lastWithdrawResult when submission is successful (even if bridging)
+            // This triggers the "confirmed" toast telling user funds arrive in ~5 mins
+            state.lastWithdrawResult = {
+              success: true,
+              txHash: result.txHash || '', // May be empty if bridging
+              amount: params.amount,
+              asset: USDC_SYMBOL,
+              timestamp: Date.now(),
+              error: '',
+            };
+
             // Only clear withdrawInProgress if we have a txHash (fully completed)
             // If bridging (no txHash), keep withdrawInProgress = true so the UI
             // continues showing the progress indicator until we detect completion
             // in the transaction history
             if (result.txHash) {
               state.withdrawInProgress = false;
-              state.lastWithdrawResult = {
-                success: true,
-                txHash: result.txHash,
-                amount: params.amount,
-                asset: USDC_SYMBOL,
-                timestamp: Date.now(),
-                error: '',
-              };
             }
             // If no txHash (bridging), keep withdrawInProgress = true
             // useWithdrawalRequests will poll getUserHistory and call

--- a/app/components/UI/Perps/hooks/index.ts
+++ b/app/components/UI/Perps/hooks/index.ts
@@ -86,6 +86,7 @@ export { usePerpsOrders } from './usePerpsOrders';
 export { usePerpsFunding } from './usePerpsFunding';
 export { useWithdrawalRequests } from './useWithdrawalRequests';
 export { useDepositRequests } from './useDepositRequests';
+export { usePendingTransactions } from './usePendingTransactions';
 export { usePerpsTransactionHistory } from './usePerpsTransactionHistory';
 
 // Event tracking hook

--- a/app/components/UI/Perps/hooks/usePendingTransactions.ts
+++ b/app/components/UI/Perps/hooks/usePendingTransactions.ts
@@ -1,0 +1,391 @@
+import { useCallback, useEffect, useState, useRef, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import Engine from '../../../../core/Engine';
+import { usePerpsSelector } from './usePerpsSelector';
+import { useStableArray } from './useStableArray';
+import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
+import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
+import type { UserHistoryItem } from '../controllers/types';
+
+export interface PendingTransaction {
+  id: string;
+  timestamp: number;
+  amount: string;
+  asset: string;
+  accountAddress: string;
+  txHash?: string;
+  status: 'pending' | 'bridging' | 'completed' | 'failed';
+  type: 'deposit' | 'withdrawal';
+  // Withdrawal-specific fields
+  destination?: string;
+  withdrawalId?: string;
+  // Deposit-specific fields
+  source?: string;
+  depositId?: string;
+}
+
+export interface UsePendingTransactionsOptions {
+  /**
+   * Skip initial fetch (useful for conditional loading)
+   */
+  skipInitialFetch?: boolean;
+}
+
+interface UsePendingTransactionsResult {
+  /** All pending deposits in the queue (for display, newest first) */
+  pendingDeposits: PendingTransaction[];
+  /** All pending withdrawals in the queue (for display, newest first) */
+  pendingWithdrawals: PendingTransaction[];
+  /** Combined pending transactions (for progress bar) */
+  allPending: PendingTransaction[];
+  /** Whether there are any pending transactions */
+  hasPendingTransactions: boolean;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+/**
+ * Combined hook to track both pending deposits and withdrawals using FIFO queue matching.
+ *
+ * This hook:
+ * 1. Returns pending deposits and withdrawals from PerpsController state (the queues)
+ * 2. Polls getUserHistory (same API as "Deposits" tab in activity view) to detect completions
+ * 3. Uses FIFO matching: oldest pending transaction matches with first completed transaction
+ * in history that happened after its submission time
+ *
+ * Key design: We use getUserHistory (same data source as the activity view "Deposits" tab).
+ * This ensures we only clear the pending indicator when the user can see the completed
+ * transaction in their activity view.
+ *
+ * Multi-transaction support: If user submits multiple deposits/withdrawals while others
+ * are still pending, each is tracked in its own queue. Oldest is matched first (FIFO).
+ */
+export const usePendingTransactions = (
+  options: UsePendingTransactionsOptions = {},
+): UsePendingTransactionsResult => {
+  const { skipInitialFetch = false } = options;
+
+  // Get current selected account address
+  const selectedAddress = useSelector(selectSelectedInternalAccountByScope)(
+    'eip155:1',
+  )?.address;
+
+  // Get all withdrawals from controller state, filtered by current account
+  const allWithdrawals = useStableArray(
+    usePerpsSelector((state) => {
+      const withdrawals = state?.withdrawalRequests || [];
+      if (!selectedAddress) return [];
+      return withdrawals.filter(
+        (req) =>
+          req.accountAddress?.toLowerCase() === selectedAddress.toLowerCase(),
+      );
+    }),
+  );
+
+  // Get all deposits from controller state, filtered by current account
+  const allDeposits = useStableArray(
+    usePerpsSelector((state) => {
+      const deposits = state?.depositRequests || [];
+      if (!selectedAddress) return [];
+      return deposits.filter(
+        (req) =>
+          req.accountAddress?.toLowerCase() === selectedAddress.toLowerCase(),
+      );
+    }),
+  );
+
+  // Get pending/bridging withdrawals sorted by timestamp (oldest first = FIFO queue)
+  const pendingWithdrawalQueue = useMemo(
+    () =>
+      allWithdrawals
+        .filter((req) => req.status === 'pending' || req.status === 'bridging')
+        .sort((a, b) => a.timestamp - b.timestamp)
+        .map((req) => ({ ...req, type: 'withdrawal' as const })),
+    [allWithdrawals],
+  );
+
+  // Get pending/bridging deposits sorted by timestamp (oldest first = FIFO queue)
+  const pendingDepositQueue = useMemo(
+    () =>
+      allDeposits
+        .filter((req) => req.status === 'pending' || req.status === 'bridging')
+        .sort((a, b) => a.timestamp - b.timestamp)
+        .map((req) => ({ ...req, type: 'deposit' as const })),
+    [allDeposits],
+  );
+
+  // Extract oldest pending timestamps for dependency tracking
+  const oldestPendingWithdrawalTimestamp =
+    pendingWithdrawalQueue[0]?.timestamp ?? null;
+  const oldestPendingDepositTimestamp =
+    pendingDepositQueue[0]?.timestamp ?? null;
+
+  // Get last completed timestamps to prevent same completion matching multiple pending transactions
+  const lastCompletedWithdrawalTimestamp = usePerpsSelector(
+    (state) => state?.lastWithdrawResult?.timestamp ?? null,
+  );
+  const lastCompletedDepositTimestamp = usePerpsSelector(
+    (state) => state?.lastDepositResult?.timestamp ?? null,
+  );
+
+  // Track if initial fetch has been done to avoid re-running on callback changes
+  const initialFetchDoneRef = useRef(false);
+
+  // Track previous transaction states for logging
+  const prevStatesRef = useRef<Map<string, string>>(new Map());
+
+  // Log meaningful state changes
+  useEffect(() => {
+    const allTransactions = [...allWithdrawals, ...allDeposits];
+    const currentStates = new Map<string, string>();
+    allTransactions.forEach((t) => currentStates.set(t.id, t.status));
+
+    const prevStates = prevStatesRef.current;
+
+    for (const transaction of allTransactions) {
+      if (!prevStates.has(transaction.id)) {
+        DevLogger.log('Transaction initialized:', {
+          id: transaction.id,
+          type: 'withdrawalId' in transaction ? 'withdrawal' : 'deposit',
+          amount: transaction.amount,
+          status: transaction.status,
+          timestamp: new Date(transaction.timestamp).toISOString(),
+        });
+      } else {
+        const prevStatus = prevStates.get(transaction.id);
+        if (prevStatus !== transaction.status) {
+          DevLogger.log('Transaction status changed:', {
+            id: transaction.id,
+            previousStatus: prevStatus,
+            newStatus: transaction.status,
+          });
+        }
+      }
+    }
+
+    prevStatesRef.current = currentStates;
+  }, [allWithdrawals, allDeposits]);
+
+  const [isLoading, setIsLoading] = useState(!skipInitialFetch);
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * Check for transaction completions using FIFO matching.
+   * Polls getUserHistory and matches the oldest pending transaction (of each type)
+   * with the first completed transaction in history that happened after its submission time.
+   */
+  const checkForCompletions = useCallback(async () => {
+    const hasPendingWithdrawals = pendingWithdrawalQueue.length > 0;
+    const hasPendingDeposits = pendingDepositQueue.length > 0;
+
+    // Only check if there are pending transactions in either queue
+    if (!hasPendingWithdrawals && !hasPendingDeposits) {
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      const controller = Engine.context.PerpsController;
+      if (!controller) {
+        throw new Error('PerpsController not available');
+      }
+
+      const provider = controller.getActiveProvider();
+      if (!provider) {
+        throw new Error('No active provider available');
+      }
+
+      if (!('getUserHistory' in provider)) {
+        throw new Error('Provider does not support user history');
+      }
+
+      // Calculate search start time from the oldest pending transaction across both queues
+      const oldestWithdrawal = pendingWithdrawalQueue[0];
+      const oldestDeposit = pendingDepositQueue[0];
+      const oldestTimestamp = Math.min(
+        oldestWithdrawal?.timestamp ?? Infinity,
+        oldestDeposit?.timestamp ?? Infinity,
+      );
+      const searchStartTime = oldestTimestamp - 60000; // 1 minute buffer
+
+      DevLogger.log('usePendingTransactions: Checking for completions (FIFO)', {
+        pendingWithdrawals: pendingWithdrawalQueue.length,
+        pendingDeposits: pendingDepositQueue.length,
+        searchStartTime: new Date(searchStartTime).toISOString(),
+      });
+
+      // Fetch user history - includes both deposits and withdrawals
+      const history: UserHistoryItem[] = await provider.getUserHistory({
+        startTime: searchStartTime,
+        endTime: undefined,
+      });
+
+      const safeHistory = Array.isArray(history) ? history : [];
+
+      // Process withdrawals if any pending
+      if (hasPendingWithdrawals && oldestWithdrawal) {
+        const completedWithdrawals = safeHistory
+          .filter(
+            (item) => item.type === 'withdrawal' && item.status === 'completed',
+          )
+          .sort((a, b) => a.timestamp - b.timestamp);
+
+        const matchingWithdrawal = completedWithdrawals.find(
+          (completed) =>
+            completed.timestamp > oldestWithdrawal.timestamp &&
+            (lastCompletedWithdrawalTimestamp === null ||
+              completed.timestamp > lastCompletedWithdrawalTimestamp),
+        );
+
+        if (matchingWithdrawal) {
+          DevLogger.log(
+            'usePendingTransactions: FIFO match found for withdrawal',
+            {
+              pendingId: oldestWithdrawal.id,
+              completedTxHash: matchingWithdrawal.txHash,
+              completedTimestamp: new Date(
+                matchingWithdrawal.timestamp,
+              ).toISOString(),
+            },
+          );
+
+          controller.completeWithdrawalFromHistory(oldestWithdrawal.id, {
+            txHash: matchingWithdrawal.txHash,
+            amount: matchingWithdrawal.amount,
+            timestamp: matchingWithdrawal.timestamp,
+            asset: matchingWithdrawal.asset,
+          });
+        }
+      }
+
+      // Process deposits if any pending
+      if (hasPendingDeposits && oldestDeposit) {
+        const completedDeposits = safeHistory
+          .filter(
+            (item) => item.type === 'deposit' && item.status === 'completed',
+          )
+          .sort((a, b) => a.timestamp - b.timestamp);
+
+        const matchingDeposit = completedDeposits.find(
+          (completed) =>
+            completed.timestamp > oldestDeposit.timestamp &&
+            (lastCompletedDepositTimestamp === null ||
+              completed.timestamp > lastCompletedDepositTimestamp),
+        );
+
+        if (matchingDeposit) {
+          DevLogger.log(
+            'usePendingTransactions: FIFO match found for deposit',
+            {
+              pendingId: oldestDeposit.id,
+              completedTxHash: matchingDeposit.txHash,
+              completedTimestamp: new Date(
+                matchingDeposit.timestamp,
+              ).toISOString(),
+            },
+          );
+
+          controller.completeDepositFromHistory(oldestDeposit.id, {
+            txHash: matchingDeposit.txHash,
+            amount: matchingDeposit.amount,
+            timestamp: matchingDeposit.timestamp,
+            asset: matchingDeposit.asset,
+          });
+        }
+      }
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error
+          ? err.message
+          : 'Failed to check transaction completions';
+      console.error('Error checking transaction completions:', errorMessage);
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    pendingWithdrawalQueue,
+    pendingDepositQueue,
+    lastCompletedWithdrawalTimestamp,
+    lastCompletedDepositTimestamp,
+  ]);
+
+  // Initial check when component mounts
+  useEffect(() => {
+    const hasPending =
+      pendingWithdrawalQueue.length > 0 || pendingDepositQueue.length > 0;
+    if (!skipInitialFetch && hasPending && !initialFetchDoneRef.current) {
+      initialFetchDoneRef.current = true;
+      checkForCompletions();
+    }
+  }, [
+    checkForCompletions,
+    skipInitialFetch,
+    pendingWithdrawalQueue.length,
+    pendingDepositQueue.length,
+  ]);
+
+  // Poll for completions when there are pending transactions
+  useEffect(() => {
+    const hasPending =
+      pendingWithdrawalQueue.length > 0 || pendingDepositQueue.length > 0;
+
+    if (!hasPending) {
+      return; // No need to poll if queues are empty
+    }
+
+    DevLogger.log('usePendingTransactions: Starting polling', {
+      pendingWithdrawals: pendingWithdrawalQueue.length,
+      pendingDeposits: pendingDepositQueue.length,
+    });
+
+    // Poll every 5 seconds when there are pending transactions
+    const pollInterval = setInterval(() => {
+      checkForCompletions();
+    }, 5000);
+
+    return () => {
+      DevLogger.log('usePendingTransactions: Stopping polling');
+      clearInterval(pollInterval);
+    };
+  }, [
+    pendingWithdrawalQueue.length,
+    pendingDepositQueue.length,
+    oldestPendingWithdrawalTimestamp,
+    oldestPendingDepositTimestamp,
+    checkForCompletions,
+  ]);
+
+  // Return pending transactions sorted by timestamp (newest first for display)
+  const pendingWithdrawalsForDisplay = useMemo(
+    () => [...pendingWithdrawalQueue].sort((a, b) => b.timestamp - a.timestamp),
+    [pendingWithdrawalQueue],
+  );
+
+  const pendingDepositsForDisplay = useMemo(
+    () => [...pendingDepositQueue].sort((a, b) => b.timestamp - a.timestamp),
+    [pendingDepositQueue],
+  );
+
+  const allPending = useMemo(
+    () =>
+      [...pendingWithdrawalsForDisplay, ...pendingDepositsForDisplay].sort(
+        (a, b) => b.timestamp - a.timestamp,
+      ),
+    [pendingWithdrawalsForDisplay, pendingDepositsForDisplay],
+  );
+
+  return {
+    pendingDeposits: pendingDepositsForDisplay,
+    pendingWithdrawals: pendingWithdrawalsForDisplay,
+    allPending,
+    hasPendingTransactions:
+      pendingWithdrawalQueue.length > 0 || pendingDepositQueue.length > 0,
+    isLoading,
+    error,
+    refetch: checkForCompletions,
+  };
+};

--- a/app/components/UI/Perps/hooks/usePendingTransactions.ts
+++ b/app/components/UI/Perps/hooks/usePendingTransactions.ts
@@ -51,8 +51,8 @@ interface UsePendingTransactionsResult {
  * This hook:
  * 1. Returns pending deposits and withdrawals from PerpsController state (the queues)
  * 2. Polls getUserHistory (same API as "Deposits" tab in activity view) to detect completions
- * 3. Uses FIFO matching: oldest pending transaction matches with first completed transaction
- * in history that happened after its submission time
+ * 3. Uses FIFO matching: oldest pending transaction matches with first completed
+ * transaction in history that happened after its submission time
  *
  * Key design: We use getUserHistory (same data source as the activity view "Deposits" tab).
  * This ensures we only clear the pending indicator when the user can see the completed
@@ -60,6 +60,14 @@ interface UsePendingTransactionsResult {
  *
  * Multi-transaction support: If user submits multiple deposits/withdrawals while others
  * are still pending, each is tracked in its own queue. Oldest is matched first (FIFO).
+ *
+ * Note on deposits: The UI currently prevents starting a new deposit while one is in-flight,
+ * so the deposit queue will typically have 0 or 1 items. However, the FIFO pattern handles
+ * multiple deposits defensively for edge cases (race conditions, app crashes, restored state)
+ * and future flexibility. Withdrawals can have multiple in-flight since the UI allows it.
+ *
+ * Deposits and withdrawals are tracked separately - a completed deposit only clears a
+ * pending deposit, and a completed withdrawal only clears a pending withdrawal.
  */
 export const usePendingTransactions = (
   options: UsePendingTransactionsOptions = {},

--- a/app/components/UI/Perps/hooks/useWithdrawalRequests.test.ts
+++ b/app/components/UI/Perps/hooks/useWithdrawalRequests.test.ts
@@ -11,6 +11,7 @@ import {
   createMockUuidFromAddress,
 } from '../../../../util/test/accountsControllerTestUtils';
 import { useSelector } from 'react-redux';
+import type { UserHistoryItem } from '../controllers/types';
 
 // Mock dependencies
 jest.mock('../../../../core/Engine');
@@ -38,13 +39,18 @@ describe('useWithdrawalRequests', () => {
 
   let mockController: {
     getActiveProvider: jest.MockedFunction<() => unknown>;
-    updateWithdrawalStatus: jest.MockedFunction<
-      (id: string, status: string, txHash?: string) => void
+    completeWithdrawalFromHistory: jest.MockedFunction<
+      (data: {
+        txHash: string;
+        amount: string;
+        timestamp: number;
+        asset?: string;
+      }) => void
     >;
   };
   let mockProvider: {
-    getUserNonFundingLedgerUpdates: jest.MockedFunction<
-      (params: unknown) => Promise<unknown[]>
+    getUserHistory: jest.MockedFunction<
+      (params: unknown) => Promise<UserHistoryItem[]>
     >;
   };
 
@@ -70,39 +76,45 @@ describe('useWithdrawalRequests', () => {
     },
   ];
 
-  const mockLedgerUpdates = [
+  // Mock user history items (same format as transaction history UI uses)
+  const mockUserHistory: UserHistoryItem[] = [
     {
-      delta: {
-        coin: 'USDC',
-        usdc: '100',
-        type: 'withdraw',
-        fee: '1',
-        nonce: 456,
+      id: 'history-1',
+      timestamp: 1640995200000,
+      type: 'withdrawal',
+      amount: '100',
+      asset: 'USDC',
+      txHash: '0xhistory1',
+      status: 'completed',
+      details: {
+        source: 'HyperLiquid',
+        recipient: '0x123',
       },
-      hash: '0xledger1',
-      time: 1640995200000,
     },
     {
-      delta: {
-        coin: 'USDC',
-        usdc: '200',
-        type: 'withdraw',
-        fee: '1',
-        nonce: 789,
+      id: 'history-2',
+      timestamp: 1640995201000,
+      type: 'withdrawal',
+      amount: '200',
+      asset: 'USDC',
+      txHash: '0xhistory2',
+      status: 'completed',
+      details: {
+        source: 'HyperLiquid',
+        recipient: '0x456',
       },
-      hash: '0xledger2',
-      time: 1640995201000,
     },
     {
-      delta: {
-        coin: 'USDC',
-        usdc: '50',
-        type: 'deposit', // Not a withdrawal
-        fee: '1',
-        nonce: 101,
+      id: 'history-3',
+      timestamp: 1640995202000,
+      type: 'deposit', // Not a withdrawal
+      amount: '50',
+      asset: 'USDC',
+      txHash: '0xhistory3',
+      status: 'completed',
+      details: {
+        source: 'Arbitrum',
       },
-      hash: '0xledger3',
-      time: 1640995202000,
     },
   ];
 
@@ -144,18 +156,18 @@ describe('useWithdrawalRequests', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.useRealTimers(); // Clear any existing fake timers first
-    jest.useFakeTimers(); // Then install fresh fake timers
+    jest.useRealTimers();
+    jest.useFakeTimers();
 
     // Mock controller
     mockController = {
       getActiveProvider: jest.fn(),
-      updateWithdrawalStatus: jest.fn(),
+      completeWithdrawalFromHistory: jest.fn(),
     };
 
-    // Mock provider
+    // Mock provider with getUserHistory (same API as transaction history UI)
     mockProvider = {
-      getUserNonFundingLedgerUpdates: jest.fn(),
+      getUserHistory: jest.fn(),
     };
 
     // Mock Engine
@@ -165,20 +177,19 @@ describe('useWithdrawalRequests', () => {
       PerpsController: mockController,
     };
 
-    // Mock usePerpsSelector to execute the selector function with mock state
+    // Mock usePerpsSelector - default to no active withdrawal
     mockUsePerpsSelector.mockImplementation((selector) =>
       selector({
         withdrawalRequests: mockPendingWithdrawals,
+        withdrawInProgress: false,
+        lastWithdrawResult: null,
       } as Partial<PerpsControllerState> as PerpsControllerState),
     );
 
-    // Mock useSelector to return the mock account for selectSelectedInternalAccountByScope
+    // Mock useSelector to return the mock account
     mockUseSelector.mockImplementation((selector) => {
-      // Check if this is the selectSelectedInternalAccountByScope selector
-      // It returns a function that takes a scope
       const result = selector(createMockState());
       if (typeof result === 'function') {
-        // This is selectSelectedInternalAccountByScope, return the mock account
         return () => mockInternalAccount;
       }
       return result;
@@ -186,9 +197,7 @@ describe('useWithdrawalRequests', () => {
 
     // Mock provider methods
     mockController.getActiveProvider.mockReturnValue(mockProvider);
-    mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue(
-      mockLedgerUpdates,
-    );
+    mockProvider.getUserHistory.mockResolvedValue(mockUserHistory);
   });
 
   afterEach(() => {
@@ -196,7 +205,7 @@ describe('useWithdrawalRequests', () => {
   });
 
   describe('initial state', () => {
-    it('returns initial state with pending withdrawals', () => {
+    it('returns pending withdrawals from controller state', () => {
       const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
         state: createMockState(),
       });
@@ -213,8 +222,6 @@ describe('useWithdrawalRequests', () => {
           }),
         ]),
       );
-      expect(result.current.isLoading).toBe(true);
-      expect(result.current.error).toBeNull();
       expect(typeof result.current.refetch).toBe('function');
     });
 
@@ -225,717 +232,17 @@ describe('useWithdrawalRequests', () => {
       );
 
       expect(result.current.isLoading).toBe(false);
-      expect(
-        mockProvider.getUserNonFundingLedgerUpdates,
-      ).not.toHaveBeenCalled();
-    });
-
-    it('uses custom startTime when provided', async () => {
-      const customStartTime = 1640995000000;
-      renderHookWithProvider(
-        () => useWithdrawalRequests({ startTime: customStartTime }),
-        { state: createMockState() },
-      );
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      expect(mockProvider.getUserNonFundingLedgerUpdates).toHaveBeenCalledWith({
-        startTime: customStartTime,
-        endTime: undefined,
-      });
-    });
-
-    it('uses start of today as default startTime', async () => {
-      const mockNow = new Date('2024-01-01T12:00:00Z');
-      jest.spyOn(global, 'Date').mockImplementation(() => mockNow);
-
-      renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      const expectedStartOfToday = new Date(
-        mockNow.getFullYear(),
-        mockNow.getMonth(),
-        mockNow.getDate(),
-      ).getTime();
-
-      expect(mockProvider.getUserNonFundingLedgerUpdates).toHaveBeenCalledWith({
-        startTime: expectedStartOfToday,
-        endTime: undefined,
-      });
-
-      jest.restoreAllMocks();
-    });
-  });
-
-  describe('fetching completed withdrawals', () => {
-    it('fetches completed withdrawals successfully', async () => {
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBeNull();
-
-      // The hook matches pending withdrawals with completed ones and updates their status
-      // So we should see the pending withdrawals updated to completed status
-      expect(result.current.withdrawalRequests).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: 'withdrawal-1',
-            amount: '100',
-            status: 'completed',
-            txHash: '0xledger1',
-            withdrawalId: '456',
-          }),
-          expect.objectContaining({
-            id: 'withdrawal-2',
-            amount: '200',
-            status: 'completed',
-            txHash: '0xledger2',
-            withdrawalId: '789',
-          }),
-        ]),
-      );
-    });
-
-    it('handles provider errors gracefully', async () => {
-      mockController.getActiveProvider.mockReturnValue(null);
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBe('No active provider available');
-    });
-
-    it('handles controller errors gracefully', async () => {
-      (mockEngine as unknown as { context: unknown }).context = {};
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBe('PerpsController not available');
-    });
-
-    it('handles provider method not supported', async () => {
-      const providerWithoutMethod = {};
-      mockController.getActiveProvider.mockReturnValue(providerWithoutMethod);
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBe(
-        'Provider does not support non-funding ledger updates',
-      );
-    });
-
-    it('handles API errors gracefully', async () => {
-      const apiError = new Error('API Error');
-      mockProvider.getUserNonFundingLedgerUpdates.mockRejectedValue(apiError);
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBe('API Error');
-    });
-
-    it('handles non-Error exceptions', async () => {
-      mockProvider.getUserNonFundingLedgerUpdates.mockRejectedValue(
-        'String error',
-      );
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBe(
-        'Failed to fetch completed withdrawals',
-      );
-    });
-
-    it('handles non-array updates response', async () => {
-      mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue(
-        null as unknown as unknown[],
-      );
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBeNull();
-      // Should not crash and should handle gracefully
-    });
-  });
-
-  describe('withdrawal data transformation', () => {
-    it('transforms ledger updates to withdrawal requests correctly', async () => {
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      const withdrawalRequests = result.current.withdrawalRequests;
-
-      // The hook matches pending withdrawals with completed ones
-      // So we should see the pending withdrawals updated with ledger data
-      const matchedWithdrawals = withdrawalRequests.filter((w) =>
-        w.txHash?.startsWith('0xledger'),
-      );
-
-      expect(matchedWithdrawals).toHaveLength(2); // Only withdrawals, not deposits
-
-      // Array is sorted by timestamp descending, so withdrawal-2 comes first
-      expect(matchedWithdrawals[0]).toEqual(
-        expect.objectContaining({
-          id: 'withdrawal-2', // Original pending withdrawal ID
-          timestamp: 1640995201000,
-          amount: '200',
-          asset: 'USDC',
-          txHash: '0xledger2',
-          status: 'completed',
-          withdrawalId: '789',
-        }),
-      );
-
-      expect(matchedWithdrawals[1]).toEqual(
-        expect.objectContaining({
-          id: 'withdrawal-1', // Original pending withdrawal ID
-          timestamp: 1640995200000,
-          amount: '100',
-          asset: 'USDC',
-          txHash: '0xledger1',
-          status: 'completed',
-          withdrawalId: '456',
-        }),
-      );
-    });
-
-    it('handles ledger updates without coin field', async () => {
-      const updatesWithoutCoin = [
-        {
-          delta: {
-            usdc: '100',
-            type: 'withdraw',
-            fee: '1',
-            nonce: 456,
-          },
-          hash: '0xledger1',
-          time: 1640995200000,
-        },
-      ];
-
-      mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue(
-        updatesWithoutCoin as unknown as unknown[],
-      );
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      const withdrawalRequests = result.current.withdrawalRequests;
-      // Find the withdrawal that was matched with the ledger update
-      const matchedWithdrawal = withdrawalRequests.find(
-        (w) => w.txHash === '0xledger1',
-      );
-
-      expect(matchedWithdrawal?.asset).toBe('USDC'); // Default to USDC
-    });
-
-    it('handles ledger updates without nonce field', async () => {
-      const updatesWithoutNonce = [
-        {
-          delta: {
-            coin: 'USDC',
-            usdc: '100',
-            type: 'withdraw',
-            fee: '1',
-          },
-          hash: '0xledger1',
-          time: 1640995200000,
-        },
-      ];
-
-      mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue(
-        updatesWithoutNonce as unknown as unknown[],
-      );
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      const withdrawalRequests = result.current.withdrawalRequests;
-      // Find the withdrawal that was matched with the ledger update
-      const matchedWithdrawal = withdrawalRequests.find(
-        (w) => w.txHash === '0xledger1',
-      );
-
-      expect(matchedWithdrawal?.withdrawalId).toBeUndefined();
-    });
-
-    it('handles negative USDC amounts correctly', async () => {
-      const updatesWithNegativeAmount = [
-        {
-          delta: {
-            coin: 'USDC',
-            usdc: '-100', // Negative amount
-            type: 'withdraw',
-            fee: '1',
-            nonce: 456,
-          },
-          hash: '0xledger1',
-          time: 1640995200000,
-        },
-      ];
-
-      mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue(
-        updatesWithNegativeAmount as unknown as unknown[],
-      );
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      const withdrawalRequests = result.current.withdrawalRequests;
-      // Find the withdrawal that was matched with the ledger update
-      const matchedWithdrawal = withdrawalRequests.find(
-        (w) => w.txHash === '0xledger1',
-      );
-
-      expect(matchedWithdrawal?.amount).toBe('100'); // Should be positive
-    });
-  });
-
-  describe('withdrawal matching and deduplication', () => {
-    it('matches pending withdrawals with completed ones', async () => {
-      // Mock pending withdrawal that matches a completed one
-      const matchingPendingWithdrawal = {
-        id: 'withdrawal-match',
-        timestamp: 1640995200000,
-        amount: '100',
-        asset: 'USDC',
-        accountAddress: mockAddress,
-        status: 'pending' as const,
-        destination: '0x123',
-      };
-
-      mockUsePerpsSelector.mockImplementation((selector) =>
-        selector({
-          withdrawalRequests: [matchingPendingWithdrawal],
-        } as Partial<PerpsControllerState> as PerpsControllerState),
-      );
-      mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue([
-        {
-          delta: {
-            coin: 'USDC',
-            usdc: '100',
-            type: 'withdraw',
-            fee: '1',
-            nonce: 456,
-          },
-          hash: '0xledger1',
-          time: 1640995200000,
-        },
-      ] as unknown as unknown[]);
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      const withdrawalRequests = result.current.withdrawalRequests;
-      const matchedWithdrawal = withdrawalRequests.find(
-        (w) => w.id === 'withdrawal-match',
-      );
-
-      expect(matchedWithdrawal).toEqual({
-        id: 'withdrawal-match',
-        timestamp: 1640995200000,
-        amount: '100',
-        asset: 'USDC',
-        accountAddress: mockAddress,
-        status: 'completed',
-        destination: '0x123',
-        txHash: '0xledger1',
-        withdrawalId: '456',
-      });
-
-      expect(mockController.updateWithdrawalStatus).toHaveBeenCalledWith(
-        'withdrawal-match',
-        'completed',
-        '0xledger1',
-      );
-    });
-
-    it('does not match withdrawals with different amounts', async () => {
-      const pendingWithdrawal = {
-        id: 'withdrawal-no-match',
-        timestamp: 1640995200000,
-        amount: '100',
-        asset: 'USDC',
-        accountAddress: mockAddress,
-        status: 'pending' as const,
-        destination: '0x123',
-      };
-
-      mockUsePerpsSelector.mockImplementation((selector) =>
-        selector({
-          withdrawalRequests: [pendingWithdrawal],
-        } as Partial<PerpsControllerState> as PerpsControllerState),
-      );
-      mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue([
-        {
-          delta: {
-            coin: 'USDC',
-            usdc: '200', // Different amount
-            type: 'withdraw',
-            fee: '1',
-            nonce: 456,
-          },
-          hash: '0xledger1',
-          time: 1640995200000,
-        },
-      ] as unknown as unknown[]);
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      const withdrawalRequests = result.current.withdrawalRequests;
-      const pendingWithdrawalResult = withdrawalRequests.find(
-        (w) => w.id === 'withdrawal-no-match',
-      );
-
-      expect(pendingWithdrawalResult?.status).toBe('pending');
-      expect(mockController.updateWithdrawalStatus).not.toHaveBeenCalled();
-    });
-
-    it('matches withdrawals even with very different timestamps (bridging can take hours)', async () => {
-      // This test verifies that withdrawals match regardless of timestamp differences
-      // because HyperLiquid -> Arbitrum bridging can take hours, not just minutes
-      const pendingWithdrawal = {
-        id: 'withdrawal-long-bridge',
-        timestamp: 1640995200000, // When withdrawal was initiated
-        amount: '100',
-        asset: 'USDC',
-        accountAddress: mockAddress,
-        status: 'pending' as const,
-        destination: '0x123',
-      };
-
-      mockUsePerpsSelector.mockImplementation((selector) =>
-        selector({
-          withdrawalRequests: [pendingWithdrawal],
-        } as Partial<PerpsControllerState> as PerpsControllerState),
-      );
-      mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue([
-        {
-          delta: {
-            coin: 'USDC',
-            usdc: '100',
-            type: 'withdraw',
-            fee: '1',
-            nonce: 456,
-          },
-          hash: '0xledger1',
-          time: 1640995200000 + 3600000, // 1 hour later (bridging took time)
-        },
-      ] as unknown as unknown[]);
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      const withdrawalRequests = result.current.withdrawalRequests;
-      const matchedWithdrawal = withdrawalRequests.find(
-        (w) => w.id === 'withdrawal-long-bridge',
-      );
-
-      // Should match and be marked completed even though timestamps differ significantly
-      expect(matchedWithdrawal?.status).toBe('completed');
-      expect(matchedWithdrawal?.txHash).toBe('0xledger1');
-      expect(mockController.updateWithdrawalStatus).toHaveBeenCalledWith(
-        'withdrawal-long-bridge',
-        'completed',
-        '0xledger1',
-      );
-    });
-
-    it('does not match withdrawals with different assets', async () => {
-      const pendingWithdrawal = {
-        id: 'withdrawal-no-match',
-        timestamp: 1640995200000,
-        amount: '100',
-        asset: 'USDC',
-        accountAddress: mockAddress,
-        status: 'pending' as const,
-        destination: '0x123',
-      };
-
-      mockUsePerpsSelector.mockImplementation((selector) =>
-        selector({
-          withdrawalRequests: [pendingWithdrawal],
-        } as Partial<PerpsControllerState> as PerpsControllerState),
-      );
-      mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue([
-        {
-          delta: {
-            coin: 'ETH', // Different asset
-            usdc: '100',
-            type: 'withdraw',
-            fee: '1',
-            nonce: 456,
-          },
-          hash: '0xledger1',
-          time: 1640995200000,
-        },
-      ] as unknown as unknown[]);
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      const withdrawalRequests = result.current.withdrawalRequests;
-      const pendingWithdrawalResult = withdrawalRequests.find(
-        (w) => w.id === 'withdrawal-no-match',
-      );
-
-      expect(pendingWithdrawalResult?.status).toBe('pending');
-      expect(mockController.updateWithdrawalStatus).not.toHaveBeenCalled();
-    });
-
-    it('allows small amount differences for matching', async () => {
-      const pendingWithdrawal = {
-        id: 'withdrawal-small-diff',
-        timestamp: 1640995200000,
-        amount: '100.00',
-        asset: 'USDC',
-        accountAddress: mockAddress,
-        status: 'pending' as const,
-        destination: '0x123',
-      };
-
-      mockUsePerpsSelector.mockImplementation((selector) =>
-        selector({
-          withdrawalRequests: [pendingWithdrawal],
-        } as Partial<PerpsControllerState> as PerpsControllerState),
-      );
-      mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue([
-        {
-          delta: {
-            coin: 'USDC',
-            usdc: '100.005', // Small difference (0.5 cents)
-            type: 'withdraw',
-            fee: '1',
-            nonce: 456,
-          },
-          hash: '0xledger1',
-          time: 1640995200000,
-        },
-      ] as unknown as unknown[]);
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      const withdrawalRequests = result.current.withdrawalRequests;
-      const matchedWithdrawal = withdrawalRequests.find(
-        (w) => w.id === 'withdrawal-small-diff',
-      );
-
-      expect(matchedWithdrawal?.status).toBe('completed');
-      expect(mockController.updateWithdrawalStatus).toHaveBeenCalled();
-    });
-
-    it('does not match completed withdrawals without txHash', async () => {
-      const pendingWithdrawal = {
-        id: 'withdrawal-no-txhash',
-        timestamp: 1640995200000,
-        amount: '100',
-        asset: 'USDC',
-        accountAddress: mockAddress,
-        status: 'pending' as const,
-        destination: '0x123',
-      };
-
-      mockUsePerpsSelector.mockImplementation((selector) =>
-        selector({
-          withdrawalRequests: [pendingWithdrawal],
-        } as Partial<PerpsControllerState> as PerpsControllerState),
-      );
-      mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue([
-        {
-          delta: {
-            coin: 'USDC',
-            usdc: '100',
-            type: 'withdraw',
-            fee: '1',
-            nonce: 456,
-          },
-          hash: '', // No txHash
-          time: 1640995200000,
-        },
-      ] as unknown as unknown[]);
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      const withdrawalRequests = result.current.withdrawalRequests;
-      const pendingWithdrawalResult = withdrawalRequests.find(
-        (w) => w.id === 'withdrawal-no-txhash',
-      );
-
-      expect(pendingWithdrawalResult?.status).toBe('pending');
-      expect(mockController.updateWithdrawalStatus).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('sorting and ordering', () => {
-    it('sorts withdrawals by timestamp descending', async () => {
-      mockUsePerpsSelector.mockImplementation((selector) =>
-        selector({
-          withdrawalRequests: [],
-        } as Partial<PerpsControllerState> as PerpsControllerState),
-      );
-      mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue([
-        {
-          delta: {
-            coin: 'USDC',
-            usdc: '100',
-            type: 'withdraw',
-            fee: '1',
-            nonce: 1,
-          },
-          hash: '0xold',
-          time: 1640995200000,
-        },
-        {
-          delta: {
-            coin: 'USDC',
-            usdc: '200',
-            type: 'withdraw',
-            fee: '1',
-            nonce: 2,
-          },
-          hash: '0xnew',
-          time: 1640995202000,
-        },
-      ] as unknown as unknown[]);
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
-
-      const withdrawalRequests = result.current.withdrawalRequests;
-      expect(withdrawalRequests[0].timestamp).toBeGreaterThan(
-        withdrawalRequests[1].timestamp,
-      );
+      expect(mockProvider.getUserHistory).not.toHaveBeenCalled();
     });
   });
 
   describe('polling behavior', () => {
-    it('polls when there are active withdrawals', async () => {
-      const activeWithdrawals = [
-        {
-          id: 'withdrawal-active',
-          timestamp: 1640995200000,
-          amount: '100',
-          asset: 'USDC',
-          accountAddress: mockAddress,
-          status: 'pending' as const,
-          destination: '0x123',
-        },
-      ];
-
+    it('polls when withdrawInProgress is true', async () => {
       mockUsePerpsSelector.mockImplementation((selector) =>
         selector({
-          withdrawalRequests: activeWithdrawals,
+          withdrawalRequests: mockPendingWithdrawals,
+          withdrawInProgress: true,
+          lastWithdrawResult: null,
         } as Partial<PerpsControllerState> as PerpsControllerState),
       );
 
@@ -948,37 +255,23 @@ describe('useWithdrawalRequests', () => {
       });
 
       // Initial call
-      expect(mockProvider.getUserNonFundingLedgerUpdates).toHaveBeenCalledTimes(
-        1,
-      );
+      expect(mockProvider.getUserHistory).toHaveBeenCalledTimes(1);
 
-      // Advance timer to trigger polling
+      // Advance timer to trigger polling (5 second interval)
       await act(async () => {
-        jest.advanceTimersByTime(10000);
+        jest.advanceTimersByTime(5000);
       });
 
       // Should have been called again for polling
-      expect(mockProvider.getUserNonFundingLedgerUpdates).toHaveBeenCalledTimes(
-        2,
-      );
+      expect(mockProvider.getUserHistory).toHaveBeenCalledTimes(2);
     });
 
-    it('does not poll when there are no active withdrawals', async () => {
-      const completedWithdrawals = [
-        {
-          id: 'withdrawal-completed',
-          timestamp: 1640995200000,
-          amount: '100',
-          asset: 'USDC',
-          accountAddress: mockAddress,
-          status: 'completed' as const,
-          txHash: '0x123',
-        },
-      ];
-
+    it('does not poll when withdrawInProgress is false', async () => {
       mockUsePerpsSelector.mockImplementation((selector) =>
         selector({
-          withdrawalRequests: completedWithdrawals,
+          withdrawalRequests: [],
+          withdrawInProgress: false,
+          lastWithdrawResult: null,
         } as Partial<PerpsControllerState> as PerpsControllerState),
       );
 
@@ -990,38 +283,16 @@ describe('useWithdrawalRequests', () => {
         jest.advanceTimersByTime(0);
       });
 
-      // Initial call
-      expect(mockProvider.getUserNonFundingLedgerUpdates).toHaveBeenCalledTimes(
-        1,
-      );
-
-      // Advance timer - should not poll
-      await act(async () => {
-        jest.advanceTimersByTime(10000);
-      });
-
-      // Should still only be called once
-      expect(mockProvider.getUserNonFundingLedgerUpdates).toHaveBeenCalledTimes(
-        1,
-      );
+      // Should not call getUserHistory when withdrawInProgress is false
+      expect(mockProvider.getUserHistory).not.toHaveBeenCalled();
     });
 
     it('stops polling when component unmounts', async () => {
-      const activeWithdrawals = [
-        {
-          id: 'withdrawal-active',
-          timestamp: 1640995200000,
-          amount: '100',
-          asset: 'USDC',
-          accountAddress: mockAddress,
-          status: 'pending' as const,
-          destination: '0x123',
-        },
-      ];
-
       mockUsePerpsSelector.mockImplementation((selector) =>
         selector({
-          withdrawalRequests: activeWithdrawals,
+          withdrawalRequests: mockPendingWithdrawals,
+          withdrawInProgress: true,
+          lastWithdrawResult: null,
         } as Partial<PerpsControllerState> as PerpsControllerState),
       );
 
@@ -1038,18 +309,259 @@ describe('useWithdrawalRequests', () => {
 
       // Advance timer after unmount
       await act(async () => {
-        jest.advanceTimersByTime(10000);
+        jest.advanceTimersByTime(5000);
       });
 
       // Should still only be called once (initial call)
-      expect(mockProvider.getUserNonFundingLedgerUpdates).toHaveBeenCalledTimes(
-        1,
+      expect(mockProvider.getUserHistory).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('withdrawal completion detection', () => {
+    it('calls completeWithdrawalFromHistory when new withdrawal is detected in history', async () => {
+      mockUsePerpsSelector.mockImplementation((selector) =>
+        selector({
+          withdrawalRequests: mockPendingWithdrawals,
+          withdrawInProgress: true,
+          lastWithdrawResult: null,
+        } as Partial<PerpsControllerState> as PerpsControllerState),
+      );
+
+      // Mock history returns a completed withdrawal
+      mockProvider.getUserHistory.mockResolvedValue([
+        {
+          id: 'history-1',
+          timestamp: 1640995200000,
+          type: 'withdrawal',
+          amount: '100',
+          asset: 'USDC',
+          txHash: '0xnewWithdrawal',
+          status: 'completed',
+          details: { source: 'HyperLiquid' },
+        },
+      ]);
+
+      renderHookWithProvider(() => useWithdrawalRequests(), {
+        state: createMockState(),
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+
+      // Should call completeWithdrawalFromHistory with the new withdrawal data
+      expect(mockController.completeWithdrawalFromHistory).toHaveBeenCalledWith(
+        {
+          txHash: '0xnewWithdrawal',
+          amount: '100',
+          timestamp: 1640995200000,
+          asset: 'USDC',
+        },
+      );
+    });
+
+    it('does not call completeWithdrawalFromHistory when txHash matches lastWithdrawResult', async () => {
+      const existingTxHash = '0xalreadyKnown';
+
+      mockUsePerpsSelector.mockImplementation((selector) =>
+        selector({
+          withdrawalRequests: [],
+          withdrawInProgress: true,
+          lastWithdrawResult: {
+            success: true,
+            txHash: existingTxHash,
+            amount: '100',
+            asset: 'USDC',
+            timestamp: Date.now(),
+            error: '',
+          },
+        } as Partial<PerpsControllerState> as PerpsControllerState),
+      );
+
+      // Mock history returns the same withdrawal
+      mockProvider.getUserHistory.mockResolvedValue([
+        {
+          id: 'history-1',
+          timestamp: 1640995200000,
+          type: 'withdrawal',
+          amount: '100',
+          asset: 'USDC',
+          txHash: existingTxHash,
+          status: 'completed',
+          details: { source: 'HyperLiquid' },
+        },
+      ]);
+
+      renderHookWithProvider(() => useWithdrawalRequests(), {
+        state: createMockState(),
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+
+      // Should call completeWithdrawalFromHistory to clear stale state
+      // (defensive case - withdrawInProgress is true but txHash matches)
+      expect(mockController.completeWithdrawalFromHistory).toHaveBeenCalledWith(
+        {
+          txHash: existingTxHash,
+          amount: '100',
+          timestamp: 1640995200000,
+          asset: 'USDC',
+        },
+      );
+    });
+
+    it('does not call completeWithdrawalFromHistory when withdrawInProgress is false', async () => {
+      mockUsePerpsSelector.mockImplementation((selector) =>
+        selector({
+          withdrawalRequests: [],
+          withdrawInProgress: false,
+          lastWithdrawResult: null,
+        } as Partial<PerpsControllerState> as PerpsControllerState),
+      );
+
+      mockProvider.getUserHistory.mockResolvedValue([
+        {
+          id: 'history-1',
+          timestamp: 1640995200000,
+          type: 'withdrawal',
+          amount: '100',
+          asset: 'USDC',
+          txHash: '0xsomeWithdrawal',
+          status: 'completed',
+          details: { source: 'HyperLiquid' },
+        },
+      ]);
+
+      renderHookWithProvider(() => useWithdrawalRequests(), {
+        state: createMockState(),
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+
+      // Should NOT call - no active withdrawal
+      expect(
+        mockController.completeWithdrawalFromHistory,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('detects new withdrawal when lastWithdrawResult has different txHash', async () => {
+      mockUsePerpsSelector.mockImplementation((selector) =>
+        selector({
+          withdrawalRequests: mockPendingWithdrawals,
+          withdrawInProgress: true,
+          lastWithdrawResult: {
+            success: true,
+            txHash: '0xoldWithdrawal',
+            amount: '50',
+            asset: 'USDC',
+            timestamp: Date.now() - 10000,
+            error: '',
+          },
+        } as Partial<PerpsControllerState> as PerpsControllerState),
+      );
+
+      // Mock history returns a NEW withdrawal
+      mockProvider.getUserHistory.mockResolvedValue([
+        {
+          id: 'history-1',
+          timestamp: 1640995300000,
+          type: 'withdrawal',
+          amount: '100',
+          asset: 'USDC',
+          txHash: '0xnewWithdrawal',
+          status: 'completed',
+          details: { source: 'HyperLiquid' },
+        },
+      ]);
+
+      renderHookWithProvider(() => useWithdrawalRequests(), {
+        state: createMockState(),
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+
+      // Should call completeWithdrawalFromHistory with the new withdrawal
+      expect(mockController.completeWithdrawalFromHistory).toHaveBeenCalledWith(
+        {
+          txHash: '0xnewWithdrawal',
+          amount: '100',
+          timestamp: 1640995300000,
+          asset: 'USDC',
+        },
+      );
+    });
+
+    it('handles recovery on mount when withdrawInProgress is true', async () => {
+      // Simulates app restart with a pending withdrawal
+      mockUsePerpsSelector.mockImplementation((selector) =>
+        selector({
+          withdrawalRequests: [
+            {
+              id: 'stuck-withdrawal',
+              timestamp: 1640995200000,
+              amount: '100',
+              asset: 'USDC',
+              accountAddress: mockAddress,
+              status: 'bridging' as const,
+            },
+          ],
+          withdrawInProgress: true,
+          lastWithdrawResult: null,
+        } as Partial<PerpsControllerState> as PerpsControllerState),
+      );
+
+      // The withdrawal completed while app was closed
+      mockProvider.getUserHistory.mockResolvedValue([
+        {
+          id: 'history-1',
+          timestamp: 1640995250000,
+          type: 'withdrawal',
+          amount: '100',
+          asset: 'USDC',
+          txHash: '0xcompletedWhileAway',
+          status: 'completed',
+          details: { source: 'HyperLiquid' },
+        },
+      ]);
+
+      renderHookWithProvider(() => useWithdrawalRequests(), {
+        state: createMockState(),
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+
+      // Should detect and complete the withdrawal on mount
+      expect(mockController.completeWithdrawalFromHistory).toHaveBeenCalledWith(
+        {
+          txHash: '0xcompletedWhileAway',
+          amount: '100',
+          timestamp: 1640995250000,
+          asset: 'USDC',
+        },
       );
     });
   });
 
-  describe('refetch functionality', () => {
-    it('refetches data when refetch is called', async () => {
+  describe('error handling', () => {
+    it('handles provider errors gracefully', async () => {
+      mockUsePerpsSelector.mockImplementation((selector) =>
+        selector({
+          withdrawalRequests: [],
+          withdrawInProgress: true,
+          lastWithdrawResult: null,
+        } as Partial<PerpsControllerState> as PerpsControllerState),
+      );
+
+      mockController.getActiveProvider.mockReturnValue(null);
+
       const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
         state: createMockState(),
       });
@@ -1058,23 +570,70 @@ describe('useWithdrawalRequests', () => {
         jest.advanceTimersByTime(0);
       });
 
-      // Initial call
-      expect(mockProvider.getUserNonFundingLedgerUpdates).toHaveBeenCalledTimes(
-        1,
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBe('No active provider available');
+    });
+
+    it('handles controller errors gracefully', async () => {
+      mockUsePerpsSelector.mockImplementation((selector) =>
+        selector({
+          withdrawalRequests: [],
+          withdrawInProgress: true,
+          lastWithdrawResult: null,
+        } as Partial<PerpsControllerState> as PerpsControllerState),
       );
 
-      // Call refetch
-      await act(async () => {
-        await result.current.refetch();
+      (mockEngine as unknown as { context: unknown }).context = {};
+
+      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
+        state: createMockState(),
       });
 
-      // Should have been called again
-      expect(mockProvider.getUserNonFundingLedgerUpdates).toHaveBeenCalledTimes(
-        2,
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBe('PerpsController not available');
+    });
+
+    it('handles provider method not supported', async () => {
+      mockUsePerpsSelector.mockImplementation((selector) =>
+        selector({
+          withdrawalRequests: [],
+          withdrawInProgress: true,
+          lastWithdrawResult: null,
+        } as Partial<PerpsControllerState> as PerpsControllerState),
+      );
+
+      const providerWithoutMethod = {};
+      mockController.getActiveProvider.mockReturnValue(providerWithoutMethod);
+
+      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
+        state: createMockState(),
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBe(
+        'Provider does not support user history',
       );
     });
 
-    it('handles refetch errors gracefully', async () => {
+    it('handles API errors gracefully', async () => {
+      mockUsePerpsSelector.mockImplementation((selector) =>
+        selector({
+          withdrawalRequests: [],
+          withdrawInProgress: true,
+          lastWithdrawResult: null,
+        } as Partial<PerpsControllerState> as PerpsControllerState),
+      );
+
+      mockProvider.getUserHistory.mockRejectedValue(new Error('API Error'));
+
       const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
         state: createMockState(),
       });
@@ -1083,16 +642,8 @@ describe('useWithdrawalRequests', () => {
         jest.advanceTimersByTime(0);
       });
 
-      // Mock error on refetch
-      mockProvider.getUserNonFundingLedgerUpdates.mockRejectedValue(
-        new Error('Refetch error'),
-      );
-
-      await act(async () => {
-        await result.current.refetch();
-      });
-
-      expect(result.current.error).toBe('Refetch error');
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBe('API Error');
     });
   });
 
@@ -1120,6 +671,8 @@ describe('useWithdrawalRequests', () => {
       mockUsePerpsSelector.mockImplementation((selector) =>
         selector({
           withdrawalRequests: [],
+          withdrawInProgress: false,
+          lastWithdrawResult: null,
         } as Partial<PerpsControllerState> as PerpsControllerState),
       );
 
@@ -1130,10 +683,30 @@ describe('useWithdrawalRequests', () => {
       expect(result.current.withdrawalRequests).toEqual([]);
     });
 
-    it('handles empty completed withdrawals', async () => {
-      mockProvider.getUserNonFundingLedgerUpdates.mockResolvedValue([]);
+    it('handles no completed withdrawals in history', async () => {
+      mockUsePerpsSelector.mockImplementation((selector) =>
+        selector({
+          withdrawalRequests: mockPendingWithdrawals,
+          withdrawInProgress: true,
+          lastWithdrawResult: null,
+        } as Partial<PerpsControllerState> as PerpsControllerState),
+      );
 
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
+      // Only deposits in history, no withdrawals
+      mockProvider.getUserHistory.mockResolvedValue([
+        {
+          id: 'history-1',
+          timestamp: 1640995200000,
+          type: 'deposit',
+          amount: '100',
+          asset: 'USDC',
+          txHash: '0xdeposit',
+          status: 'completed',
+          details: { source: 'Arbitrum' },
+        },
+      ]);
+
+      renderHookWithProvider(() => useWithdrawalRequests(), {
         state: createMockState(),
       });
 
@@ -1141,29 +714,37 @@ describe('useWithdrawalRequests', () => {
         jest.advanceTimersByTime(0);
       });
 
-      // Should return pending withdrawals sorted by timestamp descending
-      const expectedWithdrawals = [...mockPendingWithdrawals].sort(
-        (a, b) => b.timestamp - a.timestamp,
-      );
-      expect(result.current.withdrawalRequests).toEqual(expectedWithdrawals);
+      // Should NOT call - no completed withdrawals found
+      expect(
+        mockController.completeWithdrawalFromHistory,
+      ).not.toHaveBeenCalled();
     });
 
-    it('handles failed withdrawals correctly', () => {
-      const failedWithdrawals = [
+    it('sorts withdrawals by timestamp descending', () => {
+      const unsortedWithdrawals = [
         {
-          id: 'withdrawal-failed',
-          timestamp: 1640995200000,
-          amount: '100',
+          id: 'withdrawal-old',
+          timestamp: 1640995100000, // older
+          amount: '50',
           asset: 'USDC',
           accountAddress: mockAddress,
-          status: 'failed' as const,
-          destination: '0x123',
+          status: 'pending' as const,
+        },
+        {
+          id: 'withdrawal-new',
+          timestamp: 1640995300000, // newer
+          amount: '150',
+          asset: 'USDC',
+          accountAddress: mockAddress,
+          status: 'pending' as const,
         },
       ];
 
       mockUsePerpsSelector.mockImplementation((selector) =>
         selector({
-          withdrawalRequests: failedWithdrawals,
+          withdrawalRequests: unsortedWithdrawals,
+          withdrawInProgress: false,
+          lastWithdrawResult: null,
         } as Partial<PerpsControllerState> as PerpsControllerState),
       );
 
@@ -1171,48 +752,9 @@ describe('useWithdrawalRequests', () => {
         state: createMockState(),
       });
 
-      const failedWithdrawal = result.current.withdrawalRequests.find(
-        (w) => w.id === 'withdrawal-failed',
-      );
-
-      expect(failedWithdrawal?.status).toBe('failed');
-    });
-
-    it('handles multiple withdrawals with same timestamp', async () => {
-      const sameTimestampWithdrawals = [
-        {
-          id: 'withdrawal-1',
-          timestamp: 1640995200000,
-          amount: '100',
-          asset: 'USDC',
-          accountAddress: mockAddress,
-          status: 'pending' as const,
-          destination: '0x123',
-        },
-        {
-          id: 'withdrawal-2',
-          timestamp: 1640995200000,
-          amount: '200',
-          asset: 'USDC',
-          accountAddress: mockAddress,
-          status: 'pending' as const,
-          destination: '0x456',
-        },
-      ];
-
-      mockUsePerpsSelector.mockImplementation((selector) =>
-        selector({
-          withdrawalRequests: sameTimestampWithdrawals,
-        } as Partial<PerpsControllerState> as PerpsControllerState),
-      );
-
-      const { result } = renderHookWithProvider(() => useWithdrawalRequests(), {
-        state: createMockState(),
-      });
-
-      expect(result.current.withdrawalRequests).toHaveLength(2);
-      expect(result.current.withdrawalRequests[0].id).toBe('withdrawal-1');
-      expect(result.current.withdrawalRequests[1].id).toBe('withdrawal-2');
+      // Should be sorted newest first
+      expect(result.current.withdrawalRequests[0].id).toBe('withdrawal-new');
+      expect(result.current.withdrawalRequests[1].id).toBe('withdrawal-old');
     });
   });
 });

--- a/app/components/UI/Perps/hooks/useWithdrawalRequests.ts
+++ b/app/components/UI/Perps/hooks/useWithdrawalRequests.ts
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useState, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useState, useRef, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
 import { usePerpsSelector } from './usePerpsSelector';
 import { useStableArray } from './useStableArray';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
+import type { UserHistoryItem } from '../controllers/types';
 
 export interface WithdrawalRequest {
   id: string;
@@ -20,11 +21,6 @@ export interface WithdrawalRequest {
 
 export interface UseWithdrawalRequestsOptions {
   /**
-   * Start time for fetching withdrawal requests (in milliseconds)
-   * Defaults to start of today to see today's withdrawals
-   */
-  startTime?: number;
-  /**
    * Skip initial fetch (useful for conditional loading)
    */
   skipInitialFetch?: boolean;
@@ -38,47 +34,77 @@ interface UseWithdrawalRequestsResult {
 }
 
 /**
- * Hook to fetch withdrawal requests combining:
- * 1. Pending withdrawals from PerpsController state (real-time)
- * 2. Completed withdrawals from HyperLiquid API (historical)
+ * Hook to track withdrawal requests and detect completion using FIFO queue matching.
  *
- * This provides the complete withdrawal lifecycle from initiation to completion
+ * This hook:
+ * 1. Returns pending withdrawals from PerpsController state for display (the queue)
+ * 2. Polls getUserHistory (same API as "Deposits" tab in activity view) to detect completion
+ * 3. Uses FIFO matching: oldest pending withdrawal matches with first completed withdrawal
+ * in history that happened after its submission time
+ *
+ * Key design: We use getUserHistory (same data source as the activity view "Deposits" tab).
+ * This ensures we only clear the pending indicator when the user can see the completed
+ * transaction in their activity view.
+ *
+ * Multi-withdrawal support: If user submits withdrawal B while A is still pending,
+ * both are tracked in the queue. A (oldest) is matched first, then B.
  */
 export const useWithdrawalRequests = (
   options: UseWithdrawalRequestsOptions = {},
 ): UseWithdrawalRequestsResult => {
-  const { startTime, skipInitialFetch = false } = options;
+  const { skipInitialFetch = false } = options;
 
   // Get current selected account address
   const selectedAddress = useSelector(selectSelectedInternalAccountByScope)(
     'eip155:1',
   )?.address;
 
-  // Get pending withdrawals from controller state, filtered by current account
-  // useStableArray ensures we only get a new reference when the actual data changes
-  const pendingWithdrawals = useStableArray(
+  // Get all withdrawals from controller state, filtered by current account
+  const allWithdrawals = useStableArray(
     usePerpsSelector((state) => {
-      const allWithdrawals = state?.withdrawalRequests || [];
+      const withdrawals = state?.withdrawalRequests || [];
       if (!selectedAddress) return [];
-      return allWithdrawals.filter(
+      return withdrawals.filter(
         (req) =>
           req.accountAddress?.toLowerCase() === selectedAddress.toLowerCase(),
       );
     }),
   );
 
-  // Track previous withdrawal states to detect meaningful changes
+  // Get pending/bridging withdrawals sorted by timestamp (oldest first = FIFO queue)
+  // Memoized to prevent new array reference on every render
+  const pendingQueue = useMemo(
+    () =>
+      allWithdrawals
+        .filter((req) => req.status === 'pending' || req.status === 'bridging')
+        .sort((a, b) => a.timestamp - b.timestamp),
+    [allWithdrawals],
+  );
+
+  // Extract oldest pending timestamp for dependency tracking (avoids array reference issues)
+  const oldestPendingTimestamp = pendingQueue[0]?.timestamp ?? null;
+
+  // Get last completed withdrawal timestamp to prevent same completion matching multiple pending withdrawals
+  // This is critical: if we completed withdrawal A at t=250, the next completion must be AFTER t=250
+  const lastCompletedTimestamp = usePerpsSelector(
+    (state) => state?.lastWithdrawResult?.timestamp ?? null,
+  );
+
+  // Track previous withdrawal states to detect meaningful changes (for logging)
   const prevWithdrawalStatesRef = useRef<Map<string, string>>(new Map());
+
+  // Track if initial fetch has been done to avoid re-running on callback changes
+  const initialFetchDoneRef = useRef(false);
 
   // Log only meaningful withdrawal state changes (not on every render)
   useEffect(() => {
     const currentStates = new Map<string, string>();
-    pendingWithdrawals.forEach((w) => currentStates.set(w.id, w.status));
+    allWithdrawals.forEach((w) => currentStates.set(w.id, w.status));
 
     const prevStates = prevWithdrawalStatesRef.current;
 
     // Check for new withdrawals (initialized)
-    for (const withdrawal of pendingWithdrawals) {
+    for (const withdrawal of allWithdrawals) {
       if (!prevStates.has(withdrawal.id)) {
         DevLogger.log('Withdrawal initialized:', {
           id: withdrawal.id,
@@ -91,7 +117,7 @@ export const useWithdrawalRequests = (
     }
 
     // Check for status changes (progress) and completions
-    for (const withdrawal of pendingWithdrawals) {
+    for (const withdrawal of allWithdrawals) {
       const prevStatus = prevStates.get(withdrawal.id);
       if (prevStatus && prevStatus !== withdrawal.status) {
         if (withdrawal.status === 'completed') {
@@ -114,27 +140,26 @@ export const useWithdrawalRequests = (
 
     // Update ref with current states
     prevWithdrawalStatesRef.current = currentStates;
-  }, [pendingWithdrawals]);
+  }, [allWithdrawals]);
 
-  const [completedWithdrawals, setCompletedWithdrawals] = useState<
-    WithdrawalRequest[]
-  >([]);
   const [isLoading, setIsLoading] = useState(!skipInitialFetch);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchCompletedWithdrawals = useCallback(async () => {
+  /**
+   * Check for withdrawal completion using FIFO matching.
+   * Polls getUserHistory (same API as "Deposits" tab) and matches
+   * the oldest pending withdrawal with the first completed withdrawal
+   * in history that happened after its submission time.
+   */
+  const checkForWithdrawalCompletion = useCallback(async () => {
+    // Only check if there are pending withdrawals in the queue
+    if (pendingQueue.length === 0) {
+      return;
+    }
+
     try {
       setIsLoading(true);
       setError(null);
-
-      // Skip fetch if no selected address - can't attribute withdrawals to unknown account
-      if (!selectedAddress) {
-        DevLogger.log(
-          'fetchCompletedWithdrawals: No selected address, skipping fetch',
-        );
-        setIsLoading(false);
-        return;
-      }
 
       const controller = Engine.context.PerpsController;
       if (!controller) {
@@ -146,270 +171,178 @@ export const useWithdrawalRequests = (
         throw new Error('No active provider available');
       }
 
-      // Check if provider has the getUserNonFundingLedgerUpdates method
-      if (!('getUserNonFundingLedgerUpdates' in provider)) {
-        throw new Error('Provider does not support non-funding ledger updates');
+      // Check if provider has getUserHistory method
+      if (!('getUserHistory' in provider)) {
+        throw new Error('Provider does not support user history');
       }
 
-      // Use provided startTime or default to start of today (midnight UTC)
-      const now = new Date();
-      const startOfToday = new Date(
-        now.getFullYear(),
-        now.getMonth(),
-        now.getDate(),
-      ).getTime();
-      const searchStartTime = startTime ?? startOfToday;
+      // FIFO: Get the oldest pending withdrawal (first in queue)
+      const oldestPending = pendingQueue[0];
 
-      const updates = await (
-        provider as {
-          getUserNonFundingLedgerUpdates: (
-            params: unknown,
-          ) => Promise<unknown[]>;
-        }
-      ).getUserNonFundingLedgerUpdates({
+      // Only fetch history starting from before the oldest pending withdrawal
+      // This optimizes the query to only the relevant time window
+      const searchStartTime = oldestPending.timestamp - 60000; // 1 minute buffer
+
+      DevLogger.log(
+        'useWithdrawalRequests: Checking for withdrawal completion (FIFO)',
+        {
+          queueLength: pendingQueue.length,
+          oldestPendingId: oldestPending.id,
+          oldestPendingSubmittedAt: new Date(
+            oldestPending.timestamp,
+          ).toISOString(),
+          searchStartTime: new Date(searchStartTime).toISOString(),
+        },
+      );
+
+      // Fetch user history - same API as activity view "Deposits" tab
+      const history: UserHistoryItem[] = await provider.getUserHistory({
         startTime: searchStartTime,
         endTime: undefined,
       });
 
-      // Ensure updates is an array before processing
-      const safeUpdates = Array.isArray(updates) ? updates : [];
+      const safeHistory = Array.isArray(history) ? history : [];
 
-      // Transform ledger updates to withdrawal requests
-      const withdrawalData = (
-        safeUpdates as {
-          delta: {
-            coin?: string;
-            usdc: string;
-            type: string;
-            fee?: string;
-            nonce?: number;
-          };
-          hash: string;
-          time: number;
-        }[]
-      )
-        .filter((update) => {
-          const isWithdrawal = update.delta.type === 'withdraw';
-          return isWithdrawal;
-        })
-        .map((update) => ({
-          id: `withdrawal-${update.hash}`,
-          timestamp: update.time,
-          amount: Math.abs(parseFloat(update.delta.usdc)).toString(),
-          asset: update.delta.coin || 'USDC', // Default to USDC if symbol is not specified (API uses 'coin')
-          accountAddress: selectedAddress, // selectedAddress is guaranteed to exist due to early return above
-          txHash: update.hash,
-          status: 'completed' as const, // HyperLiquid ledger updates are completed transactions
-          destination: undefined, // Not available in ledger updates
-          withdrawalId: update.delta.nonce?.toString(), // Use nonce as withdrawal ID if available
-        }));
+      // Find completed withdrawals in history, sorted by timestamp (oldest first)
+      const completedWithdrawals = safeHistory
+        .filter(
+          (item) => item.type === 'withdrawal' && item.status === 'completed',
+        )
+        .sort((a, b) => a.timestamp - b.timestamp);
 
-      setCompletedWithdrawals(withdrawalData);
+      if (completedWithdrawals.length === 0) {
+        DevLogger.log(
+          'useWithdrawalRequests: No completed withdrawals in history yet',
+        );
+        return;
+      }
+
+      // FIFO matching: find the first completed withdrawal that:
+      // 1. Happened AFTER the oldest pending withdrawal was submitted
+      // 2. Happened AFTER the last completed withdrawal we processed (to avoid double-matching)
+      //
+      // The second condition is critical: if user withdraws A at t=100, B at t=200,
+      // and we find a completion at t=250, it should only match A.
+      // On the next poll, the same t=250 completion should NOT match B.
+      // Only a NEW completion (e.g., t=350) should match B.
+      const matchingCompleted = completedWithdrawals.find(
+        (completed) =>
+          completed.timestamp > oldestPending.timestamp &&
+          (lastCompletedTimestamp === null ||
+            completed.timestamp > lastCompletedTimestamp),
+      );
+
+      if (!matchingCompleted) {
+        DevLogger.log(
+          'useWithdrawalRequests: No NEW completed withdrawals after oldest pending submission',
+          {
+            oldestPendingTimestamp: new Date(
+              oldestPending.timestamp,
+            ).toISOString(),
+            lastCompletedTimestamp: lastCompletedTimestamp
+              ? new Date(lastCompletedTimestamp).toISOString()
+              : 'none',
+            latestInHistory:
+              completedWithdrawals.length > 0
+                ? new Date(
+                    completedWithdrawals[
+                      completedWithdrawals.length - 1
+                    ].timestamp,
+                  ).toISOString()
+                : 'none',
+          },
+        );
+        return;
+      }
+
+      DevLogger.log(
+        'useWithdrawalRequests: FIFO match found! NEW withdrawal completed and visible in history',
+        {
+          pendingId: oldestPending.id,
+          pendingSubmittedAt: new Date(oldestPending.timestamp).toISOString(),
+          completedTxHash: matchingCompleted.txHash,
+          completedTimestamp: new Date(
+            matchingCompleted.timestamp,
+          ).toISOString(),
+          lastCompletedTimestamp: lastCompletedTimestamp
+            ? new Date(lastCompletedTimestamp).toISOString()
+            : 'none',
+          remainingInQueue: pendingQueue.length - 1,
+        },
+      );
+
+      // Call completeWithdrawalFromHistory to remove this specific withdrawal from queue
+      controller.completeWithdrawalFromHistory(oldestPending.id, {
+        txHash: matchingCompleted.txHash,
+        amount: matchingCompleted.amount,
+        timestamp: matchingCompleted.timestamp,
+        asset: matchingCompleted.asset,
+      });
     } catch (err) {
       const errorMessage =
         err instanceof Error
           ? err.message
           : 'Failed to fetch completed withdrawals';
-      console.error('Error fetching completed withdrawals:', errorMessage);
+      console.error('Error checking withdrawal completion:', errorMessage);
       setError(errorMessage);
     } finally {
       setIsLoading(false);
     }
-  }, [startTime, selectedAddress]);
+  }, [pendingQueue, lastCompletedTimestamp]);
 
-  // Track which withdrawals have already been updated in the controller
-  // to prevent duplicate updateWithdrawalStatus calls
-  const updatedWithdrawalIdsRef = useRef<Set<string>>(new Set());
-
-  // Clear the updated withdrawal IDs ref when account changes to prevent stale data
-  // This handles the edge case where withdrawal IDs might not be globally unique
-  // across accounts (e.g., sequential IDs), ensuring the new account's withdrawals
-  // are properly processed
+  // Initial check when component mounts (if not skipping and queue has items)
+  // Uses ref to ensure this only runs once, not on every callback recreation
   useEffect(() => {
-    if (selectedAddress) {
-      updatedWithdrawalIdsRef.current.clear();
-      DevLogger.log(
-        'useWithdrawalRequests: Cleared updatedWithdrawalIdsRef on account change',
-        { selectedAddress },
-      );
+    if (
+      !skipInitialFetch &&
+      pendingQueue.length > 0 &&
+      !initialFetchDoneRef.current
+    ) {
+      initialFetchDoneRef.current = true;
+      checkForWithdrawalCompletion();
     }
-  }, [selectedAddress]);
+  }, [checkForWithdrawalCompletion, skipInitialFetch, pendingQueue.length]);
 
-  // Combine pending and completed withdrawals (pure data transformation, no side effects)
-  const allWithdrawals = useMemo(() => {
-    // Build a list that merges pending withdrawals with their completed counterparts
-    const result: WithdrawalRequest[] = [];
-
-    // Track which completed withdrawals have been matched to prevent
-    // multiple same-amount pending withdrawals from matching the same completed one
-    const matchedCompletedIds = new Set<string>();
-
-    // First, add all pending/bridging withdrawals
-    for (const pending of pendingWithdrawals) {
-      if (pending.status === 'pending' || pending.status === 'bridging') {
-        // Check if this pending withdrawal has a matching UNMATCHED completed one
-        const matchingCompleted = completedWithdrawals.find((completed) => {
-          if (!completed.txHash) return false;
-          // Skip completed withdrawals that have already been matched
-          if (matchedCompletedIds.has(completed.id)) return false;
-
-          const amountDiff = Math.abs(
-            parseFloat(pending.amount) - parseFloat(completed.amount),
-          );
-          const isAmountMatch = amountDiff < 0.01;
-          const isAssetMatch = pending.asset === completed.asset;
-
-          return isAmountMatch && isAssetMatch;
-        });
-
-        if (matchingCompleted) {
-          // Mark this completed withdrawal as matched
-          matchedCompletedIds.add(matchingCompleted.id);
-          // Merge: use pending's ID but update with completed data
-          result.push({
-            ...pending,
-            status: 'completed',
-            txHash: matchingCompleted.txHash,
-            withdrawalId: matchingCompleted.withdrawalId,
-          });
-        } else {
-          // No match found, keep as pending/bridging
-          result.push(pending);
-        }
-      } else {
-        // Already completed or failed in controller state
-        // Check if this matches an API completed withdrawal to prevent duplicates
-        // This handles the case where controller state was updated in a previous render
-        if (pending.status === 'completed' && pending.txHash) {
-          const matchingApiCompleted = completedWithdrawals.find(
-            (completed) => completed.txHash === pending.txHash,
-          );
-          if (matchingApiCompleted) {
-            matchedCompletedIds.add(matchingApiCompleted.id);
-          }
-        }
-        result.push(pending);
-      }
-    }
-
-    // Add completed withdrawals that weren't matched to any pending ones
-    // (historical withdrawals that were completed before the app started tracking)
-    for (const completed of completedWithdrawals) {
-      // Skip if already matched to a pending withdrawal
-      if (matchedCompletedIds.has(completed.id)) {
-        continue;
-      }
-
-      if (!completed.txHash) {
-        result.push(completed);
-        continue;
-      }
-
-      // This completed withdrawal wasn't matched, add it to results
-      result.push(completed);
-    }
-
-    // Sort by timestamp (newest first)
-    return result.sort((a, b) => b.timestamp - a.timestamp);
-  }, [pendingWithdrawals, completedWithdrawals]);
-
-  // Update controller state when we detect completed withdrawals that match pending ones
-  // This is a side effect that should be in useEffect, not useMemo
+  // Poll for completion when there are pending withdrawals in the queue
   useEffect(() => {
-    const controller = Engine.context.PerpsController;
-    if (!controller) return;
-
-    // Track which pending withdrawals have been matched in THIS render cycle
-    // to prevent multiple completed withdrawals from matching the same pending one
-    const matchedPendingIdsThisCycle = new Set<string>();
-
-    for (const completed of completedWithdrawals) {
-      // Skip if no txHash (not confirmed on chain)
-      if (!completed.txHash) continue;
-
-      // Find first UNMATCHED pending withdrawal that matches this completed one
-      const matchingPending = pendingWithdrawals.find((w) => {
-        if (w.status !== 'pending' && w.status !== 'bridging') {
-          return false;
-        }
-        // Skip if already matched in this render cycle
-        if (matchedPendingIdsThisCycle.has(w.id)) {
-          return false;
-        }
-        // Skip if already updated in a previous render cycle
-        if (updatedWithdrawalIdsRef.current.has(w.id)) {
-          return false;
-        }
-
-        // Match by amount - allow for small differences (fees, rounding)
-        const amountDiff = Math.abs(
-          parseFloat(w.amount) - parseFloat(completed.amount),
-        );
-        const isAmountMatch = amountDiff < 0.01;
-
-        // Asset must match
-        const isAssetMatch = w.asset === completed.asset;
-
-        return isAmountMatch && isAssetMatch;
-      });
-
-      if (matchingPending) {
-        // Mark as matched in this cycle to prevent another completed from matching it
-        matchedPendingIdsThisCycle.add(matchingPending.id);
-
-        DevLogger.log(
-          'useWithdrawalRequests: Updating withdrawal status to completed',
-          {
-            pendingId: matchingPending.id,
-            txHash: completed.txHash,
-            amount: completed.amount,
-          },
-        );
-
-        // Mark as updated to prevent duplicate calls across render cycles
-        updatedWithdrawalIdsRef.current.add(matchingPending.id);
-
-        // Update the controller state to reflect the completion
-        controller.updateWithdrawalStatus(
-          matchingPending.id,
-          'completed',
-          completed.txHash,
-        );
-      }
+    if (pendingQueue.length === 0 || !oldestPendingTimestamp) {
+      return; // No need to poll if queue is empty
     }
-  }, [completedWithdrawals, pendingWithdrawals]);
 
-  // Initial fetch when component mounts
-  useEffect(() => {
-    if (!skipInitialFetch) {
-      fetchCompletedWithdrawals();
-    }
-  }, [fetchCompletedWithdrawals, skipInitialFetch]);
-
-  // Poll for completed withdrawals when there are active withdrawals
-  useEffect(() => {
-    const hasActiveWithdrawals = pendingWithdrawals.some(
-      (w) => w.status === 'pending' || w.status === 'bridging',
+    DevLogger.log(
+      'useWithdrawalRequests: Starting polling for withdrawal completion (FIFO)',
+      {
+        queueLength: pendingQueue.length,
+        oldestSubmittedAt: new Date(oldestPendingTimestamp).toISOString(),
+      },
     );
 
-    if (!hasActiveWithdrawals) {
-      return; // No need to poll if no active withdrawals
-    }
-
-    // Poll every 10 seconds when there are active withdrawals
+    // Poll every 5 seconds when there are pending withdrawals
     const pollInterval = setInterval(() => {
-      fetchCompletedWithdrawals();
-    }, 10000); // 10 seconds
+      checkForWithdrawalCompletion();
+    }, 5000);
 
     return () => {
+      DevLogger.log('useWithdrawalRequests: Stopping polling');
       clearInterval(pollInterval);
     };
-  }, [pendingWithdrawals, fetchCompletedWithdrawals]);
+  }, [
+    pendingQueue.length,
+    oldestPendingTimestamp,
+    checkForWithdrawalCompletion,
+  ]);
+
+  // Return pending withdrawals sorted by timestamp (newest first for display)
+  // Memoized to prevent new array reference on every render
+  const sortedForDisplay = useMemo(
+    () => [...pendingQueue].sort((a, b) => b.timestamp - a.timestamp),
+    [pendingQueue],
+  );
 
   return {
-    withdrawalRequests: allWithdrawals,
+    withdrawalRequests: sortedForDisplay,
     isLoading,
     error,
-    refetch: fetchCompletedWithdrawals,
+    refetch: checkForWithdrawalCompletion,
   };
 };

--- a/app/store/migrations/118.test.ts
+++ b/app/store/migrations/118.test.ts
@@ -1,0 +1,439 @@
+import { captureException } from '@sentry/react-native';
+import migrate from './118';
+import { ensureValidState } from './util';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+interface TestState {
+  engine: {
+    backgroundState: {
+      PerpsController?: {
+        withdrawalRequests?: unknown[];
+        depositRequests?: unknown[];
+        withdrawalProgress?: {
+          progress: number;
+          lastUpdated: number;
+          activeWithdrawalId: string | null;
+        };
+        withdrawInProgress?: boolean;
+        depositInProgress?: boolean;
+        activeProvider?: string;
+        isTestnet?: boolean;
+        [key: string]: unknown;
+      };
+      [key: string]: unknown;
+    };
+  };
+}
+
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+const mockedCaptureException = jest.mocked(captureException);
+
+describe('Migration 118: Clear deposit and withdrawal request queues from PerpsController', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns state unchanged if ensureValidState returns false', () => {
+    const state = { some: 'state' };
+    mockedEnsureValidState.mockReturnValue(false);
+
+    const result = migrate(state);
+
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged if PerpsController does not exist', () => {
+    const state: TestState = {
+      engine: {
+        backgroundState: {
+          OtherController: { someData: true },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const result = migrate(state) as TestState;
+
+    expect(result).toBe(state);
+    expect(result.engine.backgroundState.PerpsController).toBeUndefined();
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('returns state unchanged if PerpsController is not an object', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          PerpsController: 'invalid',
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const result = migrate(state);
+
+    expect(result).toBe(state);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  describe('clears request queues', () => {
+    it('clears withdrawalRequests to empty array', () => {
+      const state: TestState = {
+        engine: {
+          backgroundState: {
+            PerpsController: {
+              withdrawalRequests: [
+                {
+                  id: 'withdrawal-1',
+                  status: 'pending',
+                  amount: '100',
+                },
+                {
+                  id: 'withdrawal-2',
+                  status: 'completed',
+                  amount: '200',
+                },
+              ],
+              activeProvider: 'hyperliquid',
+            },
+          },
+        },
+      };
+
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const result = migrate(state) as TestState;
+
+      expect(
+        result.engine.backgroundState.PerpsController?.withdrawalRequests,
+      ).toEqual([]);
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('clears depositRequests to empty array', () => {
+      const state: TestState = {
+        engine: {
+          backgroundState: {
+            PerpsController: {
+              depositRequests: [
+                {
+                  id: 'deposit-1',
+                  status: 'pending',
+                  amount: '100',
+                },
+                {
+                  id: 'deposit-2',
+                  status: 'completed',
+                  amount: '200',
+                },
+              ],
+              activeProvider: 'hyperliquid',
+            },
+          },
+        },
+      };
+
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const result = migrate(state) as TestState;
+
+      expect(
+        result.engine.backgroundState.PerpsController?.depositRequests,
+      ).toEqual([]);
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('clears both withdrawalRequests and depositRequests', () => {
+      const state: TestState = {
+        engine: {
+          backgroundState: {
+            PerpsController: {
+              withdrawalRequests: [
+                { id: 'withdrawal-1', status: 'pending' },
+                { id: 'withdrawal-2', status: 'bridging' },
+                { id: 'withdrawal-3', status: 'completed' },
+              ],
+              depositRequests: [
+                { id: 'deposit-1', status: 'pending' },
+                { id: 'deposit-2', status: 'completed' },
+              ],
+              activeProvider: 'hyperliquid',
+            },
+          },
+        },
+      };
+
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const result = migrate(state) as TestState;
+
+      expect(
+        result.engine.backgroundState.PerpsController?.withdrawalRequests,
+      ).toEqual([]);
+      expect(
+        result.engine.backgroundState.PerpsController?.depositRequests,
+      ).toEqual([]);
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resets progress and flags', () => {
+    it('resets withdrawalProgress', () => {
+      const mockNow = 1700000000000;
+      jest.spyOn(Date, 'now').mockReturnValue(mockNow);
+
+      const state: TestState = {
+        engine: {
+          backgroundState: {
+            PerpsController: {
+              withdrawalRequests: [],
+              withdrawalProgress: {
+                progress: 75,
+                lastUpdated: 1234567800,
+                activeWithdrawalId: 'withdrawal-1',
+              },
+              activeProvider: 'hyperliquid',
+            },
+          },
+        },
+      };
+
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const result = migrate(state) as TestState;
+
+      expect(
+        result.engine.backgroundState.PerpsController?.withdrawalProgress,
+      ).toEqual({
+        progress: 0,
+        lastUpdated: mockNow,
+        activeWithdrawalId: null,
+      });
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('resets withdrawInProgress to false', () => {
+      const state: TestState = {
+        engine: {
+          backgroundState: {
+            PerpsController: {
+              withdrawalRequests: [],
+              withdrawInProgress: true,
+              activeProvider: 'hyperliquid',
+            },
+          },
+        },
+      };
+
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const result = migrate(state) as TestState;
+
+      expect(
+        result.engine.backgroundState.PerpsController?.withdrawInProgress,
+      ).toBe(false);
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('resets depositInProgress to false', () => {
+      const state: TestState = {
+        engine: {
+          backgroundState: {
+            PerpsController: {
+              depositRequests: [],
+              depositInProgress: true,
+              activeProvider: 'hyperliquid',
+            },
+          },
+        },
+      };
+
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const result = migrate(state) as TestState;
+
+      expect(
+        result.engine.backgroundState.PerpsController?.depositInProgress,
+      ).toBe(false);
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handles missing properties', () => {
+    it('handles missing withdrawalRequests property', () => {
+      const state: TestState = {
+        engine: {
+          backgroundState: {
+            PerpsController: {
+              depositRequests: [{ id: 'deposit-1', status: 'pending' }],
+              activeProvider: 'hyperliquid',
+            },
+          },
+        },
+      };
+
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const result = migrate(state) as TestState;
+
+      expect(
+        result.engine.backgroundState.PerpsController?.withdrawalRequests,
+      ).toBeUndefined();
+      expect(
+        result.engine.backgroundState.PerpsController?.depositRequests,
+      ).toEqual([]);
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('handles missing depositRequests property', () => {
+      const state: TestState = {
+        engine: {
+          backgroundState: {
+            PerpsController: {
+              withdrawalRequests: [{ id: 'withdrawal-1', status: 'pending' }],
+              activeProvider: 'hyperliquid',
+            },
+          },
+        },
+      };
+
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const result = migrate(state) as TestState;
+
+      expect(
+        result.engine.backgroundState.PerpsController?.withdrawalRequests,
+      ).toEqual([]);
+      expect(
+        result.engine.backgroundState.PerpsController?.depositRequests,
+      ).toBeUndefined();
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('does not add withdrawalProgress if not present', () => {
+      const state: TestState = {
+        engine: {
+          backgroundState: {
+            PerpsController: {
+              withdrawalRequests: [],
+              activeProvider: 'hyperliquid',
+            },
+          },
+        },
+      };
+
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const result = migrate(state) as TestState;
+
+      expect(
+        result.engine.backgroundState.PerpsController?.withdrawalProgress,
+      ).toBeUndefined();
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('preserves other properties', () => {
+    it('preserves other PerpsController properties', () => {
+      const state: TestState = {
+        engine: {
+          backgroundState: {
+            PerpsController: {
+              withdrawalRequests: [{ id: 'withdrawal-1', status: 'pending' }],
+              depositRequests: [{ id: 'deposit-1', status: 'pending' }],
+              activeProvider: 'hyperliquid',
+              isTestnet: false,
+              someOtherProperty: 'preserved',
+            },
+          },
+        },
+      };
+
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const result = migrate(state) as TestState;
+
+      expect(
+        result.engine.backgroundState.PerpsController?.activeProvider,
+      ).toBe('hyperliquid');
+      expect(result.engine.backgroundState.PerpsController?.isTestnet).toBe(
+        false,
+      );
+      expect(
+        result.engine.backgroundState.PerpsController?.someOtherProperty,
+      ).toBe('preserved');
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('preserves other controllers in backgroundState', () => {
+      const state: TestState = {
+        engine: {
+          backgroundState: {
+            PerpsController: {
+              withdrawalRequests: [{ id: 'withdrawal-1', status: 'pending' }],
+            },
+            OtherController: {
+              shouldStayUntouched: true,
+            },
+          },
+        },
+      };
+
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const result = migrate(state) as TestState;
+
+      expect(result.engine.backgroundState.OtherController).toEqual({
+        shouldStayUntouched: true,
+      });
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles error during migration and captures exception', () => {
+      const state: TestState = {
+        engine: {
+          backgroundState: {
+            PerpsController: {
+              withdrawalRequests: [],
+            },
+          },
+        },
+      };
+
+      // Mock an error by making the property throw when accessed
+      Object.defineProperty(
+        state.engine.backgroundState.PerpsController,
+        'withdrawalRequests',
+        {
+          get() {
+            throw new Error('Test error');
+          },
+          configurable: true,
+        },
+      );
+
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const result = migrate(state);
+
+      expect(result).toBe(state);
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'Migration 118: Failed to clear transaction request queues',
+          ),
+        }),
+      );
+    });
+  });
+});

--- a/app/store/migrations/118.test.ts
+++ b/app/store/migrations/118.test.ts
@@ -410,12 +410,12 @@ describe('Migration 118: Clear deposit and withdrawal request queues from PerpsC
         },
       };
 
-      // Mock an error by making the property throw when accessed
+      // Mock an error by making the property throw when updated
       Object.defineProperty(
         state.engine.backgroundState.PerpsController,
         'withdrawalRequests',
         {
-          get() {
+          set() {
             throw new Error('Test error');
           },
           configurable: true,

--- a/app/store/migrations/118.ts
+++ b/app/store/migrations/118.ts
@@ -1,0 +1,76 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { ensureValidState } from './util';
+import { captureException } from '@sentry/react-native';
+
+/**
+ * Migration 118: Clear deposit and withdrawal request queues from PerpsController
+ *
+ * This migration clears the depositRequests and withdrawalRequests arrays to ensure
+ * users start fresh with the new FIFO queue-based pending transaction tracking.
+ *
+ * These arrays are queues for tracking active/pending transactions only - they are
+ * NOT used for displaying transaction history. Transaction history comes from the
+ * HyperLiquid getUserHistory API.
+ *
+ * This also resets related progress/status flags to ensure a clean state.
+ */
+const migration = (state: unknown): unknown => {
+  const migrationVersion = 118;
+
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  try {
+    if (
+      !hasProperty(state.engine.backgroundState, 'PerpsController') ||
+      !isObject(state.engine.backgroundState.PerpsController)
+    ) {
+      // PerpsController doesn't exist yet, nothing to migrate
+      return state;
+    }
+
+    const perpsController = state.engine.backgroundState.PerpsController;
+
+    // Clear withdrawal requests queue
+    if (hasProperty(perpsController, 'withdrawalRequests')) {
+      perpsController.withdrawalRequests = [];
+    }
+
+    // Clear deposit requests queue
+    if (hasProperty(perpsController, 'depositRequests')) {
+      perpsController.depositRequests = [];
+    }
+
+    // Reset withdrawal progress
+    if (hasProperty(perpsController, 'withdrawalProgress')) {
+      perpsController.withdrawalProgress = {
+        progress: 0,
+        lastUpdated: Date.now(),
+        activeWithdrawalId: null,
+      };
+    }
+
+    // Reset in-progress flags
+    if (hasProperty(perpsController, 'withdrawInProgress')) {
+      perpsController.withdrawInProgress = false;
+    }
+
+    if (hasProperty(perpsController, 'depositInProgress')) {
+      perpsController.depositInProgress = false;
+    }
+
+    return state;
+  } catch (error) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Failed to clear transaction request queues: ${String(
+          error,
+        )}`,
+      ),
+    );
+    return state;
+  }
+};
+
+export default migration;

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -118,6 +118,7 @@ import migration114 from './114';
 import migration115 from './115';
 import migration116 from './116';
 import migration117 from './117';
+import migration118 from './118';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -255,6 +256,7 @@ export const migrationList: MigrationsList = {
   115: migration115,
   116: migration116,
   117: migration117,
+  118: migration118,
 };
 
 // Enable both synchronous and asynchronous migrations


### PR DESCRIPTION
## **Description**

**Summary**

Replaces the fragile amount-based withdrawal/deposit completion matching with a deterministic FIFO (First In, First Out) queue approach to resolve stuck pending withdrawal indicators.

**Problem:** Pending withdrawals could get permanently stuck in the UI because the old matching logic compared amounts and assets between pending requests and completed ledger entries. This was unreliable when multiple withdrawals of the same amount/asset existed, leading to mismatches or missed completions.

**Solution:** The new approach treats pending transactions as a FIFO queue. The oldest pending transaction is matched with the first completed transaction in the user's history that occurred after its submission time. This eliminates ambiguity and ensures each pending request is resolved exactly once.

**Changes**

New usePendingTransactions hook (usePendingTransactions.ts): Combined hook that tracks both pending deposits and withdrawals using FIFO queue matching. Polls getUserHistory every 5 seconds (down from 10s) to detect completions.

Refactored useWithdrawalRequests hook (useWithdrawalRequests.ts): Rewrote from scratch to use FIFO matching instead of amount-based matching.

Replaced `getUserNonFundingLedgerUpdates` with `getUserHistory` API. Now delegates completion to the controller via `completeWithdrawalFromHistory `instead of calling `updateWithdrawalStatus` directly.

Removed `startTime` option (no longer needed -- search window is derived from oldest pending timestamp).

How FIFO Matching Works
1. Pending deposits/withdrawals are maintained as sorted queues (oldest first) in PerpsController state.
2. The hook polls getUserHistory to fetch completed transactions from the API.
3. The oldest pending withdrawal is matched with the first completed withdrawal in history where:
```
completed.timestamp > pending.timestamp AND completed.timestamp > lastCompletedTimestamp.
```

On match, the controller removes the request from the queue and bumps lastCompletedTimestamp to prevent the same history entry from being matched again.

Deposits and withdrawals are tracked independently -- a completed deposit never clears a pending withdrawal and vice versa.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
