### PR TITLE
fix(predict): remove Super Bowl LX temporary fix

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -659,8 +659,7 @@ export const parsePolymarketEvents = (
         id: event.id,
         slug: event.slug,
         providerId: 'polymarket',
-        // TODO: remove this temporary fix for Super Bowl LX
-        title: event.id === '188978' ? 'Super Bowl LX' : event.title,
+        title: event.title,
         description: event.description,
         image: event.icon,
         status: event.closed


### PR DESCRIPTION
## **Description**

This change removes an outdated hardcoded title override in `parsePolymarketEvents` for event id `188978`.

Reason for change:
1. The temporary Super Bowl-specific override is stale technical debt.
2. It can incorrectly rewrite provider data.

Improvement:
1. Event titles now consistently come from `event.title`.
2. The TODO for the temporary workaround is removed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Predict event parsing cleanup

  Scenario: parser preserves provider title for legacy event id
    Given a Polymarket event payload with id "188978" and a custom title
    When `parsePolymarketEvents` parses the payload
    Then the parsed market title matches the payload title
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to market title mapping; low complexity and no security, auth, or data persistence impact.
> 
> **Overview**
> Removes a one-off hardcoded title override in `parsePolymarketEvents` that rewrote event `188978` to "Super Bowl LX".
> 
> Polymarket market titles now always come directly from `event.title`, eliminating stale special-casing and preventing provider data from being incorrectly rewritten.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18cc72e85228c7aed93f8c38d5bb8ea93a29d978. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->