### PR TITLE
refactor(qr-scanner): improve camera permission handling in AnimatedQRScannerModal

### DIFF
--- a/app/components/UI/QRHardware/AnimatedQRScanner.test.tsx
+++ b/app/components/UI/QRHardware/AnimatedQRScanner.test.tsx
@@ -601,26 +601,48 @@ describe('AnimatedQRScannerModal - Metrics', () => {
   });
 
   describe('Camera Permission Error', () => {
-    it('calls onScanError when camera permission is not granted', async () => {
+    it('calls onScanError only after requestPermission resolves with denial', async () => {
       const mockUseCameraPermission = jest.requireMock(
         'react-native-vision-camera',
       ).useCameraPermission;
 
+      const mockRequestPermission = jest.fn().mockResolvedValue(false);
       mockUseCameraPermission.mockReturnValue({
         hasPermission: false,
-        requestPermission: jest.fn(),
+        requestPermission: mockRequestPermission,
       });
 
       render(<AnimatedQRScannerModal {...defaultProps} />);
 
       await waitFor(() => {
+        expect(mockRequestPermission).toHaveBeenCalled();
         expect(mockOnScanError).toHaveBeenCalledWith(
           'transaction.no_camera_permission',
         );
       });
     });
 
-    it('does not call onScanError when camera permission is granted', async () => {
+    it('does not call onScanError when requestPermission is granted', async () => {
+      const mockUseCameraPermission = jest.requireMock(
+        'react-native-vision-camera',
+      ).useCameraPermission;
+
+      const mockRequestPermission = jest.fn().mockResolvedValue(true);
+      mockUseCameraPermission.mockReturnValue({
+        hasPermission: false,
+        requestPermission: mockRequestPermission,
+      });
+
+      render(<AnimatedQRScannerModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockRequestPermission).toHaveBeenCalled();
+      });
+
+      expect(mockOnScanError).not.toHaveBeenCalled();
+    });
+
+    it('does not call onScanError when camera permission is already granted', async () => {
       const mockUseCameraPermission = jest.requireMock(
         'react-native-vision-camera',
       ).useCameraPermission;
@@ -645,9 +667,10 @@ describe('AnimatedQRScannerModal - Metrics', () => {
         'react-native-vision-camera',
       ).useCameraPermission;
 
+      const mockRequestPermission = jest.fn().mockResolvedValue(false);
       mockUseCameraPermission.mockReturnValue({
         hasPermission: false,
-        requestPermission: jest.fn(),
+        requestPermission: mockRequestPermission,
       });
 
       const propsWithoutVisibility = { ...defaultProps, visible: false };
@@ -657,6 +680,9 @@ describe('AnimatedQRScannerModal - Metrics', () => {
       await waitFor(() => {
         expect(mockOnScanError).not.toHaveBeenCalled();
       });
+
+      // requestPermission should not have been called since modal is not visible
+      expect(mockRequestPermission).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/QRHardware/AnimatedQRScanner.tsx
+++ b/app/components/UI/QRHardware/AnimatedQRScanner.tsx
@@ -154,10 +154,18 @@ const AnimatedQRScannerModal = (props: AnimatedQRScannerProps) => {
   }
 
   useEffect(() => {
+    let cancelled = false;
     if (!hasPermission && visible) {
-      requestPermission();
+      requestPermission().then((granted) => {
+        if (!cancelled && !granted) {
+          onScanError(strings('transaction.no_camera_permission'));
+        }
+      });
     }
-  }, [hasPermission, requestPermission, visible]);
+    return () => {
+      cancelled = true;
+    };
+  }, [hasPermission, requestPermission, visible, onScanError]);
 
   const reset = useCallback(() => {
     setURDecoder(new URRegistryDecoder());
@@ -273,13 +281,6 @@ const AnimatedQRScannerModal = (props: AnimatedQRScannerProps) => {
     ),
     [purpose, styles],
   );
-
-  // Handle camera permission error
-  useEffect(() => {
-    if (visible && !hasPermission) {
-      onScanError(strings('transaction.no_camera_permission'));
-    }
-  }, [visible, hasPermission, onScanError]);
 
   return (
     <Modal


### PR DESCRIPTION
This PR fix #20442 

This PR has improved camera permission handling in AnimatedQRScannerModal
- Updated the camera permission request logic to ensure `onScanError` is only called after the permission request resolves with denial.
- Added tests to verify that `onScanError` is not called when permission is granted or already available.
- Enhanced cleanup logic in the effect to prevent state updates on unmounted components.

This change improves the reliability of camera permission handling and enhances the user experience by preventing unnecessary error calls.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved camera permission handling in AnimatedQRScannerModal

## **Related issues**

Fixes: #20442 

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to permission-request side effects plus test updates; low risk aside from potential behavior change in when/if permission errors are surfaced.
> 
> **Overview**
> Fixes camera permission error handling in `AnimatedQRScannerModal` so `onScanError` is triggered **only after** `requestPermission()` resolves with a denial, and adds effect cleanup to avoid firing after unmount.
> 
> Updates unit tests to assert `requestPermission` is called only when the modal is visible, and to cover the granted/already-granted paths where `onScanError` must not fire.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6dcc9979e6e5ae75fa309f9150a66a00f0631fda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->