### PR TITLE
fix: create new feature flag for tokenDetailsV2 with min version

### DIFF
--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.test.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.test.tsx
@@ -36,6 +36,11 @@ jest.mock('../../Perps/components/PerpsBottomSheetTooltip', () => ({
   default: () => null,
 }));
 
+jest.mock('../../../../selectors/featureFlagController/tokenDetailsV2', () => ({
+  selectTokenDetailsV2Enabled: jest.fn(() => true),
+  selectTokenDetailsV2ButtonsEnabled: jest.fn(() => true),
+}));
+
 jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
   return {
@@ -60,9 +65,7 @@ function createState(isEligible: boolean) {
         RemoteFeatureFlagController: {
           ...(backgroundState as { RemoteFeatureFlagController?: object })
             .RemoteFeatureFlagController,
-          remoteFeatureFlags: {
-            tokenDetailsV2Buttons: true,
-          },
+          remoteFeatureFlags: {},
         },
         AccountsController: MOCK_ACCOUNTS_CONTROLLER_STATE,
       },

--- a/app/constants/featureFlags.ts
+++ b/app/constants/featureFlags.ts
@@ -14,6 +14,7 @@ export enum FeatureFlagNames {
   assetsDefiPositionsEnabled = 'assetsDefiPositionsEnabled',
   tokenDetailsV2 = 'tokenDetailsV2',
   tokenDetailsV2Buttons = 'tokenDetailsV2Buttons',
+  tokenDetailsV2ButtonLayout = 'token-details-v-2-button-layout',
 }
 
 export const DEFAULT_FEATURE_FLAG_VALUES: Partial<
@@ -22,4 +23,5 @@ export const DEFAULT_FEATURE_FLAG_VALUES: Partial<
   [FeatureFlagNames.assetsDefiPositionsEnabled]: true,
   [FeatureFlagNames.tokenDetailsV2]: false,
   [FeatureFlagNames.tokenDetailsV2Buttons]: false,
+  [FeatureFlagNames.tokenDetailsV2ButtonLayout]: false,
 };

--- a/app/constants/featureFlags.ts
+++ b/app/constants/featureFlags.ts
@@ -14,7 +14,7 @@ export enum FeatureFlagNames {
   assetsDefiPositionsEnabled = 'assetsDefiPositionsEnabled',
   tokenDetailsV2 = 'tokenDetailsV2',
   tokenDetailsV2Buttons = 'tokenDetailsV2Buttons',
-  tokenDetailsV2ButtonLayout = 'token-details-v-2-button-layout',
+  tokenDetailsV2ButtonLayout = 'tokenDetailsV2ButtonLayout',
 }
 
 export const DEFAULT_FEATURE_FLAG_VALUES: Partial<

--- a/app/selectors/featureFlagController/tokenDetailsV2/index.ts
+++ b/app/selectors/featureFlagController/tokenDetailsV2/index.ts
@@ -23,15 +23,11 @@ export const selectTokenDetailsV2Enabled = createSelector(
 export const selectTokenDetailsV2ButtonsEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean => {
-    const envOverride =
-      process.env.OVERRIDE_REMOTE_FEATURE_FLAGS &&
-      process.env.TOKEN_DETAILS_V2_BUTTONS_ENABLED;
-
-    if (envOverride === 'true') {
+    if (
+      process.env.OVERRIDE_REMOTE_FEATURE_FLAGS === 'true' &&
+      process.env.TOKEN_DETAILS_V2_BUTTONS_ENABLED === 'true'
+    ) {
       return true;
-    }
-    if (envOverride === 'false') {
-      return false;
     }
 
     const flagValue =

--- a/app/selectors/featureFlagController/tokenDetailsV2/index.ts
+++ b/app/selectors/featureFlagController/tokenDetailsV2/index.ts
@@ -23,11 +23,8 @@ export const selectTokenDetailsV2Enabled = createSelector(
 export const selectTokenDetailsV2ButtonsEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean => {
-    if (
-      process.env.OVERRIDE_REMOTE_FEATURE_FLAGS === 'true' &&
-      process.env.TOKEN_DETAILS_V2_BUTTONS_ENABLED === 'true'
-    ) {
-      return true;
+    if (process.env.OVERRIDE_REMOTE_FEATURE_FLAGS === 'true') {
+      return process.env.TOKEN_DETAILS_V2_BUTTONS_ENABLED === 'true';
     }
 
     const flagValue =

--- a/app/selectors/featureFlagController/tokenDetailsV2/index.ts
+++ b/app/selectors/featureFlagController/tokenDetailsV2/index.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_FEATURE_FLAG_VALUES,
   FeatureFlagNames,
 } from '../../../constants/featureFlags';
+import { isMinimumRequiredVersionSupported } from '../../../util/feature-flags';
 
 export const selectTokenDetailsV2Enabled = createSelector(
   selectRemoteFeatureFlags,
@@ -14,11 +15,42 @@ export const selectTokenDetailsV2Enabled = createSelector(
     ),
 );
 
+/**
+ * Evaluates the token-details-v-2-button-layout feature flag.
+ * Expects a { enabled, minimumVersion } object from LaunchDarkly.
+ * Supports environment variable override (OVERRIDE_REMOTE_FEATURE_FLAGS + TOKEN_DETAILS_V2_BUTTONS_ENABLED).
+ */
 export const selectTokenDetailsV2ButtonsEnabled = createSelector(
   selectRemoteFeatureFlags,
-  (remoteFeatureFlags) =>
-    Boolean(
-      remoteFeatureFlags[FeatureFlagNames.tokenDetailsV2Buttons] ??
-        DEFAULT_FEATURE_FLAG_VALUES[FeatureFlagNames.tokenDetailsV2Buttons],
-    ),
+  (remoteFeatureFlags): boolean => {
+    const envOverride =
+      process.env.OVERRIDE_REMOTE_FEATURE_FLAGS &&
+      process.env.TOKEN_DETAILS_V2_BUTTONS_ENABLED;
+
+    if (envOverride === 'true') {
+      return true;
+    }
+    if (envOverride === 'false') {
+      return false;
+    }
+
+    const flagValue =
+      remoteFeatureFlags[FeatureFlagNames.tokenDetailsV2ButtonLayout] ??
+      DEFAULT_FEATURE_FLAG_VALUES[FeatureFlagNames.tokenDetailsV2ButtonLayout];
+
+    if (typeof flagValue !== 'object' || flagValue === null) {
+      return false;
+    }
+
+    const { enabled, minimumVersion } = flagValue as {
+      enabled: boolean;
+      minimumVersion: string;
+    };
+
+    if (!enabled || !minimumVersion || typeof minimumVersion !== 'string') {
+      return false;
+    }
+
+    return isMinimumRequiredVersionSupported(minimumVersion);
+  },
 );


### PR DESCRIPTION

## **Description**

Creates a new FF for token details v2 with min version

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Feature-flag plumbing and selector behavior changes only; risk is mainly incorrect gating if the new flag payload/override configuration is wrong.
> 
> **Overview**
> Adds a new remote feature flag `tokenDetailsV2ButtonLayout` (default `false`) and switches `selectTokenDetailsV2ButtonsEnabled` to evaluate this flag via `validatedVersionGatedFeatureFlag`, including support for override env vars.
> 
> Updates the `AssetOverviewContent` test to mock the feature-flag selectors directly and removes reliance on `RemoteFeatureFlagController.remoteFeatureFlags.tokenDetailsV2Buttons` state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 276d02c78bc412fe857744c3942fd5f903f57073. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->