### PR TITLE
fix(perps): validate market patterns and log invalid ones to Sentry

### DIFF
--- a/app/controllers/perps/services/FeatureFlagConfigurationService.test.ts
+++ b/app/controllers/perps/services/FeatureFlagConfigurationService.test.ts
@@ -461,6 +461,25 @@ describe('FeatureFlagConfigurationService', () => {
       );
     });
 
+    it('preserves current config when all array patterns are invalid', () => {
+      mockCurrentHip3Config.allowlistMarkets = ['existing:BTC'];
+      (stripQuotes as jest.Mock).mockImplementation((s: string) => s);
+      (validateMarketPattern as jest.Mock).mockImplementation(() => {
+        throw new Error('Market pattern contains invalid characters');
+      });
+
+      mockRemoteFeatureFlagState.remoteFeatureFlags = {
+        perpsHip3AllowlistMarkets: ['"bad1"', '"bad2"'],
+      };
+
+      featureFlagConfigurationService.refreshHip3Config({
+        remoteFeatureFlagControllerState: mockRemoteFeatureFlagState,
+        context: mockContext,
+      });
+
+      // Should NOT overwrite existing config with empty array
+      expect(mockContext.setHip3Config).not.toHaveBeenCalled();
+    });
     it('logs warning for dropped invalid patterns', () => {
       (parseCommaSeparatedString as jest.Mock).mockReturnValue([
         '"bad"pattern"',

--- a/app/controllers/perps/services/FeatureFlagConfigurationService.test.ts
+++ b/app/controllers/perps/services/FeatureFlagConfigurationService.test.ts
@@ -7,11 +7,16 @@ import {
   parseCommaSeparatedString,
   stripQuotes,
 } from '../utils/stringParseUtils';
+import { validateMarketPattern } from '../utils/marketUtils';
 import type { ServiceContext } from './ServiceContext';
 import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 import type { PerpsPlatformDependencies } from '../types';
 
 jest.mock('../utils/stringParseUtils');
+jest.mock('../utils/marketUtils', () => ({
+  ...jest.requireActual('../utils/marketUtils'),
+  validateMarketPattern: jest.fn(),
+}));
 
 describe('FeatureFlagConfigurationService', () => {
   let mockContext: ServiceContext;
@@ -78,6 +83,9 @@ describe('FeatureFlagConfigurationService', () => {
 
     // stripQuotes is called after parseCommaSeparatedString - mock it to pass through values
     (stripQuotes as jest.Mock).mockImplementation((s: string) => s);
+
+    // validateMarketPattern passes by default
+    (validateMarketPattern as jest.Mock).mockImplementation(() => true);
 
     jest.clearAllMocks();
   });
@@ -391,6 +399,93 @@ describe('FeatureFlagConfigurationService', () => {
       expect(mockDeps.debugLogger.log).toHaveBeenCalledWith(
         expect.stringContaining('blocklistMarkets string was empty'),
         expect.anything(),
+      );
+    });
+
+    it('filters out invalid patterns from string allowlist', () => {
+      (parseCommaSeparatedString as jest.Mock).mockReturnValue([
+        'xyz:TSLA',
+        '"bad"pattern"',
+        'valid:*',
+      ]);
+      (stripQuotes as jest.Mock).mockImplementation((s: string) => s);
+      (validateMarketPattern as jest.Mock).mockImplementation(
+        (pattern: string) => {
+          if (pattern === '"bad"pattern"') {
+            throw new Error('Market pattern contains invalid characters');
+          }
+          return true;
+        },
+      );
+
+      mockRemoteFeatureFlagState.remoteFeatureFlags = {
+        perpsHip3AllowlistMarkets: 'xyz:TSLA,"bad"pattern",valid:*',
+      };
+
+      featureFlagConfigurationService.refreshHip3Config({
+        remoteFeatureFlagControllerState: mockRemoteFeatureFlagState,
+        context: mockContext,
+      });
+
+      expect(mockContext.setHip3Config).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowlistMarkets: ['xyz:TSLA', 'valid:*'],
+        }),
+      );
+    });
+
+    it('filters out invalid patterns from array blocklist', () => {
+      (stripQuotes as jest.Mock).mockImplementation((s: string) => s);
+      (validateMarketPattern as jest.Mock).mockImplementation(
+        (pattern: string) => {
+          if (pattern === '"invalid"') {
+            throw new Error('Market pattern contains invalid characters');
+          }
+          return true;
+        },
+      );
+
+      mockRemoteFeatureFlagState.remoteFeatureFlags = {
+        perpsHip3BlocklistMarkets: ['valid:BTC', '"invalid"', 'also:valid'],
+      };
+
+      featureFlagConfigurationService.refreshHip3Config({
+        remoteFeatureFlagControllerState: mockRemoteFeatureFlagState,
+        context: mockContext,
+      });
+
+      expect(mockContext.setHip3Config).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blocklistMarkets: ['valid:BTC', 'also:valid'],
+        }),
+      );
+    });
+
+    it('logs warning for dropped invalid patterns', () => {
+      (parseCommaSeparatedString as jest.Mock).mockReturnValue([
+        '"bad"pattern"',
+      ]);
+      (stripQuotes as jest.Mock).mockImplementation((s: string) => s);
+      (validateMarketPattern as jest.Mock).mockImplementation(() => {
+        throw new Error('Market pattern contains invalid characters');
+      });
+
+      mockRemoteFeatureFlagState.remoteFeatureFlags = {
+        perpsHip3AllowlistMarkets: '"bad"pattern"',
+      };
+
+      featureFlagConfigurationService.refreshHip3Config({
+        remoteFeatureFlagControllerState: mockRemoteFeatureFlagState,
+        context: mockContext,
+      });
+
+      expect(mockDeps.logger.error).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          context: expect.objectContaining({
+            data: expect.objectContaining({ pattern: '"bad"pattern"' }),
+          }),
+        }),
       );
     });
   });

--- a/app/controllers/perps/services/FeatureFlagConfigurationService.ts
+++ b/app/controllers/perps/services/FeatureFlagConfigurationService.ts
@@ -93,11 +93,19 @@ export class FeatureFlagConfigurationService {
         fieldName,
       );
 
+      if (validatedMarkets.length > 0) {
+        this.deps.debugLogger.log(
+          `PerpsController: HIP-3 ${fieldName} validated from array`,
+          { validatedMarkets },
+        );
+        return validatedMarkets;
+      }
+
       this.deps.debugLogger.log(
-        `PerpsController: HIP-3 ${fieldName} validated from array`,
-        { validatedMarkets },
+        `PerpsController: HIP-3 ${fieldName} array was empty after filtering`,
+        { fallbackValue: currentValue },
       );
-      return validatedMarkets;
+      return undefined;
     }
 
     this.deps.debugLogger.log(

--- a/app/controllers/perps/utils/stringParseUtils.test.ts
+++ b/app/controllers/perps/utils/stringParseUtils.test.ts
@@ -1,0 +1,75 @@
+import { stripQuotes, parseCommaSeparatedString } from './stringParseUtils';
+
+describe('stripQuotes', () => {
+  it('removes single layer of double quotes', () => {
+    expect(stripQuotes('"hello"')).toBe('hello');
+  });
+
+  it('removes single layer of single quotes', () => {
+    expect(stripQuotes("'hello'")).toBe('hello');
+  });
+
+  it('removes nested quotes (single wrapping double)', () => {
+    // Simulates LaunchDarkly returning '"xyz:TSLA"' (single quotes wrapping double quotes)
+    expect(stripQuotes(`'"xyz:TSLA"'`)).toBe('xyz:TSLA');
+  });
+
+  it('removes multiple layers of double quotes', () => {
+    expect(stripQuotes('""xyz""')).toBe('xyz');
+  });
+
+  it('removes mixed nested quotes (double wrapping single)', () => {
+    expect(stripQuotes(`"'xyz'"`)).toBe('xyz');
+  });
+
+  it('returns string unchanged when no wrapping quotes', () => {
+    expect(stripQuotes('hello')).toBe('hello');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(stripQuotes('')).toBe('');
+  });
+
+  it('does not remove mismatched quotes', () => {
+    expect(stripQuotes(`"hello'`)).toBe(`"hello'`);
+  });
+
+  it('does not remove quotes in the middle', () => {
+    expect(stripQuotes('hel"lo')).toBe('hel"lo');
+  });
+
+  it('handles deeply nested single quotes', () => {
+    expect(stripQuotes(`'''xyz'''`)).toBe('xyz');
+  });
+
+  it('handles real LaunchDarkly pattern with nested quotes', () => {
+    // The actual problematic value: single-quote wrapped double-quoted string
+    expect(stripQuotes(`'"xyz:TSLA"'`)).toBe('xyz:TSLA');
+  });
+});
+
+describe('parseCommaSeparatedString', () => {
+  it('parses comma-separated values', () => {
+    expect(parseCommaSeparatedString('BTC,ETH,SOL')).toEqual([
+      'BTC',
+      'ETH',
+      'SOL',
+    ]);
+  });
+
+  it('trims whitespace', () => {
+    expect(parseCommaSeparatedString(' BTC , ETH , SOL ')).toEqual([
+      'BTC',
+      'ETH',
+      'SOL',
+    ]);
+  });
+
+  it('filters empty values', () => {
+    expect(parseCommaSeparatedString('BTC,,SOL')).toEqual(['BTC', 'SOL']);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(parseCommaSeparatedString('')).toEqual([]);
+  });
+});

--- a/app/controllers/perps/utils/stringParseUtils.ts
+++ b/app/controllers/perps/utils/stringParseUtils.ts
@@ -1,11 +1,12 @@
 export const stripQuotes = (str: string): string => {
-  if (
-    (str.startsWith('"') && str.endsWith('"')) ||
-    (str.startsWith("'") && str.endsWith("'"))
+  let result = str;
+  while (
+    (result.startsWith('"') && result.endsWith('"')) ||
+    (result.startsWith("'") && result.endsWith("'"))
   ) {
-    return str.slice(1, -1);
+    result = result.slice(1, -1);
   }
-  return str;
+  return result;
 };
 
 export const parseCommaSeparatedString = (value: string): string[] =>


### PR DESCRIPTION
## **Description**

Defense-in-depth fix to prevent a single bad LaunchDarkly pattern from crashing the perps provider or flooding Sentry with `CLIENT_NOT_INITIALIZED` errors.

- Validate and filter invalid market patterns at both ingestion points (`FeatureFlagConfigurationService.filterValidPatterns`, `HyperLiquidProvider.compilePatternsSafely`) — invalid patterns are dropped and reported to Sentry
- Fix `stripQuotes` to handle nested quote layers (e.g. `'"xyz:TSLA"'` from LaunchDarkly)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: Sentry `CLIENT_NOT_INITIALIZED` flood caused by malformed LaunchDarkly patterns

## **Manual testing steps**

```gherkin
Feature: Invalid market pattern resilience

  Scenario: Provider initializes with bad patterns
    Given a HyperLiquidProvider with an invalid pattern in the allowlist

    When the provider is constructed
    Then it does not throw and valid patterns are compiled
    And the invalid pattern is logged to Sentry

  Scenario: Feature flag service filters bad remote config
    Given LaunchDarkly returns a market list containing an invalid pattern

    When FeatureFlagConfigurationService validates the list
    Then the invalid pattern is dropped
    And the valid patterns are applied
    And the invalid pattern is logged to Sentry
```

## **Screenshots/Recordings**

N/A — no UI changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped defensive validation/logging changes around feature-flag parsing and pattern compilation; behavior changes mainly drop invalid patterns and avoid constructor throws.
> 
> **Overview**
> Hardens HIP-3 market allow/blocklist handling so malformed LaunchDarkly values no longer crash perps setup: `FeatureFlagConfigurationService` now validates patterns via `validateMarketPattern`, **drops invalid entries**, and logs them via `logger.error`, falling back to the existing config when filtering produces an empty list.
> 
> `HyperLiquidProvider` now compiles market filters with a new `compilePatternsSafely` helper that skips patterns that fail `compileMarketPattern` and logs the error instead of throwing during construction. `stripQuotes` was updated to remove *multiple nested quote layers*, and new/expanded tests cover nested quote parsing plus invalid-pattern filtering/logging and provider resilience.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 572077d76a391b85048de23970e5007ed40349b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->