### PR TITLE
fix: add geolocalisation check on token details page

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderRedirect.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderRedirect.test.tsx
@@ -108,7 +108,7 @@ describe('PerpsOrderRedirect', () => {
     expect(MockPerpsLoader).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'Preparing order...',
-        fullScreen: true,
+        fullScreen: false,
       }),
     );
   });

--- a/app/components/UI/Perps/Views/PerpsOrderRedirect.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderRedirect.tsx
@@ -5,6 +5,11 @@ import {
   RouteProp,
   StackActions,
 } from '@react-navigation/native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+} from '@metamask/design-system-react-native';
 import Routes from '../../../../constants/navigation/Routes';
 import { usePerpsConnection } from '../hooks/usePerpsConnection';
 import { usePerpsTrading } from '../hooks/usePerpsTrading';
@@ -43,7 +48,6 @@ const PerpsOrderRedirect: React.FC = () => {
   const { showToast, PerpsToastOptions } = usePerpsToasts();
 
   const hasStartedRef = useRef(false);
-
   useEffect(() => {
     // Wait for WebSocket to be ready
     if (!isConnected || !isInitialized) return;
@@ -97,7 +101,16 @@ const PerpsOrderRedirect: React.FC = () => {
     PerpsToastOptions,
   ]);
 
-  return <PerpsLoader message="Preparing order..." fullScreen />;
+  // Match PerpsLoadingSkeleton layout ("Connecting to Perps") so both loaders look the same: top-aligned, centered, pt-20
+  return (
+    <Box
+      twClassName="flex-1 bg-default pt-20"
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Start}
+    >
+      <PerpsLoader message="Preparing order..." fullScreen={false} />
+    </Box>
+  );
 };
 
 export default PerpsOrderRedirect;

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.test.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import AssetOverviewContent, {
+  type AssetOverviewContentProps,
+} from './AssetOverviewContent';
+import { TokenOverviewSelectorsIDs } from '../../AssetOverview/TokenOverview.testIds';
+import { TokenI } from '../../Tokens/types';
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import { backgroundState } from '../../../../util/test/initial-root-state';
+import { MOCK_ACCOUNTS_CONTROLLER_STATE } from '../../../../util/test/accountsControllerTestUtils';
+import { MetaMetricsEvents } from '../../../../core/Analytics/MetaMetrics.events';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '../../Perps/constants/eventNames';
+
+const mockHandlePerpsAction = jest.fn();
+const mockTrack = jest.fn();
+
+jest.mock('../hooks/usePerpsActions', () => ({
+  usePerpsActions: () => ({
+    hasPerpsMarket: true,
+    marketData: { symbol: 'ETH', name: 'ETH', maxLeverage: '50x' },
+    isLoading: false,
+    error: null,
+    handlePerpsAction: mockHandlePerpsAction,
+  }),
+}));
+
+jest.mock('../../Perps/hooks/usePerpsEventTracking', () => ({
+  usePerpsEventTracking: () => ({ track: mockTrack }),
+}));
+
+jest.mock('../../AssetOverview/hooks/useScrollToMerklRewards', () => ({
+  useScrollToMerklRewards: jest.fn(),
+}));
+
+jest.mock('../../Perps/components/PerpsBottomSheetTooltip', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+      addListener: jest.fn(() => jest.fn()),
+    }),
+    useFocusEffect: jest.fn((cb: () => void) => cb()),
+  };
+});
+
+function createState(isEligible: boolean) {
+  return {
+    engine: {
+      backgroundState: {
+        ...backgroundState,
+        PerpsController: {
+          ...(backgroundState as { PerpsController?: object }).PerpsController,
+          isEligible,
+        },
+        RemoteFeatureFlagController: {
+          ...(backgroundState as { RemoteFeatureFlagController?: object })
+            .RemoteFeatureFlagController,
+          remoteFeatureFlags: {
+            tokenDetailsV2Buttons: true,
+          },
+        },
+        AccountsController: MOCK_ACCOUNTS_CONTROLLER_STATE,
+      },
+    },
+  };
+}
+
+const defaultToken: TokenI = {
+  address: '0x123',
+  chainId: '0x1',
+  symbol: 'ETH',
+  name: 'Ethereum',
+  decimals: 18,
+  balance: '1',
+  balanceFiat: '$2000',
+  logo: '',
+  image: '',
+  isETH: false,
+  hasBalanceError: false,
+  aggregators: [],
+};
+
+const defaultProps: AssetOverviewContentProps = {
+  token: defaultToken,
+  balance: '1',
+  mainBalance: '$2000',
+  secondaryBalance: '1 ETH',
+  currentPrice: 2000,
+  priceDiff: 0,
+  comparePrice: 2000,
+  prices: [],
+  isLoading: false,
+  timePeriod: '1d',
+  setTimePeriod: jest.fn(),
+  chartNavigationButtons: ['1d', '1w', '1m'],
+  isPerpsEnabled: true,
+  isMerklCampaignClaimingEnabled: false,
+  displayBuyButton: false,
+  displaySwapsButton: false,
+  currentCurrency: 'USD',
+  onBuy: jest.fn(),
+  onSend: jest.fn().mockResolvedValue(undefined),
+  onReceive: jest.fn(),
+  goToSwaps: jest.fn(),
+};
+
+describe('AssetOverviewContent', () => {
+  describe('Long / Short with perps eligibility', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('shows geo block modal and tracks event when Long is pressed and user is not eligible', () => {
+      const { getByTestId } = renderWithProvider(
+        <AssetOverviewContent {...defaultProps} />,
+        { state: createState(false) },
+      );
+
+      fireEvent.press(getByTestId(TokenOverviewSelectorsIDs.LONG_BUTTON));
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEvents.PERPS_SCREEN_VIEWED,
+        {
+          [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+            PERPS_EVENT_VALUE.SCREEN_TYPE.GEO_BLOCK_NOTIF,
+          [PERPS_EVENT_PROPERTY.SOURCE]:
+            PERPS_EVENT_VALUE.SOURCE.ASSET_DETAIL_SCREEN,
+        },
+      );
+      expect(mockHandlePerpsAction).not.toHaveBeenCalled();
+    });
+
+    it('shows geo block modal and tracks event when Short is pressed and user is not eligible', () => {
+      const { getByTestId } = renderWithProvider(
+        <AssetOverviewContent {...defaultProps} />,
+        { state: createState(false) },
+      );
+
+      fireEvent.press(getByTestId(TokenOverviewSelectorsIDs.SHORT_BUTTON));
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEvents.PERPS_SCREEN_VIEWED,
+        {
+          [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+            PERPS_EVENT_VALUE.SCREEN_TYPE.GEO_BLOCK_NOTIF,
+          [PERPS_EVENT_PROPERTY.SOURCE]:
+            PERPS_EVENT_VALUE.SOURCE.ASSET_DETAIL_SCREEN,
+        },
+      );
+      expect(mockHandlePerpsAction).not.toHaveBeenCalled();
+    });
+
+    it('calls handlePerpsAction with long when Long is pressed and user is eligible', () => {
+      const { getByTestId } = renderWithProvider(
+        <AssetOverviewContent {...defaultProps} />,
+        { state: createState(true) },
+      );
+
+      fireEvent.press(getByTestId(TokenOverviewSelectorsIDs.LONG_BUTTON));
+
+      expect(mockHandlePerpsAction).toHaveBeenCalledWith('long');
+      expect(mockTrack).not.toHaveBeenCalled();
+    });
+
+    it('calls handlePerpsAction with short when Short is pressed and user is eligible', () => {
+      const { getByTestId } = renderWithProvider(
+        <AssetOverviewContent {...defaultProps} />,
+        { state: createState(true) },
+      );
+
+      fireEvent.press(getByTestId(TokenOverviewSelectorsIDs.SHORT_BUTTON));
+
+      expect(mockHandlePerpsAction).toHaveBeenCalledWith('short');
+      expect(mockTrack).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/components/UI/TokenDetails/components/TokenDetailsActions.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsActions.tsx
@@ -44,6 +44,8 @@ export interface TokenDetailsActionsProps {
   onSend: () => void;
   onReceive: () => void;
   isLoading?: boolean;
+  /** Optional ref to receive a callback that resets the navigation lock. Used when Long/Short show a modal instead of navigating (e.g. geo block). */
+  resetNavigationLockRef?: React.MutableRefObject<(() => void) | null>;
 }
 
 /**
@@ -81,6 +83,7 @@ export const TokenDetailsActions: React.FC<TokenDetailsActionsProps> = ({
   onSend,
   onReceive,
   isLoading = false,
+  resetNavigationLockRef,
 }) => {
   const { styles } = useStyles(styleSheet, {});
   const canSignTransactions = useSelector(selectCanSignTransactions);
@@ -89,6 +92,19 @@ export const TokenDetailsActions: React.FC<TokenDetailsActionsProps> = ({
 
   // Prevent rapid navigation clicks - locks all buttons during navigation
   const navigationLockRef = useRef(false);
+
+  // Expose reset so parent can unlock when a non-navigating action ends (e.g. geo block modal dismissed)
+  const resetLock = useCallback(() => {
+    navigationLockRef.current = false;
+  }, []);
+  useEffect(() => {
+    if (resetNavigationLockRef) {
+      resetNavigationLockRef.current = resetLock;
+      return () => {
+        resetNavigationLockRef.current = null;
+      };
+    }
+  }, [resetNavigationLockRef, resetLock]);
 
   // Reset lock when screen comes into focus (handles return from navigation)
   useFocusEffect(


### PR DESCRIPTION

## **Description**

Adds geolocalisation check on long and short buttons

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added geolocalisation check on long/short buttons on token details page

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/99417619-cd37-41a1-bfa4-df16f6c8f3ca


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches token-details primary action flow and navigation locking; regressions could block Long/Short actions or leave buttons locked, but changes are localized and covered by unit tests.
> 
> **Overview**
> Adds a perps geolocation/eligibility gate to Token Details **Long/Short** actions: ineligible users now see a `PerpsBottomSheetTooltip` geo-block modal and an analytics event (`MetaMetricsEvents.PERPS_SCREEN_VIEWED`) is tracked instead of navigating/starting the perps flow.
> 
> Updates `TokenDetailsActions` to expose a parent-controlled reset for its navigation lock so the UI can be unlocked after a non-navigating modal is dismissed, and adds unit tests validating eligible vs ineligible behavior.
> 
> Adjusts `PerpsOrderRedirect` loader presentation to match the perps loading skeleton layout (wrap in `Box`, use `fullScreen={false}`) and updates its test accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d912e2883d884e4fdc6875b26571e416429add2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->