### PR TITLE
fix(perps): show pay row without requiring deposit amount and derive amount from margin

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -360,13 +360,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [shouldOpenLimitPrice, setShouldOpenLimitPrice] = useState(false);
 
-  const [depositAmount, setDepositAmount] = useState<string>('');
-
   const isPayRowVisible = Boolean(
-    isTradeWithAnyTokenEnabled &&
-      depositAmount &&
-      depositAmount.trim() !== '' &&
-      activeTransactionMeta,
+    isTradeWithAnyTokenEnabled && activeTransactionMeta,
   );
 
   // Handle opening limit price modal after order type modal closes
@@ -615,19 +610,14 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     orderForm.limitPrice,
   ]);
 
-  // Prefill deposit amount with margin value when available
-  useEffect(() => {
+  const depositAmount = useMemo(() => {
     if (marginRequired !== undefined && marginRequired !== null) {
-      // Format margin to 2 decimal places for the input field
-      const formattedMargin = new BigNumber(marginRequired)
+      return new BigNumber(marginRequired)
         .decimalPlaces(2, BigNumber.ROUND_HALF_UP)
         .toString(10);
-      setDepositAmount(formattedMargin);
     }
-    // Only depend on marginRequired and orderForm.amount
-    // depositAmount is intentionally excluded to avoid infinite loops
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [marginRequired, orderForm.amount]);
+    return '';
+  }, [marginRequired]);
 
   // Real-time liquidation price calculation
   const { liquidationPrice } = usePerpsLiquidationPrice(liquidationPriceParams);


### PR DESCRIPTION

## **Description**

1. **What is the reason for the change?**  
   The Perps order pay row was only shown when `depositAmount` (local state) was set. That value was prefilled in a `useEffect` from `marginRequired`, so the pay row stayed hidden until the effect ran, causing a loading/visibility issue.

2. **What is the improvement/solution?**  
   - **Pay row visibility**: `isPayRowVisible` now depends only on `isTradeWithAnyTokenEnabled` and `activeTransactionMeta`, so the pay row can show as soon as an order is in progress, without waiting for deposit amount.  
   - **Deposit amount**: Replaced `useState` + `useEffect` with a `useMemo` that derives the formatted deposit amount from `marginRequired`, removing extra state and sync issues.


## **Changelog**

CHANGELOG entry: Fixed the Perps order pay row not appearing until margin was loaded.


## **Related issues**

Jira issue: https://consensyssoftware.atlassian.net/browse/TAT-2516

## **Manual testing steps**

```gherkin
Feature: Perps order view pay row visibility

  Scenario: user opens order view with trade-with-token enabled and active order
    Given the user has "trade with any token" enabled and is on the Perps order view with a valid order (amount, etc.)

    When margin is available and there is an active transaction meta
    Then the pay row is visible without waiting for deposit amount to be set

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/f73b856c-2d75-44c8-b834-076bf68d5e24



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-state refactor in `PerpsOrderView` that changes when the Pay row appears and how `depositAmount` is derived; limited scope with low likelihood of affecting order execution beyond display/quoting updates.
> 
> **Overview**
> Fixes a Perps order view loading/visibility issue by **showing the Pay row as soon as** `trade with any token` is enabled and an `activeTransactionMeta` exists, instead of waiting for a locally-set `depositAmount`.
> 
> Refactors `depositAmount` to be **derived from `marginRequired` via `useMemo`** (formatted to 2 decimals) rather than managed with `useState` + `useEffect`, reducing sync/race issues between margin calculation and UI updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 824dc8c552d28f8d8645fddd5690afa893182888. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->