### PR TITLE
test: adds start startPositionX and startPositionY to framework scroll

### DIFF
--- a/tests/framework/Gestures.ts
+++ b/tests/framework/Gestures.ts
@@ -511,6 +511,8 @@ export default class Gestures {
       scrollAmount = 350,
       elemDescription,
       delay = 0,
+      startPositionX = NaN,
+      startPositionY = NaN,
     } = options;
 
     return Utilities.executeWithRetry(
@@ -527,7 +529,12 @@ export default class Gestures {
             await waitFor(target).toBeVisible().withTimeout(100);
             return;
           } catch {
-            await scrollableElement.scroll(scrollAmount, direction);
+            await scrollableElement.scroll(
+              scrollAmount,
+              direction,
+              startPositionX,
+              startPositionY,
+            );
             await waitFor(target).toBeVisible().withTimeout(100);
           }
         } else {

--- a/tests/framework/types.ts
+++ b/tests/framework/types.ts
@@ -91,10 +91,20 @@ export interface LongPressOptions extends GestureOptions {
   duration?: number;
 }
 
+/**
+ * The options for the scroll gesture.
+ * @param {string} direction - The direction to scroll.
+ * @param {number} scrollAmount - The amount to scroll.
+ * @param {number} delay - The delay before the scroll.
+ * @param {number} startPositionX - The starting position on the X axis.
+ * @param {number} startPositionY - The starting position on the Y axis.
+ */
 export interface ScrollOptions extends GestureOptions {
   direction?: 'up' | 'down' | 'left' | 'right';
   scrollAmount?: number;
   delay?: number;
+  startPositionX?: number;
+  startPositionY?: number;
 }
 
 // Assertions

--- a/tests/page-objects/Browser/TestSnaps.ts
+++ b/tests/page-objects/Browser/TestSnaps.ts
@@ -360,6 +360,10 @@ class TestSnaps {
     await Gestures.scrollToElement(
       this.timePickerTouchable,
       this.snapUIRendererScrollView,
+      {
+        startPositionX: 0,
+        startPositionY: 0,
+      },
     );
 
     await Gestures.waitAndTap(this.dateTimePickerTouchable);

--- a/tests/page-objects/Trending/TrendingView.ts
+++ b/tests/page-objects/Trending/TrendingView.ts
@@ -174,6 +174,8 @@ class TrendingView {
         direction: 'right',
         scrollAmount: 200,
         elemDescription: description,
+        startPositionX: 50,
+        startPositionY: 0,
       },
     );
   }

--- a/tests/smoke/predict/predict-claim-positions.spec.ts
+++ b/tests/smoke/predict/predict-claim-positions.spec.ts
@@ -222,7 +222,7 @@ describe(SmokePredictions('Claim winnings:'), () => {
           },
         );
 
-        await WalletView.scrollToPosition(positions.Won);
+        await WalletView.scrollToPosition(positions.Lost);
 
         await WalletView.tapPredictPosition(positions.Lost);
 
@@ -234,6 +234,8 @@ describe(SmokePredictions('Claim winnings:'), () => {
           },
         );
         await PredictDetailsPage.tapBackButton();
+
+        await WalletView.scrollToPosition(positions.Won);
 
         await WalletView.tapPredictPosition(positions.Won);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR adds startPositionX and startPositionY to ScrollOptions in order to allow for offset scrolling actions. 
It also fixes a snap test where the scrollable container was not allowing scrolls on Android due to its viewport.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared test framework scrolling behavior on Android, which can impact many Detox tests if the new parameters or default `NaN` handling behave differently across devices; changes are limited to test code.
> 
> **Overview**
> Adds `startPositionX`/`startPositionY` to `ScrollOptions` and threads them into Android’s `Gestures.scrollToElement()` call so Detox scrolls can start from an explicit screen offset.
> 
> Updates affected page objects/tests to pass start positions for Snap UI date-time picker scrolling and horizontal quick-action scrolling, and adjusts the predict claim smoke test to scroll to the lost position first (then winning) before asserting claim-button visibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f977d57b809091f99e23ca6c2904408451a75863. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->