### PR TITLE
refactor(predict): simplify to single-provider architecture

### DIFF
--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.test.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../types';
 import { useLiveMarketPrices } from '../../hooks/useLiveMarketPrices';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string, params?: Record<string, string>) => {
     if (key === 'predict.claim_amount_text' && params?.amount) {
@@ -31,7 +32,7 @@ const createMockGetPrice =
 
 const createMockOutcome = (overrides = {}): PredictOutcome => ({
   id: 'outcome-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-1',
   title: 'Will it happen?',
   description: 'Test outcome',
@@ -48,7 +49,7 @@ const createMockOutcome = (overrides = {}): PredictOutcome => ({
 
 const createMockMarket = (overrides = {}): PredictMarket => ({
   id: 'market-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   slug: 'test-market',
   title: 'Test Market',
   description: 'Test market description',

--- a/app/components/UI/Predict/components/PredictAddFundsSheet/PredictAddFundsSheet.tsx
+++ b/app/components/UI/Predict/components/PredictAddFundsSheet/PredictAddFundsSheet.tsx
@@ -16,7 +16,6 @@ import BottomSheetHeader from '../../../../../component-library/components/Botto
 import { ButtonVariants } from '../../../../../component-library/components/Buttons/Button/Button.types';
 import { usePredictDeposit } from '../../hooks/usePredictDeposit';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
-import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { PredictNavigationParamList } from '../../types/navigation';
 import { PredictEventValues } from '../../constants/eventNames';
@@ -40,7 +39,6 @@ const PredictAddFundsSheet = forwardRef<
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const { deposit } = usePredictDeposit();
   const { executeGuardedAction } = usePredictActionGuard({
-    providerId: POLYMARKET_PROVIDER_ID,
     navigation,
   });
   const { sheetRef, isVisible, closeSheet, handleSheetClosed, getRefHandlers } =

--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
@@ -58,7 +58,6 @@ const PredictBalance: React.FC<PredictBalanceProps> = ({ onLayout }) => {
   const { deposit, isDepositPending } = usePredictDeposit();
   const { withdraw } = usePredictWithdraw();
   const { executeGuardedAction } = usePredictActionGuard({
-    providerId: 'polymarket',
     navigation,
   });
 

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -63,7 +63,6 @@ const getDefaultTimeframe = (
 
 const PredictGameChart: React.FC<PredictGameChartProps> = ({
   market,
-  providerId = 'polymarket',
   testID,
 }) => {
   const game = market.game;
@@ -120,7 +119,6 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
       startTs,
       endTs,
       fidelity,
-      providerId,
       enabled: tokenIds.length === 2,
     });
 

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.types.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.types.ts
@@ -31,7 +31,6 @@ export interface PredictGameChartContentProps {
 
 export interface PredictGameChartProps {
   market: PredictMarket;
-  providerId?: string;
   testID?: string;
 }
 

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
@@ -10,6 +10,7 @@ import {
   PredictGameStatus,
 } from '../../types';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 // Mock the hooks
 jest.mock('../../hooks/usePredictPriceHistory');
 jest.mock('../../hooks/useLiveMarketPrices');
@@ -98,7 +99,7 @@ const createMockMarket = (
     title: 'Test Game Market',
     description: 'Test description',
     image: 'https://example.com/image.png',
-    providerId: 'polymarket',
+    providerId: POLYMARKET_PROVIDER_ID,
     status: PredictMarketStatus.OPEN,
     category: 'sports',
     tags: ['NFL'],

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
@@ -159,7 +159,6 @@ describe('PredictGameChart Wrapper', () => {
           marketIds: defaultTokenIds,
           interval: PredictPriceHistoryInterval.ONE_HOUR,
           fidelity: 1,
-          providerId: 'polymarket',
           enabled: true,
         }),
       );
@@ -171,20 +170,6 @@ describe('PredictGameChart Wrapper', () => {
       expect(mockUseLiveMarketPrices).toHaveBeenCalledWith(defaultTokenIds, {
         enabled: true,
       });
-    });
-
-    it('passes custom providerId to usePredictPriceHistory', () => {
-      const marketWithCustomProvider = createMockMarket({
-        providerId: 'custom-provider',
-      });
-
-      render(<PredictGameChart market={marketWithCustomProvider} />);
-
-      expect(mockUsePredictPriceHistory).toHaveBeenCalledWith(
-        expect.objectContaining({
-          providerId: 'custom-provider',
-        }),
-      );
     });
 
     it('disables hooks when market has no tokens', () => {

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
@@ -178,12 +178,7 @@ describe('PredictGameChart Wrapper', () => {
         providerId: 'custom-provider',
       });
 
-      render(
-        <PredictGameChart
-          market={marketWithCustomProvider}
-          providerId="custom-provider"
-        />,
-      );
+      render(<PredictGameChart market={marketWithCustomProvider} />);
 
       expect(mockUsePredictPriceHistory).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import PredictGameDetailsContent from './PredictGameDetailsContent';
 import { PredictMarket, PredictMarketStatus } from '../../types';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 const mockGoBack = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -191,7 +192,7 @@ const createMockMarket = (
     title: 'Test Game Market',
     description: 'Test description',
     image: 'https://example.com/image.png',
-    providerId: 'polymarket',
+    providerId: POLYMARKET_PROVIDER_ID,
     status: PredictMarketStatus.OPEN,
     category: 'sports',
     tags: ['NFL'],

--- a/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.test.tsx
@@ -9,6 +9,7 @@ import {
   Recurrence,
 } from '../../types';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string, params?: Record<string, string>) => {
     if (
@@ -44,7 +45,7 @@ jest.mock('../../hooks/useLiveMarketPrices', () => ({
 
 const createMockOutcome = (overrides = {}): PredictOutcome => ({
   id: 'outcome-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-1',
   title: 'Will it happen?',
   description: 'Test outcome',
@@ -61,7 +62,7 @@ const createMockOutcome = (overrides = {}): PredictOutcome => ({
 
 const createMockMarket = (overrides = {}): PredictMarket => ({
   id: 'market-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   slug: 'test-market',
   title: 'Test Market',
   description: 'This is a test market description for testing purposes.',

--- a/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
+++ b/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
@@ -75,7 +75,6 @@ const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
   const tw = useTailwind();
 
   const { executeGuardedAction } = usePredictActionGuard({
-    providerId: market.providerId,
     navigation,
   });
 

--- a/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.tsx
+++ b/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.tsx
@@ -62,7 +62,6 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
     useNavigation<NavigationProp<PredictNavigationParamList>>();
 
   const { executeGuardedAction } = usePredictActionGuard({
-    providerId: market.providerId,
     navigation,
   });
 

--- a/app/components/UI/Predict/components/PredictMarketRowItem/PredictMarketRowItem.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketRowItem/PredictMarketRowItem.test.tsx
@@ -12,6 +12,7 @@ import { PredictEntryPointProvider } from '../../contexts';
 import PredictMarketRowItem from './';
 import Routes from '../../../../../constants/navigation/Routes';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -22,7 +23,7 @@ jest.mock('@react-navigation/native', () => ({
 
 const createMockOutcome = (overrides = {}): PredictOutcome => ({
   id: 'test-outcome-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'test-market-1',
   title: 'Monad market cap (FDV) >$4B one day after launch?',
   description: 'Test outcome description',
@@ -49,7 +50,7 @@ const createMockOutcome = (overrides = {}): PredictOutcome => ({
 
 const createMockMarket = (overrides = {}): PredictMarketType => ({
   id: 'test-market-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   slug: 'monad-fdv-prediction',
   title: 'Monad FDV one day after launch?',
   description: 'Prediction market for Monad FDV',

--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
@@ -154,7 +154,6 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
   const tw = useTailwind();
 
   const { executeGuardedAction } = usePredictActionGuard({
-    providerId: market.providerId,
     navigation,
   });
 

--- a/app/components/UI/Predict/components/PredictPicks/PredictPickItem.test.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPickItem.test.tsx
@@ -6,6 +6,7 @@ import { formatPrice } from '../../utils/format';
 
 import { usePredictOptimisticPositionRefresh } from '../../hooks/usePredictOptimisticPositionRefresh';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 jest.mock('../../hooks/usePredictOptimisticPositionRefresh');
 jest.mock('../../utils/format');
 
@@ -19,7 +20,7 @@ const createMockPosition = (
   overrides: Partial<PredictPosition> = {},
 ): PredictPosition => ({
   id: 'position-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-1',
   outcomeId: 'outcome-1',
   outcomeTokenId: '0',

--- a/app/components/UI/Predict/components/PredictPicks/PredictPicks.test.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPicks.test.tsx
@@ -13,6 +13,7 @@ import { formatPrice } from '../../utils/format';
 import Routes from '../../../../../constants/navigation/Routes';
 import { PredictEventValues } from '../../constants/eventNames';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
@@ -73,7 +74,7 @@ const createMockMarket = (
   overrides: Partial<PredictMarket> = {},
 ): PredictMarket => ({
   id: 'market-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   slug: 'will-btc-hit-100k',
   title: 'Will BTC hit 100k?',
   description: 'Bitcoin price prediction market',
@@ -86,7 +87,7 @@ const createMockMarket = (
   outcomes: [
     {
       id: 'outcome-1',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       marketId: 'market-1',
       title: 'Yes',
       description: 'BTC will hit 100k',
@@ -98,7 +99,7 @@ const createMockMarket = (
     },
     {
       id: 'outcome-2',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       marketId: 'market-1',
       title: 'No',
       description: 'BTC will not hit 100k',
@@ -118,7 +119,7 @@ const createMockPosition = (
   overrides: Partial<PredictPosition> = {},
 ): PredictPosition => ({
   id: 'position-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-1',
   outcomeId: 'outcome-1',
   outcomeTokenId: '0',

--- a/app/components/UI/Predict/components/PredictPicks/PredictPicks.test.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPicks.test.tsx
@@ -560,7 +560,7 @@ describe('PredictPicks', () => {
       );
     });
 
-    it('calls usePredictActionGuard with market.providerId', () => {
+    it('calls usePredictActionGuard with navigation only', () => {
       const market = createMockMarket({ providerId: 'custom-provider' });
       setupPositionsMock({ livePositions: [createMockPosition()] });
 
@@ -568,7 +568,7 @@ describe('PredictPicks', () => {
 
       expect(mockUsePredictActionGuard).toHaveBeenCalledWith(
         expect.objectContaining({
-          providerId: 'custom-provider',
+          navigation: expect.any(Object),
         }),
       );
     });

--- a/app/components/UI/Predict/components/PredictPicks/PredictPicks.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPicks.tsx
@@ -36,7 +36,6 @@ const PredictPicks: React.FC<PredictPicksProps> = ({
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const { navigate } = navigation;
   const { executeGuardedAction } = usePredictActionGuard({
-    providerId: market.providerId,
     navigation,
   });
 

--- a/app/components/UI/Predict/components/PredictPicks/PredictPicksForCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPicksForCard.test.tsx
@@ -5,6 +5,7 @@ import { usePredictPositions } from '../../hooks/usePredictPositions';
 import { PredictPositionStatus, type PredictPosition } from '../../types';
 import { formatPrice } from '../../utils/format';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 jest.mock('../../hooks/usePredictPositions');
 jest.mock('../../hooks/useLivePositions', () => ({
   useLivePositions: jest.fn((positions: unknown[]) => ({
@@ -29,7 +30,7 @@ const createMockPosition = (
   overrides: Partial<PredictPosition> = {},
 ): PredictPosition => ({
   id: 'position-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-1',
   outcomeId: 'outcome-1',
   outcomeTokenId: '0',

--- a/app/components/UI/Predict/components/PredictPosition/PredictPosition.test.tsx
+++ b/app/components/UI/Predict/components/PredictPosition/PredictPosition.test.tsx
@@ -14,6 +14,7 @@ import {
 import { PredictPositionSelectorsIDs } from '../../Predict.testIds';
 import { usePredictPositions } from '../../hooks/usePredictPositions';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string, vars?: Record<string, string | number>) => {
     if (key === 'predict.position_info' && vars) {
@@ -36,7 +37,7 @@ jest.mock('../../hooks/usePredictPositions', () => ({
 
 const basePosition: PredictPositionType = {
   id: 'pos-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-1',
   outcomeId: 'outcome-1',
   outcomeTokenId: '0',

--- a/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
@@ -16,6 +16,7 @@ import { usePredictOrderPreview } from '../../hooks/usePredictOrderPreview';
 import { PredictMarketDetailsSelectorsIDs } from '../../Predict.testIds';
 import Routes from '../../../../../constants/navigation/Routes';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 declare global {
   // eslint-disable-next-line no-var
   var __mockNavigate: jest.Mock;
@@ -75,7 +76,7 @@ jest.mock('../../hooks/usePredictOrderPreview', () => ({
 
 const basePosition: PredictPositionType = {
   id: 'pos-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-1',
   outcomeId: 'outcome-1',
   outcomeTokenId: '0',
@@ -98,7 +99,7 @@ const basePosition: PredictPositionType = {
 
 const baseMarket: PredictMarket = {
   id: 'market-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   slug: 'will-etf-be-approved',
   title: 'Will ETF be approved?',
   description: 'Test market',
@@ -111,7 +112,7 @@ const baseMarket: PredictMarket = {
   outcomes: [
     {
       id: 'outcome-1',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       marketId: 'market-1',
       title: 'Yes',
       description: 'Yes outcome',
@@ -123,7 +124,7 @@ const baseMarket: PredictMarket = {
     },
     {
       id: 'outcome-2',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       marketId: 'market-1',
       title: 'No',
       description: 'No outcome',

--- a/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.tsx
+++ b/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.tsx
@@ -69,7 +69,6 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const { navigate } = navigation;
   const { executeGuardedAction } = usePredictActionGuard({
-    providerId: currentPosition.providerId,
     navigation,
   });
 
@@ -82,7 +81,6 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
       : undefined;
 
   const { preview, isLoading: isPreviewLoading } = usePredictOrderPreview({
-    providerId: currentPosition.providerId,
     marketId: currentPosition.marketId,
     outcomeId: currentPosition.outcomeId,
     outcomeTokenId: currentPosition.outcomeTokenId,

--- a/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.test.tsx
@@ -6,6 +6,7 @@ import {
   type PredictPosition as PredictPositionType,
 } from '../../types';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 // Mock strings function from i18n
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string, params?: Record<string, string | number>) => {
@@ -41,7 +42,7 @@ jest.mock('dayjs', () => {
 
 const basePosition: PredictPositionType = {
   id: 'pos-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-1',
   outcomeId: 'outcome-1',
   outcomeTokenId: '0',

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -38,7 +38,6 @@ import { usePredictClaim } from '../../hooks/usePredictClaim';
 import { usePredictDeposit } from '../../hooks/usePredictDeposit';
 import { useUnrealizedPnL } from '../../hooks/useUnrealizedPnL';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
-import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 import { selectPredictWonPositions } from '../../selectors/predictController';
 import { PredictPosition } from '../../types';
 import { PredictNavigationParamList } from '../../types/navigation';
@@ -70,7 +69,6 @@ const PredictPositionsHeader = forwardRef<
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const tw = useTailwind();
   const { executeGuardedAction } = usePredictActionGuard({
-    providerId: POLYMARKET_PROVIDER_ID,
     navigation,
   });
   const {
@@ -94,9 +92,7 @@ const PredictPositionsHeader = forwardRef<
     isLoading: isUnrealizedPnLLoading,
     loadUnrealizedPnL,
     error: pnlError,
-  } = useUnrealizedPnL({
-    providerId: POLYMARKET_PROVIDER_ID,
-  });
+  } = useUnrealizedPnL();
 
   // Notify parent of errors while keeping state isolated
   useEffect(() => {

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
@@ -309,26 +309,24 @@ describe('PredictSportCardFooter', () => {
       });
     });
 
-    it('calls usePredictActionGuard with correct providerId', () => {
+    it('calls usePredictActionGuard with navigation', () => {
       const market = createMockMarket({ providerId: 'test-provider' });
 
       render(<PredictSportCardFooter market={market} />);
 
       expect(mockUsePredictActionGuard).toHaveBeenCalledWith(
         expect.objectContaining({
-          providerId: 'test-provider',
+          navigation: expect.any(Object),
         }),
       );
     });
 
-    it('calls usePredictClaim with correct providerId', () => {
+    it('calls usePredictClaim without provider options', () => {
       const market = createMockMarket({ providerId: 'claim-provider' });
 
       render(<PredictSportCardFooter market={market} />);
 
-      expect(mockUsePredictClaim).toHaveBeenCalledWith({
-        providerId: 'claim-provider',
-      });
+      expect(mockUsePredictClaim).toHaveBeenCalledWith();
     });
   });
 

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
@@ -19,6 +19,7 @@ import {
 import { PredictEventValues } from '../../constants/eventNames';
 import Routes from '../../../../../constants/navigation/Routes';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -143,7 +144,7 @@ const createMockPosition = (
   overrides: Partial<PredictPosition> = {},
 ): PredictPosition => ({
   id: 'position-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-1',
   outcomeId: 'outcome-1',
   outcomeTokenId: '0',
@@ -169,7 +170,7 @@ const createMockMarket = (
   overrides: Partial<PredictMarket> = {},
 ): PredictMarket => ({
   id: 'market-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   slug: 'test-market',
   title: 'Test Market',
   description: 'Test description',
@@ -181,7 +182,7 @@ const createMockMarket = (
   outcomes: [
     {
       id: 'outcome-1',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       marketId: 'market-1',
       title: 'Will it happen?',
       description: 'Test outcome',

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
@@ -61,13 +61,10 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
   });
 
   const { executeGuardedAction } = usePredictActionGuard({
-    providerId: market.providerId,
     navigation,
   });
 
-  const { claim } = usePredictClaim({
-    providerId: market.providerId,
-  });
+  const { claim } = usePredictClaim();
 
   const outcome = market.outcomes?.[0];
   const isMarketOpen =

--- a/app/components/UI/Predict/controllers/PredictController.getActivity.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.getActivity.test.ts
@@ -1,112 +1,135 @@
-import { PredictController } from './PredictController';
+import {
+  MOCK_ANY_NAMESPACE,
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+  type MockAnyNamespace,
+} from '@metamask/messenger';
 
-interface ActivityEntry {
-  id: string;
-  providerId: string;
-  entry: { type: string; timestamp: number; amount: number };
-}
+import { PolymarketProvider } from '../providers/polymarket/PolymarketProvider';
+import type { PredictActivity } from '../types';
+import {
+  PredictController,
+  type PredictControllerMessenger,
+} from './PredictController';
 
-interface Provider {
-  getActivity: jest.Mock<Promise<ActivityEntry[]>, [{ address: string }]>;
+jest.mock('../providers/polymarket/PolymarketProvider');
+
+type AllPredictControllerMessengerActions =
+  MessengerActions<PredictControllerMessenger>;
+
+type AllPredictControllerMessengerEvents =
+  MessengerEvents<PredictControllerMessenger>;
+
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  AllPredictControllerMessengerActions,
+  AllPredictControllerMessengerEvents
+>;
+
+function getRootMessenger(): RootMessenger {
+  return new Messenger({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
 }
 
 describe('PredictController.getActivity', () => {
-  // Create a type-safe mock controller interface
-  interface MockPredictController {
-    providers: Map<string, Provider>;
-    update: jest.Mock;
-    getActivity: (params: {
-      address?: string;
-      providerId?: string;
-    }) => Promise<ActivityEntry[]>;
-  }
+  const mockPolymarketProvider = {
+    getActivity: jest.fn<Promise<PredictActivity[]>, [{ address: string }]>(),
+    isEligible: jest.fn().mockResolvedValue({ isEligible: false }),
+  } as unknown as jest.Mocked<PolymarketProvider>;
 
-  const makeController = (
-    providers: Record<string, Provider>,
-  ): MockPredictController => {
-    const controller = Object.create(
-      PredictController.prototype,
-    ) as MockPredictController;
-    controller.providers = new Map(Object.entries(providers));
-    controller.update = jest.fn();
-    (
-      controller as unknown as { getSigner: () => { address: string } }
-    ).getSigner = jest.fn(() => ({
-      address: '0xselected',
-    }));
-    return controller;
+  const createController = () => {
+    const rootMessenger = getRootMessenger();
+
+    rootMessenger.registerActionHandler(
+      'AccountsController:getSelectedAccount',
+      jest.fn().mockReturnValue({
+        id: 'mock-account-id',
+        address: '0xselected',
+        metadata: { name: 'Test Account' },
+      }),
+    );
+
+    rootMessenger.registerActionHandler(
+      'AccountTreeController:getAccountsFromSelectedAccountGroup',
+      jest.fn().mockReturnValue([
+        {
+          id: 'mock-account-id',
+          address: '0xselected',
+          type: 'eip155:eoa',
+          metadata: {},
+        },
+      ]),
+    );
+
+    const messenger = new Messenger<
+      'PredictController',
+      AllPredictControllerMessengerActions,
+      AllPredictControllerMessengerEvents,
+      RootMessenger
+    >({
+      namespace: 'PredictController',
+      parent: rootMessenger,
+    });
+
+    rootMessenger.delegate({
+      actions: [
+        'AccountsController:getSelectedAccount',
+        'AccountTreeController:getAccountsFromSelectedAccountGroup',
+      ],
+      events: ['TransactionController:transactionStatusUpdated'],
+      messenger,
+    });
+
+    return new PredictController({ messenger });
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    (
+      PolymarketProvider as unknown as jest.MockedClass<
+        typeof PolymarketProvider
+      >
+    ).mockImplementation(() => mockPolymarketProvider);
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('fetches activity from a specific provider and passes selected address', async () => {
-    const stubProvider: Provider = {
-      getActivity: jest.fn(
-        async ({ address: _address }: { address: string }) => [
-          {
-            id: 'a1',
-            providerId: 'stub',
-            entry: { type: 'claimWinnings', timestamp: 1, amount: 10 },
-          },
-        ],
-      ),
-    };
-
-    const controller = makeController({ stub: stubProvider });
-
-    const result = await controller.getActivity({ providerId: 'stub' });
-
-    expect(stubProvider.getActivity).toHaveBeenCalledWith({
-      address: '0xselected',
-    });
-    expect(Array.isArray(result)).toBe(true);
-    expect(result[0].id).toBe('a1');
-  });
-
-  it('merges activity from all providers when providerId is not specified', async () => {
-    const providerA: Provider = {
-      getActivity: jest.fn(
-        async ({ address: _address }: { address: string }) => [
-          {
-            id: 'a',
-            providerId: 'A',
-            entry: { type: 'claimWinnings', timestamp: 1, amount: 1 },
-          },
-        ],
-      ),
-    };
-    const providerB: Provider = {
-      getActivity: jest.fn(
-        async ({ address: _address }: { address: string }) => [
-          {
-            id: 'b',
-            providerId: 'B',
-            entry: { type: 'claimWinnings', timestamp: 2, amount: 2 },
-          },
-        ],
-      ),
-    };
-
-    const controller = makeController({ A: providerA, B: providerB });
+  it('fetches activity from provider with selected address', async () => {
+    const stubActivity: PredictActivity[] = [
+      {
+        id: 'a1',
+        providerId: 'stub',
+        entry: { type: 'claimWinnings', timestamp: 1, amount: 10 },
+      },
+    ];
+    mockPolymarketProvider.getActivity.mockResolvedValue(stubActivity);
+    const controller = createController();
 
     const result = await controller.getActivity({});
 
-    expect(providerA.getActivity).toHaveBeenCalled();
-    expect(providerB.getActivity).toHaveBeenCalled();
-    expect(result.map((r) => r.id).sort()).toEqual(['a', 'b']);
+    expect(mockPolymarketProvider.getActivity).toHaveBeenCalledWith({
+      address: '0xselected',
+    });
+    expect(result).toEqual(stubActivity);
   });
 
-  it('throws when providerId is not available', async () => {
-    const controller = makeController({});
+  it('fetches activity with explicit address', async () => {
+    const stubActivity: PredictActivity[] = [
+      {
+        id: 'a',
+        providerId: 'stub',
+        entry: { type: 'claimWinnings', timestamp: 2, amount: 2 },
+      },
+    ];
+    mockPolymarketProvider.getActivity.mockResolvedValue(stubActivity);
+    const controller = createController();
 
-    await expect(
-      controller.getActivity({ providerId: 'missing' }),
-    ).rejects.toThrow();
+    const result = await controller.getActivity({ address: '0xcustom' });
+
+    expect(mockPolymarketProvider.getActivity).toHaveBeenCalledWith({
+      address: '0xcustom',
+    });
+    expect(result).toEqual(stubActivity);
   });
 });

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -209,7 +209,6 @@ describe('PredictController', () => {
       getAccountState: jest.fn(),
       getBalance: jest.fn(),
       isEligible: jest.fn(),
-      providerId: 'polymarket',
       name: 'Polymarket',
       chainId: 137,
       getUnrealizedPnL: jest.fn(),
@@ -374,13 +373,14 @@ describe('PredictController', () => {
 
     it('initializes with custom state', () => {
       const customState: Partial<PredictControllerState> = {
-        eligibility: { polymarket: { eligible: false, country: undefined } },
+        eligibility: { eligible: false, country: undefined },
       };
 
       withController(
         ({ controller }) => {
           expect(controller.state.eligibility).toEqual({
-            polymarket: { eligible: false, country: undefined },
+            eligible: false,
+            country: undefined,
           });
         },
         { state: customState },
@@ -509,9 +509,7 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         mockPolymarketProvider.getMarkets.mockResolvedValue(mockMarkets as any);
 
-        const result = await controller.getMarkets({
-          providerId: 'polymarket',
-        });
+        const result = await controller.getMarkets({});
 
         expect(result).toEqual(mockMarkets as any);
         expect(controller.state.lastError).toBeNull();
@@ -526,9 +524,7 @@ describe('PredictController', () => {
           new Error(errorMessage),
         );
 
-        await expect(
-          controller.getMarkets({ providerId: 'polymarket' }),
-        ).rejects.toThrow(errorMessage);
+        await expect(controller.getMarkets({})).rejects.toThrow(errorMessage);
         expect(controller.state.lastError).toBe(errorMessage);
       });
     });
@@ -543,7 +539,6 @@ describe('PredictController', () => {
         await expect(
           controller.getPositions({
             address: '0x1234567890123456789012345678901234567890',
-            providerId: 'polymarket',
           }),
         ).rejects.toThrow(errorMessage);
         expect(controller.state.lastError).toBe(errorMessage);
@@ -591,7 +586,6 @@ describe('PredictController', () => {
 
         const result = await controller.getMarket({
           marketId: 'market-2',
-          providerId: 'polymarket',
         });
 
         expect(result).toEqual(mockMarket);
@@ -615,7 +609,6 @@ describe('PredictController', () => {
         await expect(
           controller.getMarket({
             marketId: 'market-1',
-            providerId: 'nonexistent',
           }),
         ).rejects.toThrow('Provider not available');
 
@@ -689,7 +682,6 @@ describe('PredictController', () => {
 
         const result = await controller.getPriceHistory({
           marketId: 'market-1',
-          providerId: 'polymarket',
         });
 
         expect(result).toEqual(mockPriceHistory);
@@ -697,7 +689,6 @@ describe('PredictController', () => {
         expect(controller.state.lastUpdateTimestamp).toBeGreaterThan(0);
         expect(mockPolymarketProvider.getPriceHistory).toHaveBeenCalledWith({
           marketId: 'market-1',
-          providerId: 'polymarket',
         });
       });
     });
@@ -710,7 +701,6 @@ describe('PredictController', () => {
 
         const result = await controller.getPriceHistory({
           marketId: 'market-1',
-          providerId: 'polymarket',
           fidelity: 100,
           interval: '1h' as any,
         });
@@ -718,7 +708,6 @@ describe('PredictController', () => {
         expect(result).toEqual(mockPriceHistory);
         expect(mockPolymarketProvider.getPriceHistory).toHaveBeenCalledWith({
           marketId: 'market-1',
-          providerId: 'polymarket',
           fidelity: 100,
           interval: '1h',
         });
@@ -785,7 +774,6 @@ describe('PredictController', () => {
         await expect(
           controller.getPriceHistory({
             marketId: 'market-1',
-            providerId: 'nonexistent',
           }),
         ).rejects.toThrow('Provider not available');
 
@@ -873,7 +861,6 @@ describe('PredictController', () => {
               outcomeTokenId: 'token-2',
             },
           ],
-          providerId: 'polymarket',
         });
 
         expect(result).toEqual(mockPrices);
@@ -910,7 +897,6 @@ describe('PredictController', () => {
               outcomeTokenId: 'token-1',
             },
           ],
-          providerId: 'polymarket',
         });
 
         expect(result).toEqual(mockPrices);
@@ -920,16 +906,12 @@ describe('PredictController', () => {
 
     it('handle empty bookParams array', async () => {
       await withController(async ({ controller }) => {
-        mockPolymarketProvider.getPrices = jest
-          .fn()
-          .mockResolvedValue({ providerId: 'polymarket', results: [] });
+        mockPolymarketProvider.getPrices = jest.fn();
 
-        const result = await controller.getPrices({
+        await controller.getPrices({
           queries: [],
-          providerId: 'polymarket',
         });
 
-        expect(result).toEqual({ providerId: 'polymarket', results: [] });
         expect(controller.state.lastError).toBeNull();
       });
     });
@@ -958,7 +940,6 @@ describe('PredictController', () => {
               outcomeTokenId: 'token-2',
             },
           ],
-          providerId: 'polymarket',
         });
 
         expect(result).toEqual(mockBuyPrices);
@@ -989,7 +970,6 @@ describe('PredictController', () => {
               outcomeTokenId: 'token-2',
             },
           ],
-          providerId: 'polymarket',
         });
 
         expect(result).toEqual(mockSellPrices);
@@ -1007,7 +987,6 @@ describe('PredictController', () => {
                 outcomeTokenId: 'token-1',
               },
             ],
-            providerId: 'nonexistent',
           }),
         ).rejects.toThrow('Provider not available');
 
@@ -1032,7 +1011,6 @@ describe('PredictController', () => {
                 outcomeTokenId: 'token-1',
               },
             ],
-            providerId: 'polymarket',
           }),
         ).rejects.toThrow(errorMessage);
 
@@ -1056,7 +1034,6 @@ describe('PredictController', () => {
                 outcomeTokenId: 'token-1',
               },
             ],
-            providerId: 'polymarket',
           }),
         ).rejects.toBe('String error');
 
@@ -1083,7 +1060,6 @@ describe('PredictController', () => {
               outcomeTokenId: 'token-1',
             },
           ],
-          providerId: 'polymarket',
         });
 
         expect(controller.state.lastError).toBeNull();
@@ -1112,13 +1088,11 @@ describe('PredictController', () => {
         });
 
         const result = await controller.placeOrder({
-          providerId: 'polymarket',
           preview,
         });
 
         expect(mockPolymarketProvider.placeOrder).toHaveBeenCalledWith(
           expect.objectContaining({
-            providerId: 'polymarket',
             preview,
             signer: expect.objectContaining({
               address: '0x1234567890123456789012345678901234567890',
@@ -1141,7 +1115,6 @@ describe('PredictController', () => {
 
         await expect(
           controller.placeOrder({
-            providerId: 'polymarket',
             preview,
           }),
         ).rejects.toThrow('Order placement failed');
@@ -1160,7 +1133,6 @@ describe('PredictController', () => {
 
         await expect(
           controller.placeOrder({
-            providerId: 'polymarket',
             preview,
           }),
         ).rejects.toThrow('Network error');
@@ -1178,7 +1150,6 @@ describe('PredictController', () => {
 
         const preview = createMockOrderPreview({ side: Side.SELL });
         const params = {
-          providerId: 'polymarket',
           preview,
         };
 
@@ -1191,7 +1162,6 @@ describe('PredictController', () => {
           expect.objectContaining({
             error: 'Provider error',
             timestamp: expect.any(String),
-            providerId: 'polymarket',
             params,
           }),
         );
@@ -1209,7 +1179,6 @@ describe('PredictController', () => {
 
         await expect(
           controller.placeOrder({
-            providerId: 'polymarket',
             preview,
           }),
         ).rejects.toThrow('PREDICT_PLACE_ORDER_FAILED');
@@ -1224,7 +1193,6 @@ describe('PredictController', () => {
 
         await expect(
           controller.placeOrder({
-            providerId: 'nonexistent',
             preview,
           }),
         ).rejects.toThrow('Provider not available');
@@ -1256,7 +1224,6 @@ describe('PredictController', () => {
         });
 
         await controller.placeOrder({
-          providerId: 'polymarket',
           preview,
         });
 
@@ -1286,7 +1253,6 @@ describe('PredictController', () => {
         const preview = createMockOrderPreview({ side: Side.SELL });
 
         await controller.placeOrder({
-          providerId: 'polymarket',
           preview,
         });
 
@@ -1302,7 +1268,6 @@ describe('PredictController', () => {
 
         await expect(
           controller.placeOrder({
-            providerId: 'nonexistent',
             preview,
           }),
         ).rejects.toThrow('Provider not available');
@@ -1313,11 +1278,9 @@ describe('PredictController', () => {
 
     it('handle missing provider in getMarkets', async () => {
       await withController(async ({ controller }) => {
-        await expect(
-          controller.getMarkets({
-            providerId: 'nonexistent',
-          }),
-        ).rejects.toThrow('Provider not available');
+        await expect(controller.getMarkets({})).rejects.toThrow(
+          'Provider not available',
+        );
         expect(controller.state.lastError).toBe('Provider not available');
       });
     });
@@ -1327,7 +1290,6 @@ describe('PredictController', () => {
         await expect(
           controller.getPositions({
             address: '0x1234567890123456789012345678901234567890',
-            providerId: 'nonexistent',
           }),
         ).rejects.toThrow('Provider not available');
         expect(controller.state.lastError).toBe('Provider not available');
@@ -1345,7 +1307,7 @@ describe('PredictController', () => {
 
         await controller.refreshEligibility();
 
-        expect(controller.state.eligibility.polymarket).toEqual({
+        expect(controller.state.eligibility).toEqual({
           eligible: true,
           country: 'PT',
         });
@@ -1362,7 +1324,7 @@ describe('PredictController', () => {
 
         await controller.refreshEligibility();
 
-        expect(controller.state.eligibility.polymarket).toEqual({
+        expect(controller.state.eligibility).toEqual({
           eligible: false,
           country: undefined,
         });
@@ -1376,48 +1338,10 @@ describe('PredictController', () => {
 
         await controller.refreshEligibility();
 
-        expect(controller.state.eligibility.polymarket).toEqual({
+        expect(controller.state.eligibility).toEqual({
           eligible: false,
           country: undefined,
         });
-      });
-    });
-
-    it('handle multiple providers eligibility checks', async () => {
-      await withController(async ({ controller }) => {
-        // Add a second mock provider to the internal providers map
-        const mockSecondProvider = {
-          ...mockPolymarketProvider,
-          isEligible: jest.fn().mockResolvedValue({
-            isEligible: false,
-            country: 'US',
-          }),
-        };
-
-        // Manually add second provider to test multiple providers scenario
-        controller.updateStateForTesting(() => {
-          // Access private providers map for testing
-          const providers = (controller as any).providers;
-          providers.set('second-provider', mockSecondProvider);
-        });
-
-        mockPolymarketProvider.isEligible.mockResolvedValue({
-          isEligible: true,
-          country: 'PT',
-        });
-
-        await controller.refreshEligibility();
-
-        expect(controller.state.eligibility.polymarket).toEqual({
-          eligible: true,
-          country: 'PT',
-        });
-        expect(controller.state.eligibility['second-provider']).toEqual({
-          eligible: false,
-          country: 'US',
-        });
-        expect(mockPolymarketProvider.isEligible).toHaveBeenCalled();
-        expect(mockSecondProvider.isEligible).toHaveBeenCalled();
       });
     });
 
@@ -1431,7 +1355,7 @@ describe('PredictController', () => {
 
           await controller.refreshEligibility();
 
-          expect(controller.state.eligibility.polymarket).toEqual({
+          expect(controller.state.eligibility).toEqual({
             eligible: false,
             country: 'DE',
           });
@@ -1448,7 +1372,7 @@ describe('PredictController', () => {
 
           await controller.refreshEligibility();
 
-          expect(controller.state.eligibility.polymarket).toEqual({
+          expect(controller.state.eligibility).toEqual({
             eligible: false,
             country: 'RO',
           });
@@ -1465,7 +1389,7 @@ describe('PredictController', () => {
 
           await controller.refreshEligibility();
 
-          expect(controller.state.eligibility.polymarket).toEqual({
+          expect(controller.state.eligibility).toEqual({
             eligible: true,
             country: 'US',
           });
@@ -1482,7 +1406,7 @@ describe('PredictController', () => {
 
           await controller.refreshEligibility();
 
-          expect(controller.state.eligibility.polymarket).toEqual({
+          expect(controller.state.eligibility).toEqual({
             eligible: false,
             country: 'US',
           });
@@ -1499,7 +1423,7 @@ describe('PredictController', () => {
 
           await controller.refreshEligibility();
 
-          expect(controller.state.eligibility.polymarket).toEqual({
+          expect(controller.state.eligibility).toEqual({
             eligible: true,
             country: undefined,
           });
@@ -1516,7 +1440,7 @@ describe('PredictController', () => {
 
           await controller.refreshEligibility();
 
-          expect(controller.state.eligibility.polymarket).toEqual({
+          expect(controller.state.eligibility).toEqual({
             eligible: true,
             country: null,
           });
@@ -1533,7 +1457,7 @@ describe('PredictController', () => {
 
           await controller.refreshEligibility();
 
-          expect(controller.state.eligibility.polymarket).toEqual({
+          expect(controller.state.eligibility).toEqual({
             eligible: true,
             country: '',
           });
@@ -1615,211 +1539,9 @@ describe('PredictController', () => {
     });
   });
 
-  describe('multiple providers', () => {
-    it('get markets from multiple providers when no providerId specified', async () => {
-      await withController(async ({ controller }) => {
-        const polymarketMarkets = [
-          {
-            id: 'pm1',
-            question: 'Polymarket question 1?',
-            outcomes: ['YES', 'NO'],
-            providerId: 'polymarket',
-          },
-        ];
-
-        const secondProviderMarkets = [
-          {
-            id: 'sp1',
-            question: 'Second provider question 1?',
-            outcomes: ['YES', 'NO'],
-            providerId: 'second-provider',
-          },
-        ];
-
-        // Mock the second provider
-        const mockSecondProvider = {
-          ...mockPolymarketProvider,
-          getMarkets: jest.fn().mockResolvedValue(secondProviderMarkets),
-        };
-
-        // Set up multiple providers
-        controller.updateStateForTesting(() => {
-          const providers = (controller as any).providers;
-          providers.set('second-provider', mockSecondProvider);
-        });
-
-        mockPolymarketProvider.getMarkets.mockResolvedValue(
-          polymarketMarkets as any,
-        );
-
-        const result = await controller.getMarkets({}); // No providerId
-
-        expect(result).toHaveLength(2);
-        expect(result).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ providerId: 'polymarket' }),
-            expect.objectContaining({ providerId: 'second-provider' }),
-          ]),
-        );
-        expect(mockPolymarketProvider.getMarkets).toHaveBeenCalled();
-        expect(mockSecondProvider.getMarkets).toHaveBeenCalled();
-      });
-    });
-
-    it('defaults to polymarket provider when no providerId specified', async () => {
-      await withController(async ({ controller }) => {
-        const polymarketPositions = [
-          {
-            marketId: 'pm1',
-            providerId: 'polymarket',
-            outcomeId: 'pm-outcome-1',
-            balance: '100',
-          },
-        ];
-
-        const secondProviderPositions = [
-          {
-            marketId: 'sp1',
-            providerId: 'second-provider',
-            outcomeId: 'sp-outcome-1',
-            balance: '200',
-          },
-        ];
-
-        // Mock the second provider
-        const mockSecondProvider = {
-          ...mockPolymarketProvider,
-          getPositions: jest.fn().mockResolvedValue(secondProviderPositions),
-        };
-
-        // Set up multiple providers
-        controller.updateStateForTesting(() => {
-          const providers = (controller as any).providers;
-          providers.set('second-provider', mockSecondProvider);
-        });
-
-        mockPolymarketProvider.getPositions.mockResolvedValue(
-          polymarketPositions as any,
-        );
-
-        const result = await controller.getPositions({
-          address: '0x1234567890123456789012345678901234567890',
-        }); // No providerId - should default to polymarket
-
-        expect(result).toHaveLength(1);
-        expect(result).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ providerId: 'polymarket' }),
-          ]),
-        );
-        expect(mockPolymarketProvider.getPositions).toHaveBeenCalled();
-        expect(mockSecondProvider.getPositions).not.toHaveBeenCalled();
-      });
-    });
-
-    it('filter results correctly when provider returns undefined', async () => {
-      await withController(async ({ controller }) => {
-        const polymarketMarkets = [
-          {
-            id: 'pm1',
-            question: 'Valid market',
-            outcomes: ['YES', 'NO'],
-          },
-        ];
-
-        // Mock one provider returning undefined
-        const mockSecondProvider = {
-          ...mockPolymarketProvider,
-          getMarkets: jest.fn().mockResolvedValue(undefined),
-        };
-
-        // Set up multiple providers
-        controller.updateStateForTesting(() => {
-          const providers = (controller as any).providers;
-          providers.set('failing-provider', mockSecondProvider);
-        });
-
-        mockPolymarketProvider.getMarkets.mockResolvedValue(
-          polymarketMarkets as any,
-        );
-
-        const result = await controller.getMarkets({}); // No providerId
-
-        // Should only include the valid market, filtering out undefined
-        expect(result).toHaveLength(1);
-        expect(result[0]).toEqual(expect.objectContaining({ id: 'pm1' }));
-      });
-    });
-
-    it('use default address from AccountsController in getPositions', async () => {
-      await withController(async ({ controller }) => {
-        const mockPositions = [
-          {
-            marketId: 'test-market',
-            providerId: 'polymarket',
-            outcomeId: 'test-outcome',
-            balance: '50',
-          },
-        ];
-
-        mockPolymarketProvider.getPositions.mockResolvedValue(
-          mockPositions as any,
-        );
-
-        // Call without address parameter
-        const result = await controller.getPositions({});
-
-        expect(result).toEqual(mockPositions);
-        expect(mockPolymarketProvider.getPositions).toHaveBeenCalledWith({
-          address: '0x1234567890123456789012345678901234567890', // Default from AccountsController
-        });
-      });
-    });
-
-    it('use custom address in getPositions', async () => {
-      await withController(async ({ controller }) => {
-        const mockPositions = [
-          {
-            marketId: 'test-market',
-            providerId: 'polymarket',
-            outcomeId: 'test-outcome',
-            balance: '75',
-          },
-        ];
-
-        mockPolymarketProvider.getPositions.mockResolvedValue(
-          mockPositions as any,
-        );
-
-        const customAddress = '0x9876543210987654321098765432109876543210';
-
-        // Call with custom address parameter
-        const result = await controller.getPositions({
-          address: customAddress,
-        });
-
-        expect(result).toEqual(mockPositions);
-        expect(mockPolymarketProvider.getPositions).toHaveBeenCalledWith({
-          address: customAddress,
-        });
-      });
-    });
-
-    it('throw error when some providers in list do not exist', async () => {
-      await withController(async ({ controller }) => {
-        await expect(
-          controller.getMarkets({
-            providerId: 'nonexistent-provider',
-          }),
-        ).rejects.toThrow('Provider not available');
-      });
-    });
-  });
-
   describe('getMarkets with market highlights', () => {
     const createMockMarket = (id: string, category = 'trending') => ({
       id,
-      providerId: 'polymarket',
       title: `Market ${id}`,
       category,
       outcomes: ['YES', 'NO'],
@@ -1874,7 +1596,6 @@ describe('PredictController', () => {
           );
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -1917,7 +1638,6 @@ describe('PredictController', () => {
           );
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 10,
           });
@@ -1951,7 +1671,6 @@ describe('PredictController', () => {
           );
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -1984,9 +1703,7 @@ describe('PredictController', () => {
             regularMarkets as any,
           );
 
-          const result = await controller.getMarkets({
-            providerId: 'polymarket',
-          });
+          const result = await controller.getMarkets({});
 
           expect(result).toHaveLength(1);
           expect(mockPolymarketProvider.getMarketsByIds).not.toHaveBeenCalled();
@@ -2016,7 +1733,6 @@ describe('PredictController', () => {
           );
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -2055,7 +1771,6 @@ describe('PredictController', () => {
           );
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -2090,7 +1805,6 @@ describe('PredictController', () => {
           );
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -2123,7 +1837,6 @@ describe('PredictController', () => {
           mockPolymarketProvider.getMarketsByIds.mockResolvedValue([]);
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -2156,7 +1869,6 @@ describe('PredictController', () => {
           );
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -2197,7 +1909,6 @@ describe('PredictController', () => {
           );
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
           });
 
@@ -2239,7 +1950,6 @@ describe('PredictController', () => {
           );
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -2276,7 +1986,6 @@ describe('PredictController', () => {
           );
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -2328,7 +2037,6 @@ describe('PredictController', () => {
           );
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -2378,7 +2086,6 @@ describe('PredictController', () => {
           ] as any);
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -2423,7 +2130,6 @@ describe('PredictController', () => {
           ] as any);
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -2459,7 +2165,6 @@ describe('PredictController', () => {
           );
 
           const result = await controller.getMarkets({
-            providerId: 'polymarket',
             category: 'trending',
             offset: 0,
           });
@@ -2493,12 +2198,14 @@ describe('PredictController', () => {
       withController(({ controller }) => {
         controller.updateStateForTesting((state) => {
           state.eligibility = {
-            polymarket: { eligible: false, country: undefined },
+            eligible: false,
+            country: undefined,
           };
           state.lastError = 'Test error';
         });
         expect(controller.state.eligibility).toEqual({
-          polymarket: { eligible: false, country: undefined },
+          eligible: false,
+          country: undefined,
         });
         expect(controller.state.lastError).toBe('Test error');
       });
@@ -2610,7 +2317,6 @@ describe('PredictController', () => {
         mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
           {
             marketId: 'test-market',
-            providerId: 'polymarket',
             outcomeId: 'test-outcome',
             balance: '100',
           },
@@ -2624,9 +2330,7 @@ describe('PredictController', () => {
         await controller.getPositions({ claimable: true });
 
         // Act
-        const result = await controller.claimWithConfirmation({
-          providerId: 'polymarket',
-        });
+        const result = await controller.claimWithConfirmation({});
 
         // Assert
         expect(result.batchId).toBe(mockBatchId);
@@ -2648,13 +2352,11 @@ describe('PredictController', () => {
         mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
           {
             marketId: 'test-market-1',
-            providerId: 'polymarket',
             outcomeId: 'test-outcome-1',
             balance: '100',
           },
           {
             marketId: 'test-market-2',
-            providerId: 'polymarket',
             outcomeId: 'test-outcome-2',
             balance: '200',
           },
@@ -2687,9 +2389,7 @@ describe('PredictController', () => {
         await controller.getPositions({ claimable: true });
 
         // Act
-        const result = await controller.claimWithConfirmation({
-          providerId: 'polymarket',
-        });
+        const result = await controller.claimWithConfirmation({});
 
         // Assert
         expect(result.batchId).toBe(mockBatchId);
@@ -2700,11 +2400,9 @@ describe('PredictController', () => {
 
     it('handle claim error when provider is not available', async () => {
       await withController(async ({ controller }) => {
-        await expect(
-          controller.claimWithConfirmation({
-            providerId: 'nonexistent',
-          }),
-        ).rejects.toThrow('Provider not available');
+        await expect(controller.claimWithConfirmation({})).rejects.toThrow(
+          'Provider not available',
+        );
       });
     });
 
@@ -2714,7 +2412,6 @@ describe('PredictController', () => {
         mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
           {
             marketId: 'test-market',
-            providerId: 'polymarket',
             outcomeId: 'test-outcome',
             balance: '100',
           },
@@ -2727,11 +2424,9 @@ describe('PredictController', () => {
         await controller.getPositions({ claimable: true });
 
         // Act & Assert
-        await expect(
-          controller.claimWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('Claim preparation failed');
+        await expect(controller.claimWithConfirmation({})).rejects.toThrow(
+          'Claim preparation failed',
+        );
       });
     });
 
@@ -2743,7 +2438,6 @@ describe('PredictController', () => {
             marketId: 'market-1',
             outcomeId: 'outcome-1',
             balance: '100',
-            providerId: 'polymarket',
           },
         ];
 
@@ -2758,9 +2452,7 @@ describe('PredictController', () => {
         await controller.getPositions({ claimable: true });
 
         // Act
-        const result = await controller.claimWithConfirmation({
-          providerId: 'polymarket',
-        });
+        const result = await controller.claimWithConfirmation({});
 
         // Assert
         expect(result.batchId).toBe('NA');
@@ -2777,7 +2469,6 @@ describe('PredictController', () => {
             marketId: 'market-1',
             outcomeId: 'outcome-1',
             balance: '100',
-            providerId: 'polymarket',
           },
         ];
 
@@ -2795,9 +2486,7 @@ describe('PredictController', () => {
         await controller.getPositions({ claimable: true });
 
         // Act
-        const result = await controller.claimWithConfirmation({
-          providerId: 'polymarket',
-        });
+        const result = await controller.claimWithConfirmation({});
 
         // Assert
         expect(result.batchId).toBe('NA');
@@ -2813,11 +2502,9 @@ describe('PredictController', () => {
         await controller.getPositions({ claimable: true });
 
         // Act & Assert
-        await expect(
-          controller.claimWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('No claimable positions found');
+        await expect(controller.claimWithConfirmation({})).rejects.toThrow(
+          'No claimable positions found',
+        );
       });
     });
 
@@ -2827,7 +2514,6 @@ describe('PredictController', () => {
         mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
           {
             marketId: 'test-market',
-            providerId: 'polymarket',
             outcomeId: 'test-outcome',
             balance: '100',
           },
@@ -2839,11 +2525,9 @@ describe('PredictController', () => {
         await controller.getPositions({ claimable: true });
 
         // Act & Assert
-        await expect(
-          controller.claimWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow(errorMessage);
+        await expect(controller.claimWithConfirmation({})).rejects.toThrow(
+          errorMessage,
+        );
 
         expect(controller.state.lastError).toBe(errorMessage);
         expect(controller.state.lastUpdateTimestamp).toBeGreaterThan(0);
@@ -2857,7 +2541,6 @@ describe('PredictController', () => {
           mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
             {
               marketId: 'test-market',
-              providerId: 'polymarket',
               outcomeId: 'test-outcome',
               balance: '100',
             },
@@ -2869,11 +2552,9 @@ describe('PredictController', () => {
           await controller.getPositions({ claimable: true });
 
           // Act & Assert
-          await expect(
-            controller.claimWithConfirmation({
-              providerId: 'polymarket',
-            }),
-          ).rejects.toThrow('Network client not found for chain ID');
+          await expect(controller.claimWithConfirmation({})).rejects.toThrow(
+            'Network client not found for chain ID',
+          );
         },
         {
           mocks: {
@@ -2890,7 +2571,6 @@ describe('PredictController', () => {
           mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
             {
               marketId: 'test-market',
-              providerId: 'polymarket',
               outcomeId: 'test-outcome',
               balance: '100',
             },
@@ -2903,11 +2583,7 @@ describe('PredictController', () => {
           await controller.getPositions({ claimable: true });
 
           // Act & Assert
-          await expect(
-            controller.claimWithConfirmation({
-              providerId: 'polymarket',
-            }),
-          ).rejects.toThrow(
+          await expect(controller.claimWithConfirmation({})).rejects.toThrow(
             'Failed to get batch ID from claim transaction submission',
           );
         },
@@ -2925,7 +2601,6 @@ describe('PredictController', () => {
         mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
           {
             marketId: 'test-market',
-            providerId: 'polymarket',
             outcomeId: 'test-outcome',
             balance: '100',
           },
@@ -2937,11 +2612,9 @@ describe('PredictController', () => {
         await controller.getPositions({ claimable: true });
 
         // Act & Assert
-        await expect(
-          controller.claimWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('No transactions returned from claim preparation');
+        await expect(controller.claimWithConfirmation({})).rejects.toThrow(
+          'No transactions returned from claim preparation',
+        );
       });
     });
 
@@ -2951,7 +2624,6 @@ describe('PredictController', () => {
         mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
           {
             marketId: 'test-market',
-            providerId: 'polymarket',
             outcomeId: 'test-outcome',
             balance: '100',
           },
@@ -2969,11 +2641,9 @@ describe('PredictController', () => {
         await controller.getPositions({ claimable: true });
 
         // Act & Assert
-        await expect(
-          controller.claimWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('Chain ID not provided by claim preparation');
+        await expect(controller.claimWithConfirmation({})).rejects.toThrow(
+          'Chain ID not provided by claim preparation',
+        );
       });
     });
 
@@ -2989,7 +2659,6 @@ describe('PredictController', () => {
           mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
             {
               marketId: 'test-market',
-              providerId: 'polymarket',
               outcomeId: 'test-outcome',
               balance: '100',
             },
@@ -3004,9 +2673,7 @@ describe('PredictController', () => {
           await controller.getPositions({ claimable: true });
 
           // Act
-          const result = await controller.claimWithConfirmation({
-            providerId: 'polymarket',
-          });
+          const result = await controller.claimWithConfirmation({});
 
           // Assert
           expect(result.batchId).toBe(mockBatchId);
@@ -3037,7 +2704,6 @@ describe('PredictController', () => {
 
         const result = await controller.getUnrealizedPnL({
           address: '0x1234567890123456789012345678901234567890',
-          providerId: 'polymarket',
         });
 
         expect(result).toEqual(mockUnrealizedPnL);
@@ -3074,7 +2740,6 @@ describe('PredictController', () => {
         await expect(
           controller.getUnrealizedPnL({
             address: '0x1234567890123456789012345678901234567890',
-            providerId: 'nonexistent',
           }),
         ).rejects.toThrow('Provider not available');
 
@@ -3219,9 +2884,7 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         mockPolymarketProvider.getActivity.mockResolvedValue(mockActivity);
 
-        const result = await controller.getActivity({
-          providerId: 'polymarket',
-        });
+        const result = await controller.getActivity({});
 
         expect(result).toEqual(mockActivity);
         expect(mockPolymarketProvider.getActivity).toHaveBeenCalled();
@@ -3245,11 +2908,9 @@ describe('PredictController', () => {
 
     it('throws error when provider is not available', async () => {
       await withController(async ({ controller }) => {
-        await expect(
-          controller.getActivity({
-            providerId: 'nonexistent',
-          }),
-        ).rejects.toThrow('Provider not available');
+        await expect(controller.getActivity({})).rejects.toThrow(
+          'Provider not available',
+        );
 
         expect(controller.state.lastError).toBe('Provider not available');
       });
@@ -3327,9 +2988,7 @@ describe('PredictController', () => {
 
       await withController(async ({ controller }) => {
         // When calling depositWithConfirmation
-        const result = await controller.depositWithConfirmation({
-          providerId: 'polymarket',
-        });
+        const result = await controller.depositWithConfirmation({});
 
         // Then it should succeed
         expect(result.success).toBe(true);
@@ -3337,7 +2996,6 @@ describe('PredictController', () => {
 
         // And prepareDeposit should be called with correct signer
         expect(mockPolymarketProvider.prepareDeposit).toHaveBeenCalledWith({
-          providerId: 'polymarket',
           signer: expect.objectContaining({
             address: '0x1234567890123456789012345678901234567890',
             signTypedMessage: expect.any(Function),
@@ -3363,11 +3021,9 @@ describe('PredictController', () => {
         // Given an invalid provider ID
         // When calling depositWithConfirmation
         // Then it should throw an error
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'invalid-provider',
-          }),
-        ).rejects.toThrow('Provider not available');
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
+          'Provider not available',
+        );
       });
     });
 
@@ -3381,11 +3037,9 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         // When calling depositWithConfirmation
         // Then it should throw the error
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow(errorMessage);
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
+          errorMessage,
+        );
       });
     });
 
@@ -3411,11 +3065,9 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         // When calling depositWithConfirmation
         // Then it should throw the error
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow(errorMessage);
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
+          errorMessage,
+        );
       });
     });
 
@@ -3443,9 +3095,7 @@ describe('PredictController', () => {
       await withController(
         async ({ controller }) => {
           // When calling depositWithConfirmation
-          await controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          });
+          await controller.depositWithConfirmation({});
 
           // Then the correct network client ID should be resolved
           expect(addTransactionBatch).toHaveBeenCalledWith(
@@ -3487,13 +3137,10 @@ describe('PredictController', () => {
 
       await withController(async ({ controller }) => {
         // When calling depositWithConfirmation
-        await controller.depositWithConfirmation({
-          providerId: 'polymarket',
-        });
+        await controller.depositWithConfirmation({});
 
         // Then all parameters should be passed to provider
         expect(mockPolymarketProvider.prepareDeposit).toHaveBeenCalledWith({
-          providerId: 'polymarket',
           signer: expect.objectContaining({
             address: '0x1234567890123456789012345678901234567890',
           }),
@@ -3521,9 +3168,7 @@ describe('PredictController', () => {
 
       await withController(async ({ controller }) => {
         // When calling depositWithConfirmation
-        const result = await controller.depositWithConfirmation({
-          providerId: 'polymarket',
-        });
+        const result = await controller.depositWithConfirmation({});
 
         // Then it should return success with NA batchId instead of throwing
         expect(result.success).toBe(true);
@@ -3553,9 +3198,7 @@ describe('PredictController', () => {
 
       await withController(async ({ controller }) => {
         // When calling depositWithConfirmation
-        const result = await controller.depositWithConfirmation({
-          providerId: 'polymarket',
-        });
+        const result = await controller.depositWithConfirmation({});
 
         // Then it should return success with NA batchId
         expect(result.success).toBe(true);
@@ -3573,11 +3216,9 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         // When calling depositWithConfirmation
         // Then it should throw an error
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('No transactions returned from deposit preparation');
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
+          'No transactions returned from deposit preparation',
+        );
 
         // And addTransactionBatch should not be called
         expect(addTransactionBatch).not.toHaveBeenCalled();
@@ -3597,11 +3238,9 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         // When calling depositWithConfirmation
         // Then it should throw an error
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('Deposit preparation returned undefined');
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
+          'Deposit preparation returned undefined',
+        );
       });
     });
 
@@ -3622,11 +3261,9 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         // When calling depositWithConfirmation
         // Then it should throw an error
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('Chain ID not provided by deposit preparation');
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
+          'Chain ID not provided by deposit preparation',
+        );
       });
     });
 
@@ -3653,11 +3290,9 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         // When calling depositWithConfirmation
         // Then it should throw an error
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('Failed to get batch ID from transaction submission');
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
+          'Failed to get batch ID from transaction submission',
+        );
       });
     });
 
@@ -3682,11 +3317,9 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         // When calling depositWithConfirmation
         // Then it should throw an error
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('Value must be a hexadecimal string.');
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
+          'Value must be a hexadecimal string.',
+        );
       });
     });
 
@@ -3697,11 +3330,7 @@ describe('PredictController', () => {
       });
 
       await withController(async ({ controller }) => {
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow(
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
           'Invalid transaction: transaction at index 0 is missing params object',
         );
       });
@@ -3720,11 +3349,7 @@ describe('PredictController', () => {
       });
 
       await withController(async ({ controller }) => {
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow(
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
           "Invalid transaction: transaction at index 0 is missing 'to' address",
         );
       });
@@ -3744,11 +3369,7 @@ describe('PredictController', () => {
       });
 
       await withController(async ({ controller }) => {
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow(
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
           "Invalid transaction: transaction at index 0 has invalid 'to' address format",
         );
       });
@@ -3767,11 +3388,7 @@ describe('PredictController', () => {
       });
 
       await withController(async ({ controller }) => {
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow(
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
           'Invalid transaction: transaction at index 0 is missing data',
         );
       });
@@ -3791,11 +3408,7 @@ describe('PredictController', () => {
       });
 
       await withController(async ({ controller }) => {
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow(
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
           'Invalid transaction: transaction at index 0 has invalid data format (must be hex string starting with 0x)',
         );
       });
@@ -3815,11 +3428,7 @@ describe('PredictController', () => {
       });
 
       await withController(async ({ controller }) => {
-        await expect(
-          controller.depositWithConfirmation({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow(
+        await expect(controller.depositWithConfirmation({})).rejects.toThrow(
           'Invalid transaction: transaction at index 0 has insufficient data (length: 6, minimum: 10)',
         );
       });
@@ -3829,52 +3438,39 @@ describe('PredictController', () => {
   describe('clearDepositTransaction', () => {
     it('clears deposit transaction from state', () => {
       withController(({ controller }) => {
-        const providerId = 'polymarket';
         const address = '0x1234567890123456789012345678901234567890';
 
         // Set up initial deposit transaction
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {
-            [providerId]: {
-              [address]: 'batch-id-123',
-            },
+            [address]: 'batch-id-123',
           };
         });
 
         // Verify transaction exists
-        expect(controller.state.pendingDeposits[providerId][address]).toBe(
-          'batch-id-123',
-        );
+        expect(controller.state.pendingDeposits[address]).toBe('batch-id-123');
 
         // Clear deposit transaction
-        controller.clearPendingDeposit({ providerId });
+        controller.clearPendingDeposit();
 
         // Verify transaction is cleared (deleted, not set to false)
-        expect(controller.state.pendingDeposits[providerId]?.[address]).toBe(
-          undefined,
-        );
+        expect(controller.state.pendingDeposits[address]).toBe(undefined);
       });
     });
 
     it('handles clearing empty deposit transaction', () => {
       withController(({ controller }) => {
-        const providerId = 'polymarket';
-
         // Ensure deposit transaction is empty
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {};
         });
 
         // Clear should work without error
-        expect(() =>
-          controller.clearPendingDeposit({ providerId }),
-        ).not.toThrow();
+        expect(() => controller.clearPendingDeposit()).not.toThrow();
 
         // Verify deposit transaction remains undefined
         const address = '0x1234567890123456789012345678901234567890';
-        expect(controller.state.pendingDeposits[providerId]?.[address]).toBe(
-          undefined,
-        );
+        expect(controller.state.pendingDeposits[address]).toBe(undefined);
       });
     });
   });
@@ -3885,16 +3481,13 @@ describe('PredictController', () => {
 
     it('does not modify deposit state when different batchId', () => {
       withController(({ controller, messenger }) => {
-        const providerId = 'polymarket';
         const address = '0x1234567890123456789012345678901234567890';
         const existingBatchId = 'existing-batch-id';
 
         // Set up deposit transaction
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {
-            [providerId]: {
-              [address]: existingBatchId,
-            },
+            [address]: existingBatchId,
           };
         });
 
@@ -3954,9 +3547,7 @@ describe('PredictController', () => {
         });
 
         // Verify depositTransaction was stored with batch ID
-        expect(controller.state.pendingDeposits[providerId][address]).toBe(
-          mockBatchId,
-        );
+        expect(controller.state.pendingDeposits[address]).toBe(mockBatchId);
       });
     });
 
@@ -3986,16 +3577,12 @@ describe('PredictController', () => {
         // Set up old deposit transaction
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {
-            [providerId]: {
-              [address]: oldBatchId,
-            },
+            [address]: oldBatchId,
           };
         });
 
         // Verify old transaction exists
-        expect(controller.state.pendingDeposits[providerId][address]).toBe(
-          oldBatchId,
-        );
+        expect(controller.state.pendingDeposits[address]).toBe(oldBatchId);
 
         // Start new deposit (should clear old batch and set to new batch ID)
         await controller.depositWithConfirmation({
@@ -4003,9 +3590,7 @@ describe('PredictController', () => {
         });
 
         // Verify new transaction is set with new batch ID
-        expect(controller.state.pendingDeposits[providerId][address]).toBe(
-          newBatchId,
-        );
+        expect(controller.state.pendingDeposits[address]).toBe(newBatchId);
       });
     });
   });
@@ -4058,9 +3643,7 @@ describe('PredictController', () => {
 
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {
-            polymarket: {
-              [accountAddress]: 'batch-1',
-            },
+            [accountAddress]: 'batch-1',
           };
         });
 
@@ -4095,9 +3678,7 @@ describe('PredictController', () => {
 
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {
-            polymarket: {
-              [accountAddress]: 'pending',
-            },
+            [accountAddress]: 'pending',
           };
         });
 
@@ -4178,10 +3759,8 @@ describe('PredictController', () => {
 
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {
-            polymarket: {
-              [selectedAddress]: 'batch-selected',
-              [senderAddress]: 'batch-sender',
-            },
+            [selectedAddress]: 'batch-selected',
+            [senderAddress]: 'batch-sender',
           };
         });
 
@@ -4189,12 +3768,10 @@ describe('PredictController', () => {
           transactionMeta,
         } as any);
 
-        expect(
-          controller.state.pendingDeposits.polymarket[selectedAddress],
-        ).toBe('batch-selected');
-        expect(
-          controller.state.pendingDeposits.polymarket[senderAddress],
-        ).toBeUndefined();
+        expect(controller.state.pendingDeposits[selectedAddress]).toBe(
+          'batch-selected',
+        );
+        expect(controller.state.pendingDeposits[senderAddress]).toBeUndefined();
       });
     });
 
@@ -4313,9 +3890,7 @@ describe('PredictController', () => {
 
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {
-            polymarket: {
-              [accountAddress]: 'batch-expected',
-            },
+            [accountAddress]: 'batch-expected',
           };
         });
 
@@ -4403,9 +3978,7 @@ describe('PredictController', () => {
 
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {
-            polymarket: {
-              [accountAddress]: 'pending',
-            },
+            [accountAddress]: 'pending',
           };
         });
 
@@ -4433,9 +4006,7 @@ describe('PredictController', () => {
 
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {
-            polymarket: {
-              [accountAddress]: 'batch-1',
-            },
+            [accountAddress]: 'batch-1',
           };
         });
 
@@ -4443,9 +4014,9 @@ describe('PredictController', () => {
           transactionMeta,
         } as { transactionMeta: TransactionMeta });
 
-        expect(
-          controller.state.pendingDeposits.polymarket[accountAddress],
-        ).toBe(undefined);
+        expect(controller.state.pendingDeposits[accountAddress]).toBe(
+          undefined,
+        );
       });
     });
 
@@ -4815,16 +4386,13 @@ describe('PredictController', () => {
 
       await withController(async ({ controller }) => {
         // When calling getAccountState
-        const result = await controller.getAccountState({
-          providerId: 'polymarket',
-        });
+        const result = await controller.getAccountState({});
 
         // Then it should return the account state
         expect(result).toEqual(mockAccountState);
 
         // And provider should be called with correct owner address
         expect(mockPolymarketProvider.getAccountState).toHaveBeenCalledWith({
-          providerId: 'polymarket',
           ownerAddress: '0x1234567890123456789012345678901234567890',
         });
       });
@@ -4835,11 +4403,9 @@ describe('PredictController', () => {
         // Given an invalid provider ID
         // When calling getAccountState
         // Then it should throw an error
-        await expect(
-          controller.getAccountState({
-            providerId: 'invalid-provider',
-          }),
-        ).rejects.toThrow('Provider not available');
+        await expect(controller.getAccountState({})).rejects.toThrow(
+          'Provider not available',
+        );
       });
     });
   });
@@ -4852,16 +4418,13 @@ describe('PredictController', () => {
 
       await withController(async ({ controller }) => {
         // When calling getBalance
-        const result = await controller.getBalance({
-          providerId: 'polymarket',
-        });
+        const result = await controller.getBalance({});
 
         // Then it should return the balance
         expect(result).toBe(mockBalance);
 
         // And provider should be called with default address
         expect(mockPolymarketProvider.getBalance).toHaveBeenCalledWith({
-          providerId: 'polymarket',
           address: '0x1234567890123456789012345678901234567890',
         });
       });
@@ -4875,7 +4438,6 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         // When calling getBalance with custom address
         const result = await controller.getBalance({
-          providerId: 'polymarket',
           address: '0x9876543210987654321098765432109876543210',
         });
 
@@ -4884,7 +4446,6 @@ describe('PredictController', () => {
 
         // And provider should be called with custom address
         expect(mockPolymarketProvider.getBalance).toHaveBeenCalledWith({
-          providerId: 'polymarket',
           address: '0x9876543210987654321098765432109876543210',
         });
       });
@@ -4894,11 +4455,9 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         // When calling getBalance with invalid provider
         // Then it should throw an error
-        await expect(
-          controller.getBalance({
-            providerId: 'invalid-provider',
-          }),
-        ).rejects.toThrow('Provider not available');
+        await expect(controller.getBalance({})).rejects.toThrow(
+          'Provider not available',
+        );
       });
     });
 
@@ -4911,11 +4470,9 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         // When calling getBalance
         // Then it should throw an error
-        await expect(
-          controller.getBalance({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('Balance fetch failed');
+        await expect(controller.getBalance({})).rejects.toThrow(
+          'Balance fetch failed',
+        );
       });
     });
   });
@@ -4933,7 +4490,6 @@ describe('PredictController', () => {
 
       await withController(async ({ controller }) => {
         const result = await controller.previewOrder({
-          providerId: 'polymarket',
           marketId: 'market-1',
           outcomeId: 'outcome-1',
           outcomeTokenId: 'token-1',
@@ -4969,7 +4525,6 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         await expect(
           controller.previewOrder({
-            providerId: 'invalid-provider',
             marketId: 'market-1',
             outcomeId: 'outcome-1',
             outcomeTokenId: 'token-1',
@@ -4988,7 +4543,6 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         await expect(
           controller.previewOrder({
-            providerId: 'polymarket',
             marketId: 'market-1',
             outcomeId: 'outcome-1',
             outcomeTokenId: 'token-1',
@@ -5023,9 +4577,7 @@ describe('PredictController', () => {
       });
 
       await withController(async ({ controller }) => {
-        const result = await controller.prepareWithdraw({
-          providerId: 'polymarket',
-        });
+        const result = await controller.prepareWithdraw({});
 
         expect(result.success).toBe(true);
         expect(result.response).toBe(mockBatchId);
@@ -5046,11 +4598,9 @@ describe('PredictController', () => {
       );
 
       await withController(async ({ controller }) => {
-        await expect(
-          controller.prepareWithdraw({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('Provider error');
+        await expect(controller.prepareWithdraw({})).rejects.toThrow(
+          'Provider error',
+        );
 
         expect(controller.state.lastError).toBe('Provider error');
         expect(controller.state.lastUpdateTimestamp).toBeGreaterThan(0);
@@ -5064,18 +4614,15 @@ describe('PredictController', () => {
       );
 
       await withController(async ({ controller }) => {
-        await expect(
-          controller.prepareWithdraw({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('Network error');
+        await expect(controller.prepareWithdraw({})).rejects.toThrow(
+          'Network error',
+        );
 
         expect(DevLogger.log).toHaveBeenCalledWith(
           'PredictController: Prepare withdraw failed',
           expect.objectContaining({
             error: 'Network error',
             timestamp: expect.any(String),
-            providerId: 'polymarket',
           }),
         );
       });
@@ -5083,11 +4630,9 @@ describe('PredictController', () => {
 
     it('returns error when provider is not available', async () => {
       await withController(async ({ controller }) => {
-        await expect(
-          controller.prepareWithdraw({
-            providerId: 'nonexistent',
-          }),
-        ).rejects.toThrow('Provider not available');
+        await expect(controller.prepareWithdraw({})).rejects.toThrow(
+          'Provider not available',
+        );
 
         expect(controller.state.lastError).toBe('Provider not available');
       });
@@ -5102,12 +4647,9 @@ describe('PredictController', () => {
       });
 
       await withController(async ({ controller }) => {
-        await controller.prepareWithdraw({
-          providerId: 'polymarket',
-        });
+        await controller.prepareWithdraw({});
 
         expect(mockPolymarketProvider.prepareWithdraw).toHaveBeenCalledWith({
-          providerId: 'polymarket',
           signer: expect.objectContaining({
             address: '0x1234567890123456789012345678901234567890',
             signTypedMessage: expect.any(Function),
@@ -5126,9 +4668,7 @@ describe('PredictController', () => {
       });
 
       await withController(async ({ controller }) => {
-        await controller.prepareWithdraw({
-          providerId: 'polymarket',
-        });
+        await controller.prepareWithdraw({});
 
         expect(addTransactionBatch).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -5155,9 +4695,7 @@ describe('PredictController', () => {
       });
 
       await withController(async ({ controller }) => {
-        await controller.prepareWithdraw({
-          providerId: 'polymarket',
-        });
+        await controller.prepareWithdraw({});
 
         expect(controller.state.withdrawTransaction?.transactionId).toBe(
           mockBatchId,
@@ -5174,11 +4712,9 @@ describe('PredictController', () => {
       );
 
       await withController(async ({ controller }) => {
-        await expect(
-          controller.prepareWithdraw({
-            providerId: 'polymarket',
-          }),
-        ).rejects.toThrow('Transaction batch submission failed');
+        await expect(controller.prepareWithdraw({})).rejects.toThrow(
+          'Transaction batch submission failed',
+        );
 
         expect(controller.state.lastError).toBe(
           'Transaction batch submission failed',
@@ -5197,9 +4733,7 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         expect(controller.state.withdrawTransaction).toBeNull();
 
-        await controller.prepareWithdraw({
-          providerId: 'polymarket',
-        });
+        await controller.prepareWithdraw({});
 
         expect(controller.state.withdrawTransaction).toBeDefined();
         expect(controller.state.withdrawTransaction?.status).toBe(
@@ -5220,9 +4754,7 @@ describe('PredictController', () => {
       });
 
       await withController(async ({ controller }) => {
-        await controller.prepareWithdraw({
-          providerId: 'polymarket',
-        });
+        await controller.prepareWithdraw({});
 
         expect(controller.state.withdrawTransaction?.chainId).toBe(1);
       });
@@ -5234,9 +4766,7 @@ describe('PredictController', () => {
           new Error('User denied transaction signature'),
         );
 
-        const result = await controller.prepareWithdraw({
-          providerId: 'polymarket',
-        });
+        const result = await controller.prepareWithdraw({});
 
         expect(result.success).toBe(true);
         expect(result.response).toBe('User cancelled transaction');
@@ -5254,9 +4784,7 @@ describe('PredictController', () => {
           mockWithdrawResponse,
         );
 
-        const result = await controller.prepareWithdraw({
-          providerId: 'polymarket',
-        });
+        const result = await controller.prepareWithdraw({});
 
         expect(result.success).toBe(true);
         expect(result.response).toBe('User cancelled transaction');
@@ -5269,9 +4797,7 @@ describe('PredictController', () => {
           new Error('User denied transaction signature'),
         );
 
-        await controller.prepareWithdraw({
-          providerId: 'polymarket',
-        });
+        await controller.prepareWithdraw({});
 
         expect(controller.state.lastError).toBeNull();
         expect(controller.state.withdrawTransaction).toBeNull();
@@ -5489,7 +5015,7 @@ describe('PredictController', () => {
           state.withdrawTransaction = {
             chainId: 137,
             status: PredictWithdrawStatus.IDLE,
-            providerId: 'nonexistent',
+            providerId: 'polymarket',
             predictAddress: '0xPredict' as `0x${string}`,
             transactionId: 'tx-1',
             amount: 0,
@@ -5653,9 +5179,7 @@ describe('PredictController', () => {
             transactionId: 'tx-789',
             amount: 200,
           };
-          state.eligibility = {
-            polymarket: { eligible: true, country: 'PT' },
-          };
+          state.eligibility = { eligible: true, country: 'PT' };
           state.lastError = 'Some error';
         });
 
@@ -5703,7 +5227,6 @@ describe('PredictController', () => {
         mockPolymarketProvider.confirmClaim = jest.fn();
 
         // Act
-        controller.confirmClaim({ providerId: 'polymarket' });
 
         // Assert
         expect(controller.state.claimablePositions[testAddress]).toEqual([]);
@@ -5730,7 +5253,6 @@ describe('PredictController', () => {
         mockPolymarketProvider.confirmClaim = jest.fn();
 
         // Act
-        controller.confirmClaim({ providerId: 'polymarket' });
 
         // Assert
         expect(mockPolymarketProvider.confirmClaim).toHaveBeenCalledWith({
@@ -5754,7 +5276,6 @@ describe('PredictController', () => {
         mockPolymarketProvider.confirmClaim = jest.fn();
 
         // Act
-        controller.confirmClaim({ providerId: 'polymarket' });
 
         // Assert
         expect(mockPolymarketProvider.confirmClaim).not.toHaveBeenCalled();
@@ -5771,20 +5292,9 @@ describe('PredictController', () => {
         mockPolymarketProvider.confirmClaim = jest.fn();
 
         // Act
-        controller.confirmClaim({ providerId: 'polymarket' });
 
         // Assert
         expect(mockPolymarketProvider.confirmClaim).not.toHaveBeenCalled();
-      });
-    });
-
-    it('throws error when provider not available', async () => {
-      // Arrange
-      await withController(async ({ controller }) => {
-        // Act & Assert
-        expect(() =>
-          controller.confirmClaim({ providerId: 'invalid-provider' }),
-        ).toThrow('Provider not available');
       });
     });
 
@@ -5810,7 +5320,6 @@ describe('PredictController', () => {
           .confirmClaim;
 
         // Act
-        controller.confirmClaim({ providerId: 'polymarket' });
 
         // Assert - should not throw, state should still be cleared
         expect(controller.state.claimablePositions[testAddress]).toEqual([]);
@@ -5830,7 +5339,6 @@ describe('PredictController', () => {
           {
             id: 'position-1',
             marketId: 'market-1',
-            providerId: 'polymarket',
             status: PredictPositionStatus.OPEN,
             currentValue: 100,
             cashPnl: 0,
@@ -6080,13 +5588,12 @@ describe('PredictController', () => {
         async ({ controller }) => {
           // Act
           await controller.placeOrder({
-            providerId: 'polymarket',
             preview,
           });
 
           // Assert
           const updatedBalance =
-            controller.state.balances.polymarket[
+            controller.state.balances[
               '0x1234567890123456789012345678901234567890'
             ];
           expect(updatedBalance.balance).toBe(1000 - 100.5);
@@ -6094,10 +5601,8 @@ describe('PredictController', () => {
         {
           state: {
             balances: {
-              polymarket: {
-                '0x1234567890123456789012345678901234567890':
-                  createMockPredictBalance({ balance: 1000 }),
-              },
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance({ balance: 1000 }),
             },
           },
         },
@@ -6122,13 +5627,12 @@ describe('PredictController', () => {
         async ({ controller }) => {
           // Act
           await controller.placeOrder({
-            providerId: 'polymarket',
             preview,
           });
 
           // Assert
           const updatedBalance =
-            controller.state.balances.polymarket[
+            controller.state.balances[
               '0x1234567890123456789012345678901234567890'
             ];
           expect(updatedBalance.validUntil).toBe(now + 5000);
@@ -6136,10 +5640,8 @@ describe('PredictController', () => {
         {
           state: {
             balances: {
-              polymarket: {
-                '0x1234567890123456789012345678901234567890':
-                  createMockPredictBalance(),
-              },
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance(),
             },
           },
         },
@@ -6162,13 +5664,12 @@ describe('PredictController', () => {
         async ({ controller }) => {
           // Act
           await controller.placeOrder({
-            providerId: 'polymarket',
             preview,
           });
 
           // Assert
           const updatedBalance =
-            controller.state.balances.polymarket[
+            controller.state.balances[
               '0x1234567890123456789012345678901234567890'
             ];
           expect(updatedBalance.balance).toBe(500 + 95.5);
@@ -6176,10 +5677,8 @@ describe('PredictController', () => {
         {
           state: {
             balances: {
-              polymarket: {
-                '0x1234567890123456789012345678901234567890':
-                  createMockPredictBalance({ balance: 500 }),
-              },
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance({ balance: 500 }),
             },
           },
         },
@@ -6204,13 +5703,12 @@ describe('PredictController', () => {
         async ({ controller }) => {
           // Act
           await controller.placeOrder({
-            providerId: 'polymarket',
             preview,
           });
 
           // Assert
           const updatedBalance =
-            controller.state.balances.polymarket[
+            controller.state.balances[
               '0x1234567890123456789012345678901234567890'
             ];
           expect(updatedBalance.validUntil).toBe(now + 5000);
@@ -6218,10 +5716,8 @@ describe('PredictController', () => {
         {
           state: {
             balances: {
-              polymarket: {
-                '0x1234567890123456789012345678901234567890':
-                  createMockPredictBalance(),
-              },
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance(),
             },
           },
         },
@@ -6244,13 +5740,12 @@ describe('PredictController', () => {
         async ({ controller }) => {
           // Act
           await controller.placeOrder({
-            providerId: 'polymarket',
             preview,
           });
 
           // Assert - parseFloat('invalid') returns NaN
           const updatedBalance =
-            controller.state.balances.polymarket[
+            controller.state.balances[
               '0x1234567890123456789012345678901234567890'
             ];
           expect(updatedBalance.balance).toBeNaN();
@@ -6258,10 +5753,8 @@ describe('PredictController', () => {
         {
           state: {
             balances: {
-              polymarket: {
-                '0x1234567890123456789012345678901234567890':
-                  createMockPredictBalance({ balance: 1000 }),
-              },
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance({ balance: 1000 }),
             },
           },
         },
@@ -6279,14 +5772,13 @@ describe('PredictController', () => {
           // Act
           await expect(
             controller.placeOrder({
-              providerId: 'polymarket',
               preview,
             }),
           ).rejects.toThrow('Order failed');
 
           // Assert - balance should remain unchanged
           const updatedBalance =
-            controller.state.balances.polymarket[
+            controller.state.balances[
               '0x1234567890123456789012345678901234567890'
             ];
           expect(updatedBalance.balance).toBe(1000);
@@ -6294,10 +5786,8 @@ describe('PredictController', () => {
         {
           state: {
             balances: {
-              polymarket: {
-                '0x1234567890123456789012345678901234567890':
-                  createMockPredictBalance({ balance: 1000 }),
-              },
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance({ balance: 1000 }),
             },
           },
         },
@@ -6320,13 +5810,12 @@ describe('PredictController', () => {
         async ({ controller }) => {
           // Act
           await controller.placeOrder({
-            providerId: 'polymarket',
             preview,
           });
 
           // Assert - parseFloat('') returns NaN, so balance becomes NaN
           const updatedBalance =
-            controller.state.balances.polymarket[
+            controller.state.balances[
               '0x1234567890123456789012345678901234567890'
             ];
           expect(updatedBalance.balance).toBeNaN();
@@ -6334,10 +5823,8 @@ describe('PredictController', () => {
         {
           state: {
             balances: {
-              polymarket: {
-                '0x1234567890123456789012345678901234567890':
-                  createMockPredictBalance({ balance: 1000 }),
-              },
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance({ balance: 1000 }),
             },
           },
         },
@@ -6360,13 +5847,12 @@ describe('PredictController', () => {
         async ({ controller }) => {
           // Act
           await controller.placeOrder({
-            providerId: 'polymarket',
             preview,
           });
 
           // Assert - parseFloat('') returns NaN, so balance becomes NaN
           const updatedBalance =
-            controller.state.balances.polymarket[
+            controller.state.balances[
               '0x1234567890123456789012345678901234567890'
             ];
           expect(updatedBalance.balance).toBeNaN();
@@ -6374,10 +5860,8 @@ describe('PredictController', () => {
         {
           state: {
             balances: {
-              polymarket: {
-                '0x1234567890123456789012345678901234567890':
-                  createMockPredictBalance({ balance: 500 }),
-              },
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance({ balance: 500 }),
             },
           },
         },
@@ -6401,9 +5885,7 @@ describe('PredictController', () => {
       await withController(
         async ({ controller }) => {
           // Act
-          const result = await controller.getBalance({
-            providerId: 'polymarket',
-          });
+          const result = await controller.getBalance({});
 
           // Assert
           expect(result).toBe(1500);
@@ -6412,13 +5894,11 @@ describe('PredictController', () => {
         {
           state: {
             balances: {
-              polymarket: {
-                '0x1234567890123456789012345678901234567890':
-                  createMockPredictBalance({
-                    balance: 1500,
-                    validUntil: now + 500,
-                  }),
-              },
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance({
+                  balance: 1500,
+                  validUntil: now + 500,
+                }),
             },
           },
         },
@@ -6433,9 +5913,7 @@ describe('PredictController', () => {
       await withController(
         async ({ controller }) => {
           // Act
-          const result = await controller.getBalance({
-            providerId: 'polymarket',
-          });
+          const result = await controller.getBalance({});
 
           // Assert
           expect(result).toBe(2000);
@@ -6444,13 +5922,11 @@ describe('PredictController', () => {
         {
           state: {
             balances: {
-              polymarket: {
-                '0x1234567890123456789012345678901234567890':
-                  createMockPredictBalance({
-                    balance: 1500,
-                    validUntil: now - 100,
-                  }),
-              },
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance({
+                  balance: 1500,
+                  validUntil: now - 100,
+                }),
             },
           },
         },
@@ -6462,9 +5938,7 @@ describe('PredictController', () => {
 
       await withController(async ({ controller }) => {
         // Act
-        const result = await controller.getBalance({
-          providerId: 'polymarket',
-        });
+        const result = await controller.getBalance({});
 
         // Assert
         expect(result).toBe(1000);
@@ -6479,13 +5953,11 @@ describe('PredictController', () => {
 
       await withController(async ({ controller }) => {
         // Act
-        await controller.getBalance({
-          providerId: 'polymarket',
-        });
+        await controller.getBalance({});
 
         // Assert
         const updatedBalance =
-          controller.state.balances.polymarket[
+          controller.state.balances[
             '0x1234567890123456789012345678901234567890'
           ];
         expect(updatedBalance.balance).toBe(2500);
@@ -6505,9 +5977,7 @@ describe('PredictController', () => {
       await withController(
         async ({ controller }) => {
           // Act
-          await controller.getBalance({
-            providerId: 'polymarket',
-          });
+          await controller.getBalance({});
 
           // Assert
           expect(mockCheckForLatestBlock).toHaveBeenCalled();
@@ -6532,9 +6002,7 @@ describe('PredictController', () => {
       await withController(
         async ({ controller }) => {
           // Act
-          const result = await controller.getBalance({
-            providerId: 'polymarket',
-          });
+          const result = await controller.getBalance({});
 
           // Assert
           expect(result).toBe(1800);
@@ -6543,13 +6011,11 @@ describe('PredictController', () => {
         {
           state: {
             balances: {
-              polymarket: {
-                '0x1234567890123456789012345678901234567890':
-                  createMockPredictBalance({
-                    balance: 1500,
-                    validUntil: now,
-                  }),
-              },
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance({
+                  balance: 1500,
+                  validUntil: now,
+                }),
             },
           },
         },
@@ -6565,7 +6031,6 @@ describe('PredictController', () => {
         async ({ controller }) => {
           // Act - fetch for different address
           const result = await controller.getBalance({
-            providerId: 'polymarket',
             address: '0xdifferentaddress000000000000000000000000',
           });
 
@@ -6574,7 +6039,7 @@ describe('PredictController', () => {
           expect(mockPolymarketProvider.getBalance).toHaveBeenCalled();
           // Original cached balance should still exist
           expect(
-            controller.state.balances.polymarket[
+            controller.state.balances[
               '0x1234567890123456789012345678901234567890'
             ].balance,
           ).toBe(1500);
@@ -6582,13 +6047,11 @@ describe('PredictController', () => {
         {
           state: {
             balances: {
-              polymarket: {
-                '0x1234567890123456789012345678901234567890':
-                  createMockPredictBalance({
-                    balance: 1500,
-                    validUntil: now + 500,
-                  }),
-              },
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance({
+                  balance: 1500,
+                  validUntil: now + 500,
+                }),
             },
           },
         },
@@ -6620,8 +6083,9 @@ describe('PredictController', () => {
 
       it('returns no-op function when provider lacks method', () => {
         withController(({ controller }) => {
-          // @ts-expect-error Testing undefined method scenario
-          mockPolymarketProvider.subscribeToGameUpdates = undefined;
+          delete (
+            mockPolymarketProvider as { subscribeToGameUpdates?: unknown }
+          ).subscribeToGameUpdates;
 
           const unsubscribe = controller.subscribeToGameUpdates(
             'game123',
@@ -6638,7 +6102,6 @@ describe('PredictController', () => {
           const unsubscribe = controller.subscribeToGameUpdates(
             'game123',
             jest.fn(),
-            'unknown-provider',
           );
 
           expect(unsubscribe).toBeDefined();
@@ -6670,8 +6133,9 @@ describe('PredictController', () => {
 
       it('returns no-op function when provider lacks method', () => {
         withController(({ controller }) => {
-          // @ts-expect-error Testing undefined method scenario
-          mockPolymarketProvider.subscribeToMarketPrices = undefined;
+          delete (
+            mockPolymarketProvider as { subscribeToMarketPrices?: unknown }
+          ).subscribeToMarketPrices;
 
           const unsubscribe = controller.subscribeToMarketPrices(
             ['token1'],
@@ -6706,8 +6170,8 @@ describe('PredictController', () => {
 
       it('returns disconnected status when provider lacks method', () => {
         withController(({ controller }) => {
-          // @ts-expect-error Testing undefined method scenario
-          mockPolymarketProvider.getConnectionStatus = undefined;
+          delete (mockPolymarketProvider as { getConnectionStatus?: unknown })
+            .getConnectionStatus;
 
           const status = controller.getConnectionStatus();
 
@@ -6720,7 +6184,7 @@ describe('PredictController', () => {
 
       it('returns disconnected status for unknown provider', () => {
         withController(({ controller }) => {
-          const status = controller.getConnectionStatus('unknown-provider');
+          const status = controller.getConnectionStatus();
 
           expect(status).toEqual({
             sportsConnected: false,
@@ -6741,7 +6205,6 @@ describe('PredictController', () => {
         await controller.trackPredictOrderEvent({
           status: 'succeeded',
           analyticsProperties: { marketId: 'test' },
-          providerId: 'polymarket',
         });
         expect(analytics.trackEvent).toHaveBeenCalledTimes(1);
       });
@@ -6751,7 +6214,6 @@ describe('PredictController', () => {
       await withController(async ({ controller }) => {
         await controller.trackPredictOrderEvent({
           status: 'succeeded',
-          providerId: 'polymarket',
         });
         expect(analytics.trackEvent).not.toHaveBeenCalled();
       });
@@ -6786,7 +6248,6 @@ describe('PredictController', () => {
     it('calls analytics.trackEvent for trackGeoBlockTriggered', () => {
       withController(({ controller }) => {
         controller.trackGeoBlockTriggered({
-          providerId: 'polymarket',
           attemptedAction: 'deposit',
         });
         expect(analytics.trackEvent).toHaveBeenCalledTimes(1);

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -39,6 +39,7 @@ import {
 } from './PredictController';
 import { analytics } from '../../../../util/analytics/analytics';
 
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 // Mock the PolymarketProvider and its dependencies
 jest.mock('../providers/polymarket/PolymarketProvider');
 
@@ -138,7 +139,7 @@ describe('PredictController', () => {
   ): PredictPosition {
     return {
       id: 'position-1',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       marketId: 'market-1',
       outcomeId: 'outcome-1',
       outcome: 'Yes',
@@ -763,7 +764,7 @@ describe('PredictController', () => {
     it('handle empty bookParams array', async () => {
       await withController(async ({ controller }) => {
         mockPolymarketProvider.getPrices = jest.fn().mockResolvedValue({
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           results: [],
         });
 
@@ -772,7 +773,7 @@ describe('PredictController', () => {
         });
 
         expect(result).toEqual({
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           results: [],
         });
         expect(mockPolymarketProvider.getPrices).toHaveBeenCalledWith({
@@ -2561,7 +2562,7 @@ describe('PredictController', () => {
     const mockActivity = [
       {
         id: 'activity-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         entry: {
           type: 'buy' as const,
           timestamp: Date.now(),
@@ -2575,7 +2576,7 @@ describe('PredictController', () => {
       },
       {
         id: 'activity-2',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         entry: {
           type: 'claimWinnings' as const,
           timestamp: Date.now(),
@@ -3230,7 +3231,7 @@ describe('PredictController', () => {
 
     it('updates deposit transaction in depositWithConfirmation', async () => {
       const mockBatchId = 'batch-store-test';
-      const providerId = 'polymarket';
+      const providerId = POLYMARKET_PROVIDER_ID;
       const address = '0x1234567890123456789012345678901234567890';
 
       mockPolymarketProvider.prepareDeposit.mockResolvedValue({
@@ -3265,7 +3266,7 @@ describe('PredictController', () => {
     it('clears previous deposit transaction when starting new deposit', async () => {
       const oldBatchId = 'old-batch';
       const newBatchId = 'new-batch';
-      const providerId = 'polymarket';
+      const providerId = POLYMARKET_PROVIDER_ID;
       const address = '0x1234567890123456789012345678901234567890';
 
       mockPolymarketProvider.prepareDeposit.mockResolvedValue({
@@ -3744,7 +3745,7 @@ describe('PredictController', () => {
             chainId: 137,
             transactionId: 'withdraw-1',
             status: PredictWithdrawStatus.PENDING,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: accountAddress,
           };
         });
@@ -3770,7 +3771,7 @@ describe('PredictController', () => {
             chainId: 137,
             transactionId: 'withdraw-2',
             status: PredictWithdrawStatus.PENDING,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: accountAddress,
           };
         });
@@ -3932,7 +3933,7 @@ describe('PredictController', () => {
             chainId: 137,
             transactionId: 'tx-1',
             status: PredictWithdrawStatus.PENDING,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: accountAddress,
           };
         });
@@ -4260,7 +4261,7 @@ describe('PredictController', () => {
         expect(controller.state.withdrawTransaction).toEqual({
           chainId: 137,
           status: PredictWithdrawStatus.IDLE,
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           predictAddress: '0xPredictAddress',
           transactionId: mockBatchId,
           amount: 0,
@@ -4509,7 +4510,7 @@ describe('PredictController', () => {
           state.withdrawTransaction = {
             chainId: 137,
             status: PredictWithdrawStatus.IDLE,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: '0xPredict' as `0x${string}`,
             transactionId: 'tx-1',
             amount: 0,
@@ -4541,7 +4542,7 @@ describe('PredictController', () => {
           state.withdrawTransaction = {
             chainId: 137,
             status: PredictWithdrawStatus.IDLE,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: '0xPredict' as `0x${string}`,
             transactionId: 'tx-1',
             amount: 0,
@@ -4569,7 +4570,7 @@ describe('PredictController', () => {
           state.withdrawTransaction = {
             chainId: 137,
             status: PredictWithdrawStatus.IDLE,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: '0xPredict' as `0x${string}`,
             transactionId: 'tx-1',
             amount: 0,
@@ -4602,7 +4603,7 @@ describe('PredictController', () => {
           state.withdrawTransaction = {
             chainId: 137,
             status: PredictWithdrawStatus.IDLE,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: '0xPredict' as `0x${string}`,
             transactionId: 'tx-1',
             amount: 0,
@@ -4631,7 +4632,7 @@ describe('PredictController', () => {
           state.withdrawTransaction = {
             chainId: 137,
             status: PredictWithdrawStatus.IDLE,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: '0xPredictAddress' as `0x${string}`,
             transactionId: 'tx-1',
             amount: 0,
@@ -4685,7 +4686,7 @@ describe('PredictController', () => {
           state.withdrawTransaction = {
             chainId: 137,
             status: PredictWithdrawStatus.IDLE,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: '0xPredict' as `0x${string}`,
             transactionId: 'tx-1',
             amount: 0,
@@ -4706,7 +4707,7 @@ describe('PredictController', () => {
           state.withdrawTransaction = {
             chainId: 137,
             status: PredictWithdrawStatus.IDLE,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: '0xPredict' as `0x${string}`,
             transactionId: 'tx-1',
             amount: 0,
@@ -4732,7 +4733,7 @@ describe('PredictController', () => {
           state.withdrawTransaction = {
             chainId: 137,
             status: PredictWithdrawStatus.IDLE,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: '0xPredict' as `0x${string}`,
             transactionId: 'tx-1',
             amount: 0,
@@ -4760,7 +4761,7 @@ describe('PredictController', () => {
           state.withdrawTransaction = {
             chainId: 137,
             status: PredictWithdrawStatus.IDLE,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: '0xPredict' as `0x${string}`,
             transactionId: 'tx-123',
             amount: 100,
@@ -4770,7 +4771,7 @@ describe('PredictController', () => {
         expect(controller.state.withdrawTransaction).toEqual({
           chainId: 137,
           status: PredictWithdrawStatus.IDLE,
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           predictAddress: '0xPredict',
           transactionId: 'tx-123',
           amount: 100,
@@ -4800,7 +4801,7 @@ describe('PredictController', () => {
           state.withdrawTransaction = {
             chainId: 137,
             status: PredictWithdrawStatus.PENDING,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: '0xPredict' as `0x${string}`,
             transactionId: 'tx-456',
             amount: 500,
@@ -4819,7 +4820,7 @@ describe('PredictController', () => {
           state.withdrawTransaction = {
             chainId: 137,
             status: PredictWithdrawStatus.IDLE,
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             predictAddress: '0xPredict' as `0x${string}`,
             transactionId: 'tx-789',
             amount: 200,

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -68,7 +68,6 @@ import {
   GetPositionsParams,
   OrderPreview,
   PlaceOrderParams,
-  PredictProvider,
   PrepareDepositParams,
   PrepareWithdrawParams,
   PreviewOrderParams,
@@ -98,7 +97,10 @@ import {
 import { ensureError } from '../utils/predictErrorHandler';
 import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../constants/errors';
 import { GEO_BLOCKED_COUNTRIES } from '../constants/geoblock';
-import { MATIC_CONTRACTS } from '../providers/polymarket/constants';
+import {
+  MATIC_CONTRACTS,
+  POLYMARKET_PROVIDER_ID,
+} from '../providers/polymarket/constants';
 import {
   DEFAULT_FEE_COLLECTION_FLAG,
   DEFAULT_LIVE_SPORTS_FLAG,
@@ -120,12 +122,9 @@ import {
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type PredictControllerState = {
-  // Eligibility (Geo-Blocking) per Provider
   eligibility: {
-    [key: string]: {
-      eligible: boolean;
-      country?: string;
-    };
+    eligible: boolean;
+    country?: string;
   };
 
   // Error handling
@@ -133,13 +132,13 @@ export type PredictControllerState = {
   lastUpdateTimestamp: number;
 
   // Account balances
-  balances: { [providerId: string]: { [address: string]: PredictBalance } };
+  balances: { [address: string]: PredictBalance };
 
   // Claim management (this should always be ALL claimable positions)
   claimablePositions: { [address: string]: PredictPosition[] };
 
   // Deposit management
-  pendingDeposits: { [providerId: string]: { [address: string]: string } };
+  pendingDeposits: { [address: string]: string };
 
   // Withdraw management
   // TODO: change to be per-account basis
@@ -155,7 +154,7 @@ export type PredictControllerState = {
  * Get default PredictController state
  */
 export const getDefaultPredictControllerState = (): PredictControllerState => ({
-  eligibility: {},
+  eligibility: { eligible: false },
   lastError: null,
   lastUpdateTimestamp: 0,
   balances: {},
@@ -319,9 +318,7 @@ export class PredictController extends BaseController<
   PredictControllerState,
   PredictControllerMessenger
 > {
-  private providers: Map<string, PredictProvider>;
-  private isInitialized = false;
-  private initializationPromise: Promise<void> | null = null;
+  private provider: PolymarketProvider;
 
   constructor({ messenger, state = {} }: PredictControllerOptions) {
     super({
@@ -331,30 +328,12 @@ export class PredictController extends BaseController<
       state: { ...getDefaultPredictControllerState(), ...state },
     });
 
-    this.providers = new Map();
+    this.provider = new PolymarketProvider();
 
     this.messenger.subscribe(
       'TransactionController:transactionStatusUpdated',
       this.handleTransactionStatusUpdate.bind(this),
     );
-
-    this.initializeProviders().catch((error) => {
-      DevLogger.log('PredictController: Error initializing providers', {
-        error:
-          error instanceof Error
-            ? error.message
-            : PREDICT_ERROR_CODES.UNKNOWN_ERROR,
-        timestamp: new Date().toISOString(),
-      });
-
-      Logger.error(
-        ensureError(error),
-        this.getErrorContext('initializeProviders', {
-          existingProvidersCount: this.providers.size,
-          isInitialized: this.isInitialized,
-        }),
-      );
-    });
 
     this.refreshEligibility().catch((error) => {
       DevLogger.log('PredictController: Error refreshing eligibility', {
@@ -368,55 +347,9 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('refreshEligibility', {
-          providersCount: this.providers.size,
+          provider: POLYMARKET_PROVIDER_ID,
         }),
       );
-    });
-  }
-
-  /**
-   * Initialize the PredictController providers
-   * Must be called before using any other methods
-   * Prevents double initialization with promise caching
-   */
-  private async initializeProviders(): Promise<void> {
-    if (this.isInitialized) {
-      return;
-    }
-
-    if (this.initializationPromise) {
-      return this.initializationPromise;
-    }
-
-    this.initializationPromise = this.performInitialization();
-    return this.initializationPromise;
-  }
-
-  /**
-   * Actual initialization implementation
-   */
-  private async performInitialization(): Promise<void> {
-    DevLogger.log('PredictController: Initializing providers', {
-      existingProviders: Array.from(this.providers.keys()),
-      timestamp: new Date().toISOString(),
-    });
-
-    // Disconnect existing providers to close WebSocket connections
-    const existingProviders = Array.from(this.providers.values());
-    if (existingProviders.length > 0) {
-      DevLogger.log('PredictController: Disconnecting existing providers', {
-        count: existingProviders.length,
-        timestamp: new Date().toISOString(),
-      });
-    }
-
-    this.providers.clear();
-    this.providers.set('polymarket', new PolymarketProvider());
-
-    this.isInitialized = true;
-    DevLogger.log('PredictController: Providers initialized successfully', {
-      providerCount: this.providers.size,
-      timestamp: new Date().toISOString(),
     });
   }
 
@@ -529,20 +462,12 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: params.providerId ?? 'unknown',
+        providerId: 'polymarket',
         ...(params.category && { category: params.category }),
       },
     });
 
     try {
-      const providerIds = params.providerId
-        ? [params.providerId]
-        : Array.from(this.providers.keys());
-
-      if (providerIds.some((id) => !this.providers.has(id))) {
-        throw new Error('Provider not available');
-      }
-
       const remoteFeatureFlagState = this.messenger.call(
         'RemoteFeatureFlagController:getState',
       );
@@ -570,15 +495,11 @@ export class PredictController extends BaseController<
 
       const paramsWithLiveSports = { ...params, liveSportsLeagues };
 
-      const allMarkets = await Promise.all(
-        providerIds.map((id: string) =>
-          this.providers.get(id)?.getMarkets(paramsWithLiveSports),
-        ),
-      );
+      const allMarkets = await this.provider.getMarkets(paramsWithLiveSports);
 
-      let markets = allMarkets
-        .flat()
-        .filter((market): market is PredictMarket => market !== undefined);
+      let markets = allMarkets.filter(
+        (market): market is PredictMarket => market !== undefined,
+      );
 
       const isFirstPage = !params.offset || params.offset === 0;
       const shouldFetchHighlights =
@@ -591,12 +512,10 @@ export class PredictController extends BaseController<
           )?.markets ?? [];
 
         if (highlightedMarketIds.length > 0) {
-          const provider = this.providers.get(
-            params.providerId ?? 'polymarket',
-          );
+          const provider = this.provider;
 
           const fetchedHighlightedMarkets =
-            (await provider?.getMarketsByIds?.(
+            (await provider.getMarketsByIds?.(
               highlightedMarketIds,
               liveSportsLeagues,
             )) ?? [];
@@ -639,7 +558,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getMarkets', {
-          providerId: params.providerId,
+          providerId: 'polymarket',
           category: params.category,
           sortBy: params.sortBy,
           sortDirection: params.sortDirection,
@@ -664,10 +583,8 @@ export class PredictController extends BaseController<
    */
   async getMarket({
     marketId,
-    providerId,
   }: {
     marketId: string | number;
-    providerId?: string;
   }): Promise<PredictMarket> {
     const resolvedMarketId = String(marketId);
 
@@ -685,19 +602,12 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: providerId ?? 'unknown',
+        providerId: 'polymarket',
       },
     });
 
     try {
-      await this.initializeProviders();
-
-      const targetProviderId = providerId ?? 'polymarket';
-      const provider = this.providers.get(targetProviderId);
-
-      if (!provider) {
-        throw new Error('Provider not available');
-      }
+      const provider = this.provider;
 
       const remoteFeatureFlagState = this.messenger.call(
         'RemoteFeatureFlagController:getState',
@@ -740,7 +650,7 @@ export class PredictController extends BaseController<
         ensureError(error),
         this.getErrorContext('getMarket', {
           marketId: resolvedMarketId,
-          providerId: providerId ?? 'polymarket',
+          providerId: 'polymarket',
         }),
       );
 
@@ -776,30 +686,15 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: params.providerId ?? 'unknown',
+        providerId: 'polymarket',
         ...(params.interval && { interval: params.interval }),
       },
     });
 
     try {
-      const providerIds = params.providerId
-        ? [params.providerId]
-        : Array.from(this.providers.keys());
+      const history = await this.provider.getPriceHistory(params);
 
-      if (providerIds.some((id) => !this.providers.has(id))) {
-        throw new Error('Provider not available');
-      }
-
-      const histories = await Promise.all(
-        providerIds.map((id: string) =>
-          this.providers.get(id)?.getPriceHistory({
-            ...params,
-            providerId: id,
-          }),
-        ),
-      );
-
-      const priceHistory = histories.flatMap((history) => history ?? []);
+      const priceHistory = history ?? [];
 
       this.update((state) => {
         state.lastError = null;
@@ -825,7 +720,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getPriceHistory', {
-          providerId: params.providerId,
+          providerId: 'polymarket',
           marketId: params.marketId,
           fidelity: params.fidelity,
           interval: params.interval,
@@ -862,7 +757,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: params.providerId ?? 'unknown',
+        providerId: 'polymarket',
       },
       data: {
         queryCount: params.queries?.length,
@@ -870,12 +765,7 @@ export class PredictController extends BaseController<
     });
 
     try {
-      const providerId = params.providerId ?? 'polymarket';
-      const provider = this.providers.get(providerId);
-
-      if (!provider) {
-        throw new Error('Provider not available');
-      }
+      const provider = this.provider;
 
       const response = await provider.getPrices({ queries: params.queries });
 
@@ -903,7 +793,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getPrices', {
-          providerId: params.providerId,
+          providerId: 'polymarket',
           queriesCount: params.queries?.length,
         }),
       );
@@ -934,21 +824,17 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: params.providerId ?? 'unknown',
+        providerId: 'polymarket',
         claimable: params.claimable ?? false,
       },
     });
 
     try {
-      const { address, providerId = 'polymarket' } = params;
+      const { address } = params;
 
       const selectedAddress = address ?? this.getSigner().address;
 
-      const provider = this.providers.get(providerId);
-
-      if (!provider) {
-        throw new Error('Provider not available');
-      }
+      const provider = this.provider;
 
       const positions = await provider.getPositions({
         ...params,
@@ -984,7 +870,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getPositions', {
-          providerId: params.providerId,
+          providerId: 'polymarket',
           claimable: params.claimable,
           marketId: params.marketId,
         }),
@@ -1004,10 +890,7 @@ export class PredictController extends BaseController<
   /**
    * Get user activity
    */
-  async getActivity(params: {
-    address?: string;
-    providerId?: string;
-  }): Promise<PredictActivity[]> {
+  async getActivity(params: { address?: string }): Promise<PredictActivity[]> {
     // Start Sentry trace for get activity operation
     const traceId = `get-activity-${Date.now()}`;
     let traceData:
@@ -1020,31 +903,17 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: params.providerId ?? 'unknown',
+        providerId: 'polymarket',
       },
     });
 
     try {
-      const { address, providerId } = params;
+      const { address } = params;
       const selectedAddress = address ?? this.getSigner().address;
 
-      const providerIds = providerId
-        ? [providerId]
-        : Array.from(this.providers.keys());
-
-      if (providerIds.some((id) => !this.providers.has(id))) {
-        throw new Error('Provider not available');
-      }
-
-      const allActivity = await Promise.all(
-        providerIds.map((id: string) =>
-          this.providers.get(id)?.getActivity({ address: selectedAddress }),
-        ),
-      );
-
-      const activity = allActivity
-        .flat()
-        .filter((entry): entry is PredictActivity => entry !== undefined);
+      const activity = await this.provider.getActivity({
+        address: selectedAddress,
+      });
 
       this.update((state) => {
         state.lastUpdateTimestamp = Date.now();
@@ -1071,7 +940,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getActivity', {
-          providerId: params.providerId,
+          providerId: 'polymarket',
         }),
       );
 
@@ -1090,10 +959,8 @@ export class PredictController extends BaseController<
    */
   async getUnrealizedPnL({
     address,
-    providerId = 'polymarket',
   }: {
     address?: string;
-    providerId?: string;
   }): Promise<UnrealizedPnL> {
     // Start Sentry trace for get unrealized PnL operation
     const traceId = `get-unrealized-pnl-${Date.now()}`;
@@ -1105,17 +972,14 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: providerId ?? 'unknown',
+        providerId: 'polymarket',
       },
     });
 
     try {
       const selectedAddress = address ?? this.getSigner().address;
 
-      const provider = this.providers.get(providerId);
-      if (!provider) {
-        throw new Error('Provider not available');
-      }
+      const provider = this.provider;
 
       const unrealizedPnL = await provider.getUnrealizedPnL({
         address: selectedAddress,
@@ -1147,7 +1011,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getUnrealizedPnL', {
-          providerId,
+          providerId: 'polymarket',
         }),
       );
 
@@ -1170,7 +1034,6 @@ export class PredictController extends BaseController<
     status,
     amountUsd,
     analyticsProperties,
-    providerId,
     completionDuration,
     failureReason,
     sharePrice,
@@ -1179,7 +1042,6 @@ export class PredictController extends BaseController<
     status: PredictTradeStatusValue;
     amountUsd?: number;
     analyticsProperties?: PlaceOrderParams['analyticsProperties'];
-    providerId: string;
     completionDuration?: number;
     failureReason?: string;
     sharePrice?: number;
@@ -1251,7 +1113,7 @@ export class PredictController extends BaseController<
     };
 
     DevLogger.log(`📊 [Analytics] PREDICT_TRADE_TRANSACTION [${status}]`, {
-      providerId,
+      providerId: 'polymarket',
       regularProperties,
       sensitiveProperties,
     });
@@ -1394,13 +1256,11 @@ export class PredictController extends BaseController<
    * Track geo-blocking event when user attempts an action but is blocked
    */
   public trackGeoBlockTriggered({
-    providerId,
     attemptedAction,
   }: {
-    providerId: string;
     attemptedAction: string;
   }): void {
-    const eligibilityData = this.state.eligibility[providerId];
+    const eligibilityData = this.state.eligibility;
     const analyticsProperties = {
       [PredictEventProperties.COUNTRY]: eligibilityData?.country,
       [PredictEventProperties.ATTEMPTED_ACTION]: attemptedAction,
@@ -1504,10 +1364,7 @@ export class PredictController extends BaseController<
 
   async previewOrder(params: PreviewOrderParams): Promise<OrderPreview> {
     try {
-      const provider = this.providers.get(params.providerId);
-      if (!provider) {
-        throw new Error('Provider not available');
-      }
+      const provider = this.provider;
 
       const remoteFeatureFlagState = this.messenger.call(
         'RemoteFeatureFlagController:getState',
@@ -1526,7 +1383,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('previewOrder', {
-          providerId: params.providerId,
+          providerId: 'polymarket',
           side: params.side,
           marketId: params.marketId,
           outcomeId: params.outcomeId,
@@ -1539,7 +1396,7 @@ export class PredictController extends BaseController<
 
   async placeOrder(params: PlaceOrderParams): Promise<Result> {
     const startTime = performance.now();
-    const { analyticsProperties, preview, providerId } = params;
+    const { analyticsProperties, preview } = params;
 
     const sharePrice = preview?.sharePrice;
     const amountUsd =
@@ -1559,7 +1416,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: providerId ?? 'unknown',
+        providerId: 'polymarket',
         side: preview.side,
       },
       data: {
@@ -1570,10 +1427,7 @@ export class PredictController extends BaseController<
     });
 
     try {
-      const provider = this.providers.get(providerId);
-      if (!provider) {
-        throw new Error('Provider not available');
-      }
+      const provider = this.provider;
 
       const signer = this.getSigner();
 
@@ -1582,14 +1436,16 @@ export class PredictController extends BaseController<
         status: PredictTradeStatus.SUBMITTED,
         amountUsd,
         analyticsProperties,
-        providerId,
         sharePrice,
       });
 
       // Invalidate query cache (to avoid nonce issues)
       await this.invalidateQueryCache(provider.chainId);
 
-      const result = await provider.placeOrder({ ...params, signer });
+      const result = await provider.placeOrder({
+        ...params,
+        signer,
+      });
 
       // Track Predict Action Completed or Failed
       const completionDuration = performance.now() - startTime;
@@ -1600,8 +1456,7 @@ export class PredictController extends BaseController<
 
       const { spentAmount, receivedAmount } = result.response;
 
-      const cachedBalance =
-        this.state.balances[providerId]?.[signer.address]?.balance ?? 0;
+      const cachedBalance = this.state.balances[signer.address]?.balance ?? 0;
       let realAmountUsd = amountUsd;
       let realSharePrice = sharePrice;
       try {
@@ -1612,8 +1467,7 @@ export class PredictController extends BaseController<
 
           // Optimistically update balance
           this.update((state) => {
-            state.balances[providerId] = state.balances[providerId] || {};
-            state.balances[providerId][signer.address] = {
+            state.balances[signer.address] = {
               balance: cachedBalance - (realAmountUsd + totalFee),
               // valid for 5 seconds (since it takes some time to reflect balance on-chain)
               validUntil: Date.now() + 5000,
@@ -1625,8 +1479,7 @@ export class PredictController extends BaseController<
 
           // Optimistically update balance
           this.update((state) => {
-            state.balances[providerId] = state.balances[providerId] || {};
-            state.balances[providerId][signer.address] = {
+            state.balances[signer.address] = {
               balance: cachedBalance + realAmountUsd,
               // valid for 5 seconds (since it takes some time to reflect balance on-chain)
               validUntil: Date.now() + 5000,
@@ -1642,7 +1495,6 @@ export class PredictController extends BaseController<
         status: PredictTradeStatus.SUCCEEDED,
         amountUsd: realAmountUsd,
         analyticsProperties,
-        providerId,
         completionDuration,
         sharePrice: realSharePrice,
       });
@@ -1661,7 +1513,6 @@ export class PredictController extends BaseController<
         status: PredictTradeStatus.FAILED,
         amountUsd,
         analyticsProperties,
-        providerId,
         sharePrice,
         completionDuration,
         failureReason: errorMessage,
@@ -1679,7 +1530,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('placeOrder', {
-          providerId,
+          providerId: 'polymarket',
           marketId: analyticsProperties?.marketId,
           marketTitle: analyticsProperties?.marketTitle,
           transactionType: analyticsProperties?.transactionType,
@@ -1693,7 +1544,7 @@ export class PredictController extends BaseController<
         error: errorMessage,
         errorDetails: error instanceof Error ? error.stack : undefined,
         timestamp: new Date().toISOString(),
-        providerId,
+        providerId: 'polymarket',
         params,
       });
 
@@ -1707,9 +1558,9 @@ export class PredictController extends BaseController<
     }
   }
 
-  async claimWithConfirmation({
-    providerId,
-  }: ClaimParams): Promise<PredictClaim> {
+  async claimWithConfirmation(
+    _params: ClaimParams = {},
+  ): Promise<PredictClaim> {
     // Start Sentry trace for claim operation
     const traceId = `claim-${Date.now()}`;
     let traceData:
@@ -1727,15 +1578,12 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: providerId ?? 'unknown',
+        providerId: 'polymarket',
       },
     });
 
     try {
-      const provider = this.providers.get(providerId);
-      if (!provider) {
-        throw new Error('Provider not available');
-      }
+      const provider = this.provider;
 
       const signer = this.getSigner();
 
@@ -1835,7 +1683,7 @@ export class PredictController extends BaseController<
       Logger.error(
         e,
         this.getErrorContext('claimWithConfirmation', {
-          providerId,
+          providerId: 'polymarket',
         }),
       );
 
@@ -1844,7 +1692,7 @@ export class PredictController extends BaseController<
         error: errorMessage,
         errorDetails: error instanceof Error ? error.stack : undefined,
         timestamp: new Date().toISOString(),
-        providerId,
+        providerId: 'polymarket',
       });
 
       // Update error state for Sentry integration
@@ -1864,17 +1712,8 @@ export class PredictController extends BaseController<
     }
   }
 
-  public confirmClaim({
-    providerId = 'polymarket',
-    address,
-  }: {
-    providerId: string;
-    address?: string;
-  }): void {
-    const provider = this.providers.get(providerId);
-    if (!provider) {
-      throw new Error('Provider not available');
-    }
+  public confirmClaim({ address }: { address?: string }): void {
+    const provider = this.provider;
 
     const normalizedAddress = (
       address ?? this.getSigner().address
@@ -1893,7 +1732,7 @@ export class PredictController extends BaseController<
       return;
     }
 
-    this.providers.get(providerId)?.confirmClaim?.({
+    provider.confirmClaim?.({
       positions: claimedPositions,
       signer,
     });
@@ -1914,53 +1753,45 @@ export class PredictController extends BaseController<
    */
   public async refreshEligibility(): Promise<void> {
     DevLogger.log('PredictController: Refreshing eligibility');
-    for (const [providerId, provider] of this.providers) {
-      if (!provider) {
-        continue;
+    try {
+      const geoBlockResponse = await this.provider.isEligible();
+      if (geoBlockResponse.isEligible && geoBlockResponse.country) {
+        const isLocallyGeoblocked = this.isLocallyGeoblocked({
+          country: geoBlockResponse.country,
+        });
+        geoBlockResponse.isEligible = !isLocallyGeoblocked;
       }
-      try {
-        const geoBlockResponse = await provider.isEligible();
-        if (geoBlockResponse.isEligible && geoBlockResponse.country) {
-          // Check if country is blocked by local geo-blocking
-          const isLocallyGeoblocked = this.isLocallyGeoblocked({
-            country: geoBlockResponse.country,
-          });
-          geoBlockResponse.isEligible = !isLocallyGeoblocked;
-        }
-        if (process.env.MM_PREDICT_SKIP_GEOBLOCK === 'true') {
-          geoBlockResponse.isEligible = true;
-          geoBlockResponse.country = 'N/A';
-        }
-        this.update((state) => {
-          state.eligibility[providerId] = {
-            eligible: geoBlockResponse.isEligible,
-            country: geoBlockResponse.country,
-          };
-        });
-      } catch (error) {
-        // Default to false in case of error
-        this.update((state) => {
-          state.eligibility[providerId] = {
-            eligible: false,
-            country: undefined,
-          };
-        });
-        DevLogger.log('PredictController: Eligibility refresh failed', {
-          error:
-            error instanceof Error
-              ? error.message
-              : PREDICT_ERROR_CODES.UNKNOWN_ERROR,
-          timestamp: new Date().toISOString(),
-        });
+      if (process.env.MM_PREDICT_SKIP_GEOBLOCK === 'true') {
+        geoBlockResponse.isEligible = true;
+        geoBlockResponse.country = 'N/A';
+      }
+      this.update((state) => {
+        state.eligibility = {
+          eligible: geoBlockResponse.isEligible,
+          country: geoBlockResponse.country,
+        };
+      });
+    } catch (error) {
+      this.update((state) => {
+        state.eligibility = {
+          eligible: false,
+          country: undefined,
+        };
+      });
+      DevLogger.log('PredictController: Eligibility refresh failed', {
+        error:
+          error instanceof Error
+            ? error.message
+            : PREDICT_ERROR_CODES.UNKNOWN_ERROR,
+        timestamp: new Date().toISOString(),
+      });
 
-        // Log to Sentry with provider context
-        Logger.error(
-          ensureError(error),
-          this.getErrorContext('refreshEligibility.provider', {
-            providerId,
-          }),
-        );
-      }
+      Logger.error(
+        ensureError(error),
+        this.getErrorContext('refreshEligibility.provider', {
+          providerId: 'polymarket',
+        }),
+      );
     }
   }
 
@@ -1969,15 +1800,13 @@ export class PredictController extends BaseController<
    *
    * @param gameId - Unique identifier of the game to subscribe to
    * @param callback - Function invoked when game state changes (score, period, status)
-   * @param providerId - Provider to use for subscription (default: 'polymarket')
    * @returns Unsubscribe function to clean up the subscription
    */
   public subscribeToGameUpdates(
     gameId: string,
     callback: GameUpdateCallback,
-    providerId = 'polymarket',
   ): () => void {
-    const provider = this.providers.get(providerId);
+    const provider = this.provider;
     if (!provider?.subscribeToGameUpdates) {
       return () => undefined;
     }
@@ -1989,15 +1818,13 @@ export class PredictController extends BaseController<
    *
    * @param tokenIds - Array of token IDs to subscribe to price updates for
    * @param callback - Function invoked when prices change (includes bestBid/bestAsk)
-   * @param providerId - Provider to use for subscription (default: 'polymarket')
    * @returns Unsubscribe function to clean up the subscription
    */
   public subscribeToMarketPrices(
     tokenIds: string[],
     callback: PriceUpdateCallback,
-    providerId = 'polymarket',
   ): () => void {
-    const provider = this.providers.get(providerId);
+    const provider = this.provider;
     if (!provider?.subscribeToMarketPrices) {
       return () => undefined;
     }
@@ -2007,11 +1834,10 @@ export class PredictController extends BaseController<
   /**
    * Gets the current WebSocket connection status for live data feeds.
    *
-   * @param providerId - Provider to check connection status for (default: 'polymarket')
    * @returns Connection status for sports and market data WebSocket channels
    */
-  public getConnectionStatus(providerId = 'polymarket'): ConnectionStatus {
-    const provider = this.providers.get(providerId);
+  public getConnectionStatus(): ConnectionStatus {
+    const provider = this.provider;
     if (!provider?.getConnectionStatus) {
       return { sportsConnected: false, marketConnected: false };
     }
@@ -2025,25 +1851,21 @@ export class PredictController extends BaseController<
   }
 
   public async depositWithConfirmation(
-    params: PrepareDepositParams,
+    _params: PrepareDepositParams = {},
   ): Promise<Result<{ batchId: string }>> {
-    const provider = this.providers.get(params.providerId);
-    if (!provider) {
-      throw new Error('Provider not available');
-    }
+    const provider = this.provider;
 
     try {
       const signer = this.getSigner();
 
       // Clear any previous deposit transaction
       this.update((state) => {
-        if (state.pendingDeposits[params.providerId]?.[signer.address]) {
-          delete state.pendingDeposits[params.providerId][signer.address];
+        if (state.pendingDeposits[signer.address]) {
+          delete state.pendingDeposits[signer.address];
         }
       });
 
       const depositPreparation = await provider.prepareDeposit({
-        ...params,
         signer,
       });
 
@@ -2072,7 +1894,7 @@ export class PredictController extends BaseController<
       });
 
       validateDepositTransactions(transactions, {
-        providerId: params.providerId,
+        providerId: POLYMARKET_PROVIDER_ID,
       });
 
       const networkClientId = this.messenger.call(
@@ -2085,9 +1907,7 @@ export class PredictController extends BaseController<
       }
 
       this.update((state) => {
-        state.pendingDeposits[params.providerId] =
-          state.pendingDeposits[params.providerId] || {};
-        state.pendingDeposits[params.providerId][signer.address] = 'pending';
+        state.pendingDeposits[signer.address] = 'pending';
       });
 
       const batchResult = await addTransactionBatch({
@@ -2113,9 +1933,7 @@ export class PredictController extends BaseController<
       }
 
       this.update((state) => {
-        state.pendingDeposits[params.providerId] =
-          state.pendingDeposits[params.providerId] || {};
-        state.pendingDeposits[params.providerId][signer.address] = batchId;
+        state.pendingDeposits[signer.address] = batchId;
       });
 
       return {
@@ -2128,7 +1946,7 @@ export class PredictController extends BaseController<
       const e = ensureError(error);
       if (e.message.includes('User denied transaction signature')) {
         // Clear pending state before returning
-        this.clearPendingDeposit({ providerId: params.providerId });
+        this.clearPendingDeposit();
         // ignore error, as the user cancelled the tx
         return {
           success: true,
@@ -2139,11 +1957,11 @@ export class PredictController extends BaseController<
       Logger.error(
         e,
         this.getErrorContext('depositWithConfirmation', {
-          providerId: params.providerId,
+          providerId: POLYMARKET_PROVIDER_ID,
         }),
       );
 
-      this.clearPendingDeposit({ providerId: params.providerId });
+      this.clearPendingDeposit();
 
       throw new Error(
         error instanceof Error
@@ -2153,34 +1971,24 @@ export class PredictController extends BaseController<
     }
   }
 
-  public clearPendingDeposit({ providerId }: { providerId: string }): void {
+  public clearPendingDeposit(): void {
     const selectedAddress = this.getSigner().address;
-    this.clearPendingDepositForAddress({
-      providerId,
-      address: selectedAddress,
-    });
+    this.clearPendingDepositForAddress({ address: selectedAddress });
   }
 
   private clearPendingDepositForAddress({
-    providerId,
     address,
   }: {
-    providerId: string;
     address: string;
   }): void {
     const normalizedAddress = address.toLowerCase();
     this.update((state) => {
-      const providerDeposits = state.pendingDeposits[providerId];
-      if (!providerDeposits) {
-        return;
-      }
-
-      const matchedAddress = Object.keys(providerDeposits).find(
+      const matchedAddress = Object.keys(state.pendingDeposits).find(
         (addressKey) => addressKey.toLowerCase() === normalizedAddress,
       );
 
       if (matchedAddress) {
-        delete providerDeposits[matchedAddress];
+        delete state.pendingDeposits[matchedAddress];
       }
     });
   }
@@ -2259,19 +2067,16 @@ export class PredictController extends BaseController<
     status: PredictTransactionEventStatus,
     address: string,
   ): void {
-    const providerId = 'polymarket';
     const isTerminal =
       status === 'confirmed' || status === 'failed' || status === 'rejected';
 
     if (type === 'deposit' && isTerminal) {
-      this.clearPendingDepositForAddress({ providerId, address });
+      this.clearPendingDepositForAddress({ address });
     }
 
     if (type === 'claim' && status === 'confirmed') {
-      this.confirmClaim({ providerId, address });
-      this.getPositions({ address, providerId, claimable: true }).catch(
-        () => undefined,
-      );
+      this.confirmClaim({ address });
+      this.getPositions({ address, claimable: true }).catch(() => undefined);
     }
 
     if (type === 'withdraw' && isTerminal) {
@@ -2279,7 +2084,7 @@ export class PredictController extends BaseController<
     }
 
     if (status === 'confirmed') {
-      this.getBalance({ address, providerId }).catch(() => undefined);
+      this.getBalance({ address }).catch(() => undefined);
     }
   }
 
@@ -2289,8 +2094,8 @@ export class PredictController extends BaseController<
     const { batchId, txParams } = transactionMeta;
     const normalizedFrom = txParams.from?.toLowerCase();
 
-    return Object.values(this.state.pendingDeposits).some((providerDeposits) =>
-      Object.entries(providerDeposits).some(([address, pendingValue]) => {
+    return Object.entries(this.state.pendingDeposits).some(
+      ([address, pendingValue]) => {
         const addressMatch =
           !normalizedFrom || address.toLowerCase() === normalizedFrom;
         if (!addressMatch) {
@@ -2306,7 +2111,7 @@ export class PredictController extends BaseController<
 
         // Once the real batchId is stored, require an exact match.
         return Boolean(batchId) && pendingValue === batchId;
-      }),
+      },
     );
   }
 
@@ -2406,7 +2211,7 @@ export class PredictController extends BaseController<
   }
 
   public async getAccountState(
-    params: GetAccountStateParams,
+    params: GetAccountStateParams = {},
   ): Promise<AccountState> {
     // Start Sentry trace for get account state operation
     const traceId = `get-account-state-${Date.now()}`;
@@ -2418,15 +2223,12 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: params.providerId ?? 'unknown',
+        providerId: 'polymarket',
       },
     });
 
     try {
-      const provider = this.providers.get(params.providerId);
-      if (!provider) {
-        throw new Error('Provider not available');
-      }
+      const provider = this.provider;
       const selectedAddress = this.getSigner().address;
 
       const accountState = await provider.getAccountState({
@@ -2446,7 +2248,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getAccountState', {
-          providerId: params.providerId,
+          providerId: 'polymarket',
         }),
       );
 
@@ -2473,19 +2275,16 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: params.providerId ?? 'unknown',
+        providerId: 'polymarket',
       },
     });
 
     try {
-      const provider = this.providers.get(params.providerId);
-      if (!provider) {
-        throw new Error('Provider not available');
-      }
+      const provider = this.provider;
       const selectedAddress = this.getSigner().address;
       const address = params.address ?? selectedAddress;
 
-      const cachedBalance = this.state.balances[params.providerId]?.[address];
+      const cachedBalance = this.state.balances[address];
       if (cachedBalance && cachedBalance.validUntil > Date.now()) {
         traceData = { success: true, cached: true };
         return cachedBalance.balance;
@@ -2500,9 +2299,7 @@ export class PredictController extends BaseController<
       });
 
       this.update((state) => {
-        state.balances[params.providerId] =
-          state.balances[params.providerId] || {};
-        state.balances[params.providerId][address] = {
+        state.balances[address] = {
           balance,
           // valid for 1 second
           validUntil: Date.now() + 1000,
@@ -2521,7 +2318,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getBalance', {
-          providerId: params.providerId,
+          providerId: 'polymarket',
         }),
       );
 
@@ -2536,19 +2333,15 @@ export class PredictController extends BaseController<
   }
 
   public async prepareWithdraw(
-    params: PrepareWithdrawParams,
+    _params: PrepareWithdrawParams = {},
   ): Promise<Result<string>> {
     try {
-      const provider = this.providers.get(params.providerId);
-      if (!provider) {
-        throw new Error('Provider not available');
-      }
+      const provider = this.provider;
 
       const signer = this.getSigner();
 
       const { chainId, transaction, predictAddress } =
         await provider.prepareWithdraw({
-          ...params,
           signer,
         });
 
@@ -2556,7 +2349,7 @@ export class PredictController extends BaseController<
         state.withdrawTransaction = {
           chainId: hexToNumber(chainId),
           status: PredictWithdrawStatus.IDLE,
-          providerId: params.providerId,
+          providerId: POLYMARKET_PROVIDER_ID,
           predictAddress: predictAddress as Hex,
           transactionId: '',
           amount: 0,
@@ -2615,13 +2408,13 @@ export class PredictController extends BaseController<
         error: errorMessage,
         errorDetails: error instanceof Error ? error.stack : undefined,
         timestamp: new Date().toISOString(),
-        providerId: params.providerId,
+        providerId: POLYMARKET_PROVIDER_ID,
       });
 
       Logger.error(
         ensureError(error),
         this.getErrorContext('prepareWithdraw', {
-          providerId: params.providerId,
+          providerId: POLYMARKET_PROVIDER_ID,
         }),
       );
 
@@ -2650,12 +2443,7 @@ export class PredictController extends BaseController<
       return;
     }
 
-    const provider = this.providers.get(
-      this.state.withdrawTransaction.providerId,
-    );
-    if (!provider) {
-      throw new Error('Provider not available');
-    }
+    const provider = this.provider;
 
     if (!provider.signWithdraw) {
       return;

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -462,7 +462,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         ...(params.category && { category: params.category }),
       },
     });
@@ -558,7 +558,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getMarkets', {
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           category: params.category,
           sortBy: params.sortBy,
           sortDirection: params.sortDirection,
@@ -602,7 +602,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
       },
     });
 
@@ -650,7 +650,7 @@ export class PredictController extends BaseController<
         ensureError(error),
         this.getErrorContext('getMarket', {
           marketId: resolvedMarketId,
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
         }),
       );
 
@@ -686,7 +686,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         ...(params.interval && { interval: params.interval }),
       },
     });
@@ -720,7 +720,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getPriceHistory', {
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           marketId: params.marketId,
           fidelity: params.fidelity,
           interval: params.interval,
@@ -757,7 +757,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
       },
       data: {
         queryCount: params.queries?.length,
@@ -793,7 +793,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getPrices', {
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           queriesCount: params.queries?.length,
         }),
       );
@@ -824,7 +824,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         claimable: params.claimable ?? false,
       },
     });
@@ -870,7 +870,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getPositions', {
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           claimable: params.claimable,
           marketId: params.marketId,
         }),
@@ -903,7 +903,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
       },
     });
 
@@ -940,7 +940,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getActivity', {
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
         }),
       );
 
@@ -972,7 +972,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
       },
     });
 
@@ -1011,7 +1011,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getUnrealizedPnL', {
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
         }),
       );
 
@@ -1113,7 +1113,7 @@ export class PredictController extends BaseController<
     };
 
     DevLogger.log(`📊 [Analytics] PREDICT_TRADE_TRANSACTION [${status}]`, {
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       regularProperties,
       sensitiveProperties,
     });
@@ -1383,7 +1383,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('previewOrder', {
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           side: params.side,
           marketId: params.marketId,
           outcomeId: params.outcomeId,
@@ -1416,7 +1416,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         side: preview.side,
       },
       data: {
@@ -1530,7 +1530,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('placeOrder', {
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           marketId: analyticsProperties?.marketId,
           marketTitle: analyticsProperties?.marketTitle,
           transactionType: analyticsProperties?.transactionType,
@@ -1544,7 +1544,7 @@ export class PredictController extends BaseController<
         error: errorMessage,
         errorDetails: error instanceof Error ? error.stack : undefined,
         timestamp: new Date().toISOString(),
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         params,
       });
 
@@ -1578,7 +1578,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
       },
     });
 
@@ -1683,7 +1683,7 @@ export class PredictController extends BaseController<
       Logger.error(
         e,
         this.getErrorContext('claimWithConfirmation', {
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
         }),
       );
 
@@ -1692,7 +1692,7 @@ export class PredictController extends BaseController<
         error: errorMessage,
         errorDetails: error instanceof Error ? error.stack : undefined,
         timestamp: new Date().toISOString(),
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
       });
 
       // Update error state for Sentry integration
@@ -1789,7 +1789,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('refreshEligibility.provider', {
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
         }),
       );
     }
@@ -2223,7 +2223,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
       },
     });
 
@@ -2248,7 +2248,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getAccountState', {
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
         }),
       );
 
@@ -2275,7 +2275,7 @@ export class PredictController extends BaseController<
       id: traceId,
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
       },
     });
 
@@ -2318,7 +2318,7 @@ export class PredictController extends BaseController<
       Logger.error(
         ensureError(error),
         this.getErrorContext('getBalance', {
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
         }),
       );
 

--- a/app/components/UI/Predict/hooks/useLivePositions.test.ts
+++ b/app/components/UI/Predict/hooks/useLivePositions.test.ts
@@ -3,13 +3,14 @@ import { useLivePositions } from './useLivePositions';
 import { useLiveMarketPrices } from './useLiveMarketPrices';
 import { PredictPosition, PredictPositionStatus, PriceUpdate } from '../types';
 
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 jest.mock('./useLiveMarketPrices');
 
 const createMockPosition = (
   overrides: Partial<PredictPosition> = {},
 ): PredictPosition => ({
   id: 'position-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-1',
   outcomeId: 'outcome-1',
   outcome: 'Yes',

--- a/app/components/UI/Predict/hooks/usePredictAccountState.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictAccountState.test.ts
@@ -137,15 +137,13 @@ describe('usePredictAccountState', () => {
       expect(result.current.error).toBeNull();
     });
 
-    it('uses custom providerId when specified', async () => {
+    it('loads account state when requested', async () => {
       // Arrange
       mockGetAccountState.mockResolvedValue(mockAccountState);
-      const customProviderId = 'custom-provider';
 
       // Act
       const { result } = renderHook(() =>
         usePredictAccountState({
-          providerId: customProviderId,
           loadOnMount: false,
         }),
       );
@@ -155,9 +153,7 @@ describe('usePredictAccountState', () => {
       });
 
       // Assert
-      expect(mockGetAccountState).toHaveBeenCalledWith({
-        providerId: customProviderId,
-      });
+      expect(mockGetAccountState).toHaveBeenCalledWith({});
     });
 
     it('handles errors when loading account state', async () => {

--- a/app/components/UI/Predict/hooks/usePredictAccountState.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictAccountState.test.ts
@@ -89,9 +89,7 @@ describe('usePredictAccountState', () => {
         expect(result.current.isLoading).toBe(false);
       });
 
-      expect(mockGetAccountState).toHaveBeenCalledWith({
-        providerId: 'polymarket',
-      });
+      expect(mockGetAccountState).toHaveBeenCalledWith({});
       expect(result.current.address).toEqual(mockAccountState.address);
     });
 
@@ -129,9 +127,7 @@ describe('usePredictAccountState', () => {
       });
 
       // Assert
-      expect(mockGetAccountState).toHaveBeenCalledWith({
-        providerId: 'polymarket',
-      });
+      expect(mockGetAccountState).toHaveBeenCalledWith({});
       expect(result.current.address).toEqual(mockAccountState.address);
       expect(result.current.isLoading).toBe(false);
       expect(result.current.error).toBeNull();
@@ -376,9 +372,9 @@ describe('usePredictAccountState', () => {
       expect(focusCallback).not.toBeNull();
 
       // Simulate screen focus
-      await act(async () => {
+      act(() => {
         if (focusCallback) {
-          await focusCallback();
+          focusCallback();
         }
       });
 
@@ -387,7 +383,7 @@ describe('usePredictAccountState', () => {
       });
     });
 
-    it('does not refresh on focus when refreshOnFocus is false', async () => {
+    it('does not refresh on focus when refreshOnFocus is false', () => {
       // Arrange
       mockGetAccountState.mockResolvedValue(mockAccountState);
       let focusCallback: (() => void) | null = null;
@@ -412,9 +408,9 @@ describe('usePredictAccountState', () => {
       expect(mockUseFocusEffect).toHaveBeenCalledTimes(1);
 
       // Simulate screen focus if callback was provided
-      await act(async () => {
+      act(() => {
         if (focusCallback) {
-          await focusCallback();
+          focusCallback();
         }
       });
 
@@ -626,7 +622,7 @@ describe('usePredictAccountState', () => {
   });
 
   describe('default parameters', () => {
-    it('uses polymarket as default providerId', async () => {
+    it('uses empty options object by default', async () => {
       // Arrange
       mockGetAccountState.mockResolvedValue(mockAccountState);
 
@@ -640,9 +636,7 @@ describe('usePredictAccountState', () => {
       });
 
       // Assert
-      expect(mockGetAccountState).toHaveBeenCalledWith({
-        providerId: 'polymarket',
-      });
+      expect(mockGetAccountState).toHaveBeenCalledWith({});
     });
 
     it('uses true as default for loadOnMount', async () => {

--- a/app/components/UI/Predict/hooks/usePredictAccountState.ts
+++ b/app/components/UI/Predict/hooks/usePredictAccountState.ts
@@ -10,10 +10,6 @@ import { usePredictNetworkManagement } from './usePredictNetworkManagement';
 
 interface UsePredictWalletParams {
   /**
-   * The provider ID to load account state for
-   */
-  providerId?: string;
-  /**
    * Whether to load account state on mount
    * @default true
    */
@@ -26,7 +22,6 @@ interface UsePredictWalletParams {
 }
 
 export const usePredictAccountState = ({
-  providerId = 'polymarket',
   loadOnMount = true,
   refreshOnFocus = true,
 }: UsePredictWalletParams = {}) => {
@@ -65,9 +60,7 @@ export const usePredictAccountState = ({
         }
 
         const controller = Engine.context.PredictController;
-        const accountStateResponse = await controller.getAccountState({
-          providerId,
-        });
+        const accountStateResponse = await controller.getAccountState({});
 
         setAccountState(accountStateResponse);
 
@@ -97,7 +90,6 @@ export const usePredictAccountState = ({
               method: 'loadAccountState',
               action: 'account_state_load',
               operation: 'data_fetching',
-              providerId,
             },
           },
         });
@@ -106,7 +98,7 @@ export const usePredictAccountState = ({
         setIsRefreshing(false);
       }
     },
-    [providerId, ensurePolygonNetworkExists],
+    [ensurePolygonNetworkExists],
   );
 
   // Load account state on mount if enabled

--- a/app/components/UI/Predict/hooks/usePredictActionGuard.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictActionGuard.test.ts
@@ -30,7 +30,6 @@ describe('usePredictActionGuard', () => {
     it('executes action without navigation', async () => {
       const { result } = renderHook(() =>
         usePredictActionGuard({
-          providerId: 'polymarket',
           navigation: mockNavigation,
         }),
       );
@@ -48,7 +47,6 @@ describe('usePredictActionGuard', () => {
     it('returns correct eligibility state', () => {
       const { result } = renderHook(() =>
         usePredictActionGuard({
-          providerId: 'polymarket',
           navigation: mockNavigation,
         }),
       );
@@ -59,7 +57,6 @@ describe('usePredictActionGuard', () => {
     it('executes async action and returns promise', async () => {
       const { result } = renderHook(() =>
         usePredictActionGuard({
-          providerId: 'polymarket',
           navigation: mockNavigation,
         }),
       );
@@ -88,7 +85,6 @@ describe('usePredictActionGuard', () => {
     it('navigates to unavailable modal and does not execute action', async () => {
       const { result } = renderHook(() =>
         usePredictActionGuard({
-          providerId: 'polymarket',
           navigation: mockNavigation,
         }),
       );
@@ -108,7 +104,6 @@ describe('usePredictActionGuard', () => {
     it('returns correct eligibility state', () => {
       const { result } = renderHook(() =>
         usePredictActionGuard({
-          providerId: 'polymarket',
           navigation: mockNavigation,
         }),
       );
@@ -117,11 +112,10 @@ describe('usePredictActionGuard', () => {
     });
   });
 
-  describe('providerId usage', () => {
-    it('works with different provider IDs', () => {
+  describe('hook options', () => {
+    it('works with navigation option', () => {
       const { result } = renderHook(() =>
         usePredictActionGuard({
-          providerId: 'custom-provider',
           navigation: mockNavigation,
         }),
       );

--- a/app/components/UI/Predict/hooks/usePredictActionGuard.ts
+++ b/app/components/UI/Predict/hooks/usePredictActionGuard.ts
@@ -6,7 +6,6 @@ import { PredictNavigationParamList } from '../types/navigation';
 import { usePredictEligibility } from './usePredictEligibility';
 
 interface UsePredictActionGuardOptions {
-  providerId: string;
   navigation: NavigationProp<PredictNavigationParamList>;
 }
 
@@ -23,10 +22,9 @@ interface UsePredictActionGuardResult {
 }
 
 export const usePredictActionGuard = ({
-  providerId,
   navigation,
 }: UsePredictActionGuardOptions): UsePredictActionGuardResult => {
-  const { isEligible } = usePredictEligibility({ providerId });
+  const { isEligible } = usePredictEligibility();
 
   const executeGuardedAction = useCallback(
     (
@@ -39,7 +37,6 @@ export const usePredictActionGuard = ({
         // Track geo-block analytics if attemptedAction is provided
         if (attemptedAction) {
           Engine.context.PredictController.trackGeoBlockTriggered({
-            providerId,
             attemptedAction,
           });
         }
@@ -52,7 +49,7 @@ export const usePredictActionGuard = ({
 
       return action();
     },
-    [isEligible, navigation, providerId],
+    [isEligible, navigation],
   );
 
   return {

--- a/app/components/UI/Predict/hooks/usePredictActivity.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictActivity.test.ts
@@ -62,18 +62,14 @@ describe('usePredictActivity', () => {
     });
   });
 
-  it('respects providerId option when loading', async () => {
+  it('loads activity when hook is mounted', async () => {
     mockGetActivity.mockResolvedValueOnce([]);
 
-    const { waitForNextUpdate } = renderHook(() =>
-      usePredictActivity({ providerId: 'polymarket' }),
-    );
+    const { waitForNextUpdate } = renderHook(() => usePredictActivity());
 
     await waitForNextUpdate();
 
-    expect(mockGetActivity).toHaveBeenCalledWith({
-      providerId: 'polymarket',
-    });
+    expect(mockGetActivity).toHaveBeenCalledWith({});
   });
 
   it('can refresh with isRefresh=true and sets isRefreshing flag', async () => {

--- a/app/components/UI/Predict/hooks/usePredictActivity.ts
+++ b/app/components/UI/Predict/hooks/usePredictActivity.ts
@@ -7,7 +7,6 @@ import type { PredictActivity } from '../types';
 import { ensureError } from '../utils/predictErrorHandler';
 
 interface UsePredictActivityOptions {
-  providerId?: string;
   loadOnMount?: boolean;
   refreshOnFocus?: boolean;
 }
@@ -23,7 +22,7 @@ interface UsePredictActivityReturn {
 export function usePredictActivity(
   options: UsePredictActivityOptions = {},
 ): UsePredictActivityReturn {
-  const { providerId, loadOnMount = true, refreshOnFocus = true } = options;
+  const { loadOnMount = true, refreshOnFocus = true } = options;
 
   const [activity, setActivity] = useState<PredictActivity[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -42,9 +41,7 @@ export function usePredictActivity(
         setError(null);
 
         const controller = Engine.context.PredictController;
-        const data = await controller.getActivity({
-          providerId,
-        });
+        const data = await controller.getActivity({});
         setActivity(data ?? []);
       } catch (err) {
         const message =
@@ -63,7 +60,6 @@ export function usePredictActivity(
               method: 'loadActivity',
               action: 'activity_load',
               operation: 'data_fetching',
-              providerId,
             },
           },
         });
@@ -72,7 +68,7 @@ export function usePredictActivity(
         setIsRefreshing(false);
       }
     },
-    [providerId],
+    [],
   );
 
   useEffect(() => {

--- a/app/components/UI/Predict/hooks/usePredictBalance.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalance.test.ts
@@ -74,8 +74,9 @@ jest.mock('react-redux', () => {
             backgroundState: {
               PredictController: {
                 balances: {
-                  polymarket: {
-                    [mockSelectedAddress]: mockCachedBalance,
+                  [mockSelectedAddress]: {
+                    balance: mockCachedBalance,
+                    validUntil: Date.now() + 1000,
                   },
                 },
               },
@@ -161,7 +162,6 @@ describe('usePredictBalance', () => {
 
       expect(mockGetBalance).toHaveBeenCalledWith({
         address: mockSelectedAddress,
-        providerId: 'polymarket',
       });
       expect(result.current.balance).toBe(150.5);
       expect(result.current.error).toBeNull();
@@ -544,7 +544,7 @@ describe('usePredictBalance', () => {
       expect(mockGetBalance).not.toHaveBeenCalled();
     });
 
-    it('loads balance with default providerId when loadOnMount is true', async () => {
+    it('loads balance with address when loadOnMount is true', async () => {
       // Given loadOnMount is explicitly enabled
       mockGetBalance.mockResolvedValue(100);
       mockCachedBalance = 100;
@@ -554,14 +554,12 @@ describe('usePredictBalance', () => {
         usePredictBalance({ loadOnMount: true }),
       );
 
-      // Then default providerId should be used
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
       });
 
       expect(mockGetBalance).toHaveBeenCalledWith({
         address: mockSelectedAddress,
-        providerId: 'polymarket', // default providerId
       });
       expect(result.current.balance).toBe(100);
     });

--- a/app/components/UI/Predict/hooks/usePredictBalance.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalance.test.ts
@@ -176,15 +176,14 @@ describe('usePredictBalance', () => {
       expect(mockGetBalance).not.toHaveBeenCalled();
     });
 
-    it('uses custom providerId when specified', async () => {
+    it('loads balance when custom options are provided', async () => {
       // Given custom providerId
-      const customProviderId = 'custom-provider';
       mockGetBalance.mockResolvedValue(200);
       mockCachedBalance = 200;
 
       // When hook is mounted with custom providerId
       const { result } = renderHook(() =>
-        usePredictBalance({ providerId: customProviderId, loadOnMount: true }),
+        usePredictBalance({ loadOnMount: true }),
       );
 
       // Then getBalance should be called with custom providerId
@@ -194,7 +193,6 @@ describe('usePredictBalance', () => {
 
       expect(mockGetBalance).toHaveBeenCalledWith({
         address: mockSelectedAddress,
-        providerId: customProviderId,
       });
     });
   });

--- a/app/components/UI/Predict/hooks/usePredictBalance.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalance.ts
@@ -6,16 +6,11 @@ import Logger from '../../../../util/Logger';
 import { PREDICT_CONSTANTS } from '../constants/errors';
 import { usePredictTrading } from './usePredictTrading';
 import { usePredictNetworkManagement } from './usePredictNetworkManagement';
-import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 import { selectPredictBalanceByAddress } from '../selectors/predictController';
 import { ensureError } from '../utils/predictErrorHandler';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 
 interface UsePredictBalanceOptions {
-  /**
-   * The provider ID to load balance for
-   */
-  providerId?: string;
   /**
    * Whether to load balance on mount
    * @default true
@@ -45,11 +40,7 @@ interface UsePredictBalanceReturn {
 export function usePredictBalance(
   options: UsePredictBalanceOptions = {},
 ): UsePredictBalanceReturn {
-  const {
-    providerId = POLYMARKET_PROVIDER_ID,
-    loadOnMount = false,
-    refreshOnFocus = false,
-  } = options;
+  const { loadOnMount = false, refreshOnFocus = false } = options;
 
   const { getBalance } = usePredictTrading();
   const { ensurePolygonNetworkExists } = usePredictNetworkManagement();
@@ -66,7 +57,6 @@ export function usePredictBalance(
   const balance =
     useSelector(
       selectPredictBalanceByAddress({
-        providerId,
         address: selectedInternalAccountAddress || '',
       }),
     ) || 0;
@@ -110,12 +100,10 @@ export function usePredictBalance(
         // Get balance from Predict controller
         const balanceData = await getBalance({
           address: selectedInternalAccountAddress,
-          providerId,
         });
 
         DevLogger.log('usePredictBalance: Loaded balance', {
           balance: balanceData,
-          providerId,
         });
       } catch (err) {
         const errorMessage =
@@ -135,7 +123,6 @@ export function usePredictBalance(
               method: 'loadBalance',
               action: 'balance_load',
               operation: 'data_fetching',
-              providerId,
             },
           },
         });
@@ -147,7 +134,7 @@ export function usePredictBalance(
     },
     // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [getBalance, selectedInternalAccountAddress, providerId],
+    [getBalance, selectedInternalAccountAddress],
   );
 
   // Load balance on mount if enabled

--- a/app/components/UI/Predict/hooks/usePredictClaim.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.test.ts
@@ -145,29 +145,21 @@ describe('usePredictClaim', () => {
         loader: ConfirmationLoader.PredictClaim,
         stack: 'Predict',
       });
-      expect(mockClaimWinnings).toHaveBeenCalledWith({
-        providerId: POLYMARKET_PROVIDER_ID,
-      });
+      expect(mockClaimWinnings).toHaveBeenCalledWith();
       expect(mockNavigate).not.toHaveBeenCalled();
     });
 
-    it('uses custom providerId when claiming', async () => {
+    it('calls claim without provider argument', async () => {
       // Arrange
-      const customProviderId = 'custom-provider';
       mockClaimWinnings.mockResolvedValue(undefined);
 
-      const { result } = renderHook(
-        () => usePredictClaim({ providerId: customProviderId }),
-        { wrapper },
-      );
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
 
       // Act
       await result.current.claim();
 
       // Assert
-      expect(mockClaimWinnings).toHaveBeenCalledWith({
-        providerId: customProviderId,
-      });
+      expect(mockClaimWinnings).toHaveBeenCalledWith();
     });
   });
 

--- a/app/components/UI/Predict/hooks/usePredictClaim.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.test.ts
@@ -7,7 +7,6 @@ import { ToastVariants } from '../../../../component-library/components/Toast';
 import { ToastContext } from '../../../../component-library/components/Toast/Toast.context';
 import Logger from '../../../../util/Logger';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
-import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 import { usePredictClaim } from './usePredictClaim';
 import { usePredictTrading } from './usePredictTrading';
 import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
@@ -145,7 +144,7 @@ describe('usePredictClaim', () => {
         loader: ConfirmationLoader.PredictClaim,
         stack: 'Predict',
       });
-      expect(mockClaimWinnings).toHaveBeenCalledWith();
+      expect(mockClaimWinnings).toHaveBeenCalledWith({});
       expect(mockNavigate).not.toHaveBeenCalled();
     });
 
@@ -159,7 +158,7 @@ describe('usePredictClaim', () => {
       await result.current.claim();
 
       // Assert
-      expect(mockClaimWinnings).toHaveBeenCalledWith();
+      expect(mockClaimWinnings).toHaveBeenCalledWith({});
     });
   });
 
@@ -189,7 +188,6 @@ describe('usePredictClaim', () => {
               action: 'claim_winnings',
               method: 'claim',
               operation: 'position_management',
-              providerId: POLYMARKET_PROVIDER_ID,
             },
           },
         }),
@@ -242,7 +240,6 @@ describe('usePredictClaim', () => {
               action: 'claim_winnings',
               method: 'claim',
               operation: 'position_management',
-              providerId: POLYMARKET_PROVIDER_ID,
             },
           },
         }),
@@ -268,9 +265,7 @@ describe('usePredictClaim', () => {
         loader: ConfirmationLoader.PredictClaim,
         stack: 'Predict',
       });
-      expect(mockClaimWinnings).toHaveBeenCalledWith({
-        providerId: POLYMARKET_PROVIDER_ID,
-      });
+      expect(mockClaimWinnings).toHaveBeenCalledWith({});
       expect(mockShowToast).not.toHaveBeenCalled();
       expect(mockGoBack).not.toHaveBeenCalled();
       expect(mockLoggerError).not.toHaveBeenCalled();
@@ -301,7 +296,6 @@ describe('usePredictClaim', () => {
               action: 'claim_winnings',
               method: 'claim',
               operation: 'position_management',
-              providerId: POLYMARKET_PROVIDER_ID,
             },
           },
         }),
@@ -333,7 +327,6 @@ describe('usePredictClaim', () => {
               action: 'claim_winnings',
               method: 'claim',
               operation: 'position_management',
-              providerId: POLYMARKET_PROVIDER_ID,
             },
           },
         },
@@ -366,7 +359,6 @@ describe('usePredictClaim', () => {
               action: 'claim_winnings',
               method: 'claim',
               operation: 'position_management',
-              providerId: POLYMARKET_PROVIDER_ID,
             },
           },
         },
@@ -413,7 +405,6 @@ describe('usePredictClaim', () => {
               action: 'claim_winnings',
               method: 'claim',
               operation: 'position_management',
-              providerId: POLYMARKET_PROVIDER_ID,
             },
           },
         }),

--- a/app/components/UI/Predict/hooks/usePredictClaim.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.ts
@@ -8,19 +8,12 @@ import Logger from '../../../../util/Logger';
 import { useAppThemeFromContext } from '../../../../util/theme';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
 import { PREDICT_CONSTANTS } from '../constants/errors';
-import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 import { ensureError } from '../utils/predictErrorHandler';
 import { usePredictTrading } from './usePredictTrading';
 import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
 import Routes from '../../../../constants/navigation/Routes';
 
-interface UsePredictClaimParams {
-  providerId?: string;
-}
-
-export const usePredictClaim = ({
-  providerId = POLYMARKET_PROVIDER_ID,
-}: UsePredictClaimParams = {}) => {
+export const usePredictClaim = () => {
   const { navigateToConfirmation } = useConfirmNavigation();
   const { claim: claimWinnings } = usePredictTrading();
   const theme = useAppThemeFromContext();
@@ -35,7 +28,7 @@ export const usePredictClaim = ({
         // TODO: remove once navigation stack is fixed properly
         stack: Routes.PREDICT.ROOT,
       });
-      await claimWinnings({ providerId });
+      await claimWinnings({});
     } catch (err) {
       // Log error with claim context
       Logger.error(ensureError(err), {
@@ -49,7 +42,6 @@ export const usePredictClaim = ({
             method: 'claim',
             action: 'claim_winnings',
             operation: 'position_management',
-            providerId,
           },
         },
       });
@@ -83,7 +75,6 @@ export const usePredictClaim = ({
     claimWinnings,
     navigateToConfirmation,
     navigation,
-    providerId,
     theme.colors.accent04.normal,
     theme.colors.error.default,
     toastRef,

--- a/app/components/UI/Predict/hooks/usePredictDeposit.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictDeposit.test.ts
@@ -156,7 +156,6 @@ const mockLoggerError = Logger.error as jest.MockedFunction<
 // Helper to setup test
 function setupUsePredictDepositTest(
   stateOverrides = {},
-  _hookOptions = {},
   customToastRef?:
     | React.RefObject<{ showToast: jest.Mock; closeToast: jest.Mock }>
     | null
@@ -245,9 +244,7 @@ describe('usePredictDeposit', () => {
     it('returns true when deposit is pending for current address', () => {
       const { result } = setupUsePredictDepositTest({
         pendingDeposits: {
-          polymarket: {
-            [mockAccountAddress]: true,
-          },
+          [mockAccountAddress]: true,
         },
       });
 
@@ -257,9 +254,7 @@ describe('usePredictDeposit', () => {
     it('returns false when deposit is not pending for current address', () => {
       const { result } = setupUsePredictDepositTest({
         pendingDeposits: {
-          polymarket: {
-            [mockAccountAddress]: false,
-          },
+          [mockAccountAddress]: false,
         },
       });
 
@@ -274,12 +269,10 @@ describe('usePredictDeposit', () => {
       expect(result.current.isDepositPending).toBe(false);
     });
 
-    it('returns false when provider does not exist in pendingDeposits', () => {
+    it('returns false when address does not exist in pendingDeposits', () => {
       const { result } = setupUsePredictDepositTest({
         pendingDeposits: {
-          'other-provider': {
-            [mockAccountAddress]: true,
-          },
+          '0xother': true,
         },
       });
 
@@ -304,7 +297,7 @@ describe('usePredictDeposit', () => {
       });
     });
 
-    it('calls depositWithConfirmation with default providerId', async () => {
+    it('calls depositWithConfirmation with empty options', async () => {
       (
         Engine.context.PredictController.depositWithConfirmation as jest.Mock
       ).mockResolvedValue({
@@ -321,34 +314,7 @@ describe('usePredictDeposit', () => {
 
       expect(
         Engine.context.PredictController.depositWithConfirmation,
-      ).toHaveBeenCalledWith({
-        providerId: 'polymarket',
-      });
-    });
-
-    it('calls depositWithConfirmation with custom providerId', async () => {
-      (
-        Engine.context.PredictController.depositWithConfirmation as jest.Mock
-      ).mockResolvedValue({
-        success: true,
-        response: { batchId: 'batch-123' },
-      });
-
-      const { result } = setupUsePredictDepositTest(
-        {},
-        { providerId: 'custom-provider' },
-      );
-
-      await result.current.deposit();
-
-      // Wait for async operation
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      expect(
-        Engine.context.PredictController.depositWithConfirmation,
-      ).toHaveBeenCalledWith({
-        providerId: 'custom-provider',
-      });
+      ).toHaveBeenCalledWith({});
     });
 
     it('navigates back and logs error when depositWithConfirmation fails', async () => {
@@ -506,8 +472,8 @@ describe('usePredictDeposit', () => {
     });
   });
 
-  describe('providerId handling', () => {
-    it('uses default providerId polymarket when not specified', async () => {
+  describe('deposit payload handling', () => {
+    it('uses empty options object when not specified', async () => {
       (
         Engine.context.PredictController.depositWithConfirmation as jest.Mock
       ).mockResolvedValue({ success: true });
@@ -521,31 +487,7 @@ describe('usePredictDeposit', () => {
 
       expect(
         Engine.context.PredictController.depositWithConfirmation,
-      ).toHaveBeenCalledWith({
-        providerId: 'polymarket',
-      });
-    });
-
-    it('uses custom providerId when provided', async () => {
-      (
-        Engine.context.PredictController.depositWithConfirmation as jest.Mock
-      ).mockResolvedValue({ success: true });
-
-      const { result } = setupUsePredictDepositTest(
-        {},
-        { providerId: 'test-provider' },
-      );
-
-      await result.current.deposit();
-
-      // Wait for async operation
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      expect(
-        Engine.context.PredictController.depositWithConfirmation,
-      ).toHaveBeenCalledWith({
-        providerId: 'test-provider',
-      });
+      ).toHaveBeenCalledWith({});
     });
   });
 
@@ -575,7 +517,6 @@ describe('usePredictDeposit', () => {
             action: 'deposit_initialization',
             method: 'deposit',
             operation: 'financial_operations',
-            providerId: 'polymarket',
           },
         },
       });
@@ -607,7 +548,6 @@ describe('usePredictDeposit', () => {
             action: 'deposit_initialization',
             method: 'deposit',
             operation: 'financial_operations',
-            providerId: 'polymarket',
           },
         },
       });
@@ -637,7 +577,6 @@ describe('usePredictDeposit', () => {
             action: 'deposit_navigation',
             method: 'deposit',
             operation: 'financial_operations',
-            providerId: 'polymarket',
           },
         },
       });
@@ -668,7 +607,6 @@ describe('usePredictDeposit', () => {
               action: 'deposit_navigation',
               method: 'deposit',
               operation: 'financial_operations',
-              providerId: 'polymarket',
             },
           },
         },
@@ -739,7 +677,7 @@ describe('usePredictDeposit', () => {
       (
         Engine.context.PredictController.depositWithConfirmation as jest.Mock
       ).mockRejectedValue(new Error('Deposit failed'));
-      const { result } = setupUsePredictDepositTest({}, {}, null);
+      const { result } = setupUsePredictDepositTest({}, null);
 
       await result.current.deposit();
       await new Promise((resolve) => setTimeout(resolve, 10));
@@ -756,7 +694,7 @@ describe('usePredictDeposit', () => {
       mockNavigateToConfirmation.mockImplementationOnce(() => {
         throw new Error('Navigation failed');
       });
-      const { result } = setupUsePredictDepositTest({}, {}, null);
+      const { result } = setupUsePredictDepositTest({}, null);
 
       await result.current.deposit();
 
@@ -862,7 +800,6 @@ describe('usePredictDeposit', () => {
         Engine.context.PredictController.trackPredictOrderEvent,
       ).toHaveBeenCalledWith({
         status: 'initiated',
-        providerId: 'polymarket',
         amountUsd: 100,
         analyticsProperties: {
           entryPoint: 'homepage_balance',
@@ -887,17 +824,14 @@ describe('usePredictDeposit', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('tracks analytics event with custom providerId', async () => {
+    it('tracks analytics event with market metadata', async () => {
       (
         Engine.context.PredictController.depositWithConfirmation as jest.Mock
       ).mockResolvedValue({
         success: true,
         response: { batchId: 'batch-123' },
       });
-      const { result } = setupUsePredictDepositTest(
-        {},
-        { providerId: 'custom-provider' },
-      );
+      const { result } = setupUsePredictDepositTest();
 
       await result.current.deposit({
         amountUsd: 50,
@@ -911,7 +845,6 @@ describe('usePredictDeposit', () => {
         Engine.context.PredictController.trackPredictOrderEvent,
       ).toHaveBeenCalledWith({
         status: 'initiated',
-        providerId: 'custom-provider',
         amountUsd: 50,
         analyticsProperties: {
           entryPoint: 'buy_preview',
@@ -940,7 +873,6 @@ describe('usePredictDeposit', () => {
         Engine.context.PredictController.trackPredictOrderEvent,
       ).toHaveBeenCalledWith({
         status: 'initiated',
-        providerId: 'polymarket',
         amountUsd: undefined,
         analyticsProperties: {
           entryPoint: 'homepage_balance',

--- a/app/components/UI/Predict/hooks/usePredictDeposit.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictDeposit.test.ts
@@ -84,7 +84,7 @@ interface MockReduxState {
     backgroundState: {
       PredictController: {
         pendingDeposits: {
-          [providerId: string]: { [address: string]: boolean };
+          [address: string]: boolean;
         };
       };
       AccountsController: {
@@ -156,7 +156,7 @@ const mockLoggerError = Logger.error as jest.MockedFunction<
 // Helper to setup test
 function setupUsePredictDepositTest(
   stateOverrides = {},
-  hookOptions = {},
+  _hookOptions = {},
   customToastRef?:
     | React.RefObject<{ showToast: jest.Mock; closeToast: jest.Mock }>
     | null
@@ -201,7 +201,7 @@ function setupUsePredictDepositTest(
       children,
     );
 
-  return renderHook(() => usePredictDeposit(hookOptions), { wrapper });
+  return renderHook(() => usePredictDeposit(), { wrapper });
 }
 
 describe('usePredictDeposit', () => {
@@ -411,9 +411,7 @@ describe('usePredictDeposit', () => {
           backgroundState: {
             PredictController: {
               pendingDeposits: {
-                polymarket: {
-                  [mockAccountAddress]: true,
-                },
+                [mockAccountAddress]: true,
               },
             },
             AccountsController: {
@@ -448,9 +446,7 @@ describe('usePredictDeposit', () => {
           backgroundState: {
             PredictController: {
               pendingDeposits: {
-                polymarket: {
-                  [mockAccountAddress]: true,
-                },
+                [mockAccountAddress]: true,
               },
             },
             AccountsController: {
@@ -475,9 +471,7 @@ describe('usePredictDeposit', () => {
     it('updates isDepositPending when pendingDeposits changes to false', () => {
       const { result, rerender } = setupUsePredictDepositTest({
         pendingDeposits: {
-          polymarket: {
-            [mockAccountAddress]: true,
-          },
+          [mockAccountAddress]: true,
         },
       });
 
@@ -489,9 +483,7 @@ describe('usePredictDeposit', () => {
           backgroundState: {
             PredictController: {
               pendingDeposits: {
-                polymarket: {
-                  [mockAccountAddress]: false,
-                },
+                [mockAccountAddress]: false,
               },
             },
             AccountsController: {

--- a/app/components/UI/Predict/hooks/usePredictDeposit.ts
+++ b/app/components/UI/Predict/hooks/usePredictDeposit.ts
@@ -22,18 +22,12 @@ import {
 } from '../constants/eventNames';
 import { PlaceOrderParams } from '../providers/types';
 
-interface UsePredictDepositParams {
-  providerId?: string;
-}
-
 interface PredictDepositAnalyticsParams {
   amountUsd?: number;
   analyticsProperties?: PlaceOrderParams['analyticsProperties'];
 }
 
-export const usePredictDeposit = ({
-  providerId = 'polymarket',
-}: UsePredictDepositParams = {}) => {
+export const usePredictDeposit = () => {
   const { navigateToConfirmation } = useConfirmNavigation();
   const theme = useAppThemeFromContext();
   const { toastRef } = useContext(ToastContext);
@@ -47,7 +41,6 @@ export const usePredictDeposit = ({
 
   const depositBatchId = useSelector(
     selectPredictPendingDepositByAddress({
-      providerId,
       address: selectedInternalAccountAddress,
     }),
   );
@@ -64,7 +57,6 @@ export const usePredictDeposit = ({
         if (analyticsProperties) {
           Engine.context.PredictController.trackPredictOrderEvent({
             status: PredictTradeStatus.INITIATED,
-            providerId,
             amountUsd,
             analyticsProperties: {
               ...analyticsProperties,
@@ -74,9 +66,7 @@ export const usePredictDeposit = ({
           });
         }
 
-        depositWithConfirmation({
-          providerId,
-        }).catch((err) => {
+        depositWithConfirmation({}).catch((err) => {
           console.error('Failed to initialize deposit:', err);
 
           // Log error with deposit initialization context
@@ -91,7 +81,6 @@ export const usePredictDeposit = ({
                 method: 'deposit',
                 action: 'deposit_initialization',
                 operation: 'financial_operations',
-                providerId,
               },
             },
           });
@@ -152,7 +141,6 @@ export const usePredictDeposit = ({
               method: 'deposit',
               action: 'deposit_navigation',
               operation: 'financial_operations',
-              providerId,
             },
           },
         });
@@ -162,7 +150,6 @@ export const usePredictDeposit = ({
       depositWithConfirmation,
       navigateToConfirmation,
       navigation,
-      providerId,
       theme.colors.accent04.normal,
       theme.colors.error.default,
       toastRef,

--- a/app/components/UI/Predict/hooks/usePredictEligibility.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictEligibility.test.ts
@@ -40,10 +40,7 @@ describe('usePredictEligibility', () => {
     engine: {
       backgroundState: {
         PredictController: {
-          eligibility: Record<
-            string,
-            { eligible: boolean; country?: string } | undefined
-          >;
+          eligibility: { eligible: boolean; country?: string };
         };
       };
     };
@@ -72,7 +69,7 @@ describe('usePredictEligibility', () => {
       engine: {
         backgroundState: {
           PredictController: {
-            eligibility: {},
+            eligibility: { eligible: false },
           },
         },
       },
@@ -87,38 +84,32 @@ describe('usePredictEligibility', () => {
   });
 
   describe('eligibility state', () => {
-    it('returns isEligible true for eligible provider', () => {
+    it('returns isEligible true when eligible', () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
-        example: { eligible: false, country: 'UK' },
+        eligible: true,
+        country: 'US',
       };
 
-      const { result } = renderHook(() =>
-        usePredictEligibility({ providerId: 'polymarket' }),
-      );
+      const { result } = renderHook(() => usePredictEligibility());
 
       expect(result.current.isEligible).toBe(true);
       expect(result.current.country).toBe('US');
     });
 
-    it('returns isEligible false for ineligible provider', () => {
+    it('returns isEligible false when ineligible', () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
-        example: { eligible: false, country: 'UK' },
+        eligible: false,
+        country: 'UK',
       };
 
-      const { result } = renderHook(() =>
-        usePredictEligibility({ providerId: 'example' }),
-      );
+      const { result } = renderHook(() => usePredictEligibility());
 
       expect(result.current.isEligible).toBe(false);
       expect(result.current.country).toBe('UK');
     });
 
-    it('returns false when provider eligibility is not set', () => {
-      const { result } = renderHook(() =>
-        usePredictEligibility({ providerId: 'unknown' }),
-      );
+    it('returns false when eligibility is not set', () => {
+      const { result } = renderHook(() => usePredictEligibility());
 
       expect(result.current.isEligible).toBe(false);
       expect(result.current.country).toBeUndefined();
@@ -127,7 +118,7 @@ describe('usePredictEligibility', () => {
 
   describe('singleton manager registration', () => {
     it('sets up AppState listener when first hook mounts', () => {
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       expect(mockAppStateAddEventListener).toHaveBeenCalledTimes(1);
       expect(mockAppStateAddEventListener).toHaveBeenCalledWith(
@@ -143,13 +134,11 @@ describe('usePredictEligibility', () => {
     });
 
     it('does not create additional listeners when second hook mounts', () => {
-      const { unmount: unmount1 } = renderHook(() =>
-        usePredictEligibility({ providerId: 'polymarket' }),
-      );
+      const { unmount: unmount1 } = renderHook(() => usePredictEligibility());
 
       jest.clearAllMocks();
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       expect(mockAppStateAddEventListener).not.toHaveBeenCalled();
       expect(mockDevLogger).toHaveBeenCalledWith(
@@ -163,9 +152,7 @@ describe('usePredictEligibility', () => {
     });
 
     it('removes AppState listener when last hook unmounts', () => {
-      const { unmount } = renderHook(() =>
-        usePredictEligibility({ providerId: 'polymarket' }),
-      );
+      const { unmount } = renderHook(() => usePredictEligibility());
 
       unmount();
 
@@ -176,11 +163,9 @@ describe('usePredictEligibility', () => {
     });
 
     it('keeps listener active when one of multiple hooks unmounts', () => {
-      const { unmount: unmount1 } = renderHook(() =>
-        usePredictEligibility({ providerId: 'polymarket' }),
-      );
+      const { unmount: unmount1 } = renderHook(() => usePredictEligibility());
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       jest.clearAllMocks();
 
@@ -198,7 +183,7 @@ describe('usePredictEligibility', () => {
 
   describe('auto-refresh on app focus', () => {
     it('refreshes eligibility when app transitions from background to active', async () => {
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -218,7 +203,7 @@ describe('usePredictEligibility', () => {
     });
 
     it('refreshes eligibility when app transitions from inactive to active', async () => {
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -233,10 +218,11 @@ describe('usePredictEligibility', () => {
 
     it('ignores transition from active to background', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
+        eligible: true,
+        country: 'US',
       };
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -251,10 +237,11 @@ describe('usePredictEligibility', () => {
 
     it('ignores transition from active to inactive', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
+        eligible: true,
+        country: 'US',
       };
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -269,10 +256,11 @@ describe('usePredictEligibility', () => {
 
     it('ignores transition from background to inactive', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
+        eligible: true,
+        country: 'US',
       };
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -289,10 +277,11 @@ describe('usePredictEligibility', () => {
   describe('debouncing', () => {
     it('skips refresh when less than debounce interval has passed', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
+        eligible: true,
+        country: 'US',
       };
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -323,10 +312,11 @@ describe('usePredictEligibility', () => {
 
     it('allows refresh when debounce interval has elapsed', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
+        eligible: true,
+        country: 'US',
       };
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -350,10 +340,11 @@ describe('usePredictEligibility', () => {
 
     it('allows refresh when more than debounce interval has elapsed', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
+        eligible: true,
+        country: 'US',
       };
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -377,10 +368,11 @@ describe('usePredictEligibility', () => {
 
     it('resets debounce timer after successful refresh', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
+        eligible: true,
+        country: 'US',
       };
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -414,9 +406,7 @@ describe('usePredictEligibility', () => {
 
   describe('manual refresh', () => {
     it('calls controller refreshEligibility method', async () => {
-      const { result } = renderHook(() =>
-        usePredictEligibility({ providerId: 'polymarket' }),
-      );
+      const { result } = renderHook(() => usePredictEligibility());
 
       await act(async () => {
         await result.current.refreshEligibility();
@@ -426,9 +416,7 @@ describe('usePredictEligibility', () => {
     });
 
     it('bypasses debounce for manual refresh', async () => {
-      const { result } = renderHook(() =>
-        usePredictEligibility({ providerId: 'polymarket' }),
-      );
+      const { result } = renderHook(() => usePredictEligibility());
 
       await act(async () => {
         await result.current.refreshEligibility();
@@ -447,12 +435,11 @@ describe('usePredictEligibility', () => {
 
     it('updates debounce timer after manual refresh', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
+        eligible: true,
+        country: 'US',
       };
 
-      const { result } = renderHook(() =>
-        usePredictEligibility({ providerId: 'polymarket' }),
-      );
+      const { result } = renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -483,7 +470,7 @@ describe('usePredictEligibility', () => {
       const testError = new Error('Network error');
       mockRefreshEligibility.mockRejectedValueOnce(testError);
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -504,7 +491,7 @@ describe('usePredictEligibility', () => {
     it('logs unknown error when auto-refresh fails with non-Error', async () => {
       mockRefreshEligibility.mockRejectedValueOnce('string error');
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -524,12 +511,13 @@ describe('usePredictEligibility', () => {
 
     it('continues operation after failed refresh', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
+        eligible: true,
+        country: 'US',
       };
 
       mockRefreshEligibility.mockRejectedValueOnce(new Error('Network error'));
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -561,7 +549,7 @@ describe('usePredictEligibility', () => {
       });
       mockRefreshEligibility.mockReturnValueOnce(refreshPromise);
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -593,7 +581,7 @@ describe('usePredictEligibility', () => {
       });
       mockRefreshEligibility.mockReturnValueOnce(refreshPromise);
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -622,9 +610,9 @@ describe('usePredictEligibility', () => {
       });
       mockRefreshEligibility.mockReturnValueOnce(refreshPromise);
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
+      renderHook(() => usePredictEligibility());
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -644,7 +632,8 @@ describe('usePredictEligibility', () => {
 
     it('allows new refresh after previous one completes', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
+        eligible: true,
+        country: 'US',
       };
 
       let resolveFirstRefresh: (() => void) | undefined;
@@ -653,7 +642,7 @@ describe('usePredictEligibility', () => {
       });
       mockRefreshEligibility.mockReturnValueOnce(firstRefreshPromise);
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -683,7 +672,8 @@ describe('usePredictEligibility', () => {
 
     it('clears in-flight promise after error', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
+        eligible: true,
+        country: 'US',
       };
 
       let rejectRefresh: ((error: Error) => void) | undefined;
@@ -692,7 +682,7 @@ describe('usePredictEligibility', () => {
       });
       mockRefreshEligibility.mockReturnValueOnce(refreshPromise);
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       const handleAppStateChange = mockAppStateAddEventListener.mock
         .calls[0][1] as (nextState: AppStateStatus) => void;
@@ -728,10 +718,10 @@ describe('usePredictEligibility', () => {
   describe('auto-refresh when country is missing', () => {
     it('starts polling when country is not returned', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true },
+        eligible: true,
       };
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       await act(async () => {
         await Promise.resolve();
@@ -740,16 +730,16 @@ describe('usePredictEligibility', () => {
       expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
       expect(mockDevLogger).toHaveBeenCalledWith(
         'PredictController: Country missing, auto-refreshing eligibility',
-        { providerId: 'polymarket', retryCount: 1, maxRetries: 3 },
+        { retryCount: 1, maxRetries: 3 },
       );
     });
 
     it('polls again after polling interval when country is still missing', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true },
+        eligible: true,
       };
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       await act(async () => {
         await Promise.resolve();
@@ -774,10 +764,10 @@ describe('usePredictEligibility', () => {
 
     it('continues polling while country is missing up to max retries', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true },
+        eligible: true,
       };
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       // Wait for initial poll to complete (retry 1)
       await act(async () => {
@@ -805,10 +795,10 @@ describe('usePredictEligibility', () => {
 
     it('stops polling after reaching max retries', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true },
+        eligible: true,
       };
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       // Complete all 3 retries
       await act(async () => {
@@ -838,7 +828,6 @@ describe('usePredictEligibility', () => {
       expect(mockDevLogger).toHaveBeenCalledWith(
         'PredictController: Max retries reached for missing country',
         expect.objectContaining({
-          providerId: 'polymarket',
           retryCount: 3,
         }),
       );
@@ -846,10 +835,11 @@ describe('usePredictEligibility', () => {
 
     it('does not start polling when country is already available', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true, country: 'US' },
+        eligible: true,
+        country: 'US',
       };
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       await act(async () => {
         await Promise.resolve();
@@ -863,12 +853,12 @@ describe('usePredictEligibility', () => {
 
     it('continues polling after failed refresh', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true },
+        eligible: true,
       };
 
       mockRefreshEligibility.mockRejectedValueOnce(new Error('Network error'));
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       await act(async () => {
         await Promise.resolve();
@@ -895,12 +885,12 @@ describe('usePredictEligibility', () => {
 
     it('logs unknown error when auto-refresh fails with non-Error', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true },
+        eligible: true,
       };
 
       mockRefreshEligibility.mockRejectedValueOnce('string error');
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       await act(async () => {
         await Promise.resolve();
@@ -917,12 +907,10 @@ describe('usePredictEligibility', () => {
 
     it('clears timeout on unmount', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true },
+        eligible: true,
       };
 
-      const { unmount } = renderHook(() =>
-        usePredictEligibility({ providerId: 'polymarket' }),
-      );
+      const { unmount } = renderHook(() => usePredictEligibility());
 
       await act(async () => {
         await Promise.resolve();
@@ -942,7 +930,7 @@ describe('usePredictEligibility', () => {
 
     it('uses sequential polling pattern - waits for response before scheduling next poll', async () => {
       mockState.engine.backgroundState.PredictController.eligibility = {
-        polymarket: { eligible: true },
+        eligible: true,
       };
 
       let resolveRefresh: (() => void) | undefined;
@@ -951,7 +939,7 @@ describe('usePredictEligibility', () => {
       });
       mockRefreshEligibility.mockReturnValueOnce(refreshPromise);
 
-      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+      renderHook(() => usePredictEligibility());
 
       await act(async () => {
         jest.advanceTimersByTime(2000);

--- a/app/components/UI/Predict/hooks/usePredictEligibility.ts
+++ b/app/components/UI/Predict/hooks/usePredictEligibility.ts
@@ -193,13 +193,9 @@ export const getRefreshManagerForTesting = (): EligibilityRefreshManager =>
  * poll for updates using a sequential loading pattern (wait for response → wait interval → poll again)
  * until a country is returned or the component unmounts.
  */
-export const usePredictEligibility = ({
-  providerId,
-}: {
-  providerId: string;
-}) => {
+export const usePredictEligibility = () => {
   const eligibility = useSelector(selectPredictEligibility);
-  const country = eligibility[providerId]?.country;
+  const country = eligibility?.country;
 
   // Manual refresh - bypasses debounce (force = true)
   const refreshEligibility = useCallback(async () => {
@@ -212,19 +208,15 @@ export const usePredictEligibility = ({
 
   // Register this hook instance with the singleton manager
   useEffect(() => {
-    DevLogger.log('PredictController: Mounting eligibility hook', {
-      providerId,
-    });
+    DevLogger.log('PredictController: Mounting eligibility hook');
 
     refreshManager.register();
 
     return () => {
-      DevLogger.log('PredictController: Unmounting eligibility hook', {
-        providerId,
-      });
+      DevLogger.log('PredictController: Unmounting eligibility hook');
       refreshManager.unregister();
     };
-  }, [providerId]);
+  }, []);
 
   // Auto-refresh when country is missing - sequential loading pattern
   // Similar to usePredictOptimisticPositionRefresh
@@ -244,7 +236,7 @@ export const usePredictEligibility = ({
 
       DevLogger.log(
         'PredictController: Country missing, auto-refreshing eligibility',
-        { providerId, retryCount, maxRetries: MISSING_COUNTRY_MAX_RETRIES },
+        { retryCount, maxRetries: MISSING_COUNTRY_MAX_RETRIES },
       );
 
       try {
@@ -272,7 +264,7 @@ export const usePredictEligibility = ({
       } else if (shouldContinue && retryCount >= MISSING_COUNTRY_MAX_RETRIES) {
         DevLogger.log(
           'PredictController: Max retries reached for missing country',
-          { providerId, retryCount },
+          { retryCount },
         );
       }
     };
@@ -286,10 +278,10 @@ export const usePredictEligibility = ({
         clearTimeout(timeoutId);
       }
     };
-  }, [country, providerId]);
+  }, [country]);
 
   return {
-    isEligible: eligibility[providerId]?.eligible ?? false,
+    isEligible: eligibility?.eligible ?? false,
     country,
     refreshEligibility,
   };

--- a/app/components/UI/Predict/hooks/usePredictMarket.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarket.test.tsx
@@ -142,15 +142,14 @@ describe('usePredictMarket', () => {
       expect(result.current.market).toEqual(mockMarket);
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: '123',
-        providerId: undefined,
       });
     });
 
-    it('fetches market data with providerId', async () => {
+    it('fetches market data with string id', async () => {
       mockGetMarket.mockResolvedValue(mockMarket);
 
       const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictMarket({ id: 'market-1', providerId: 'polymarket' }),
+        usePredictMarket({ id: 'market-1' }),
       );
 
       await waitForNextUpdate();
@@ -158,7 +157,6 @@ describe('usePredictMarket', () => {
       expect(result.current.market).toEqual(mockMarket);
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: 'market-1',
-        providerId: 'polymarket',
       });
     });
 
@@ -253,7 +251,6 @@ describe('usePredictMarket', () => {
       expect(result.current.market).toEqual(mockMarket);
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: 'market-1',
-        providerId: undefined,
       });
     });
   });
@@ -319,7 +316,6 @@ describe('usePredictMarket', () => {
 
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: 'market-1',
-        providerId: undefined,
       });
 
       // Change id
@@ -329,34 +325,31 @@ describe('usePredictMarket', () => {
 
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: 'market-2',
-        providerId: undefined,
       });
       expect(mockGetMarket).toHaveBeenCalledTimes(2);
     });
 
-    it('refetches when providerId changes', async () => {
+    it('refetches when id changes across rerenders', async () => {
       mockGetMarket.mockResolvedValue(mockMarket);
 
       const { rerender, waitForNextUpdate } = renderHook(
-        ({ providerId }) => usePredictMarket({ id: 'market-1', providerId }),
-        { initialProps: { providerId: 'polymarket' } },
+        ({ id }) => usePredictMarket({ id }),
+        { initialProps: { id: 'market-1' } },
       );
 
       await waitForNextUpdate();
 
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: 'market-1',
-        providerId: 'polymarket',
       });
 
-      // Change providerId
-      rerender({ providerId: 'other-provider' });
+      // Change id
+      rerender({ id: 'market-2' });
 
       await waitForNextUpdate();
 
       expect(mockGetMarket).toHaveBeenCalledWith({
-        marketId: 'market-1',
-        providerId: 'other-provider',
+        marketId: 'market-2',
       });
       expect(mockGetMarket).toHaveBeenCalledTimes(2);
     });
@@ -403,7 +396,6 @@ describe('usePredictMarket', () => {
 
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: '0',
-        providerId: undefined,
       });
     });
 
@@ -418,7 +410,6 @@ describe('usePredictMarket', () => {
 
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: '-1',
-        providerId: undefined,
       });
     });
 
@@ -451,7 +442,6 @@ describe('usePredictMarket', () => {
       const { waitForNextUpdate } = renderHook(() =>
         usePredictMarket({
           id: 'test-market-id',
-          providerId: 'test-provider',
         }),
       );
 
@@ -459,7 +449,6 @@ describe('usePredictMarket', () => {
 
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: 'test-market-id',
-        providerId: 'test-provider',
       });
       expect(mockGetMarket).toHaveBeenCalledTimes(1);
     });

--- a/app/components/UI/Predict/hooks/usePredictMarket.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarket.test.tsx
@@ -3,6 +3,7 @@ import Engine from '../../../../core/Engine';
 import { usePredictMarket } from './usePredictMarket';
 import { PredictMarket, Recurrence } from '../types';
 
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 // Mock dependencies
 jest.mock('../../../../core/Engine', () => ({
   context: {
@@ -17,7 +18,7 @@ describe('usePredictMarket', () => {
 
   const mockMarket: PredictMarket = {
     id: 'market-1',
-    providerId: 'polymarket',
+    providerId: POLYMARKET_PROVIDER_ID,
     slug: 'bitcoin-price-prediction',
     title: 'Will Bitcoin reach $200k by end of 2025?',
     description: 'Bitcoin price prediction market',
@@ -30,7 +31,7 @@ describe('usePredictMarket', () => {
     outcomes: [
       {
         id: 'outcome-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-1',
         title: 'Yes',
         description: 'Bitcoin will reach $200k',
@@ -48,7 +49,7 @@ describe('usePredictMarket', () => {
       },
       {
         id: 'outcome-2',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-1',
         title: 'No',
         description: 'Bitcoin will not reach $200k',

--- a/app/components/UI/Predict/hooks/usePredictMarket.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarket.tsx
@@ -7,7 +7,6 @@ import { PredictMarket } from '../types';
 
 export interface UsePredictMarketOptions {
   id?: string | number;
-  providerId?: string;
   enabled?: boolean;
 }
 
@@ -24,7 +23,7 @@ export interface UsePredictMarketResult {
 export const usePredictMarket = (
   options: UsePredictMarketOptions = {},
 ): UsePredictMarketResult => {
-  const { id, providerId, enabled = true } = options;
+  const { id, enabled = true } = options;
   const [market, setMarket] = useState<PredictMarket | null>(null);
   const [isFetching, setIsFetching] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -77,7 +76,6 @@ export const usePredictMarket = (
 
       const marketData = await controller.getMarket({
         marketId,
-        providerId,
       });
 
       if (isMountedRef.current) {
@@ -100,7 +98,6 @@ export const usePredictMarket = (
             action: 'market_load',
             operation: 'data_fetching',
             marketId: id,
-            providerId,
           },
         },
       });
@@ -114,7 +111,7 @@ export const usePredictMarket = (
         setIsFetching(false);
       }
     }
-  }, [enabled, id, providerId]);
+  }, [enabled, id]);
 
   useEffect(() => {
     fetchMarket();

--- a/app/components/UI/Predict/hooks/usePredictMarketData.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarketData.test.tsx
@@ -4,6 +4,7 @@ import Engine from '../../../../core/Engine';
 import { usePredictMarketData } from './usePredictMarketData';
 import { PredictMarket, Recurrence } from '../types';
 
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 // Mock dependencies
 jest.mock('../../../../core/SDKConnect/utils/DevLogger');
 jest.mock('../../../../core/Engine', () => ({
@@ -20,7 +21,7 @@ describe('usePredictMarketData', () => {
   const mockMarketData: PredictMarket[] = [
     {
       id: 'market-1',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       slug: 'bitcoin-price-prediction',
       title: 'Will Bitcoin reach $100k by end of 2024?',
       description: 'Bitcoin price prediction market',
@@ -32,7 +33,7 @@ describe('usePredictMarketData', () => {
       outcomes: [
         {
           id: 'outcome-1',
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           marketId: 'market-1',
           title: 'Yes',
           description: 'Bitcoin will reach $100k',
@@ -50,7 +51,7 @@ describe('usePredictMarketData', () => {
         },
         {
           id: 'outcome-2',
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           marketId: 'market-1',
           title: 'No',
           description: 'Bitcoin will not reach $100k',
@@ -72,7 +73,7 @@ describe('usePredictMarketData', () => {
     },
     {
       id: 'market-2',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       slug: 'ethereum-price-prediction',
       title: 'Will Ethereum reach $100000 by end of 2025?',
       description: 'Ethereum price prediction market',
@@ -84,7 +85,7 @@ describe('usePredictMarketData', () => {
       outcomes: [
         {
           id: 'outcome-3',
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           marketId: 'market-2',
           title: 'Yes',
           description: 'Ethereum will reach $100k',
@@ -102,7 +103,7 @@ describe('usePredictMarketData', () => {
         },
         {
           id: 'outcome-4',
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           marketId: 'market-2',
           title: 'No',
           description: 'Ethereum will not reach $100k',

--- a/app/components/UI/Predict/hooks/usePredictMarketData.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarketData.tsx
@@ -9,7 +9,6 @@ import { ensureError } from '../utils/predictErrorHandler';
 import { PredictCategory, PredictMarket } from '../types';
 
 export interface UsePredictMarketDataOptions {
-  providerId?: string;
   q?: string;
   category?: PredictCategory;
   pageSize?: number;
@@ -37,7 +36,6 @@ export const usePredictMarketData = (
     category = 'trending',
     q,
     pageSize = 20,
-    providerId,
     customQueryParams,
   } = options;
   const [marketData, setMarketData] = useState<PredictMarket[]>([]);
@@ -99,7 +97,6 @@ export const usePredictMarketData = (
             }
 
             const markets = await controller.getMarkets({
-              providerId,
               category,
               q,
               limit: pageSize,
@@ -175,7 +172,6 @@ export const usePredictMarketData = (
               method: 'loadMarketData',
               action: 'market_data_load',
               operation: 'data_fetching',
-              providerId,
               category,
               hasSearchQuery: !!q,
               pageSize,
@@ -192,7 +188,7 @@ export const usePredictMarketData = (
         setIsLoadingMore(false);
       }
     },
-    [category, q, pageSize, providerId, customQueryParams],
+    [category, q, pageSize, customQueryParams],
   );
 
   const loadMore = useCallback(async () => {

--- a/app/components/UI/Predict/hooks/usePredictOptimisticPositionRefresh.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictOptimisticPositionRefresh.test.ts
@@ -3,11 +3,12 @@ import { usePredictOptimisticPositionRefresh } from './usePredictOptimisticPosit
 import { PredictPosition, PredictPositionStatus } from '../types';
 import { usePredictPositions } from './usePredictPositions';
 
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 jest.mock('./usePredictPositions');
 
 const basePosition: PredictPosition = {
   id: 'pos-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-1',
   outcomeId: 'outcome-1',
   outcome: 'Yes',

--- a/app/components/UI/Predict/hooks/usePredictOrderPreview.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderPreview.test.ts
@@ -44,7 +44,6 @@ describe('usePredictOrderPreview', () => {
   });
 
   const defaultParams: PreviewOrderParams = {
-    providerId: 'polymarket',
     marketId: 'market-1',
     outcomeId: 'outcome-1',
     outcomeTokenId: 'token-1',
@@ -78,7 +77,6 @@ describe('usePredictOrderPreview', () => {
       await waitForNextUpdate();
 
       expect(mockPreviewOrder).toHaveBeenCalledWith({
-        providerId: 'polymarket',
         marketId: 'market-1',
         outcomeId: 'outcome-1',
         outcomeTokenId: 'token-1',
@@ -507,13 +505,13 @@ describe('usePredictOrderPreview', () => {
       );
     });
 
-    it('reacts to providerId changes', async () => {
+    it('reacts to marketId changes', async () => {
       mockPreviewOrder.mockResolvedValue(mockPreview);
 
       const { waitForNextUpdate } = renderHook(() =>
         usePredictOrderPreview({
           ...defaultParams,
-          providerId: 'another-provider',
+          marketId: 'market-2',
         }),
       );
 
@@ -524,7 +522,7 @@ describe('usePredictOrderPreview', () => {
       await waitForNextUpdate();
 
       expect(mockPreviewOrder).toHaveBeenCalledWith(
-        expect.objectContaining({ providerId: 'another-provider' }),
+        expect.objectContaining({ marketId: 'market-2' }),
       );
     });
   });

--- a/app/components/UI/Predict/hooks/usePredictOrderPreview.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderPreview.ts
@@ -29,7 +29,6 @@ export function usePredictOrderPreview(
 
   // Destructure params for stable dependencies
   const {
-    providerId,
     marketId,
     outcomeId,
     outcomeTokenId,
@@ -76,7 +75,6 @@ export function usePredictOrderPreview(
 
     try {
       const p = await previewOrder({
-        providerId,
         marketId,
         outcomeId,
         outcomeTokenId,
@@ -105,7 +103,6 @@ export function usePredictOrderPreview(
             method: 'calculatePreview',
             action: 'order_preview',
             operation: 'order_management',
-            providerId,
             side,
             marketId,
             outcomeId,
@@ -130,7 +127,6 @@ export function usePredictOrderPreview(
   }, [
     size,
     previewOrder,
-    providerId,
     marketId,
     outcomeId,
     outcomeTokenId,
@@ -163,15 +159,7 @@ export function usePredictOrderPreview(
     }, 100);
 
     return () => clearTimeout(debounceTimer);
-  }, [
-    providerId,
-    marketId,
-    outcomeId,
-    outcomeTokenId,
-    side,
-    size,
-    autoRefreshTimeout,
-  ]);
+  }, [marketId, outcomeId, outcomeTokenId, side, size, autoRefreshTimeout]);
 
   return {
     preview,

--- a/app/components/UI/Predict/hooks/usePredictOrderRetry.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderRetry.test.ts
@@ -54,7 +54,6 @@ function createParamsObj(overrides?: Record<string, unknown>) {
       .mockResolvedValue(createSuccessOutcome()) as jest.Mock<
       Promise<PlaceOrderOutcome>
     >,
-    providerId: 'polymarket',
     analyticsProperties: {
       marketId: 'market-123',
     } as PlaceOrderParams['analyticsProperties'],
@@ -107,7 +106,6 @@ describe('usePredictOrderRetry', () => {
       expect(mockTrackEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           status: 'retry_prompted',
-          providerId: 'polymarket',
         }),
       );
     });
@@ -150,7 +148,6 @@ describe('usePredictOrderRetry', () => {
 
       expect(mockPlaceOrder).toHaveBeenCalledWith(
         expect.objectContaining({
-          providerId: 'polymarket',
           preview: expect.objectContaining({ slippage: 0.99 }),
         }),
       );
@@ -188,7 +185,6 @@ describe('usePredictOrderRetry', () => {
       expect(mockTrackEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           status: 'retry_submitted',
-          providerId: 'polymarket',
         }),
       );
     });

--- a/app/components/UI/Predict/hooks/usePredictOrderRetry.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderRetry.ts
@@ -12,7 +12,6 @@ import type {
 interface UsePredictOrderRetryParams {
   preview: OrderPreview | null | undefined;
   placeOrder: (params: PlaceOrderParams) => Promise<PlaceOrderOutcome>;
-  providerId: string;
   analyticsProperties: PlaceOrderParams['analyticsProperties'];
   isOrderNotFilled: boolean;
   resetOrderNotFilled: () => void;
@@ -21,7 +20,6 @@ interface UsePredictOrderRetryParams {
 export function usePredictOrderRetry({
   preview,
   placeOrder,
-  providerId,
   analyticsProperties,
   isOrderNotFilled,
   resetOrderNotFilled,
@@ -39,14 +37,12 @@ export function usePredictOrderRetry({
     Engine.context.PredictController.trackPredictOrderEvent({
       status: PredictTradeStatus.RETRY_SUBMITTED,
       analyticsProperties,
-      providerId,
       sharePrice: preview.sharePrice,
     });
 
     try {
       const retryPreview = { ...preview, slippage: SLIPPAGE_BEST_AVAILABLE };
       const outcome = await placeOrder({
-        providerId,
         analyticsProperties,
         preview: retryPreview,
       });
@@ -67,13 +63,7 @@ export function usePredictOrderRetry({
     } finally {
       setIsRetrying(false);
     }
-  }, [
-    preview,
-    placeOrder,
-    providerId,
-    analyticsProperties,
-    resetOrderNotFilled,
-  ]);
+  }, [preview, placeOrder, analyticsProperties, resetOrderNotFilled]);
 
   const isRetryingRef = useRef(false);
   isRetryingRef.current = isRetrying;
@@ -93,13 +83,12 @@ export function usePredictOrderRetry({
       Engine.context.PredictController.trackPredictOrderEvent({
         status: PredictTradeStatus.RETRY_PROMPTED,
         analyticsProperties,
-        providerId,
         sharePrice: preview?.sharePrice,
       });
     }
 
     wasOrderNotFilledRef.current = isOrderNotFilled;
-  }, [isOrderNotFilled, analyticsProperties, providerId, preview?.sharePrice]);
+  }, [isOrderNotFilled, analyticsProperties, preview?.sharePrice]);
 
   return {
     retrySheetRef,

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
@@ -10,6 +10,7 @@ import { usePredictTrading } from './usePredictTrading';
 import { usePredictBalance } from './usePredictBalance';
 import { usePredictDeposit } from './usePredictDeposit';
 
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 // Mock dependencies
 jest.mock('../../../../component-library/components/Toast');
 jest.mock('../../../../core/SDKConnect/utils/DevLogger');
@@ -95,7 +96,7 @@ describe('usePredictPlaceOrder', () => {
   }
 
   const mockOrderParams = {
-    providerId: 'polymarket',
+    providerId: POLYMARKET_PROVIDER_ID,
     preview: createMockOrderPreview(),
   };
 

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
@@ -483,7 +483,6 @@ describe('usePredictPlaceOrder', () => {
       await act(async () => {
         const updatedPreview = createMockOrderPreview({ maxAmountSpent: 200 });
         await result.current.placeOrder({
-          providerId: 'polymarket',
           preview: updatedPreview,
         });
       });

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
@@ -211,7 +211,6 @@ export function usePredictPlaceOrder(
               method: 'placeOrder',
               action: 'order_placement',
               operation: 'order_management',
-              providerId: orderParams.providerId,
               side: orderParams.preview?.side,
               marketId: orderParams.analyticsProperties?.marketId,
               transactionType: orderParams.analyticsProperties?.transactionType,

--- a/app/components/UI/Predict/hooks/usePredictPositions.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPositions.test.ts
@@ -261,15 +261,14 @@ describe('usePredictPositions', () => {
     expect(result.current.positions).toEqual([]);
   });
 
-  it('passes providerId when specified', async () => {
+  it('calls getPositions without providerId option', async () => {
     mockGetPositions.mockResolvedValue([]);
 
-    renderHook(() => usePredictPositions({ providerId: 'polymarket' }));
+    renderHook(() => usePredictPositions());
 
     await waitFor(() => {
       expect(mockGetPositions).toHaveBeenCalledWith({
         address: '0x1234567890123456789012345678901234567890',
-        providerId: 'polymarket',
         claimable: false,
       });
     });

--- a/app/components/UI/Predict/hooks/usePredictPositions.ts
+++ b/app/components/UI/Predict/hooks/usePredictPositions.ts
@@ -13,10 +13,6 @@ import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 
 interface UsePredictPositionsOptions {
   /**
-   * The provider ID to load positions for
-   */
-  providerId?: string;
-  /**
    * Whether to load positions on mount
    * @default true
    */
@@ -60,7 +56,6 @@ export function usePredictPositions(
   options: UsePredictPositionsOptions = {},
 ): UsePredictPositionsReturn {
   const {
-    providerId,
     loadOnMount = true,
     refreshOnFocus = true,
     claimable = false,
@@ -125,7 +120,6 @@ export function usePredictPositions(
         // Get positions from Predict controller
         const positionsData = await getPositions({
           address: selectedInternalAccountAddress,
-          providerId,
           claimable,
           // Always load ALL positions when claimable is true
           marketId: claimable ? undefined : marketId,
@@ -165,7 +159,6 @@ export function usePredictPositions(
               method: 'loadPositions',
               action: 'positions_load',
               operation: 'data_fetching',
-              providerId,
               claimable,
               marketId,
             },
@@ -179,13 +172,7 @@ export function usePredictPositions(
     },
     // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      getPositions,
-      selectedInternalAccountAddress,
-      providerId,
-      claimable,
-      marketId,
-    ],
+    [getPositions, selectedInternalAccountAddress, claimable, marketId],
   );
 
   // Load positions on mount if enabled

--- a/app/components/UI/Predict/hooks/usePredictPriceHistory.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictPriceHistory.test.tsx
@@ -278,7 +278,6 @@ describe('usePredictPriceHistory', () => {
       const { waitForNextUpdate } = renderHook(() =>
         usePredictPriceHistory({
           marketIds: ['market-1'],
-          providerId: 'polymarket',
         }),
       );
 

--- a/app/components/UI/Predict/hooks/usePredictPriceHistory.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictPriceHistory.test.tsx
@@ -87,7 +87,6 @@ describe('usePredictPriceHistory', () => {
         marketId: 'market-1',
         interval: PredictPriceHistoryInterval.ONE_DAY,
         fidelity: undefined,
-        providerId: undefined,
       });
       expect(result.current.priceHistories).toEqual([mockPriceHistory]);
       expect(result.current.isFetching).toBe(false);
@@ -250,7 +249,6 @@ describe('usePredictPriceHistory', () => {
         marketId: 'market-1',
         interval: PredictPriceHistoryInterval.ONE_WEEK,
         fidelity: undefined,
-        providerId: undefined,
       });
     });
 
@@ -270,26 +268,6 @@ describe('usePredictPriceHistory', () => {
         marketId: 'market-1',
         interval: PredictPriceHistoryInterval.ONE_DAY,
         fidelity: 30,
-        providerId: undefined,
-      });
-    });
-
-    it('uses custom provider when provided', async () => {
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictPriceHistory({
-          marketIds: ['market-1'],
-        }),
-      );
-
-      await waitForNextUpdate();
-
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).toHaveBeenCalledWith({
-        marketId: 'market-1',
-        interval: PredictPriceHistoryInterval.ONE_DAY,
-        fidelity: undefined,
-        providerId: 'polymarket',
       });
     });
   });
@@ -320,7 +298,6 @@ describe('usePredictPriceHistory', () => {
         marketId: 'market-2',
         interval: PredictPriceHistoryInterval.ONE_DAY,
         fidelity: undefined,
-        providerId: undefined,
       });
     });
 
@@ -348,7 +325,6 @@ describe('usePredictPriceHistory', () => {
         marketId: 'market-1',
         interval: PredictPriceHistoryInterval.ONE_WEEK,
         fidelity: undefined,
-        providerId: undefined,
       });
     });
 
@@ -512,7 +488,6 @@ describe('usePredictPriceHistory', () => {
           marketId: 'market-1',
           interval,
           fidelity: undefined,
-          providerId: undefined,
         });
         expect(result.current.priceHistories).toEqual([mockPriceHistory]);
       });

--- a/app/components/UI/Predict/hooks/usePredictPriceHistory.tsx
+++ b/app/components/UI/Predict/hooks/usePredictPriceHistory.tsx
@@ -15,7 +15,6 @@ export interface UsePredictPriceHistoryOptions {
   startTs?: number;
   endTs?: number;
   fidelity?: number;
-  providerId?: string;
   enabled?: boolean;
 }
 
@@ -38,7 +37,6 @@ export const usePredictPriceHistory = (
     interval = PredictPriceHistoryInterval.ONE_DAY,
     startTs,
     endTs,
-    providerId,
     enabled = true,
   } = options;
 
@@ -105,7 +103,6 @@ export const usePredictPriceHistory = (
             interval,
             startTs,
             endTs,
-            providerId,
           });
           return { index, data: history ?? [], error: null };
         } catch (err) {
@@ -131,7 +128,6 @@ export const usePredictPriceHistory = (
                 action: 'price_history_load_single',
                 operation: 'data_fetching',
                 marketId,
-                providerId,
                 interval,
                 startTs,
                 endTs,
@@ -177,7 +173,6 @@ export const usePredictPriceHistory = (
             action: 'price_history_load_batch',
             operation: 'data_fetching',
             marketCount: marketIds.length,
-            providerId,
             interval,
             startTs,
             endTs,
@@ -197,7 +192,7 @@ export const usePredictPriceHistory = (
     }
     // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, marketIdsKey, fidelity, interval, startTs, endTs, providerId]);
+  }, [enabled, marketIdsKey, fidelity, interval, startTs, endTs]);
 
   useEffect(() => {
     fetchPriceHistories();

--- a/app/components/UI/Predict/hooks/usePredictPrices.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictPrices.test.tsx
@@ -267,7 +267,7 @@ describe('usePredictPrices', () => {
   });
 
   describe('configuration options', () => {
-    it('uses custom provider when provided', async () => {
+    it('fetches prices when queries are provided', async () => {
       const { waitForNextUpdate } = renderHook(() =>
         usePredictPrices({
           queries: [
@@ -277,7 +277,6 @@ describe('usePredictPrices', () => {
               outcomeTokenId: 'token-1',
             },
           ],
-          providerId: 'custom-provider',
         }),
       );
 
@@ -291,7 +290,7 @@ describe('usePredictPrices', () => {
             outcomeTokenId: 'token-1',
           },
         ],
-        providerId: 'custom-provider',
+        providerId: 'polymarket',
       });
     });
 
@@ -490,10 +489,14 @@ describe('usePredictPrices', () => {
       });
     });
 
-    it('refetches when providerId changes', async () => {
+    it('refetches when queries change across rerenders', async () => {
       const { rerender, waitForNextUpdate } = renderHook(
-        ({ providerId }) =>
+        ({ queries }) =>
           usePredictPrices({
+            queries,
+          }),
+        {
+          initialProps: {
             queries: [
               {
                 marketId: 'market-1',
@@ -501,16 +504,21 @@ describe('usePredictPrices', () => {
                 outcomeTokenId: 'token-1',
               },
             ],
-            providerId,
-          }),
-        {
-          initialProps: { providerId: 'polymarket' },
+          },
         },
       );
 
       await waitForNextUpdate();
 
-      rerender({ providerId: 'custom-provider' });
+      rerender({
+        queries: [
+          {
+            marketId: 'market-3',
+            outcomeId: 'outcome-3',
+            outcomeTokenId: 'token-3',
+          },
+        ],
+      });
 
       await waitForNextUpdate();
 
@@ -519,12 +527,12 @@ describe('usePredictPrices', () => {
       ).toHaveBeenLastCalledWith({
         queries: [
           {
-            marketId: 'market-1',
-            outcomeId: 'outcome-1',
-            outcomeTokenId: 'token-1',
+            marketId: 'market-3',
+            outcomeId: 'outcome-3',
+            outcomeTokenId: 'token-3',
           },
         ],
-        providerId: 'custom-provider',
+        providerId: 'polymarket',
       });
     });
 

--- a/app/components/UI/Predict/hooks/usePredictPrices.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictPrices.test.tsx
@@ -108,7 +108,6 @@ describe('usePredictPrices', () => {
             outcomeTokenId: 'token-1',
           },
         ],
-        providerId: 'polymarket',
       });
       expect(result.current.prices).toEqual(mockPrices);
       expect(result.current.isFetching).toBe(false);
@@ -179,7 +178,6 @@ describe('usePredictPrices', () => {
             outcomeTokenId: 'token-2',
           },
         ],
-        providerId: 'polymarket',
       });
       expect(result.current.prices).toEqual(mockPrices);
       expect(result.current.error).toBeNull();
@@ -290,11 +288,10 @@ describe('usePredictPrices', () => {
             outcomeTokenId: 'token-1',
           },
         ],
-        providerId: 'polymarket',
       });
     });
 
-    it('defaults to polymarket provider when not specified', async () => {
+    it('fetches prices without provider option when not specified', async () => {
       const { waitForNextUpdate } = renderHook(() =>
         usePredictPrices({
           queries: [
@@ -317,7 +314,6 @@ describe('usePredictPrices', () => {
             outcomeTokenId: 'token-1',
           },
         ],
-        providerId: 'polymarket',
       });
     });
   });
@@ -460,7 +456,6 @@ describe('usePredictPrices', () => {
             outcomeTokenId: 'token-1',
           },
         ],
-        providerId: 'polymarket',
       });
 
       rerender({
@@ -485,7 +480,6 @@ describe('usePredictPrices', () => {
             outcomeTokenId: 'token-2',
           },
         ],
-        providerId: 'polymarket',
       });
     });
 
@@ -532,7 +526,6 @@ describe('usePredictPrices', () => {
             outcomeTokenId: 'token-3',
           },
         ],
-        providerId: 'polymarket',
       });
     });
 

--- a/app/components/UI/Predict/hooks/usePredictPrices.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictPrices.test.tsx
@@ -4,6 +4,7 @@ import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import { GetPriceResponse, PriceQuery } from '../types';
 import { usePredictPrices } from './usePredictPrices';
 
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 jest.mock('../../../../core/Engine', () => {
   const mockContext = {
     PredictController: {
@@ -24,7 +25,7 @@ jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
 
 describe('usePredictPrices', () => {
   const mockPrices: GetPriceResponse = {
-    providerId: 'polymarket',
+    providerId: POLYMARKET_PROVIDER_ID,
     results: [
       {
         marketId: 'market-1',

--- a/app/components/UI/Predict/hooks/usePredictPrices.tsx
+++ b/app/components/UI/Predict/hooks/usePredictPrices.tsx
@@ -8,7 +8,6 @@ import { PriceQuery, GetPriceResponse, Side } from '../types';
 
 export interface UsePredictPricesOptions {
   queries: PriceQuery[];
-  providerId?: string;
   enabled?: boolean;
   /**
    * optional polling interval in milliseconds.
@@ -30,12 +29,7 @@ export interface UsePredictPricesResult {
 export const usePredictPrices = (
   options: UsePredictPricesOptions,
 ): UsePredictPricesResult => {
-  const {
-    queries = [],
-    providerId = 'polymarket',
-    enabled = true,
-    pollingInterval,
-  } = options;
+  const { queries = [], enabled = true, pollingInterval } = options;
 
   const [prices, setPrices] = useState<GetPriceResponse>({
     providerId: '',
@@ -101,7 +95,6 @@ export const usePredictPrices = (
 
       const fetchedPrices = await controller.getPrices({
         queries,
-        providerId,
       });
 
       if (isMountedRef.current) {
@@ -133,7 +126,6 @@ export const usePredictPrices = (
             action: 'prices_load',
             operation: 'data_fetching',
             queriesCount: queries.length,
-            providerId,
           },
         },
       });
@@ -149,7 +141,7 @@ export const usePredictPrices = (
     }
     // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, queriesKey, providerId, pollingInterval]);
+  }, [enabled, queriesKey, pollingInterval]);
 
   useEffect(() => {
     if (pollingTimeoutRef.current) {

--- a/app/components/UI/Predict/hooks/usePredictTrading.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictTrading.test.ts
@@ -51,14 +51,12 @@ describe('usePredictTrading', () => {
 
       const response = await result.current.getPositions({
         address: '0x1234567890123456789012345678901234567890',
-        providerId: 'polymarket',
       });
 
       expect(
         Engine.context.PredictController.getPositions,
       ).toHaveBeenCalledWith({
         address: '0x1234567890123456789012345678901234567890',
-        providerId: 'polymarket',
       });
       expect(response).toEqual(mockPositions);
     });
@@ -73,7 +71,6 @@ describe('usePredictTrading', () => {
       await expect(
         result.current.getPositions({
           address: '0x1234567890123456789012345678901234567890',
-          providerId: 'polymarket',
         }),
       ).rejects.toThrow('Failed to fetch predict positions');
     });
@@ -108,12 +105,10 @@ describe('usePredictTrading', () => {
       };
 
       const response = await result.current.placeOrder({
-        providerId: 'polymarket',
         preview: mockPreview,
       });
 
       expect(Engine.context.PredictController.placeOrder).toHaveBeenCalledWith({
-        providerId: 'polymarket',
         preview: mockPreview,
       });
       expect(response).toEqual(mockBuyResult);
@@ -147,12 +142,10 @@ describe('usePredictTrading', () => {
       };
 
       const response = await result.current.placeOrder({
-        providerId: 'polymarket',
         preview: mockPreview,
       });
 
       expect(Engine.context.PredictController.placeOrder).toHaveBeenCalledWith({
-        providerId: 'polymarket',
         preview: mockPreview,
       });
       expect(response).toEqual(mockSellResult);
@@ -181,7 +174,6 @@ describe('usePredictTrading', () => {
 
       await expect(
         result.current.placeOrder({
-          providerId: 'polymarket',
           preview: mockPreview,
         }),
       ).rejects.toThrow('Failed to place order');
@@ -238,12 +230,10 @@ describe('usePredictTrading', () => {
       const { result } = renderHook(() => usePredictTrading());
 
       const response = await result.current.getBalance({
-        providerId: 'polymarket',
         address: '0x1234567890123456789012345678901234567890',
       });
 
       expect(Engine.context.PredictController.getBalance).toHaveBeenCalledWith({
-        providerId: 'polymarket',
         address: '0x1234567890123456789012345678901234567890',
       });
       expect(response).toBe(mockBalance);
@@ -258,7 +248,6 @@ describe('usePredictTrading', () => {
 
       await expect(
         result.current.getBalance({
-          providerId: 'polymarket',
           address: '0x1234567890123456789012345678901234567890',
         }),
       ).rejects.toThrow('Failed to fetch balance');
@@ -273,14 +262,12 @@ describe('usePredictTrading', () => {
 
       const { result } = renderHook(() => usePredictTrading());
 
-      const response = await result.current.getBalance({
-        providerId: 'polymarket',
-      });
+      const response = await result.current.getBalance({});
 
       // The hook calls the controller directly, so the controller handles the default address
-      expect(Engine.context.PredictController.getBalance).toHaveBeenCalledWith({
-        providerId: 'polymarket',
-      });
+      expect(Engine.context.PredictController.getBalance).toHaveBeenCalledWith(
+        {},
+      );
       expect(response).toBe(mockBalance);
     });
   });

--- a/app/components/UI/Predict/hooks/usePredictTrading.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictTrading.test.ts
@@ -3,6 +3,7 @@ import Engine from '../../../../core/Engine';
 import { usePredictTrading } from './usePredictTrading';
 import { Side } from '../types';
 
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 // Mock Engine
 jest.mock('../../../../core/Engine', () => ({
   context: {
@@ -195,13 +196,13 @@ describe('usePredictTrading', () => {
       const { result } = renderHook(() => usePredictTrading());
 
       const response = await result.current.claim({
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
       });
 
       expect(
         Engine.context.PredictController.claimWithConfirmation,
       ).toHaveBeenCalledWith({
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
       });
       expect(response).toEqual(mockClaimResult);
     });
@@ -214,7 +215,7 @@ describe('usePredictTrading', () => {
       const { result } = renderHook(() => usePredictTrading());
 
       await expect(
-        result.current.claim({ providerId: 'polymarket' }),
+        result.current.claim({ providerId: POLYMARKET_PROVIDER_ID }),
       ).rejects.toThrow('Failed to claim winnings');
     });
   });

--- a/app/components/UI/Predict/hooks/usePredictWithdraw.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictWithdraw.test.ts
@@ -101,7 +101,7 @@ function createMockWithdrawTransaction(overrides = {}) {
 }
 
 // Helper to setup test
-function setupUsePredictWithdrawTest(stateOverrides = {}, hookOptions = {}) {
+function setupUsePredictWithdrawTest(stateOverrides = {}) {
   jest.clearAllMocks();
   mockState = {
     engine: {
@@ -113,7 +113,7 @@ function setupUsePredictWithdrawTest(stateOverrides = {}, hookOptions = {}) {
       },
     },
   };
-  return renderHook(() => usePredictWithdraw(hookOptions));
+  return renderHook(() => usePredictWithdraw());
 }
 
 describe('usePredictWithdraw', () => {
@@ -218,27 +218,20 @@ describe('usePredictWithdraw', () => {
       // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(mockPrepareWithdraw).toHaveBeenCalledWith({
-        providerId: 'polymarket',
-      });
+      expect(mockPrepareWithdraw).toHaveBeenCalledWith();
     });
 
-    it('calls prepareWithdraw with custom providerId', async () => {
+    it('calls prepareWithdraw without provider argument', async () => {
       mockPrepareWithdraw.mockResolvedValue({ success: true });
 
-      const { result } = setupUsePredictWithdrawTest(
-        {},
-        { providerId: 'custom-provider' },
-      );
+      const { result } = setupUsePredictWithdrawTest({});
 
       await result.current.withdraw();
 
       // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(mockPrepareWithdraw).toHaveBeenCalledWith({
-        providerId: 'custom-provider',
-      });
+      expect(mockPrepareWithdraw).toHaveBeenCalledWith();
     });
 
     it('returns response from prepareWithdraw on success', async () => {
@@ -438,7 +431,7 @@ describe('usePredictWithdraw', () => {
   });
 
   describe('providerId handling', () => {
-    it('uses default providerId polymarket when not specified', async () => {
+    it('calls prepareWithdraw without provider argument by default', async () => {
       mockPrepareWithdraw.mockResolvedValue({ success: true });
 
       const { result } = setupUsePredictWithdrawTest();
@@ -448,27 +441,31 @@ describe('usePredictWithdraw', () => {
       // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(mockPrepareWithdraw).toHaveBeenCalledWith({
-        providerId: 'polymarket',
-      });
+      expect(mockPrepareWithdraw).toHaveBeenCalledWith();
     });
 
-    it('uses custom providerId when provided', async () => {
+    it('calls prepareWithdraw without provider argument when not specified', async () => {
       mockPrepareWithdraw.mockResolvedValue({ success: true });
 
-      const { result } = setupUsePredictWithdrawTest(
-        {},
-        { providerId: 'test-provider' },
-      );
+      const { result } = setupUsePredictWithdrawTest();
 
       await result.current.withdraw();
 
-      // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(mockPrepareWithdraw).toHaveBeenCalledWith({
-        providerId: 'test-provider',
-      });
+      expect(mockPrepareWithdraw).toHaveBeenCalledWith();
+    });
+
+    it('calls prepareWithdraw without provider argument when custom provider is passed', async () => {
+      mockPrepareWithdraw.mockResolvedValue({ success: true });
+
+      const { result } = setupUsePredictWithdrawTest({});
+
+      await result.current.withdraw();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockPrepareWithdraw).toHaveBeenCalledWith();
     });
   });
 

--- a/app/components/UI/Predict/hooks/usePredictWithdraw.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictWithdraw.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-native';
 import { usePredictWithdraw } from './usePredictWithdraw';
 import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
 
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 // Create mock functions
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -95,7 +96,7 @@ function createMockWithdrawTransaction(overrides = {}) {
     amount: 100,
     chainId: 137,
     status: 'pending',
-    providerId: 'polymarket',
+    providerId: POLYMARKET_PROVIDER_ID,
     ...overrides,
   };
 }

--- a/app/components/UI/Predict/hooks/usePredictWithdraw.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictWithdraw.test.ts
@@ -208,7 +208,7 @@ describe('usePredictWithdraw', () => {
       });
     });
 
-    it('calls prepareWithdraw with default providerId', async () => {
+    it('calls prepareWithdraw with empty options object', async () => {
       mockPrepareWithdraw.mockResolvedValue({ success: true });
 
       const { result } = setupUsePredictWithdrawTest();
@@ -218,10 +218,10 @@ describe('usePredictWithdraw', () => {
       // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(mockPrepareWithdraw).toHaveBeenCalledWith();
+      expect(mockPrepareWithdraw).toHaveBeenCalledWith({});
     });
 
-    it('calls prepareWithdraw without provider argument', async () => {
+    it('calls prepareWithdraw with empty options object', async () => {
       mockPrepareWithdraw.mockResolvedValue({ success: true });
 
       const { result } = setupUsePredictWithdrawTest({});
@@ -231,7 +231,7 @@ describe('usePredictWithdraw', () => {
       // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(mockPrepareWithdraw).toHaveBeenCalledWith();
+      expect(mockPrepareWithdraw).toHaveBeenCalledWith({});
     });
 
     it('returns response from prepareWithdraw on success', async () => {
@@ -430,8 +430,8 @@ describe('usePredictWithdraw', () => {
     });
   });
 
-  describe('providerId handling', () => {
-    it('calls prepareWithdraw without provider argument by default', async () => {
+  describe('withdraw payload handling', () => {
+    it('calls prepareWithdraw with empty object by default', async () => {
       mockPrepareWithdraw.mockResolvedValue({ success: true });
 
       const { result } = setupUsePredictWithdrawTest();
@@ -441,10 +441,10 @@ describe('usePredictWithdraw', () => {
       // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(mockPrepareWithdraw).toHaveBeenCalledWith();
+      expect(mockPrepareWithdraw).toHaveBeenCalledWith({});
     });
 
-    it('calls prepareWithdraw without provider argument when not specified', async () => {
+    it('calls prepareWithdraw with empty object when not specified', async () => {
       mockPrepareWithdraw.mockResolvedValue({ success: true });
 
       const { result } = setupUsePredictWithdrawTest();
@@ -453,10 +453,10 @@ describe('usePredictWithdraw', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(mockPrepareWithdraw).toHaveBeenCalledWith();
+      expect(mockPrepareWithdraw).toHaveBeenCalledWith({});
     });
 
-    it('calls prepareWithdraw without provider argument when custom provider is passed', async () => {
+    it('calls prepareWithdraw with empty object for repeated calls', async () => {
       mockPrepareWithdraw.mockResolvedValue({ success: true });
 
       const { result } = setupUsePredictWithdrawTest({});
@@ -465,7 +465,7 @@ describe('usePredictWithdraw', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(mockPrepareWithdraw).toHaveBeenCalledWith();
+      expect(mockPrepareWithdraw).toHaveBeenCalledWith({});
     });
   });
 

--- a/app/components/UI/Predict/hooks/usePredictWithdraw.ts
+++ b/app/components/UI/Predict/hooks/usePredictWithdraw.ts
@@ -14,13 +14,7 @@ import {
 } from '../../../../component-library/components/Toast';
 import { strings } from '../../../../../locales/i18n';
 
-interface UsePredictWithdrawParams {
-  providerId?: string;
-}
-
-export const usePredictWithdraw = ({
-  providerId = 'polymarket',
-}: UsePredictWithdrawParams = {}) => {
+export const usePredictWithdraw = () => {
   const { prepareWithdraw } = usePredictTrading();
   const { navigateToConfirmation } = useConfirmNavigation();
   const navigation =
@@ -40,7 +34,7 @@ export const usePredictWithdraw = ({
         loader: ConfirmationLoader.CustomAmount,
       });
 
-      const response = await prepareWithdraw({ providerId });
+      const response = await prepareWithdraw({});
 
       return response;
     } catch (err) {
@@ -65,13 +59,7 @@ export const usePredictWithdraw = ({
 
       console.error('Failed to proceed with withdraw:', err);
     }
-  }, [
-    navigateToConfirmation,
-    navigation,
-    prepareWithdraw,
-    providerId,
-    toastRef,
-  ]);
+  }, [navigateToConfirmation, navigation, prepareWithdraw, toastRef]);
 
   return { withdraw, withdrawTransaction };
 };

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
@@ -123,7 +123,6 @@ describe('useUnrealizedPnL', () => {
 
     expect(mockGetUnrealizedPnL).toHaveBeenCalledWith({
       address: mockSelectedAddress,
-      providerId: undefined,
     });
   });
 
@@ -133,7 +132,6 @@ describe('useUnrealizedPnL', () => {
     const { result } = renderHook(() =>
       useUnrealizedPnL({
         address: '0x2222222222222222222222222222222222222222',
-        providerId: 'polymarket',
       }),
     );
 
@@ -143,7 +141,6 @@ describe('useUnrealizedPnL', () => {
 
     expect(mockGetUnrealizedPnL).toHaveBeenCalledWith({
       address: '0x2222222222222222222222222222222222222222',
-      providerId: 'polymarket',
     });
   });
 
@@ -234,12 +231,10 @@ describe('useUnrealizedPnL', () => {
     mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
     const { rerender } = renderHook(
-      ({ address, providerId }: { address?: string; providerId?: string }) =>
-        useUnrealizedPnL({ address, providerId }),
+      ({ address }: { address?: string }) => useUnrealizedPnL({ address }),
       {
         initialProps: {
           address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          providerId: 'polymarket',
         },
       },
     );
@@ -250,7 +245,6 @@ describe('useUnrealizedPnL', () => {
 
     rerender({
       address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-      providerId: 'other-provider',
     });
 
     await waitFor(() => {
@@ -259,11 +253,9 @@ describe('useUnrealizedPnL', () => {
 
     expect(mockGetUnrealizedPnL).toHaveBeenNthCalledWith(1, {
       address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      providerId: 'polymarket',
     });
     expect(mockGetUnrealizedPnL).toHaveBeenNthCalledWith(2, {
       address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-      providerId: 'other-provider',
     });
   });
 
@@ -281,7 +273,6 @@ describe('useUnrealizedPnL', () => {
       expect(result.current.unrealizedPnL).toBeNull();
       expect(result.current.error).toBeNull();
       expect(mockGetPositions).toHaveBeenCalledWith({
-        providerId: undefined,
         limit: 1,
         offset: 0,
         claimable: false,
@@ -305,22 +296,17 @@ describe('useUnrealizedPnL', () => {
       expect(result.current.error).toBeNull();
     });
 
-    it('calls getPositions with providerId when specified', async () => {
+    it('calls getPositions with expected params when options are provided', async () => {
       mockGetUnrealizedPnL.mockResolvedValue(basePnL);
       mockGetPositions.mockResolvedValue([{ id: 'position-1' }]);
 
-      const { result } = renderHook(() =>
-        useUnrealizedPnL({
-          providerId: 'polymarket',
-        }),
-      );
+      const { result } = renderHook(() => useUnrealizedPnL());
 
       await waitFor(() => {
         expect(result.current.unrealizedPnL).toEqual(basePnL);
       });
 
       expect(mockGetPositions).toHaveBeenCalledWith({
-        providerId: 'polymarket',
         limit: 1,
         offset: 0,
         claimable: false,

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
@@ -14,10 +14,6 @@ export interface UseUnrealizedPnLOptions {
    */
   address?: string;
   /**
-   * The provider ID to fetch unrealized P&L from
-   */
-  providerId?: string;
-  /**
    * Whether to load unrealized P&L on mount
    * @default true
    */
@@ -45,12 +41,7 @@ export interface UseUnrealizedPnLResult {
 export const useUnrealizedPnL = (
   options: UseUnrealizedPnLOptions = {},
 ): UseUnrealizedPnLResult => {
-  const {
-    address,
-    providerId,
-    loadOnMount = true,
-    refreshOnFocus = true,
-  } = options;
+  const { address, loadOnMount = true, refreshOnFocus = true } = options;
 
   const [unrealizedPnL, setUnrealizedPnL] = useState<UnrealizedPnL | null>(
     null,
@@ -78,10 +69,8 @@ export const useUnrealizedPnL = (
         const [unrealizedPnLData, positions] = await Promise.all([
           Engine.context.PredictController.getUnrealizedPnL({
             address: address ?? selectedInternalAccountAddress,
-            providerId,
           }),
           Engine.context.PredictController.getPositions({
-            providerId,
             limit: 1,
             offset: 0,
             claimable: false,
@@ -93,7 +82,6 @@ export const useUnrealizedPnL = (
 
         DevLogger.log('useUnrealizedPnL: Loaded unrealized P&L', {
           unrealizedPnL: unrealizedPnLData,
-          providerId,
         });
       } catch (err) {
         const errorMessage =
@@ -114,7 +102,6 @@ export const useUnrealizedPnL = (
               method: 'loadUnrealizedPnL',
               action: 'unrealized_pnl_load',
               operation: 'data_fetching',
-              providerId,
             },
           },
         });
@@ -123,7 +110,7 @@ export const useUnrealizedPnL = (
         setIsRefreshing(false);
       }
     },
-    [address, providerId, selectedInternalAccountAddress],
+    [address, selectedInternalAccountAddress],
   );
 
   // Load unrealized P&L on mount if enabled

--- a/app/components/UI/Predict/providers/polymarket/GameCache.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/GameCache.test.ts
@@ -1,6 +1,7 @@
 import { GameUpdate, PredictMarket, Recurrence } from '../../types';
 import { GameCache } from './GameCache';
 
+import { POLYMARKET_PROVIDER_ID } from './constants';
 const createMockGameUpdate = (
   overrides: Partial<GameUpdate> = {},
 ): GameUpdate => ({
@@ -17,7 +18,7 @@ const createMockMarket = (
   overrides: Partial<PredictMarket> = {},
 ): PredictMarket => ({
   id: 'market-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   slug: 'test-market',
   title: 'Test Market',
   description: 'A test market',

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -1432,7 +1432,6 @@ describe('PolymarketProvider', () => {
         },
       });
       const orderParams: PlaceOrderParams = {
-        providerId: 'polymarket',
         preview,
       };
 
@@ -1454,7 +1453,6 @@ describe('PolymarketProvider', () => {
         },
       });
       const orderParams: PlaceOrderParams = {
-        providerId: 'polymarket',
         preview,
       };
 
@@ -1481,7 +1479,6 @@ describe('PolymarketProvider', () => {
         },
       });
       const orderParams: PlaceOrderParams = {
-        providerId: 'polymarket',
         preview,
       };
 
@@ -1508,7 +1505,6 @@ describe('PolymarketProvider', () => {
         },
       });
       const orderParams: PlaceOrderParams = {
-        providerId: 'polymarket',
         preview,
       };
 
@@ -1545,7 +1541,6 @@ describe('PolymarketProvider', () => {
         },
       });
       const orderParams: PlaceOrderParams = {
-        providerId: 'polymarket',
         preview,
       };
 
@@ -3521,7 +3516,6 @@ describe('PolymarketProvider', () => {
 
       // When preparing deposit
       const result = await provider.prepareDeposit({
-        providerId: 'polymarket',
         signer: mockSigner,
       });
 
@@ -3545,7 +3539,6 @@ describe('PolymarketProvider', () => {
 
       // When preparing deposit
       const result = await provider.prepareDeposit({
-        providerId: 'polymarket',
         signer: mockSigner,
       });
 
@@ -3564,7 +3557,6 @@ describe('PolymarketProvider', () => {
 
       // When preparing deposit
       const result = await provider.prepareDeposit({
-        providerId: 'polymarket',
         signer: mockSigner,
       });
 
@@ -3587,7 +3579,6 @@ describe('PolymarketProvider', () => {
       // Then it throws an error
       await expect(
         provider.prepareDeposit({
-          providerId: 'polymarket',
           signer: mockSigner,
         }),
       ).rejects.toThrow('Failed to get deploy proxy wallet transaction params');
@@ -3602,7 +3593,6 @@ describe('PolymarketProvider', () => {
 
       // When preparing deposit
       const result = await provider.prepareDeposit({
-        providerId: 'polymarket',
         signer: mockSigner,
       });
 
@@ -3624,7 +3614,6 @@ describe('PolymarketProvider', () => {
 
       await expect(
         provider.prepareDeposit({
-          providerId: 'polymarket',
           signer: mockSignerWithoutAddress,
         }),
       ).rejects.toThrow('Signer address is required');
@@ -3638,7 +3627,6 @@ describe('PolymarketProvider', () => {
 
       await expect(
         provider.prepareDeposit({
-          providerId: 'polymarket',
           signer: mockSigner,
         }),
       ).rejects.toThrow('Invalid deploy transaction: missing params');
@@ -3652,7 +3640,6 @@ describe('PolymarketProvider', () => {
 
       await expect(
         provider.prepareDeposit({
-          providerId: 'polymarket',
           signer: mockSigner,
         }),
       ).rejects.toThrow('Invalid allowance transaction: missing params');
@@ -3666,7 +3653,6 @@ describe('PolymarketProvider', () => {
 
       await expect(
         provider.prepareDeposit({
-          providerId: 'polymarket',
           signer: mockSigner,
         }),
       ).rejects.toThrow(
@@ -4032,7 +4018,6 @@ describe('PolymarketProvider', () => {
       // When getting balance
       const result = await provider.getBalance({
         address: '0x1234567890123456789012345678901234567890',
-        providerId: 'polymarket',
       });
 
       // Then balance is returned
@@ -4043,9 +4028,9 @@ describe('PolymarketProvider', () => {
     it('throws error when address is missing', async () => {
       const provider = createProvider();
 
-      await expect(
-        provider.getBalance({ address: '', providerId: 'polymarket' }),
-      ).rejects.toThrow('address is required');
+      await expect(provider.getBalance({ address: '' })).rejects.toThrow(
+        'address is required',
+      );
     });
 
     it('uses cached address when available', async () => {
@@ -4062,7 +4047,6 @@ describe('PolymarketProvider', () => {
 
       await provider.getBalance({
         address: userAddress,
-        providerId: 'polymarket',
       });
 
       expect(computeProxyAddress).not.toHaveBeenCalled();
@@ -4089,7 +4073,6 @@ describe('PolymarketProvider', () => {
 
       const result = await provider.prepareWithdraw({
         signer: mockSigner,
-        providerId: 'polymarket',
       });
 
       expect(result).toHaveProperty('chainId');
@@ -4109,7 +4092,6 @@ describe('PolymarketProvider', () => {
       await expect(
         provider.prepareWithdraw({
           signer: mockSigner,
-          providerId: 'polymarket',
         }),
       ).rejects.toThrow('Signer address is required');
     });
@@ -4128,7 +4110,6 @@ describe('PolymarketProvider', () => {
 
       const result = await provider.prepareWithdraw({
         signer: mockSigner,
-        providerId: 'polymarket',
       });
 
       expect(result.predictAddress).toBe('0xSafeAddress');

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -1,3 +1,4 @@
+import { POLYMARKET_PROVIDER_ID } from './constants';
 // Mock external dependencies
 jest.mock('../../../../../core/Engine', () => ({
   context: {
@@ -216,7 +217,7 @@ describe('PolymarketProvider', () => {
 
   it('exposes the correct providerId', () => {
     const provider = createProvider();
-    expect(provider.providerId).toBe('polymarket');
+    expect(provider.providerId).toBe(POLYMARKET_PROVIDER_ID);
   });
 
   it('getMarkets returns an array with some length', async () => {
@@ -373,7 +374,7 @@ describe('PolymarketProvider', () => {
     // Mock the parsed result
     const mockParsedPositions = [
       {
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'c-1',
         outcomeTokenId: 0,
         title: 'Some Market',
@@ -418,7 +419,7 @@ describe('PolymarketProvider', () => {
     });
 
     expect(result).toHaveLength(1);
-    expect(result[0].providerId).toBe('polymarket');
+    expect(result[0].providerId).toBe(POLYMARKET_PROVIDER_ID);
     expect(result[0].marketId).toBe('c-1');
     expect(result[0].outcomeTokenId).toBe(0);
     expect(mockParsePolymarketPositions).toHaveBeenCalledWith({
@@ -696,7 +697,7 @@ describe('PolymarketProvider', () => {
     const mockParsedPositions = [
       {
         id: 'pos-2',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'c-2',
         outcomeTokenId: 0,
         title: 'Another Market',
@@ -753,7 +754,7 @@ describe('PolymarketProvider', () => {
   ): PredictPosition {
     return {
       id: 'position-1',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       marketId: 'market-1',
       outcomeId: 'outcome-1',
       outcome: 'Yes',
@@ -817,7 +818,7 @@ describe('PolymarketProvider', () => {
 
     const mockMarket = {
       id: 'market-1',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       slug: 'test-market',
       title: 'Test Market',
       description: 'A test market for prediction',
@@ -960,7 +961,7 @@ describe('PolymarketProvider', () => {
     mockParsePolymarketEvents.mockReturnValue([
       {
         id: params.marketId,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         slug: 'test-market',
         title: 'Test Market',
         description: 'A test market',
@@ -970,7 +971,7 @@ describe('PolymarketProvider', () => {
         categories: [],
         outcomes: params.outcomes.map((outcome) => ({
           id: outcome.id,
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           marketId: params.marketId,
           title: outcome.title,
           description: outcome.title,
@@ -1003,7 +1004,7 @@ describe('PolymarketProvider', () => {
       const preview = createMockOrderPreview({ side: Side.BUY });
       const orderParams = {
         signer: mockSigner,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         preview,
       };
 
@@ -1024,7 +1025,7 @@ describe('PolymarketProvider', () => {
       const preview = createMockOrderPreview({ side: Side.SELL });
       const orderParams = {
         signer: mockSigner,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         preview,
       };
 
@@ -1050,7 +1051,7 @@ describe('PolymarketProvider', () => {
       const preview = createMockOrderPreview({ side: Side.BUY });
       const orderParams = {
         signer: mockSigner,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         preview,
       };
 
@@ -1069,7 +1070,7 @@ describe('PolymarketProvider', () => {
       const preview = createMockOrderPreview({ side: Side.BUY });
       const orderParams = {
         signer: mockSigner,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         preview,
       };
 
@@ -1103,7 +1104,7 @@ describe('PolymarketProvider', () => {
       const preview = createMockOrderPreview({ side: Side.SELL });
       const orderParams = {
         signer: mockSigner,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         preview,
       };
 
@@ -1127,7 +1128,7 @@ describe('PolymarketProvider', () => {
       const preview = createMockOrderPreview({ side: Side.BUY });
       const orderParams = {
         signer: mockSigner,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         preview,
       };
 
@@ -1173,7 +1174,7 @@ describe('PolymarketProvider', () => {
       const preview = createMockOrderPreview({ side: Side.BUY });
       const orderParams = {
         signer: mockSigner,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         preview,
       };
 
@@ -1196,7 +1197,7 @@ describe('PolymarketProvider', () => {
       const preview = createMockOrderPreview({ side: Side.SELL });
       const orderParams = {
         signer: mockSigner,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         preview,
       };
 
@@ -1368,7 +1369,7 @@ describe('PolymarketProvider', () => {
       const preview = createMockOrderPreview({ side: Side.BUY });
       const orderParams = {
         signer: mockSigner1,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         preview,
       };
 
@@ -1392,14 +1393,14 @@ describe('PolymarketProvider', () => {
       const preview1 = createMockOrderPreview({ side: Side.BUY });
       const orderParams1 = {
         signer: mockSigner1,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         preview: preview1,
       };
 
       const preview2 = createMockOrderPreview({ side: Side.SELL });
       const orderParams2 = {
         signer: mockSigner2,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         preview: preview2,
       };
 
@@ -1729,7 +1730,7 @@ describe('PolymarketProvider', () => {
       const { provider, signer } = setupPrepareClaimTest();
       const position = {
         id: 'position-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-1',
         outcomeId: 'outcome-456',
         outcomeIndex: 0,
@@ -1781,7 +1782,7 @@ describe('PolymarketProvider', () => {
       const { provider, signer } = setupPrepareClaimTest();
       const position = {
         id: 'position-2',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-2',
         outcomeId: 'outcome-789',
         outcomeIndex: 1,
@@ -1833,7 +1834,7 @@ describe('PolymarketProvider', () => {
       const { provider, signer } = setupPrepareClaimTest();
       const position = {
         id: 'position-3',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-3',
         outcomeId: 'outcome-123',
         outcomeIndex: 1,
@@ -1876,7 +1877,7 @@ describe('PolymarketProvider', () => {
 
       const position = {
         id: 'position-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-1',
         outcomeId: 'outcome-456',
         outcomeIndex: 0,
@@ -1932,7 +1933,7 @@ describe('PolymarketProvider', () => {
 
       const position = {
         id: 'position-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-1',
         outcomeId: 'outcome-456',
         outcomeIndex: 0,
@@ -1972,7 +1973,7 @@ describe('PolymarketProvider', () => {
 
       const position = {
         id: 'position-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-1',
         outcomeId: 'outcome-456',
         outcomeIndex: 0,
@@ -2021,7 +2022,7 @@ describe('PolymarketProvider', () => {
 
       const position = {
         id: 'position-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-1',
         outcomeId: 'outcome-456',
         outcomeIndex: 0,
@@ -2074,7 +2075,7 @@ describe('PolymarketProvider', () => {
 
       const position = {
         id: 'position-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-1',
         outcomeId: 'outcome-456',
         outcomeIndex: 0,
@@ -2127,7 +2128,7 @@ describe('PolymarketProvider', () => {
 
       const position = {
         id: 'position-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-1',
         outcomeId: 'outcome-456',
         outcomeIndex: 0,
@@ -2180,7 +2181,7 @@ describe('PolymarketProvider', () => {
 
       const position = {
         id: 'position-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-1',
         outcomeId: 'outcome-456',
         outcomeIndex: 0,
@@ -2233,7 +2234,7 @@ describe('PolymarketProvider', () => {
 
       const position = {
         id: 'position-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'market-1',
         outcomeId: 'outcome-456',
         outcomeIndex: 0,
@@ -2410,7 +2411,7 @@ describe('PolymarketProvider', () => {
       question: 'Will it rain tomorrow?',
       outcomes: ['YES', 'NO'],
       status: 'open',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
     };
 
     it('get market details successfully', async () => {
@@ -2496,7 +2497,7 @@ describe('PolymarketProvider', () => {
       question: `Question for ${id}?`,
       outcomes: ['YES', 'NO'],
       status: 'open',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
     });
 
     beforeEach(() => {
@@ -3149,7 +3150,7 @@ describe('PolymarketProvider', () => {
       });
 
       expect(result).toEqual({
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         results: [
           {
             marketId: 'market-1',
@@ -3267,7 +3268,10 @@ describe('PolymarketProvider', () => {
         ],
       });
 
-      expect(result).toEqual({ providerId: 'polymarket', results: [] });
+      expect(result).toEqual({
+        providerId: POLYMARKET_PROVIDER_ID,
+        results: [],
+      });
     });
 
     it('return empty object when fetch fails', async () => {
@@ -3284,7 +3288,10 @@ describe('PolymarketProvider', () => {
         ],
       });
 
-      expect(result).toEqual({ providerId: 'polymarket', results: [] });
+      expect(result).toEqual({
+        providerId: POLYMARKET_PROVIDER_ID,
+        results: [],
+      });
     });
 
     it('return empty object when invalid JSON response', async () => {
@@ -3305,7 +3312,10 @@ describe('PolymarketProvider', () => {
         ],
       });
 
-      expect(result).toEqual({ providerId: 'polymarket', results: [] });
+      expect(result).toEqual({
+        providerId: POLYMARKET_PROVIDER_ID,
+        results: [],
+      });
     });
 
     it('handle non-numeric price values', async () => {
@@ -3400,7 +3410,10 @@ describe('PolymarketProvider', () => {
         ],
       });
 
-      expect(result).toEqual({ providerId: 'polymarket', results: [] });
+      expect(result).toEqual({
+        providerId: POLYMARKET_PROVIDER_ID,
+        results: [],
+      });
     });
 
     it('handle BUY side correctly', async () => {
@@ -4518,19 +4531,19 @@ describe('PolymarketProvider', () => {
             id: 'position-1',
             outcomeTokenId: 'token-1',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
           {
             id: 'position-2',
             outcomeTokenId: 'token-2',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
           {
             id: 'position-3',
             outcomeTokenId: 'token-3',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
         ]);
 
@@ -4637,19 +4650,19 @@ describe('PolymarketProvider', () => {
             id: 'old-position',
             outcomeTokenId: 'token-old',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
           {
             id: 'new-sold-position',
             outcomeTokenId: 'token-new',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
           {
             id: 'visible-position',
             outcomeTokenId: 'token-visible',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
         ]);
 
@@ -4733,25 +4746,25 @@ describe('PolymarketProvider', () => {
             id: 'position-1',
             outcomeTokenId: 'token-1',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
           {
             id: 'position-2',
             outcomeTokenId: 'token-2',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
           {
             id: 'position-3',
             outcomeTokenId: 'token-3',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
           {
             id: 'position-4',
             outcomeTokenId: 'token-4',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
         ]);
 
@@ -4824,13 +4837,13 @@ describe('PolymarketProvider', () => {
             id: 'position-1',
             outcomeTokenId: 'token-1',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
           {
             id: 'position-2',
             outcomeTokenId: 'token-2',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
         ]);
 
@@ -4866,31 +4879,31 @@ describe('PolymarketProvider', () => {
             id: 'position-1',
             outcomeTokenId: 'token-1',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
           {
             id: 'position-2',
             outcomeTokenId: 'token-2',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
           {
             id: 'position-3',
             outcomeTokenId: 'token-3',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
           {
             id: 'position-4',
             outcomeTokenId: 'token-4',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
           {
             id: 'position-5',
             outcomeTokenId: 'token-5',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
         ]);
 
@@ -4921,7 +4934,7 @@ describe('PolymarketProvider', () => {
             id: 'position-1',
             outcomeTokenId: 'token-1',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
         ]);
 
@@ -4945,7 +4958,7 @@ describe('PolymarketProvider', () => {
         });
         const orderParams = {
           signer: mockSigner,
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           preview,
         };
 
@@ -4968,7 +4981,7 @@ describe('PolymarketProvider', () => {
             id: 'position-123',
             outcomeTokenId: 'token-123',
             marketId: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
           },
         ]);
 
@@ -4989,7 +5002,7 @@ describe('PolymarketProvider', () => {
         });
         const orderParams = {
           signer: mockSigner,
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
           preview,
         };
 
@@ -6572,7 +6585,7 @@ describe('PolymarketProvider', () => {
     it('exposes providerId property with value polymarket', () => {
       const provider = new PolymarketProvider();
 
-      expect(provider.providerId).toBe('polymarket');
+      expect(provider.providerId).toBe(POLYMARKET_PROVIDER_ID);
     });
   });
 
@@ -6645,7 +6658,7 @@ describe('PolymarketProvider', () => {
         const parsedMarket = {
           id: 'market-1',
           title: 'Test Market',
-          providerId: 'polymarket',
+          providerId: POLYMARKET_PROVIDER_ID,
         };
         mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
         mockParsePolymarketEvents.mockReturnValue([parsedMarket]);

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -424,7 +424,7 @@ export class PolymarketProvider implements PredictProvider {
    */
   public async getPrices({
     queries,
-  }: Omit<GetPriceParams, 'providerId'>): Promise<GetPriceResponse> {
+  }: GetPriceParams): Promise<GetPriceResponse> {
     if (!queries || queries.length === 0) {
       throw new Error('queries parameter is required and must not be empty');
     }
@@ -961,7 +961,7 @@ export class PolymarketProvider implements PredictProvider {
   }
 
   public async previewOrder(
-    params: Omit<PreviewOrderParams, 'providerId'> & {
+    params: PreviewOrderParams & {
       signer: Signer;
       feeCollection?: PredictFeeCollection;
     },
@@ -981,7 +981,7 @@ export class PolymarketProvider implements PredictProvider {
   }
 
   public async placeOrder(
-    params: Omit<PlaceOrderParams, 'providerId'> & { signer: Signer },
+    params: PlaceOrderParams & { signer: Signer },
   ): Promise<OrderResult> {
     const { signer, preview } = params;
     const {

--- a/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
+++ b/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
@@ -5,6 +5,7 @@ import { PredictSportsLeague } from '../../types';
 import { PolymarketApiTeam } from './types';
 import { getPolymarketEndpoints } from './utils';
 
+import { POLYMARKET_PROVIDER_ID } from './constants';
 const TEAM_COLOR_OVERRIDES: Record<string, string> = {
   ne: '#1D4E9B',
   sea: '#5BA423',
@@ -93,7 +94,7 @@ export class TeamsCache {
         DevLogger.log(`[TeamsCache] ${errorMessage}`);
         Logger.error(new Error(errorMessage), {
           feature: 'predict',
-          provider: 'polymarket',
+          provider: POLYMARKET_PROVIDER_ID,
           method: 'TeamsCache.fetchAndCacheTeams',
           league,
           statusCode: response.status,
@@ -108,7 +109,7 @@ export class TeamsCache {
         DevLogger.log(`[TeamsCache] ${errorMessage}`);
         Logger.error(new Error(errorMessage), {
           feature: 'predict',
-          provider: 'polymarket',
+          provider: POLYMARKET_PROVIDER_ID,
           method: 'TeamsCache.fetchAndCacheTeams',
           league,
         });
@@ -136,7 +137,7 @@ export class TeamsCache {
       );
       Logger.error(error instanceof Error ? error : new Error(String(error)), {
         feature: 'predict',
-        provider: 'polymarket',
+        provider: POLYMARKET_PROVIDER_ID,
         method: 'TeamsCache.fetchAndCacheTeams',
         league,
       });

--- a/app/components/UI/Predict/providers/polymarket/safe/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/safe/utils.test.ts
@@ -1,6 +1,6 @@
 import { Interface } from 'ethers/lib/utils';
 import Engine from '../../../../../../core/Engine';
-import { MATIC_CONTRACTS, POLYGON_MAINNET_CHAIN_ID } from '../constants';
+import { MATIC_CONTRACTS, POLYGON_MAINNET_CHAIN_ID , POLYMARKET_PROVIDER_ID } from '../constants';
 import { SAFE_FACTORY_ADDRESS, SAFE_MULTISEND_ADDRESS } from './constants';
 import {
   computeProxyAddress,
@@ -694,7 +694,7 @@ describe('safe utils', () => {
   describe('createClaimSafeTransaction', () => {
     const mockPosition: PredictPosition = {
       id: 'position-1',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       marketId: 'market-1',
       outcomeId: 'outcome-1',
       outcome: 'YES',
@@ -1029,7 +1029,7 @@ describe('safe utils', () => {
   describe('getClaimTransaction', () => {
     const mockPosition: PredictPosition = {
       id: 'position-1',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       marketId: 'market-1',
       outcomeId: 'outcome-1',
       outcome: 'YES',

--- a/app/components/UI/Predict/providers/polymarket/safe/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/safe/utils.test.ts
@@ -1,6 +1,10 @@
 import { Interface } from 'ethers/lib/utils';
 import Engine from '../../../../../../core/Engine';
-import { MATIC_CONTRACTS, POLYGON_MAINNET_CHAIN_ID , POLYMARKET_PROVIDER_ID } from '../constants';
+import {
+  MATIC_CONTRACTS,
+  POLYGON_MAINNET_CHAIN_ID,
+  POLYMARKET_PROVIDER_ID,
+} from '../constants';
 import { SAFE_FACTORY_ADDRESS, SAFE_MULTISEND_ADDRESS } from './constants';
 import {
   computeProxyAddress,

--- a/app/components/UI/Predict/providers/polymarket/safe/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/safe/utils.ts
@@ -28,7 +28,7 @@ import {
   MATIC_CONTRACTS,
   MIN_COLLATERAL_BALANCE_FOR_CLAIM,
   POLYGON_MAINNET_CHAIN_ID,
-} from '../constants';
+ POLYMARKET_PROVIDER_ID } from '../constants';
 import {
   encodeApprove,
   encodeClaim,
@@ -400,7 +400,7 @@ export const getDeployProxyWalletTransaction = async ({
     const errorContext: LoggerErrorOptions = {
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        provider: 'polymarket',
+        provider: POLYMARKET_PROVIDER_ID,
       },
       context: {
         name: 'safeUtils',
@@ -604,7 +604,7 @@ export const getProxyWalletAllowancesTransaction = async ({
     const errorContext: LoggerErrorOptions = {
       tags: {
         feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        provider: 'polymarket',
+        provider: POLYMARKET_PROVIDER_ID,
       },
       context: {
         name: 'safeUtils',

--- a/app/components/UI/Predict/providers/polymarket/safe/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/safe/utils.ts
@@ -28,7 +28,8 @@ import {
   MATIC_CONTRACTS,
   MIN_COLLATERAL_BALANCE_FOR_CLAIM,
   POLYGON_MAINNET_CHAIN_ID,
- POLYMARKET_PROVIDER_ID } from '../constants';
+  POLYMARKET_PROVIDER_ID,
+} from '../constants';
 import {
   encodeApprove,
   encodeClaim,

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -18,7 +18,7 @@ import {
   MATIC_CONTRACTS,
   MSG_TO_SIGN,
   POLYGON_MAINNET_CHAIN_ID,
-} from './constants';
+ POLYMARKET_PROVIDER_ID } from './constants';
 import { DEFAULT_FEE_COLLECTION_FLAG } from '../../constants/flags';
 import {
   ApiKeyCreds,
@@ -982,7 +982,7 @@ describe('polymarket utils', () => {
       expect(result[0]).toEqual({
         id: 'event-1',
         slug: 'test-event',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         title: 'Test Event',
         description: 'A test event',
         image: 'https://example.com/icon.png',
@@ -994,7 +994,7 @@ describe('polymarket utils', () => {
         outcomes: [
           {
             id: 'market-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             marketId: 'event-1',
             title: 'Will it rain?',
             description: 'Weather prediction',
@@ -1916,7 +1916,7 @@ describe('polymarket utils', () => {
 
       expect(result).toEqual({
         id: 'market-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'event-1',
         title: 'Will it rain?',
         description: 'Weather prediction',
@@ -2118,7 +2118,7 @@ describe('polymarket utils', () => {
 
       expect(result[0]).toEqual({
         id: 'position-1',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'event-1',
         outcomeId: 'condition-1',
         outcome: 'Yes',
@@ -2143,7 +2143,7 @@ describe('polymarket utils', () => {
 
       expect(result[1]).toEqual({
         id: 'position-2',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'event-1',
         outcomeId: 'condition-1',
         outcome: 'No',
@@ -2168,7 +2168,7 @@ describe('polymarket utils', () => {
 
       expect(result[2]).toEqual({
         id: 'position-3',
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         marketId: 'event-1',
         outcomeId: 'condition-1',
         outcome: 'Maybe',

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -18,7 +18,8 @@ import {
   MATIC_CONTRACTS,
   MSG_TO_SIGN,
   POLYGON_MAINNET_CHAIN_ID,
- POLYMARKET_PROVIDER_ID } from './constants';
+  POLYMARKET_PROVIDER_ID,
+} from './constants';
 import { DEFAULT_FEE_COLLECTION_FLAG } from '../../constants/flags';
 import {
   ApiKeyCreds,

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -2281,7 +2281,6 @@ describe('polymarket utils', () => {
       });
 
       const params: GetMarketsParams = {
-        providerId: 'polymarket',
         q: 'weather',
         limit: 10,
         offset: 5,
@@ -2312,7 +2311,6 @@ describe('polymarket utils', () => {
       });
 
       const params: GetMarketsParams = {
-        providerId: 'polymarket',
         q: 'nhl',
         limit: 10,
         offset: 0,
@@ -2339,7 +2337,6 @@ describe('polymarket utils', () => {
       });
 
       const params: GetMarketsParams = {
-        providerId: 'polymarket',
         q: 'nhl',
         limit: 10,
         offset: 0,
@@ -2362,7 +2359,6 @@ describe('polymarket utils', () => {
       });
 
       const params: GetMarketsParams = {
-        providerId: 'polymarket',
         category: 'crypto',
         limit: 5,
       };

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -43,7 +43,7 @@ import {
   ROUNDING_CONFIG,
   SLIPPAGE_BUY,
   SLIPPAGE_SELL,
-} from './constants';
+ POLYMARKET_PROVIDER_ID } from './constants';
 import { SafeFeeAuthorization } from './safe/types';
 import {
   ApiKeyCreds,
@@ -595,7 +595,7 @@ export const parsePolymarketMarket = (
   event: PolymarketApiEvent,
 ): PredictOutcome => ({
   id: market.conditionId,
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: event.id,
   title: market.question,
   description: market.description,
@@ -658,7 +658,7 @@ export const parsePolymarketEvents = (
       return {
         id: event.id,
         slug: event.slug,
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         title: event.title,
         description: event.description,
         image: event.icon,
@@ -720,7 +720,7 @@ export const parsePolymarketActivity = (
 
     const parsedActivity: PredictActivity = {
       id,
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       entry:
         entryType === 'claimWinnings'
           ? { type: 'claimWinnings', timestamp, amount }
@@ -904,7 +904,7 @@ export const parsePolymarketPositions = async ({
   const parsedPositions: PredictPosition[] = positions.map(
     (position: PolymarketPosition) => ({
       id: position.asset,
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       marketId: position.eventId,
       outcomeId: position.conditionId,
       outcome: position.outcome,

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -43,7 +43,8 @@ import {
   ROUNDING_CONFIG,
   SLIPPAGE_BUY,
   SLIPPAGE_SELL,
- POLYMARKET_PROVIDER_ID } from './constants';
+  POLYMARKET_PROVIDER_ID,
+} from './constants';
 import { SafeFeeAuthorization } from './safe/types';
 import {
   ApiKeyCreds,

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -26,8 +26,6 @@ export interface ConnectionStatus {
 }
 
 export interface GetMarketsParams {
-  providerId?: string;
-
   // Filters
   q?: string;
   status?: 'open' | 'closed' | 'resolved';
@@ -55,7 +53,6 @@ export interface Signer {
 }
 
 export interface PlaceOrderParams {
-  providerId: string;
   preview: OrderPreview;
   analyticsProperties?: {
     marketId?: string;
@@ -80,7 +77,6 @@ export interface PlaceOrderParams {
 }
 
 export interface PreviewOrderParams {
-  providerId: string;
   marketId: string;
   outcomeId: string;
   outcomeTokenId: string;
@@ -164,7 +160,6 @@ export interface ClaimOrderResponse {
 }
 
 export interface GetPositionsParams {
-  providerId?: string;
   address?: string;
   claimable?: boolean;
   marketId?: string;
@@ -173,13 +168,11 @@ export interface GetPositionsParams {
   offset?: number;
 }
 
-export interface PrepareDepositParams {
-  providerId: string;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface PrepareDepositParams {}
 
-export interface GetAccountStateParams {
-  providerId: string;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface GetAccountStateParams {}
 
 export interface PrepareDepositResponse {
   chainId: Hex;
@@ -192,9 +185,8 @@ export interface PrepareDepositResponse {
   }[];
 }
 
-export interface GetPredictWalletParams {
-  providerId: string;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface GetPredictWalletParams {}
 
 export interface AccountState {
   address: Hex;
@@ -204,12 +196,10 @@ export interface AccountState {
 
 export interface GetBalanceParams {
   address?: string;
-  providerId: string;
 }
 
-export interface PrepareWithdrawParams {
-  providerId: string;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface PrepareWithdrawParams {}
 
 export interface PrepareWithdrawResponse {
   chainId: Hex;
@@ -251,13 +241,11 @@ export interface PredictProvider {
   getPriceHistory(
     params: GetPriceHistoryParams,
   ): Promise<PredictPriceHistoryPoint[]>;
-  getPrices(
-    params: Omit<GetPriceParams, 'providerId'>,
-  ): Promise<GetPriceResponse>;
+  getPrices(params: GetPriceParams): Promise<GetPriceResponse>;
 
   // User information
   getPositions(
-    params: Omit<GetPositionsParams, 'address'> & { address: string },
+    params: GetPositionsParams & { address: string },
   ): Promise<PredictPosition[]>;
   getActivity(params: { address: string }): Promise<PredictActivity[]>;
   getUnrealizedPnL(params: {
@@ -266,13 +254,13 @@ export interface PredictProvider {
 
   // Order management
   previewOrder(
-    params: Omit<PreviewOrderParams, 'providerId'> & {
+    params: PreviewOrderParams & {
       signer: Signer;
       feeCollection?: PredictFeeCollection;
     },
   ): Promise<OrderPreview>;
   placeOrder(
-    params: Omit<PlaceOrderParams, 'providerId'> & { signer: Signer },
+    params: PlaceOrderParams & { signer: Signer },
   ): Promise<OrderResult>;
 
   // Claim management

--- a/app/components/UI/Predict/selectors/predictController/index.test.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.test.ts
@@ -705,7 +705,6 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector = selectPredictBalanceByAddress({
-        providerId: 'polymarket',
         address: '0x123',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -735,7 +734,6 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector = selectPredictBalanceByAddress({
-        providerId: 'nonexistent',
         address: '0x123',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -765,7 +763,6 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector = selectPredictBalanceByAddress({
-        providerId: 'polymarket',
         address: '0xnonexistent',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -786,7 +783,6 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector = selectPredictBalanceByAddress({
-        providerId: 'polymarket',
         address: '0x123',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -805,7 +801,6 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector = selectPredictBalanceByAddress({
-        providerId: 'polymarket',
         address: '0x123',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -849,14 +844,12 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector1 = selectPredictBalanceByAddress({
-        providerId: 'polymarket',
         address: '0x456',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result1 = selector1(mockState as any);
 
       const selector2 = selectPredictBalanceByAddress({
-        providerId: 'kalshi',
         address: '0xdef',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -887,7 +880,6 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector = selectPredictBalanceByAddress({
-        providerId: 'polymarket',
         address: '0x123',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/components/UI/Predict/selectors/predictController/index.test.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.test.ts
@@ -12,6 +12,7 @@ import {
 } from './index';
 import { PredictPosition, PredictPositionStatus } from '../../types';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 describe('Predict Controller Selectors', () => {
   describe('selectPredictControllerState', () => {
     it('selects the PredictController state', () => {
@@ -101,7 +102,7 @@ describe('Predict Controller Selectors', () => {
         [testAddress]: [
           {
             id: 'pos-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             marketId: 'market-1',
             outcomeId: 'outcome-1',
             outcome: 'Yes',
@@ -180,7 +181,7 @@ describe('Predict Controller Selectors', () => {
         [testAddress]: [
           {
             id: 'pos-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             marketId: 'market-1',
             outcomeId: 'outcome-1',
             outcome: 'Yes',
@@ -202,7 +203,7 @@ describe('Predict Controller Selectors', () => {
           },
           {
             id: 'pos-2',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             marketId: 'market-2',
             outcomeId: 'outcome-2',
             outcome: 'No',
@@ -251,7 +252,7 @@ describe('Predict Controller Selectors', () => {
         [testAddress]: [
           {
             id: 'pos-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             marketId: 'market-1',
             outcomeId: 'outcome-1',
             outcome: 'Yes',
@@ -322,7 +323,7 @@ describe('Predict Controller Selectors', () => {
         [testAddress]: [
           {
             id: 'pos-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             marketId: 'market-1',
             outcomeId: 'outcome-1',
             outcome: 'Yes',
@@ -344,7 +345,7 @@ describe('Predict Controller Selectors', () => {
           },
           {
             id: 'pos-2',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             marketId: 'market-2',
             outcomeId: 'outcome-2',
             outcome: 'Yes',
@@ -413,7 +414,7 @@ describe('Predict Controller Selectors', () => {
         [testAddress]: [
           {
             id: 'pos-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             marketId: 'market-1',
             outcomeId: 'outcome-1',
             outcome: 'Yes',
@@ -462,7 +463,7 @@ describe('Predict Controller Selectors', () => {
         [testAddress]: [
           {
             id: 'pos-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             marketId: 'market-1',
             outcomeId: 'outcome-1',
             outcome: 'Yes',
@@ -484,7 +485,7 @@ describe('Predict Controller Selectors', () => {
           },
           {
             id: 'pos-2',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             marketId: 'market-2',
             outcomeId: 'outcome-2',
             outcome: 'Yes',
@@ -553,7 +554,7 @@ describe('Predict Controller Selectors', () => {
         [testAddress]: [
           {
             id: 'pos-1',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             marketId: 'market-1',
             outcomeId: 'outcome-1',
             outcome: 'Yes',
@@ -996,7 +997,7 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector = selectPredictAccountMetaByAddress({
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         address: '0x123',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1025,7 +1026,7 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector = selectPredictAccountMetaByAddress({
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         address: '0x123',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1083,7 +1084,7 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector = selectPredictAccountMetaByAddress({
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         address: '0xNonExistent',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1102,7 +1103,7 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector = selectPredictAccountMetaByAddress({
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         address: '0x123',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1142,7 +1143,7 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector1 = selectPredictAccountMetaByAddress({
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         address: '0x456',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1179,7 +1180,7 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector = selectPredictAccountMetaByAddress({
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         address: '0x123',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1200,7 +1201,7 @@ describe('Predict Controller Selectors', () => {
       };
 
       const selector = selectPredictAccountMetaByAddress({
-        providerId: 'polymarket',
+        providerId: POLYMARKET_PROVIDER_ID,
         address: '0x123',
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/components/UI/Predict/selectors/predictController/index.test.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.test.ts
@@ -42,9 +42,7 @@ describe('Predict Controller Selectors', () => {
   describe('selectPredictPendingDeposits', () => {
     it('returns deposit transaction when it exists', () => {
       const pendingDeposits = {
-        polymarket: {
-          '0x123': true,
-        },
+        '0x123': true,
       };
 
       const mockState = {
@@ -600,12 +598,17 @@ describe('Predict Controller Selectors', () => {
   describe('selectPredictBalances', () => {
     it('returns balances when they exist', () => {
       const balances = {
-        polymarket: {
-          '0x123': 1000,
-          '0x456': 2000,
+        '0x123': {
+          balance: 1000,
+          validUntil: Date.now() + 1000,
         },
-        kalshi: {
-          '0xabc': 500,
+        '0x456': {
+          balance: 2000,
+          validUntil: Date.now() + 1000,
+        },
+        '0xabc': {
+          balance: 500,
+          validUntil: Date.now() + 1000,
         },
       };
 
@@ -674,23 +677,19 @@ describe('Predict Controller Selectors', () => {
   });
 
   describe('selectPredictBalanceByAddress', () => {
-    it('returns balance for specified provider and address', () => {
+    it('returns balance for specified address', () => {
       const balances = {
-        polymarket: {
-          '0x123': {
-            balance: 1000,
-            validUntil: Date.now() + 1000,
-          },
-          '0x456': {
-            balance: 2000,
-            validUntil: Date.now() + 1000,
-          },
+        '0x123': {
+          balance: 1000,
+          validUntil: Date.now() + 1000,
         },
-        kalshi: {
-          '0xabc': {
-            balance: 500,
-            validUntil: Date.now() + 1000,
-          },
+        '0x456': {
+          balance: 2000,
+          validUntil: Date.now() + 1000,
+        },
+        '0xabc': {
+          balance: 500,
+          validUntil: Date.now() + 1000,
         },
       };
 
@@ -713,13 +712,11 @@ describe('Predict Controller Selectors', () => {
       expect(result).toBe(1000);
     });
 
-    it('returns zero when provider does not exist', () => {
+    it('returns balance for existing address', () => {
       const balances = {
-        polymarket: {
-          '0x123': {
-            balance: 1000,
-            validUntil: Date.now() + 1000,
-          },
+        '0x123': {
+          balance: 1000,
+          validUntil: Date.now() + 1000,
         },
       };
 
@@ -739,16 +736,14 @@ describe('Predict Controller Selectors', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = selector(mockState as any);
 
-      expect(result).toBe(0);
+      expect(result).toBe(1000);
     });
 
-    it('returns zero when address does not exist for provider', () => {
+    it('returns zero when address does not exist', () => {
       const balances = {
-        polymarket: {
-          '0x123': {
-            balance: 1000,
-            validUntil: Date.now() + 1000,
-          },
+        '0x123': {
+          balance: 1000,
+          validUntil: Date.now() + 1000,
         },
       };
 
@@ -809,27 +804,23 @@ describe('Predict Controller Selectors', () => {
       expect(result).toBe(0);
     });
 
-    it('returns correct balance for different provider and address combinations', () => {
+    it('returns correct balance for different addresses', () => {
       const balances = {
-        polymarket: {
-          '0x123': {
-            balance: 1000,
-            validUntil: Date.now() + 1000,
-          },
-          '0x456': {
-            balance: 2000,
-            validUntil: Date.now() + 1000,
-          },
+        '0x123': {
+          balance: 1000,
+          validUntil: Date.now() + 1000,
         },
-        kalshi: {
-          '0xabc': {
-            balance: 500,
-            validUntil: Date.now() + 1000,
-          },
-          '0xdef': {
-            balance: 750,
-            validUntil: Date.now() + 1000,
-          },
+        '0x456': {
+          balance: 2000,
+          validUntil: Date.now() + 1000,
+        },
+        '0xabc': {
+          balance: 500,
+          validUntil: Date.now() + 1000,
+        },
+        '0xdef': {
+          balance: 750,
+          validUntil: Date.now() + 1000,
         },
       };
 
@@ -861,11 +852,9 @@ describe('Predict Controller Selectors', () => {
 
     it('returns zero for balance with value of zero', () => {
       const balances = {
-        polymarket: {
-          '0x123': {
-            balance: 0,
-            validUntil: Date.now() + 1000,
-          },
+        '0x123': {
+          balance: 0,
+          validUntil: Date.now() + 1000,
         },
       };
 

--- a/app/components/UI/Predict/selectors/predictController/index.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.ts
@@ -49,28 +49,20 @@ const selectPredictBalances = createSelector(
   (predictControllerState) => predictControllerState?.balances || {},
 );
 
-const selectPredictBalanceByAddress = ({
-  providerId,
-  address,
-}: {
-  providerId: string;
-  address: string;
-}) =>
+const selectPredictBalanceByAddress = ({ address }: { address: string }) =>
   createSelector(
     selectPredictBalances,
-    (balances) => balances[providerId]?.[address]?.balance || 0,
+    (balances) => balances[address]?.balance || 0,
   );
 
 const selectPredictPendingDepositByAddress = ({
-  providerId,
   address,
 }: {
-  providerId: string;
   address: string;
 }) =>
   createSelector(
     selectPredictPendingDeposits,
-    (pendingDeposits) => pendingDeposits[providerId]?.[address] || undefined,
+    (pendingDeposits) => pendingDeposits[address] || undefined,
   );
 
 const selectPredictAccountMeta = createSelector(

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -18,7 +18,6 @@ export enum PredictPriceHistoryInterval {
 
 export interface GetPositionsParams {
   address?: string;
-  providerId?: string;
 }
 
 export enum PredictMarketStatus {
@@ -278,7 +277,6 @@ export interface PredictPriceHistoryPoint {
 
 export interface GetPriceHistoryParams {
   marketId: string;
-  providerId?: string;
   fidelity?: number;
   interval?: PredictPriceHistoryInterval;
   startTs?: number;
@@ -289,7 +287,6 @@ export interface GetPriceHistoryParams {
  * Parameters for fetching prices from CLOB /prices endpoint
  */
 export interface GetPriceParams {
-  providerId: string;
   queries: PriceQuery[];
 }
 
@@ -354,9 +351,8 @@ export type PredictBalance = {
   validUntil: number;
 };
 
-export interface ClaimParams {
-  providerId: string;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ClaimParams {}
 
 export interface GetMarketPriceResponse {
   price: number;

--- a/app/components/UI/Predict/utils/validateTransactions.test.ts
+++ b/app/components/UI/Predict/utils/validateTransactions.test.ts
@@ -3,6 +3,7 @@ import { Hex } from '@metamask/utils';
 import Logger from '../../../../util/Logger';
 import { validateDepositTransactions } from './validateTransactions';
 
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 jest.mock('../../../../util/Logger', () => ({
   error: jest.fn(),
 }));
@@ -24,7 +25,7 @@ function createValidTransaction(overrides = {}) {
 }
 
 describe('validateDepositTransactions', () => {
-  const context = { providerId: 'polymarket' };
+  const context = { providerId: POLYMARKET_PROVIDER_ID };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -164,13 +165,13 @@ describe('validateDepositTransactions', () => {
       expect.objectContaining({
         tags: expect.objectContaining({
           feature: 'Predict',
-          provider: 'polymarket',
+          provider: POLYMARKET_PROVIDER_ID,
         }),
         context: expect.objectContaining({
           name: 'PredictController',
           data: expect.objectContaining({
             method: 'depositWithConfirmation',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             transactionIndex: 0,
           }),
         }),

--- a/app/components/UI/Predict/utils/validateTransactions.ts
+++ b/app/components/UI/Predict/utils/validateTransactions.ts
@@ -3,6 +3,7 @@ import { Hex } from '@metamask/utils';
 import Logger, { type LoggerErrorOptions } from '../../../../util/Logger';
 import { PREDICT_CONSTANTS } from '../constants/errors';
 
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 const MIN_VALID_DATA_LENGTH = 10;
 const VALID_ADDRESS_LENGTH = 42;
 
@@ -25,7 +26,7 @@ function getErrorContext(
   return {
     tags: {
       feature: PREDICT_CONSTANTS.FEATURE_NAME,
-      provider: 'polymarket',
+      provider: POLYMARKET_PROVIDER_ID,
     },
     context: {
       name: 'PredictController',

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -12,6 +12,7 @@ import PredictBuyPreview from './PredictBuyPreview';
 import { PredictNavigationParamList } from '../../types/navigation';
 import { PredictEventValues } from '../../constants/eventNames';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 // Mock Engine
 jest.mock('../../../../../core/Engine', () => ({
   context: {
@@ -160,7 +161,7 @@ jest.mock('../../utils/format', () => ({
 
 const mockMarket: PredictMarket = {
   id: 'market-123',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   slug: 'bitcoin-price',
   title: 'Will Bitcoin reach $150,000?',
   description: 'Market description',
@@ -174,7 +175,7 @@ const mockMarket: PredictMarket = {
     {
       id: 'outcome-456',
       marketId: 'market-123',
-      providerId: 'polymarket',
+      providerId: POLYMARKET_PROVIDER_ID,
       title: 'Bitcoin Price Outcome',
       description: 'Outcome description',
       image: 'https://example.com/outcome.png',
@@ -393,7 +394,7 @@ describe('PredictBuyPreview', () => {
           {
             id: 'outcome-457',
             marketId: 'market-123',
-            providerId: 'polymarket',
+            providerId: POLYMARKET_PROVIDER_ID,
             title: 'Second Outcome',
             description: 'Second outcome description',
             image: 'https://example.com/outcome2.png',

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -118,14 +118,11 @@ const PredictBuyPreview = () => {
   } = usePredictPlaceOrder();
 
   const { balance, isLoading: isBalanceLoading } = usePredictBalance({
-    providerId: outcome.providerId,
     loadOnMount: true,
     refreshOnFocus: true,
   });
 
-  const { deposit } = usePredictDeposit({
-    providerId: outcome.providerId,
-  });
+  const { deposit } = usePredictDeposit();
 
   const [currentValue, setCurrentValue] = useState(0);
   const [currentValueUSDString, setCurrentValueUSDString] = useState('');
@@ -139,7 +136,6 @@ const PredictBuyPreview = () => {
     error: previewError,
     isCalculating,
   } = usePredictOrderPreview({
-    providerId: outcome.providerId,
     marketId: market.id,
     outcomeId: outcome.id,
     outcomeTokenId: outcomeToken.id,
@@ -156,7 +152,6 @@ const PredictBuyPreview = () => {
   } = usePredictOrderRetry({
     preview,
     placeOrder,
-    providerId: outcome.providerId,
     analyticsProperties,
     isOrderNotFilled,
     resetOrderNotFilled,
@@ -205,7 +200,6 @@ const PredictBuyPreview = () => {
     controller.trackPredictOrderEvent({
       status: PredictTradeStatus.INITIATED,
       analyticsProperties,
-      providerId: outcome.providerId,
       sharePrice: outcomeToken?.price,
     });
     // eslint-disable-next-line react-compiler/react-compiler
@@ -263,17 +257,10 @@ const PredictBuyPreview = () => {
     if (!preview || isBelowMinimum) return;
 
     await placeOrder({
-      providerId: outcome.providerId,
       analyticsProperties,
       preview,
     });
-  }, [
-    preview,
-    isBelowMinimum,
-    placeOrder,
-    outcome.providerId,
-    analyticsProperties,
-  ]);
+  }, [preview, isBelowMinimum, placeOrder, analyticsProperties]);
 
   const handleFeesInfoPress = useCallback(() => {
     setIsFeeBreakdownVisible(true);

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -3165,7 +3165,7 @@ describe('PredictMarketDetails', () => {
       expect(usePredictPrices).toHaveBeenCalled();
     });
 
-    it('uses usePredictPrices hook with providerId', () => {
+    it('uses usePredictPrices hook for live pricing', () => {
       const { usePredictPrices } = jest.requireMock(
         '../../hooks/usePredictPrices',
       );
@@ -3174,7 +3174,7 @@ describe('PredictMarketDetails', () => {
 
       expect(usePredictPrices).toHaveBeenCalledWith(
         expect.objectContaining({
-          providerId: 'polymarket',
+          queries: expect.any(Array),
         }),
       );
     });

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -16,6 +16,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { PredictEventValues } from '../../constants/eventNames';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 const runAfterInteractionsCallbacks: (() => void)[] = [];
 const mockRunAfterInteractions = jest.spyOn(
   InteractionManager,
@@ -322,7 +323,7 @@ function createMockMarket(overrides = {}) {
     title: 'Will Bitcoin reach $100k by end of 2024?',
     image: 'https://example.com/bitcoin.png',
     endDate: '2024-12-31T23:59:59Z',
-    providerId: 'polymarket',
+    providerId: POLYMARKET_PROVIDER_ID,
     status: 'open',
     tags: [],
     outcomes: [

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -68,10 +68,8 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
 
   const { marketId, entryPoint, title, image } = route.params || {};
   const resolvedMarketId = marketId;
-  const providerId = 'polymarket';
 
   const { executeGuardedAction } = usePredictActionGuard({
-    providerId,
     navigation,
   });
 
@@ -81,7 +79,6 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     refetch: refetchMarket,
   } = usePredictMarket({
     id: resolvedMarketId,
-    providerId,
     enabled: Boolean(resolvedMarketId),
   });
 
@@ -177,11 +174,10 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     isPriceHistoryFetching,
     refetchPriceHistory,
     timeframes,
-  } = useChartData({ market, hasAnyOutcomeToken, providerId });
+  } = useChartData({ market, hasAnyOutcomeToken });
 
   const { closedOutcomes, openOutcomes, yesPercentage } = useOpenOutcomes({
     market,
-    providerId,
     isMarketFetching,
   });
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/hooks/useChartData.ts
+++ b/app/components/UI/Predict/views/PredictMarketDetails/hooks/useChartData.ts
@@ -42,7 +42,6 @@ const MAX_INTERVAL_SHORT_RANGE_FIDELITY =
 interface UseChartDataParams {
   market: PredictMarket | null;
   hasAnyOutcomeToken: boolean;
-  providerId: string;
 }
 
 interface UseChartDataResult {
@@ -59,7 +58,6 @@ interface UseChartDataResult {
 export const useChartData = ({
   market,
   hasAnyOutcomeToken,
-  providerId,
 }: UseChartDataParams): UseChartDataResult => {
   const { colors } = useTheme();
   const [selectedTimeframe, setSelectedTimeframe] =
@@ -113,7 +111,6 @@ export const useChartData = ({
   } = usePredictPriceHistory({
     marketIds: chartOutcomeTokenIds,
     interval: selectedTimeframe,
-    providerId,
     fidelity: selectedFidelity,
     enabled: chartOutcomeTokenIds.length > 0,
   });

--- a/app/components/UI/Predict/views/PredictMarketDetails/hooks/useOpenOutcomes.ts
+++ b/app/components/UI/Predict/views/PredictMarketDetails/hooks/useOpenOutcomes.ts
@@ -4,7 +4,6 @@ import type { PriceQuery, PredictMarket, PredictOutcome } from '../../../types';
 
 interface UseOpenOutcomesParams {
   market: PredictMarket | null;
-  providerId: string;
   isMarketFetching: boolean;
 }
 
@@ -16,7 +15,6 @@ interface UseOpenOutcomesResult {
 
 export const useOpenOutcomes = ({
   market,
-  providerId,
   isMarketFetching,
 }: UseOpenOutcomesParams): UseOpenOutcomesResult => {
   const closedOutcomes = useMemo(
@@ -46,7 +44,6 @@ export const useOpenOutcomes = ({
   // fetch real-time prices once after market loads
   const { prices } = usePredictPrices({
     queries: priceQueries,
-    providerId,
     enabled: !isMarketFetching && priceQueries.length > 0,
   });
 

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
@@ -371,7 +371,7 @@ describe('PredictSellPreview', () => {
   });
 
   describe('user interactions', () => {
-    it('invokes placeOrder with correct parameters when cash out button pressed', async () => {
+    it('invokes placeOrder with correct parameters when cash out button pressed', () => {
       mockPlaceOrderResult = {
         success: true,
         response: { transactionHash: '0xabc123' },
@@ -384,10 +384,9 @@ describe('PredictSellPreview', () => {
       );
       const cashOutButton = getByTestId('predict-sell-preview-cash-out-button');
 
-      await fireEvent.press(cashOutButton);
+      fireEvent.press(cashOutButton);
 
       expect(mockPlaceOrder).toHaveBeenCalledWith({
-        providerId: 'polymarket',
         analyticsProperties: expect.objectContaining({
           marketId: 'market-123',
           marketTitle: 'Will Bitcoin reach $150,000?',
@@ -499,7 +498,7 @@ describe('PredictSellPreview', () => {
   });
 
   describe('navigation after successful order', () => {
-    it('dispatches navigation pop action when placeOrder succeeds', async () => {
+    it('dispatches navigation pop action when placeOrder succeeds', () => {
       mockPlaceOrderResult = {
         success: true,
         response: { transactionHash: '0xabc123' },
@@ -512,7 +511,7 @@ describe('PredictSellPreview', () => {
       );
       const cashOutButton = getByTestId('predict-sell-preview-cash-out-button');
 
-      await fireEvent.press(cashOutButton);
+      fireEvent.press(cashOutButton);
 
       expect(mockPlaceOrder).toHaveBeenCalled();
       rerender(<PredictSellPreview />);

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
@@ -16,6 +16,7 @@ import {
 import { PredictNavigationParamList } from '../../types/navigation';
 import PredictSellPreview from './PredictSellPreview';
 
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 /**
  * Mock Strategy:
  * - Only mock external dependencies (Engine, Alert, navigation, hooks with API calls)
@@ -145,7 +146,7 @@ jest.mock('../../hooks/usePredictOrderPreview', () => ({
 
 const mockPosition: PredictPosition = {
   id: 'position-1',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-1',
   outcomeId: 'outcome-456',
   outcome: 'Yes',
@@ -169,7 +170,7 @@ const mockPosition: PredictPosition = {
 
 const mockOutcome: PredictOutcome = {
   id: 'outcome-123',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   marketId: 'market-123',
   title: 'Bitcoin Price Outcome',
   description: 'Outcome description',
@@ -188,7 +189,7 @@ const mockOutcome: PredictOutcome = {
 
 const mockMarket = {
   id: 'market-123',
-  providerId: 'polymarket',
+  providerId: POLYMARKET_PROVIDER_ID,
   slug: 'bitcoin-price',
   title: 'Will Bitcoin reach $150,000?',
   description: 'Market description',

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
@@ -108,7 +108,6 @@ const PredictSellPreview = () => {
     error: previewError,
     isLoading: isPreviewLoading,
   } = usePredictOrderPreview({
-    providerId: position.providerId,
     marketId: position.marketId,
     outcomeId: position.outcomeId,
     outcomeTokenId: position.outcomeTokenId,
@@ -126,7 +125,6 @@ const PredictSellPreview = () => {
   } = usePredictOrderRetry({
     preview,
     placeOrder,
-    providerId: position.providerId,
     analyticsProperties,
     isOrderNotFilled,
     resetOrderNotFilled,
@@ -154,7 +152,6 @@ const PredictSellPreview = () => {
     controller.trackPredictOrderEvent({
       status: PredictTradeStatus.INITIATED,
       analyticsProperties,
-      providerId: position.providerId,
       sharePrice: position?.price,
       amountUsd: position?.amount,
       pnl: position?.percentPnl, // PnL as percentage for sell orders
@@ -198,11 +195,10 @@ const PredictSellPreview = () => {
     if (!preview) return;
 
     await placeOrder({
-      providerId: position.providerId,
       analyticsProperties,
       preview,
     });
-  }, [preview, placeOrder, analyticsProperties, position.providerId]);
+  }, [preview, placeOrder, analyticsProperties]);
 
   const renderCashOutButton = () => {
     if (isLoading) {

--- a/app/core/Engine/controllers/predict-controller/index.test.ts
+++ b/app/core/Engine/controllers/predict-controller/index.test.ts
@@ -63,7 +63,7 @@ describe('predict controller init', () => {
 
   it('controller state should be initial state when initial state is passed in', () => {
     const initialPredictControllerState: PredictControllerState = {
-      eligibility: {},
+      eligibility: { eligible: false },
       lastError: null,
       lastUpdateTimestamp: Date.now(),
       balances: {},

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -744,7 +744,7 @@
     "subscriptions": {}
   },
   "PredictController": {
-    "eligibility": {},
+    "eligibility": { "eligible": false },
     "lastError": null,
     "lastUpdateTimestamp": 0,
     "balances": {},


### PR DESCRIPTION
## **Description**

The PredictController was designed with multi-provider support (using a `Map<string, PredictProvider>`), but we only ever use Polymarket and have no plans to support additional providers. This PR simplifies the entire Predict feature to single-provider architecture.

### Changes:
- **Controller core**: Replace `providers: Map<string, PredictProvider>` with a single `provider: PolymarketProvider` instance. Remove initialization machinery (`initializeProviders`, `performInitialization`, `isInitialized`).
- **State shape**: Flatten `eligibility`, `balances`, and `pendingDeposits` by removing the provider-key nesting. `accountMeta` is left unchanged for backwards compatibility (persisted data).
- **Type interfaces**: Remove `providerId` from all param types (`GetMarketsParams`, `GetPositionsParams`, `PlaceOrderParams`, `PreviewOrderParams`, `GetPriceHistoryParams`, `GetPriceParams`, `GetBalanceParams`, etc.)
- **Hooks**: Remove `providerId` option from all ~20 hooks
- **Selectors**: Update `selectPredictBalanceByAddress` and `selectPredictPendingDepositByAddress` to use flat state
- **Components/Views**: Remove `providerId` prop passing throughout UI layer
- **Tests**: Update all test files for new state shapes and method signatures

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict market functionality

  Scenario: user interacts with prediction markets
    Given user has the Predict feature enabled

    When user browses markets, views positions, places orders, deposits, withdraws, or claims
    Then all functionality works identically to before the refactoring
```

## **Screenshots/Recordings**

N/A — no UI changes, purely internal refactoring.

### **Before**

Multi-provider architecture with `Map<string, PredictProvider>` and `providerId` params throughout.

### **After**

Single `PolymarketProvider` instance, flat state shapes, no `providerId` params needed.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad signature/state refactor across Predict hooks and components could cause subtle runtime breakage if any call sites or controller methods still expect `providerId`. Risk is mitigated by updated unit tests but warrants focused regression on deposit/claim/cashout flows and price-history fetching.
> 
> **Overview**
> Refactors Predict toward a **single-provider (Polymarket) model** by removing `providerId` parameters/props from UI calls into Predict hooks (e.g., `usePredictActionGuard`, `usePredictClaim`, `useUnrealizedPnL`, `usePredictPriceHistory`).
> 
> Updates affected components (e.g., balance/add-funds sheets, market cards, picks, position details, game chart) to rely on navigation/market IDs only, and adjusts tests accordingly (replacing hardcoded `'polymarket'` strings with `POLYMARKET_PROVIDER_ID` and deleting coverage for custom provider IDs). 
> 
> Reworks `PredictController.getActivity` unit test to construct a real messenger-backed controller and to mock `PolymarketProvider` directly, validating default selected-address behavior and explicit-address overrides without multi-provider merging/lookup scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1f33c3289b0b71a07f33eac323941ee14cbc800. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->