### PR TITLE
fix: 25693 fix the align issue f ledger screen.

### DIFF
--- a/app/components/Views/LedgerConnect/Scan.tsx
+++ b/app/components/Views/LedgerConnect/Scan.tsx
@@ -34,6 +34,7 @@ const createStyles = (colors: Colors) =>
       borderRadius: 5,
       borderWidth: 2,
       height: 45,
+      justifyContent: 'center',
       width: Device.getDeviceWidth() * 0.85,
     },
   });

--- a/app/components/Views/LedgerConnect/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/LedgerConnect/__snapshots__/index.test.tsx.snap
@@ -507,6 +507,7 @@ exports[`LedgerConnect render matches latest snapshot 1`] = `
               "borderRadius": 5,
               "borderWidth": 2,
               "height": 45,
+              "justifyContent": "center",
               "width": 42.5,
             }
           }

--- a/app/components/Views/LedgerSelectAccount/index.styles.ts
+++ b/app/components/Views/LedgerSelectAccount/index.styles.ts
@@ -49,6 +49,7 @@ const createStyles = (colors: Colors) =>
       borderRadius: 5,
       borderWidth: 2,
       height: 45,
+      justifyContent: 'center',
       width: Device.getDeviceWidth() * 0.85,
     },
     navbarRightButton: {


### PR DESCRIPTION
style: center button content in LedgerConnect and LedgerSelectAccount… components

Updated styles in `Scan.tsx` and `index.styles.ts` to center the button content by adding `justifyContent: 'center'` to the button styles, enhancing the UI consistency across the Ledger components.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix #25693 styling issue in for ledger devices

## **Related issues**

Fixes: #25693


## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Style-only changes limited to Ledger selector layout plus a snapshot update; no functional, security, or data-flow impact.
> 
> **Overview**
> Fixes a Ledger UI alignment issue by centering the contents of the device/path selector containers.
> 
> Adds `justifyContent: 'center'` to the dropdown wrapper styles in `LedgerConnect/Scan.tsx` and `LedgerSelectAccount/index.styles.ts`, and updates the LedgerConnect Jest snapshot accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70e5b969c6e0a53b8984e90c15332dd692f8ee3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->