### PR TITLE
fix: metrics for gas 'gas_fee_presented'

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/gas.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/gas.test.ts
@@ -123,7 +123,7 @@ describe('getGasMetricsProperties', () => {
     ]);
   });
 
-  it('returns n_a as gas_fee_presented when no dapp suggested fees and estimates not loaded', () => {
+  it('returns not_loaded as gas_fee_presented when no dapp suggested fees and estimates not loaded', () => {
     const request = createMockRequest({
       gasFeeEstimatesLoaded: false,
       dappSuggestedGasFees: undefined,
@@ -131,7 +131,7 @@ describe('getGasMetricsProperties', () => {
 
     const result = getGasMetricsProperties(request);
 
-    expect(result.properties.gas_fee_presented).toBe('n_a');
+    expect(result.properties.gas_fee_presented).toBe('not_loaded');
   });
 
   it('returns gas_insufficient_native_asset as true when balance is insufficient', () => {

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/gas.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/gas.test.ts
@@ -1,12 +1,18 @@
-import {
-  TransactionMeta,
-  GasFeeEstimateType,
-} from '@metamask/transaction-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
 
 import { getGasMetricsProperties } from './gas';
 import { TransactionMetricsBuilderRequest } from '../types';
 import { TRANSACTION_EVENTS } from '../../../../Analytics/events/confirmations';
 import { RootState } from '../../../../../reducers';
+
+jest.mock('@metamask/assets-controllers', () => ({
+  getNativeTokenAddress: jest.fn(),
+}));
+
+const mockGetNativeTokenAddress = getNativeTokenAddress as jest.MockedFunction<
+  typeof getNativeTokenAddress
+>;
 
 const createMockState = (
   balance: string = '0x100000000000000000',
@@ -47,6 +53,13 @@ const createMockRequest = (
 });
 
 describe('getGasMetricsProperties', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockGetNativeTokenAddress.mockReturnValue(
+      '0x0000000000000000000000000000000000000000',
+    );
+  });
+
   it('returns gas_estimation_failed as true when gasFeeEstimatesLoaded is false', () => {
     const request = createMockRequest({ gasFeeEstimatesLoaded: false });
 
@@ -63,35 +76,17 @@ describe('getGasMetricsProperties', () => {
     expect(result.properties.gas_estimation_failed).toBe(false);
   });
 
-  it('includes low/medium/high options for FeeMarket estimate type', () => {
+  it('returns medium as gas_fee_presented when gasFeeEstimatesLoaded is true and no dapp suggested fees', () => {
     const request = createMockRequest({
       gasFeeEstimatesLoaded: true,
-      gasFeeEstimates: {
-        type: GasFeeEstimateType.FeeMarket,
-      } as TransactionMeta['gasFeeEstimates'],
     });
 
     const result = getGasMetricsProperties(request);
 
-    expect(result.properties.gas_fee_presented).toContain('low');
-    expect(result.properties.gas_fee_presented).toContain('medium');
-    expect(result.properties.gas_fee_presented).toContain('high');
+    expect(result.properties.gas_fee_presented).toBe('medium');
   });
 
-  it('includes network_proposed for GasPrice estimate type', () => {
-    const request = createMockRequest({
-      gasFeeEstimatesLoaded: true,
-      gasFeeEstimates: {
-        type: GasFeeEstimateType.GasPrice,
-      } as TransactionMeta['gasFeeEstimates'],
-    });
-
-    const result = getGasMetricsProperties(request);
-
-    expect(result.properties.gas_fee_presented).toContain('network_proposed');
-  });
-
-  it('includes dapp_proposed when dappSuggestedGasFees exists', () => {
+  it('returns dapp_proposed as gas_fee_presented when dappSuggestedGasFees exists', () => {
     const request = createMockRequest({
       gasFeeEstimatesLoaded: true,
       dappSuggestedGasFees: {
@@ -101,7 +96,7 @@ describe('getGasMetricsProperties', () => {
 
     const result = getGasMetricsProperties(request);
 
-    expect(result.properties.gas_fee_presented).toContain('dapp_proposed');
+    expect(result.properties.gas_fee_presented).toBe('dapp_proposed');
   });
 
   it('returns gas_fee_selected from userFeeLevel', () => {
@@ -126,6 +121,66 @@ describe('getGasMetricsProperties', () => {
       'ETH',
       'USDC',
     ]);
+  });
+
+  it('returns n_a as gas_fee_presented when no dapp suggested fees and estimates not loaded', () => {
+    const request = createMockRequest({
+      gasFeeEstimatesLoaded: false,
+      dappSuggestedGasFees: undefined,
+    });
+
+    const result = getGasMetricsProperties(request);
+
+    expect(result.properties.gas_fee_presented).toBe('n_a');
+  });
+
+  it('returns gas_paid_with as symbol of matching gasFeeToken', () => {
+    const request = createMockRequest({
+      gasFeeTokens: [
+        { symbol: 'ETH', tokenAddress: '0xeth' },
+        { symbol: 'USDC', tokenAddress: '0xusdc' },
+      ] as unknown as TransactionMeta['gasFeeTokens'],
+      selectedGasFeeToken: '0xusdc',
+    });
+    mockGetNativeTokenAddress.mockReturnValue(
+      '0x0000000000000000000000000000000000000000',
+    );
+
+    const result = getGasMetricsProperties(request);
+
+    expect(result.properties.gas_paid_with).toBe('USDC');
+  });
+
+  it('returns gas_paid_with as pre-funded_ETH when selectedGasFeeToken is native token address', () => {
+    const nativeAddress = '0x0000000000000000000000000000000000000000';
+    const request = createMockRequest({
+      chainId: '0x1',
+      gasFeeTokens: [
+        { symbol: 'ETH', tokenAddress: nativeAddress },
+      ] as unknown as TransactionMeta['gasFeeTokens'],
+      selectedGasFeeToken: nativeAddress,
+    });
+    mockGetNativeTokenAddress.mockReturnValue(nativeAddress);
+
+    const result = getGasMetricsProperties(request);
+
+    expect(result.properties.gas_paid_with).toBe('pre-funded_ETH');
+  });
+
+  it('returns gas_paid_with as undefined when no selectedGasFeeToken', () => {
+    const request = createMockRequest({
+      gasFeeTokens: [
+        { symbol: 'ETH', tokenAddress: '0xeth' },
+      ] as unknown as TransactionMeta['gasFeeTokens'],
+      selectedGasFeeToken: undefined,
+    });
+    mockGetNativeTokenAddress.mockReturnValue(
+      '0x0000000000000000000000000000000000000000',
+    );
+
+    const result = getGasMetricsProperties(request);
+
+    expect(result.properties.gas_paid_with).toBeUndefined();
   });
 
   it('returns gas_insufficient_native_asset as true when balance is insufficient', () => {

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/gas.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/gas.test.ts
@@ -134,55 +134,6 @@ describe('getGasMetricsProperties', () => {
     expect(result.properties.gas_fee_presented).toBe('n_a');
   });
 
-  it('returns gas_paid_with as symbol of matching gasFeeToken', () => {
-    const request = createMockRequest({
-      gasFeeTokens: [
-        { symbol: 'ETH', tokenAddress: '0xeth' },
-        { symbol: 'USDC', tokenAddress: '0xusdc' },
-      ] as unknown as TransactionMeta['gasFeeTokens'],
-      selectedGasFeeToken: '0xusdc',
-    });
-    mockGetNativeTokenAddress.mockReturnValue(
-      '0x0000000000000000000000000000000000000000',
-    );
-
-    const result = getGasMetricsProperties(request);
-
-    expect(result.properties.gas_paid_with).toBe('USDC');
-  });
-
-  it('returns gas_paid_with as pre-funded_ETH when selectedGasFeeToken is native token address', () => {
-    const nativeAddress = '0x0000000000000000000000000000000000000000';
-    const request = createMockRequest({
-      chainId: '0x1',
-      gasFeeTokens: [
-        { symbol: 'ETH', tokenAddress: nativeAddress },
-      ] as unknown as TransactionMeta['gasFeeTokens'],
-      selectedGasFeeToken: nativeAddress,
-    });
-    mockGetNativeTokenAddress.mockReturnValue(nativeAddress);
-
-    const result = getGasMetricsProperties(request);
-
-    expect(result.properties.gas_paid_with).toBe('pre-funded_ETH');
-  });
-
-  it('returns gas_paid_with as undefined when no selectedGasFeeToken', () => {
-    const request = createMockRequest({
-      gasFeeTokens: [
-        { symbol: 'ETH', tokenAddress: '0xeth' },
-      ] as unknown as TransactionMeta['gasFeeTokens'],
-      selectedGasFeeToken: undefined,
-    });
-    mockGetNativeTokenAddress.mockReturnValue(
-      '0x0000000000000000000000000000000000000000',
-    );
-
-    const result = getGasMetricsProperties(request);
-
-    expect(result.properties.gas_paid_with).toBeUndefined();
-  });
-
   it('returns gas_insufficient_native_asset as true when balance is insufficient', () => {
     const state = createMockState('0x1');
     const request = createMockRequest(

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/gas.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/gas.ts
@@ -1,5 +1,4 @@
 import {
-  GasFeeEstimateType,
   GasFeeEstimateLevel,
   type TransactionMeta,
 } from '@metamask/transaction-controller';
@@ -21,7 +20,6 @@ export function getGasMetricsProperties({
     chainId,
     dappSuggestedGasFees,
     gasFeeEstimatesLoaded,
-    gasFeeEstimates,
     gasFeeTokens,
     selectedGasFeeToken,
     txParams,
@@ -29,29 +27,11 @@ export function getGasMetricsProperties({
   } = transactionMeta;
 
   const { from } = txParams ?? {};
-  const { type: gasFeeEstimateType } = gasFeeEstimates ?? {};
 
-  const presentedGasFeeOptions = ['custom'];
+  let presentedGasFeeOption: string = GasFeeEstimateLevel.Medium;
 
-  if (gasFeeEstimatesLoaded) {
-    if (
-      gasFeeEstimateType === GasFeeEstimateType.FeeMarket ||
-      gasFeeEstimateType === GasFeeEstimateType.Legacy
-    ) {
-      presentedGasFeeOptions.push(
-        GasFeeEstimateLevel.Low,
-        GasFeeEstimateLevel.Medium,
-        GasFeeEstimateLevel.High,
-      );
-    }
-
-    if (gasFeeEstimateType === GasFeeEstimateType.GasPrice) {
-      presentedGasFeeOptions.push('network_proposed');
-    }
-
-    if (dappSuggestedGasFees) {
-      presentedGasFeeOptions.push('dapp_proposed');
-    }
+  if (dappSuggestedGasFees) {
+    presentedGasFeeOption = 'dapp_proposed';
   }
 
   const gas_payment_tokens_available = gasFeeTokens?.map(
@@ -77,7 +57,7 @@ export function getGasMetricsProperties({
   return {
     properties: {
       gas_estimation_failed: !gasFeeEstimatesLoaded,
-      gas_fee_presented: presentedGasFeeOptions,
+      gas_fee_presented: presentedGasFeeOption,
       gas_fee_selected: userFeeLevel,
       gas_insufficient_native_asset,
       gas_paid_with,

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/gas.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/gas.ts
@@ -28,7 +28,7 @@ export function getGasMetricsProperties({
 
   const { from } = txParams ?? {};
 
-  let presentedGasFeeOption: string = 'n_a';
+  let presentedGasFeeOption: string = 'not_loaded';
 
   if (dappSuggestedGasFees) {
     presentedGasFeeOption = 'dapp_proposed';

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/gas.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/gas.ts
@@ -28,10 +28,12 @@ export function getGasMetricsProperties({
 
   const { from } = txParams ?? {};
 
-  let presentedGasFeeOption: string = GasFeeEstimateLevel.Medium;
+  let presentedGasFeeOption: string = 'n_a';
 
   if (dappSuggestedGasFees) {
     presentedGasFeeOption = 'dapp_proposed';
+  } else if (gasFeeEstimatesLoaded) {
+    presentedGasFeeOption = GasFeeEstimateLevel.Medium;
   }
 
   const gas_payment_tokens_available = gasFeeTokens?.map(


### PR DESCRIPTION
## **Description**

Fix metrics for gas `gas_fee_presented`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5550

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only change that alters the shape/values of the `gas_fee_presented` property; low risk aside from potential downstream analytics/dashboard expectations.
> 
> **Overview**
> Updates `getGasMetricsProperties` to report `gas_fee_presented` as a **single string value** instead of an array of options, simplifying it to `'dapp_proposed'` when dapp-suggested gas fees exist, `'medium'` when estimates are loaded, and `'not_loaded'` otherwise.
> 
> Adjusts unit tests accordingly, removing assertions tied to `GasFeeEstimateType`/multiple fee options and adding coverage for the `'not_loaded'` case; also mocks `getNativeTokenAddress` for deterministic `gas_paid_with` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f11b54cf07c689b5cc3e4704df0f707e86a67bb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->