### PR TITLE
fix: usd_amount_source quotes requested always 0

### DIFF
--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
@@ -12,9 +12,8 @@ import { selectNetworkConfigurations } from '../../../../../selectors/networkCon
 import { selectMultichainAssetsRates } from '../../../../../selectors/multichain';
 import {
   calcTokenFiatValue,
-  convertFiatToUsd,
+  calcUsdAmountFromFiat,
 } from '../../utils/exchange-rates';
-import { Hex } from '@metamask/utils';
 
 export const useUnifiedSwapBridgeContext = () => {
   const smartTransactionsEnabled = useSelector(selectShouldUseSmartTransaction);
@@ -49,18 +48,13 @@ export const useUnifiedSwapBridgeContext = () => {
     ],
   );
 
-  const nativeCurrency = fromToken?.chainId
-    ? networkConfigurationsByChainId[fromToken.chainId as Hex]?.nativeCurrency
-    : undefined;
-  const currencyEntry = nativeCurrency
-    ? evmMultiChainCurrencyRates?.[nativeCurrency]
-    : undefined;
   const usdAmountSource =
-    convertFiatToUsd(
+    calcUsdAmountFromFiat({
       tokenFiatValue,
-      currencyEntry?.conversionRate,
-      currencyEntry?.usdConversionRate,
-    ) ?? 0;
+      chainId: fromToken?.chainId,
+      networkConfigurationsByChainId,
+      evmMultiChainCurrencyRates,
+    }) ?? 0;
 
   return useMemo(
     () => ({

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
@@ -10,7 +10,11 @@ import { selectCurrencyRates } from '../../../../../selectors/currencyRateContro
 import { selectTokenMarketData } from '../../../../../selectors/tokenRatesController';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
 import { selectMultichainAssetsRates } from '../../../../../selectors/multichain';
-import { calcTokenFiatValue } from '../../utils/exchange-rates';
+import {
+  calcTokenFiatValue,
+  convertFiatToUsd,
+} from '../../utils/exchange-rates';
+import { Hex } from '@metamask/utils';
 
 export const useUnifiedSwapBridgeContext = () => {
   const smartTransactionsEnabled = useSelector(selectShouldUseSmartTransaction);
@@ -25,7 +29,6 @@ export const useUnifiedSwapBridgeContext = () => {
   );
   const nonEvmMultichainAssetRates = useSelector(selectMultichainAssetsRates);
 
-  const usdConversionRate = evmMultiChainCurrencyRates?.usd?.conversionRate;
   const tokenFiatValue = useMemo(
     () =>
       calcTokenFiatValue({
@@ -46,9 +49,17 @@ export const useUnifiedSwapBridgeContext = () => {
     ],
   );
 
-  const usdAmountSource = usdConversionRate
-    ? tokenFiatValue / usdConversionRate
-    : 0;
+  const nativeCurrency = fromToken?.chainId
+    ? networkConfigurationsByChainId[fromToken.chainId as Hex]?.nativeCurrency
+    : undefined;
+  const currencyEntry = nativeCurrency
+    ? evmMultiChainCurrencyRates?.[nativeCurrency]
+    : undefined;
+  const usdAmountSource = convertFiatToUsd(
+    tokenFiatValue,
+    currencyEntry?.conversionRate,
+    currencyEntry?.usdConversionRate,
+  );
 
   return useMemo(
     () => ({

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
@@ -55,11 +55,12 @@ export const useUnifiedSwapBridgeContext = () => {
   const currencyEntry = nativeCurrency
     ? evmMultiChainCurrencyRates?.[nativeCurrency]
     : undefined;
-  const usdAmountSource = convertFiatToUsd(
-    tokenFiatValue,
-    currencyEntry?.conversionRate,
-    currencyEntry?.usdConversionRate,
-  );
+  const usdAmountSource =
+    convertFiatToUsd(
+      tokenFiatValue,
+      currencyEntry?.conversionRate,
+      currencyEntry?.usdConversionRate,
+    ) ?? 0;
 
   return useMemo(
     () => ({

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
@@ -157,12 +157,11 @@ describe('useUnifiedSwapBridgeContext', () => {
     mockSelectDestToken.mockReturnValue({ symbol: 'USDC' });
     mockSelectSourceAmount.mockReturnValue('1');
     mockSelectCurrencyRates.mockReturnValue({
-      usd: { conversionRate: 1 },
-      ETH: { conversionRate: 1 },
+      ETH: { conversionRate: 2000, usdConversionRate: 2000 },
     });
     mockSelectTokenMarketData.mockReturnValue({
       '0x1': {
-        '0x0000000000000000000000000000000000000000': { price: 2000 },
+        '0x0000000000000000000000000000000000000000': { price: 1 },
       },
     });
     mockSelectNetworkConfigurations.mockReturnValue({
@@ -177,6 +176,8 @@ describe('useUnifiedSwapBridgeContext', () => {
     );
 
     expect(result.current.usd_amount_source).toBeDefined();
+    // 1 ETH, price=1 (native), conversionRate=2000, usdConversionRate=2000
+    // tokenFiatValue = 1 * 2000 * 1 = 2000, usdAmount = 2000 * (2000/2000) = 2000
     expect(result.current.usd_amount_source).toBe(2000);
   });
 

--- a/app/components/UI/Bridge/utils/exchange-rates.test.tsx
+++ b/app/components/UI/Bridge/utils/exchange-rates.test.tsx
@@ -19,8 +19,8 @@ jest.mock('@metamask/assets-controllers');
 describe('exchange-rates', () => {
   describe('convertFiatToUsd', () => {
     it('converts fiat value to USD using the rate ratio', () => {
-      // 100 EUR * (2500 USD/ETH / 2300 EUR/ETH) ≈ 108.6957 USD
-      expect(convertFiatToUsd(100, 2300, 2500)).toBeCloseTo(108.6957, 4);
+      // 100 EUR * (2500 USD/ETH / 2000 EUR/ETH) = 125 USD
+      expect(convertFiatToUsd(100, 2000, 2500)).toBe(125);
     });
 
     it('returns undefined when conversionRate is null', () => {
@@ -28,7 +28,7 @@ describe('exchange-rates', () => {
     });
 
     it('returns undefined when usdConversionRate is null', () => {
-      expect(convertFiatToUsd(100, 2300, null)).toBeUndefined();
+      expect(convertFiatToUsd(100, 2000, null)).toBeUndefined();
     });
 
     it('returns undefined when conversionRate is undefined', () => {
@@ -36,7 +36,7 @@ describe('exchange-rates', () => {
     });
 
     it('returns undefined when usdConversionRate is undefined', () => {
-      expect(convertFiatToUsd(100, 2300, undefined)).toBeUndefined();
+      expect(convertFiatToUsd(100, 2000, undefined)).toBeUndefined();
     });
 
     it('returns undefined when both rates are zero', () => {
@@ -44,7 +44,7 @@ describe('exchange-rates', () => {
     });
 
     it('returns 0 when fiatValue is 0', () => {
-      expect(convertFiatToUsd(0, 2300, 2500)).toBe(0);
+      expect(convertFiatToUsd(0, 2000, 2500)).toBe(0);
     });
 
     it('returns the same value when rates are equal (1:1 ratio)', () => {
@@ -59,8 +59,8 @@ describe('exchange-rates', () => {
     };
 
     const mockEvmMultiChainCurrencyRates = {
-      ETH: { conversionRate: 2300, usdConversionRate: 2500 },
-      POL: { conversionRate: 0.9, usdConversionRate: 1.0 },
+      ETH: { conversionRate: 2000, usdConversionRate: 2500 },
+      POL: { conversionRate: 0.5, usdConversionRate: 1.0 },
     };
 
     it('converts fiat to USD using the correct chain native currency rates', () => {
@@ -71,8 +71,8 @@ describe('exchange-rates', () => {
         evmMultiChainCurrencyRates: mockEvmMultiChainCurrencyRates,
       });
 
-      // 100 * (2500 / 2300) ≈ 108.6957
-      expect(result).toBeCloseTo(108.6957, 4);
+      // 100 * (2500 / 2000) = 125
+      expect(result).toBe(125);
     });
 
     it('uses the correct rates for a different chain', () => {
@@ -83,8 +83,8 @@ describe('exchange-rates', () => {
         evmMultiChainCurrencyRates: mockEvmMultiChainCurrencyRates,
       });
 
-      // 50 * (1.0 / 0.9) ≈ 55.5556
-      expect(result).toBeCloseTo(55.5556, 4);
+      // 50 * (1.0 / 0.5) = 100
+      expect(result).toBe(100);
     });
 
     it('falls back to any available entry for non-EVM chains', () => {
@@ -103,11 +103,11 @@ describe('exchange-rates', () => {
         evmMultiChainCurrencyRates: mockEvmMultiChainCurrencyRates,
       });
 
-      // Falls back to ETH entry: 100 * (2500 / 2300) ≈ 108.6957
-      expect(result).toBeCloseTo(108.6957, 4);
+      // Falls back to ETH entry: 100 * (2500 / 2000) = 125
+      expect(result).toBe(125);
     });
 
-    it('returns undefined when chainId is undefined', () => {
+    it('falls back to any entry when chainId is undefined', () => {
       const result = calcUsdAmountFromFiat({
         tokenFiatValue: 100,
         chainId: undefined,
@@ -115,8 +115,8 @@ describe('exchange-rates', () => {
         evmMultiChainCurrencyRates: mockEvmMultiChainCurrencyRates,
       });
 
-      // Falls back to any entry with both rates: ETH
-      expect(result).toBeCloseTo(108.6957, 4);
+      // Falls back to any entry with both rates: ETH → 100 * (2500 / 2000) = 125
+      expect(result).toBe(125);
     });
 
     it('returns undefined when evmMultiChainCurrencyRates is undefined', () => {
@@ -163,7 +163,7 @@ describe('exchange-rates', () => {
       });
 
       // No native currency found, falls back to first entry with both rates
-      expect(result).toBeCloseTo(108.6957, 4);
+      expect(result).toBe(125);
     });
   });
 

--- a/app/components/UI/Bridge/utils/exchange-rates.test.tsx
+++ b/app/components/UI/Bridge/utils/exchange-rates.test.tsx
@@ -4,6 +4,8 @@ import { Hex } from '@metamask/utils';
 import { handleFetch } from '@metamask/controller-utils';
 import {
   calcTokenFiatValue,
+  calcUsdAmountFromFiat,
+  convertFiatToUsd,
   getDisplayCurrencyValue,
   fetchTokenExchangeRates,
 } from './exchange-rates';
@@ -15,6 +17,156 @@ jest.mock('@metamask/controller-utils');
 jest.mock('@metamask/assets-controllers');
 
 describe('exchange-rates', () => {
+  describe('convertFiatToUsd', () => {
+    it('converts fiat value to USD using the rate ratio', () => {
+      // 100 EUR * (2500 USD/ETH / 2300 EUR/ETH) ≈ 108.6957 USD
+      expect(convertFiatToUsd(100, 2300, 2500)).toBeCloseTo(108.6957, 4);
+    });
+
+    it('returns undefined when conversionRate is null', () => {
+      expect(convertFiatToUsd(100, null, 2500)).toBeUndefined();
+    });
+
+    it('returns undefined when usdConversionRate is null', () => {
+      expect(convertFiatToUsd(100, 2300, null)).toBeUndefined();
+    });
+
+    it('returns undefined when conversionRate is undefined', () => {
+      expect(convertFiatToUsd(100, undefined, 2500)).toBeUndefined();
+    });
+
+    it('returns undefined when usdConversionRate is undefined', () => {
+      expect(convertFiatToUsd(100, 2300, undefined)).toBeUndefined();
+    });
+
+    it('returns undefined when both rates are zero', () => {
+      expect(convertFiatToUsd(100, 0, 0)).toBeUndefined();
+    });
+
+    it('returns 0 when fiatValue is 0', () => {
+      expect(convertFiatToUsd(0, 2300, 2500)).toBe(0);
+    });
+
+    it('returns the same value when rates are equal (1:1 ratio)', () => {
+      expect(convertFiatToUsd(100, 2000, 2000)).toBe(100);
+    });
+  });
+
+  describe('calcUsdAmountFromFiat', () => {
+    const mockNetworkConfigurations = {
+      '0x1': { nativeCurrency: 'ETH' },
+      '0x89': { nativeCurrency: 'POL' },
+    };
+
+    const mockEvmMultiChainCurrencyRates = {
+      ETH: { conversionRate: 2300, usdConversionRate: 2500 },
+      POL: { conversionRate: 0.9, usdConversionRate: 1.0 },
+    };
+
+    it('converts fiat to USD using the correct chain native currency rates', () => {
+      const result = calcUsdAmountFromFiat({
+        tokenFiatValue: 100,
+        chainId: '0x1',
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        evmMultiChainCurrencyRates: mockEvmMultiChainCurrencyRates,
+      });
+
+      // 100 * (2500 / 2300) ≈ 108.6957
+      expect(result).toBeCloseTo(108.6957, 4);
+    });
+
+    it('uses the correct rates for a different chain', () => {
+      const result = calcUsdAmountFromFiat({
+        tokenFiatValue: 50,
+        chainId: '0x89',
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        evmMultiChainCurrencyRates: mockEvmMultiChainCurrencyRates,
+      });
+
+      // 50 * (1.0 / 0.9) ≈ 55.5556
+      expect(result).toBeCloseTo(55.5556, 4);
+    });
+
+    it('falls back to any available entry for non-EVM chains', () => {
+      const solanaChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+      const networkConfigsWithSolana = {
+        ...mockNetworkConfigurations,
+        [solanaChainId]: {
+          nativeCurrency: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+        },
+      };
+
+      const result = calcUsdAmountFromFiat({
+        tokenFiatValue: 100,
+        chainId: solanaChainId,
+        networkConfigurationsByChainId: networkConfigsWithSolana,
+        evmMultiChainCurrencyRates: mockEvmMultiChainCurrencyRates,
+      });
+
+      // Falls back to ETH entry: 100 * (2500 / 2300) ≈ 108.6957
+      expect(result).toBeCloseTo(108.6957, 4);
+    });
+
+    it('returns undefined when chainId is undefined', () => {
+      const result = calcUsdAmountFromFiat({
+        tokenFiatValue: 100,
+        chainId: undefined,
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        evmMultiChainCurrencyRates: mockEvmMultiChainCurrencyRates,
+      });
+
+      // Falls back to any entry with both rates: ETH
+      expect(result).toBeCloseTo(108.6957, 4);
+    });
+
+    it('returns undefined when evmMultiChainCurrencyRates is undefined', () => {
+      const result = calcUsdAmountFromFiat({
+        tokenFiatValue: 100,
+        chainId: '0x1',
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        evmMultiChainCurrencyRates: undefined,
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when no entry has both rates', () => {
+      const result = calcUsdAmountFromFiat({
+        tokenFiatValue: 100,
+        chainId: '0x1',
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        evmMultiChainCurrencyRates: {
+          ETH: { conversionRate: null, usdConversionRate: null },
+        },
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns 0 when tokenFiatValue is 0', () => {
+      const result = calcUsdAmountFromFiat({
+        tokenFiatValue: 0,
+        chainId: '0x1',
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        evmMultiChainCurrencyRates: mockEvmMultiChainCurrencyRates,
+      });
+
+      expect(result).toBe(0);
+    });
+
+    it('falls back when chainId has no matching network config', () => {
+      const result = calcUsdAmountFromFiat({
+        tokenFiatValue: 100,
+        chainId: '0xdeadbeef',
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        evmMultiChainCurrencyRates: mockEvmMultiChainCurrencyRates,
+      });
+
+      // No native currency found, falls back to first entry with both rates
+      expect(result).toBeCloseTo(108.6957, 4);
+    });
+  });
+
   describe('calcTokenFiatValue', () => {
     const mockChainId = '0x1' as Hex;
     const mockTokenAddress =

--- a/app/components/UI/Bridge/utils/exchange-rates.ts
+++ b/app/components/UI/Bridge/utils/exchange-rates.ts
@@ -86,13 +86,13 @@ export const calcUsdAmountFromFiat = ({
   // Try the chain's native currency first, then fall back to any entry with
   // both rates. The fallback covers non-EVM chains whose nativeCurrency
   // (a CAIP asset ID) won't exist in the EVM-only currency rates map.
-  const chainCurrencyEntry = nativeCurrency
+  const evmChainCurrencyEntry = nativeCurrency
     ? evmMultiChainCurrencyRates?.[nativeCurrency]
     : undefined;
-  const fallbackCurrencyEntry = Object.values(
+  const fallbackEvmCurrencyEntry = Object.values(
     evmMultiChainCurrencyRates ?? {},
   ).find((entry) => entry?.conversionRate && entry?.usdConversionRate);
-  const currencyEntry = chainCurrencyEntry ?? fallbackCurrencyEntry;
+  const currencyEntry = evmChainCurrencyEntry ?? fallbackEvmCurrencyEntry;
   return convertFiatToUsd(
     tokenFiatValue,
     currencyEntry?.conversionRate,

--- a/app/components/UI/Bridge/utils/exchange-rates.ts
+++ b/app/components/UI/Bridge/utils/exchange-rates.ts
@@ -23,6 +23,28 @@ import { safeToChecksumAddress } from '../../../../util/address';
 import { toAssetId } from '../hooks/useAssetMetadata/utils';
 import { formatCurrency } from './currencyUtils';
 
+/**
+ * Converts a fiat value from the user's current currency to USD.
+ * Uses the ratio of usdConversionRate / conversionRate for the chain's native
+ * currency, since both rates share the same native token denominator
+ * (e.g. USD/ETH ÷ EUR/ETH = USD/EUR).
+ *
+ * @param fiatValue - The value in the user's current fiat currency
+ * @param conversionRate - Native token to user's fiat currency rate (e.g. 1 ETH = 2300 EUR)
+ * @param usdConversionRate - Native token to USD rate (e.g. 1 ETH = 2500 USD)
+ * @returns The value in USD, or 0 if rates are unavailable
+ */
+export const convertFiatToUsd = (
+  fiatValue: number,
+  conversionRate: number | null | undefined,
+  usdConversionRate: number | null | undefined,
+): number => {
+  if (!conversionRate || !usdConversionRate) {
+    return 0;
+  }
+  return fiatValue * (usdConversionRate / conversionRate);
+};
+
 export interface CalcTokenFiatValueParams {
   token: BridgeToken | undefined;
   amount: string | undefined;

--- a/app/components/UI/Bridge/utils/exchange-rates.ts
+++ b/app/components/UI/Bridge/utils/exchange-rates.ts
@@ -38,9 +38,9 @@ export const convertFiatToUsd = (
   fiatValue: number,
   conversionRate: number | null | undefined,
   usdConversionRate: number | null | undefined,
-): number => {
+): number | undefined => {
   if (!conversionRate || !usdConversionRate) {
-    return 0;
+    return undefined;
   }
   return fiatValue * (usdConversionRate / conversionRate);
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an issue where for `Unified SwapBridge Quotes Requested` events, `usd_amount_source` was always `0`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3386

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


<img width="646" height="589" alt="Screenshot 2026-02-06 at 6 04 54 PM" src="https://github.com/user-attachments/assets/0e4c22e0-f0fc-4174-a781-054f8768811c" />
<img width="496" height="523" alt="Screenshot 2026-02-06 at 6 05 02 PM" src="https://github.com/user-attachments/assets/4084f84d-9162-4c75-a004-4307bca5e157" />
<img width="525" height="542" alt="Screenshot 2026-02-06 at 6 05 21 PM" src="https://github.com/user-attachments/assets/10562770-cc43-465a-bc17-a2cb26b52fe4" />
<img width="549" height="545" alt="Screenshot 2026-02-06 at 6 05 34 PM" src="https://github.com/user-attachments/assets/af66dc55-34b4-4936-8243-905f56fe74e0" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches currency conversion logic used for analytics values; wrong rate selection or missing-rate fallbacks could misreport USD amounts across chains/currencies, but scope is limited and covered by new unit tests.
> 
> **Overview**
> Fixes `Unified SwapBridge Quotes Requested` analytics so `usd_amount_source` is no longer always `0` by converting the already-computed token fiat value into USD.
> 
> Adds `convertFiatToUsd`/`calcUsdAmountFromFiat` helpers that derive USD via the native-currency rate ratio (`usdConversionRate / conversionRate`), including a fallback path for non-EVM chains, and updates hook + tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0a8f185b268ee1bd647968f99443bc9e5de5199. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->