### PR TITLE
feat(ramps):  lazy load i118 events module in ramps sdk hook

### DIFF
--- a/app/components/UI/Ramp/Aggregator/sdk/index.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/sdk/index.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Text } from 'react-native';
-import { screen } from '@testing-library/react-native';
-import { RampSDKProvider, useRampSDK } from './index';
+import { act, screen } from '@testing-library/react-native';
+import { RampSDKProvider, useRampSDK, SDK } from './index';
+import { I18nEvents } from '../../../../../../locales/i18n';
 import { RampType } from '../types';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
@@ -91,5 +92,50 @@ describe('RampSDKProvider', () => {
     expect(contextValue?.rampType).toBe(RampType.SELL);
     expect(contextValue?.isBuy).toBe(false);
     expect(contextValue?.isSell).toBe(true);
+  });
+
+  it('syncs SDK locale on mount and subscribes to locale changes', () => {
+    const setLocaleSpy = jest.spyOn(SDK, 'setLocale');
+    const TestComponent = () => <Text>Test</Text>;
+
+    renderWithProvider(
+      <RampSDKProvider>
+        <TestComponent />
+      </RampSDKProvider>,
+      { state: mockedState },
+    );
+
+    expect(setLocaleSpy).toHaveBeenCalledWith(expect.any(String));
+
+    setLocaleSpy.mockClear();
+
+    act(() => {
+      I18nEvents.emit('localeChanged', 'es');
+    });
+
+    expect(setLocaleSpy).toHaveBeenCalledWith('es');
+
+    setLocaleSpy.mockRestore();
+  });
+
+  it('removes locale listener on unmount', () => {
+    const removeListenerSpy = jest.spyOn(I18nEvents, 'removeListener');
+    const TestComponent = () => <Text>Test</Text>;
+
+    const { unmount } = renderWithProvider(
+      <RampSDKProvider>
+        <TestComponent />
+      </RampSDKProvider>,
+      { state: mockedState },
+    );
+
+    unmount();
+
+    expect(removeListenerSpy).toHaveBeenCalledWith(
+      'localeChanged',
+      expect.any(Function),
+    );
+
+    removeListenerSpy.mockRestore();
   });
 });

--- a/app/components/UI/Ramp/Aggregator/sdk/index.tsx
+++ b/app/components/UI/Ramp/Aggregator/sdk/index.tsx
@@ -55,10 +55,6 @@ export const SDK = OnRampSdk.create(environment, context, {
   locale: I18n.locale,
 });
 
-I18nEvents.addListener('localeChanged', (locale) => {
-  SDK.setLocale(locale);
-});
-
 interface RampSDKConfig {
   POLLING_INTERVAL: number;
   POLLING_INTERVAL_HIGHLIGHT: number;
@@ -134,6 +130,17 @@ export const RampSDKProvider = ({
     provider: true,
     internal: isDevelopmentOrInternalBuild,
   });
+
+  useEffect(() => {
+    SDK.setLocale(I18n.locale);
+    const handleLocaleChanged = (locale: string) => {
+      SDK.setLocale(locale);
+    };
+    I18nEvents.addListener('localeChanged', handleLocaleChanged);
+    return () => {
+      I18nEvents.removeListener('localeChanged', handleLocaleChanged);
+    };
+  }, []);
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
- Move `I18nEvents.addListener` from module-level side effect to lazy initialization inside `RampSDKProvider`'s `useEffect`
- This prevents downstream test failures when unrelated modules transitively import `sdk/index.tsx`, since the listener no longer runs at import time
- The provider now also syncs `SDK.setLocale(I18n.locale)` on mount, handling cases where the locale changed while the ramp flow was inactive
- Cleanup via `removeListener` on unmount prevents memory leaks

## Test plan
- [x] Existing `RampSDKProvider` tests still pass
- [x] Added test: SDK locale is synced on mount and updated on `localeChanged` events
- [x] Added test: locale listener is removed on unmount

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to event subscription timing/cleanup plus unit tests; minimal impact beyond ensuring locale updates occur only while the provider is mounted.
> 
> **Overview**
> **Locale handling for the Ramp SDK is now initialized lazily in `RampSDKProvider` instead of at module import time.** The provider now calls `SDK.setLocale(I18n.locale)` on mount, subscribes to `I18nEvents` `localeChanged` updates, and removes the listener on unmount to avoid leaks and import-time side effects.
> 
> Tests were expanded to validate locale sync on mount, reacting to emitted `localeChanged` events, and proper listener cleanup on unmount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 630765ac24563060e27ab9f44517126f43a7fc07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->