### PR TITLE
refactor: streamline event handling in account syncing tests

### DIFF
--- a/tests/smoke/identity/account-syncing/multi-srp.spec.ts
+++ b/tests/smoke/identity/account-syncing/multi-srp.spec.ts
@@ -6,10 +6,7 @@ import Assertions from '../../../framework/Assertions';
 import { SmokeIdentity } from '../../../tags';
 import { withIdentityFixtures } from '../utils/withIdentityFixtures';
 import { arrangeTestUtils } from '../utils/helpers';
-import {
-  UserStorageMockttpControllerEvents,
-  UserStorageMockttpController,
-} from '../utils/user-storage/userStorageMockttpController';
+import { UserStorageMockttpController } from '../utils/user-storage/userStorageMockttpController';
 import { goToImportSrp, inputSrp } from '../../../flows/accounts.flow';
 import ImportSrpView from '../../../page-objects/importSrp/ImportSrpView';
 import { IDENTITY_TEAM_SEED_PHRASE_2 } from '../utils/constants';
@@ -70,10 +67,9 @@ describe(SmokeIdentity('Account syncing - Mutiple SRPs'), () => {
           },
         );
 
-        const {
-          prepareEventsEmittedCounter,
-          waitUntilSyncedAccountsNumberEquals,
-        } = arrangeTestUtils(userStorageMockttpController);
+        const { waitUntilSyncedAccountsNumberEquals } = arrangeTestUtils(
+          userStorageMockttpController,
+        );
 
         // Wait for the initial full sync to complete before adding accounts.
         // The AccountTreeController's enqueueSingleGroupSync silently drops
@@ -82,15 +78,8 @@ describe(SmokeIdentity('Account syncing - Mutiple SRPs'), () => {
         // the first full sync has finished pushing the initial group.
         await waitUntilSyncedAccountsNumberEquals(1);
 
-        // Set up event counter AFTER the initial sync completes so it only
-        // tracks events from subsequent account mutations.
-        const { waitUntilEventsEmittedNumberEquals } =
-          prepareEventsEmittedCounter(
-            UserStorageMockttpControllerEvents.PUT_SINGLE,
-          );
-
         await AccountListBottomSheet.tapAddAccountButtonV2();
-        await waitUntilEventsEmittedNumberEquals(1);
+        await waitUntilSyncedAccountsNumberEquals(2);
 
         await Assertions.expectElementToBeVisible(
           AccountListBottomSheet.getAccountElementByAccountNameV2(
@@ -154,7 +143,9 @@ describe(SmokeIdentity('Account syncing - Mutiple SRPs'), () => {
           },
         );
 
-        await waitUntilEventsEmittedNumberEquals(5);
+        // Allow time for the rename sync to reach the mock server before
+        // this fixture tears down, so Phase 3 sees the updated name.
+        await waitUntilSyncedAccountsNumberEquals(4);
       },
     );
 

--- a/tests/smoke/identity/utils/helpers.ts
+++ b/tests/smoke/identity/utils/helpers.ts
@@ -51,12 +51,22 @@ export const arrangeTestUtils = (
   const BASE_INTERVAL = 1000;
 
   const prepareEventsEmittedCounter = (
-    event: AsEnum<typeof UserStorageMockttpControllerEvents>,
+    eventOrEvents:
+      | AsEnum<typeof UserStorageMockttpControllerEvents>
+      | AsEnum<typeof UserStorageMockttpControllerEvents>[],
   ) => {
     let counter = 0;
-    userStorageMockttpController.eventEmitter.on(event, () => {
+    const events = Array.isArray(eventOrEvents)
+      ? eventOrEvents
+      : [eventOrEvents];
+
+    const incrementCounter = () => {
       counter += 1;
-    });
+    };
+
+    for (const event of events) {
+      userStorageMockttpController.eventEmitter.on(event, incrementCounter);
+    }
 
     const waitUntilEventsEmittedNumberEquals = (
       expectedNumber: number,
@@ -85,7 +95,7 @@ export const arrangeTestUtils = (
             clearInterval(ids.interval);
             reject(
               new Error(
-                `Timeout waiting for event ${event} to be emitted ${expectedNumber} times\n Actual: ${counter}`,
+                `Timeout waiting for event(s) ${events.join(', ')} to be emitted ${expectedNumber} times\n Actual: ${counter}`,
               ),
             );
           }, BASE_TIMEOUT);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
 - Fix flaky "Account syncing - Multiple SRPs" E2E test that times out waiting for `PUT_SINGLE` events
  - Replace `PUT_SINGLE` event counting with data-based `waitUntilSyncedAccountsNumberEquals` checks in the multi-srp test     
  - Update `prepareEventsEmittedCounter` helper to accept an array of events, enabling combined `PUT_SINGLE`/`PUT_BATCH` listening for
  other tests
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust waiting/verification logic and broaden event counting; no production code paths are affected.
> 
> **Overview**
> Improves reliability of the `Account syncing - Multiple SRPs` smoke test by replacing `PUT_SINGLE` event-count assertions with `waitUntilSyncedAccountsNumberEquals` checks after account creation.
> 
> Extends `prepareEventsEmittedCounter` to accept a single event *or* an array, and updates the rename step to wait for either `PUT_SINGLE` or `PUT_BATCH` reaching the mock server before the fixture teardown (to ensure the renamed account is persisted for the next phase).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fba43c68acfd460045417a9aff4a4f1e6950c4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->