### PR TITLE
refactor: simplify section state management in TrendingView

### DIFF
--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -32,6 +32,23 @@ import TrendingFeedSessionManager from '../../UI/Trending/services/TrendingFeedS
 import Section, { RefreshConfig } from './components/Sections/Section';
 import { TrendingViewSelectorsIDs } from './TrendingView.testIds';
 
+const curriedSetSectionState =
+  (setState: (updater: (prev: Set<SectionId>) => Set<SectionId>) => void) =>
+  (sectionId: SectionId) =>
+  (isActive: boolean): void => {
+    setState((prev) => {
+      const newSet = new Set(prev);
+
+      if (isActive) {
+        newSet.add(sectionId);
+      } else {
+        newSet.delete(sectionId);
+      }
+
+      return newSet;
+    });
+  };
+
 /**
  * Custom hook to track boolean state for each section
  * Returns the Set of sections with that state and callbacks to update them
@@ -48,23 +65,9 @@ const useSectionStateTracker = (
 
   const callbacks = useMemo(() => {
     const result = {} as Record<SectionId, (isActive: boolean) => void>;
-
-    sections.forEach((section) => {
-      result[section.id] = (isActive: boolean) => {
-        setActiveSections((currentSections) => {
-          const updatedSections = new Set(currentSections);
-
-          if (isActive) {
-            updatedSections.add(section.id);
-          } else {
-            updatedSections.delete(section.id);
-          }
-
-          return updatedSections;
-        });
-      };
+    sections.forEach((s) => {
+      result[s.id] = curriedSetSectionState(setActiveSections)(s.id);
     });
-
     return result;
   }, [sections]);
 


### PR DESCRIPTION
## **Description**

SonarQube reported that we have 6 nested functions/layers here. Decoupled and used curried funcs to reduce nesting to 2 functions/layers.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: refactor: simplify section state management in TrendingView

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2280

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of local React state update callbacks with no functional or data-flow changes expected; risk is limited to potential mistakes in the Set add/remove logic.
> 
> **Overview**
> Refactors `TrendingView.tsx`’s `useSectionStateTracker` by extracting the per-section `setActiveSections` updater into a shared curried helper (`curriedSetSectionState`), reducing callback nesting while keeping behavior the same.
> 
> Each section’s `toggleSection*State` callback is now created by partially applying `setActiveSections` and the `sectionId`, instead of inlining the `setState`/`Set` mutation logic inside the `useMemo` loop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a56f99900d12453d7c2aeba9787461adf2ad7e39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->