### PR TITLE
fix(card): cp-7.65.0 use shared isBaanxLoginEnabled logic in KYC notification deeplink handler

### DIFF
--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleCardKycNotification.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleCardKycNotification.test.ts
@@ -9,9 +9,9 @@ import {
   selectSelectedCountry,
   selectUserCardLocation,
   selectCardGeoLocation,
+  selectAlwaysShowCardButton,
 } from '../../../../redux/slices/card';
 import {
-  selectCardExperimentalSwitch,
   selectCardSupportedCountries,
   selectDisplayCardButtonFeatureFlag,
   selectCardFeatureFlag,
@@ -76,9 +76,7 @@ describe('handleCardKycNotification', () => {
       'international',
     );
     (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('US');
-    (selectCardExperimentalSwitch as unknown as jest.Mock).mockReturnValue(
-      false,
-    );
+    (selectAlwaysShowCardButton as unknown as jest.Mock).mockReturnValue(false);
     (
       selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
     ).mockReturnValue(false);
@@ -114,8 +112,8 @@ describe('handleCardKycNotification', () => {
       );
     });
 
-    it('enables navigation when cardExperimentalSwitch is enabled', async () => {
-      (selectCardExperimentalSwitch as unknown as jest.Mock).mockReturnValue(
+    it('enables navigation when alwaysShowCardButton is enabled', async () => {
+      (selectAlwaysShowCardButton as unknown as jest.Mock).mockReturnValue(
         true,
       );
 
@@ -142,7 +140,7 @@ describe('handleCardKycNotification', () => {
 
   describe('onboarding flow', () => {
     beforeEach(() => {
-      (selectCardExperimentalSwitch as unknown as jest.Mock).mockReturnValue(
+      (selectAlwaysShowCardButton as unknown as jest.Mock).mockReturnValue(
         true,
       );
       (selectOnboardingId as unknown as jest.Mock).mockReturnValue(
@@ -336,7 +334,7 @@ describe('handleCardKycNotification', () => {
 
   describe('authenticated flow', () => {
     beforeEach(() => {
-      (selectCardExperimentalSwitch as unknown as jest.Mock).mockReturnValue(
+      (selectAlwaysShowCardButton as unknown as jest.Mock).mockReturnValue(
         true,
       );
       (selectOnboardingId as unknown as jest.Mock).mockReturnValue(null);
@@ -488,7 +486,7 @@ describe('handleCardKycNotification', () => {
 
   describe('fallback behavior', () => {
     beforeEach(() => {
-      (selectCardExperimentalSwitch as unknown as jest.Mock).mockReturnValue(
+      (selectAlwaysShowCardButton as unknown as jest.Mock).mockReturnValue(
         true,
       );
       (selectOnboardingId as unknown as jest.Mock).mockReturnValue(null);
@@ -519,7 +517,7 @@ describe('handleCardKycNotification', () => {
 
   describe('error handling', () => {
     beforeEach(() => {
-      (selectCardExperimentalSwitch as unknown as jest.Mock).mockReturnValue(
+      (selectAlwaysShowCardButton as unknown as jest.Mock).mockReturnValue(
         true,
       );
     });
@@ -643,7 +641,7 @@ describe('handleCardKycNotification', () => {
 
   describe('logging', () => {
     beforeEach(() => {
-      (selectCardExperimentalSwitch as unknown as jest.Mock).mockReturnValue(
+      (selectAlwaysShowCardButton as unknown as jest.Mock).mockReturnValue(
         true,
       );
     });

--- a/app/core/DeeplinkManager/handlers/legacy/handleCardKycNotification.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleCardKycNotification.ts
@@ -8,14 +8,15 @@ import {
   selectSelectedCountry,
   selectUserCardLocation,
   selectCardGeoLocation,
+  selectAlwaysShowCardButton,
 } from '../../../redux/slices/card';
 import {
-  selectCardExperimentalSwitch,
   selectCardSupportedCountries,
   selectDisplayCardButtonFeatureFlag,
   selectCardFeatureFlag,
   CardFeatureFlag,
 } from '../../../../selectors/featureFlagController/card';
+import { isBaanxLoginEnabled } from '../../../../components/UI/Card/hooks/isBaanxLoginEnabled';
 import { CardSDK } from '../../../../components/UI/Card/sdk/CardSDK';
 import { mapCountryToLocation } from '../../../../components/UI/Card/util/mapCountryToLocation';
 import {
@@ -56,19 +57,17 @@ export const handleCardKycNotification = async () => {
     const state = ReduxService.store.getState();
 
     // Check feature flags
-    const cardGeoLocation = selectCardGeoLocation(state);
-    const isCardExperimentalSwitchEnabled = selectCardExperimentalSwitch(state);
-    const displayCardButtonFeatureFlag =
-      selectDisplayCardButtonFeatureFlag(state);
-    const cardSupportedCountries = selectCardSupportedCountries(
-      state,
-    ) as Record<string, boolean>;
-    const shouldOnboardingBeEnabled =
-      isCardExperimentalSwitchEnabled ||
-      (cardSupportedCountries?.[cardGeoLocation as string] === true &&
-        displayCardButtonFeatureFlag);
+    const shouldHandleKycNotification = isBaanxLoginEnabled({
+      alwaysShowCardButton: selectAlwaysShowCardButton(state),
+      cardGeoLocation: selectCardGeoLocation(state) as string,
+      cardSupportedCountries: selectCardSupportedCountries(state) as Record<
+        string,
+        boolean
+      >,
+      displayCardButtonFeatureFlag: selectDisplayCardButtonFeatureFlag(state),
+    });
 
-    if (!shouldOnboardingBeEnabled) {
+    if (!shouldHandleKycNotification) {
       Logger.log(
         '[handleCardKycNotification] Card feature is not enabled, skipping',
       );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The `handleCardKycNotification` deeplink handler had its own inline feature flag verification logic using `selectCardExperimentalSwitch`, which diverged from the canonical check used across the rest of the Card feature. The shared `isBaanxLoginEnabled` utility (used by the `useIsBaanxLoginEnabled` hook) defines the single source of truth for whether the Baanx/Card feature is enabled, based on `alwaysShowCardButton`, `cardGeoLocation`, `cardSupportedCountries`, and `displayCardButtonFeatureFlag`.

This PR replaces the inline logic with a call to `isBaanxLoginEnabled`, ensuring the deeplink handler uses the same enablement criteria as the rest of the app. Tests have been updated accordingly.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed card KYC notification deeplink using incorrect feature flag check

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Card KYC notification deeplink

  Scenario: user taps a card KYC push notification when the card feature is enabled
    Given the user has the card feature enabled (via alwaysShowCardButton or supported country + feature flag)
    And the user has a pending or completed KYC verification

    When user taps on the card KYC push notification deeplink
    Then the user is navigated to the correct screen based on their verification state (KYCFailed, Complete, KYCPending, or CardHome)

  Scenario: user taps a card KYC push notification when the card feature is disabled
    Given the user does not have the card feature enabled

    When user taps on the card KYC push notification deeplink
    Then nothing happens and the handler exits early
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to deeplink feature-gating logic with corresponding test updates; primary risk is inadvertently changing when the handler early-exits vs navigates.
> 
> **Overview**
> `handleCardKycNotification` now uses the shared `isBaanxLoginEnabled` check (driven by `alwaysShowCardButton` and supported-country + `displayCardButtonFeatureFlag`) instead of its own inline logic based on `selectCardExperimentalSwitch`.
> 
> Tests were updated to mock `selectAlwaysShowCardButton` and validate navigation behavior under the new enablement criteria.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbf4b20f53059529002c66ce8034bba75137cdde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->