### PR TITLE
Perps: row item styles

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.styles.ts
@@ -36,6 +36,10 @@ const styleSheet = (params: { theme: Theme }) => {
     headerTitle: {
       textAlign: 'left',
     },
+    marketListHeaderTitle: {
+      fontSize: 24,
+      lineHeight: 34,
+    },
     headerActions: {
       flexDirection: 'row',
       alignItems: 'center',

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -207,6 +207,9 @@ const PerpsMarketListView = ({
   });
 
   const renderMarketList = () => {
+    // Figma market list rows use compact dimensions.
+    const isCompactMarketRows = true;
+
     // Skeleton List - show immediately while loading
     if (isLoadingMarkets) {
       return (
@@ -309,6 +312,10 @@ const PerpsMarketListView = ({
           onMarketPress={handleMarketPress}
           sortBy={sortBy}
           showBadge={false}
+          iconSize={isCompactMarketRows ? 32 : undefined}
+          rowVerticalPadding={isCompactMarketRows ? 0 : undefined}
+          rowHeight={isCompactMarketRows ? 54 : undefined}
+          rowIsCompact={isCompactMarketRows}
           filterKey={marketTypeFilter}
           testID={PerpsMarketListViewSelectorsIDs.MARKET_LIST}
         />

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -13,6 +13,7 @@ import Icon, {
 } from '../../../../../component-library/components/Icons/Icon';
 import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import TextFieldSearch from '../../../../../component-library/components/Form/TextFieldSearch/TextFieldSearch';
+import { HeaderBaseVariant } from '../../../../../component-library/components/HeaderBase';
 import { strings } from '../../../../../../locales/i18n';
 import Text, {
   TextVariant,
@@ -318,7 +319,9 @@ const PerpsMarketListView = ({
   return (
     <SafeAreaView style={styles.container}>
       <HeaderCompactStandard
+        variant={HeaderBaseVariant.Display}
         title={title || strings('perps.home.markets')}
+        titleProps={{ style: styles.marketListHeaderTitle }}
         onBack={handleBackPressed}
         backButtonProps={{
           testID: `${PerpsMarketListViewSelectorsIDs.CLOSE_BUTTON}-back-button`,

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -329,6 +329,7 @@ const PerpsMarketListView = ({
         variant={HeaderBaseVariant.Display}
         title={title || strings('perps.home.markets')}
         titleProps={{ style: styles.marketListHeaderTitle }}
+        twClassName="gap-1.5"
         onBack={handleBackPressed}
         backButtonProps={{
           testID: `${PerpsMarketListViewSelectorsIDs.CLOSE_BUTTON}-back-button`,

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -114,6 +114,11 @@ const PerpsTabView = () => {
       ? styles.exploreSectionHeaderWithBalance // 24px/4px
       : styles.exploreSectionHeaderNoBalance; // 16px/4px
 
+  // Orders header: depends on whether positions are visible
+  const ordersHeaderStyle = hasPositions
+    ? styles.ordersHeaderBelowPositions // 20px/8px
+    : styles.ordersHeaderAtTop; // 24px/4px
+
   // Track wallet home perps tab viewed - declarative (main's event name, privacy-compliant count)
   usePerpsEventTracking({
     eventName: MetaMetricsEvents.PERPS_SCREEN_VIEWED,
@@ -204,7 +209,7 @@ const PerpsTabView = () => {
 
     return (
       <>
-        <View style={styles.sectionHeader}>
+        <View style={[styles.sectionHeader, ordersHeaderStyle]}>
           <Text variant={TextVariant.BodyMDMedium} style={styles.sectionTitle}>
             {strings('perps.order.open_orders')}
           </Text>
@@ -242,7 +247,7 @@ const PerpsTabView = () => {
 
     return (
       <>
-        <View style={styles.sectionHeader}>
+        <View style={[styles.sectionHeader, styles.positionsHeader]}>
           <Text
             variant={TextVariant.BodyMDMedium}
             style={styles.sectionTitle}

--- a/app/components/UI/Perps/components/PerpsHomeSection/PerpsHomeSection.tsx
+++ b/app/components/UI/Perps/components/PerpsHomeSection/PerpsHomeSection.tsx
@@ -124,13 +124,16 @@ const PerpsHomeSection: React.FC<PerpsHomeSectionProps> = ({
   }
 
   const showAction = onActionPress && !isLoading && !isEmpty;
-
   return (
     <View style={styles.section} testID={testID}>
       {/* Section Header */}
       <View style={styles.headerContainer}>
         <SectionHeader
-          title={title}
+          title={
+            <Text variant={TextVariant.BodyLGMedium} color={TextColor.Default}>
+              {title}
+            </Text>
+          }
           justifyContent={showAction ? BoxJustifyContent.Between : undefined}
           endAccessory={
             showAction ? (

--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.tsx
@@ -45,6 +45,9 @@ const PerpsMarketList: React.FC<PerpsMarketListProps> = ({
   sortBy = 'volume',
   showBadge = true,
   contentContainerStyle,
+  rowVerticalPadding,
+  rowHeight,
+  rowIsCompact,
   filterKey,
   testID = 'perps-market-list',
 }) => {
@@ -58,9 +61,20 @@ const PerpsMarketList: React.FC<PerpsMarketListProps> = ({
         iconSize={iconSize}
         displayMetric={sortBy}
         showBadge={showBadge}
+        verticalPadding={rowVerticalPadding}
+        rowHeight={rowHeight}
+        isCompact={rowIsCompact}
       />
     ),
-    [onMarketPress, iconSize, sortBy, showBadge],
+    [
+      onMarketPress,
+      iconSize,
+      sortBy,
+      showBadge,
+      rowVerticalPadding,
+      rowHeight,
+      rowIsCompact,
+    ],
   );
 
   const renderEmpty = useCallback(

--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.types.ts
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.types.ts
@@ -49,6 +49,21 @@ export interface PerpsMarketListProps {
    */
   contentContainerStyle?: StyleProp<ViewStyle>;
   /**
+   * Optional vertical padding for each market row item.
+   * Used for compact displays (e.g., search results).
+   */
+  rowVerticalPadding?: number;
+  /**
+   * Optional fixed height for each market row item.
+   * Used for compact displays (e.g., search results).
+   */
+  rowHeight?: number;
+  /**
+   * Compact mode for market row items.
+   * Used for compact displays (e.g., search results).
+   */
+  rowIsCompact?: boolean;
+  /**
    * Optional key to force FlashList re-mount when filters change.
    * This fixes rendering issues when data changes rapidly.
    */

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.styles.ts
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.styles.ts
@@ -34,7 +34,7 @@ const styleSheet = (params: {
     tokenHeader: {
       flexDirection: 'row',
       alignItems: 'center',
-      gap: 8,
+      gap: 6,
     },
     secondRow: {
       flexDirection: 'row',

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.styles.ts
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.styles.ts
@@ -1,12 +1,24 @@
 import { StyleSheet } from 'react-native';
 
-const styleSheet = (params: { vars: { compact: boolean } }) =>
-  StyleSheet.create({
+const styleSheet = (params: {
+  vars: {
+    compact?: boolean;
+    verticalPadding?: number;
+    rowHeight?: number;
+    isCompact?: boolean;
+  };
+}) => {
+  const isCompact = params.vars.isCompact ?? params.vars.compact ?? false;
+  const verticalPadding = params.vars.verticalPadding ?? (isCompact ? 8 : 12);
+  const rowHeight = params.vars.rowHeight;
+
+  return StyleSheet.create({
     container: {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      paddingVertical: params.vars.compact ? 8 : 12,
+      paddingVertical: verticalPadding,
+      ...(rowHeight !== undefined && { height: rowHeight }),
     },
     perpIcon: {
       marginRight: 16,
@@ -28,7 +40,7 @@ const styleSheet = (params: { vars: { compact: boolean } }) =>
       flexDirection: 'row',
       alignItems: 'center',
       gap: 8,
-      marginTop: 2,
+      marginTop: isCompact ? 0 : 2,
     },
     rightSection: {
       alignItems: 'flex-end',
@@ -38,11 +50,12 @@ const styleSheet = (params: { vars: { compact: boolean } }) =>
       alignItems: 'flex-end',
     },
     price: {
-      marginBottom: 2,
+      marginBottom: isCompact ? 0 : 2,
     },
     priceChange: {
-      marginTop: 2,
+      marginTop: isCompact ? 0 : 2,
     },
   });
+};
 
 export default styleSheet;

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
@@ -36,8 +36,17 @@ const PerpsMarketRowItem = ({
   displayMetric = 'volume',
   showBadge = false, // We can re-enable this if/when we decide to render the badges for stocks and commodities
   compact = false,
+  verticalPadding,
+  rowHeight,
+  isCompact,
 }: PerpsMarketRowItemProps) => {
-  const { styles } = useStyles(styleSheet, { compact });
+  const resolvedCompact = isCompact ?? compact;
+  const { styles } = useStyles(styleSheet, {
+    compact: resolvedCompact,
+    verticalPadding,
+    rowHeight,
+    isCompact: resolvedCompact,
+  });
 
   // Subscribe to live prices for just this symbol
   const livePrices = usePerpsLivePrices({

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.types.ts
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.types.ts
@@ -35,9 +35,24 @@ export interface PerpsMarketRowItemProps {
    */
   showBadge?: boolean;
   /**
-   * When true, uses reduced vertical padding (8px instead of 16px).
-   * Useful when embedded in feed cards alongside other row item types.
+   * Legacy compact mode.
+   * When true, uses reduced vertical padding and compact inner spacing.
    * @default false
    */
   compact?: boolean;
+  /**
+   * Optional vertical padding for the row container.
+   * Used for compact displays (e.g., search results).
+   */
+  verticalPadding?: number;
+  /**
+   * Optional fixed height for the row container.
+   * Used for compact displays (e.g., search results).
+   */
+  rowHeight?: number;
+  /**
+   * Compact mode for search results.
+   * Adjusts internal spacing to fit the compact row height.
+   */
+  isCompact?: boolean;
 }

--- a/app/components/UI/Perps/components/PerpsMarketTypeSection/PerpsMarketTypeSection.styles.ts
+++ b/app/components/UI/Perps/components/PerpsMarketTypeSection/PerpsMarketTypeSection.styles.ts
@@ -13,6 +13,9 @@ const styleSheet = (params: { theme: Theme }) => {
       paddingVertical: 4,
       backgroundColor: theme.colors.background.muted,
     },
+    marketListContentContainer: {
+      paddingBottom: 0,
+    },
   });
 };
 

--- a/app/components/UI/Perps/components/PerpsMarketTypeSection/PerpsMarketTypeSection.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTypeSection/PerpsMarketTypeSection.tsx
@@ -131,6 +131,7 @@ const PerpsMarketTypeSection: React.FC<PerpsMarketTypeSectionProps> = ({
           sortBy={sortBy}
           onMarketPress={handleMarketPress}
           showBadge={false}
+          contentContainerStyle={styles.marketListContentContainer}
         />
       </View>
     </View>

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.styles.ts
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.styles.ts
@@ -49,7 +49,7 @@ const styleSheet = (params: { theme: Theme }) => {
       flex: 1,
     },
     iconContainer: {
-      marginRight: 12,
+      marginRight: 16,
     },
     activityInfo: {
       flex: 1,

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.styles.ts
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.styles.ts
@@ -14,7 +14,7 @@ const styleSheet = (params: { theme: Theme }) => {
     header: {
       flexDirection: 'row',
       alignItems: 'center',
-      marginBottom: 8,
+      marginBottom: 12,
       paddingHorizontal: 16,
     },
     titleRow: {

--- a/app/components/UI/Perps/components/PerpsWatchlistMarkets/PerpsWatchlistMarkets.styles.ts
+++ b/app/components/UI/Perps/components/PerpsWatchlistMarkets/PerpsWatchlistMarkets.styles.ts
@@ -21,8 +21,6 @@ const styleSheet = (params: { theme: Theme }) => {
     contentContainer: {
       marginHorizontal: 16,
       borderRadius: 16,
-      paddingTop: 8,
-      paddingBottom: 8,
       backgroundColor: theme.colors.background.section,
     },
     listContent: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Perps: align Activity/Home row spacing and compact Markets rows
  Summary
  market-row support for explore/filter/search list states.

  Issues addressed (Before -> After)
  1. Activity row padding/radius/icon gap mismatch
  - Before: padding: 12, row corner radius 8, icon gap 12.
  - After: paddingVertical: 16, paddingHorizontal: 16, row corner radius 16, icon gap 16.
  - Code: PerpsRecentActivityList.styles.ts
  2. Extra container vertical padding on Home sections
  - Before: section containers added extra vertical padding in addition to row padding.
  - After: container vertical padding removed so vertical rhythm comes from rows.
  - Code: PerpsHomeView.styles.ts, PerpsWatchlistMarkets.styles.ts, PerpsMarketTypeSection.styles.ts
  3. Market type section bottom whitespace
  - Before: extra list bottom spacing in Home market card.
  - After: PerpsMarketTypeSection passes contentContainerStyle with bottom override.
  - Code: PerpsMarketTypeSection.tsx, PerpsMarketTypeSection.styles.ts

  - Before: PerpsCard used paddingVertical: 6.
  - After: PerpsCard uses paddingVertical: 16.
  - Code: PerpsCard.styles.ts

  5. Compact market rows for list/filter/search states

  - Before: market rows used default (larger) row layout.
  - After: compact row dimensions applied (height: 54, icon 32, no extra vertical row padding) in Market List view.
  - Code: PerpsMarketListView.tsx

  6. Reusable compact row props in list/item components

  - Before: PerpsMarketList / PerpsMarketRowItem did not accept compact layout params.
  - After: added row sizing/padding/compact props and style handling.
  - Code: PerpsMarketList.tsx, PerpsMarketList.types.ts, PerpsMarketRowItem.tsx, PerpsMarketRowItem.types.ts, PerpsMarketRowItem.styles.ts,
    PerpsMarketRowItem.test.tsx

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: align Activity/Home row spacing and compact Markets rows

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
