### PR TITLE
chore: remove selected swap token pinning logic

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -176,31 +176,14 @@ export const BridgeTokenSelector: React.FC = () => {
   );
 
   // Create includeAssets array from tokens with balance to be sent to API
-  // Selected token is prepended to pin it to the top of the list
   // Stringified to avoid triggering the useEffect when only balances change
   const includeAssets = useMemo(() => {
-    // Only include selected token if it matches current network and search filters
-    const shouldPinSelectedToken =
-      selectedToken &&
-      chainIdsToFetch.includes(formatChainIdToCaip(selectedToken.chainId)) &&
-      tokenMatchesQuery(selectedToken, searchQuery);
-
-    const selectedAsset = shouldPinSelectedToken
-      ? tokenToIncludeAsset(selectedToken)
-      : null;
-
-    // Convert balance tokens, excluding selected to avoid duplicates
     const balanceAssets = filteredTokensWithBalance
       .map(tokenToIncludeAsset)
-      .filter(
-        (asset): asset is IncludeAsset =>
-          asset !== null && asset.assetId !== selectedAsset?.assetId,
-      );
+      .filter((asset): asset is IncludeAsset => asset !== null);
 
-    return JSON.stringify(
-      selectedAsset ? [selectedAsset, ...balanceAssets] : balanceAssets,
-    );
-  }, [filteredTokensWithBalance, selectedToken, chainIdsToFetch, searchQuery]);
+    return JSON.stringify(balanceAssets);
+  }, [filteredTokensWithBalance]);
 
   // Fetch popular tokens
   const { popularTokens, isLoading: isPopularTokensLoading } = usePopularTokens(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Remove the logic in BridgeTokenSelector that pins the currently selected token to the top of the includeAssets list sent to the popular tokens and search APIs. Previously, the includeAssets memo would prepend the selected token to ensure it always appeared first in the asset list. This pinning is no longer needed — the selected token should appear in its natural sorted position alongside other tokens.
The change simplifies the includeAssets memo by removing the shouldPinSelectedToken check, the selectedAsset construction, the duplicate-exclusion filter, and the conditional prepending. The dependency array is also simplified from [filteredTokensWithBalance, selectedToken, chainIdsToFetch, searchQuery] to just [filteredTokensWithBalance], which reduces unnecessary recomputation when the selected token or network filter changes without affecting the underlying balance list.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Token list ordering in Bridge asset picker

  Scenario: selected token is not pinned to the top of the list
    Given the user has a source token selected (e.g. USDC on Ethereum)
    And the user opens the Bridge token selector

    When the token list loads
    Then the previously selected token appears in its natural sorted position
    And the previously selected token is NOT forced to the top of the list

  Scenario: token list displays correctly after network filter change
    Given the user has the Bridge token selector open
    And a specific network filter is selected

    When the user switches to a different network or "All"
    Then the token list updates to show tokens for the selected network
    And no token is artificially pinned to the top

  Scenario: search results are unaffected by selected token
    Given the user has a source token selected
    And the user opens the Bridge token selector

    When the user searches for a token (e.g. "ETH")
    Then search results appear in their natural API-returned order
    And the selected token is not prepended to search results
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to token-list ordering/filtering logic; risk is limited to which assets are prioritized in bridge token API queries.
> 
> **Overview**
> Removes the Bridge token selector logic that *prepended/pinned the currently selected token* into the `includeAssets` list used by `usePopularTokens`/`useSearchTokens`.
> 
> `includeAssets` is now derived solely from `filteredTokensWithBalance` (stringified), dropping the selected-token filtering/deduping and narrowing the memo dependencies accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd23006e527caeb90aeb2c972104ff552333cd47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->