### PR TITLE
fix: initial predict deposit using polygon usdce

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -3346,7 +3346,6 @@ describe('PredictController', () => {
           networkClientId: 'polygon-mainnet',
           disableHook: true,
           disableSequential: true,
-          disableUpgrade: true,
           skipInitialGasEstimate: true,
           transactions: mockTransactions,
         });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -2050,7 +2050,6 @@ export class PredictController extends BaseController<
         networkClientId,
         disableHook: true,
         disableSequential: true,
-        disableUpgrade: true,
         skipInitialGasEstimate: true,
         transactions,
       });


### PR DESCRIPTION
## **Description**

Remove `disableUpgrade` optimisation for Predict deposits to ensure non-Relay transactions using Polygon USDCe can still upgrade the EOA.

Intentionally not applied per transaction data to reduce complexity and improve stability.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6820](https://github.com/MetaMask/MetaMask-planning/issues/6820)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction submission options for deposits; behavior changes could affect batching/upgrade flow on Polygon and should be validated against real deposit scenarios.
> 
> **Overview**
> Predict deposits no longer pass `disableUpgrade: true` to `addTransactionBatch` in `PredictController.depositWithConfirmation`, allowing the underlying transaction flow to perform an account upgrade when required (e.g., non-relay Polygon USDCe deposits).
> 
> Updates the deposit unit test to match the new `addTransactionBatch` call signature (removing the `disableUpgrade` expectation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19019f24c08f4a5fe924afff064e85142a9c7016. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->