### PR TITLE
fix(perps): ensure subscription client before HIP-3 subscriptions

### DIFF
--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -1313,6 +1313,9 @@ export class HyperLiquidSubscriptionService {
     userAddress: string,
     dexName: string,
   ): Promise<void> {
+    await this.clientService.ensureSubscriptionClient(
+      this.walletService.createWalletAdapter(),
+    );
     const subscriptionClient = this.clientService.getSubscriptionClient();
     if (!subscriptionClient) {
       throw new Error('Subscription client not available');
@@ -1440,6 +1443,9 @@ export class HyperLiquidSubscriptionService {
     userAddress: string,
     dexName: string,
   ): Promise<void> {
+    await this.clientService.ensureSubscriptionClient(
+      this.walletService.createWalletAdapter(),
+    );
     const subscriptionClient = this.clientService.getSubscriptionClient();
     if (!subscriptionClient) {
       throw new Error('Subscription client not available');


### PR DESCRIPTION
## **Description**

Apply the `ensureSubscriptionClient()` pattern consistently to all HIP-3 subscription methods.

`createClearinghouseSubscription` and `createOpenOrdersSubscription` were missing `ensureSubscriptionClient()` calls before accessing the subscription client. This creates a potential race condition during WebSocket reconnection where the client could be destroyed between the parent method's check and the child's `getSubscriptionClient()` call.

The fix adds the same `ensureSubscriptionClient()` guard already used by `createUserDataSubscription` and `createAssetCtxsSubscription`, ensuring all subscription creation methods follow the same defensive pattern.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: Sentry perps socket "Subscription client not available" errors

## **Manual testing steps**

```gherkin
Feature: Perps WebSocket subscription resilience

  Scenario: User reconnects to perps after network interruption
    Given user has perps positions open and is viewing the perps UI

    When user experiences a brief network disconnection and reconnects
    Then clearinghouse and open orders subscriptions resume without errors
```

## **Screenshots/Recordings**

N/A - internal WebSocket fix, no UI changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
