### PR TITLE
fix(perps): reduce debug log verbosity 

### DIFF
--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -4701,7 +4701,9 @@ export class HyperLiquidProvider implements PerpsProvider {
             aggregateByTime: params?.aggregateByTime || false,
           });
 
-      this.deps.debugLogger.log('User fills received:', rawFills);
+      this.deps.debugLogger.log('User fills received:', {
+        count: rawFills?.length ?? 0,
+      });
 
       // Transform HyperLiquid fills to abstract OrderFill type
       const fills = (rawFills || []).reduce((acc: OrderFill[], fill) => {
@@ -4763,7 +4765,9 @@ export class HyperLiquidProvider implements PerpsProvider {
         user: userAddress,
       });
 
-      this.deps.debugLogger.log('User orders received:', rawOrders);
+      this.deps.debugLogger.log('User orders received:', {
+        count: rawOrders?.length ?? 0,
+      });
 
       // Transform HyperLiquid orders to abstract Order type
       const orders: Order[] = (rawOrders || []).map((rawOrder) => {
@@ -4937,7 +4941,9 @@ export class HyperLiquidProvider implements PerpsProvider {
         endTime: params?.endTime,
       });
 
-      this.deps.debugLogger.log('User funding received:', rawFunding);
+      this.deps.debugLogger.log('User funding received:', {
+        count: rawFunding?.length ?? 0,
+      });
 
       // Transform HyperLiquid funding to abstract Funding type
       const funding: Funding[] = (rawFunding || []).map((rawFundingItem) => {


### PR DESCRIPTION
## **Description**

The `HyperLiquidProvider` debug logger was dumping entire arrays of user fills, orders, and funding data on every fetch. With active accounts, these arrays can contain hundreds of items, producing massive log output that drowns out useful debug information.

This PR replaces the verbose raw-array logging with summary counts:
- `'User fills received:', rawFills` → `'User fills received:', { count: rawFills?.length ?? 0 }`
- `'User orders received:', rawOrders` → `'User orders received:', { count: rawOrders?.length ?? 0 }`
- `'User funding received:', rawFunding` → `'User funding received:', { count: rawFunding?.length ?? 0 }`

The actual data processing is unchanged — only the debug log payloads are reduced.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: Perps debug log noise reduction

## **Manual testing steps**

```gherkin
Feature: Reduced debug log verbosity for perps provider

  Scenario: user triggers fills/orders/funding fetch
    Given the app is running in debug mode
    And the user has an active perps account with fills, orders, and funding history

    When the provider fetches user fills, orders, or funding data
    Then the debug log shows summary counts (e.g. "User fills received: { count: 42 }")
    And the debug log does NOT dump the full array contents
    And the actual data processing and UI display remain correct
```

## **Screenshots/Recordings**

### **Before**

<!-- Not applicable — log output change only, no UI changes -->

### **After**

<!-- Not applicable — log output change only, no UI changes -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change that does not affect perps data fetching or processing; low chance of functional impact beyond reduced debug detail.
> 
> **Overview**
> Reduces debug log noise in `HyperLiquidProvider` by replacing logging of full `rawFills`, `rawOrders`, and `rawFunding` arrays with a lightweight `{ count }` summary.
> 
> No changes to fetching or transformation logic; only the debug log payloads are adjusted to avoid large log output for active accounts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 109631182dd0b24004cdb99da4c5351079b95f09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->