### PR TITLE
Unit tests passing new logic

### DIFF
--- a/app/store/migrations/118.test.ts
+++ b/app/store/migrations/118.test.ts
@@ -410,12 +410,12 @@ describe('Migration 118: Clear deposit and withdrawal request queues from PerpsC
         },
       };
 
-      // Mock an error by making the property throw when accessed
+      // Mock an error by making the property throw when updated
       Object.defineProperty(
         state.engine.backgroundState.PerpsController,
         'withdrawalRequests',
         {
-          get() {
+          set() {
             throw new Error('Test error');
           },
           configurable: true,


### PR DESCRIPTION
Update `useWithdrawalRequests` unit tests to align with the new `completeWithdrawalFromHistory` signature, FIFO timestamp matching logic, and pending withdrawal queue behavior.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-8ae9cecc-6a1f-410d-a937-3e30b01987f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ae9cecc-6a1f-410d-a937-3e30b01987f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only updates to reflect new FIFO queue polling/completion logic and a small tweak to a migration test’s error simulation; low risk to production behavior.
> 
> **Overview**
> Updates `useWithdrawalRequests` unit tests to match the new FIFO pending-withdrawal queue behavior: polling now depends on whether the queue is non-empty (not `withdrawInProgress`), and completion detection is validated via *timestamp-based* matching against `lastWithdrawResult`.
> 
> Adjusts test expectations for the updated `completeWithdrawalFromHistory` signature (now takes `withdrawalRequestId` plus completion payload) and tweaks `migration 118`’s error-path test to throw on property *set* (matching the migration’s in-place state mutation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b812c99198733d0c6c7bc088d736a904a88f3347. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->