### PR TITLE
feat(MerklRewards): implement caching and deduplication for Merkl rewards API

### DIFF
--- a/app/components/UI/Earn/components/MerklRewards/constants.ts
+++ b/app/components/UI/Earn/components/MerklRewards/constants.ts
@@ -23,6 +23,14 @@ export const DISTRIBUTOR_CLAIMED_ABI = [
   'function claimed(address user, address token) external view returns (uint208 amount, uint48 timestamp, bytes32 merkleRoot)',
 ];
 
+/**
+ * Cache TTL for Merkl rewards API responses (2 minutes).
+ * Merkle trees update infrequently, so cached data stays valid for a while.
+ * This allows the "Claim bonus" tap to use pre-warmed data from the
+ * display fetch that runs on mount, eliminating the API latency.
+ */
+export const MERKL_REWARDS_CACHE_TTL_MS = 2 * 60 * 1000;
+
 // ABI for the claim method
 export const DISTRIBUTOR_CLAIM_ABI = [
   'function claim(address[] calldata users, address[] calldata tokens, uint256[] calldata amounts, bytes32[][] calldata proofs)',

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklClaim.test.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklClaim.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { renderHook, act } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { useMerklClaim } from './useMerklClaim';
 import { addTransaction } from '../../../../../../util/transaction-controller';
@@ -42,8 +42,13 @@ jest.mock('../../../../../../util/Logger', () => ({
   error: jest.fn(),
 }));
 
-// Mock fetch globally
-global.fetch = jest.fn();
+// Mock merkl-client to bypass module-level cache
+const mockFetchMerklRewardsForAsset = jest.fn();
+jest.mock('../merkl-client', () => ({
+  fetchMerklRewardsForAsset: (...args: unknown[]) =>
+    mockFetchMerklRewardsForAsset(...args),
+  clearMerklRewardsCache: jest.fn(),
+}));
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockAddTransaction = addTransaction as jest.MockedFunction<
@@ -71,42 +76,33 @@ const mockAsset: TokenI = {
   isNative: false,
 };
 
-// Helper to create mock reward data
+// Helper to create mock reward data (shape returned by fetchMerklRewardsForAsset)
 const createMockRewardData = (overrides?: {
   address?: string;
   chainId?: number;
   symbol?: string;
   amount?: string;
-}) => [
-  {
-    rewards: [
-      {
-        token: {
-          address:
-            overrides?.address ?? '0x8d652c6d4A8F3Db96Cd866C1a9220B1447F29898',
-          chainId: overrides?.chainId ?? 1,
-          symbol: overrides?.symbol ?? 'aglaMerkl',
-          decimals: 18,
-          price: null,
-        },
-        accumulated: '0',
-        unclaimed: '0',
-        pending: overrides?.amount ?? '1000000000000000000',
-        proofs: [
-          '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-        ],
-        amount: overrides?.amount ?? '1000000000000000000',
-        claimed: '0',
-        recipient: mockSelectedAddress,
-      },
-    ],
+}) => ({
+  token: {
+    address: overrides?.address ?? '0x8d652c6d4A8F3Db96Cd866C1a9220B1447F29898',
+    chainId: overrides?.chainId ?? 1,
+    symbol: overrides?.symbol ?? 'aglaMerkl',
+    decimals: 18,
+    price: null,
   },
-];
+  pending: overrides?.amount ?? '1000000000000000000',
+  proofs: [
+    '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  ],
+  amount: overrides?.amount ?? '1000000000000000000',
+  claimed: '0',
+  recipient: mockSelectedAddress,
+});
 
 describe('useMerklClaim', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (global.fetch as jest.Mock).mockClear();
+    mockFetchMerklRewardsForAsset.mockReset();
 
     mockUseSelector.mockImplementation((selector: unknown) => {
       if (selector === selectSelectedInternalAccountFormattedAddress) {
@@ -195,10 +191,7 @@ describe('useMerklClaim', () => {
   });
 
   it('fetches rewards and submits transaction successfully', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => createMockRewardData(),
-    });
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(createMockRewardData());
 
     mockAddTransaction.mockResolvedValueOnce({
       result: Promise.resolve('0xabc123'),
@@ -217,9 +210,11 @@ describe('useMerklClaim', () => {
     // isClaiming is false after addTransaction resolves
     expect(result.current.isClaiming).toBe(false);
     expect(result.current.error).toBe(null);
-    expect(global.fetch).toHaveBeenCalled();
-    const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
-    expect(fetchCall[0]).toContain(`chainId=${Number(CHAIN_IDS.MAINNET)}`);
+    expect(mockFetchMerklRewardsForAsset).toHaveBeenCalledWith(
+      mockAsset,
+      mockSelectedAddress,
+      expect.any(AbortSignal),
+    );
 
     const txCall = mockAddTransaction.mock.calls[0][0];
     expect(txCall.from).toBe(mockSelectedAddress);
@@ -228,91 +223,9 @@ describe('useMerklClaim', () => {
   });
 
   it('sets error when API fetch fails', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-    });
-
-    const { result } = renderHook(() => useMerklClaim(mockAsset));
-
-    await act(async () => {
-      try {
-        await result.current.claimRewards();
-      } catch {
-        // Expected to throw
-      }
-    });
-
-    await waitFor(() => {
-      expect(result.current.error).toBeTruthy();
-    });
-
-    expect(result.current.isClaiming).toBe(false);
-    expect(result.current.error).toContain('Failed to fetch Merkl rewards');
-  });
-
-  it('throws error when no claimable rewards found', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => [{ rewards: [] }],
-    });
-
-    const { result } = renderHook(() => useMerklClaim(mockAsset));
-
-    await act(async () => {
-      try {
-        await result.current.claimRewards();
-      } catch {
-        // Expected
-      }
-    });
-
-    await waitFor(() => expect(result.current.error).toBeTruthy());
-    expect(result.current.error).toBe('No claimable rewards found');
-    expect(result.current.isClaiming).toBe(false);
-  });
-
-  it('throws error when no matching token found in rewards', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () =>
-        createMockRewardData({
-          address: '0x1111111111111111111111111111111111111111',
-          symbol: 'OTHER',
-        }),
-    });
-
-    const { result } = renderHook(() => useMerklClaim(mockAsset));
-
-    await act(async () => {
-      try {
-        await result.current.claimRewards();
-      } catch {
-        // Expected
-      }
-    });
-
-    await waitFor(() => expect(result.current.error).toBeTruthy());
-    expect(result.current.error).toBe('No claimable rewards found');
-    expect(result.current.isClaiming).toBe(false);
-  });
-
-  it('finds matching reward in second data array element', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => [
-        ...createMockRewardData({
-          address: '0x1111111111111111111111111111111111111111',
-          symbol: 'OTHER',
-        }),
-        createMockRewardData({ amount: '2500000000000000000' })[0],
-      ],
-    });
-
-    mockAddTransaction.mockResolvedValueOnce({
-      result: Promise.resolve('0xabc123'),
-      transactionMeta: { id: 'tx-123' },
-    } as never);
+    mockFetchMerklRewardsForAsset.mockRejectedValueOnce(
+      new Error('Failed to fetch Merkl rewards: 500'),
+    );
 
     const { result } = renderHook(() => useMerklClaim(mockAsset));
 
@@ -321,14 +234,27 @@ describe('useMerklClaim', () => {
     });
 
     expect(result.current.isClaiming).toBe(false);
-    expect(mockAddTransaction.mock.calls[0][0].to).toBe(
-      '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
-    );
+    expect(result.current.error).toContain('Failed to fetch Merkl rewards');
+  });
+
+  it('sets error when no claimable rewards found', async () => {
+    // fetchMerklRewardsForAsset returns null when no matching reward exists
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useMerklClaim(mockAsset));
+
+    await act(async () => {
+      await result.current.claimRewards();
+    });
+
+    expect(result.current.error).toBe('No claimable rewards found');
+    expect(result.current.isClaiming).toBe(false);
   });
 
   it('sets error and returns undefined on network failure', async () => {
-    const error = new Error('Network error');
-    (global.fetch as jest.Mock).mockRejectedValueOnce(error);
+    mockFetchMerklRewardsForAsset.mockRejectedValueOnce(
+      new Error('Network error'),
+    );
 
     const { result } = renderHook(() => useMerklClaim(mockAsset));
 
@@ -343,10 +269,7 @@ describe('useMerklClaim', () => {
   });
 
   it('sets isClaiming to true during claim process', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => createMockRewardData(),
-    });
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(createMockRewardData());
 
     mockAddTransaction.mockResolvedValueOnce({
       result: Promise.resolve('0xabc123'),
@@ -380,15 +303,13 @@ describe('useMerklClaim', () => {
       address: '0x1234567890123456789012345678901234567890' as const,
     };
 
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () =>
-        createMockRewardData({
-          address: '0x1234567890123456789012345678901234567890',
-          chainId: Number(CHAIN_IDS.LINEA_MAINNET),
-          symbol: 'mUSD',
-        }),
-    });
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(
+      createMockRewardData({
+        address: '0x1234567890123456789012345678901234567890',
+        chainId: Number(CHAIN_IDS.LINEA_MAINNET),
+        symbol: 'mUSD',
+      }),
+    );
 
     mockAddTransaction.mockResolvedValueOnce({
       result: Promise.resolve('0xabc123'),
@@ -401,9 +322,10 @@ describe('useMerklClaim', () => {
       await result.current.claimRewards();
     });
 
-    const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
-    expect(fetchCall[0]).toContain(
-      `chainId=${Number(CHAIN_IDS.LINEA_MAINNET)}`,
+    expect(mockFetchMerklRewardsForAsset).toHaveBeenCalledWith(
+      lineaAsset,
+      mockSelectedAddress,
+      expect.any(AbortSignal),
     );
     expect(mockAddTransaction.mock.calls[0][0].chainId).toBe(
       `0x${Number(CHAIN_IDS.LINEA_MAINNET).toString(16)}`,
@@ -411,36 +333,9 @@ describe('useMerklClaim', () => {
   });
 
   it('always uses Linea chain ID for claims even when token.chainId is undefined', async () => {
-    // Create reward data without chainId in token
-    const rewardDataWithoutChainId = [
-      {
-        rewards: [
-          {
-            token: {
-              address: '0x8d652c6d4A8F3Db96Cd866C1a9220B1447F29898',
-              chainId: undefined, // No chainId from API
-              symbol: 'aglaMerkl',
-              decimals: 18,
-              price: null,
-            },
-            accumulated: '0',
-            unclaimed: '0',
-            pending: '1000000000000000000',
-            proofs: [
-              '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-            ],
-            amount: '1000000000000000000',
-            claimed: '0',
-            recipient: mockSelectedAddress,
-          },
-        ],
-      },
-    ];
-
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => rewardDataWithoutChainId,
-    });
+    const rewardData = createMockRewardData();
+    rewardData.token.chainId = undefined as unknown as number;
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(rewardData);
 
     mockAddTransaction.mockResolvedValueOnce({
       result: Promise.resolve('0xabc123'),
@@ -462,10 +357,7 @@ describe('useMerklClaim', () => {
   it('returns transaction hash after successful submission', async () => {
     const expectedTxHash = '0xabc123';
 
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => createMockRewardData(),
-    });
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(createMockRewardData());
 
     mockAddTransaction.mockResolvedValueOnce({
       result: Promise.resolve(expectedTxHash),
@@ -485,10 +377,7 @@ describe('useMerklClaim', () => {
   });
 
   it('does not set error when user rejects the transaction (EIP-1193 code 4001)', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => createMockRewardData(),
-    });
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(createMockRewardData());
 
     // Create error with EIP-1193 user rejection code
     const userRejectionError = Object.assign(
@@ -513,10 +402,7 @@ describe('useMerklClaim', () => {
   });
 
   it('sets error for non-user-rejection errors (no code 4001)', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => createMockRewardData(),
-    });
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(createMockRewardData());
 
     // Error without code 4001 should set error state
     mockAddTransaction.mockRejectedValueOnce(new Error('Network error'));
@@ -561,10 +447,9 @@ describe('useMerklClaim', () => {
 
   describe('isClaiming reset after addTransaction', () => {
     it('sets isClaiming to false after addTransaction resolves (before waiting for tx hash)', async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: async () => createMockRewardData(),
-      });
+      mockFetchMerklRewardsForAsset.mockResolvedValueOnce(
+        createMockRewardData(),
+      );
 
       // Create a deferred promise so we can control when result resolves
       let resolveResult!: (value: string) => void;
@@ -607,10 +492,9 @@ describe('useMerklClaim', () => {
     });
 
     it('returns undefined and sets isClaiming to false when transactionMeta is undefined', async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: async () => createMockRewardData(),
-      });
+      mockFetchMerklRewardsForAsset.mockResolvedValueOnce(
+        createMockRewardData(),
+      );
 
       mockAddTransaction.mockResolvedValueOnce({
         result: Promise.resolve('0xabc123'),

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklClaim.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklClaim.ts
@@ -137,7 +137,10 @@ export const useMerklClaim = (asset: TokenI | undefined) => {
       const { name, code, message } = e as Error & { code?: number };
 
       // Ignore AbortError - component unmounted or request was cancelled
+      // Still reset isClaiming so the spinner doesn't stick if the component
+      // is still mounted (e.g. a stale abort from a deduplicated request).
       if (name === 'AbortError') {
+        setIsClaiming(false);
         return undefined;
       }
 

--- a/app/components/UI/Earn/hooks/useMerklClaimStatus.ts
+++ b/app/components/UI/Earn/hooks/useMerklClaimStatus.ts
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import Engine from '../../../../core/Engine';
 import useEarnToasts from './useEarnToasts';
 import { MERKL_CLAIM_ORIGIN } from '../components/MerklRewards/constants';
+import { clearMerklRewardsCache } from '../components/MerklRewards/merkl-client';
 import Logger from '../../../../util/Logger';
 
 /**
@@ -99,6 +100,8 @@ export const useMerklClaimStatus = () => {
           // Show success toast (same as mUSD conversion success per AC)
           showToast(EarnToastOptions.bonusClaim.success);
           shownToastsRef.current.add(toastKey);
+          // Invalidate cached Merkl rewards so the next fetch reflects the new on-chain state
+          clearMerklRewardsCache();
           // Refresh token balances so user sees updated balance on home page
           if (chainId) {
             refreshTokenBalances(chainId);

--- a/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.test.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.test.tsx
@@ -21,8 +21,10 @@ import { useMusdConversionTokens } from '../../../Earn/hooks/useMusdConversionTo
 import { useMusdConversionEligibility } from '../../../Earn/hooks/useMusdConversionEligibility';
 import {
   selectIsMusdConversionFlowEnabledFlag,
+  selectMerklCampaignClaimingEnabledFlag,
   selectStablecoinLendingEnabledFlag,
 } from '../../../Earn/selectors/featureFlags';
+import { isEligibleForMerklRewards } from '../../../Earn/components/MerklRewards/hooks/useMerklRewards';
 import { MUSD_CONVERSION_APY } from '../../../Earn/constants/musd';
 import { EARN_EXPERIENCES } from '../../../Earn/constants/experiences';
 
@@ -211,6 +213,11 @@ const mockSelectStablecoinLendingEnabledFlag =
     typeof selectStablecoinLendingEnabledFlag
   >;
 
+const mockSelectMerklCampaignClaimingEnabledFlag =
+  selectMerklCampaignClaimingEnabledFlag as jest.MockedFunction<
+    typeof selectMerklCampaignClaimingEnabledFlag
+  >;
+
 jest.mock('../../util/deriveBalanceFromAssetMarketDetails', () => ({
   deriveBalanceFromAssetMarketDetails: jest.fn(() => ({
     balanceFiat: '$100.00',
@@ -337,6 +344,9 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
     isStockToken?: boolean;
     isStablecoinLendingEnabled?: boolean;
     earnToken?: Record<string, unknown> | null;
+    isMerklClaimingEnabled?: boolean;
+    claimableReward?: string | null;
+    isMerklEligible?: boolean;
   }
 
   function prepareMocks({
@@ -348,6 +358,9 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
     isStockToken = false,
     isStablecoinLendingEnabled = false,
     earnToken,
+    isMerklClaimingEnabled = false,
+    claimableReward = null,
+    isMerklEligible = false,
   }: PrepareMocksOptions = {}) {
     jest.clearAllMocks();
 
@@ -355,6 +368,14 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
     mockSelectStablecoinLendingEnabledFlag.mockReturnValue(
       isStablecoinLendingEnabled ?? false,
     );
+    mockSelectMerklCampaignClaimingEnabledFlag.mockReturnValue(
+      isMerklClaimingEnabled,
+    );
+    mockUseMerklRewards.mockReturnValue({
+      claimableReward,
+      isLoading: false,
+    });
+    (isEligibleForMerklRewards as jest.Mock).mockReturnValue(isMerklEligible);
 
     // Stock token mocks
     mockIsStockToken.mockReturnValue(isStockToken);
@@ -401,6 +422,10 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
 
         if (selector === selectStablecoinLendingEnabledFlag) {
           return isStablecoinLendingEnabled;
+        }
+
+        if (selector === selectMerklCampaignClaimingEnabledFlag) {
+          return isMerklClaimingEnabled;
         }
 
         const selectorString = selector.toString();
@@ -1157,6 +1182,62 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
           symbol: 'TEST',
         }),
       );
+    });
+  });
+
+  describe('Merkl Claim Bonus', () => {
+    const claimableAsset = {
+      ...defaultAsset,
+      address: '0x8d652c6d4A8F3Db96Cd866C1a9220B1447F29898',
+    };
+    const assetKey: FlashListAssetKey = {
+      address: claimableAsset.address,
+      chainId: '0x1',
+      isStaked: false,
+    };
+
+    it('shows "Claim bonus" replacing percentage when all conditions are met', () => {
+      prepareMocks({
+        asset: claimableAsset,
+        pricePercentChange1d: 5.0,
+        isMerklClaimingEnabled: true,
+        claimableReward: '1000000000000000000',
+        isMerklEligible: true,
+      });
+
+      const { getByText, queryByText } = renderWithProvider(
+        <TokenListItemV2
+          assetKey={assetKey}
+          showRemoveMenu={jest.fn()}
+          setShowScamWarningModal={jest.fn()}
+          privacyMode={false}
+        />,
+      );
+
+      expect(getByText(strings('earn.claim_bonus'))).toBeOnTheScreen();
+      expect(queryByText('+5.00%')).toBeNull();
+    });
+
+    it('falls back to percentage when merkl claiming is disabled', () => {
+      prepareMocks({
+        asset: claimableAsset,
+        pricePercentChange1d: 1.5,
+        isMerklClaimingEnabled: false,
+        claimableReward: '1000000000000000000',
+        isMerklEligible: true,
+      });
+
+      const { queryByText, getByText } = renderWithProvider(
+        <TokenListItemV2
+          assetKey={assetKey}
+          showRemoveMenu={jest.fn()}
+          setShowScamWarningModal={jest.fn()}
+          privacyMode={false}
+        />,
+      );
+
+      expect(queryByText(strings('earn.claim_bonus'))).toBeNull();
+      expect(getByText('+1.50%')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.test.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.test.tsx
@@ -161,11 +161,44 @@ jest.mock('../../../Stake/hooks/useStakingChain', () => ({
   useStakingChainByChainId: () => ({ isStakingSupportedChain: false }),
 }));
 
+const mockClaimRewards = jest.fn();
+const mockUseMerklClaim = jest.fn((_asset?: unknown) => ({
+  claimRewards: mockClaimRewards,
+  isClaiming: false,
+  error: null,
+}));
+jest.mock('../../../Earn/components/MerklRewards/hooks/useMerklClaim', () => ({
+  useMerklClaim: (...args: [unknown]) => mockUseMerklClaim(...args),
+}));
+
+const mockUsePendingMerklClaim = jest.fn(() => ({
+  hasPendingClaim: false,
+}));
+jest.mock(
+  '../../../Earn/components/MerklRewards/hooks/usePendingMerklClaim',
+  () => ({
+    usePendingMerklClaim: () => mockUsePendingMerklClaim(),
+  }),
+);
+
+const mockUseMerklRewards = jest.fn((_opts?: unknown) => ({
+  claimableReward: null as string | null,
+  isLoading: false,
+}));
+jest.mock(
+  '../../../Earn/components/MerklRewards/hooks/useMerklRewards',
+  () => ({
+    useMerklRewards: (...args: [unknown]) => mockUseMerklRewards(...args),
+    isEligibleForMerklRewards: jest.fn(() => false),
+  }),
+);
+
 jest.mock('../../../Earn/selectors/featureFlags', () => ({
   selectPooledStakingEnabledFlag: jest.fn(() => true),
   selectStablecoinLendingEnabledFlag: jest.fn(() => false),
   selectIsMusdConversionFlowEnabledFlag: jest.fn(() => false),
   selectMusdConversionPaymentTokensAllowlist: jest.fn(() => ({})),
+  selectMerklCampaignClaimingEnabledFlag: jest.fn(() => false),
 }));
 
 const mockSelectIsMusdConversionFlowEnabledFlag =

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -20,7 +20,6 @@ import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/us
 import { PERPS_CURRENCY } from '../../../constants/perps';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { BigNumber } from 'bignumber.js';
-import { MERKL_CLAIM_CHAIN_ID } from '../../../../../UI/Earn/components/MerklRewards/constants';
 import {
   convertMusdClaimAmount,
   decodeMerklClaimAmount,
@@ -115,11 +114,12 @@ function useDecodedAmount() {
  */
 function useClaimAmount(): { amount: BigNumber | null; isConverted: boolean } {
   const { transactionMeta } = useTransactionDetails();
-  const { networkNativeCurrency } = useNetworkInfo(MERKL_CLAIM_CHAIN_ID);
+  const { chainId } = transactionMeta;
+  const { networkNativeCurrency } = useNetworkInfo(chainId);
 
   const conversionRate = new BigNumber(
     useSelector((state: RootState) =>
-      selectConversionRateByChainId(state, MERKL_CLAIM_CHAIN_ID),
+      selectConversionRateByChainId(state, chainId),
     ) ?? 0,
   );
   const currencyRates = useSelector(selectCurrencyRates);

--- a/app/components/Views/confirmations/components/info/musd-claim-info/musd-claim-info.tsx
+++ b/app/components/Views/confirmations/components/info/musd-claim-info/musd-claim-info.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { View } from 'react-native';
+import { Hex } from '@metamask/utils';
 
 import { strings } from '../../../../../../../locales/i18n';
-import { MERKL_CLAIM_CHAIN_ID } from '../../../../../UI/Earn/components/MerklRewards/constants';
 import InfoSection from '../../UI/info-row/info-section';
 import InfoRowDivider from '../../UI/info-row-divider';
 import { HeroRow } from '../../rows/transactions/hero-row';
@@ -10,18 +10,21 @@ import AccountRow from '../../rows/transactions/account-row';
 import NetworkRow from '../../rows/transactions/network-row';
 import GasFeesDetailsRow from '../../rows/transactions/gas-fee-details-row';
 import { ConfirmationInfoComponentIDs } from '../../../constants/info-ids';
+import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 
-export const MusdClaimInfo = () => (
-  <View testID={ConfirmationInfoComponentIDs.MUSD_CLAIM}>
-    <HeroRow />
-    <InfoSection>
-      <AccountRow
-        label={strings('stake.claiming_to')}
-        chainId={MERKL_CLAIM_CHAIN_ID}
-      />
-      <InfoRowDivider />
-      <NetworkRow chainId={MERKL_CLAIM_CHAIN_ID} />
-    </InfoSection>
-    <GasFeesDetailsRow disableUpdate />
-  </View>
-);
+export const MusdClaimInfo = () => {
+  const transactionMetadata = useTransactionMetadataRequest();
+  const chainId = transactionMetadata?.chainId as Hex;
+
+  return (
+    <View testID={ConfirmationInfoComponentIDs.MUSD_CLAIM}>
+      <HeroRow />
+      <InfoSection>
+        <AccountRow label={strings('stake.claiming_to')} chainId={chainId} />
+        <InfoRowDivider />
+        <NetworkRow chainId={chainId} />
+      </InfoSection>
+      <GasFeesDetailsRow disableUpdate />
+    </View>
+  );
+};

--- a/app/components/Views/confirmations/components/info/musd-claim-info/musd-claim-info.tsx
+++ b/app/components/Views/confirmations/components/info/musd-claim-info/musd-claim-info.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { View } from 'react-native';
-import { Hex } from '@metamask/utils';
 
 import { strings } from '../../../../../../../locales/i18n';
 import InfoSection from '../../UI/info-row/info-section';
@@ -10,26 +9,15 @@ import AccountRow from '../../rows/transactions/account-row';
 import NetworkRow from '../../rows/transactions/network-row';
 import GasFeesDetailsRow from '../../rows/transactions/gas-fee-details-row';
 import { ConfirmationInfoComponentIDs } from '../../../constants/info-ids';
-import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 
-export const MusdClaimInfo = () => {
-  const transactionMetadata = useTransactionMetadataRequest();
-
-  if (!transactionMetadata) {
-    return null;
-  }
-
-  const chainId = transactionMetadata.chainId as Hex;
-
-  return (
-    <View testID={ConfirmationInfoComponentIDs.MUSD_CLAIM}>
-      <HeroRow />
-      <InfoSection>
-        <AccountRow label={strings('stake.claiming_to')} chainId={chainId} />
-        <InfoRowDivider />
-        <NetworkRow chainId={chainId} />
-      </InfoSection>
-      <GasFeesDetailsRow disableUpdate />
-    </View>
-  );
-};
+export const MusdClaimInfo = () => (
+  <View testID={ConfirmationInfoComponentIDs.MUSD_CLAIM}>
+    <HeroRow />
+    <InfoSection>
+      <AccountRow label={strings('stake.claiming_to')} />
+      <InfoRowDivider />
+      <NetworkRow />
+    </InfoSection>
+    <GasFeesDetailsRow disableUpdate />
+  </View>
+);

--- a/app/components/Views/confirmations/components/info/musd-claim-info/musd-claim-info.tsx
+++ b/app/components/Views/confirmations/components/info/musd-claim-info/musd-claim-info.tsx
@@ -14,7 +14,12 @@ import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTr
 
 export const MusdClaimInfo = () => {
   const transactionMetadata = useTransactionMetadataRequest();
-  const chainId = transactionMetadata?.chainId as Hex;
+
+  if (!transactionMetadata) {
+    return null;
+  }
+
+  const chainId = transactionMetadata.chainId as Hex;
 
   return (
     <View testID={ConfirmationInfoComponentIDs.MUSD_CLAIM}>

--- a/app/components/Views/confirmations/components/rows/transactions/account-row/account-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/account-row/account-row.tsx
@@ -7,14 +7,17 @@ import { getFormattedAddressFromInternalAccount } from '../../../../../../../cor
 import Name from '../../../../../../UI/Name';
 import { NameType } from '../../../../../../UI/Name/Name.types';
 import { EVM_SCOPE } from '../../../../../../UI/Earn/constants/networks';
+import { useTransactionMetadataRequest } from '../../../../hooks/transactions/useTransactionMetadataRequest';
 import InfoRow from '../../../UI/info-row';
 
 interface AccountRowProps {
   label: string;
-  chainId: Hex;
+  chainId?: Hex;
 }
 
-const AccountRow = ({ label, chainId }: AccountRowProps) => {
+const AccountRow = ({ label, chainId: chainIdProp }: AccountRowProps) => {
+  const transactionMetadata = useTransactionMetadataRequest();
+  const chainId = chainIdProp ?? (transactionMetadata?.chainId as Hex);
   const selectedAccount = useSelector(selectSelectedInternalAccountByScope)(
     EVM_SCOPE,
   );

--- a/app/components/Views/confirmations/components/rows/transactions/network-row/network-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/network-row/network-row.tsx
@@ -10,6 +10,7 @@ import AvatarNetwork from '../../../../../../../component-library/components/Ava
 import { AvatarSize } from '../../../../../../../component-library/components/Avatars/Avatar/Avatar.types';
 import { getNetworkImageSource } from '../../../../../../../util/networks';
 import useNetworkInfo from '../../../../hooks/useNetworkInfo';
+import { useTransactionMetadataRequest } from '../../../../hooks/transactions/useTransactionMetadataRequest';
 import InfoRow from '../../../UI/info-row';
 
 const styles = StyleSheet.create({
@@ -23,11 +24,13 @@ const styles = StyleSheet.create({
 });
 
 interface NetworkRowProps {
-  chainId: Hex;
+  chainId?: Hex;
   style?: Record<string, unknown>;
 }
 
-const NetworkRow = ({ chainId, style }: NetworkRowProps) => {
+const NetworkRow = ({ chainId: chainIdProp, style }: NetworkRowProps) => {
+  const transactionMetadata = useTransactionMetadataRequest();
+  const chainId = chainIdProp ?? (transactionMetadata?.chainId as Hex);
   const { networkName } = useNetworkInfo(chainId);
   const networkImage = getNetworkImageSource({ chainId });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds in-memory caching with TTL and request deduplication for Merkl rewards API responses, following the existing Sentinel API caching pattern in the codebase.

**Why:** When a user taps "Claim bonus", useMerklClaim re-fetches the same Merkl API endpoint that useMerklRewards already fetched on mount (to display the claimable amount). This redundant network call adds ~100-300ms of latency before the transaction can be submitted. With caching, the claim path hits the warm cache in ~7ms instead.

**What changed:**

- **Merkl API caching layer** (merkl-client.ts): In-memory cache keyed by request URL with a 2-minute TTL. Concurrent requests to the same URL are deduplicated (single in-flight promise). Failed responses are not cached.
- **Cache invalidation** (useMerklClaimStatus.ts): Cache is cleared when a claim transaction is confirmed on-chain, so the next fetch reflects updated state.
- **TokenListItemV2 claim flow** (TokenListItemV2.tsx): Fixed "Claim bonus" tap which was incorrectly navigating to asset overview instead of triggering the claim. Now uses the same MerklClaimHandler pattern as V1, with spinner during claiming state. When "Claim bonus" CTA is displayed, it replaces both token price and percentage change (not just percentage change).
- **Dynamic chain ID in confirmation UI** (musd-claim-info.tsx, transaction-details-hero.tsx): Reads chain ID from transaction metadata instead of hardcoding MERKL_CLAIM_CHAIN_ID, making the confirmation screen chain-agnostic.

**Note:** The dominant claim latency (~1.4s) comes from TransactionController.addTransaction() (gas estimation, nonce resolution, security checks via RPC). The cache eliminates the Merkl API portion and also provides resilience against API slowness or outages.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved claim bonus responsiveness by caching Merkl API responses and fixed claim bonus button in token list V2 layout

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-310

## **Manual testing steps**

```gherkin
Feature: Merkl rewards claim bonus caching

  Scenario: user claims bonus with cached API response
    Given the user has a token with claimable Merkl rewards
    And the "Claim bonus" CTA is visible in the token list

    When user taps "Claim bonus"
    Then a spinner is shown on the token list item
    And the transaction confirmation screen appears (~1.4s, no Merkl API delay)
    And the spinner is replaced by the confirmation UI

  Scenario: cache is invalidated after successful claim
    Given the user has completed a claim transaction
    And the transaction is confirmed on-chain

    When the token list re-renders
    Then the Merkl API is re-fetched with fresh data
    And the "Claim bonus" CTA reflects the updated claimable amount

  Scenario: claim bonus replaces token price in V2 layout
    Given the user is on the token list V2 layout
    And a token has claimable Merkl rewards

    When the "Claim bonus" CTA is displayed
    Then the token price and percentage change are hidden
    And only the "Claim bonus" text is shown in their place
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="396" height="836" alt="Screenshot 2026-02-12 at 15 52 26" src="https://github.com/user-attachments/assets/285f4438-1c9d-4cf2-9d25-9adc593a4358" />

<!-- [screenshots/recordings] -->

### **After**
<img width="391" height="835" alt="Screenshot 2026-02-12 at 15 49 54" src="https://github.com/user-attachments/assets/a291c3c4-1caa-41a9-8437-96709a322c06" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches claim/transaction UX and adds shared caching/deduplication around network requests; main risk is stale/incorrect cache usage affecting displayed claimability and claim triggering, mitigated by TTL, invalidation on confirmed claims, and tests.
> 
> **Overview**
> **Adds an in-memory caching layer for the Merkl rewards API** with a 2-minute TTL and in-flight request deduplication in `merkl-client`, plus `clearMerklRewardsCache()` and cache-focused unit tests (including TTL, dedup, and error/no-cache behavior).
> 
> **Improves the Merkl “Claim bonus” UX and correctness**: token list V2 now uses `MerklClaimHandler` to wire claim state/handler, shows a spinner while claiming, and the CTA triggers the claim (not navigation) while hiding token price/percent-change when active; the cache is invalidated on claim confirmation via `useMerklClaimStatus`.
> 
> **Makes confirmation UI chain-agnostic** by deriving chain/network display and conversion rates from transaction metadata instead of hardcoding `MERKL_CLAIM_CHAIN_ID`, and ensures `useMerklClaim` resets `isClaiming` on `AbortError` to avoid stuck spinners.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e0a6a7819acd59fbdd79cfcb99536bec8a92e82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->