### PR TITLE
feat(perps): show Learn more in menu regardless of empty state

### DIFF
--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -329,20 +329,16 @@ const PerpsHomeView = () => {
       });
     }
 
-    // Avoid duplicate "Learn more" button (shown in empty state card)
-    if (!isBalanceEmpty) {
-      items.push({
-        label: strings(LEARN_MORE_CONFIG.TitleKey),
-        onPress: () => navigtateToTutorial(),
-        testID: PerpsHomeViewSelectorsIDs.LEARN_MORE_BUTTON,
-      });
-    }
+    items.push({
+      label: strings(LEARN_MORE_CONFIG.TitleKey),
+      onPress: () => navigtateToTutorial(),
+      testID: PerpsHomeViewSelectorsIDs.LEARN_MORE_BUTTON,
+    });
 
     return items;
   }, [
     navigateToContactSupport,
     navigtateToTutorial,
-    isBalanceEmpty,
     isFeedbackEnabled,
     handleGiveFeedback,
   ]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

1. **What is the reason for the change?**  
   The Perps home overflow menu previously hid the "Learn more" item when the user had an empty balance to avoid duplicating the "Learn more" CTA already shown on the empty-state card. Users with an empty state could only use that card and had no "Learn more" in the menu.

2. **What is the improvement/solution?**  
   Always show "Learn more" in the Perps home menu, independent of balance. Users can access the tutorial from the menu in all states, and the empty-state card can still offer the same link without conflicting with the menu.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Always display learn more about perps link

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2526

## **Manual testing steps**

```gherkin
Feature: Perps

  Scenario: user has no activity in perps
    Given user visits the perps home screen

    Then user should see the link to learn more about Perps
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="1206" height="2622" alt="simulator_screenshot_D734BD34-3FE8-4B2A-B9E0-6E1AEF9E30A9" src="https://github.com/user-attachments/assets/ad4dbf11-1224-4366-be9d-33a3f2ebcbd4" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/menu logic change with no auth, funds movement, or data handling impact; main risk is minor UX duplication in the empty state.
> 
> **Overview**
> The Perps home navigation/overflow menu now **always** includes the `Learn more` item, instead of hiding it when the balance is empty to avoid duplicating the empty-state CTA.
> 
> This removes the `isBalanceEmpty` gating and dependency from the `navigationItems` memo, so `Learn more` consistently routes to the tutorial from the menu in all states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 149606fc6cbd7399f7b36210d8917dc54a443d85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->