### PR TITLE
fix: Input text misalignment

### DIFF
--- a/app/component-library/components/Form/TextField/foundation/Input/Input.styles.ts
+++ b/app/component-library/components/Form/TextField/foundation/Input/Input.styles.ts
@@ -45,6 +45,7 @@ const styleSheet = (params: { theme: Theme; vars: InputStyleSheetVars }) => {
         fontWeight: theme.typography[textVariant].fontWeight,
         fontSize: theme.typography[textVariant].fontSize,
         letterSpacing: theme.typography[textVariant].letterSpacing,
+        lineHeight: 0,
         // iOS-specific fix for custom font baseline alignment
         ...(Platform.OS === 'ios' && {
           textAlignVertical: 'center',

--- a/app/component-library/components/Form/TextField/foundation/Input/__snapshots__/Input.test.tsx.snap
+++ b/app/component-library/components/Form/TextField/foundation/Input/__snapshots__/Input.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Input should render correctly 1`] = `
       "fontSize": 16,
       "fontWeight": "400",
       "letterSpacing": 0,
+      "lineHeight": 0,
       "opacity": 1,
       "textAlignVertical": "center",
     }

--- a/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
+++ b/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
@@ -221,6 +221,7 @@ exports[`SnapUIAddressInput renders with an invalid CAIP Account ID 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
+            "lineHeight": 0,
             "opacity": 1,
             "textAlignVertical": "center",
           }

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
@@ -298,6 +298,7 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
+                        "lineHeight": 0,
                         "opacity": 1,
                         "textAlignVertical": "center",
                       }
@@ -459,6 +460,7 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
+                        "lineHeight": 0,
                         "opacity": 1,
                         "textAlignVertical": "center",
                       }
@@ -555,6 +557,7 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
+                        "lineHeight": 0,
                         "opacity": 1,
                         "textAlignVertical": "center",
                       }
@@ -715,6 +718,7 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
+                        "lineHeight": 0,
                         "opacity": 1,
                         "textAlignVertical": "center",
                       }
@@ -810,6 +814,7 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
+                        "lineHeight": 0,
                         "opacity": 1,
                         "textAlignVertical": "center",
                       }
@@ -1965,6 +1970,7 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
+                          "lineHeight": 0,
                           "opacity": 1,
                           "textAlignVertical": "center",
                         }
@@ -2163,6 +2169,7 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
+                        "lineHeight": 0,
                         "opacity": 1,
                         "textAlignVertical": "center",
                       }

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
@@ -156,6 +156,7 @@ exports[`SnapUIDateTimePicker can show an error 1`] = `
                           "fontSize": 16,
                           "fontWeight": "400",
                           "letterSpacing": 0,
+                          "lineHeight": 0,
                           "opacity": 1,
                           "textAlignVertical": "center",
                         }
@@ -335,6 +336,7 @@ exports[`SnapUIDateTimePicker renders a date picker 1`] = `
                           "fontSize": 16,
                           "fontWeight": "400",
                           "letterSpacing": 0,
+                          "lineHeight": 0,
                           "opacity": 1,
                           "textAlignVertical": "center",
                         }
@@ -499,6 +501,7 @@ exports[`SnapUIDateTimePicker renders a date time picker 1`] = `
                           "fontSize": 16,
                           "fontWeight": "400",
                           "letterSpacing": 0,
+                          "lineHeight": 0,
                           "opacity": 1,
                           "textAlignVertical": "center",
                         }
@@ -663,6 +666,7 @@ exports[`SnapUIDateTimePicker renders a time picker 1`] = `
                           "fontSize": 16,
                           "fontWeight": "400",
                           "letterSpacing": 0,
+                          "lineHeight": 0,
                           "opacity": 1,
                           "textAlignVertical": "center",
                         }
@@ -842,6 +846,7 @@ exports[`SnapUIDateTimePicker renders inside a field 1`] = `
                           "fontSize": 16,
                           "fontWeight": "400",
                           "letterSpacing": 0,
+                          "lineHeight": 0,
                           "opacity": 1,
                           "textAlignVertical": "center",
                         }

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -151,6 +151,7 @@ exports[`SnapUIForm will render 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
+                          "lineHeight": 0,
                           "opacity": 1,
                           "textAlignVertical": "center",
                         }
@@ -372,6 +373,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
+                          "lineHeight": 0,
                           "opacity": 1,
                           "textAlignVertical": "center",
                         }

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/input.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/input.test.ts.snap
@@ -138,6 +138,7 @@ exports[`SnapUIInput handles disabled input 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
+                        "lineHeight": 0,
                         "opacity": 1,
                         "textAlignVertical": "center",
                       }
@@ -298,6 +299,7 @@ exports[`SnapUIInput renders with initial value 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
+                        "lineHeight": 0,
                         "opacity": 1,
                         "textAlignVertical": "center",
                       }

--- a/app/components/UI/Card/Views/CardAuthentication/__snapshots__/CardAuthentication.test.tsx.snap
+++ b/app/components/UI/Card/Views/CardAuthentication/__snapshots__/CardAuthentication.test.tsx.snap
@@ -718,6 +718,7 @@ exports[`CardAuthentication Component Login Step - Component Rendering matches l
                                           "fontWeight": "400",
                                           "height": 46,
                                           "letterSpacing": 0,
+                                          "lineHeight": 0,
                                           "opacity": 1,
                                           "textAlignVertical": "center",
                                         }
@@ -832,6 +833,7 @@ exports[`CardAuthentication Component Login Step - Component Rendering matches l
                                           "fontWeight": "400",
                                           "height": 46,
                                           "letterSpacing": 0,
+                                          "lineHeight": 0,
                                           "opacity": 1,
                                           "textAlignVertical": "center",
                                         }

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/ActivationKeyForm.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/ActivationKeyForm.test.tsx.snap
@@ -588,6 +588,7 @@ exports[`AddActivationKey renders correctly 1`] = `
                                         "fontWeight": "400",
                                         "height": 46,
                                         "letterSpacing": 0,
+                                        "lineHeight": 0,
                                         "opacity": 1,
                                         "textAlignVertical": "center",
                                       }
@@ -702,6 +703,7 @@ exports[`AddActivationKey renders correctly 1`] = `
                                         "fontWeight": "400",
                                         "height": 46,
                                         "letterSpacing": 0,
+                                        "lineHeight": 0,
                                         "opacity": 1,
                                         "textAlignVertical": "center",
                                       }

--- a/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
@@ -685,6 +685,7 @@ exports[`FiatSelectorModal renders the modal with currency list 1`] = `
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -1685,6 +1686,7 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -2685,6 +2687,7 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -3685,6 +3688,7 @@ exports[`FiatSelectorModal search displays max 20 results 1`] = `
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }

--- a/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
@@ -871,6 +871,7 @@ exports[`TokenSelectModal renders the modal with token list 1`] = `
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }

--- a/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
@@ -690,6 +690,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -808,6 +809,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -974,6 +976,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -1258,6 +1261,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -2134,6 +2138,7 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -2252,6 +2257,7 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -2418,6 +2424,7 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -2702,6 +2709,7 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -3578,6 +3586,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -3696,6 +3705,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -3862,6 +3872,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -4146,6 +4157,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -5022,6 +5034,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -5140,6 +5153,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -5306,6 +5320,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -5590,6 +5605,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -6466,6 +6482,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -6599,6 +6616,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -6780,6 +6798,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -7079,6 +7098,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -7970,6 +7990,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -8103,6 +8124,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -8284,6 +8306,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -8568,6 +8591,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -9459,6 +9483,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -9592,6 +9617,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -9773,6 +9799,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }

--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
@@ -688,6 +688,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -819,6 +820,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -945,6 +947,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -1199,6 +1202,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -1351,6 +1355,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -2225,6 +2230,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -2341,6 +2347,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -2467,6 +2474,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -2683,6 +2691,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -2820,6 +2829,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -3694,6 +3704,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -3810,6 +3821,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -3936,6 +3948,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -4160,6 +4173,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -4297,6 +4311,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -5171,6 +5186,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -5287,6 +5303,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
+                                            "lineHeight": 0,
                                             "opacity": 1,
                                             "textAlignVertical": "center",
                                           }
@@ -5413,6 +5430,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -5530,6 +5548,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -5658,6 +5677,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }
@@ -5795,6 +5815,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
+                                              "lineHeight": 0,
                                               "opacity": 1,
                                               "textAlignVertical": "center",
                                             }

--- a/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
@@ -630,6 +630,7 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                                         "fontWeight": "400",
                                         "height": 46,
                                         "letterSpacing": 0,
+                                        "lineHeight": 0,
                                         "opacity": 1,
                                         "textAlignVertical": "center",
                                       }
@@ -1350,6 +1351,7 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                                         "fontWeight": "400",
                                         "height": 46,
                                         "letterSpacing": 0,
+                                        "lineHeight": 0,
                                         "opacity": 1,
                                         "textAlignVertical": "center",
                                       }
@@ -2084,6 +2086,7 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                                         "fontWeight": "400",
                                         "height": 46,
                                         "letterSpacing": 0,
+                                        "lineHeight": 0,
                                         "opacity": 1,
                                         "textAlignVertical": "center",
                                       }
@@ -2804,6 +2807,7 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                                         "fontWeight": "400",
                                         "height": 46,
                                         "letterSpacing": 0,
+                                        "lineHeight": 0,
                                         "opacity": 1,
                                         "textAlignVertical": "center",
                                       }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -685,6 +685,7 @@ exports[`RegionSelectorModal Component handles empty regions array from navigati
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -1454,6 +1455,7 @@ exports[`RegionSelectorModal Component receives and uses regions from navigation
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -2419,6 +2421,7 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -3616,6 +3619,7 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -4426,6 +4430,7 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -5324,6 +5329,7 @@ exports[`RegionSelectorModal Component render matches snapshot with allRegionsSe
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -6521,6 +6527,7 @@ exports[`RegionSelectorModal Component render matches snapshot with custom selec
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -7718,6 +7725,7 @@ exports[`RegionSelectorModal Component sorts recommended regions to the top when
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
@@ -685,6 +685,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -1550,6 +1551,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -2359,6 +2361,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -3224,6 +3227,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -4089,6 +4093,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -5217,6 +5222,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -871,6 +871,7 @@ exports[`TokenSelectorModal Component displays empty state when no tokens match 
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -3106,6 +3107,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }

--- a/app/components/UI/Ramp/Deposit/components/DepositPhoneField/__snapshots__/DepositPhoneField.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/DepositPhoneField/__snapshots__/DepositPhoneField.test.tsx.snap
@@ -154,6 +154,7 @@ exports[`DepositPhoneField renders correctly after flag button press 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
+            "lineHeight": 0,
             "opacity": 1,
             "textAlignVertical": "center",
           }
@@ -321,6 +322,7 @@ exports[`DepositPhoneField renders correctly after input change 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
+            "lineHeight": 0,
             "opacity": 1,
             "textAlignVertical": "center",
           }
@@ -488,6 +490,7 @@ exports[`DepositPhoneField renders correctly with default props 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
+            "lineHeight": 0,
             "opacity": 1,
             "textAlignVertical": "center",
           }
@@ -655,6 +658,7 @@ exports[`DepositPhoneField renders correctly with different region 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
+            "lineHeight": 0,
             "opacity": 1,
             "textAlignVertical": "center",
           }
@@ -822,6 +826,7 @@ exports[`DepositPhoneField renders correctly with error message 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
+            "lineHeight": 0,
             "opacity": 1,
             "textAlignVertical": "center",
           }
@@ -1004,6 +1009,7 @@ exports[`DepositPhoneField renders correctly with long phone number 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
+            "lineHeight": 0,
             "opacity": 1,
             "textAlignVertical": "center",
           }
@@ -1172,6 +1178,7 @@ exports[`DepositPhoneField renders correctly with onSubmitEditing callback 1`] =
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
+            "lineHeight": 0,
             "opacity": 1,
             "textAlignVertical": "center",
           }
@@ -1339,6 +1346,7 @@ exports[`DepositPhoneField renders correctly with special characters in phone nu
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
+            "lineHeight": 0,
             "opacity": 1,
             "textAlignVertical": "center",
           }
@@ -1506,6 +1514,7 @@ exports[`DepositPhoneField renders correctly with unsupported region 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
+            "lineHeight": 0,
             "opacity": 1,
             "textAlignVertical": "center",
           }
@@ -1673,6 +1682,7 @@ exports[`DepositPhoneField renders correctly with value 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
+            "lineHeight": 0,
             "opacity": 1,
             "textAlignVertical": "center",
           }
@@ -1840,6 +1850,7 @@ exports[`DepositPhoneField updates phone region when region is selected from mod
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
+            "lineHeight": 0,
             "opacity": 1,
             "textAlignVertical": "center",
           }

--- a/app/components/UI/Ramp/Views/Settings/RegionSelector/__snapshots__/RegionSelector.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Settings/RegionSelector/__snapshots__/RegionSelector.test.tsx.snap
@@ -445,6 +445,7 @@ exports[`RegionSelector clears search and scrolls to top when clear button is pr
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -1520,6 +1521,7 @@ exports[`RegionSelector clears search text when clear button is pressed 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -2595,6 +2597,7 @@ exports[`RegionSelector displays empty state when search has no results 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -3166,6 +3169,7 @@ exports[`RegionSelector displays grouped search results showing country and matc
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -3978,6 +3982,7 @@ exports[`RegionSelector displays standalone countries in search results 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -4647,6 +4652,7 @@ exports[`RegionSelector displays standalone states in search results 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -5459,6 +5465,7 @@ exports[`RegionSelector does not highlight country when regionCode does not matc
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -6538,6 +6545,7 @@ exports[`RegionSelector does not highlight state when country does not match 1`]
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -7232,6 +7240,7 @@ exports[`RegionSelector does not highlight state when state ID does not match 1`
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -7941,6 +7950,7 @@ exports[`RegionSelector does not highlight state when userRegion has no state 1`
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -8644,6 +8654,7 @@ exports[`RegionSelector falls back to userCountryCode when regionInTransit is nu
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -9519,6 +9530,7 @@ exports[`RegionSelector filters regions when search text is entered 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -10242,6 +10254,7 @@ exports[`RegionSelector highlights country when regionCode exactly matches count
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -11352,6 +11365,7 @@ exports[`RegionSelector highlights country when regionCode starts with country c
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -12483,6 +12497,7 @@ exports[`RegionSelector highlights state in grouped search results when parent c
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -13350,6 +13365,7 @@ exports[`RegionSelector highlights state when selected in state view 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -14075,6 +14091,7 @@ exports[`RegionSelector limits search results 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -15985,6 +16002,7 @@ exports[`RegionSelector navigates back to countries view when back button is pre
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -16652,6 +16670,7 @@ exports[`RegionSelector navigates to states view when country with states is sel
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -17335,6 +17354,7 @@ exports[`RegionSelector renders countries list 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -18410,6 +18430,7 @@ exports[`RegionSelector renders country with supported set to false 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -19037,6 +19058,7 @@ exports[`RegionSelector renders country without flag 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -19681,6 +19703,7 @@ exports[`RegionSelector renders description text only in country view 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -20740,6 +20763,7 @@ exports[`RegionSelector renders description text only in country view 2`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -21423,6 +21447,7 @@ exports[`RegionSelector renders disabled country 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -22482,6 +22507,7 @@ exports[`RegionSelector renders disabled state 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -23165,6 +23191,7 @@ exports[`RegionSelector renders error state when countries error occurs 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -23710,6 +23737,7 @@ exports[`RegionSelector renders loading state when regions are loading 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -24229,6 +24257,7 @@ exports[`RegionSelector renders recommended countries 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -24960,6 +24989,7 @@ exports[`RegionSelector renders state with supported set to false 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -25555,6 +25585,7 @@ exports[`RegionSelector renders state without stateId 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -26205,6 +26236,7 @@ exports[`RegionSelector renders states view 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -26888,6 +26920,7 @@ exports[`RegionSelector renders unsupported country 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -27947,6 +27980,7 @@ exports[`RegionSelector renders unsupported state 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -28630,6 +28664,7 @@ exports[`RegionSelector renders when country has states and user region state is
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -29761,6 +29796,7 @@ exports[`RegionSelector renders with empty regions array 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -30264,6 +30300,7 @@ exports[`RegionSelector renders with selected user region 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -31379,6 +31416,7 @@ exports[`RegionSelector resets search when navigating to state view 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -32062,6 +32100,7 @@ exports[`RegionSelector scrolls to top when search text changes 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -32617,6 +32656,7 @@ exports[`RegionSelector sets up back button in state view 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -33300,6 +33340,7 @@ exports[`RegionSelector shows state name in country view when user has selected 
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }
@@ -34441,6 +34482,7 @@ exports[`RegionSelector sorts regions with recommended first when no search 1`] 
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
+                                  "lineHeight": 0,
                                   "opacity": 1,
                                   "textAlignVertical": "center",
                                 }

--- a/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
@@ -720,6 +720,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -1581,6 +1582,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }
@@ -3956,6 +3958,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
+                                      "lineHeight": 0,
                                       "opacity": 1,
                                       "textAlignVertical": "center",
                                     }

--- a/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
@@ -217,6 +217,7 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                       "fontWeight": "400",
                       "height": 46,
                       "letterSpacing": 0,
+                      "lineHeight": 0,
                       "opacity": 1,
                       "textAlignVertical": "center",
                     }
@@ -372,6 +373,7 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                       "fontWeight": "400",
                       "height": 46,
                       "letterSpacing": 0,
+                      "lineHeight": 0,
                       "opacity": 1,
                       "textAlignVertical": "center",
                     }

--- a/app/components/Views/EditAccountName/__snapshots__/EditAccountName.test.tsx.snap
+++ b/app/components/Views/EditAccountName/__snapshots__/EditAccountName.test.tsx.snap
@@ -113,6 +113,7 @@ exports[`EditAccountName should render correctly 1`] = `
                 "fontWeight": "400",
                 "height": 46,
                 "letterSpacing": 0,
+                "lineHeight": 0,
                 "opacity": 1,
                 "textAlignVertical": "center",
               }
@@ -217,6 +218,7 @@ exports[`EditAccountName should render correctly 1`] = `
                 "fontWeight": "400",
                 "height": 46,
                 "letterSpacing": 0,
+                "lineHeight": 0,
                 "opacity": 1,
                 "textAlignVertical": "center",
               }

--- a/app/components/Views/Login/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Login/__snapshots__/index.test.tsx.snap
@@ -128,6 +128,7 @@ exports[`Login renders matching snapshot 1`] = `
                 "fontWeight": "400",
                 "height": 46,
                 "letterSpacing": 0,
+                "lineHeight": 0,
                 "opacity": 1,
                 "textAlignVertical": "center",
               }
@@ -430,6 +431,7 @@ exports[`Login renders matching snapshot when password input is focused 1`] = `
                 "fontWeight": "400",
                 "height": 46,
                 "letterSpacing": 0,
+                "lineHeight": 0,
                 "opacity": 1,
                 "textAlignVertical": "center",
               }

--- a/app/components/Views/ResetPassword/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ResetPassword/__snapshots__/index.test.tsx.snap
@@ -199,6 +199,7 @@ exports[`ResetPassword render matches snapshot 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
+                          "lineHeight": 0,
                           "opacity": 1,
                           "textAlignVertical": "center",
                         }


### PR DESCRIPTION
## **Description**

**Reason for the change**

On iOS, `TextInput` can show intermittent placeholder text misalignment or clipping. This comes from a React Native bug: `TextInput` still uses the default `usesFontLeading = YES` in `NSLayoutManager`, while `Text` was fixed in 2020 with `usesFontLeading = NO`. With Geist’s large ascender/leading, Fabric’s text measurement becomes inconsistent, so placeholder alignment is unstable. 

**Improvement / solution**

Add `lineHeight: 0` to the Input base styles in `Input.styles.ts`. This gives Fabric a fixed line height and avoids the faulty font-leading calculation. Unlike `lineHeight: 20`, it does not reintroduce the multi-line wrapping issue. No native changes or rebuilds are required.

**References**

- [React Native #39145](https://github.com/facebook/react-native/issues/39145)  
- [React Native #45268](https://github.com/facebook/react-native/issues/45268)  
- [RN fix for Text only](https://github.com/facebook/react-native/commit/5d08aab526b2702b46ff75ea7e943a33aa6df288)

---

## **Changelog**

CHANGELOG entry: Fixed intermittent placeholder text alignment and clipping in text inputs on iOS.

---

## **Related issues**

Fixes: 

---

## **Manual testing steps**

```gherkin
Feature: Text input placeholder alignment

  Scenario: user views single-line text inputs on iOS
    Given the app is running on an iOS device or simulator
    When the user opens screens with text inputs (e.g. Send, Swap, custom token amount)
    Then placeholder text is vertically aligned and does not shift or clip on focus/blur or after re-renders
```

---

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/b401bc85-1222-4dcd-859a-c9266283cebd

### **After**


https://github.com/user-attachments/assets/e0cf18cd-e3a0-4fef-b050-73bb611216ff

Verified on Android
![IMG_0029](https://github.com/user-attachments/assets/a78a2150-e4e5-431c-9430-1c2fd1f48ba6)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, style-only change to a shared input component; main risk is unintended layout differences in text rendering across platforms and screens.
> 
> **Overview**
> Fixes intermittent iOS `TextInput` placeholder vertical misalignment/clipping by forcing a fixed `lineHeight: 0` in the shared `Input` base styles (`Input.styles.ts`).
> 
> Updates a large set of Jest snapshots across screens/components that render this `Input` to reflect the new style output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd3cd24beac44a7022998ad1d179a780159085a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->