### PR TITLE
fix: bulletproof noble perf patches

### DIFF
--- a/metro.transform.js
+++ b/metro.transform.js
@@ -9,6 +9,7 @@ const {
 const { ESLint } = require('eslint');
 const defaultTransformer = require('metro-react-native-babel-transformer');
 const svgTransformer = require('react-native-svg-transformer');
+const { patchNobleLibraries } = require('./metro');
 
 // Code fence removal variables
 const fileExtsToScan = ['.js', '.jsx', '.cjs', '.mjs', '.ts', '.tsx'];
@@ -108,6 +109,8 @@ module.exports.transform = async ({ src, filename, options }) => {
   if (filename.endsWith('.svg')) {
     return svgTransformer.transform({ src, filename, options });
   }
+
+  src = patchNobleLibraries(src, filename);
 
   const environment = process.env.METAMASK_ENVIRONMENT ?? 'production';
   const shouldLintFencedFiles = environment === 'production';

--- a/metro/index.js
+++ b/metro/index.js
@@ -1,0 +1,13 @@
+/* eslint-disable import/no-commonjs */
+const { patchNobleCurvesSecp256k1 } = require('./noble-curves-secp256k1');
+const { patchNobleHashesHmac } = require('./noble-hashes-hmac');
+const { patchNobleHashesSha3 } = require('./noble-hashes-sha3');
+
+function patchNobleLibraries(src, filename) {
+  src = patchNobleCurvesSecp256k1(src, filename);
+  src = patchNobleHashesHmac(src, filename);
+  src = patchNobleHashesSha3(src, filename);
+  return src;
+}
+
+module.exports = { patchNobleLibraries };

--- a/metro/noble-curves-secp256k1.js
+++ b/metro/noble-curves-secp256k1.js
@@ -1,0 +1,49 @@
+/* eslint-disable import/no-commonjs */
+/* eslint-disable import/no-nodejs-modules */
+const path = require('path');
+
+/*
+ * How this patch works?
+ * 1. Match filename with node_modules/@noble/curves/secp256k1.js (each library could have different version of @noble/curves)
+ * 2. If this's ESM version (@noble/curves v2+), it removes export statement and adds a new patch to the end of the file
+ * 3. If this's CJS version (@noble/curves v1), it adds a new patch to the end of the file
+ */
+
+const cjsPatch =
+  "exports.secp256k1 = Object.freeze({ ...exports.secp256k1, getPublicKey: require('@metamask/native-utils').getPublicKey });";
+const esmPatch =
+  "const patchedSecp256k1 = Object.freeze({ ...secp256k1, getPublicKey: require('@metamask/native-utils').getPublicKey });\nexport { patchedSecp256k1 as secp256k1 };";
+const esmExportNeedle = 'export const secp256k1';
+
+const nodeModulesSegment = `${path.sep}node_modules${path.sep}`;
+const nobleCurvesSegment = `${path.sep}@noble${path.sep}curves${path.sep}secp256k1.js`;
+
+function shouldPatch(filename) {
+  if (!filename.endsWith('secp256k1.js')) {
+    return false;
+  }
+  const normalized = path.normalize(filename);
+  return (
+    normalized.includes(nodeModulesSegment) &&
+    normalized.includes(nobleCurvesSegment)
+  );
+}
+
+function patchNobleCurvesSecp256k1(src, filename) {
+  if (!shouldPatch(filename)) {
+    return src;
+  }
+  if (src.includes(cjsPatch) || src.includes(esmPatch)) {
+    return src;
+  }
+  if (src.includes(esmExportNeedle)) {
+    const withoutExport = src.replace(esmExportNeedle, 'const secp256k1');
+    return `${withoutExport}\n${esmPatch}\n`;
+  }
+  if (src.includes('exports.secp256k1')) {
+    return `${src}\n${cjsPatch}\n`;
+  }
+  throw new Error(`Failed to patch @noble/curves secp256k1 in ${filename}`);
+}
+
+module.exports = { patchNobleCurvesSecp256k1 };

--- a/metro/noble-hashes-hmac.js
+++ b/metro/noble-hashes-hmac.js
@@ -1,0 +1,86 @@
+/* eslint-disable import/no-commonjs */
+/* eslint-disable import/no-nodejs-modules */
+const path = require('path');
+const fs = require('fs');
+
+/*
+ * How this patch works?
+ * 1. Match filename with node_modules/@noble/hashes/hmac.js (each library could have different version of @noble/hashes)
+ * 2. If this's ESM version (@noble/hashes v2+), it removes export statement and adds a new patch to the end of the file
+ * 3. If this's CJS version (@noble/hashes v1), it adds a new patch to the end of the file
+ */
+
+// Some @noble/hashes versions export sha512 from sha2.js while others use sha512.js.
+// Resolve based on the local module directory to keep nested node_modules consistent.
+const shaImportByDir = new Map();
+function getShaModulePath(filename) {
+  const dir = path.dirname(filename);
+  if (shaImportByDir.has(dir)) {
+    return shaImportByDir.get(dir);
+  }
+  const sha512Path = path.join(dir, 'sha512.js');
+  const result = fs.existsSync(sha512Path) ? './sha512' : './sha2';
+  shaImportByDir.set(dir, result);
+  return result;
+}
+
+function buildCommonPatch(shaModulePath) {
+  return [
+    `const nobleHashesSha2 = require('${shaModulePath}');`,
+    "const { hmacSha512 } = require('@metamask/native-utils');",
+    'const originalHmac = hmac;',
+    'const patchedHmac = (hash, key, message) => {',
+    '  if (hash === nobleHashesSha2.sha512) {',
+    '    try {',
+    '      return hmacSha512(key, message);',
+    '    } catch (error) {',
+    "      console.error('Error in @metamask/native-utils.hmacSha512, falling back to original implementation', error);",
+    '    }',
+    '  }',
+    '  return originalHmac(hash, key, message);',
+    '};',
+    'Object.assign(patchedHmac, originalHmac);',
+  ].join('\n');
+}
+const cjsExportLine = 'exports.hmac = patchedHmac;';
+const esmExportLine = 'export { patchedHmac as hmac };';
+
+const nodeModulesSegment = `${path.sep}node_modules${path.sep}`;
+const nobleHashesSegment = `${path.sep}@noble${path.sep}hashes${path.sep}hmac.js`;
+
+function shouldPatch(filename) {
+  if (!filename.endsWith('hmac.js')) {
+    return false;
+  }
+  const normalized = path.normalize(filename);
+  return (
+    normalized.includes(nodeModulesSegment) &&
+    normalized.includes(nobleHashesSegment)
+  );
+}
+
+function patchNobleHashesHmac(src, filename) {
+  if (!shouldPatch(filename)) {
+    return src;
+  }
+  if (src.includes('export const hmac')) {
+    const shaModulePath = getShaModulePath(filename);
+    const esmPatch = `${buildCommonPatch(shaModulePath)}\n${esmExportLine}`;
+    if (src.includes(esmPatch)) {
+      return src;
+    }
+    const withoutExport = src.replace('export const hmac', 'const hmac');
+    return `${withoutExport}\n${esmPatch}\n`;
+  }
+  if (src.includes('exports.hmac')) {
+    const shaModulePath = getShaModulePath(filename);
+    const cjsPatch = `${buildCommonPatch(shaModulePath)}\n${cjsExportLine}`;
+    if (src.includes(cjsPatch)) {
+      return src;
+    }
+    return `${src}\n${cjsPatch}\n`;
+  }
+  throw new Error(`Failed to patch @noble/hashes hmac in ${filename}`);
+}
+
+module.exports = { patchNobleHashesHmac };

--- a/metro/noble-hashes-sha3.js
+++ b/metro/noble-hashes-sha3.js
@@ -1,0 +1,69 @@
+/* eslint-disable import/no-commonjs */
+/* eslint-disable import/no-nodejs-modules */
+const path = require('path');
+
+/*
+ * How this patch works?
+ * 1. Match filename with node_modules/@noble/hashes/sha3.js (each library could have different version of @noble/hashes)
+ * 2. If this's ESM version (@noble/hashes v2+), it removes export statement and adds a new patch to the end of the file
+ * 3. If this's CJS version (@noble/hashes v1), it adds a new patch to the end of the file
+ */
+
+function buildCommonPatch() {
+  return [
+    "const { keccak256 } = require('@metamask/native-utils');",
+    'const originalKeccak256 = keccak_256;',
+    'const patchedKeccak256 = (value) => {',
+    '  try {',
+    '    return keccak256(value);',
+    '  } catch (error) {',
+    "    console.error('Error in @metamask/native-utils.keccak256, falling back to original implementation', error);",
+    '  }',
+    '  return originalKeccak256(value);',
+    '};',
+    'Object.assign(patchedKeccak256, originalKeccak256);',
+  ].join('\n');
+}
+const cjsExportLine = 'exports.keccak_256 = patchedKeccak256;';
+const esmExportLine = 'export { patchedKeccak256 as keccak_256 };';
+
+const nodeModulesSegment = `${path.sep}node_modules${path.sep}`;
+const nobleHashesSegment = `${path.sep}@noble${path.sep}hashes${path.sep}sha3.js`;
+
+function shouldPatch(filename) {
+  if (!filename.endsWith('sha3.js')) {
+    return false;
+  }
+  const normalized = path.normalize(filename);
+  return (
+    normalized.includes(nodeModulesSegment) &&
+    normalized.includes(nobleHashesSegment)
+  );
+}
+
+function patchNobleHashesSha3(src, filename) {
+  if (!shouldPatch(filename)) {
+    return src;
+  }
+  if (src.includes('export const keccak_256')) {
+    const esmPatch = `${buildCommonPatch()}\n${esmExportLine}`;
+    if (src.includes(esmPatch)) {
+      return src;
+    }
+    const withoutExport = src.replace(
+      'export const keccak_256',
+      'const keccak_256',
+    );
+    return `${withoutExport}\n${esmPatch}\n`;
+  }
+  if (src.includes('exports.keccak_256')) {
+    const cjsPatch = `${buildCommonPatch()}\n${cjsExportLine}`;
+    if (src.includes(cjsPatch)) {
+      return src;
+    }
+    return `${src}\n${cjsPatch}\n`;
+  }
+  throw new Error(`Failed to patch @noble/hashes sha3 in ${filename}`);
+}
+
+module.exports = { patchNobleHashesSha3 };

--- a/shimPerf.js
+++ b/shimPerf.js
@@ -3,55 +3,7 @@
 /* eslint-disable import/no-nodejs-modules */
 import { Buffer } from '@craftzdog/react-native-buffer';
 
-import { getPublicKey, hmacSha512, keccak256 } from '@metamask/native-utils';
-
-// Monkey patch getPublicKey from @noble/curves with much faster C++ implementation
-// IMPORTANT: This patching works only if @noble/curves version in root package.json is same as @noble/curves version in package.json of @scure/bip32.
-const secp256k1_1 = require('@noble/curves/secp256k1');
-secp256k1_1.secp256k1.getPublicKey = getPublicKey;
-
-// Monkey patch hmacSha512 from @noble/hashes
-const nobleHashesHmac = require('@noble/hashes/hmac');
-const nobleHashesSha2 = require('@noble/hashes/sha2');
-const originalHmac = nobleHashesHmac.hmac;
-const patchedHmac = (hash, key, message) => {
-  if (hash === nobleHashesSha2.sha512) {
-    try {
-      return hmacSha512(key, message);
-    } catch (error) {
-      console.error(
-        'Error in @metamask/native-utils.hmacSha512, falling back to original implementation',
-        error,
-      );
-    }
-  }
-  return originalHmac(hash, key, message);
-};
-
-// add missing hmac.create polyfill with original implementation
-Object.assign(patchedHmac, originalHmac);
-nobleHashesHmac.hmac = patchedHmac;
-
-// Monkey patch keccak256 from @noble/hashes
-const nobleHashesSha3 = require('@noble/hashes/sha3');
-const originalNobleHashesSha3Keccak256 = nobleHashesSha3.keccak_256;
-const patchedNobleHashesSha3Keccak256 = (value) => {
-  try {
-    return keccak256(value);
-  } catch (error) {
-    console.error(
-      'Error in @metamask/native-utils.keccak256, falling back to original implementation',
-      error,
-    );
-  }
-  return originalNobleHashesSha3Keccak256(value);
-};
-// We need to use Object.assign to ensure added properties are not overridden (e.g. keccak_256.create())
-Object.assign(
-  patchedNobleHashesSha3Keccak256,
-  originalNobleHashesSha3Keccak256,
-);
-nobleHashesSha3.keccak_256 = patchedNobleHashesSha3Keccak256;
+import { keccak256 } from '@metamask/native-utils';
 
 // Monkey patch keccak256 from js-sha3
 const jsSha3 = require('js-sha3');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### What's problem?

With previous approach using monkey patching in `shimPerf.js` it patched only one version of `@noble` libraries defined in root `package.json` and skipped other. That resulted in perf issues when some external library used little different version, it silently broke patching and used only slow JS version then. 

Another problem is there are 11 versions for `@noble/curves` and `@noble/hashes` (22 in total). So my first though was to deduplicate these version, but that always resulted in random errors in the app. It did not work because there are two major versions 1.x and 2.x with breaking changes and there also seems to be breaking changes between 1.x version. Also 2.x version are ESM only so there is quite big diff.

#### Possible solution 1

I tried to use `yarn patch` to apply necessary changes to `@noble` packages, but due to yarn patch limitations it required patch file for each version se in the end there was over 22 patches (although relative simple). It also did not solve issue with silent fails e.g. when someones adds new version to app code it's not patched by default. I also tried add some script to check for this but in the end it was quite complicated and annoying.

#### Possible solution 2

I also tried to use Metro resolver for swapping file for patched version, for example if app requested `@noble/curves/secpt256k1.js` metro actually resolved `app/patchedSecpt256k1.js`. It is quite relative simple but there was issue that there are other unpatched functions in that file which I had to reexport only but due to how Metro works it will use import these functions from @noble version defined in root `package.json`. It worked in the end but it could really mix things up in unexpected ways and I was afraid of some random undefined behavior.

### Possible solution 3 (one that I ended up with)

I used Metro transformer to apply patches to files across all versions. It may looks quite complicated on first sight but it's actually very simple and reliable. Custom transformers check if file is CJS or ESM variant of `@noble` and then appends patch code to very end of file (nearly same code that was in `shimPerf.js`), so there is never be problem with conflicts. For ESM variant it needs to replace `export const abc` with just `const abc` because we need to export patched version ourselves, but that's only very small change.

It's also going to automatically patch any new version because it's only appending code at the end file. It should be zero maintenance unless there is big refactoring in library (e.g. moving functions to different file), but that should fail build time so no random behavior.



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies Metro transform behavior and rewrites third-party module source at build time, which could cause bundling/build failures or subtle crypto behavior differences across @noble versions if the patch heuristics mis-detect ESM/CJS exports.
> 
> **Overview**
> Moves the @noble performance monkey-patches out of `shimPerf.js` and into the Metro transformer so they apply consistently across nested `node_modules` and multiple @noble versions.
> 
> `metro.transform.js` now runs `patchNobleLibraries()` on every non-SVG file before further processing, and new `metro/*` patchers append/override exports in `@noble/curves/secp256k1` and `@noble/hashes` (`hmac`, `sha3`) to route `getPublicKey`, `hmacSha512`, and `keccak256` through `@metamask/native-utils` with fallback to the original JS implementations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a554d1f652398a5190db245ca898d01145d526d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->