### PR TITLE
fix: revert header from `Expandable` component

### DIFF
--- a/app/components/Views/confirmations/components/UI/expandable/expandable.styles.ts
+++ b/app/components/Views/confirmations/components/UI/expandable/expandable.styles.ts
@@ -24,11 +24,22 @@ const styleSheet = (params: {
       backgroundColor: theme.colors.background.alternative,
       paddingTop: 24,
       paddingBottom: 34,
+      paddingHorizontal: 16,
       borderTopLeftRadius: 8,
       borderTopRightRadius: 8,
     },
     modalExpandedContent: {
       paddingHorizontal: 16,
+    },
+    modalHeader: {
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingBottom: 16,
+    },
+    expandedContentTitle: {
+      width: '90%',
+      textAlign: 'center',
     },
   });
 };

--- a/app/components/Views/confirmations/components/UI/expandable/expandable.styles.ts
+++ b/app/components/Views/confirmations/components/UI/expandable/expandable.styles.ts
@@ -28,9 +28,6 @@ const styleSheet = (params: {
       borderTopLeftRadius: 8,
       borderTopRightRadius: 8,
     },
-    modalExpandedContent: {
-      paddingHorizontal: 16,
-    },
     modalHeader: {
       display: 'flex',
       flexDirection: 'row',

--- a/app/components/Views/confirmations/components/UI/expandable/expandable.tsx
+++ b/app/components/Views/confirmations/components/UI/expandable/expandable.tsx
@@ -2,9 +2,17 @@ import React, { ReactNode, useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 
 import { useStyles } from '../../../../../../component-library/hooks';
-import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import BottomModal from '../bottom-modal';
 import styleSheet from './expandable.styles';
+import {
+  ButtonIcon,
+  ButtonIconSize,
+  FontWeight,
+  IconName,
+  IconSize,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 
 interface ExpandableProps {
   collapsedContent: ReactNode;
@@ -45,14 +53,25 @@ const Expandable = ({
       {expanded && (
         <BottomModal onClose={() => setExpanded(false)}>
           <View style={styles.modalContent}>
-            <HeaderCompactStandard
-              title={expandedContentTitle}
-              onClose={() => setExpanded(false)}
-              closeButtonProps={{
-                testID: collapseButtonTestID ?? 'collapseButtonTestID',
-              }}
-            />
-            <View style={styles.modalExpandedContent}>{expandedContent}</View>
+            <View style={styles.modalHeader}>
+              <ButtonIcon
+                iconProps={{
+                  size: IconSize.Sm,
+                }}
+                size={ButtonIconSize.Sm}
+                onPress={() => setExpanded(false)}
+                iconName={IconName.ArrowLeft}
+                testID={collapseButtonTestID ?? 'collapseButtonTestID'}
+              />
+              <Text
+                variant={TextVariant.BodyMd}
+                fontWeight={FontWeight.Bold}
+                style={styles.expandedContentTitle}
+              >
+                {expandedContentTitle}
+              </Text>
+            </View>
+            {expandedContent}
           </View>
         </BottomModal>
       )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR reverts the expandable icons changes that were causing visual regression issues in the UI.

**Reason for change:**
The expandable icons implementation introduced in a previous PR caused unintended visual issues where icons were not displaying correctly or the expandable behavior was inconsistent across different screen sizes and states.

**Solution:**
Revert the expandable icons changes to restore the previous stable icon behavior while a proper fix is investigated.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/25783

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

[copy-close-icons-explandable.webm](https://github.com/user-attachments/assets/68947e22-afdd-4728-b702-6cca2597015b)


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI/layout change to the confirmations `Expandable` modal; main risk is minor visual/regression or testID-driven UI test breakage.
> 
> **Overview**
> Replaces the `Expandable` bottom-sheet header UI by removing `HeaderCompactStandard` and rendering a custom header composed of a design-system `ButtonIcon` (back arrow) plus centered title `Text`.
> 
> Adjusts modal styling by moving horizontal padding onto `modalContent`, adding new `modalHeader`/`expandedContentTitle` styles, and rendering `expandedContent` directly (removing the extra padded wrapper).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c3bacb9ce1c5e848e2e5c0e83cd1e58f96a7ceb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->