### PR TITLE
fix(perps):  cp-7.65.0 markets filters

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketCategoryBadge/PerpsMarketCategoryBadge.styles.ts
+++ b/app/components/UI/Perps/components/PerpsMarketCategoryBadge/PerpsMarketCategoryBadge.styles.ts
@@ -10,8 +10,8 @@ export const styleSheet = (params: {
     vars: { isSelected },
   } = params;
 
-  // Use same base styling as PerpsMarketSortDropdowns for visual consistency
-  // Selected state: inverse overlay background for high contrast distinction
+  // Selected state: uses icon.default as bg (dark in light mode, white in dark mode)
+  // with icon.inverse text for strong contrast in both themes.
   // Unselected state: muted background (same as Volume dropdown)
   return StyleSheet.create({
     badge: {
@@ -22,7 +22,7 @@ export const styleSheet = (params: {
       paddingVertical: 8,
       borderRadius: 8,
       backgroundColor: isSelected
-        ? theme.colors.overlay.inverse
+        ? theme.colors.icon.default
         : theme.colors.background.muted,
       gap: 4,
     },

--- a/app/components/UI/Perps/components/PerpsMarketCategoryBadges/PerpsMarketCategoryBadges.styles.ts
+++ b/app/components/UI/Perps/components/PerpsMarketCategoryBadges/PerpsMarketCategoryBadges.styles.ts
@@ -3,12 +3,6 @@ import type { Theme } from '../../../../../util/theme/models';
 
 export const styleSheet = (_params: { theme: Theme }) =>
   StyleSheet.create({
-    // Used for single selected badge (View container)
-    container: {
-      flexDirection: 'row',
-      paddingVertical: 8,
-      paddingHorizontal: 16,
-    },
     // Used for ScrollView when showing all badges
     scrollContainer: {
       flexDirection: 'row',

--- a/app/components/UI/Perps/components/PerpsMarketCategoryBadges/PerpsMarketCategoryBadges.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketCategoryBadges/PerpsMarketCategoryBadges.test.tsx
@@ -70,22 +70,28 @@ describe('PerpsMarketCategoryBadges', () => {
   });
 
   describe('Selected state (category selected)', () => {
-    it('shows only selected badge with dismiss icon when category is selected', () => {
-      const { getByText, queryByText, getByTestId } = render(
+    it('shows all badges when a category is selected, with dismiss icon on selected one', () => {
+      const { getByText, getByTestId, queryByTestId } = render(
         <PerpsMarketCategoryBadges
           {...defaultProps}
           selectedCategory="crypto"
         />,
       );
 
+      // All badges should remain visible
       expect(getByText('Crypto')).toBeTruthy();
+      expect(getByText('Stocks')).toBeTruthy();
+      expect(getByText('Commodities')).toBeTruthy();
+      expect(getByText('Forex')).toBeTruthy();
+
+      // Selected badge should show dismiss icon, others should not
       expect(getByTestId('category-badges-crypto-dismiss')).toBeTruthy();
-      expect(queryByText('Stocks')).toBeNull();
-      expect(queryByText('Commodities')).toBeNull();
-      expect(queryByText('Forex')).toBeNull();
+      expect(queryByTestId('category-badges-stocks-dismiss')).toBeNull();
+      expect(queryByTestId('category-badges-commodities-dismiss')).toBeNull();
+      expect(queryByTestId('category-badges-forex-dismiss')).toBeNull();
     });
 
-    it('calls onCategorySelect with "all" when dismiss is pressed', () => {
+    it('calls onCategorySelect with "all" when selected badge is tapped again (toggle off)', () => {
       const onCategorySelect = jest.fn();
       const { getByTestId } = render(
         <PerpsMarketCategoryBadges
@@ -95,16 +101,31 @@ describe('PerpsMarketCategoryBadges', () => {
         />,
       );
 
-      // Press the badge (which triggers dismiss when showDismiss is true)
+      // Tapping the already-selected badge should deselect (back to 'all')
       fireEvent.press(getByTestId('category-badges-crypto'));
       expect(onCategorySelect).toHaveBeenCalledWith('all');
     });
 
-    it('renders selected badge for each category type', () => {
-      const categories = ['crypto', 'stocks', 'commodities', 'forex'] as const;
-      const labels = ['Crypto', 'Stocks', 'Commodities', 'Forex'];
+    it('calls onCategorySelect with new category when unselected badge is tapped', () => {
+      const onCategorySelect = jest.fn();
+      const { getByText } = render(
+        <PerpsMarketCategoryBadges
+          {...defaultProps}
+          selectedCategory="crypto"
+          onCategorySelect={onCategorySelect}
+        />,
+      );
 
-      categories.forEach((category, index) => {
+      // Tapping a different badge should select that category
+      fireEvent.press(getByText('Stocks'));
+      expect(onCategorySelect).toHaveBeenCalledWith('stocks');
+    });
+
+    it('renders all badges for each selected category type', () => {
+      const categories = ['crypto', 'stocks', 'commodities', 'forex'] as const;
+      const allLabels = ['Crypto', 'Stocks', 'Commodities', 'Forex'];
+
+      categories.forEach((category) => {
         const { getByText } = render(
           <PerpsMarketCategoryBadges
             {...defaultProps}
@@ -112,7 +133,10 @@ describe('PerpsMarketCategoryBadges', () => {
           />,
         );
 
-        expect(getByText(labels[index])).toBeTruthy();
+        // All badges should be visible regardless of which is selected
+        allLabels.forEach((label) => {
+          expect(getByText(label)).toBeTruthy();
+        });
       });
     });
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The Perps market category filter pills had two UX issues:

1. **Pills disappeared when a category was selected** — selecting a category (e.g. "Crypto") would hide all other pills and show only the selected one with a dismiss "×". This made it impossible to quickly switch between categories without first dismissing the current filter.

2. **Selected pill was invisible in light mode** — the selected pill background used `theme.colors.overlay.inverse` which resolves to `#ffffff` (white) in **both** light and dark themes. On a white/light background this made the selected pill completely invisible.

### Changes

**`PerpsMarketCategoryBadges`** — Removed the dual-render-path pattern. The component now always renders all pills in a horizontal `ScrollView`. The selected pill is visually highlighted and shows a dismiss "×" icon. Tapping the selected pill toggles it off (back to "all"). Tapping another pill switches the filter directly. Removed unused `View` and `FadeOut` imports, and the unused `container` style.

**`PerpsMarketCategoryBadge.styles`** — Changed the selected pill background from `overlay.inverse` (`#ffffff` in both themes) to `icon.default` (`#121314` in light mode, `#ffffff` in dark mode), ensuring strong contrast in both themes. Text color (`icon.inverse`) already correctly inverts per theme.

**Tests** — Updated `PerpsMarketCategoryBadges.test.tsx` to reflect the new behavior: all pills remain visible when one is selected, tapping a selected pill deselects it, tapping a different pill switches categories, and the dismiss icon only appears on the selected pill.

## **Changelog**

CHANGELOG entry: Fixed Perps market category filter pills disappearing when a category is selected, and fixed selected pill being invisible in light mode

## **Related issues**

Fixes: #25900

## **Manual testing steps**

```gherkin
Feature: Perps Market Category Filter Pills

  Scenario: user views category pills with no filter active
    Given the user is on the Perps markets list screen
    And no category filter is selected

    When the user views the filter bar
    Then all category pills (Crypto, Stocks, Commodities, Forex, New) are visible
    And no pill is highlighted

  Scenario: user selects a category filter
    Given the user is on the Perps markets list screen
    And no category filter is selected

    When the user taps the "Crypto" pill
    Then the "Crypto" pill is highlighted with a dark background (light mode) or white background (dark mode)
    And the "Crypto" pill shows a dismiss "×" icon
    And all other pills (Stocks, Commodities, Forex, New) remain visible and unselected
    And the market list is filtered to show only Crypto markets

  Scenario: user deselects a category filter by tapping the selected pill
    Given the user is on the Perps markets list screen
    And the "Crypto" category filter is active

    When the user taps the "Crypto" pill (or its dismiss "×" icon)
    Then no category filter is active
    And all pills return to unselected state
    And the market list shows all markets

  Scenario: user switches category filter directly
    Given the user is on the Perps markets list screen
    And the "Crypto" category filter is active

    When the user taps the "Stocks" pill
    Then the "Stocks" pill becomes highlighted with dismiss icon
    And the "Crypto" pill returns to unselected state
    And the market list is filtered to show only Stocks markets

  Scenario: selected pill is visible in light mode
    Given the user is using the app in light mode
    And the user is on the Perps markets list screen

    When the user taps any category pill
    Then the selected pill is clearly visible with a dark background and white text
    And it is distinguishable from the unselected pills
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

- Selecting a category hid all other pills, showing only the selected one
- Selected pill was invisible in light mode (white on white)

### **After**

- All pills always remain visible; selected pill is highlighted with dismiss "×"
- Selected pill has strong contrast in both light and dark modes


https://github.com/user-attachments/assets/f54536f0-29e2-4c71-8bdd-d4549db51619



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only behavior/styling change limited to the Perps category filter pills, with updated unit tests; low risk aside from potential UX regressions in selection toggling.
> 
> **Overview**
> Fixes Perps market category filter pills UX by always rendering the full horizontal list and letting the selected pill *toggle off* back to `all` when tapped again (instead of switching to a single-pill dismiss-only view).
> 
> Updates selected-pill styling to use `theme.colors.icon.default` for the background (with `icon.inverse` text) to ensure the selected state is visible in light mode, removes unused container styling/animations, and adjusts tests to cover the new toggle/switch and dismiss-icon behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8411e053ce73446d6d8ab2b239b361266d806cab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->