### PR TITLE
fix(perps): show order submitted toast via execution hook callback cp-7.66.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -253,7 +253,6 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   const orderTypeRef = useRef<OrderType>('market');
 
   const isSubmittingRef = useRef(false);
-  const hasShownSubmittedToastRef = useRef(false);
   const orderStartTimeRef = useRef<number>(0);
   const inputMethodRef = useRef<InputMethod>('default');
 
@@ -530,6 +529,15 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   // Order execution using new hook
   const { placeOrder: executeOrder, isPlacing: isPlacingOrder } =
     usePerpsOrderExecution({
+      onSubmitted: () => {
+        showToast(
+          PerpsToastOptions.orderManagement[orderForm.type].submitted(
+            orderForm.direction,
+            positionSize,
+            orderForm.asset,
+          ),
+        );
+      },
       onSuccess: (_position) => {
         showToast(
           PerpsToastOptions.orderManagement[orderForm.type].confirmed(
@@ -549,30 +557,6 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
         );
       },
     });
-
-  useEffect(() => {
-    if (isPlacingOrder && !hasShownSubmittedToastRef.current) {
-      showToast(
-        PerpsToastOptions.orderManagement[orderForm.type].submitted(
-          orderForm.direction,
-          positionSize,
-          orderForm.asset,
-        ),
-      );
-      hasShownSubmittedToastRef.current = true;
-    } else if (!isPlacingOrder && hasShownSubmittedToastRef.current) {
-      // Reset the flag when order placement is complete
-      hasShownSubmittedToastRef.current = false;
-    }
-  }, [
-    PerpsToastOptions.orderManagement,
-    isPlacingOrder,
-    orderForm.asset,
-    orderForm.direction,
-    orderForm.type,
-    positionSize,
-    showToast,
-  ]);
 
   // Memoize liquidation price params to prevent infinite recalculation
   const liquidationPriceParams = useMemo(() => {
@@ -837,14 +821,6 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
 
         // Show deposit toast and set up tracking before confirming
         handleDepositConfirm(activeTransactionMeta, () => {
-          hasShownSubmittedToastRef.current = true;
-          showToast(
-            PerpsToastOptions.orderManagement[orderForm.type].submitted(
-              orderForm.direction,
-              positionSize,
-              orderForm.asset,
-            ),
-          );
           handlePlaceOrder(true);
         });
 
@@ -1059,7 +1035,6 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
       executeOrder,
       showToast,
       PerpsToastOptions.formValidation.orderForm,
-      PerpsToastOptions.orderManagement,
       PerpsToastOptions.positionManagement.tpsl,
       updatePositionTPSL,
       marginRequired,

--- a/app/components/UI/Perps/hooks/usePerpsOrderDepositTracking.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderDepositTracking.test.ts
@@ -1,0 +1,262 @@
+import { renderHook, act } from '@testing-library/react-native';
+import {
+  TransactionStatus,
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { usePerpsOrderDepositTracking } from './usePerpsOrderDepositTracking';
+
+const mockShowToast = jest.fn();
+const mockSubscribe = jest.fn();
+
+jest.mock('./usePerpsToasts', () => ({
+  __esModule: true,
+  default: () => ({
+    showToast: mockShowToast,
+    PerpsToastOptions: {
+      accountManagement: {
+        deposit: {
+          inProgress: jest.fn((_percent: number, transactionId: string) => ({
+            inProgress: true,
+            transactionId,
+          })),
+          takingLonger: {
+            closeButtonOptions: { onPress: undefined },
+          },
+          tradeCanceled: { tradeCanceled: true },
+          error: { error: true },
+        },
+      },
+    },
+  }),
+}));
+
+jest.mock('../../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    controllerMessenger: {
+      subscribe: (...args: unknown[]) => mockSubscribe(...args),
+    },
+  },
+}));
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => key),
+}));
+
+jest.mock('@metamask/perps-controller', () => ({
+  PERPS_CONSTANTS: {
+    DepositTakingLongerToastDelayMs: 100,
+  },
+}));
+
+describe('usePerpsOrderDepositTracking', () => {
+  const transactionId = 'tx-123';
+  const perpsDepositMeta: TransactionMeta = {
+    id: transactionId,
+    type: TransactionType.perpsDepositAndOrder,
+    status: TransactionStatus.submitted,
+  } as TransactionMeta;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns handleDepositConfirm function', () => {
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
+
+    expect(typeof result.current.handleDepositConfirm).toBe('function');
+  });
+
+  it('does nothing when transaction type is not perpsDepositAndOrder', () => {
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
+    const otherMeta = {
+      id: 'other-id',
+      type: TransactionType.simpleSend,
+      status: TransactionStatus.submitted,
+    } as TransactionMeta;
+    const callback = jest.fn();
+
+    act(() => {
+      result.current.handleDepositConfirm(otherMeta, callback);
+    });
+
+    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockSubscribe).not.toHaveBeenCalled();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('shows progress toast and subscribes to controller when type is perpsDepositAndOrder', () => {
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
+
+    act(() => {
+      result.current.handleDepositConfirm(perpsDepositMeta, jest.fn());
+    });
+
+    expect(mockShowToast).toHaveBeenCalled();
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      'TransactionController:transactionFailed',
+      expect.any(Function),
+    );
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      'TransactionController:transactionStatusUpdated',
+      expect.any(Function),
+    );
+  });
+
+  it('invokes callback when transaction status becomes confirmed', () => {
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
+    let statusUpdatedHandler: (payload: {
+      transactionMeta: TransactionMeta;
+    }) => void;
+
+    mockSubscribe.mockImplementation(
+      (
+        _event: string,
+        handler: (payload: { transactionMeta: TransactionMeta }) => void,
+      ) => {
+        if (_event === 'TransactionController:transactionStatusUpdated') {
+          statusUpdatedHandler = handler;
+        }
+      },
+    );
+
+    const callback = jest.fn();
+    act(() => {
+      result.current.handleDepositConfirm(perpsDepositMeta, callback);
+    });
+
+    expect(statusUpdatedHandler).toBeDefined();
+    act(() => {
+      (
+        statusUpdatedHandler as (payload: {
+          transactionMeta: TransactionMeta;
+        }) => void
+      )({
+        transactionMeta: {
+          ...perpsDepositMeta,
+          id: transactionId,
+          status: TransactionStatus.confirmed,
+        } as TransactionMeta,
+      });
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke callback when transaction confirms after cancel trade requested', () => {
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
+    let statusUpdatedHandler: (payload: {
+      transactionMeta: TransactionMeta;
+    }) => void;
+
+    mockSubscribe.mockImplementation(
+      (
+        _event: string,
+        handler: (payload: { transactionMeta: TransactionMeta }) => void,
+      ) => {
+        if (_event === 'TransactionController:transactionStatusUpdated') {
+          statusUpdatedHandler = handler;
+        }
+      },
+    );
+
+    const callback = jest.fn();
+    act(() => {
+      result.current.handleDepositConfirm(perpsDepositMeta, callback);
+    });
+
+    jest.advanceTimersByTime(100);
+
+    const takingLongerCall = mockShowToast.mock.calls.find(
+      (call: unknown[]) =>
+        Array.isArray(call) &&
+        call[0] &&
+        typeof call[0] === 'object' &&
+        'closeButtonOptions' in (call[0] as Record<string, unknown>),
+    );
+    const closeButtonOptions = takingLongerCall?.[0] as {
+      closeButtonOptions?: { onPress: () => void };
+    };
+    act(() => {
+      closeButtonOptions?.closeButtonOptions?.onPress?.();
+    });
+
+    expect(statusUpdatedHandler).toBeDefined();
+    act(() => {
+      (
+        statusUpdatedHandler as (payload: {
+          transactionMeta: TransactionMeta;
+        }) => void
+      )({
+        transactionMeta: {
+          ...perpsDepositMeta,
+          id: transactionId,
+          status: TransactionStatus.confirmed,
+        } as TransactionMeta,
+      });
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('shows error toast when transaction fails with matching id', () => {
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
+    let failedHandler: (payload: { transactionMeta: TransactionMeta }) => void;
+
+    mockSubscribe.mockImplementation(
+      (
+        _event: string,
+        handler: (payload: { transactionMeta: TransactionMeta }) => void,
+      ) => {
+        if (_event === 'TransactionController:transactionFailed') {
+          failedHandler = handler;
+        }
+      },
+    );
+
+    act(() => {
+      result.current.handleDepositConfirm(perpsDepositMeta, jest.fn());
+    });
+
+    mockShowToast.mockClear();
+
+    expect(failedHandler).toBeDefined();
+    act(() => {
+      (
+        failedHandler as (payload: { transactionMeta: TransactionMeta }) => void
+      )({
+        transactionMeta: {
+          id: transactionId,
+          type: TransactionType.perpsDepositAndOrder,
+        } as TransactionMeta,
+      });
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith({ error: true });
+  });
+
+  it('shows taking longer toast after delay', () => {
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
+
+    act(() => {
+      result.current.handleDepositConfirm(perpsDepositMeta, jest.fn());
+    });
+
+    mockShowToast.mockClear();
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(mockShowToast).toHaveBeenCalled();
+    expect(mockShowToast.mock.calls[0][0]).toMatchObject({
+      closeButtonOptions: expect.any(Object),
+    });
+  });
+});

--- a/app/components/UI/Perps/hooks/usePerpsOrderDepositTracking.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderDepositTracking.test.ts
@@ -111,9 +111,9 @@ describe('usePerpsOrderDepositTracking', () => {
 
   it('invokes callback when transaction status becomes confirmed', () => {
     const { result } = renderHook(() => usePerpsOrderDepositTracking());
-    let statusUpdatedHandler: (payload: {
-      transactionMeta: TransactionMeta;
-    }) => void;
+    const handlers: {
+      statusUpdated?: (payload: { transactionMeta: TransactionMeta }) => void;
+    } = {};
 
     mockSubscribe.mockImplementation(
       (
@@ -121,7 +121,7 @@ describe('usePerpsOrderDepositTracking', () => {
         handler: (payload: { transactionMeta: TransactionMeta }) => void,
       ) => {
         if (_event === 'TransactionController:transactionStatusUpdated') {
-          statusUpdatedHandler = handler;
+          handlers.statusUpdated = handler;
         }
       },
     );
@@ -131,6 +131,7 @@ describe('usePerpsOrderDepositTracking', () => {
       result.current.handleDepositConfirm(perpsDepositMeta, callback);
     });
 
+    const statusUpdatedHandler = handlers.statusUpdated;
     expect(statusUpdatedHandler).toBeDefined();
     act(() => {
       (
@@ -151,9 +152,9 @@ describe('usePerpsOrderDepositTracking', () => {
 
   it('does not invoke callback when transaction confirms after cancel trade requested', () => {
     const { result } = renderHook(() => usePerpsOrderDepositTracking());
-    let statusUpdatedHandler: (payload: {
-      transactionMeta: TransactionMeta;
-    }) => void;
+    const handlers: {
+      statusUpdated?: (payload: { transactionMeta: TransactionMeta }) => void;
+    } = {};
 
     mockSubscribe.mockImplementation(
       (
@@ -161,7 +162,7 @@ describe('usePerpsOrderDepositTracking', () => {
         handler: (payload: { transactionMeta: TransactionMeta }) => void,
       ) => {
         if (_event === 'TransactionController:transactionStatusUpdated') {
-          statusUpdatedHandler = handler;
+          handlers.statusUpdated = handler;
         }
       },
     );
@@ -187,6 +188,7 @@ describe('usePerpsOrderDepositTracking', () => {
       closeButtonOptions?.closeButtonOptions?.onPress?.();
     });
 
+    const statusUpdatedHandler = handlers.statusUpdated;
     expect(statusUpdatedHandler).toBeDefined();
     act(() => {
       (
@@ -207,7 +209,9 @@ describe('usePerpsOrderDepositTracking', () => {
 
   it('shows error toast when transaction fails with matching id', () => {
     const { result } = renderHook(() => usePerpsOrderDepositTracking());
-    let failedHandler: (payload: { transactionMeta: TransactionMeta }) => void;
+    const handlers: {
+      failed?: (payload: { transactionMeta: TransactionMeta }) => void;
+    } = {};
 
     mockSubscribe.mockImplementation(
       (
@@ -215,7 +219,7 @@ describe('usePerpsOrderDepositTracking', () => {
         handler: (payload: { transactionMeta: TransactionMeta }) => void,
       ) => {
         if (_event === 'TransactionController:transactionFailed') {
-          failedHandler = handler;
+          handlers.failed = handler;
         }
       },
     );
@@ -226,10 +230,12 @@ describe('usePerpsOrderDepositTracking', () => {
 
     mockShowToast.mockClear();
 
-    expect(failedHandler).toBeDefined();
+    expect(handlers.failed).toBeDefined();
     act(() => {
       (
-        failedHandler as (payload: { transactionMeta: TransactionMeta }) => void
+        handlers.failed as (payload: {
+          transactionMeta: TransactionMeta;
+        }) => void
       )({
         transactionMeta: {
           id: transactionId,

--- a/app/components/UI/Perps/hooks/usePerpsOrderDepositTracking.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderDepositTracking.ts
@@ -3,9 +3,8 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 import Engine from '../../../../core/Engine';
-import { ToastContext } from '../../../../component-library/components/Toast';
 import { strings } from '../../../../../locales/i18n';
 import { PERPS_CONSTANTS } from '@metamask/perps-controller';
 import usePerpsToasts from './usePerpsToasts';
@@ -24,7 +23,6 @@ import usePerpsToasts from './usePerpsToasts';
  */
 export const usePerpsOrderDepositTracking = () => {
   const { showToast, PerpsToastOptions } = usePerpsToasts();
-  const { toastRef } = useContext(ToastContext);
 
   const showProgressToast = useCallback(
     (transactionId: string) => {
@@ -83,7 +81,6 @@ export const usePerpsOrderDepositTracking = () => {
         ) {
           if (failedTransactionMeta.id === transactionId) {
             clearTimeout(depositLongerTimeoutId);
-            toastRef?.current?.closeToast();
             showToast(PerpsToastOptions.accountManagement.deposit.error);
           }
         }
@@ -99,7 +96,6 @@ export const usePerpsOrderDepositTracking = () => {
           updatedTransactionMeta.status === TransactionStatus.confirmed
         ) {
           clearTimeout(depositLongerTimeoutId);
-          toastRef?.current?.closeToast();
           if (!cancelTradeRequested) {
             callback?.();
           }
@@ -115,12 +111,7 @@ export const usePerpsOrderDepositTracking = () => {
         handleTransactionStatusUpdated,
       );
     },
-    [
-      showToast,
-      toastRef,
-      showProgressToast,
-      PerpsToastOptions.accountManagement.deposit,
-    ],
+    [showToast, showProgressToast, PerpsToastOptions.accountManagement.deposit],
   );
 
   return {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -16,6 +16,8 @@ import { usePerpsMeasurement } from './usePerpsMeasurement';
 import { usePerpsTrading } from './usePerpsTrading';
 
 interface UsePerpsOrderExecutionParams {
+  /** Called when the order has been successfully submitted to the exchange (before position fetch). */
+  onSubmitted?: () => void;
   onSuccess?: (position?: Position) => void;
   onError?: (error: string) => void;
 }
@@ -34,7 +36,7 @@ interface UsePerpsOrderExecutionReturn {
 export function usePerpsOrderExecution(
   params: UsePerpsOrderExecutionParams = {},
 ): UsePerpsOrderExecutionReturn {
-  const { onSuccess, onError } = params;
+  const { onSubmitted, onSuccess, onError } = params;
   const { placeOrder: controllerPlaceOrder, getPositions } = usePerpsTrading();
   const { track } = usePerpsEventTracking();
 
@@ -62,6 +64,8 @@ export function usePerpsOrderExecution(
           'usePerpsOrderExecution: Placing order',
           JSON.stringify(orderParams, null, 2),
         );
+
+        onSubmitted?.();
 
         const result = await controllerPlaceOrder(orderParams);
         setLastResult(result);
@@ -232,7 +236,14 @@ export function usePerpsOrderExecution(
         setIsPlacing(false);
       }
     },
-    [controllerPlaceOrder, getPositions, onSuccess, onError, track],
+    [
+      controllerPlaceOrder,
+      getPositions,
+      onSubmitted,
+      onSuccess,
+      onError,
+      track,
+    ],
   );
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The "order submitted" toast was previously driven by a `useEffect` that watched `isPlacingOrder`, and was also triggered manually in the deposit-confirm path. That led to timing issues and possible duplicate toasts. In addition, `usePerpsOrderDepositTracking` was using `ToastContext` and calling `toastRef?.current?.closeToast()` on success/failure, which was brittle and coupled the hook to the toast implementation.

**Changes:**
1. **usePerpsOrderExecution** – Added an optional `onSubmitted` callback, invoked when the order is successfully submitted to the exchange (before the position fetch). This gives a single, well-defined moment to show the "submitted" toast.
2. **PerpsOrderView** – Removed `hasShownSubmittedToastRef` and the `useEffect` that showed the submitted toast from `isPlacingOrder`. The view now passes an `onSubmitted` handler into `usePerpsOrderExecution` to show the toast. Removed the duplicate submitted toast and ref mutation from the deposit-confirm callback.
3. **usePerpsOrderDepositTracking** – Removed use of `ToastContext` and all `toastRef?.current?.closeToast()` calls. Rely on the normal toast flow (e.g. showing error/success toasts) instead of manually closing toasts. Dropped unused `useContext` and `ToastContext` imports.

Result: one place shows the submitted toast (execution hook callback), no duplicate toasts, and deposit tracking no longer depends on the toast ref.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Perps order "submitted" toast timing and removed duplicate toasts when placing orders (including after deposit).

## **Related issues**

Jira issue: https://consensyssoftware.atlassian.net/browse/TAT-2551

## **Manual testing steps**

```gherkin
Feature: Perps order submitted toast

  Scenario: user places a market order
    Given user is on Perps order view with a valid order form

    When user taps Place Order and the order is submitted to the exchange
    Then a single "order submitted" toast is shown
    And no duplicate submitted toasts appear
    And the toast does not disappear after a split of a second
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/66bf7bdd-3152-47e8-a6f9-78177dbf5dd8



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI feedback/notification timing changes around Perps order submission and deposit tracking, with added unit tests and no changes to core order or transaction execution logic.
> 
> **Overview**
> Routes the **Perps “order submitted” toast** through a new `usePerpsOrderExecution` `onSubmitted` callback, removing the prior `isPlacing`-driven `useEffect` + deposit-confirm manual toast path to avoid timing issues/duplicates.
> 
> Decouples `usePerpsOrderDepositTracking` from `ToastContext` by removing toast-ref closing behavior and relying on normal toast replacements for deposit progress/taking-longer/error states. Adds targeted tests covering the new `onSubmitted` toast behavior and deposit-tracking event handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa89d0057d12221f4818f57a1c41b9ab8e9f1135. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->