### PR TITLE
fix: check chainRanking for enabled swaps networks

### DIFF
--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -14,8 +14,6 @@ import reducer, {
   selectBip44DefaultPair,
   selectGasIncludedQuoteParams,
   selectIsBridgeEnabledSource,
-  selectIsBridgeEnabledDest,
-  selectIsSwapsLive,
   selectDestChainRanking,
 } from '.';
 import {
@@ -531,69 +529,28 @@ describe('bridge slice', () => {
     });
 
     it('returns false when bridge is not enabled as source for the chain', () => {
-      const mockState = cloneDeep(mockRootState) as unknown as RootState;
-      // @ts-expect-error - Mock state has correct structure at runtime
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2!.chains[
-        'eip155:1'
-      ].isActiveSrc = false;
+      const mockState = cloneDeep(mockRootState);
+      // Remove chain from chainRanking to disable it (chainRanking presence = enabled)
+      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2.chainRanking =
+        mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2.chainRanking.filter(
+          (chain) => chain.chainId !== 'eip155:1',
+        );
 
-      const result = selectIsBridgeEnabledSource(mockState, '0x1');
+      const result = selectIsBridgeEnabledSource(
+        mockState as unknown as RootState,
+        '0x1',
+      );
 
       expect(result).toBe(false);
     });
 
-    it('returns undefined when chain is not in bridge config', () => {
+    it('returns false when chain is not in bridge config', () => {
       const result = selectIsBridgeEnabledSource(
         mockRootState as unknown as RootState,
         '0x999' as Hex,
       );
 
-      expect(result).toBeUndefined();
-    });
-  });
-
-  describe('selectIsBridgeEnabledDest', () => {
-    it('returns true when bridge is enabled as destination for the chain', () => {
-      const result = selectIsBridgeEnabledDest(
-        mockRootState as unknown as RootState,
-        '0x1',
-      );
-
-      expect(result).toBe(true);
-    });
-
-    it('returns false when bridge is not enabled as destination for the chain', () => {
-      const mockState = cloneDeep(mockRootState) as unknown as RootState;
-      // @ts-expect-error - Mock state has correct structure at runtime
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2!.chains[
-        'eip155:1'
-      ].isActiveDest = false;
-
-      const result = selectIsBridgeEnabledDest(mockState, '0x1');
-
       expect(result).toBe(false);
-    });
-
-    it('returns false when support flag is false', () => {
-      const mockState = cloneDeep(mockRootState) as unknown as RootState;
-      // @ts-expect-error - Mock state has correct structure at runtime
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2!.support = false;
-
-      const result = selectIsBridgeEnabledDest(mockState, '0x1');
-
-      expect(result).toBe(false);
-    });
-
-    it('returns undefined when chain is not in bridge config', () => {
-      const result = selectIsBridgeEnabledDest(
-        mockRootState as unknown as RootState,
-        '0x999' as Hex,
-      );
-
-      expect(result).toBeUndefined();
     });
   });
 
@@ -631,81 +588,6 @@ describe('bridge slice', () => {
       // This is the key difference from selectSourceChainRanking which filters
       // by user-configured networks
       expect(result.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('selectIsSwapsLive', () => {
-    it('returns true when bridge is enabled as both source and destination', () => {
-      const result = selectIsSwapsLive(
-        mockRootState as unknown as RootState,
-        '0x1',
-      );
-
-      expect(result).toBe(true);
-    });
-
-    it('returns true when bridge is enabled only as source', () => {
-      const mockState = cloneDeep(mockRootState) as unknown as RootState;
-      // @ts-expect-error - Mock state has correct structure at runtime
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2!.chains[
-        'eip155:1'
-      ].isActiveDest = false;
-
-      const result = selectIsSwapsLive(mockState, '0x1');
-
-      expect(result).toBe(true);
-    });
-
-    it('returns true when bridge is enabled only as destination', () => {
-      const mockState = cloneDeep(mockRootState) as unknown as RootState;
-      // @ts-expect-error - Mock state has correct structure at runtime
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2!.chains[
-        'eip155:1'
-      ].isActiveSrc = false;
-
-      const result = selectIsSwapsLive(mockState, '0x1');
-
-      expect(result).toBe(true);
-    });
-
-    it('returns false when bridge is disabled for both source and destination', () => {
-      const mockState = cloneDeep(mockRootState) as unknown as RootState;
-      // @ts-expect-error - Mock state has correct structure at runtime
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2!.chains[
-        'eip155:1'
-      ].isActiveSrc = false;
-      // @ts-expect-error - Mock state has correct structure at runtime
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2!.chains[
-        'eip155:1'
-      ].isActiveDest = false;
-
-      const result = selectIsSwapsLive(mockState, '0x1');
-
-      expect(result).toBe(false);
-    });
-
-    it('returns undefined when chain is not in bridge config', () => {
-      const result = selectIsSwapsLive(
-        mockRootState as unknown as RootState,
-        '0x999' as Hex,
-      );
-
-      expect(result).toBeUndefined();
-    });
-
-    it('returns false when support flag is disabled', () => {
-      const mockState = cloneDeep(mockRootState) as unknown as RootState;
-      // @ts-expect-error - Mock state has correct structure at runtime
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2!.support = false;
-
-      const result = selectIsSwapsLive(mockState, '0x1');
-
-      expect(result).toBe(false);
     });
   });
 });

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -329,11 +329,8 @@ export const selectIsBridgeEnabledSourceFactory = createSelector(
   (bridgeFeatureFlags) => (chainId: Hex | CaipChainId) => {
     const caipChainId = formatChainIdToCaip(chainId);
 
-    return (
-      bridgeFeatureFlags.support &&
-      bridgeFeatureFlags.chainRanking?.some(
-        (chain) => chain.chainId === caipChainId,
-      )
+    return bridgeFeatureFlags.chainRanking?.some(
+      (chain) => chain.chainId === caipChainId,
     );
   },
 );


### PR DESCRIPTION
## **Description**

The `isActiveSrc` and `isActiveDest` properties on the `chains` feature flag are being deprecated. If a chain exists in the `chainRanking` array, it is now assumed to be enabled as both source and destination. This PR migrates all selectors that previously checked `chains[chainId].isActiveSrc` / `chains[chainId].isActiveDest` to instead check for the chain's presence in `chainRanking`.

This eliminates a pain point where adding a new network required an entry in both `chainRanking` and `chains` — now `chainRanking` is the single source of truth for whether a network is enabled.

**Changes:**
- `selectIsBridgeEnabledSourceFactory` — checks `chainRanking` presence instead of `chains[chainId].isActiveSrc`
- `selectEnabledSourceChains` — same migration
- Removed `selectEnabledDestChains`, `selectIsBridgeEnabledDest`, and `selectIsSwapsLive` selectors (no longer needed with the new model)
- Removed unused imports (`PopularList`, `selectHasCreatedSolanaMainnetAccount`)
- Updated tests to match new behavior: disabling a chain means removing it from `chainRanking`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Bridge chain enablement via chainRanking

  Scenario: user opens swap/bridge for a supported network
    Given the user has a wallet with tokens on Ethereum Mainnet
    When user opens the swap or bridge view
    Then Ethereum Mainnet is available as a source network

  Scenario: user opens swap/bridge for a network not in chainRanking
    Given the user has a wallet on a network not listed in chainRanking
    When user opens the swap or bridge view
    Then that network is not available as a source network

  Scenario: user selects destination token on a newly added network
    Given a new network has been added to chainRanking
    When user opens the bridge token selector for destination
    Then the new network appears and its default destination token loads correctly
```

## **Screenshots/Recordings**

Not applicable — no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core selector logic that gates which networks appear/enabled for bridge/swap, and removes selectors that may have downstream callers if not fully migrated.
> 
> **Overview**
> Switches bridge/swap network enablement checks to rely solely on feature-flag `chainRanking` membership, replacing deprecated `chains[caipId].isActiveSrc/isActiveDest` lookups.
> 
> Removes destination/live enablement selectors (`selectEnabledDestChains`, `selectIsBridgeEnabledDest`, `selectIsSwapsLive`) and related imports, and updates unit tests to reflect the new behavior (a chain is disabled by removing it from `chainRanking`, and unknown chains now return `false` rather than `undefined`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9591fd74d65eb02336c8b3a76bb973560200d43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->