### PR TITLE
fix(typed-sign): align DAI permit UI with signer coercion and correct hex expiry display

### DIFF
--- a/app/components/Views/confirmations/components/data-tree/data-field.tsx
+++ b/app/components/Views/confirmations/components/data-tree/data-field.tsx
@@ -62,6 +62,22 @@ function isTokenValueField(label: string, primaryType?: PrimaryType) {
   );
 }
 
+function parseTypedSignDateValue(value: string) {
+  try {
+    const parsedValue = BigInt(value);
+    if (
+      parsedValue > BigInt(Number.MAX_SAFE_INTEGER) ||
+      parsedValue < BigInt(Number.MIN_SAFE_INTEGER)
+    ) {
+      return undefined;
+    }
+
+    return Number(parsedValue);
+  } catch {
+    return undefined;
+  }
+}
+
 const createStyles = (depth: number) =>
   StyleSheet.create({
     container: {
@@ -99,13 +115,15 @@ const DataField = memo(
     if (type === 'address' && isValidHexAddress(value as Hex)) {
       fieldDisplay = <Address address={value} chainId={chainId} />;
     } else if (isDateField(label, primaryType) && Boolean(value)) {
-      const intValue = parseInt(value, 10);
+      const intValue = parseTypedSignDateValue(value);
 
       fieldDisplay =
         intValue === NONE_DATE_VALUE ? (
           <Text>{strings('confirm.none')}</Text>
+        ) : intValue === undefined ? (
+          <Text>{value}</Text>
         ) : (
-          <InfoDate unixTimestamp={parseInt(value, 10)} />
+          <InfoDate unixTimestamp={intValue} />
         );
     } else if (isTokenValueField(label, primaryType)) {
       fieldDisplay = (

--- a/app/components/Views/confirmations/components/data-tree/data-tree.test.tsx
+++ b/app/components/Views/confirmations/components/data-tree/data-tree.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import DataTree, { DataTreeInput } from './data-tree';
-import { PrimaryTypeOrder } from '../../constants/signatures';
+import { PrimaryType, PrimaryTypeOrder } from '../../constants/signatures';
 import { NONE_DATE_VALUE } from '../../utils/date';
 
 const timestamp = 1647359825; // March 15, 2022  15:57:05 UTC
@@ -98,5 +98,62 @@ describe('NoChangeSimulation', () => {
     // token value field
     expect(getByText('Buy Amount')).toBeDefined();
     expect(getByText('100')).toBeDefined();
+  });
+
+  it('parses hex date fields using bigint coercion', async () => {
+    const { getByText } = renderWithProvider(
+      <DataTree
+        data={
+          {
+            expiry: {
+              type: 'uint256',
+              value: '0x62f5f80d',
+            },
+          } as DataTreeInput
+        }
+        chainId="0x1"
+        primaryType={PrimaryType.Permit}
+      />,
+      {
+        state: {
+          engine: {
+            backgroundState,
+          },
+        },
+      },
+    );
+
+    expect(getByText('Expiry')).toBeDefined();
+    expect(getByText('12 August 2022, 06:49')).toBeDefined();
+  });
+
+  it('falls back to the original string for large hex date values', async () => {
+    const largeHexDate =
+      '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+    const { getByText } = renderWithProvider(
+      <DataTree
+        data={
+          {
+            expiry: {
+              type: 'uint256',
+              value: largeHexDate,
+            },
+          } as DataTreeInput
+        }
+        chainId="0x1"
+        primaryType={PrimaryType.Permit}
+      />,
+      {
+        state: {
+          engine: {
+            backgroundState,
+          },
+        },
+      },
+    );
+
+    expect(getByText('Expiry')).toBeDefined();
+    expect(getByText(largeHexDate)).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.test.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.test.tsx
@@ -238,6 +238,29 @@ describe('SimulationValueDisplay', () => {
     expect(await findByText('Unlimited')).toBeDefined();
   });
 
+  it('renders Dai Approve for allowed string "false" to match signing coercion', async () => {
+    (
+      useGetTokenStandardAndDetails as jest.MockedFn<
+        typeof useGetTokenStandardAndDetails
+      >
+    ).mockReturnValue(mockErc20TokenDetails);
+
+    const { findByText } = renderWithProvider(
+      <SimulationValueDisplay
+        canDisplayValueAsUnlimited
+        modalHeaderText={'Spending cap'}
+        tokenContract={'0x6b175474e89094c44da98b954eedeac495271d0f'}
+        value={undefined}
+        chainId={'0x1'}
+        allowed={'false'}
+      />,
+      { state: mockInitialState },
+    );
+
+    expect(await findByText('0x6B175...71d0F')).toBeDefined();
+    expect(await findByText('Unlimited')).toBeDefined();
+  });
+
   it('invokes method to track missing decimal information for ERC20 tokens only once', async () => {
     (
       useGetTokenStandardAndDetails as jest.MockedFn<

--- a/app/components/Views/confirmations/components/title/title.test.tsx
+++ b/app/components/Views/confirmations/components/title/title.test.tsx
@@ -29,6 +29,40 @@ import Title from './title';
 jest.mock('../../hooks/useGetTokenStandardAndDetails');
 
 describe('Confirm Title', () => {
+  const typedSignRequestId = 'fb2029e1-b0ab-11ef-9227-05a11087c334';
+  const daiPermitAllowedStringFalseData = JSON.stringify({
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+        { name: 'verifyingContract', type: 'address' },
+      ],
+      Permit: [
+        { name: 'holder', type: 'address' },
+        { name: 'spender', type: 'address' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'expiry', type: 'uint256' },
+        { name: 'allowed', type: 'bool' },
+      ],
+    },
+    primaryType: 'Permit',
+    domain: {
+      name: 'Dai Stablecoin',
+      version: '1',
+      chainId: 1,
+      verifyingContract: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    },
+    message: {
+      holder: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
+      spender: '0x5B38Da6a701c568545dCfcB03FcB875f56beddC4',
+      nonce: '0',
+      expiry:
+        '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+      allowed: 'false',
+    },
+  });
+
   const mockUseGetTokenStandardAndDetails = jest.mocked(
     useGetTokenStandardAndDetails,
   );
@@ -52,6 +86,43 @@ describe('Confirm Title', () => {
     expect(
       getByText('This site wants permission to spend your tokens.'),
     ).toBeTruthy();
+  });
+
+  it('renders permit title for DAI permit when allowed is string "false"', () => {
+    const state = merge({}, typedSignV4ConfirmationState, {
+      engine: {
+        backgroundState: {
+          ApprovalController: {
+            pendingApprovals: {
+              [typedSignRequestId]: {
+                requestData: {
+                  data: daiPermitAllowedStringFalseData,
+                },
+              },
+            },
+          },
+          SignatureController: {
+            signatureRequests: {
+              [typedSignRequestId]: {
+                messageParams: {
+                  data: daiPermitAllowedStringFalseData,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const { getByText, queryByText } = renderWithProvider(<Title />, {
+      state,
+    });
+
+    expect(getByText('Spending cap request')).toBeTruthy();
+    expect(
+      getByText('This site wants permission to spend your tokens.'),
+    ).toBeTruthy();
+    expect(queryByText('Remove permission')).toBeNull();
   });
 
   it('renders the title and subtitle for a permit NFT signature', () => {

--- a/app/components/Views/confirmations/utils/signature.test.ts
+++ b/app/components/Views/confirmations/utils/signature.test.ts
@@ -1,4 +1,6 @@
 import {
+  isPermitDaiRevoke,
+  isPermitDaiUnlimited,
   parseAndNormalizeSignTypedData,
   isRecognizedPermit,
   isTypedSignV3V4Request,
@@ -15,6 +17,7 @@ import {
   SignatureRequest,
   SignatureRequestType,
 } from '@metamask/signature-controller';
+import { TOKEN_ADDRESS } from '../constants/tokens';
 import {
   mockTypedSignV3Message,
   personalSignSignatureRequest,
@@ -173,6 +176,27 @@ describe('Signature Utils', () => {
         // String values are not matched by the large value regex, so JSON.parse result is used
         expect(result.message.value).toBe('123');
       });
+    });
+  });
+
+  describe('DAI permit coercion helpers', () => {
+    it('mirrors bool truthiness coercion for DAI permit unlimited checks', () => {
+      expect(isPermitDaiUnlimited(TOKEN_ADDRESS.DAI, true)).toBe(true);
+      expect(isPermitDaiUnlimited(TOKEN_ADDRESS.DAI, 'false')).toBe(true);
+      expect(isPermitDaiUnlimited(TOKEN_ADDRESS.DAI, 0)).toBe(false);
+    });
+
+    it('does not classify DAI permit as revoke when allowed is the string "false"', () => {
+      expect(isPermitDaiRevoke(TOKEN_ADDRESS.DAI, 'false')).toBe(false);
+    });
+
+    it('classifies DAI permit as revoke for zero-like numeric values', () => {
+      expect(isPermitDaiRevoke(TOKEN_ADDRESS.DAI, undefined, '0x0')).toBe(true);
+      expect(isPermitDaiRevoke(TOKEN_ADDRESS.DAI, undefined, '0')).toBe(true);
+    });
+
+    it('classifies DAI permit as revoke when allowed is an empty string', () => {
+      expect(isPermitDaiRevoke(TOKEN_ADDRESS.DAI, '')).toBe(true);
     });
   });
 

--- a/app/components/Views/confirmations/utils/signature.ts
+++ b/app/components/Views/confirmations/utils/signature.ts
@@ -40,32 +40,60 @@ interface ValueType {
 /**
  * Support backwards compatibility DAI while it's still being deprecated. See EIP-2612 for more info.
  */
+const coerceAllowedToBoolean = (
+  allowed?: number | string | boolean | null,
+): boolean | undefined => {
+  if (allowed === undefined) {
+    return undefined;
+  }
+
+  return Boolean(allowed);
+};
+
+const coerceNumberishToBigInt = (
+  value?: number | string | BigNumber | null,
+): bigint | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  try {
+    if (value instanceof BigNumber) {
+      return BigInt(value.toFixed());
+    }
+    return BigInt(value);
+  } catch {
+    return undefined;
+  }
+};
+
 export const isPermitDaiUnlimited = (
   tokenAddress: string,
-  allowed?: number | string | boolean,
+  allowed?: number | string | boolean | null,
 ) => {
   if (!tokenAddress) return false;
 
+  const parsedAllowed = coerceAllowedToBoolean(allowed);
+
   return (
     tokenAddress.toLowerCase() === TOKEN_ADDRESS.DAI.toLowerCase() &&
-    Number(allowed) > 0
+    parsedAllowed === true
   );
 };
 
 export const isPermitDaiRevoke = (
   tokenAddress: string,
-  allowed?: number | string | boolean,
-  value?: number | string | BigNumber,
+  allowed?: number | string | boolean | null,
+  value?: number | string | BigNumber | null,
 ) => {
   if (!tokenAddress) return false;
 
+  const parsedAllowed = coerceAllowedToBoolean(allowed);
+  const parsedValue = coerceNumberishToBigInt(value);
+
   return (
     tokenAddress.toLowerCase() === TOKEN_ADDRESS.DAI.toLowerCase() &&
-    (allowed === 0 ||
-      allowed === false ||
-      allowed === 'false' ||
-      value === '0' ||
-      (value instanceof BigNumber && value.eq(0)))
+    (parsedAllowed === false || parsedValue === BigInt(0))
   );
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->


  ## Summary

  This PR fixes a typed-sign confirmation mismatch for legacy DAI Permit by aligning UI interpretation with `@metamask/eth-sig-
  util` coercion behavior.

  ## Problem

  - The UI previously treated `allowed: 'false'` (string) as a revoke.
  - The signer encodes `bool` using JavaScript coercion (`Boolean(value)`), so `'false'` is truthy and signs as `true`.
  - Date-like permit fields (such as `expiry`) were parsed with `parseInt(value, 10)`, which can misrender hex values.

  ## What changed

  - Updated DAI permit helper logic to mirror signer semantics:
    - Unlimited if `Boolean(allowed) === true`
    - Revoke if `Boolean(allowed) === false` or permit `value` coerces to `0`
  - Updated typed-sign date parsing to use `BigInt(value)` semantics for hex/decimal parity.
  - For out-of-range date values, UI now renders the raw value instead of showing a misleading timestamp.
  - Added regression tests for DAI permit coercion and typed-sign date parsing/rendering.

  ## Specific coercion case that triggers revoke

  A non-boolean `allowed` that coerces to `false` now correctly triggers revoke behavior in the UI, matching signing behavior.

  Example:
  - `allowed: ''` (empty string) -> `Boolean('') === false` -> revoke

  (Contrast:
  - `allowed: 'false'` -> `Boolean('false') === true`, so it is no longer shown as revoke.)

  ## Tests

  - `yarn jest --watchman=false app/components/Views/confirmations/utils/signature.test.ts`
  - `yarn jest --watchman=false app/components/Views/confirmations/components/data-tree/data-tree.test.tsx app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.test.tsx app/components/Views/confirmations/components/title/title.test.tsx`


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: 

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6980

## **Manual testing steps**

Use this test dApp: https://web3.internal-five.ai-preview.cantina.sh/

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches permit revoke/unlimited classification used across confirmation title and simulation displays; incorrect coercion could mislabel approvals vs revokes, but changes are narrowly scoped and covered by new tests.
> 
> **Overview**
> Typed-sign confirmation logic now mirrors signer coercion for legacy DAI Permit: `allowed` is interpreted via JS truthiness (so string `'false'` is treated as *approve/unlimited*, while revoke is driven by falsy `allowed` or a zero-ish `value`).
> 
> Date-like typed-sign fields (e.g., `expiry`) are now parsed via `BigInt` to correctly support hex inputs, and the UI falls back to displaying the raw string when values exceed JS safe integer range instead of showing an incorrect timestamp. Adds regression tests covering hex date parsing/out-of-range fallback and DAI permit/title/simulation behavior when `allowed` is `'false'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5480331d1c9ccd87c1f836eb2ccd336d98981aea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->