### PR TITLE
feat: homogenize spacing on Explore page for perps items

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.styles.ts
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.styles.ts
@@ -1,12 +1,12 @@
 import { StyleSheet } from 'react-native';
 
-const styleSheet = () =>
+const styleSheet = (params: { vars: { compact: boolean } }) =>
   StyleSheet.create({
     container: {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      paddingVertical: 16,
+      paddingVertical: params.vars.compact ? 8 : 16,
     },
     perpIcon: {
       marginRight: 16,

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
@@ -11,13 +11,7 @@ jest.mock('../../../../../component-library/hooks', () => ({
     const actualStyleSheet = jest.requireActual(
       './PerpsMarketRowItem.styles',
     ).default;
-    const mockTheme = {
-      colors: {
-        background: { default: '#FFFFFF', muted: '#F2F4F6' },
-        text: { default: '#24272A', muted: '#6A737D' },
-      },
-    };
-    return { styles: actualStyleSheet({ theme: mockTheme }) };
+    return { styles: actualStyleSheet({ vars: { compact: false } }) };
   }),
 }));
 

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
@@ -37,8 +37,9 @@ const PerpsMarketRowItem = ({
   iconSize = HOME_SCREEN_CONFIG.DefaultIconSize,
   displayMetric = 'volume',
   showBadge = false, // We can re-enable this if/when we decide to render the badges for stocks and commodities
+  compact = false,
 }: PerpsMarketRowItemProps) => {
-  const { styles } = useStyles(styleSheet, {});
+  const { styles } = useStyles(styleSheet, { compact });
 
   // Subscribe to live prices for just this symbol
   const livePrices = usePerpsLivePrices({

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.types.ts
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.types.ts
@@ -32,4 +32,10 @@ export interface PerpsMarketRowItemProps {
    * @default true
    */
   showBadge?: boolean;
+  /**
+   * When true, uses reduced vertical padding (8px instead of 16px).
+   * Useful when embedded in feed cards alongside other row item types.
+   * @default false
+   */
+  compact?: boolean;
 }

--- a/app/components/Views/TrendingView/sections.config.tsx
+++ b/app/components/Views/TrendingView/sections.config.tsx
@@ -222,6 +222,7 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
           );
         }}
         showBadge={false}
+        compact
       />
     ),
     // Using trending skeleton cause PerpsMarketRowSkeleton has too much spacing


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Homogenized spacing on Explore page for perps items by adding a compact mode for PerpsMarketRowItem styling.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: homogenize spacing on Explore page for perps items

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2634

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="399" height="813" alt="image" src="https://github.com/user-attachments/assets/5536c575-6b64-4885-8494-93b7b26fc4c8" />

<!-- [screenshots/recordings] -->

### **After**
<img width="394" height="823" alt="image" src="https://github.com/user-attachments/assets/a36c85e8-e9db-4dea-9cab-ea75c28392f6" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely UI spacing behavior gated behind a new optional prop and a single call site, with minimal blast radius and no data/auth logic changes.
> 
> **Overview**
> Adds an optional `compact` mode to `PerpsMarketRowItem` that reduces vertical padding (16px  8px) via `useStyles` vars, enabling tighter list spacing.
> 
> Updates Trending/Explore perps rows to render in compact mode, and adjusts the component test mocks to match the new `useStyles` params signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7734b043053fd45d618dba3ac4605b1a38a355e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->