### PR TITLE
fix: Change loggers in `MMPay`

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -16,6 +16,7 @@ import { updateTransaction } from '../../../../../util/transaction-controller';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { hasTransactionType } from '../../utils/transaction';
+import Logger from '../../../../../util/Logger';
 
 export function useTransactionPayToken(): {
   isNative?: boolean;
@@ -56,8 +57,8 @@ export function useTransactionPayToken(): {
           tokenAddress: newPayToken.address,
           chainId: newPayToken.chainId,
         });
-      } catch (e) {
-        console.error('Error updating payment token', e);
+      } catch (error) {
+        Logger.error(error as Error, 'Error updating payment token');
       }
 
       // perps deposits only use relay, so doesn't need gasFeeToken update

--- a/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.ts
@@ -16,6 +16,7 @@ import { BigNumber } from 'bignumber.js';
 import { parseStandardTokenTransactionData } from '../../utils/transaction';
 import { getTokenTransferData } from '../../utils/transaction-pay';
 import { useConfirmationContext } from '../../context/confirmation-context';
+import Logger from '../../../../../util/Logger';
 
 export function useUpdateTokenAmount() {
   const dispatch = useDispatch();
@@ -79,9 +80,9 @@ export function useUpdateTokenAmount() {
           transactionIndex: nestedCallIndex,
           transactionData: newData,
         }).catch((error) => {
-          console.error(
-            'Failed to update token amount in nested transaction',
+          Logger.error(
             error,
+            'Failed to update token amount in nested transaction',
           );
         });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR leverage usage of `Logger.error` in two places in MMPay flow, have no affect of UIX flow.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Related with: https://github.com/MetaMask/MetaMask-planning/issues/6973

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change that doesn’t alter transaction update logic or data flow; main risk is reduced local console visibility if `Logger` behavior differs by environment.
> 
> **Overview**
> Switches error handling in the MMPay confirmation hooks to use the shared `Logger.error` instead of `console.error`.
> 
> In `useTransactionPayToken`, failures from `TransactionPayController.updatePaymentToken` now log via `Logger.error`. In `useUpdateTokenAmount`, failures updating nested atomic batch transactions now log via `Logger.error` with the existing message preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cef8e06be32571514ea17794821f528e9a64a60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->