### PR TITLE
test: Fixed price API mocking that would show NaN in token balance

### DIFF
--- a/tests/api-mocking/mock-responses/defaults/price-apis.ts
+++ b/tests/api-mocking/mock-responses/defaults/price-apis.ts
@@ -138,10 +138,98 @@ export const PRICE_API_MOCKS: MockEventsObject = {
         },
       },
     },
-    // NOTE: v3/spot-prices is intentionally NOT mocked.
-    // Any static mock response causes NaN because the app expects prices for
-    // dynamically requested asset IDs. When assets aren't in the response,
-    // calculations result in NaN. Letting this endpoint use live API works correctly.
+    {
+      // v3/spot-prices with full market data matching the live API response format.
+      // Requests include includeMarketData=true, so response must include market data fields.
+      urlEndpoint: /https:\/\/price\.api\.cx\.metamask\.io\/v3\/spot-prices/,
+      responseCode: 200,
+      response: {
+        // Ethereum Mainnet
+        'eip155:1/slip44:60': {
+          price: 4291.85,
+          usd: 4291.85,
+          eth: 1.0,
+          marketCap: 516000000000,
+          allTimeHigh: 4878.26,
+          allTimeLow: 0.43,
+          totalVolume: 15000000000,
+          high1d: 4350.0,
+          low1d: 4200.0,
+          circulatingSupply: 120000000,
+          dilutedMarketCap: 516000000000,
+          marketCapPercentChange1d: -1.5,
+          priceChange1d: -65.0,
+          pricePercentChange1h: -0.2,
+          pricePercentChange1d: -1.5,
+          pricePercentChange7d: 2.3,
+          pricePercentChange14d: 5.1,
+          pricePercentChange30d: 8.7,
+          pricePercentChange200d: 45.2,
+          pricePercentChange1y: 120.5,
+        },
+        // Linea (ETH on Linea)
+        'eip155:59144/slip44:60': {
+          price: 4291.85,
+          usd: 4291.85,
+          eth: 1.0,
+          marketCap: 516000000000,
+          allTimeHigh: 4878.26,
+          allTimeLow: 0.43,
+          totalVolume: 15000000000,
+          high1d: 4350.0,
+          low1d: 4200.0,
+          pricePercentChange1d: -1.5,
+        },
+        // Bitcoin
+        'bip122:000000000019d6689c085ae165831e93/slip44:0': {
+          price: 100000,
+          usd: 100000,
+          eth: 23.3,
+          marketCap: 1950000000000,
+          allTimeHigh: 108000,
+          allTimeLow: 67.81,
+          totalVolume: 35000000000,
+          high1d: 101500,
+          low1d: 98500,
+          pricePercentChange1d: -0.8,
+        },
+        // Solana
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
+          price: 75,
+          usd: 75,
+          eth: 0.0175,
+          marketCap: 35000000000,
+          pricePercentChange1d: -2.1,
+        },
+        // Polygon
+        'eip155:137/slip44:966': {
+          price: 0.5,
+          usd: 0.5,
+          eth: 0.000116,
+          marketCap: 5000000000,
+          pricePercentChange1d: -1.2,
+        },
+        // Common ERC20 tokens
+        'eip155:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f': {
+          price: 1.0,
+          usd: 1.0,
+          eth: 0.000233,
+          pricePercentChange1d: 0.01,
+        },
+        'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': {
+          price: 1.0,
+          usd: 1.0,
+          eth: 0.000233,
+          pricePercentChange1d: 0.0,
+        },
+        'eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7': {
+          price: 1.0,
+          usd: 1.0,
+          eth: 0.000233,
+          pricePercentChange1d: -0.01,
+        },
+      },
+    },
     {
       urlEndpoint: /https:\/\/min-api\.cryptocompare\.com\/data\/pricemulti/,
       responseCode: 200,

--- a/tests/api-mocking/mock-responses/defaults/price-apis.ts
+++ b/tests/api-mocking/mock-responses/defaults/price-apis.ts
@@ -9,7 +9,7 @@ export const PRICE_API_MOCKS: MockEventsObject = {
   GET: [
     {
       urlEndpoint:
-        /^https:\/\/price\.api\.cx\.metamask\.io\/v1\/supportedVsCurrencies$/,
+        /https:\/\/price\.api\.cx\.metamask\.io\/v1\/supportedVsCurrencies/,
       responseCode: 200,
       response: [
         'usd',
@@ -68,7 +68,7 @@ export const PRICE_API_MOCKS: MockEventsObject = {
     },
     {
       urlEndpoint:
-        /^https:\/\/price\.api\.cx\.metamask\.io\/v2\/supportedNetworks$/,
+        /https:\/\/price\.api\.cx\.metamask\.io\/v2\/supportedNetworks/,
       responseCode: 200,
       response: [
         'eip155:1',
@@ -96,8 +96,7 @@ export const PRICE_API_MOCKS: MockEventsObject = {
       ],
     },
     {
-      urlEndpoint:
-        /^https:\/\/price\.api\.cx\.metamask\.io\/v1\/exchange-rates\?baseCurrency=.*$/,
+      urlEndpoint: /https:\/\/price\.api\.cx\.metamask\.io\/v1\/exchange-rates/,
       responseCode: 200,
       response: {
         usd: {
@@ -139,38 +138,12 @@ export const PRICE_API_MOCKS: MockEventsObject = {
         },
       },
     },
+    // NOTE: v3/spot-prices is intentionally NOT mocked.
+    // Any static mock response causes NaN because the app expects prices for
+    // dynamically requested asset IDs. When assets aren't in the response,
+    // calculations result in NaN. Letting this endpoint use live API works correctly.
     {
-      urlEndpoint:
-        /^https:\/\/price\.api\.cx\.metamask\.io\/v3\/spot-prices(\?.*)?$/,
-      responseCode: 200,
-      response: {
-        'eip155:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f': {
-          usd: 0.999588,
-          eth: 0.000233,
-        },
-        'eip155:1/slip44:60': {
-          usd: 4280.15,
-          eth: 1.0,
-        },
-        'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': {
-          usd: 1.0,
-          eth: 0.000233,
-        },
-        'eip155:137/erc20:0x2791bca1f2de4661ed88a30c99a7a9449aa84174': {
-          usd: 1.0,
-          eth: 0.000344,
-          price: 1.0,
-        },
-        'eip155:137/slip44:966': {
-          usd: 1.0,
-          price: 1.0,
-          eth: 0.000344,
-        },
-      },
-    },
-    {
-      urlEndpoint:
-        /^https:\/\/min-api\.cryptocompare\.com\/data\/pricemulti\?.*$/,
+      urlEndpoint: /https:\/\/min-api\.cryptocompare\.com\/data\/pricemulti/,
       responseCode: 200,
       response: {
         BTC: { USD: 120000 },
@@ -183,13 +156,13 @@ export const PRICE_API_MOCKS: MockEventsObject = {
       },
     },
     {
-      urlEndpoint: /^https:\/\/min-api\.cryptocompare\.com\/data\/price\?.*$/,
+      urlEndpoint: /https:\/\/min-api\.cryptocompare\.com\/data\/price/,
       responseCode: 200,
       response: {},
     },
     {
       urlEndpoint:
-        /^https:\/\/price\.api\.cx\.metamask\.io\/v2\/chains\/\d+\/spot-prices\?.*$/,
+        /https:\/\/price\.api\.cx\.metamask\.io\/v2\/chains\/\d+\/spot-prices/,
       responseCode: 200,
       response: {
         '0x0000000000000000000000000000000000000000': {
@@ -238,7 +211,7 @@ export const PRICE_API_MOCKS: MockEventsObject = {
     },
     {
       urlEndpoint:
-        /^https:\/\/price\.api\.cx\.metamask\.io\/v1\/chains\/\d+\/historical-prices\/0x[a-fA-F0-9]{40}\?.*$/,
+        /https:\/\/price\.api\.cx\.metamask\.io\/v1\/chains\/\d+\/historical-prices/,
       responseCode: 200,
       response: {
         prices: [

--- a/tests/api-mocking/mock-responses/defaults/price-apis.ts
+++ b/tests/api-mocking/mock-responses/defaults/price-apis.ts
@@ -1,4 +1,5 @@
 import { MockEventsObject } from '../../../framework';
+import { MUSD_MAINNET } from '../../../constants/musd-mainnet.ts';
 
 /**
  * Mock data for cryptocurrency price API endpoints used in E2E testing.
@@ -228,6 +229,13 @@ export const PRICE_API_MOCKS: MockEventsObject = {
           eth: 0.000233,
           pricePercentChange1d: -0.01,
         },
+        // mUSD (MetaMask USD) - used by mUSD conversion E2E
+        [`eip155:1/erc20:${MUSD_MAINNET}`]: {
+          price: 1.0,
+          usd: 1.0,
+          eth: 0.000233,
+          pricePercentChange1d: 0.0,
+        },
       },
     },
     {
@@ -295,6 +303,41 @@ export const PRICE_API_MOCKS: MockEventsObject = {
           pricePercentChange200d: 0,
           pricePercentChange1y: 0,
         },
+        [MUSD_MAINNET]: {
+          id: 'metamask-usd',
+          price: 1.0,
+          marketCap: 120000000,
+          allTimeHigh: 1.1,
+          allTimeLow: 0.1,
+          totalVolume: 9000000,
+          high1d: 1.05,
+          low1d: 0.95,
+          circulatingSupply: 120000000,
+          dilutedMarketCap: 120000000,
+          marketCapPercentChange1d: 0,
+          priceChange1d: 0,
+          pricePercentChange1h: 0,
+          pricePercentChange1d: 0,
+          pricePercentChange7d: 0,
+          pricePercentChange14d: 0,
+          pricePercentChange30d: 0,
+          pricePercentChange200d: 0,
+          pricePercentChange1y: 0,
+        },
+      },
+    },
+    {
+      urlEndpoint:
+        /https:\/\/price\.api\.cx\.metamask\.io\/v3\/historical-prices/,
+      responseCode: 200,
+      response: {
+        prices: [
+          [1756219032177, 1.0],
+          [1756219379449, 1.0],
+          [1756219657580, 1.0],
+          [1756219967818, 1.0],
+          [1756220274872, 1.0],
+        ],
       },
     },
     {

--- a/tests/api-mocking/mock-responses/musd/musd-mocks.ts
+++ b/tests/api-mocking/mock-responses/musd/musd-mocks.ts
@@ -14,12 +14,6 @@ import {
 } from '../transaction-pay.ts';
 import { MUSD_MAINNET } from '../../../constants/musd-mainnet.ts';
 import { MUSD_RAMP_TOKENS_RESPONSE } from './musd-ramp-tokens-response.ts';
-import {
-  MUSD_SPOT_PRICES_V3_RESPONSE,
-  MUSD_CHAINS_SPOT_PRICES_V2_RESPONSE,
-  MUSD_EXCHANGE_RATES_V1_RESPONSE,
-  MUSD_HISTORICAL_PRICES_RESPONSE,
-} from './musd-price-responses.ts';
 import { MUSD_TOKEN_API_RESPONSE } from './musd-token-response.ts';
 
 export async function setupMusdMocks(mockServer: Mockttp): Promise<void> {
@@ -62,33 +56,8 @@ export async function setupMusdMocks(mockServer: Mockttp): Promise<void> {
     responseCode: 200,
   });
 
-  await setupMockRequest(mockServer, {
-    url: /price\.api\.cx\.metamask\.io\/v3\/spot-prices/,
-    response: MUSD_SPOT_PRICES_V3_RESPONSE,
-    requestMethod: 'GET',
-    responseCode: 200,
-  });
-
-  await setupMockRequest(mockServer, {
-    url: /price\.api\.cx\.metamask\.io\/v2\/chains\/\d+\/spot-prices/,
-    response: MUSD_CHAINS_SPOT_PRICES_V2_RESPONSE,
-    requestMethod: 'GET',
-    responseCode: 200,
-  });
-
-  await setupMockRequest(mockServer, {
-    url: /price\.api\.cx\.metamask\.io\/v1\/exchange-rates/,
-    response: MUSD_EXCHANGE_RATES_V1_RESPONSE,
-    requestMethod: 'GET',
-    responseCode: 200,
-  });
-
-  await setupMockRequest(mockServer, {
-    url: /price\.api\.cx\.metamask\.io\/v3\/historical-prices/,
-    response: MUSD_HISTORICAL_PRICES_RESPONSE,
-    requestMethod: 'GET',
-    responseCode: 200,
-  });
+  // Price API (v3/spot-prices, v2/chains/spot-prices, v1/exchange-rates, v3/historical-prices)
+  // is provided by the global default mocks (PRICE_API_MOCKS) which include mUSD.
 
   await setupMockRequest(mockServer, {
     url: new RegExp(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The PR fixes the problem that when the mobile app start is shows NaN in the wallet. The v3/spot-prices mock is the culprit because it returns a static set of asset IDs, but the app requests different assets (like the native ETH on localhost/ganache network). When the requested asset isn't in the response, the calculation results in NaN.

BEFORE
<img width="344" height="729" alt="Screenshot 2026-02-05 at 2 45 34 PM" src="https://github.com/user-attachments/assets/36c20c7d-561a-4a9e-b591-90663077ec30" />

AFTER:
<img width="351" height="770" alt="Screenshot 2026-02-05 at 5 45 47 PM" src="https://github.com/user-attachments/assets/adde04e0-cc0f-43d8-ba2e-4f5d746ce485" />

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mocking changes with no production runtime impact; main risk is E2E flakiness if the relaxed URL regexes over-match unintended requests.
> 
> **Overview**
> Fixes E2E price API mocking so wallet/token balances don’t compute to `NaN` when the app requests assets not present in the mock response.
> 
> The default `PRICE_API_MOCKS` now returns a richer `v3/spot-prices` payload (including market-data fields), expands coverage to additional networks/assets (including mUSD via `MUSD_MAINNET`), adds a `v3/historical-prices` mock, and loosens several URL matchers to be less query-string sensitive.
> 
> The mUSD E2E mock setup removes its dedicated price API stubs and relies on the shared default price mocks instead, reducing duplication and ensuring consistent price responses across tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6245ff7ac2acf4b50c878248ed3623dd65bcfb95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->