### PR TITLE
Perps: align Home and Markets header typography/spacing

### DIFF
--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.styles.ts
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.styles.ts
@@ -14,7 +14,7 @@ const styleSheet = (params: { theme: Theme }) => {
     header: {
       flexDirection: 'row',
       alignItems: 'center',
-      marginBottom: 8,
+      marginBottom: 12,
       paddingHorizontal: 16,
     },
     titleRow: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

  Perps: align Home and Markets header typography/spacing
  
  Uses `TextVariant.BodyLGMedium` intentionally for this header/list-item update.

  In our design tokens, BodyLGMedium and HeadingMD share the same size and line-height (fontSize5, lineHeight4), but differ in weight (medium vs bold). There is currently no medium-weight heading variant in TextVariant, so `BodyLGMedium` is the closest token match to the Figma spec while preserving the intended hierarchy styling.
  
  https://www.figma.com/design/Jp8owZibGXg26diIjDjVuq/Mobile-Perps?node-id=13924-14951&m=dev
  
  https://www.figma.com/design/Jp8owZibGXg26diIjDjVuq/Mobile-Perps?node-id=12331-5993&m=dev

  1. Home section header typography mismatch
  - Before: Home section titles (e.g., Positions/Orders) used HeadingMD in places.
  - After: Home section titles use BodyLGMedium for consistent section heading style.
  - Code: PerpsHomeSection.tsx
  2. Activity header typography mismatch
  - Before: Activity title used HeadingMD.
  - After: Activity title uses BodyLGMedium in loading/empty/populated states.
  - Code: PerpsRecentActivityList.tsx, PerpsRecentActivityList.test.tsx
  3. Activity header bottom spacing inconsistency
  - Before: Activity header marginBottom: 8.
  - After: Activity header marginBottom: 12.
  4. Perps Tab header spacing logic for Positions/Orders
  - After: Explicit top/below-section spacing variants applied based on layout state.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/a396b376-f7a5-4134-9f9c-64419eefc063

<img width="429" height="893" alt="Screenshot 2026-02-10 at 10 15 29 AM" src="https://github.com/user-attachments/assets/0df87ee1-01be-4514-a65a-1fd3d95d6c14" />
<img width="437" height="919" alt="Screenshot 2026-02-10 at 10 15 49 AM" src="https://github.com/user-attachments/assets/05f28cbd-2af6-4236-9676-61e00a9519c6" />
<img width="428" height="897" alt="Screenshot 2026-02-10 at 10 19 08 AM" src="https://github.com/user-attachments/assets/a3d842c1-f78d-4793-a163-2d0c327b7fc6" />
<img width="429" height="888" alt="Screenshot 2026-02-10 at 10 29 54 AM" src="https://github.com/user-attachments/assets/25a11d73-df79-4059-97c9-9914ab3aeb68" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
