### PR TITLE
test: adds the ability to run state migrations on E2E context

### DIFF
--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -57,7 +57,7 @@ const createStoreAndPersistor = async () => {
         const changed = stateBefore !== stateAfter;
         // eslint-disable-next-line no-console
         console.log(
-          `[E2E Migration - store/index.ts] Migration ${i} ${changed ? '✅ CHANGED state' : '⏭️  no-op (state unchanged)'}`,
+          `[E2E Migration - store/index.ts] Migration ${i} ${changed ? ' changed state' : ' no-op (state unchanged)'}`,
         );
       }
     }

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -15,6 +15,10 @@ import { onPersistedDataLoaded } from '../actions/user';
 import { setBasicFunctionality } from '../actions/settings';
 import Logger from '../util/Logger';
 import devToolsEnhancer from 'redux-devtools-expo-dev-plugin';
+import {
+  migrationList,
+  version as currentMigrationVersion,
+} from './migrations';
 
 // TODO: Improve type safety by using real Action types instead of `AnyAction`
 const pReducer = persistReducer<RootState, AnyAction>(
@@ -31,9 +35,39 @@ const createStoreAndPersistor = async () => {
     op: TraceOperation.StoreInit,
   });
   // Obtain the initial state from ReadOnlyNetworkStore for E2E tests.
-  const initialState = isE2E
-    ? await ReadOnlyNetworkStore.getState()
-    : undefined;
+  let initialState = isE2E ? await ReadOnlyNetworkStore.getState() : undefined;
+
+  // If the fixture state includes a _persist.version marker, run migrations on it
+  // before injecting as preloadedState. This uses the raw migrationList (not the
+  // asyncified version) to avoid controller inflate/deflate side effects.
+  // Set the marker via FixtureBuilder.withMigrateFrom(version).
+  if (isE2E && initialState?._persist?.version !== undefined) {
+    const fromVersion: number = initialState._persist.version;
+    // eslint-disable-next-line no-console
+    console.log(
+      `[E2E Migrations - store/index.ts] Running migrations ${fromVersion + 1}→${currentMigrationVersion} on fixture state`,
+    );
+
+    for (let i = fromVersion + 1; i <= currentMigrationVersion; i++) {
+      const migration = migrationList[i];
+      if (migration) {
+        const stateBefore = JSON.stringify(initialState);
+        initialState = await Promise.resolve(migration(initialState));
+        const stateAfter = JSON.stringify(initialState);
+        const changed = stateBefore !== stateAfter;
+        // eslint-disable-next-line no-console
+        console.log(
+          `[E2E Migration - store/index.ts] Migration ${i} ${changed ? '✅ CHANGED state' : '⏭️  no-op (state unchanged)'}`,
+        );
+      }
+    }
+
+    // eslint-disable-next-line no-console
+    console.log('[E2E Migrations - store/index.ts] All migrations complete');
+
+    // Remove the _persist marker so persistReducer doesn't re-run migrations
+    delete initialState._persist;
+  }
 
   const sagaMiddleware = createSagaMiddleware();
 

--- a/tests/framework/fixtures/FixtureBuilder.ts
+++ b/tests/framework/fixtures/FixtureBuilder.ts
@@ -82,6 +82,11 @@ export interface MusdFixtureOptions {
   musdBalance?: number;
 }
 
+export interface FixtureBuilderOptions {
+  onboarding?: boolean;
+  migrateFrom?: number;
+}
+
 /**
  * The migration version that the default E2E fixture state represents.
  * Migrations from `E2E_FIXTURE_FROM_MIGRATION_VERSION + 1` through the current
@@ -109,14 +114,16 @@ class FixtureBuilder {
    * @param {Object} options - Options for the fixture builder.
    * @param {boolean} options.onboarding - Flag indicating if onboarding fixture should be used.
    */
-  constructor({ onboarding = false } = {}) {
-    if (onboarding) {
+  constructor(options: FixtureBuilderOptions) {
+    if (options.onboarding) {
       this.withOnboardingFixture();
     } else {
       this.withDefaultFixture();
       // Always run migrations on the fixture state during E2E app startup.
       // Bump E2E_FIXTURE_FROM_MIGRATION_VERSION to control which migrations run.
-      this.withMigrateFrom(E2E_FIXTURE_FROM_MIGRATION_VERSION);
+      this.withMigrateFrom(
+        options.migrateFrom ?? E2E_FIXTURE_FROM_MIGRATION_VERSION,
+      );
     }
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Currently, the E2E runs with a preloaded state coming from fixtures **without running migrations**.

### Context
Some context on how state is injected now: 
1. Store creation (app/store/index.ts lines 34-48):
```typescript
  // Obtain the initial state from ReadOnlyNetworkStore for E2E tests.
  const initialState = isE2E
    ? await ReadOnlyNetworkStore.getState()
    : undefined;
  // ...
  store = configureStore({
    reducer: pReducer,
    middleware: middlewares,
    preloadedState: initialState,
    // ...
  });
```

The fixture's .state is injected as preloadedState directly into the Redux store.

2. Rehydration (persistStore is called on line 78):
This triggers redux-persist to call getStoredState(config), which reads from config.storage -- which is MigratedStorage (FilesystemStorage + AsyncStorage fallback), NOT ReadOnlyNetworkStore.

3. On a fresh install (E2E with delete: true):

Both FilesystemStorage and AsyncStorage are empty, so getStoredState returns undefined.

`createMigrate` receives undefined state (node_modules/redux-persist/es/createMigrate.js):
```typescript
if (!state) {
  return Promise.resolve(undefined);
}
```

This means that E2E, migrations never execute.

### Proposed solution
- Build fixtures on FixtureBuilder with `withMigrateFrom` (exepct for the onboarding fixture)
- When initializing store, the custom property on the fixture `this.fixture.state._persist` passes in the current migration E2E is using
- Migrations run on store init. This is safely guarded with `isE2E` and `initialState?._persist?.version !=== undefined`


### Log example:
```
[E2E Migration - store/index.ts] Migration 104 changed state
[E2E Migration - store/index.ts] Migration 105 no-op (state unchanged)
[E2E Migration - store/index.ts] Migration 106 no-op (state unchanged)
[E2E Migration - store/index.ts] Migration 107 no-op (state unchanged)
[E2E Migration - store/index.ts] Migration 108 no-op (state unchanged)
[E2E Migration - store/index.ts] Migration 109 no-op (state unchanged)
[E2E Migration - store/index.ts] Migration 110 no-op (state unchanged)
[E2E Migration - store/index.ts] Migration 111 changed state
[E2E Migration - store/index.ts] Migration 112 no-op (state unchanged)
[E2E Migration - store/index.ts] Migration 113 no-op (state unchanged)
[E2E Migration - store/index.ts] Migration 114 changed state
```


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1396

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches store initialization in `app/store/index.ts`; incorrect version markers or non-idempotent migrations could break E2E startup or produce misleading fixture state, but changes are gated to `isE2E`.
> 
> **Overview**
> E2E test startup now **optionally runs Redux state migrations** on fixture-provided `preloadedState` before the store is created, when the fixture includes a `_persist.version` marker. This executes `migrationList` from `version+1` through the current app migration version, logs per-migration no-op/changed status, and then removes `_persist` to avoid `redux-persist` re-running migrations.
> 
> `FixtureBuilder` now stamps default (non-onboarding) fixtures with a configurable migration baseline via `E2E_FIXTURE_FROM_MIGRATION_VERSION` and a new `withMigrateFrom(version)` helper so E2E suites can validate specific migration ranges against fixture state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 952f16aab37aa0c5fb6de4116d846b69bb1ac2ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->