### PR TITLE
 fix(perps): remove rounded bottom on limit price row when pay row is visible 

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -1280,8 +1280,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
               <View
                 style={[
                   styles.detailItem,
-                  // If TP/SL is hidden, this is the last item so round bottom corners
-                  hideTPSL && styles.detailItemLast,
+                  // Only round bottom corners when this is the last item (no TP/SL and no Pay row below)
+                  hideTPSL && !isPayRowVisible && styles.detailItemLast,
                 ]}
               >
                 <TouchableOpacity onPress={() => setIsLimitPriceVisible(true)}>


### PR DESCRIPTION
## **Description**

When the Perps order form showed both the limit price row and the "Pay with" row (e.g. limit order with no TP/SL), the limit price row kept rounded bottom corners. That made two stacked sections both look like separate cards.

## **Changelog**

CHANGELOG entry: Fixed the limit price row in Perps order form so it no longer shows rounded bottom borders when the Pay with row is visible below it.


## **Related issues**

Jira issue: https://consensyssoftware.atlassian.net/browse/TAT-2520

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="1206" height="2622" alt="simulator_screenshot_AD2D4ECC-99D5-4CD5-8D0B-89695984EA33" src="https://github.com/user-attachments/assets/934c9d45-0d9f-4b27-b248-bebb62ffb756" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI conditional styling change limited to the Perps order details stack; no business logic, data, or transaction flow is affected.
> 
> **Overview**
> Fixes a Perps order form styling bug where the `limit price` row incorrectly kept rounded bottom corners when the `Pay with` row was visible beneath it.
> 
> The `detailItemLast` styling is now applied to the limit price row only when *both* TP/SL is hidden and the pay row is not rendered, preventing two stacked rows from looking like separate cards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee9369c10c785a8215f541c600062850f9b11290. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->