### PR TITLE
feat(merklRewards): enhance analytics tracking for claim and tooltip interactions

### DIFF
--- a/app/components/UI/Earn/components/MerklRewards/ClaimMerklRewards.tsx
+++ b/app/components/UI/Earn/components/MerklRewards/ClaimMerklRewards.tsx
@@ -101,13 +101,25 @@ const ClaimMerklRewards: React.FC<ClaimMerklRewardsProps> = ({ asset }) => {
 
     const params: ClaimOnLineaBottomSheetParams = {
       onContinue: handleContinueClaim,
+      analyticsContext: {
+        network_chain_id: asset.chainId,
+        network_name: network?.name,
+        asset_symbol: asset.symbol,
+      },
     };
 
     navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
       screen: Routes.MODAL.CLAIM_ON_LINEA,
       params,
     });
-  }, [trackClaimButtonClicked, handleContinueClaim, navigation]);
+  }, [
+    trackClaimButtonClicked,
+    handleContinueClaim,
+    navigation,
+    asset.chainId,
+    asset.symbol,
+    network?.name,
+  ]);
 
   return (
     <View style={styles.claimButtonContainer}>

--- a/app/components/UI/Earn/components/MerklRewards/PendingMerklRewards.tsx
+++ b/app/components/UI/Earn/components/MerklRewards/PendingMerklRewards.tsx
@@ -18,6 +18,9 @@ import {
 import { strings } from '../../../../../../locales/i18n';
 import useTooltipModal from '../../../../hooks/useTooltipModal';
 import AppConstants from '../../../../../core/AppConstants';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { EVENT_NAME } from '../../../../../core/Analytics/MetaMetrics.events';
+import { MUSD_EVENTS_CONSTANTS } from '../../constants/events/musdEvents';
 
 interface PendingMerklRewardsProps {
   claimableReward: string | null;
@@ -26,16 +29,30 @@ interface PendingMerklRewardsProps {
 /**
  * Component to display pending Merkl rewards information (annual bonus and claimable bonus)
  */
+const TOOLTIP_NAME_CLAIM_BONUS_INFO = 'Claim Bonus Info';
+const EXPERIENCE_MUSD_BONUS = 'MUSD_BONUS';
+
 const PendingMerklRewards: React.FC<PendingMerklRewardsProps> = ({
   claimableReward,
 }) => {
   const { openTooltipModal } = useTooltipModal();
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const handleTermsPress = useCallback(() => {
     Linking.openURL(AppConstants.URLS.MUSD_CONVERSION_BONUS_TERMS_OF_USE);
   }, []);
 
   const handleInfoPress = useCallback(() => {
+    trackEvent(
+      createEventBuilder(EVENT_NAME.TOOLTIP_OPENED)
+        .addProperties({
+          text: strings('asset_overview.merkl_rewards.claimable_bonus'),
+          location: MUSD_EVENTS_CONSTANTS.EVENT_LOCATIONS.ASSET_OVERVIEW,
+          tooltip_name: TOOLTIP_NAME_CLAIM_BONUS_INFO,
+          experience: EXPERIENCE_MUSD_BONUS,
+        })
+        .build(),
+    );
     openTooltipModal(
       strings('asset_overview.merkl_rewards.claimable_bonus'),
       <Text variant={TextVariant.BodyMd}>
@@ -53,7 +70,7 @@ const PendingMerklRewards: React.FC<PendingMerklRewardsProps> = ({
       undefined,
       strings('asset_overview.merkl_rewards.ok'),
     );
-  }, [openTooltipModal, handleTermsPress]);
+  }, [openTooltipModal, handleTermsPress, trackEvent, createEventBuilder]);
 
   // Don't render anything if there's no claimable reward
   if (!claimableReward) {

--- a/app/components/UI/Earn/constants/events/musdEvents.ts
+++ b/app/components/UI/Earn/constants/events/musdEvents.ts
@@ -6,6 +6,7 @@ const EVENT_LOCATIONS = {
   HOME_SCREEN: 'home',
   TOKEN_LIST_ITEM: 'token_list_item',
   ASSET_OVERVIEW: 'asset_overview',
+  CLAIM_BONUS_BOTTOM_SHEET: 'claim_bonus_bottom_sheet',
   CONVERSION_EDUCATION_SCREEN: 'conversion_education_screen',
   CUSTOM_AMOUNT_SCREEN: 'custom_amount_screen', // Single convert screen.
   BUY_SCREEN: 'buy_screen', // Buy mUSD screen.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Add analytics tracking for two Segment events in the mUSD claim bonus flow:

1. **mUSD Claim Bonus Button Clicked** (updated) — now also fires from the `ClaimOnLineaBottomSheet` when the user taps "Continue" (`action_type: claim_bonus`) or dismisses via the close button (`action_type: dismiss`). The existing event from the asset overview "Claim" CTA is unchanged. Network/asset context is forwarded from the parent component via route params.

2. **Tooltip Opened** (new trigger) — fires when the user taps the info (i) icon next to "Claimable bonus" in `PendingMerklRewards`, with `tooltip_name: "Claim Bonus Info"`, `location: "asset_overview"`, and `experience: "MUSD_BONUS"`.

Both events use the non-deprecated `useAnalytics` hook and `EVENT_NAME` constants.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: mUSD Claim Bonus Button Clicked from bottom sheet

  Scenario: User taps Continue in claim bottom sheet
    Given the user is on the mUSD asset overview with a claimable bonus displayed
    When the user taps the "Claim" button
    Then "mUSD Claim Bonus Button Clicked" fires with location "asset_overview" and action_type "claim_bonus"
    And the ClaimOnLinea bottom sheet opens
    When the user taps "Continue" in the bottom sheet
    Then "mUSD Claim Bonus Button Clicked" fires with location "claim_bonus_bottom_sheet" and action_type "claim_bonus"

  Scenario: User dismisses the claim bottom sheet
    Given the ClaimOnLinea bottom sheet is open
    When the user taps the close (X) button
    Then "mUSD Claim Bonus Button Clicked" fires with location "claim_bonus_bottom_sheet" and action_type "dismiss"
    And the bottom sheet closes
    
Feature: Tooltip Opened for claimable bonus info

  Scenario: User opens the claimable bonus tooltip
    Given the user is on the mUSD asset overview with a claimable bonus displayed
    When the user taps the info (i) icon next to "Claimable bonus"
    Then "Tooltip Opened" fires with tooltip_name "Claim Bonus Info", location "asset_overview", and experience "MUSD_BONUS"
    And the tooltip modal opens with bonus description text
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds analytics event tracking and constants, with minimal impact on user flow beyond extra side-effect calls; risk is limited to incorrect/missing analytics properties.
> 
> **Overview**
> Adds additional analytics instrumentation to the mUSD Merkl rewards flow.
> 
> The claim-on-Linea bottom sheet now fires `EVENT_NAME.MUSD_CLAIM_BONUS_BUTTON_CLICKED` for both **Continue** (`action_type: claim_bonus`) and **Close** (`action_type: dismiss`), and `ClaimMerklRewards` forwards optional network/asset context via new `analyticsContext` route params (with a new `CLAIM_BONUS_BOTTOM_SHEET` location constant). `PendingMerklRewards` now tracks `EVENT_NAME.TOOLTIP_OPENED` when the “Claimable bonus” info icon is tapped, including tooltip metadata and experience, with tests updated to assert these events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbce1439e73fe403e814772d5c41f7dcc9d8dc5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->