### PR TITLE
fix(confirmations): update bonus payout subtitle

### DIFF
--- a/app/components/Views/confirmations/components/title/title.test.tsx
+++ b/app/components/Views/confirmations/components/title/title.test.tsx
@@ -320,9 +320,7 @@ describe('Confirm Title', () => {
       state: musdClaimState,
     });
     expect(getByText('Claim bonus')).toBeTruthy();
-    expect(
-      getByText('Bonus payout will be on Linea Mainnet Network.'),
-    ).toBeTruthy();
+    expect(getByText('Bonus will be paid out on Linea Mainnet.')).toBeTruthy();
   });
 
   it.each([TransactionType.lendingDeposit, TransactionType.lendingWithdraw])(

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5790,7 +5790,7 @@
     "earn_a_percentage_bonus": "Earn a {{percentage}}% bonus",
     "claimable_bonus": "Claimable bonus",
     "claim_bonus": "Claim bonus",
-    "claim_bonus_subtitle": "Bonus payout will be on {{networkName}} Network.",
+    "claim_bonus_subtitle": "Bonus will be paid out on {{networkName}}.",
     "empty_state_cta": {
       "heading": "Lend {{tokenSymbol}} and earn",
       "body": "Lend your {{tokenSymbol}} with {{protocol}} and earn",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates the claim bonus subtitle copy to be more concise and natural-sounding.

**Before:** "Bonus payout will be on {{networkName}} Network."
**After:** "Bonus will be paid out on {{networkName}}."

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated mUSD claim bonus subtitle copy

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-312

## **Manual testing steps**

```gherkin
Feature: mUSD Claim Bonus Subtitle

  Scenario: user views claim bonus confirmation screen
    Given user has mUSD tokens with claimable yield rewards
    And user is on the mUSD token details screen

    When user taps the "Claim" button to claim bonus
    Then the confirmation screen displays "Claim bonus" as the title
    And the subtitle shows "Bonus will be paid out on Linea."
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="388" height="565" alt="Screenshot 2026-02-12 at 16 55 22" src="https://github.com/user-attachments/assets/d4508e6d-7114-4859-a3e0-3d369fe9a8ef" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only localization copy change plus a matching test update; no logic, security, or data-handling behavior is modified.
> 
> **Overview**
> Updates the `mUSD` claim bonus confirmation subtitle to a shorter, more natural sentence by changing `earn.claim_bonus_subtitle` from “Bonus payout will be on {{networkName}} Network.” to “Bonus will be paid out on {{networkName}}.”
> 
> Adjusts the `Title` component test to assert the new subtitle text for the Linea Mainnet case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 428bdafd241bdcdd1c183dc965dcf6e78e6f8e1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->