### PR TITLE
feat(settings): cp-7.66.0 add feature flag to toggle between Account Menu and legacy Settings

### DIFF
--- a/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
@@ -16,6 +16,7 @@ import TabBar from './TabBar';
 import { TabBarIconKey, ExtendedBottomTabDescriptor } from './TabBar.types';
 import Routes from '../../../../constants/navigation/Routes';
 import { selectAssetsTrendingTokensEnabled } from '../../../../selectors/featureFlagController/assetsTrendingTokens';
+import { useAccountMenuEnabled } from '../../../../selectors/featureFlagController/accountMenu/useAccountMenuEnabled';
 
 // Minimal descriptor interface for tests - only includes what TabBar component uses
 interface TestTabDescriptor {
@@ -32,6 +33,14 @@ interface TestDescriptors {
 
 // Mock trending tokens feature flag selector
 jest.mock('../../../../selectors/featureFlagController/assetsTrendingTokens');
+
+// Mock account menu feature flag hook
+jest.mock(
+  '../../../../selectors/featureFlagController/accountMenu/useAccountMenuEnabled',
+  () => ({
+    useAccountMenuEnabled: jest.fn(() => false),
+  }),
+);
 
 // Mock the navigation object with proper typing
 const navigation: NavigationHelpers<ParamListBase> = {
@@ -124,7 +133,10 @@ describe('TabBar', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('navigates to the correct screen when a tab is pressed', () => {
+  it('navigates to the correct screen when a tab is pressed and account menu is disabled', () => {
+    // Explicitly disable the account menu feature flag for this test
+    jest.mocked(useAccountMenuEnabled).mockReturnValue(false);
+
     const { getByTestId } = renderWithProvider(
       <TabBar
         state={state as TabNavigationState<ParamListBase>}
@@ -160,7 +172,7 @@ describe('TabBar', () => {
 
     fireEvent.press(getByTestId(`tab-bar-item-${TabBarIconKey.Setting}`));
     expect(navigation.navigate).toHaveBeenCalledWith(Routes.SETTINGS_VIEW, {
-      screen: Routes.ACCOUNTS_MENU_VIEW,
+      screen: 'Settings',
     });
   });
 
@@ -254,5 +266,24 @@ describe('TabBar', () => {
 
     fireEvent.press(getByTestId(`tab-bar-item-${TabBarIconKey.Trending}`));
     expect(navigation.navigate).not.toHaveBeenCalledWith(Routes.TRENDING_VIEW);
+  });
+
+  it('navigates to Accounts Menu when settings tab is pressed and account menu is enabled', () => {
+    // Enable the account menu feature flag for this test
+    jest.mocked(useAccountMenuEnabled).mockReturnValue(true);
+
+    const { getByTestId } = renderWithProvider(
+      <TabBar
+        state={state as TabNavigationState<ParamListBase>}
+        descriptors={descriptors as Record<string, ExtendedBottomTabDescriptor>}
+        navigation={navigation}
+      />,
+      { state: mockInitialState },
+    );
+
+    fireEvent.press(getByTestId(`tab-bar-item-${TabBarIconKey.Setting}`));
+    expect(navigation.navigate).toHaveBeenCalledWith(Routes.SETTINGS_VIEW, {
+      screen: Routes.ACCOUNTS_MENU_VIEW,
+    });
   });
 });

--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -28,6 +28,7 @@ import {
 } from './TabBar.constants';
 import { selectChainId } from '../../../../selectors/networkController';
 import { selectAssetsTrendingTokensEnabled } from '../../../../selectors/featureFlagController/assetsTrendingTokens';
+import { useAccountMenuEnabled } from '../../../../selectors/featureFlagController/accountMenu/useAccountMenuEnabled';
 
 const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
   const { trackEvent, createEventBuilder } = useMetrics();
@@ -36,6 +37,7 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
   const isAssetsTrendingTokensEnabled = useSelector(
     selectAssetsTrendingTokensEnabled,
   );
+  const isAccountMenuEnabled = useAccountMenuEnabled();
   const tabBarRef = useRef(null);
   const previousTabIndexRef = useRef<number>(state.index);
   const tw = useTailwind();
@@ -98,7 +100,9 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
             break;
           case Routes.SETTINGS_VIEW:
             navigation.navigate(Routes.SETTINGS_VIEW, {
-              screen: Routes.ACCOUNTS_MENU_VIEW,
+              screen: isAccountMenuEnabled
+                ? Routes.ACCOUNTS_MENU_VIEW
+                : 'Settings',
             });
             break;
           case Routes.TRENDING_VIEW:
@@ -138,6 +142,7 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
       createEventBuilder,
       tw,
       isAssetsTrendingTokensEnabled,
+      isAccountMenuEnabled,
     ],
   );
 

--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -106,6 +106,7 @@ import {
   selectPredictEnabledFlag,
 } from '../../UI/Predict';
 import { selectAssetsTrendingTokensEnabled } from '../../../selectors/featureFlagController/assetsTrendingTokens';
+import { useAccountMenuEnabled } from '../../../selectors/featureFlagController/accountMenu/useAccountMenuEnabled';
 import PerpsPositionTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView';
 import PerpsOrderTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView';
 import PerpsFundingTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView';
@@ -354,164 +355,172 @@ const NotificationsOptInStack = () => (
   </Stack.Navigator>
 );
 
-const SettingsFlow = () => (
-  <Stack.Navigator initialRouteName={Routes.ACCOUNTS_MENU_VIEW}>
-    <Stack.Screen
-      name={Routes.ACCOUNTS_MENU_VIEW}
-      component={AccountsMenu}
-      options={{ headerShown: false }}
-    />
-    <Stack.Screen
-      name="Settings"
-      component={Settings}
-      options={{ headerShown: false }}
-    />
-    <Stack.Screen
-      name="GeneralSettings"
-      component={GeneralSettings}
-      options={{ headerShown: false }}
-    />
-    <Stack.Screen
-      name="AdvancedSettings"
-      component={AdvancedSettings}
-      options={AdvancedSettings.navigationOptions}
-    />
-    <Stack.Screen name="SDKSessionsManager" component={SDKSessionsManager} />
-    <Stack.Screen name="PermissionsManager" component={PermissionsManager} />
-    <Stack.Screen
-      name="SecuritySettings"
-      component={SecuritySettings}
-      options={SecuritySettings.navigationOptions}
-    />
+const SettingsFlow = () => {
+  const isAccountMenuEnabled = useAccountMenuEnabled();
 
-    <Stack.Screen name={Routes.RAMP.SETTINGS} component={RampSettings} />
-    <Stack.Screen
-      name={Routes.RAMP.ACTIVATION_KEY_FORM}
-      component={RampActivationKeyForm}
-    />
-    {
-      /**
-       * This screen should only accessed in test mode.
-       * It is used to test the AES crypto functions.
-       *
-       * If this is in production, it is a bug.
-       */
-      isTest && (
-        <Stack.Screen
-          name="AesCryptoTestForm"
-          component={AesCryptoTestForm}
-          options={AesCryptoTestForm.navigationOptions}
-        />
-      )
-    }
-    <Stack.Screen
-      name="ExperimentalSettings"
-      component={ExperimentalSettings}
-      options={ExperimentalSettings.navigationOptions}
-    />
-    <Stack.Screen
-      name="CompanySettings"
-      component={AppInformation}
-      options={AppInformation.navigationOptions}
-    />
-    {process.env.MM_ENABLE_SETTINGS_PAGE_DEV_OPTIONS === 'true' && (
+  return (
+    <Stack.Navigator
+      initialRouteName={
+        isAccountMenuEnabled ? Routes.ACCOUNTS_MENU_VIEW : 'Settings'
+      }
+    >
       <Stack.Screen
-        name={Routes.SETTINGS.DEVELOPER_OPTIONS}
-        component={DeveloperOptions}
-        options={DeveloperOptions.navigationOptions}
+        name={Routes.ACCOUNTS_MENU_VIEW}
+        component={AccountsMenu}
+        options={{ headerShown: false }}
       />
-    )}
+      <Stack.Screen
+        name="Settings"
+        component={Settings}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="GeneralSettings"
+        component={GeneralSettings}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="AdvancedSettings"
+        component={AdvancedSettings}
+        options={AdvancedSettings.navigationOptions}
+      />
+      <Stack.Screen name="SDKSessionsManager" component={SDKSessionsManager} />
+      <Stack.Screen name="PermissionsManager" component={PermissionsManager} />
+      <Stack.Screen
+        name="SecuritySettings"
+        component={SecuritySettings}
+        options={SecuritySettings.navigationOptions}
+      />
 
-    <Stack.Screen
-      name="ContactsSettings"
-      component={Contacts}
-      options={Contacts.navigationOptions}
-    />
-    <Stack.Screen
-      name="ContactForm"
-      component={ContactForm}
-      options={ContactForm.navigationOptions}
-    />
-    <Stack.Screen
-      name="AccountPermissionsAsFullScreen"
-      component={AccountPermissions}
-      options={{ headerShown: false }}
-      initialParams={{
-        initialScreen: AccountPermissionsScreens.PermissionsSummary,
-      }}
-    />
-    <Stack.Screen
-      name={Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL}
-      component={RevealPrivateCredential}
-    />
-    <Stack.Screen
-      name={Routes.WALLET.WALLET_CONNECT_SESSIONS_VIEW}
-      component={WalletConnectSessions}
-      options={WalletConnectSessions.navigationOptions}
-    />
-    <Stack.Screen
-      name="ResetPassword"
-      component={ResetPassword}
-      options={ResetPassword.navigationOptions}
-    />
-    <Stack.Screen
-      name="WalletRecovery"
-      component={WalletRecovery}
-      options={WalletRecovery.navigationOptions}
-    />
-    <Stack.Screen
-      name="AccountBackupStep1B"
-      component={AccountBackupStep1B}
-      options={AccountBackupStep1B.navigationOptions}
-    />
-    <Stack.Screen
-      name="ManualBackupStep1"
-      component={ManualBackupStep1}
-      options={ManualBackupStep1.navigationOptions}
-    />
-    <Stack.Screen
-      name="ManualBackupStep2"
-      component={ManualBackupStep2}
-      options={ManualBackupStep2.navigationOptions}
-    />
-    <Stack.Screen
-      name="ManualBackupStep3"
-      component={ManualBackupStep3}
-      options={ManualBackupStep3.navigationOptions}
-    />
-    <Stack.Screen
-      name="EnterPasswordSimple"
-      component={EnterPasswordSimple}
-      options={EnterPasswordSimple.navigationOptions}
-    />
-    <Stack.Screen
-      name={Routes.SETTINGS.NOTIFICATIONS}
-      component={NotificationsSettings}
-      options={NotificationsSettings.navigationOptions}
-    />
-    <Stack.Screen
-      name={Routes.SETTINGS.BACKUP_AND_SYNC}
-      component={BackupAndSyncSettings}
-      options={BackupAndSyncSettings.navigationOptions}
-    />
-    <Stack.Screen
-      name={Routes.SETTINGS.REGION_SELECTOR}
-      component={RegionSelector}
-      options={RegionSelector.navigationOptions}
-    />
-    {
-      ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
-    }
-    <Stack.Screen
-      name={Routes.SNAPS.SNAPS_SETTINGS_LIST}
-      component={SnapsSettingsStack}
-      options={{ headerShown: false }}
-    />
-    {
-      ///: END:ONLY_INCLUDE_IF
-    }
-  </Stack.Navigator>
-);
+      <Stack.Screen name={Routes.RAMP.SETTINGS} component={RampSettings} />
+      <Stack.Screen
+        name={Routes.RAMP.ACTIVATION_KEY_FORM}
+        component={RampActivationKeyForm}
+      />
+      {
+        /**
+         * This screen should only accessed in test mode.
+         * It is used to test the AES crypto functions.
+         *
+         * If this is in production, it is a bug.
+         */
+        isTest && (
+          <Stack.Screen
+            name="AesCryptoTestForm"
+            component={AesCryptoTestForm}
+            options={AesCryptoTestForm.navigationOptions}
+          />
+        )
+      }
+      <Stack.Screen
+        name="ExperimentalSettings"
+        component={ExperimentalSettings}
+        options={ExperimentalSettings.navigationOptions}
+      />
+      <Stack.Screen
+        name="CompanySettings"
+        component={AppInformation}
+        options={AppInformation.navigationOptions}
+      />
+      {process.env.MM_ENABLE_SETTINGS_PAGE_DEV_OPTIONS === 'true' && (
+        <Stack.Screen
+          name={Routes.SETTINGS.DEVELOPER_OPTIONS}
+          component={DeveloperOptions}
+          options={DeveloperOptions.navigationOptions}
+        />
+      )}
+
+      <Stack.Screen
+        name="ContactsSettings"
+        component={Contacts}
+        options={Contacts.navigationOptions}
+      />
+      <Stack.Screen
+        name="ContactForm"
+        component={ContactForm}
+        options={ContactForm.navigationOptions}
+      />
+      <Stack.Screen
+        name="AccountPermissionsAsFullScreen"
+        component={AccountPermissions}
+        options={{ headerShown: false }}
+        initialParams={{
+          initialScreen: AccountPermissionsScreens.PermissionsSummary,
+        }}
+      />
+      <Stack.Screen
+        name={Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL}
+        component={RevealPrivateCredential}
+      />
+      <Stack.Screen
+        name={Routes.WALLET.WALLET_CONNECT_SESSIONS_VIEW}
+        component={WalletConnectSessions}
+        options={WalletConnectSessions.navigationOptions}
+      />
+      <Stack.Screen
+        name="ResetPassword"
+        component={ResetPassword}
+        options={ResetPassword.navigationOptions}
+      />
+      <Stack.Screen
+        name="WalletRecovery"
+        component={WalletRecovery}
+        options={WalletRecovery.navigationOptions}
+      />
+      <Stack.Screen
+        name="AccountBackupStep1B"
+        component={AccountBackupStep1B}
+        options={AccountBackupStep1B.navigationOptions}
+      />
+      <Stack.Screen
+        name="ManualBackupStep1"
+        component={ManualBackupStep1}
+        options={ManualBackupStep1.navigationOptions}
+      />
+      <Stack.Screen
+        name="ManualBackupStep2"
+        component={ManualBackupStep2}
+        options={ManualBackupStep2.navigationOptions}
+      />
+      <Stack.Screen
+        name="ManualBackupStep3"
+        component={ManualBackupStep3}
+        options={ManualBackupStep3.navigationOptions}
+      />
+      <Stack.Screen
+        name="EnterPasswordSimple"
+        component={EnterPasswordSimple}
+        options={EnterPasswordSimple.navigationOptions}
+      />
+      <Stack.Screen
+        name={Routes.SETTINGS.NOTIFICATIONS}
+        component={NotificationsSettings}
+        options={NotificationsSettings.navigationOptions}
+      />
+      <Stack.Screen
+        name={Routes.SETTINGS.BACKUP_AND_SYNC}
+        component={BackupAndSyncSettings}
+        options={BackupAndSyncSettings.navigationOptions}
+      />
+      <Stack.Screen
+        name={Routes.SETTINGS.REGION_SELECTOR}
+        component={RegionSelector}
+        options={RegionSelector.navigationOptions}
+      />
+      {
+        ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+      }
+      <Stack.Screen
+        name={Routes.SNAPS.SNAPS_SETTINGS_LIST}
+        component={SnapsSettingsStack}
+        options={{ headerShown: false }}
+      />
+      {
+        ///: END:ONLY_INCLUDE_IF
+      }
+    </Stack.Navigator>
+  );
+};
 
 const UnmountOnBlurComponent = (children) => (
   <UnmountOnBlur>{children}</UnmountOnBlur>

--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.test.tsx
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.test.tsx
@@ -11,9 +11,11 @@ import {
   LOGIN_OPTIONS,
   META_METRICS_DATA_MARKETING_SECTION,
   META_METRICS_SECTION,
+  SDK_SECTION,
   SECURITY_SETTINGS_DELETE_WALLET_BUTTON,
   TURN_ON_REMEMBER_ME,
 } from './SecuritySettings.constants';
+import { useAccountMenuEnabled } from '../../../../selectors/featureFlagController/accountMenu/useAccountMenuEnabled';
 import { SecurityPrivacyViewSelectorsIDs } from './SecurityPrivacyView.testIds';
 import SECURITY_ALERTS_TOGGLE_TEST_ID from './constants';
 import { MOCK_ACCOUNTS_CONTROLLER_STATE } from '../../../../util/test/accountsControllerTestUtils';
@@ -80,6 +82,13 @@ jest.mock(
   }),
 );
 
+jest.mock(
+  '../../../../selectors/featureFlagController/accountMenu/useAccountMenuEnabled',
+  () => ({
+    useAccountMenuEnabled: jest.fn(() => false),
+  }),
+);
+
 describe('SecuritySettings', () => {
   beforeEach(() => {
     mockUseParamsValues = {
@@ -108,7 +117,7 @@ describe('SecuritySettings', () => {
     });
     expect(wrapper.toJSON()).toMatchSnapshot();
   });
-  it('renders all sections', () => {
+  it('renders all sections when account menu is disabled', () => {
     const { getByText, getByTestId } = renderWithProvider(
       <SecuritySettings />,
       {
@@ -122,6 +131,32 @@ describe('SecuritySettings', () => {
     expect(getByTestId(AUTO_LOCK_SECTION)).toBeTruthy();
     expect(getByTestId(LOGIN_OPTIONS)).toBeTruthy();
     expect(getByTestId(TURN_ON_REMEMBER_ME)).toBeTruthy();
+    expect(getByTestId(SDK_SECTION)).toBeTruthy();
+    expect(getByTestId(CLEAR_PRIVACY_SECTION)).toBeTruthy();
+    expect(getByTestId(CLEAR_BROWSER_HISTORY_SECTION)).toBeTruthy();
+    expect(getByTestId(META_METRICS_SECTION)).toBeTruthy();
+    expect(getByTestId(DELETE_METRICS_BUTTON)).toBeTruthy();
+    expect(getByTestId(META_METRICS_DATA_MARKETING_SECTION)).toBeTruthy();
+    expect(getByTestId(SECURITY_SETTINGS_DELETE_WALLET_BUTTON)).toBeTruthy();
+  });
+
+  it('renders all sections without SDK section when account menu is enabled', () => {
+    jest.mocked(useAccountMenuEnabled).mockReturnValue(true);
+
+    const { getByText, getByTestId, queryByTestId } = renderWithProvider(
+      <SecuritySettings />,
+      {
+        state: initialState,
+      },
+    );
+    expect(getByText(strings('app_settings.protect_title'))).toBeTruthy();
+    expect(
+      getByTestId(SecurityPrivacyViewSelectorsIDs.CHANGE_PASSWORD_CONTAINER),
+    ).toBeTruthy();
+    expect(getByTestId(AUTO_LOCK_SECTION)).toBeTruthy();
+    expect(getByTestId(LOGIN_OPTIONS)).toBeTruthy();
+    expect(getByTestId(TURN_ON_REMEMBER_ME)).toBeTruthy();
+    expect(queryByTestId(SDK_SECTION)).toBeNull();
     expect(getByTestId(CLEAR_PRIVACY_SECTION)).toBeTruthy();
     expect(getByTestId(CLEAR_BROWSER_HISTORY_SECTION)).toBeTruthy();
     expect(getByTestId(META_METRICS_SECTION)).toBeTruthy();

--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
@@ -33,7 +33,10 @@ import createStyles from './SecuritySettings.styles';
 import { HeadingProps, SecuritySettingsParams } from './SecuritySettings.types';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useParams } from '../../../../util/navigation/navUtils';
-import { CLEAR_BROWSER_HISTORY_SECTION } from './SecuritySettings.constants';
+import {
+  CLEAR_BROWSER_HISTORY_SECTION,
+  SDK_SECTION,
+} from './SecuritySettings.constants';
 import Text, {
   TextVariant,
   TextColor,
@@ -57,6 +60,7 @@ import IPFSGatewaySettings from '../../Settings/IPFSGatewaySettings';
 import BatchAccountBalanceSettings from '../../Settings/BatchAccountBalanceSettings';
 import useCheckNftAutoDetectionModal from '../../../hooks/useCheckNftAutoDetectionModal';
 import useCheckMultiRpcModal from '../../../hooks/useCheckMultiRpcModal';
+import { useAccountMenuEnabled } from '../../../../selectors/featureFlagController/accountMenu/useAccountMenuEnabled';
 
 const Heading: React.FC<HeadingProps> = ({ children, first }) => {
   const { colors } = useTheme();
@@ -86,6 +90,7 @@ const Settings: React.FC = () => {
   const isBasicFunctionalityEnabled = useSelector(
     (state: RootState) => state?.settings?.basicFunctionalityEnabled,
   );
+  const isAccountMenuEnabled = useAccountMenuEnabled();
 
   const scrollViewRef = useRef<ScrollView>(null);
   const detectNftComponentRef = useRef<View>(null);
@@ -220,6 +225,34 @@ const Settings: React.FC = () => {
       );
     }
   };
+
+  const goToSDKSessionManager = () => {
+    navigation.navigate('SDKSessionsManager');
+  };
+
+  const renderSDKSettings = () => (
+    <View style={styles.halfSetting} testID={SDK_SECTION}>
+      <Text variant={TextVariant.BodyLGMedium}>
+        {strings('app_settings.manage_sdk_connections_title')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMD}
+        color={TextColor.Alternative}
+        style={styles.desc}
+      >
+        {strings('app_settings.manage_sdk_connections_text')}
+      </Text>
+      <View style={styles.accessory}>
+        <Button
+          variant={ButtonVariants.Secondary}
+          size={ButtonSize.Lg}
+          width={ButtonWidthTypes.Full}
+          label={strings('app_settings.manage_sdk_connections_title')}
+          onPress={goToSDKSessionManager}
+        />
+      </View>
+    </View>
+  );
 
   const toggleClearBrowserHistoryModal = () => {
     setBrowserHistoryModalVisible(!browserHistoryModalVisible);
@@ -399,6 +432,7 @@ const Settings: React.FC = () => {
         >
           {strings('app_settings.privacy_browser_subheading')}
         </Text>
+        {!isAccountMenuEnabled && renderSDKSettings()}
         <ClearPrivacy />
         {renderClearBrowserHistorySection()}
         <ClearCookiesSection />

--- a/app/components/Views/Settings/SecuritySettings/__snapshots__/SecuritySettings.test.tsx.snap
+++ b/app/components/Views/Settings/SecuritySettings/__snapshots__/SecuritySettings.test.tsx.snap
@@ -731,6 +731,90 @@ exports[`SecuritySettings renders correctly 1`] = `
       </Text>
       <View
         style={
+          {
+            "marginTop": 16,
+          }
+        }
+        testID="sdk-section"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#121314",
+              "fontFamily": "Geist-Medium",
+              "fontSize": 18,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Manage connections
+        </Text>
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#686e7d",
+              "fontFamily": "Geist-Regular",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+              "marginTop": 8,
+            }
+          }
+        >
+          Remove connections to sites and/or MetaMask SDK.
+        </Text>
+        <View
+          style={
+            {
+              "marginTop": 16,
+            }
+          }
+        >
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessible={true}
+            activeOpacity={1}
+            onPress={[Function]}
+            onPressIn={[Function]}
+            onPressOut={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "alignSelf": "stretch",
+                "backgroundColor": "#3c4d9d0f",
+                "borderColor": "transparent",
+                "borderRadius": 12,
+                "borderWidth": 1,
+                "flexDirection": "row",
+                "height": 48,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "paddingHorizontal": 16,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist-Medium",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Manage connections
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+      <View
+        style={
           [
             {
               "marginTop": 32,

--- a/app/components/Views/Settings/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/__snapshots__/index.test.tsx.snap
@@ -750,6 +750,100 @@ exports[`Settings renders settings component with all sections 1`] = `
       </TouchableOpacity>
       <TouchableOpacity
         onPress={[Function]}
+        testID="contacts-settings"
+      >
+        <View
+          accessibilityRole="none"
+          accessible={true}
+          style={
+            {
+              "backgroundColor": "#ffffff",
+              "padding": 16,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+              testID="listitemcolumn"
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist-Medium",
+                    "fontSize": 18,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                Contacts
+              </Text>
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#686e7d",
+                    "fontFamily": "Geist-Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                Add, edit, remove, and manage your accounts.
+              </Text>
+            </View>
+            <View
+              accessible={false}
+              style={
+                {
+                  "width": 16,
+                }
+              }
+              testID="listitem-gap"
+            />
+            <View
+              style={
+                {
+                  "flex": -1,
+                }
+              }
+              testID="listitemcolumn"
+            >
+              <SvgMock
+                color="#121314"
+                fill="currentColor"
+                height={20}
+                name="ArrowRight"
+                style={
+                  {
+                    "height": 20,
+                    "paddingLeft": 16,
+                    "width": 20,
+                  }
+                }
+                width={20}
+              />
+            </View>
+          </View>
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={[Function]}
         testID="snaps"
       >
         <View
@@ -1126,6 +1220,86 @@ exports[`Settings renders settings component with all sections 1`] = `
       </TouchableOpacity>
       <TouchableOpacity
         onPress={[Function]}
+        testID="about-metamask-settings"
+      >
+        <View
+          accessibilityRole="none"
+          accessible={true}
+          style={
+            {
+              "backgroundColor": "#ffffff",
+              "padding": 16,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+              testID="listitemcolumn"
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist-Medium",
+                    "fontSize": 18,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                About MetaMask Beta
+              </Text>
+            </View>
+            <View
+              accessible={false}
+              style={
+                {
+                  "width": 16,
+                }
+              }
+              testID="listitem-gap"
+            />
+            <View
+              style={
+                {
+                  "flex": -1,
+                }
+              }
+              testID="listitemcolumn"
+            >
+              <SvgMock
+                color="#121314"
+                fill="currentColor"
+                height={20}
+                name="ArrowRight"
+                style={
+                  {
+                    "height": 20,
+                    "paddingLeft": 16,
+                    "width": 20,
+                  }
+                }
+                width={20}
+              />
+            </View>
+          </View>
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={[Function]}
       >
         <View
           accessibilityRole="none"
@@ -1213,6 +1387,150 @@ exports[`Settings renders settings component with all sections 1`] = `
                 }
                 width={20}
               />
+            </View>
+          </View>
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={[Function]}
+        testID="request-settings"
+      >
+        <View
+          accessibilityRole="none"
+          accessible={true}
+          style={
+            {
+              "backgroundColor": "#ffffff",
+              "padding": 16,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+              testID="listitemcolumn"
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist-Medium",
+                    "fontSize": 18,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                Request a feature
+              </Text>
+            </View>
+          </View>
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={[Function]}
+        testID="contact-settings"
+      >
+        <View
+          accessibilityRole="none"
+          accessible={true}
+          style={
+            {
+              "backgroundColor": "#ffffff",
+              "padding": 16,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+              testID="listitemcolumn"
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist-Medium",
+                    "fontSize": 18,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                Contact support
+              </Text>
+            </View>
+          </View>
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={[Function]}
+        testID="lock-settings"
+      >
+        <View
+          accessibilityRole="none"
+          accessible={true}
+          style={
+            {
+              "backgroundColor": "#ffffff",
+              "padding": 16,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+              testID="listitemcolumn"
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#4459ff",
+                    "fontFamily": "Geist-Medium",
+                    "fontSize": 18,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                Lock
+              </Text>
             </View>
           </View>
         </View>

--- a/app/components/Views/Settings/index.test.tsx
+++ b/app/components/Views/Settings/index.test.tsx
@@ -25,6 +25,7 @@ jest.mock('../../../core/Analytics/whenEngineReady', () => ({
 // Import the mocked Authentication
 import { Authentication } from '../../../core';
 import { AvatarAccountType } from '../../../component-library/components/Avatars/Avatar';
+import { useAccountMenuEnabled } from '../../../selectors/featureFlagController/accountMenu/useAccountMenuEnabled';
 
 const initialState = {
   user: { seedphraseBackedUp: true, passwordSet: true },
@@ -62,6 +63,13 @@ jest.mock('../../../util/networks', () => ({
 jest.mock('../../../util/notifications/constants/config', () => ({
   isNotificationsFeatureEnabled: jest.fn(() => true),
 }));
+
+jest.mock(
+  '../../../selectors/featureFlagController/accountMenu/useAccountMenuEnabled',
+  () => ({
+    useAccountMenuEnabled: jest.fn(() => false),
+  }),
+);
 
 describe('Settings', () => {
   beforeEach(() => {
@@ -121,6 +129,14 @@ describe('Settings', () => {
     const advancedSettings = getByTestId(SettingsViewSelectorsIDs.ADVANCED);
     expect(advancedSettings).toBeDefined();
   });
+  it('renders contacts settings button when account menu is disabled', () => {
+    jest.mocked(useAccountMenuEnabled).mockReturnValue(false);
+    const { getByTestId } = renderWithProvider(<Settings />, {
+      state: initialState,
+    });
+    const contactsSettings = getByTestId(SettingsViewSelectorsIDs.CONTACTS);
+    expect(contactsSettings).toBeDefined();
+  });
   it('render feature request button', () => {
     const { getByTestId } = renderWithProvider(<Settings />, {
       state: initialState,
@@ -137,7 +153,36 @@ describe('Settings', () => {
     );
     expect(experimentalSettings).toBeDefined();
   });
-  it('renders permissions settings button when enabled', () => {
+  it('renders about metamask button', () => {
+    const { getByTestId } = renderWithProvider(<Settings />, {
+      state: initialState,
+    });
+    const aboutMetamask = getByTestId(SettingsViewSelectorsIDs.ABOUT_METAMASK);
+    expect(aboutMetamask).toBeDefined();
+  });
+  it('renders request feature button', () => {
+    const { getByTestId } = renderWithProvider(<Settings />, {
+      state: initialState,
+    });
+    const requestFeature = getByTestId(SettingsViewSelectorsIDs.REQUEST);
+    expect(requestFeature).toBeDefined();
+  });
+  it('renders contact support button', () => {
+    const { getByTestId } = renderWithProvider(<Settings />, {
+      state: initialState,
+    });
+    const contactSupport = getByTestId(SettingsViewSelectorsIDs.CONTACT);
+    expect(contactSupport).toBeDefined();
+  });
+  it('renders lock button', () => {
+    const { getByTestId } = renderWithProvider(<Settings />, {
+      state: initialState,
+    });
+    const lock = getByTestId(SettingsViewSelectorsIDs.LOCK);
+    expect(lock).toBeDefined();
+  });
+  it('renders permissions settings button when enabled and account menu is disabled', () => {
+    jest.mocked(useAccountMenuEnabled).mockReturnValue(false);
     const { getByTestId } = renderWithProvider(<Settings />, {
       state: initialState,
     });
@@ -204,6 +249,81 @@ describe('Settings', () => {
       );
 
       expect(featureFlagOverrideTitle).toBeDefined();
+    });
+  });
+
+  describe('Account Menu Feature Flag', () => {
+    it('hides contacts when account menu is enabled', () => {
+      jest.mocked(useAccountMenuEnabled).mockReturnValue(true);
+
+      const { queryByTestId } = renderWithProvider(<Settings />, {
+        state: initialState,
+      });
+
+      expect(queryByTestId(SettingsViewSelectorsIDs.CONTACTS)).toBeNull();
+    });
+
+    it('hides permissions when account menu is enabled', () => {
+      jest.mocked(useAccountMenuEnabled).mockReturnValue(true);
+
+      const { queryByTestId } = renderWithProvider(<Settings />, {
+        state: initialState,
+      });
+
+      expect(queryByTestId(SettingsViewSelectorsIDs.PERMISSIONS)).toBeNull();
+    });
+
+    it('hides about metamask when account menu is enabled', () => {
+      jest.mocked(useAccountMenuEnabled).mockReturnValue(true);
+
+      const { queryByTestId } = renderWithProvider(<Settings />, {
+        state: initialState,
+      });
+
+      expect(queryByTestId(SettingsViewSelectorsIDs.ABOUT_METAMASK)).toBeNull();
+    });
+
+    it('hides request feature when account menu is enabled', () => {
+      jest.mocked(useAccountMenuEnabled).mockReturnValue(true);
+
+      const { queryByTestId } = renderWithProvider(<Settings />, {
+        state: initialState,
+      });
+
+      expect(queryByTestId(SettingsViewSelectorsIDs.REQUEST)).toBeNull();
+    });
+
+    it('hides contact support when account menu is enabled', () => {
+      jest.mocked(useAccountMenuEnabled).mockReturnValue(true);
+
+      const { queryByTestId } = renderWithProvider(<Settings />, {
+        state: initialState,
+      });
+
+      expect(queryByTestId(SettingsViewSelectorsIDs.CONTACT)).toBeNull();
+    });
+
+    it('hides lock button when account menu is enabled', () => {
+      jest.mocked(useAccountMenuEnabled).mockReturnValue(true);
+
+      const { queryByTestId } = renderWithProvider(<Settings />, {
+        state: initialState,
+      });
+
+      expect(queryByTestId(SettingsViewSelectorsIDs.LOCK)).toBeNull();
+    });
+
+    it('still renders core settings sections when account menu is enabled', () => {
+      jest.mocked(useAccountMenuEnabled).mockReturnValue(true);
+
+      const { getByTestId } = renderWithProvider(<Settings />, {
+        state: initialState,
+      });
+
+      expect(getByTestId(SettingsViewSelectorsIDs.GENERAL)).toBeDefined();
+      expect(getByTestId(SettingsViewSelectorsIDs.SECURITY)).toBeDefined();
+      expect(getByTestId(SettingsViewSelectorsIDs.ADVANCED)).toBeDefined();
+      expect(getByTestId(SettingsViewSelectorsIDs.EXPERIMENTAL)).toBeDefined();
     });
   });
 });

--- a/app/components/Views/Settings/index.tsx
+++ b/app/components/Views/Settings/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { StyleSheet, ScrollView } from 'react-native';
+import { StyleSheet, ScrollView, Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import SettingsDrawer from '../../UI/SettingsDrawer';
@@ -8,17 +8,21 @@ import { MetaMetricsEvents } from '../../../core/Analytics';
 import { useSelector } from 'react-redux';
 import { useTheme } from '../../../util/theme';
 import Routes from '../../../constants/navigation/Routes';
+import { Authentication } from '../../../core/';
 import { Colors } from '../../../util/theme/models';
 import { SettingsViewSelectorsIDs } from './SettingsView.testIds';
 ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
 import { createSnapsSettingsListNavDetails } from '../Snaps/SnapsSettingsList/SnapsSettingsList';
 ///: END:ONLY_INCLUDE_IF
+import { TextColor } from '../../../component-library/components/Texts/Text';
 import { useMetrics } from '../../../components/hooks/useMetrics';
 import { isNotificationsFeatureEnabled } from '../../../util/notifications';
 import { isTest } from '../../../util/test/utils';
 import { isPermissionsSettingsV1Enabled } from '../../../util/networks';
+import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 import { selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
 import HeaderCompactStandard from '../../../component-library/components-temp/HeaderCompactStandard';
+import { useAccountMenuEnabled } from '../../../selectors/featureFlagController/accountMenu/useAccountMenuEnabled';
 
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
@@ -42,6 +46,9 @@ const Settings = () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (state: any) => state.user.seedphraseBackedUp,
   );
+
+  const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
+  const isAccountMenuEnabled = useAccountMenuEnabled();
 
   const handleBack = useCallback(() => {
     navigation.goBack();
@@ -101,6 +108,15 @@ const Settings = () => {
     navigation.navigate('AesCryptoTestForm');
   };
 
+  const onPressInfo = () => {
+    trackEvent(createEventBuilder(MetaMetricsEvents.SETTINGS_ABOUT).build());
+    navigation.navigate('CompanySettings');
+  };
+
+  const onPressContacts = () => {
+    navigation.navigate('ContactsSettings');
+  };
+
   const onPressDeveloperOptions = () => {
     navigation.navigate('DeveloperOptions');
   };
@@ -112,10 +128,81 @@ const Settings = () => {
     navigation.navigate('PermissionsManager');
   };
 
+  const goToBrowserUrl = (url: string, title: string) => {
+    navigation.navigate('Webview', {
+      screen: 'SimpleWebview',
+      params: {
+        url,
+        title,
+      },
+    });
+  };
+
   ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
   const onPressSnaps = () => {
     navigation.navigate(...createSnapsSettingsListNavDetails());
   };
+  ///: END:ONLY_INCLUDE_IF
+
+  const submitFeedback = () => {
+    trackEvent(
+      createEventBuilder(
+        MetaMetricsEvents.NAVIGATION_TAPS_SEND_FEEDBACK,
+      ).build(),
+    );
+    goToBrowserUrl(
+      'https://community.metamask.io/c/feature-requests-ideas/',
+      strings('app_settings.request_feature'),
+    );
+  };
+
+  const showHelp = () => {
+    let supportUrl = 'https://support.metamask.io';
+
+    ///: BEGIN:ONLY_INCLUDE_IF(beta)
+    supportUrl = 'https://intercom.help/internal-beta-testing/en/';
+    ///: END:ONLY_INCLUDE_IF
+
+    goToBrowserUrl(supportUrl, strings('app_settings.contact_support'));
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.NAVIGATION_TAPS_GET_HELP).build(),
+    );
+  };
+
+  const onPressLock = async () => {
+    await Authentication.lockApp({ reset: false, locked: false });
+  };
+
+  const lock = () => {
+    Alert.alert(
+      strings('drawer.lock_title'),
+      '',
+      [
+        {
+          text: strings('drawer.lock_cancel'),
+          onPress: () => null,
+          style: 'cancel',
+        },
+        {
+          text: strings('drawer.lock_ok'),
+          onPress: onPressLock,
+        },
+      ],
+      { cancelable: false },
+    );
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.NAVIGATION_TAPS_LOGOUT).build(),
+    );
+  };
+
+  let aboutMetaMaskTitle = strings('app_settings.info_title');
+
+  ///: BEGIN:ONLY_INCLUDE_IF(flask)
+  aboutMetaMaskTitle = strings('app_settings.info_title_flask');
+  ///: END:ONLY_INCLUDE_IF
+
+  ///: BEGIN:ONLY_INCLUDE_IF(beta)
+  aboutMetaMaskTitle = strings('app_settings.info_title_beta');
   ///: END:ONLY_INCLUDE_IF
 
   const oauthFlow = useSelector(selectSeedlessOnboardingLoginFlow);
@@ -169,12 +256,20 @@ const Settings = () => {
             testID={SettingsViewSelectorsIDs.NOTIFICATIONS}
           />
         )}
-        {isPermissionsSettingsV1Enabled && (
+        {!isAccountMenuEnabled && isPermissionsSettingsV1Enabled && (
           <SettingsDrawer
             description={strings('app_settings.permissions_desc')}
             onPress={goToManagePermissions}
             title={strings('app_settings.permissions_title')}
             testID={SettingsViewSelectorsIDs.PERMISSIONS}
+          />
+        )}
+        {!isAccountMenuEnabled && isEvmSelected && (
+          <SettingsDrawer
+            description={strings('app_settings.contacts_desc')}
+            onPress={onPressContacts}
+            title={strings('app_settings.contacts_title')}
+            testID={SettingsViewSelectorsIDs.CONTACTS}
           />
         )}
         {
@@ -219,6 +314,13 @@ const Settings = () => {
             />
           )
         }
+        {!isAccountMenuEnabled && (
+          <SettingsDrawer
+            title={aboutMetaMaskTitle}
+            onPress={onPressInfo}
+            testID={SettingsViewSelectorsIDs.ABOUT_METAMASK}
+          />
+        )}
         {process.env.MM_ENABLE_SETTINGS_PAGE_DEV_OPTIONS === 'true' && (
           <SettingsDrawer
             title={strings('app_settings.developer_options.title')}
@@ -232,6 +334,31 @@ const Settings = () => {
               'app_settings.feature_flag_override.description',
             )}
             onPress={onPressFeatureFlagOverride}
+          />
+        )}
+        {!isAccountMenuEnabled && (
+          <SettingsDrawer
+            title={strings('app_settings.request_feature')}
+            onPress={submitFeedback}
+            renderArrowRight={false}
+            testID={SettingsViewSelectorsIDs.REQUEST}
+          />
+        )}
+        {!isAccountMenuEnabled && (
+          <SettingsDrawer
+            title={strings('app_settings.contact_support')}
+            onPress={showHelp}
+            renderArrowRight={false}
+            testID={SettingsViewSelectorsIDs.CONTACT}
+          />
+        )}
+        {!isAccountMenuEnabled && (
+          <SettingsDrawer
+            title={strings('drawer.lock')}
+            onPress={lock}
+            renderArrowRight={false}
+            testID={SettingsViewSelectorsIDs.LOCK}
+            titleColor={TextColor.Primary}
           />
         )}
       </ScrollView>

--- a/app/selectors/featureFlagController/accountMenu/index.test.ts
+++ b/app/selectors/featureFlagController/accountMenu/index.test.ts
@@ -1,0 +1,73 @@
+import { selectAccountMenuEnabled } from '.';
+import { hasMinimumRequiredVersion } from '../../../util/remoteFeatureFlag';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('1.0.0'),
+}));
+
+jest.mock('../../../util/remoteFeatureFlag', () => ({
+  ...jest.requireActual('../../../util/remoteFeatureFlag'),
+  hasMinimumRequiredVersion: jest.fn(),
+}));
+
+describe('Account Menu Feature Flag Selectors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(hasMinimumRequiredVersion).mockReturnValue(true);
+  });
+
+  describe('selectAccountMenuEnabled', () => {
+    it('returns true when remote flag is valid and enabled', () => {
+      const result = selectAccountMenuEnabled.resultFunc({
+        mobileUxAccountMenu: {
+          enabled: true,
+          minimumVersion: '1.0.0',
+        },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns false when remote flag is valid but disabled', () => {
+      const result = selectAccountMenuEnabled.resultFunc({
+        mobileUxAccountMenu: {
+          enabled: false,
+          minimumVersion: '1.0.0',
+        },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when version check fails', () => {
+      jest.mocked(hasMinimumRequiredVersion).mockReturnValue(false);
+      const result = selectAccountMenuEnabled.resultFunc({
+        mobileUxAccountMenu: {
+          enabled: true,
+          minimumVersion: '99.0.0',
+        },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote flag is invalid', () => {
+      const result = selectAccountMenuEnabled.resultFunc({
+        mobileUxAccountMenu: {
+          enabled: 'invalid',
+          minimumVersion: 123,
+        },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote feature flags are empty', () => {
+      const result = selectAccountMenuEnabled.resultFunc({});
+      expect(result).toBe(false);
+    });
+
+    it('returns false when mobileUxAccountMenu flag is missing', () => {
+      const result = selectAccountMenuEnabled.resultFunc({
+        someOtherFlag: true,
+      });
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/app/selectors/featureFlagController/accountMenu/index.ts
+++ b/app/selectors/featureFlagController/accountMenu/index.ts
@@ -1,0 +1,22 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '..';
+import {
+  validatedVersionGatedFeatureFlag,
+  VersionGatedFeatureFlag,
+} from '../../../util/remoteFeatureFlag';
+
+const ACCOUNT_MENU_FLAG_KEY = 'mobileUxAccountMenu';
+
+/**
+ * Selector for the account menu feature flag.
+ * Returns true if the feature is enabled AND the current version meets the minimum version requirement.
+ */
+export const selectAccountMenuEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const remoteFlag = remoteFeatureFlags[
+      ACCOUNT_MENU_FLAG_KEY
+    ] as unknown as VersionGatedFeatureFlag;
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
+);

--- a/app/selectors/featureFlagController/accountMenu/useAccountMenuEnabled.test.ts
+++ b/app/selectors/featureFlagController/accountMenu/useAccountMenuEnabled.test.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useAccountMenuEnabled } from './useAccountMenuEnabled';
+import { selectAccountMenuEnabled } from '.';
+
+jest.mock('.', () => ({
+  selectAccountMenuEnabled: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn((selector) => selector()),
+}));
+
+describe('useAccountMenuEnabled', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true when account menu is enabled', () => {
+    jest.mocked(selectAccountMenuEnabled).mockReturnValue(true);
+
+    const { result } = renderHook(() => useAccountMenuEnabled());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when account menu is disabled', () => {
+    jest.mocked(selectAccountMenuEnabled).mockReturnValue(false);
+
+    const { result } = renderHook(() => useAccountMenuEnabled());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/app/selectors/featureFlagController/accountMenu/useAccountMenuEnabled.ts
+++ b/app/selectors/featureFlagController/accountMenu/useAccountMenuEnabled.ts
@@ -1,0 +1,12 @@
+import { useSelector } from 'react-redux';
+import { selectAccountMenuEnabled } from '.';
+
+/**
+ * Hook to check if the Account Menu feature is enabled.
+ * Returns true if the feature is enabled AND the current version meets the minimum version requirement.
+ */
+export const useAccountMenuEnabled = () => {
+  const isAccountMenuEnabled = useSelector(selectAccountMenuEnabled);
+
+  return isAccountMenuEnabled;
+};

--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -7,7 +7,7 @@ import SettingsView from '../Settings/SettingsView';
 import BrowserView from '../Browser/BrowserView';
 import WalletView from './WalletView';
 import TrendingView from '../Trending/TrendingView';
-import AccountMenu from '../AccountMenu/AccountMenu';
+
 class TabBarComponent {
   get tabBarExploreButton(): DetoxElement {
     return Matchers.getElementByID(TabBarSelectorIDs.EXPLORE);
@@ -89,7 +89,6 @@ class TabBarComponent {
         // Ensure we're on WalletView where the hamburger menu is located
         await this.tapWallet();
         await WalletView.tapHamburgerMenu();
-        await AccountMenu.tapSettings();
         await Assertions.expectElementToBeVisible(SettingsView.title);
       },
       {

--- a/tests/smoke/identity/account-syncing/account-syncing-settings-toggle.spec.ts
+++ b/tests/smoke/identity/account-syncing/account-syncing-settings-toggle.spec.ts
@@ -19,7 +19,6 @@ import {
   USER_STORAGE_GROUPS_FEATURE_KEY,
   USER_STORAGE_WALLETS_FEATURE_KEY,
 } from '@metamask/account-tree-controller';
-import AccountMenu from '../../../page-objects/AccountMenu/AccountMenu';
 
 describe(SmokeIdentity('Account syncing - Setting'), () => {
   let sharedUserStorageController: UserStorageMockttpController;
@@ -124,17 +123,8 @@ describe(SmokeIdentity('Account syncing - Setting'), () => {
         await Assertions.expectElementToBeVisible(
           SettingsView.backupAndSyncSectionButton,
         );
-
-        // needs settings back button
-        await SettingsView.tapBackButton();
-
-        await Assertions.expectElementToBeVisible(AccountMenu.backButton);
-        await Assertions.expectElementToBeVisible(AccountMenu.container);
-
-        await AccountMenu.tapBack();
-
-        // tapBack
         // Close settings drawer (opened from hamburger menu) to return to wallet view
+        await SettingsView.tapBackButton();
         await Assertions.expectElementToBeVisible(WalletView.container);
         // Wait for settings drawer to fully close and tab bar to be visible
         await Assertions.expectElementToBeVisible(

--- a/tests/smoke/identity/contact-syncing/contact-sync-toggle.spec.ts
+++ b/tests/smoke/identity/contact-syncing/contact-sync-toggle.spec.ts
@@ -6,14 +6,13 @@ import { USER_STORAGE_FEATURE_NAMES } from '@metamask/profile-sync-controller/sd
 import { withIdentityFixtures } from '../utils/withIdentityFixtures';
 import { arrangeTestUtils } from '../utils/helpers';
 import { UserStorageMockttpController } from '../utils/user-storage/userStorageMockttpController';
+import TabBarComponent from '../../../page-objects/wallet/TabBarComponent';
 import SettingsView from '../../../page-objects/Settings/SettingsView';
 import BackupAndSyncView from '../../../page-objects/Settings/BackupAndSyncView';
 import { createUserStorageController } from '../utils/mocks';
 import ContactsView from '../../../page-objects/Settings/Contacts/ContactsView';
 import AddContactView from '../../../page-objects/Settings/Contacts/AddContactView';
 import CommonView from '../../../page-objects/CommonView';
-import WalletView from '../../../page-objects/wallet/WalletView';
-import AccountMenu from '../../../page-objects/AccountMenu/AccountMenu';
 
 describe(SmokeIdentity('Contacts syncing - Settings'), () => {
   let sharedUserStorageController: UserStorageMockttpController;
@@ -42,12 +41,12 @@ describe(SmokeIdentity('Contacts syncing - Settings'), () => {
         await loginToApp();
 
         // First fixture: Create a contact with sync enabled
-        await WalletView.tapHamburgerMenu();
-        await Assertions.expectElementToBeVisible(AccountMenu.contactsButton);
-
-        await AccountMenu.tapContacts();
+        await TabBarComponent.tapSettings();
+        await Assertions.expectElementToBeVisible(
+          SettingsView.contactsSettingsButton,
+        );
+        await SettingsView.tapContacts();
         await Assertions.expectElementToBeVisible(ContactsView.container);
-
         await ContactsView.tapAddContactButton();
         await Assertions.expectElementToBeVisible(AddContactView.container);
 
@@ -82,27 +81,18 @@ describe(SmokeIdentity('Contacts syncing - Settings'), () => {
         await loginToApp();
 
         // Second fixture: Verify first contact exists and disable sync
-        // await TabBarComponent.tapSettings();
-        await WalletView.tapHamburgerMenu();
-        await Assertions.expectElementToBeVisible(AccountMenu.contactsButton);
-
-        await AccountMenu.tapContacts();
+        await TabBarComponent.tapSettings();
+        await Assertions.expectElementToBeVisible(
+          SettingsView.contactsSettingsButton,
+        );
+        await SettingsView.tapContacts();
         await Assertions.expectElementToBeVisible(ContactsView.container);
-
         await ContactsView.expectContactIsVisible(TEST_CONTACT_NAME);
-
         await CommonView.tapBackButton();
-        await Assertions.expectElementToBeVisible(AccountMenu.backButton);
-        await Assertions.expectElementToBeVisible(AccountMenu.container);
-
-        await AccountMenu.tapBack();
+        await SettingsView.tapBackButton();
 
         // Disable contact syncing
-        await WalletView.tapHamburgerMenu();
-        await Assertions.expectElementToBeVisible(AccountMenu.settingsButton);
-
-        await AccountMenu.tapSettings();
-
+        await TabBarComponent.tapSettings();
         await Assertions.expectElementToBeVisible(
           SettingsView.backupAndSyncSectionButton,
         );
@@ -121,13 +111,13 @@ describe(SmokeIdentity('Contacts syncing - Settings'), () => {
 
         await CommonView.tapBackButton();
         await SettingsView.tapBackButton();
-        await AccountMenu.tapBack();
 
         // Add second contact while sync is disabled
-        await WalletView.tapHamburgerMenu();
-        await Assertions.expectElementToBeVisible(AccountMenu.contactsButton);
-        await AccountMenu.tapContacts();
-
+        await TabBarComponent.tapSettings();
+        await Assertions.expectElementToBeVisible(
+          SettingsView.contactsSettingsButton,
+        );
+        await SettingsView.tapContacts();
         await Assertions.expectElementToBeVisible(ContactsView.container);
         await ContactsView.tapAddContactButton();
         await Assertions.expectElementToBeVisible(AddContactView.container);
@@ -151,9 +141,11 @@ describe(SmokeIdentity('Contacts syncing - Settings'), () => {
         await loginToApp();
 
         // Third fixture: Verify only synced contact persists after fresh login
-        await WalletView.tapHamburgerMenu();
-        await Assertions.expectElementToBeVisible(AccountMenu.contactsButton);
-        await AccountMenu.tapContacts();
+        await TabBarComponent.tapSettings();
+        await Assertions.expectElementToBeVisible(
+          SettingsView.contactsSettingsButton,
+        );
+        await SettingsView.tapContacts();
         await Assertions.expectElementToBeVisible(ContactsView.container);
         // Contact added with sync enabled should be visible
         await ContactsView.expectContactIsVisible(TEST_CONTACT_NAME);

--- a/tests/smoke/identity/contact-syncing/sync-users-contacts.spec.ts
+++ b/tests/smoke/identity/contact-syncing/sync-users-contacts.spec.ts
@@ -2,17 +2,17 @@
 // eslint-disable-next-line no-restricted-syntax
 import { loginToApp } from '../../../flows/wallet.flow';
 import TestHelpers from '../../../helpers';
+import TabBarComponent from '../../../page-objects/wallet/TabBarComponent';
 import { SmokeIdentity } from '../../../tags';
 import ContactsView from '../../../page-objects/Settings/Contacts/ContactsView';
 import AddContactView from '../../../page-objects/Settings/Contacts/AddContactView';
+import SettingsView from '../../../page-objects/Settings/SettingsView';
 import Assertions from '../../../framework/Assertions';
 import { USER_STORAGE_FEATURE_NAMES } from '@metamask/profile-sync-controller/sdk';
 import { arrangeTestUtils } from '../utils/helpers';
 import { withIdentityFixtures } from '../utils/withIdentityFixtures';
 import { UserStorageMockttpController } from '../utils/user-storage/userStorageMockttpController';
 import { createUserStorageController } from '../utils/mocks';
-import WalletView from '../../../page-objects/wallet/WalletView';
-import AccountMenu from '../../../page-objects/AccountMenu/AccountMenu';
 
 describe(SmokeIdentity('Contact syncing - syncs new contacts'), () => {
   const NEW_CONTACT_NAME = 'New Test Contact';
@@ -36,10 +36,11 @@ describe(SmokeIdentity('Contact syncing - syncs new contacts'), () => {
       async ({ userStorageMockttpController }) => {
         await loginToApp();
 
-        await WalletView.tapHamburgerMenu();
-        await Assertions.expectElementToBeVisible(AccountMenu.contactsButton);
-
-        await AccountMenu.tapContacts();
+        await TabBarComponent.tapSettings();
+        await Assertions.expectElementToBeVisible(
+          SettingsView.contactsSettingsButton,
+        );
+        await SettingsView.tapContacts();
         await Assertions.expectElementToBeVisible(ContactsView.container);
         await ContactsView.tapAddContactButton();
         await Assertions.expectElementToBeVisible(AddContactView.container);
@@ -73,9 +74,11 @@ describe(SmokeIdentity('Contact syncing - syncs new contacts'), () => {
       async () => {
         await loginToApp();
 
-        await WalletView.tapHamburgerMenu();
-        await Assertions.expectElementToBeVisible(AccountMenu.contactsButton);
-        await AccountMenu.tapContacts();
+        await TabBarComponent.tapSettings();
+        await Assertions.expectElementToBeVisible(
+          SettingsView.contactsSettingsButton,
+        );
+        await SettingsView.tapContacts();
         await Assertions.expectElementToBeVisible(ContactsView.container);
 
         await ContactsView.expectContactIsVisible(NEW_CONTACT_NAME);

--- a/tests/smoke/snaps/test-snap-management.spec.ts
+++ b/tests/smoke/snaps/test-snap-management.spec.ts
@@ -9,7 +9,6 @@ import SettingsView from '../../page-objects/Settings/SettingsView';
 import SnapSettingsView from '../../page-objects/Settings/SnapSettingsView';
 import { Assertions } from '../../framework';
 import BrowserView from '../../page-objects/Browser/BrowserView';
-import AccountMenu from '../../page-objects/AccountMenu/AccountMenu';
 
 jest.setTimeout(150_000);
 
@@ -48,7 +47,6 @@ describe(FlaskBuildTests('Snap Management Tests'), () => {
         await SnapSettingsView.tapBackButton();
         await SnapSettingsView.tapBackButton();
         await SettingsView.tapBackButton();
-        await AccountMenu.tapBack();
 
         await navigateToBrowserView();
 
@@ -79,7 +77,6 @@ describe(FlaskBuildTests('Snap Management Tests'), () => {
         await SnapSettingsView.tapBackButton();
         await SnapSettingsView.tapBackButton();
         await SettingsView.tapBackButton();
-        await AccountMenu.tapBack();
 
         await navigateToBrowserView();
 


### PR DESCRIPTION
## **Description**

This PR introduces the `mobileUxAccountMenu` feature flag to enable gradual rollout of the Account Menu feature. Originally we wanted to ship for this RC as is in this [PR](https://github.com/MetaMask/metamask-mobile/pull/25611) but we found some UI refinements were needed. The feature is being moved behind a feature flag and be hidden from this current RC and to allow for final design refinements for the next RC.

**Why is this change required?**
The Account Menu feature requires additional refinements before full release. A feature flag allows us to:

- Control rollout via LaunchDarkly
- Maintain backward compatibility with existing Settings flow
- Iterate on design improvements without blocking the next release

**What does this PR do?**
Adds `selectAccountMenuEnabled` selector and `useAccountMenuEnabled` hook using the `mobileUxAccountMenu` remote feature flag
- Implements conditional navigation: enabled → `AccountsMenuView`, disabled → legacy `Settings`
- Hides duplicate sections in Settings when Account Menu is enabled (Permissions, Contacts, About MetaMask, Request Feature, Contact Support, Lock)
- Hides SDK section in `SecuritySettings` when Account Menu is enabled
- Adds unit tests for both enabled/disabled states
- Reverts E2E spec files to pre-Account Menu state to avoid test skipping (4 files: account-syncing-settings-toggle, contact-sync-toggle, sync-users-contacts, test-snap-management). The E2E tests will be added again once the feature is ready

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added feature flag mobileUxAccountMenu to control Account Menu rollout

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-397

## **Manual testing steps**

```gherkin
Scenario 1: Feature flag disabled (default behavior)

Given the mobileUxAccountMenu feature flag is disabled
When I tap the Settings tab in TabBar
Then I should navigate to the legacy Settings screen
And I should see all sections including Permissions, Contacts, About MetaMask, Request Feature, Contact Support, and Lock
And I should see the SDK section in Security Settings

Scenario 2: Feature flag enabled (new behavior)

Given the mobileUxAccountMenu feature flag is enabled
When I tap the Settings tab in TabBar
Then I should navigate to the AccountsMenuView screen
And the legacy Settings screen should hide duplicate sections (Permissions, Contacts, About MetaMask, Request Feature, Contact Support, Lock)
And the SDK section should be hidden in Security Settings
```

## **Screenshots/Recordings**

Feature Flag Off

https://github.com/user-attachments/assets/65e9a0a2-8c70-4d84-9f26-302d27d5b1c9

Feature Flag On

https://github.com/user-attachments/assets/12503ba2-5219-4783-95c6-0fdef0ac8ecb

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches primary navigation paths into Settings and conditionally hides/redirects multiple Settings entries based on a remote flag, so misconfiguration or routing mismatches could strand users or break test flows.
> 
> **Overview**
> Adds a new remote, version-gated feature flag (`mobileUxAccountMenu`) via `selectAccountMenuEnabled` + `useAccountMenuEnabled`, and wires it into navigation so the Settings tab/flow can start at either `AccountsMenu` (flag on) or the legacy `Settings` screen (flag off).
> 
> Updates the legacy Settings/Security UI to *avoid duplicate entry points* when the account menu is enabled (e.g., hides Permissions/Contacts/About/feedback/help/lock entries in `Settings`, and hides the SDK connections section in `SecuritySettings`), while adding the missing legacy actions (open support/feature request webviews and lock flow).
> 
> Expands unit tests and snapshots to cover both flag states, and adjusts Detox smoke tests/page objects to navigate to Settings/Contacts without relying on the Account Menu screens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad08c93d966d3b66ff44cc1995b6eed53bae9814. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->