### PR TITLE
fix: keep keypad state on flip and close it when dest token input is pressed

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
+++ b/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
@@ -926,258 +926,258 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                               </View>
                             </RCTScrollView>
                             <View
-                              onLayout={[Function]}
-                              onStartShouldSetResponder={[Function]}
                               style={
                                 [
+                                  {},
                                   {
-                                    "bottom": 0,
-                                    "left": 0,
-                                    "position": "absolute",
-                                    "right": 0,
-                                  },
-                                  {
-                                    "paddingBottom": 0,
+                                    "alignContent": "flex-end",
+                                    "gap": 16,
+                                    "paddingHorizontal": 16,
+                                    "paddingTop": 16,
                                   },
                                 ]
                               }
                             >
                               <View
-                                collapsable={false}
-                                enabled={true}
-                                handlerTag={-1}
-                                handlerType="PanGestureHandler"
-                                onGestureHandlerEvent={[Function]}
-                                onGestureHandlerStateChange={[Function]}
-                                onLayout={[Function]}
+                                style={
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  }
+                                }
+                              >
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  activeOpacity={1}
+                                  onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
+                                      "borderWidth": 1,
+                                      "flex": 1,
+                                      "flexDirection": "row",
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                  >
+                                    25%
+                                  </Text>
+                                </TouchableOpacity>
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  activeOpacity={1}
+                                  onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
+                                      "borderWidth": 1,
+                                      "flex": 1,
+                                      "flexDirection": "row",
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                  >
+                                    50%
+                                  </Text>
+                                </TouchableOpacity>
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  activeOpacity={1}
+                                  onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
+                                      "borderWidth": 1,
+                                      "flex": 1,
+                                      "flexDirection": "row",
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                  >
+                                    75%
+                                  </Text>
+                                </TouchableOpacity>
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  activeOpacity={1}
+                                  onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
+                                      "borderWidth": 1,
+                                      "flex": 1,
+                                      "flexDirection": "row",
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                  >
+                                    90%
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "backgroundColor": "#ffffff",
-                                      "borderBottomColor": "#ffffff",
-                                      "borderColor": "#b7bbc866",
-                                      "borderTopLeftRadius": 24,
-                                      "borderTopRightRadius": 24,
-                                      "borderWidth": 1,
-                                      "marginHorizontal": -1,
-                                      "maxHeight": 1334,
-                                      "overflow": "hidden",
-                                      "paddingBottom": 0,
-                                      "shadowColor": "#0000001a",
-                                      "shadowOffset": {
-                                        "height": 2,
-                                        "width": 0,
-                                      },
-                                      "shadowOpacity": 1,
-                                      "shadowRadius": 40,
+                                      "display": "flex",
+                                      "gap": 12,
                                     },
-                                    {
-                                      "transform": [
-                                        {
-                                          "translateY": 1334,
-                                        },
-                                      ],
-                                    },
+                                    undefined,
                                   ]
                                 }
                               >
                                 <View
                                   style={
-                                    {
-                                      "alignItems": "center",
-                                      "alignSelf": "stretch",
-                                      "padding": 4,
-                                    }
-                                  }
-                                >
-                                  <View
-                                    style={
-                                      {
-                                        "backgroundColor": "#b7bbc866",
-                                        "borderRadius": 2,
-                                        "height": 4,
-                                        "width": 40,
-                                      }
-                                    }
-                                  />
-                                </View>
-                                <View
-                                  style={
                                     [
-                                      {},
-                                      {
-                                        "alignContent": "flex-end",
-                                        "gap": 16,
-                                        "paddingHorizontal": 16,
-                                        "paddingTop": 16,
-                                      },
-                                    ]
-                                  }
-                                >
-                                  <View
-                                    style={
                                       {
                                         "display": "flex",
                                         "flexDirection": "row",
                                         "gap": 12,
                                         "justifyContent": "space-between",
-                                      }
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
                                     }
                                   >
                                     <TouchableOpacity
                                       accessibilityRole="button"
                                       accessible={true}
-                                      activeOpacity={1}
                                       onPress={[Function]}
-                                      onPressIn={[Function]}
-                                      onPressOut={[Function]}
                                       style={
-                                        {
-                                          "alignItems": "center",
-                                          "alignSelf": "flex-start",
-                                          "backgroundColor": "#3c4d9d0f",
-                                          "borderColor": "transparent",
-                                          "borderRadius": 12,
-                                          "borderWidth": 1,
-                                          "flex": 1,
-                                          "flexDirection": "row",
-                                          "height": 40,
-                                          "justifyContent": "center",
-                                          "overflow": "hidden",
-                                          "paddingHorizontal": 16,
-                                        }
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
                                       }
                                     >
                                       <Text
-                                        accessibilityRole="text"
+                                        accessibilityRole="none"
                                         style={
-                                          {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Medium",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
-                                          }
+                                          [
+                                            {
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
+                                            },
+                                            undefined,
+                                          ]
                                         }
                                       >
-                                        25%
-                                      </Text>
-                                    </TouchableOpacity>
-                                    <TouchableOpacity
-                                      accessibilityRole="button"
-                                      accessible={true}
-                                      activeOpacity={1}
-                                      onPress={[Function]}
-                                      onPressIn={[Function]}
-                                      onPressOut={[Function]}
-                                      style={
-                                        {
-                                          "alignItems": "center",
-                                          "alignSelf": "flex-start",
-                                          "backgroundColor": "#3c4d9d0f",
-                                          "borderColor": "transparent",
-                                          "borderRadius": 12,
-                                          "borderWidth": 1,
-                                          "flex": 1,
-                                          "flexDirection": "row",
-                                          "height": 40,
-                                          "justifyContent": "center",
-                                          "overflow": "hidden",
-                                          "paddingHorizontal": 16,
-                                        }
-                                      }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
-                                        style={
-                                          {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Medium",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
-                                          }
-                                        }
-                                      >
-                                        50%
-                                      </Text>
-                                    </TouchableOpacity>
-                                    <TouchableOpacity
-                                      accessibilityRole="button"
-                                      accessible={true}
-                                      activeOpacity={1}
-                                      onPress={[Function]}
-                                      onPressIn={[Function]}
-                                      onPressOut={[Function]}
-                                      style={
-                                        {
-                                          "alignItems": "center",
-                                          "alignSelf": "flex-start",
-                                          "backgroundColor": "#3c4d9d0f",
-                                          "borderColor": "transparent",
-                                          "borderRadius": 12,
-                                          "borderWidth": 1,
-                                          "flex": 1,
-                                          "flexDirection": "row",
-                                          "height": 40,
-                                          "justifyContent": "center",
-                                          "overflow": "hidden",
-                                          "paddingHorizontal": 16,
-                                        }
-                                      }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
-                                        style={
-                                          {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Medium",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
-                                          }
-                                        }
-                                      >
-                                        75%
-                                      </Text>
-                                    </TouchableOpacity>
-                                    <TouchableOpacity
-                                      accessibilityRole="button"
-                                      accessible={true}
-                                      activeOpacity={1}
-                                      onPress={[Function]}
-                                      onPressIn={[Function]}
-                                      onPressOut={[Function]}
-                                      style={
-                                        {
-                                          "alignItems": "center",
-                                          "alignSelf": "flex-start",
-                                          "backgroundColor": "#3c4d9d0f",
-                                          "borderColor": "transparent",
-                                          "borderRadius": 12,
-                                          "borderWidth": 1,
-                                          "flex": 1,
-                                          "flexDirection": "row",
-                                          "height": 40,
-                                          "justifyContent": "center",
-                                          "overflow": "hidden",
-                                          "paddingHorizontal": 16,
-                                        }
-                                      }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
-                                        style={
-                                          {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Medium",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
-                                          }
-                                        }
-                                      >
-                                        90%
+                                        1
                                       </Text>
                                     </TouchableOpacity>
                                   </View>
@@ -1186,691 +1186,613 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                       [
                                         {
                                           "display": "flex",
-                                          "gap": 12,
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
                                         },
                                         undefined,
                                       ]
                                     }
                                   >
-                                    <View
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
                                       style={
                                         [
                                           {
-                                            "display": "flex",
-                                            "flexDirection": "row",
-                                            "gap": 12,
-                                            "justifyContent": "space-between",
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
                                           },
                                           undefined,
                                         ]
                                       }
                                     >
-                                      <View
+                                      <Text
+                                        accessibilityRole="none"
                                         style={
                                           [
                                             {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
                                             },
                                             undefined,
                                           ]
                                         }
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            1
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            2
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            3
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                    </View>
-                                    <View
+                                        2
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
                                       style={
                                         [
                                           {
-                                            "display": "flex",
-                                            "flexDirection": "row",
-                                            "gap": 12,
-                                            "justifyContent": "space-between",
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
                                           },
                                           undefined,
                                         ]
                                       }
                                     >
-                                      <View
+                                      <Text
+                                        accessibilityRole="none"
                                         style={
                                           [
                                             {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
                                             },
                                             undefined,
                                           ]
                                         }
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            4
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            5
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            6
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                    </View>
-                                    <View
+                                        3
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexDirection": "row",
+                                        "gap": 12,
+                                        "justifyContent": "space-between",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
                                       style={
                                         [
                                           {
-                                            "display": "flex",
-                                            "flexDirection": "row",
-                                            "gap": 12,
-                                            "justifyContent": "space-between",
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
                                           },
                                           undefined,
                                         ]
                                       }
                                     >
-                                      <View
+                                      <Text
+                                        accessibilityRole="none"
                                         style={
                                           [
                                             {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
                                             },
                                             undefined,
                                           ]
                                         }
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            7
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            8
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            9
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                    </View>
-                                    <View
+                                        4
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
                                       style={
                                         [
                                           {
-                                            "display": "flex",
-                                            "flexDirection": "row",
-                                            "gap": 12,
-                                            "justifyContent": "space-between",
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
                                           },
                                           undefined,
                                         ]
                                       }
                                     >
-                                      <View
+                                      <Text
+                                        accessibilityRole="none"
                                         style={
                                           [
                                             {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
                                             },
                                             undefined,
                                           ]
                                         }
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              {
-                                                "backgroundColor": "transparent",
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            .
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
+                                        5
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="none"
                                         style={
                                           [
                                             {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
                                             },
                                             undefined,
                                           ]
                                         }
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            0
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
+                                        6
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexDirection": "row",
+                                        "gap": 12,
+                                        "justifyContent": "space-between",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="none"
                                         style={
                                           [
                                             {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
                                             },
                                             undefined,
                                           ]
                                         }
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          delayLongPress={500}
-                                          onLongPress={[Function]}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                          testID="keypad-delete-button"
-                                        >
-                                          <SvgMock
-                                            fill="currentColor"
-                                            name="Backspace"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "height": 32,
-                                                  "width": 32,
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          />
-                                        </TouchableOpacity>
-                                      </View>
-                                    </View>
+                                        7
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="none"
+                                        style={
+                                          [
+                                            {
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
+                                            },
+                                            undefined,
+                                          ]
+                                        }
+                                      >
+                                        8
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="none"
+                                        style={
+                                          [
+                                            {
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
+                                            },
+                                            undefined,
+                                          ]
+                                        }
+                                      >
+                                        9
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexDirection": "row",
+                                        "gap": 12,
+                                        "justifyContent": "space-between",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          {
+                                            "backgroundColor": "transparent",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="none"
+                                        style={
+                                          [
+                                            {
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
+                                            },
+                                            undefined,
+                                          ]
+                                        }
+                                      >
+                                        .
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="none"
+                                        style={
+                                          [
+                                            {
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
+                                            },
+                                            undefined,
+                                          ]
+                                        }
+                                      >
+                                        0
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      delayLongPress={500}
+                                      onLongPress={[Function]}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                      testID="keypad-delete-button"
+                                    >
+                                      <SvgMock
+                                        fill="currentColor"
+                                        name="Backspace"
+                                        style={
+                                          [
+                                            {
+                                              "color": "#121314",
+                                              "height": 32,
+                                              "width": 32,
+                                            },
+                                            undefined,
+                                          ]
+                                        }
+                                      />
+                                    </TouchableOpacity>
                                   </View>
                                 </View>
                               </View>
@@ -2829,258 +2751,258 @@ exports[`BridgeView renders 1`] = `
                               </View>
                             </RCTScrollView>
                             <View
-                              onLayout={[Function]}
-                              onStartShouldSetResponder={[Function]}
                               style={
                                 [
+                                  {},
                                   {
-                                    "bottom": 0,
-                                    "left": 0,
-                                    "position": "absolute",
-                                    "right": 0,
-                                  },
-                                  {
-                                    "paddingBottom": 0,
+                                    "alignContent": "flex-end",
+                                    "gap": 16,
+                                    "paddingHorizontal": 16,
+                                    "paddingTop": 16,
                                   },
                                 ]
                               }
                             >
                               <View
-                                collapsable={false}
-                                enabled={true}
-                                handlerTag={-1}
-                                handlerType="PanGestureHandler"
-                                onGestureHandlerEvent={[Function]}
-                                onGestureHandlerStateChange={[Function]}
-                                onLayout={[Function]}
+                                style={
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  }
+                                }
+                              >
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  activeOpacity={1}
+                                  onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
+                                      "borderWidth": 1,
+                                      "flex": 1,
+                                      "flexDirection": "row",
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                  >
+                                    25%
+                                  </Text>
+                                </TouchableOpacity>
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  activeOpacity={1}
+                                  onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
+                                      "borderWidth": 1,
+                                      "flex": 1,
+                                      "flexDirection": "row",
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                  >
+                                    50%
+                                  </Text>
+                                </TouchableOpacity>
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  activeOpacity={1}
+                                  onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
+                                      "borderWidth": 1,
+                                      "flex": 1,
+                                      "flexDirection": "row",
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                  >
+                                    75%
+                                  </Text>
+                                </TouchableOpacity>
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  activeOpacity={1}
+                                  onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "transparent",
+                                      "borderRadius": 12,
+                                      "borderWidth": 1,
+                                      "flex": 1,
+                                      "flexDirection": "row",
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "paddingHorizontal": 16,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                  >
+                                    90%
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "backgroundColor": "#ffffff",
-                                      "borderBottomColor": "#ffffff",
-                                      "borderColor": "#b7bbc866",
-                                      "borderTopLeftRadius": 24,
-                                      "borderTopRightRadius": 24,
-                                      "borderWidth": 1,
-                                      "marginHorizontal": -1,
-                                      "maxHeight": 1334,
-                                      "overflow": "hidden",
-                                      "paddingBottom": 0,
-                                      "shadowColor": "#0000001a",
-                                      "shadowOffset": {
-                                        "height": 2,
-                                        "width": 0,
-                                      },
-                                      "shadowOpacity": 1,
-                                      "shadowRadius": 40,
+                                      "display": "flex",
+                                      "gap": 12,
                                     },
-                                    {
-                                      "transform": [
-                                        {
-                                          "translateY": 1334,
-                                        },
-                                      ],
-                                    },
+                                    undefined,
                                   ]
                                 }
                               >
                                 <View
                                   style={
-                                    {
-                                      "alignItems": "center",
-                                      "alignSelf": "stretch",
-                                      "padding": 4,
-                                    }
-                                  }
-                                >
-                                  <View
-                                    style={
-                                      {
-                                        "backgroundColor": "#b7bbc866",
-                                        "borderRadius": 2,
-                                        "height": 4,
-                                        "width": 40,
-                                      }
-                                    }
-                                  />
-                                </View>
-                                <View
-                                  style={
                                     [
-                                      {},
-                                      {
-                                        "alignContent": "flex-end",
-                                        "gap": 16,
-                                        "paddingHorizontal": 16,
-                                        "paddingTop": 16,
-                                      },
-                                    ]
-                                  }
-                                >
-                                  <View
-                                    style={
                                       {
                                         "display": "flex",
                                         "flexDirection": "row",
                                         "gap": 12,
                                         "justifyContent": "space-between",
-                                      }
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
                                     }
                                   >
                                     <TouchableOpacity
                                       accessibilityRole="button"
                                       accessible={true}
-                                      activeOpacity={1}
                                       onPress={[Function]}
-                                      onPressIn={[Function]}
-                                      onPressOut={[Function]}
                                       style={
-                                        {
-                                          "alignItems": "center",
-                                          "alignSelf": "flex-start",
-                                          "backgroundColor": "#3c4d9d0f",
-                                          "borderColor": "transparent",
-                                          "borderRadius": 12,
-                                          "borderWidth": 1,
-                                          "flex": 1,
-                                          "flexDirection": "row",
-                                          "height": 40,
-                                          "justifyContent": "center",
-                                          "overflow": "hidden",
-                                          "paddingHorizontal": 16,
-                                        }
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
                                       }
                                     >
                                       <Text
-                                        accessibilityRole="text"
+                                        accessibilityRole="none"
                                         style={
-                                          {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Medium",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
-                                          }
+                                          [
+                                            {
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
+                                            },
+                                            undefined,
+                                          ]
                                         }
                                       >
-                                        25%
-                                      </Text>
-                                    </TouchableOpacity>
-                                    <TouchableOpacity
-                                      accessibilityRole="button"
-                                      accessible={true}
-                                      activeOpacity={1}
-                                      onPress={[Function]}
-                                      onPressIn={[Function]}
-                                      onPressOut={[Function]}
-                                      style={
-                                        {
-                                          "alignItems": "center",
-                                          "alignSelf": "flex-start",
-                                          "backgroundColor": "#3c4d9d0f",
-                                          "borderColor": "transparent",
-                                          "borderRadius": 12,
-                                          "borderWidth": 1,
-                                          "flex": 1,
-                                          "flexDirection": "row",
-                                          "height": 40,
-                                          "justifyContent": "center",
-                                          "overflow": "hidden",
-                                          "paddingHorizontal": 16,
-                                        }
-                                      }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
-                                        style={
-                                          {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Medium",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
-                                          }
-                                        }
-                                      >
-                                        50%
-                                      </Text>
-                                    </TouchableOpacity>
-                                    <TouchableOpacity
-                                      accessibilityRole="button"
-                                      accessible={true}
-                                      activeOpacity={1}
-                                      onPress={[Function]}
-                                      onPressIn={[Function]}
-                                      onPressOut={[Function]}
-                                      style={
-                                        {
-                                          "alignItems": "center",
-                                          "alignSelf": "flex-start",
-                                          "backgroundColor": "#3c4d9d0f",
-                                          "borderColor": "transparent",
-                                          "borderRadius": 12,
-                                          "borderWidth": 1,
-                                          "flex": 1,
-                                          "flexDirection": "row",
-                                          "height": 40,
-                                          "justifyContent": "center",
-                                          "overflow": "hidden",
-                                          "paddingHorizontal": 16,
-                                        }
-                                      }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
-                                        style={
-                                          {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Medium",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
-                                          }
-                                        }
-                                      >
-                                        75%
-                                      </Text>
-                                    </TouchableOpacity>
-                                    <TouchableOpacity
-                                      accessibilityRole="button"
-                                      accessible={true}
-                                      activeOpacity={1}
-                                      onPress={[Function]}
-                                      onPressIn={[Function]}
-                                      onPressOut={[Function]}
-                                      style={
-                                        {
-                                          "alignItems": "center",
-                                          "alignSelf": "flex-start",
-                                          "backgroundColor": "#3c4d9d0f",
-                                          "borderColor": "transparent",
-                                          "borderRadius": 12,
-                                          "borderWidth": 1,
-                                          "flex": 1,
-                                          "flexDirection": "row",
-                                          "height": 40,
-                                          "justifyContent": "center",
-                                          "overflow": "hidden",
-                                          "paddingHorizontal": 16,
-                                        }
-                                      }
-                                    >
-                                      <Text
-                                        accessibilityRole="text"
-                                        style={
-                                          {
-                                            "color": "#121314",
-                                            "fontFamily": "Geist-Medium",
-                                            "fontSize": 16,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
-                                          }
-                                        }
-                                      >
-                                        90%
+                                        1
                                       </Text>
                                     </TouchableOpacity>
                                   </View>
@@ -3089,691 +3011,613 @@ exports[`BridgeView renders 1`] = `
                                       [
                                         {
                                           "display": "flex",
-                                          "gap": 12,
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
                                         },
                                         undefined,
                                       ]
                                     }
                                   >
-                                    <View
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
                                       style={
                                         [
                                           {
-                                            "display": "flex",
-                                            "flexDirection": "row",
-                                            "gap": 12,
-                                            "justifyContent": "space-between",
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
                                           },
                                           undefined,
                                         ]
                                       }
                                     >
-                                      <View
+                                      <Text
+                                        accessibilityRole="none"
                                         style={
                                           [
                                             {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
                                             },
                                             undefined,
                                           ]
                                         }
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            1
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            2
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            3
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                    </View>
-                                    <View
+                                        2
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
                                       style={
                                         [
                                           {
-                                            "display": "flex",
-                                            "flexDirection": "row",
-                                            "gap": 12,
-                                            "justifyContent": "space-between",
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
                                           },
                                           undefined,
                                         ]
                                       }
                                     >
-                                      <View
+                                      <Text
+                                        accessibilityRole="none"
                                         style={
                                           [
                                             {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
                                             },
                                             undefined,
                                           ]
                                         }
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            4
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            5
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            6
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                    </View>
-                                    <View
+                                        3
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexDirection": "row",
+                                        "gap": 12,
+                                        "justifyContent": "space-between",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
                                       style={
                                         [
                                           {
-                                            "display": "flex",
-                                            "flexDirection": "row",
-                                            "gap": 12,
-                                            "justifyContent": "space-between",
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
                                           },
                                           undefined,
                                         ]
                                       }
                                     >
-                                      <View
+                                      <Text
+                                        accessibilityRole="none"
                                         style={
                                           [
                                             {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
                                             },
                                             undefined,
                                           ]
                                         }
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            7
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            8
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            9
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                    </View>
-                                    <View
+                                        4
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
                                       style={
                                         [
                                           {
-                                            "display": "flex",
-                                            "flexDirection": "row",
-                                            "gap": 12,
-                                            "justifyContent": "space-between",
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
                                           },
                                           undefined,
                                         ]
                                       }
                                     >
-                                      <View
+                                      <Text
+                                        accessibilityRole="none"
                                         style={
                                           [
                                             {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
                                             },
                                             undefined,
                                           ]
                                         }
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              {
-                                                "backgroundColor": "transparent",
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            .
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
+                                        5
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="none"
                                         style={
                                           [
                                             {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
                                             },
                                             undefined,
                                           ]
                                         }
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#3c4d9d0f",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="none"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "fontFamily": "Geist-Bold",
-                                                  "fontSize": 32,
-                                                  "fontWeight": "500",
-                                                  "letterSpacing": 0,
-                                                  "lineHeight": 40,
-                                                  "textAlign": "center",
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          >
-                                            0
-                                          </Text>
-                                        </TouchableOpacity>
-                                      </View>
-                                      <View
+                                        6
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexDirection": "row",
+                                        "gap": 12,
+                                        "justifyContent": "space-between",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="none"
                                         style={
                                           [
                                             {
-                                              "display": "flex",
-                                              "flexBasis": "0%",
-                                              "flexGrow": 1,
-                                              "flexShrink": 1,
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
                                             },
                                             undefined,
                                           ]
                                         }
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          delayLongPress={500}
-                                          onLongPress={[Function]}
-                                          onPress={[Function]}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "borderRadius": 12,
-                                                "height": 48,
-                                                "justifyContent": "center",
-                                                "paddingHorizontal": 16,
-                                              },
-                                              undefined,
-                                            ]
-                                          }
-                                          testID="keypad-delete-button"
-                                        >
-                                          <SvgMock
-                                            fill="currentColor"
-                                            name="Backspace"
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#121314",
-                                                  "height": 32,
-                                                  "width": 32,
-                                                },
-                                                undefined,
-                                              ]
-                                            }
-                                          />
-                                        </TouchableOpacity>
-                                      </View>
-                                    </View>
+                                        7
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="none"
+                                        style={
+                                          [
+                                            {
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
+                                            },
+                                            undefined,
+                                          ]
+                                        }
+                                      >
+                                        8
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="none"
+                                        style={
+                                          [
+                                            {
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
+                                            },
+                                            undefined,
+                                          ]
+                                        }
+                                      >
+                                        9
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexDirection": "row",
+                                        "gap": 12,
+                                        "justifyContent": "space-between",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          {
+                                            "backgroundColor": "transparent",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="none"
+                                        style={
+                                          [
+                                            {
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
+                                            },
+                                            undefined,
+                                          ]
+                                        }
+                                      >
+                                        .
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "backgroundColor": "#3c4d9d0f",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="none"
+                                        style={
+                                          [
+                                            {
+                                              "color": "#121314",
+                                              "fontFamily": "Geist-Bold",
+                                              "fontSize": 32,
+                                              "fontWeight": "500",
+                                              "letterSpacing": 0,
+                                              "lineHeight": 40,
+                                              "textAlign": "center",
+                                            },
+                                            undefined,
+                                          ]
+                                        }
+                                      >
+                                        0
+                                      </Text>
+                                    </TouchableOpacity>
+                                  </View>
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "display": "flex",
+                                          "flexBasis": "0%",
+                                          "flexGrow": 1,
+                                          "flexShrink": 1,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      delayLongPress={500}
+                                      onLongPress={[Function]}
+                                      onPress={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "borderRadius": 12,
+                                            "height": 48,
+                                            "justifyContent": "center",
+                                            "paddingHorizontal": 16,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                      testID="keypad-delete-button"
+                                    >
+                                      <SvgMock
+                                        fill="currentColor"
+                                        name="Backspace"
+                                        style={
+                                          [
+                                            {
+                                              "color": "#121314",
+                                              "height": 32,
+                                              "width": 32,
+                                            },
+                                            undefined,
+                                          ]
+                                        }
+                                      />
+                                    </TouchableOpacity>
                                   </View>
                                 </View>
                               </View>

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -324,12 +324,6 @@ const BridgeView = () => {
     dispatch(setSourceAmount(value || undefined));
   };
 
-  const onFlipButtonPress = async () => {
-    await handleSwitchTokens(destTokenAmount)();
-    inputRef.current?.focus();
-    keypadRef.current?.open();
-  };
-
   const handleSourceMaxPress = () => {
     if (latestSourceBalance?.displayBalance) {
       dispatch(setSourceAmountAsMax(latestSourceBalance.displayBalance));
@@ -465,7 +459,7 @@ const BridgeView = () => {
             isQuoteSponsored={isQuoteSponsored}
           />
           <FLipQuoteButton
-            onPress={onFlipButtonPress}
+            onPress={handleSwitchTokens(destTokenAmount)}
             disabled={
               !destChainId ||
               !destToken ||
@@ -483,6 +477,7 @@ const BridgeView = () => {
             }
             testID={BridgeViewSelectorsIDs.DESTINATION_TOKEN_AREA}
             tokenType={TokenInputAreaType.Destination}
+            onInputPress={() => keypadRef.current?.close()}
             onTokenPress={handleDestTokenPress}
             isLoading={!destTokenAmount && isLoading}
             style={styles.destTokenArea}


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

keep keypad state on flip and close it when dest token input is pressed

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: keep keypad state on flip and close it when dest token input is pressed

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4124

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI interaction change limited to keypad open/close behavior plus test-only mocks and snapshot updates; minimal impact outside the Bridge screen.
> 
> **Overview**
> Updates `BridgeView` keypad interactions: flipping source/destination tokens now calls `handleSwitchTokens` directly (no forced refocus or `keypadRef.open()`), and pressing the destination amount input explicitly closes the keypad.
> 
> Strengthens test coverage by mocking `BottomSheetDialog` to make close behavior synchronous in JSDOM, adding a regression test for closing the keypad via destination input, and updating the flip test to assert the keypad open/closed state is preserved; snapshots are updated to match UI output changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f228f6302a469b794213fa15cc36cc01af045e81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->