### PR TITLE
fix: network fee display on confirmation page if conversion rate is not available for the currency

### DIFF
--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
@@ -134,7 +134,7 @@ describe('useFeeCalculations', () => {
     expect(result.current.calculateGasEstimate).toBeDefined();
   });
 
-  it('computes fees with zero fiat when currencyRates entry is null and nativeConversionRate is undefined', () => {
+  it('returns native fees but no fiat when conversion rate is undefined', () => {
     const clonedState = cloneDeep(stakingDepositConfirmationState);
 
     clonedState.engine.backgroundState.CurrencyRateController.currencyRates.ETH =
@@ -151,7 +151,8 @@ describe('useFeeCalculations', () => {
       },
     );
 
-    expect(result.current.estimatedFeeFiat).toBe('< $0.01');
+    expect(result.current.estimatedFeeFiat).toBeNull();
+    expect(result.current.estimatedFeeFiatPrecise).toBeNull();
     expect(result.current.estimatedFeeNative).toBe('0.0001');
     expect(result.current.preciseNativeFeeInHex).toBe('0x5572e9c22d00');
     expect(result.current.calculateGasEstimate).toBeDefined();

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
@@ -134,7 +134,7 @@ describe('useFeeCalculations', () => {
     expect(result.current.calculateGasEstimate).toBeDefined();
   });
 
-  it('returns all nulls when currencyRates entry is null (nativeCurrency undefined)', () => {
+  it('computes fees with zero fiat when currencyRates entry is null and nativeConversionRate is undefined', () => {
     const clonedState = cloneDeep(stakingDepositConfirmationState);
 
     clonedState.engine.backgroundState.CurrencyRateController.currencyRates.ETH =
@@ -151,8 +151,9 @@ describe('useFeeCalculations', () => {
       },
     );
 
-    expect(result.current.estimatedFeeFiat).toBeNull();
-    expect(result.current.estimatedFeeNative).not.toBeNull();
+    expect(result.current.estimatedFeeFiat).toBe('< $0.01');
+    expect(result.current.estimatedFeeNative).toBe('0.0001');
+    expect(result.current.preciseNativeFeeInHex).toBe('0x5572e9c22d00');
     expect(result.current.calculateGasEstimate).toBeDefined();
   });
 

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -79,7 +79,8 @@ export const useFeeCalculations = (
   const { gasFeeEstimates } = useGasFeeEstimates(networkClientId);
   const shouldHideFiat =
     (isTestNet(chainId as Hex) && !showFiatOnTestnets) ||
-    nativeConversionRate === null;
+    nativeConversionRate === null ||
+    nativeConversionRate === undefined;
 
   // `gasUsed` is the gas limit actually used by the transaction in the
   // simulation environment.

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -77,7 +77,9 @@ export const useFeeCalculations = (
   const { maxFeePerGas, maxPriorityFeePerGas } =
     useEIP1559TxFees(transactionMeta);
   const { gasFeeEstimates } = useGasFeeEstimates(networkClientId);
-  const shouldHideFiat = isTestNet(chainId as Hex) && !showFiatOnTestnets;
+  const shouldHideFiat =
+    (isTestNet(chainId as Hex) && !showFiatOnTestnets) ||
+    nativeConversionRate === null;
 
   // `gasUsed` is the gas limit actually used by the transaction in the
   // simulation environment.

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculationsTransactionBatch.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculationsTransactionBatch.test.ts
@@ -170,9 +170,9 @@ describe('useFeeCalculationsTransactionBatch', () => {
       },
     );
 
-    expect(result.current.estimatedFeeFiat).toBe(null);
-    expect(result.current.estimatedFeeNative).toBe(null);
-    expect(result.current.preciseNativeFeeInHex).toBe(null);
+    expect(result.current.estimatedFeeFiat).toBe('< $0.01');
+    expect(result.current.estimatedFeeNative).toBe('0');
+    expect(result.current.preciseNativeFeeInHex).toBe('0x2632e314a000');
     expect(result.current.calculateGasEstimate).toBeDefined();
   });
 

--- a/app/components/Views/confirmations/utils/gas.test.ts
+++ b/app/components/Views/confirmations/utils/gas.test.ts
@@ -88,7 +88,7 @@ describe('gas utils', () => {
       expect(result.preciseNativeFeeInHex).toBe('0x5572e9c22d00');
     });
 
-    it('passes null conversionRate to getValueFromWeiHex when nativeConversionRate is null', () => {
+    it('passes BigNumber(0) conversionRate to getValueFromWeiHex when nativeConversionRate is null', () => {
       getFeesFromHex({
         hexFee: '0x5572e9c22d00',
         nativeConversionRate: null,
@@ -107,7 +107,7 @@ describe('gas utils', () => {
       expect(mockGetValueFromWeiHex).toHaveBeenCalledWith(
         expect.objectContaining({
           fromCurrency: 'GWEI',
-          conversionRate: null,
+          conversionRate: new BigNumber(0),
         }),
       );
     });

--- a/app/components/Views/confirmations/utils/gas.test.ts
+++ b/app/components/Views/confirmations/utils/gas.test.ts
@@ -1,0 +1,207 @@
+import { BigNumber } from 'bignumber.js';
+import { getFeesFromHex, calculateGasEstimate } from './gas';
+import {
+  getValueFromWeiHex,
+  multiplyHexes,
+} from '../../../../util/conversions';
+
+jest.mock('../../../../../locales/i18n', () => ({
+  __esModule: true,
+  default: { locale: 'en-US' },
+}));
+
+jest.mock('../../../../components/UI/SimulationDetails/formatAmount', () => ({
+  formatAmount: jest.fn((_locale: string, amount: BigNumber) =>
+    amount.toFixed(4),
+  ),
+}));
+
+jest.mock('../../../../util/conversions', () => ({
+  addHexes: jest.fn(
+    (a: string, b: string) =>
+      `0x${(parseInt(a, 16) + parseInt(b, 16)).toString(16)}`,
+  ),
+  decGWEIToHexWEI: jest.fn(() => '0x3b9aca00'),
+  decimalToHex: jest.fn(() => '0x0'),
+  getValueFromWeiHex: jest.fn(() => '0.05'),
+  multiplyHexes: jest.fn(() => '0xabc'),
+}));
+
+const mockGetValueFromWeiHex = jest.mocked(getValueFromWeiHex);
+const mockMultiplyHexes = jest.mocked(multiplyHexes);
+
+describe('gas utils', () => {
+  const mockFiatFormatter = jest.fn(
+    (amount: BigNumber) => `$${amount.toFixed(2)}`,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetValueFromWeiHex.mockReturnValue('0.05' as never);
+    mockMultiplyHexes.mockReturnValue('0xabc' as never);
+  });
+
+  describe('getFeesFromHex', () => {
+    it('returns all nulls when nativeCurrency is undefined', () => {
+      const result = getFeesFromHex({
+        hexFee: '0x5572e9c22d00',
+        nativeConversionRate: 3000,
+        nativeCurrency: undefined,
+        fiatFormatter: mockFiatFormatter,
+        shouldHideFiat: false,
+      });
+
+      expect(result).toEqual({
+        currentCurrencyFee: null,
+        nativeCurrencyFee: null,
+        preciseCurrentCurrencyFee: null,
+        preciseNativeCurrencyFee: null,
+        preciseNativeFeeInHex: null,
+      });
+    });
+
+    it('computes fees when nativeConversionRate is null and nativeCurrency is defined', () => {
+      const result = getFeesFromHex({
+        hexFee: '0x5572e9c22d00',
+        nativeConversionRate: null,
+        nativeCurrency: 'ETH',
+        fiatFormatter: mockFiatFormatter,
+        shouldHideFiat: false,
+      });
+
+      expect(result.nativeCurrencyFee).not.toBeNull();
+      expect(result.preciseNativeCurrencyFee).toContain('ETH');
+      expect(result.preciseNativeFeeInHex).toBe('0x5572e9c22d00');
+    });
+
+    it('computes fees when nativeConversionRate is undefined and nativeCurrency is defined', () => {
+      const result = getFeesFromHex({
+        hexFee: '0x5572e9c22d00',
+        nativeConversionRate: undefined,
+        nativeCurrency: 'ETH',
+        fiatFormatter: mockFiatFormatter,
+        shouldHideFiat: false,
+      });
+
+      expect(result.nativeCurrencyFee).not.toBeNull();
+      expect(result.preciseNativeCurrencyFee).toContain('ETH');
+      expect(result.preciseNativeFeeInHex).toBe('0x5572e9c22d00');
+    });
+
+    it('passes null conversionRate to getValueFromWeiHex when nativeConversionRate is null', () => {
+      getFeesFromHex({
+        hexFee: '0x5572e9c22d00',
+        nativeConversionRate: null,
+        nativeCurrency: 'ETH',
+        fiatFormatter: mockFiatFormatter,
+        shouldHideFiat: false,
+      });
+
+      expect(mockGetValueFromWeiHex).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fromCurrency: 'WEI',
+          conversionRate: 1,
+        }),
+      );
+
+      expect(mockGetValueFromWeiHex).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fromCurrency: 'GWEI',
+          conversionRate: null,
+        }),
+      );
+    });
+
+    it('passes BigNumber conversionRate to getValueFromWeiHex when nativeConversionRate is a number', () => {
+      getFeesFromHex({
+        hexFee: '0x5572e9c22d00',
+        nativeConversionRate: 3596.25,
+        nativeCurrency: 'ETH',
+        fiatFormatter: mockFiatFormatter,
+        shouldHideFiat: false,
+      });
+
+      expect(mockGetValueFromWeiHex).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fromCurrency: 'GWEI',
+          conversionRate: new BigNumber(3596.25),
+        }),
+      );
+    });
+
+    it('sets currentCurrencyFee to null when shouldHideFiat is true', () => {
+      const result = getFeesFromHex({
+        hexFee: '0x5572e9c22d00',
+        nativeConversionRate: null,
+        nativeCurrency: 'ETH',
+        fiatFormatter: mockFiatFormatter,
+        shouldHideFiat: true,
+      });
+
+      expect(result.currentCurrencyFee).toBeNull();
+      expect(result.preciseCurrentCurrencyFee).toBeNull();
+      expect(result.nativeCurrencyFee).not.toBeNull();
+      expect(result.preciseNativeCurrencyFee).toContain('ETH');
+    });
+
+    it('formats currentCurrencyFee as less than threshold when precise fee is below 0.01', () => {
+      mockGetValueFromWeiHex.mockReturnValue('0.005' as never);
+
+      const result = getFeesFromHex({
+        hexFee: '0x100',
+        nativeConversionRate: 80,
+        nativeCurrency: 'ETH',
+        fiatFormatter: mockFiatFormatter,
+        shouldHideFiat: false,
+      });
+
+      expect(result.currentCurrencyFee).toBe('< $0.01');
+    });
+
+    it('formats currentCurrencyFee normally when precise fee is 0.01 or above', () => {
+      mockGetValueFromWeiHex.mockReturnValue('0.05' as never);
+
+      const result = getFeesFromHex({
+        hexFee: '0x100',
+        nativeConversionRate: 3000,
+        nativeCurrency: 'ETH',
+        fiatFormatter: mockFiatFormatter,
+        shouldHideFiat: false,
+      });
+
+      expect(result.currentCurrencyFee).toBe('$0.05');
+    });
+  });
+
+  describe('calculateGasEstimate', () => {
+    const mockGetFeesFromHexFn = jest.fn(() => ({
+      currentCurrencyFee: '$1.00',
+      nativeCurrencyFee: '0.001',
+      preciseCurrentCurrencyFee: '1.00',
+      preciseNativeCurrencyFee: '0.001 ETH',
+      preciseNativeFeeInHex: '0xabc',
+    }));
+
+    beforeEach(() => {
+      mockGetFeesFromHexFn.mockClear();
+    });
+
+    it('returns fees from receipt gas price when receiptGasPrice is provided', () => {
+      mockMultiplyHexes.mockReturnValue('0xdef' as never);
+
+      calculateGasEstimate({
+        feePerGas: '0x100',
+        priorityFeePerGas: '0x10',
+        gasPrice: '0x50',
+        gas: '0x5208',
+        shouldUseEIP1559FeeLogic: true,
+        estimatedBaseFee: '10',
+        getFeesFromHexFn: mockGetFeesFromHexFn,
+        receiptGasPrice: '0x200',
+      });
+
+      expect(mockMultiplyHexes).toHaveBeenCalledWith('0x200', '0x5208');
+      expect(mockGetFeesFromHexFn).toHaveBeenCalledWith('0xdef');
+    });
+  });
+});

--- a/app/components/Views/confirmations/utils/gas.ts
+++ b/app/components/Views/confirmations/utils/gas.ts
@@ -36,9 +36,10 @@ export function getFeesFromHex({
     };
   }
 
-  const nativeConversionRateInBN = nativeConversionRate
-    ? new BigNumber(nativeConversionRate)
-    : null;
+  const nativeConversionRateInBN =
+    nativeConversionRate === undefined || nativeConversionRate === null
+      ? null
+      : new BigNumber(nativeConversionRate);
   const locale = I18n.locale;
   const nativeCurrencyFee = formatAmount(
     locale,

--- a/app/components/Views/confirmations/utils/gas.ts
+++ b/app/components/Views/confirmations/utils/gas.ts
@@ -38,7 +38,7 @@ export function getFeesFromHex({
 
   const nativeConversionRateInBN =
     nativeConversionRate === undefined || nativeConversionRate === null
-      ? null
+      ? new BigNumber(0)
       : new BigNumber(nativeConversionRate);
   const locale = I18n.locale;
   const nativeCurrencyFee = formatAmount(

--- a/app/components/Views/confirmations/utils/gas.ts
+++ b/app/components/Views/confirmations/utils/gas.ts
@@ -26,11 +26,7 @@ export function getFeesFromHex({
   fiatFormatter: (amount: BigNumber) => string;
   shouldHideFiat: boolean;
 }) {
-  if (
-    nativeConversionRate === undefined ||
-    nativeConversionRate === null ||
-    !nativeCurrency
-  ) {
+  if (!nativeCurrency) {
     return {
       currentCurrencyFee: null,
       nativeCurrencyFee: null,
@@ -40,7 +36,9 @@ export function getFeesFromHex({
     };
   }
 
-  const nativeConversionRateInBN = new BigNumber(nativeConversionRate);
+  const nativeConversionRateInBN = nativeConversionRate
+    ? new BigNumber(nativeConversionRate)
+    : null;
   const locale = I18n.locale;
   const nativeCurrencyFee = formatAmount(
     locale,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix network fee display on confirmation page if conversion rate is not available for the currency. Show native currency as network fee if conversion rate is not available.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/25727

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
<img width="397" height="852" alt="Screenshot 2026-02-13 at 5 27 03 PM" src="https://github.com/user-attachments/assets/f7536300-8f09-435d-9e6c-19986def6473" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logic change is narrowly scoped to fee formatting/display when conversion rates are missing, with updated and new unit tests covering the new behavior.
> 
> **Overview**
> Fixes confirmation fee display when the network’s native currency conversion rate is missing.
> 
> `useFeeCalculations` now treats `nativeConversionRate` being `null`/`undefined` as a reason to hide fiat, while `getFeesFromHex` still computes native fee strings using a zero conversion rate (returning `null` only for fiat fields). Adds focused unit tests for `gas` utils and updates hook tests to assert native-fee-only behavior in these cases (including adjusted expectations for batch fee tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c93b12a5fc5009d52faa575d804581c4848662ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->