### PR TITLE
fix: time left translation string

### DIFF
--- a/app/components/UI/Rewards/components/RewardItem/RewardItem.test.tsx
+++ b/app/components/UI/Rewards/components/RewardItem/RewardItem.test.tsx
@@ -42,7 +42,12 @@ const mockSelectRewardsActiveAccountAddress =
 
 // Mock i18n
 jest.mock('../../../../../../locales/i18n', () => ({
-  strings: jest.fn((key: string) => key),
+  strings: jest.fn((key: string, params?: Record<string, string | number>) => {
+    if (params) {
+      return `${key} ${JSON.stringify(params)}`;
+    }
+    return key;
+  }),
 }));
 
 // Mock format utils
@@ -277,8 +282,8 @@ describe('RewardItem', () => {
         />,
       );
 
-      expect(getByText(/2d 5h/)).toBeDefined();
       expect(getByText(/rewards.unlocked_rewards.time_left/)).toBeDefined();
+      expect(getByText(/2d 5h/)).toBeDefined();
     });
 
     it('hides claim button when end of season reward claim has expired', () => {

--- a/app/components/UI/Rewards/components/RewardItem/RewardItem.tsx
+++ b/app/components/UI/Rewards/components/RewardItem/RewardItem.tsx
@@ -143,7 +143,9 @@ const RewardItem: React.FC<RewardItemProps> = ({
               fontWeight={FontWeight.Medium}
               twClassName="text-text-alternative"
             >
-              {remainingTime} {strings('rewards.unlocked_rewards.time_left')}
+              {strings('rewards.unlocked_rewards.time_left', {
+                time: remainingTime,
+              })}
             </Text>
           </Box>
         );

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -7470,7 +7470,7 @@
       "claim_label": "Einfordern",
       "claimed_label": "Eingefordert",
       "reward_claimed": "Belohnung eingefordert",
-      "time_left": "verbleibend",
+      "time_left": "{{time}} verbleibend",
       "expired": "Abgelaufen"
     },
     "end_of_season_rewards": {

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -7470,7 +7470,7 @@
       "claim_label": "Εξαργύρωση",
       "claimed_label": "Διεκδικήθηκε",
       "reward_claimed": "Η ανταμοιβή εξαργυρώθηκε",
-      "time_left": "απομένει",
+      "time_left": "απομένει {{time}}",
       "expired": "Έληξε"
     },
     "end_of_season_rewards": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7552,7 +7552,7 @@
       "claim_label": "Claim",
       "claimed_label": "Claimed",
       "reward_claimed": "Reward claimed",
-      "time_left": "left",
+      "time_left": "{{time}} left",
       "expired": "Expired"
     },
     "end_of_season_rewards": {

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -7470,7 +7470,7 @@
       "claim_label": "Reclamar",
       "claimed_label": "Reclamada",
       "reward_claimed": "Recompensa reclamada",
-      "time_left": "restantes",
+      "time_left": "{{time}} restantes",
       "expired": "Vencida"
     },
     "end_of_season_rewards": {

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -7470,7 +7470,7 @@
       "claim_label": "Réclamer",
       "claimed_label": "Réclamé",
       "reward_claimed": "Récompense réclamée",
-      "time_left": "Il reste",
+      "time_left": "Il reste {{time}}",
       "expired": "Expiré"
     },
     "end_of_season_rewards": {

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -7470,7 +7470,7 @@
       "claim_label": "क्लेम करें",
       "claimed_label": "क्लेम किया गया",
       "reward_claimed": "रिवॉर्ड क्लेम किया गया",
-      "time_left": "बचा है",
+      "time_left": "{{time}} बचा है",
       "expired": "एक्सपायर हो गया"
     },
     "end_of_season_rewards": {

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -7470,7 +7470,7 @@
       "claim_label": "Klaim",
       "claimed_label": "Diklaim",
       "reward_claimed": "Reward diklaim",
-      "time_left": "tersisa",
+      "time_left": "{{time}} tersisa",
       "expired": "Kedaluwarsa"
     },
     "end_of_season_rewards": {

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -7470,7 +7470,7 @@
       "claim_label": "請求",
       "claimed_label": "請求済み",
       "reward_claimed": "リワードを請求しました",
-      "time_left": "残り",
+      "time_left": "残り {{time}}",
       "expired": "期限切れ"
     },
     "end_of_season_rewards": {

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -7470,7 +7470,7 @@
       "claim_label": "청구",
       "claimed_label": "받음",
       "reward_claimed": "보상받음",
-      "time_left": "남음",
+      "time_left": "{{time}} 남음",
       "expired": "만료됨"
     },
     "end_of_season_rewards": {

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -7470,7 +7470,7 @@
       "claim_label": "Resgatar",
       "claimed_label": "Resgatada",
       "reward_claimed": "Recompensa resgatada",
-      "time_left": "restante",
+      "time_left": "{{time}} restante",
       "expired": "Expirada"
     },
     "end_of_season_rewards": {

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -7470,7 +7470,7 @@
       "claim_label": "Получить",
       "claimed_label": "Получено",
       "reward_claimed": "Вознаграждение получено",
-      "time_left": "осталось",
+      "time_left": "осталось {{time}}",
       "expired": "Просрочено"
     },
     "end_of_season_rewards": {

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -7470,7 +7470,7 @@
       "claim_label": "I-claim",
       "claimed_label": "Na-claim",
       "reward_claimed": "Na-claim na reward",
-      "time_left": "natitira",
+      "time_left": "{{time}} natitira",
       "expired": "Nag-expire"
     },
     "end_of_season_rewards": {

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -7470,7 +7470,7 @@
       "claim_label": "Al",
       "claimed_label": "Alındı",
       "reward_claimed": "Ödül alındı",
-      "time_left": "kaldı",
+      "time_left": "{{time}} kaldı",
       "expired": "Süresi doldu"
     },
     "end_of_season_rewards": {

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -7470,7 +7470,7 @@
       "claim_label": "Nhận",
       "claimed_label": "Đã nhận",
       "reward_claimed": "Phần thưởng đã nhận",
-      "time_left": "còn lại",
+      "time_left": "còn {{time}}",
       "expired": "Đã hết hạn"
     },
     "end_of_season_rewards": {

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -7470,7 +7470,7 @@
       "claim_label": "领取",
       "claimed_label": "已领取",
       "reward_claimed": "已领取奖励",
-      "time_left": "剩余时间",
+      "time_left": "剩余 {{time}}",
       "expired": "已过期"
     },
     "end_of_season_rewards": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fix time left appears out of order in some languages https://consensyssoftware.atlassian.net/browse/RWDS-1006
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/i18n-only change affecting a single label; main risk is incorrect placeholder usage causing bad rendering in some locales.
> 
> **Overview**
> Fixes the **"time left" label ordering** in the rewards UI by switching `RewardItem` to render `rewards.unlocked_rewards.time_left` as a parameterized i18n string (passing `{ time: remainingTime }`) instead of concatenating `remainingTime` + label.
> 
> Updates `time_left` translations across all supported locales to include a `{{time}}` placeholder (with language-appropriate placement), and adjusts the `RewardItem` test i18n mock to support params so the time-left assertions continue to pass.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d097fe42b0c306412348d4797a2af67524cf663. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->