### PR TITLE
fix: add source to unifiedSwapBridge completed event for trending

### DIFF
--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
@@ -25,6 +25,7 @@ import {
   setSourceToken,
   setDestToken,
   setIsDestTokenManuallySet,
+  setSource,
 } from '../../../../../core/redux/slices/bridge';
 import { trace, TraceName } from '../../../../../util/trace';
 import { useCurrentNetworkInfo } from '../../../../hooks/useCurrentNetworkInfo';
@@ -156,10 +157,17 @@ export const useSwapBridgeNavigation = ({
         sourceToken = getNativeSourceToken(EthScope.Mainnet);
       }
 
+      // Check if user is in an active trending session for analytics attribution
+      const isFromTrending =
+        TrendingFeedSessionManager.getInstance().isFromTrending;
+
       // Reset the manual dest token flag on navigation so auto-update works correctly
       // This ensures if user previously manually set dest, then closed and reopened the app,
       // changing source token will still auto-update the dest token
       dispatch(setIsDestTokenManuallySet(false));
+
+      // Store the source in Redux so it can be attached to the Completed event
+      dispatch(setSource(isFromTrending ? 'trending' : undefined));
 
       // Pre-populate Redux state before navigation to prevent empty button flash
       dispatch(setSourceToken(sourceToken));
@@ -214,10 +222,6 @@ export const useSwapBridgeNavigation = ({
           ? ActionLocation.NAVBAR
           : ActionLocation.ASSET_DETAILS,
       });
-      // Check if user is in an active trending session for analytics
-      const isFromTrending =
-        TrendingFeedSessionManager.getInstance().isFromTrending;
-
       const swapEventProperties = {
         location,
         chain_id_source: getDecimalChainId(sourceToken.chainId),

--- a/app/core/Engine/controllers/bridge-controller/bridge-controller-init.ts
+++ b/app/core/Engine/controllers/bridge-controller/bridge-controller-init.ts
@@ -76,10 +76,8 @@ export const bridgeControllerInit: ControllerInitFunction<
         // Capture source early — any event before Completed means bridge is active
         if (event !== UnifiedSwapBridgeEventName.Completed) {
           cachedSource = getState()?.bridge?.source;
-        }
-
-        // Enrich Completed event with source attribution
-        if (event === UnifiedSwapBridgeEventName.Completed) {
+        } else {
+          // Enrich Completed event with source attribution
           if (cachedSource) {
             enrichedProperties = {
               ...enrichedProperties,

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -11,6 +11,8 @@ import reducer, {
   setDestToken,
   setIsDestTokenManuallySet,
   selectIsDestTokenManuallySet,
+  setSource,
+  selectSource,
   selectBip44DefaultPair,
   selectGasIncludedQuoteParams,
   selectIsBridgeEnabledSource,
@@ -241,6 +243,52 @@ describe('bridge slice', () => {
       const result = selectIsDestTokenManuallySet(mockState);
 
       expect(result).toBe(true);
+    });
+  });
+
+  describe('setSource', () => {
+    it('sets the source to trending', () => {
+      const action = setSource('trending');
+      const state = reducer(initialState, action);
+
+      expect(state.source).toBe('trending');
+    });
+
+    it('clears the source when set to undefined', () => {
+      const stateWithSource = {
+        ...initialState,
+        source: 'trending',
+      };
+
+      const action = setSource(undefined);
+      const state = reducer(stateWithSource, action);
+
+      expect(state.source).toBeUndefined();
+    });
+  });
+
+  describe('selectSource', () => {
+    it('returns undefined from initial state', () => {
+      const mockState = {
+        bridge: initialState,
+      } as RootState;
+
+      const result = selectSource(mockState);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns source when set', () => {
+      const mockState = {
+        bridge: {
+          ...initialState,
+          source: 'trending',
+        },
+      } as RootState;
+
+      const result = selectSource(mockState);
+
+      expect(result).toBe('trending');
     });
   });
 

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -63,6 +63,12 @@ export interface BridgeState {
    * When false, changing source network will update dest to the default for that network.
    */
   isDestTokenManuallySet: boolean;
+  /**
+   * Tracks the navigation source that initiated the bridge/swap flow (e.g. 'trending').
+   * Used to enrich the Unified SwapBridge Completed event with attribution context.
+   * Cleared when bridge state resets.
+   */
+  source?: string;
 }
 
 export const initialState: BridgeState = {
@@ -169,6 +175,9 @@ const slice = createSlice({
     },
     setIsGasIncluded7702Supported: (state, action: PayloadAction<boolean>) => {
       state.isGasIncluded7702Supported = action.payload;
+    },
+    setSource: (state, action: PayloadAction<string | undefined>) => {
+      state.source = action.payload;
     },
   },
   extraReducers: (builder) => {
@@ -579,6 +588,11 @@ export const selectIsDestTokenManuallySet = createSelector(
   (bridgeState) => bridgeState.isDestTokenManuallySet,
 );
 
+export const selectSource = createSelector(
+  selectBridgeState,
+  (bridgeState) => bridgeState.source,
+);
+
 export const selectIsGaslessSwapEnabled = createSelector(
   selectIsSwap,
   selectBridgeFeatureFlags,
@@ -656,4 +670,5 @@ export const {
   setIsSelectingToken,
   setIsGasIncludedSTXSendBundleSupported,
   setIsGasIncluded7702Supported,
+  setSource,
 } = actions;


### PR DESCRIPTION

## **Description**

Adds `source: 'trending'` attribution to the "Unified SwapBridge Completed" analytics event when the user initiates a swap from the trending feed.

**Problem**: There was no way to attribute completed swap/bridge transactions back to the trending feed entry point.

**Solution**: Store the navigation source in the bridge Redux slice when the user taps Swap, then enrich the Completed event with that source in the mobile `trackMetaMetricsFn` callback. This is a mobile-only change — no modifications to `@metamask/bridge-controller` or `@metamask/bridge-status-controller` are needed.

**Key detail**: The `BridgeView` dispatches `resetBridgeState()` on unmount, which can clear the source before the Completed event fires. To handle this, the source is cached from Redux when earlier bridge events fire (e.g. `PageViewed`), and the cached value is used when the Completed event arrives.

### Local testing with console logs

To verify the event enrichment locally, add a `console.log` inside `trackMetaMetricsFn` in `app/core/Engine/controllers/bridge-controller/bridge-controller-init.ts`:

```typescript
// Inside the trackMetaMetricsFn callback, after the enrichment logic:
if (event === UnifiedSwapBridgeEventName.Completed) {
  console.log('[BridgeAnalytics] Completed event', {
    event,
    cachedSource,
    enrichedProperties,
  });
}
```

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added source:trending for unifiedSwapBridge completed event

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes that add a small piece of Redux state and enrich a single event; primary risk is incorrect attribution or cache leakage, covered by new unit tests.
> 
> **Overview**
> Adds a `source` field to the bridge Redux slice and sets it during swap/bridge navigation based on `TrendingFeedSessionManager`, enabling attribution like `source: 'trending'`.
> 
> Updates mobile `bridgeControllerInit` analytics wiring to cache this `source` from Redux when early bridge events fire and *only* enrich the `UnifiedSwapBridgeEventName.Completed` event with it, then clears the cache to avoid leaking across sessions. Tests were added/updated to cover the new action/selector and the Completed-event enrichment behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c2899acc5e658ad14a09df47b989ea6a248f311. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->