### PR TITLE
feat(ramps): use widget url from state instead of fetching on demand

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/Settings/Settings.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/Settings.test.tsx
@@ -141,7 +141,7 @@ const mockUseRampsControllerInitialValues: ReturnType<
   setSelectedQuote: jest.fn(),
   startQuotePolling: jest.fn(),
   stopQuotePolling: jest.fn(),
-  getWidgetUrl: jest.fn(),
+  widgetUrl: null,
   quotesLoading: false,
   quotesError: null,
 };

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -101,6 +101,7 @@ function BuildQuote() {
     startQuotePolling,
     stopQuotePolling,
     widgetUrl,
+    widgetUrlLoading,
     paymentMethodsLoading,
     selectedPaymentMethod,
   } = useRampsController();
@@ -293,12 +294,19 @@ function BuildQuote() {
     return true;
   }, [selectedQuote, amountAsNumber, selectedPaymentMethod]);
 
+  const requiresWidgetUrl =
+    selectedQuote !== null && !isNativeProvider(selectedQuote);
+
+  const widgetUrlReady = !requiresWidgetUrl || Boolean(widgetUrl?.url);
+
   const canContinue =
     hasAmount &&
     !quotesLoading &&
+    !widgetUrlLoading &&
     selectedQuote !== null &&
     quoteMatchesAmount &&
-    quoteMatchesCurrentContext;
+    quoteMatchesCurrentContext &&
+    widgetUrlReady;
 
   return (
     <ScreenLayout>
@@ -343,7 +351,9 @@ function BuildQuote() {
                 onPress={handleContinuePress}
                 isFullWidth
                 isDisabled={!canContinue}
-                isLoading={quotesLoading}
+                isLoading={
+                  quotesLoading || (requiresWidgetUrl && widgetUrlLoading)
+                }
                 testID={BuildQuoteSelectors.CONTINUE_BUTTON}
               >
                 {strings('fiat_on_ramp.continue')}

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/ProviderSelection.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/ProviderSelection.test.tsx
@@ -65,7 +65,7 @@ const defaultMockController: UseRampsControllerResult = {
   setSelectedQuote: mockSetSelectedQuote,
   startQuotePolling: jest.fn(),
   stopQuotePolling: jest.fn(),
-  getWidgetUrl: jest.fn(),
+  widgetUrl: null,
   quotesLoading: false,
   quotesError: null,
 };

--- a/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.test.tsx
+++ b/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.test.tsx
@@ -118,7 +118,7 @@ const mockUseRampsControllerInitialValues: ReturnType<
   setSelectedQuote: jest.fn(),
   startQuotePolling: jest.fn(),
   stopQuotePolling: jest.fn(),
-  getWidgetUrl: jest.fn(),
+  widgetUrl: null,
   quotesLoading: false,
   quotesError: null,
 };

--- a/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.test.tsx
+++ b/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.test.tsx
@@ -178,7 +178,7 @@ describe('TokenSelection Component', () => {
       setSelectedQuote: jest.fn(),
       startQuotePolling: jest.fn(),
       stopQuotePolling: jest.fn(),
-      getWidgetUrl: jest.fn(),
+      widgetUrl: null,
       quotesLoading: false,
       quotesError: null,
     });
@@ -319,7 +319,7 @@ describe('TokenSelection Component', () => {
       setSelectedQuote: jest.fn(),
       startQuotePolling: jest.fn(),
       stopQuotePolling: jest.fn(),
-      getWidgetUrl: jest.fn(),
+      widgetUrl: null,
       quotesLoading: false,
       quotesError: null,
     });
@@ -373,7 +373,7 @@ describe('TokenSelection Component', () => {
       setSelectedQuote: jest.fn(),
       startQuotePolling: jest.fn(),
       stopQuotePolling: jest.fn(),
-      getWidgetUrl: jest.fn(),
+      widgetUrl: null,
       quotesLoading: false,
       quotesError: null,
     });
@@ -439,7 +439,7 @@ describe('TokenSelection Component', () => {
       setSelectedQuote: jest.fn(),
       startQuotePolling: jest.fn(),
       stopQuotePolling: jest.fn(),
-      getWidgetUrl: jest.fn(),
+      widgetUrl: null,
       quotesLoading: false,
       quotesError: null,
     });
@@ -515,7 +515,7 @@ describe('TokenSelection Component', () => {
       setSelectedQuote: jest.fn(),
       startQuotePolling: jest.fn(),
       stopQuotePolling: jest.fn(),
-      getWidgetUrl: jest.fn(),
+      widgetUrl: null,
       quotesLoading: false,
       quotesError: null,
     });
@@ -595,7 +595,7 @@ describe('TokenSelection Component', () => {
       setSelectedQuote: jest.fn(),
       startQuotePolling: jest.fn(),
       stopQuotePolling: jest.fn(),
-      getWidgetUrl: jest.fn(),
+      widgetUrl: null,
       quotesLoading: false,
       quotesError: null,
     });
@@ -677,7 +677,7 @@ describe('TokenSelection Component', () => {
       setSelectedQuote: jest.fn(),
       startQuotePolling: jest.fn(),
       stopQuotePolling: jest.fn(),
-      getWidgetUrl: jest.fn(),
+      widgetUrl: null,
       quotesLoading: false,
       quotesError: null,
     });

--- a/app/components/UI/Ramp/hooks/useRampsController.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsController.test.ts
@@ -63,6 +63,14 @@ jest.mock('./useRampsPaymentMethods', () => ({
   })),
 }));
 
+jest.mock('./useRampsWidgetUrl', () => ({
+  useRampsWidgetUrl: jest.fn(() => ({
+    widgetUrl: null,
+    isLoading: false,
+    error: null,
+  })),
+}));
+
 const createMockStore = () =>
   configureStore({
     reducer: {
@@ -120,6 +128,9 @@ describe('useRampsController', () => {
       selectedPaymentMethod: null,
       paymentMethodsLoading: false,
       paymentMethodsError: null,
+      widgetUrl: null,
+      widgetUrlLoading: false,
+      widgetUrlError: null,
     });
 
     expect(typeof result.current.setUserRegion).toBe('function');

--- a/app/components/UI/Ramp/hooks/useRampsController.ts
+++ b/app/components/UI/Ramp/hooks/useRampsController.ts
@@ -16,6 +16,10 @@ import {
   type UseRampsPaymentMethodsResult,
 } from './useRampsPaymentMethods';
 import { useRampsQuotes, type UseRampsQuotesResult } from './useRampsQuotes';
+import {
+  useRampsWidgetUrl,
+  type UseRampsWidgetUrlResult,
+} from './useRampsWidgetUrl';
 
 /**
  * Result returned by the useRampsController hook.
@@ -61,9 +65,13 @@ export interface UseRampsControllerResult {
   setSelectedQuote: UseRampsQuotesResult['setSelectedQuote'];
   startQuotePolling: UseRampsQuotesResult['startQuotePolling'];
   stopQuotePolling: UseRampsQuotesResult['stopQuotePolling'];
-  getWidgetUrl: UseRampsQuotesResult['getWidgetUrl'];
   quotesLoading: UseRampsQuotesResult['isLoading'];
   quotesError: UseRampsQuotesResult['error'];
+
+  // Widget URL
+  widgetUrl: UseRampsWidgetUrlResult['widgetUrl'];
+  widgetUrlLoading: UseRampsWidgetUrlResult['isLoading'];
+  widgetUrlError: UseRampsWidgetUrlResult['error'];
 }
 
 /**
@@ -115,6 +123,11 @@ export interface UseRampsControllerResult {
  *   getQuotes,
  *   setSelectedQuote,
  *
+ *   // Widget URL
+ *   widgetUrl,
+ *   widgetUrlLoading,
+ *   widgetUrlError,
+ *
  * } = useRampsController();
  * ```
  */
@@ -156,12 +169,17 @@ export function useRampsController(): UseRampsControllerResult {
     selectedQuote,
     startQuotePolling,
     stopQuotePolling,
-    getWidgetUrl,
     isLoading: quotesLoading,
     error: quotesError,
     getQuotes,
     setSelectedQuote,
   } = useRampsQuotes();
+
+  const {
+    widgetUrl,
+    isLoading: widgetUrlLoading,
+    error: widgetUrlError,
+  } = useRampsWidgetUrl();
 
   return {
     // User region
@@ -202,9 +220,13 @@ export function useRampsController(): UseRampsControllerResult {
     setSelectedQuote,
     startQuotePolling,
     stopQuotePolling,
-    getWidgetUrl,
     quotesLoading,
     quotesError,
+
+    // Widget URL
+    widgetUrl,
+    widgetUrlLoading,
+    widgetUrlError,
   };
 }
 

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
@@ -14,7 +14,6 @@ jest.mock('../../../../core/Engine', () => ({
       stopQuotePolling: jest.fn(),
       getQuotes: jest.fn(),
       setSelectedQuote: jest.fn(),
-      getWidgetUrl: jest.fn(),
     },
   },
 }));
@@ -65,7 +64,7 @@ describe('useRampsQuotes', () => {
   });
 
   describe('return value structure', () => {
-    it('returns quotes, selectedQuote, startQuotePolling, stopQuotePolling, getWidgetUrl, isLoading, and error', () => {
+    it('returns quotes, selectedQuote, startQuotePolling, stopQuotePolling, isLoading, and error', () => {
       const store = createMockStore();
       const { result } = renderHook(() => useRampsQuotes(), {
         wrapper: wrapper(store),
@@ -81,7 +80,6 @@ describe('useRampsQuotes', () => {
       expect(typeof result.current.stopQuotePolling).toBe('function');
       expect(typeof result.current.getQuotes).toBe('function');
       expect(typeof result.current.setSelectedQuote).toBe('function');
-      expect(typeof result.current.getWidgetUrl).toBe('function');
     });
   });
 
@@ -250,37 +248,6 @@ describe('useRampsQuotes', () => {
       expect(
         Engine.context.RampsController.stopQuotePolling,
       ).toHaveBeenCalled();
-    });
-  });
-
-  describe('getWidgetUrl', () => {
-    it('calls Engine.context.RampsController.getWidgetUrl with quote', async () => {
-      const store = createMockStore();
-      const { result } = renderHook(() => useRampsQuotes(), {
-        wrapper: wrapper(store),
-      });
-
-      const testQuote: Quote = {
-        provider: '/providers/test',
-        quote: {
-          amountIn: 100,
-          amountOut: 0.05,
-          paymentMethod: '/payments/card',
-          buyURL: 'https://on-ramp.uat-api.cx.metamask.io/test/buy-widget',
-        },
-      } as Quote;
-
-      (
-        Engine.context.RampsController.getWidgetUrl as jest.Mock
-      ).mockResolvedValue('https://global.transak.com/?apiKey=test');
-
-      await act(async () => {
-        await result.current.getWidgetUrl(testQuote);
-      });
-
-      expect(Engine.context.RampsController.getWidgetUrl).toHaveBeenCalledWith(
-        testQuote,
-      );
     });
   });
 });

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.ts
@@ -69,13 +69,6 @@ export interface UseRampsQuotesResult {
    */
   stopQuotePolling: () => void;
   /**
-   * Fetches the widget URL from a quote for redirect providers.
-   * Makes a request to the buyURL endpoint to get the actual provider widget URL.
-   * @param quote - The quote to fetch the widget URL from.
-   * @returns Promise resolving to the widget URL string, or null if not available.
-   */
-  getWidgetUrl: (quote: Quote) => Promise<string | null>;
-  /**
    * Whether the quotes request is currently loading.
    */
   isLoading: boolean;
@@ -122,11 +115,6 @@ export function useRampsQuotes(): UseRampsQuotesResult {
     [],
   );
 
-  const getWidgetUrl = useCallback(
-    (quote: Quote) => Engine.context.RampsController.getWidgetUrl(quote),
-    [],
-  );
-
   return {
     quotes,
     selectedQuote,
@@ -134,7 +122,6 @@ export function useRampsQuotes(): UseRampsQuotesResult {
     setSelectedQuote,
     startQuotePolling,
     stopQuotePolling,
-    getWidgetUrl,
     isLoading,
     error,
   };

--- a/app/components/UI/Ramp/hooks/useRampsWidgetUrl.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsWidgetUrl.test.ts
@@ -1,0 +1,116 @@
+import { renderHook } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import React from 'react';
+import { useRampsWidgetUrl } from './useRampsWidgetUrl';
+
+const mockBuyWidget = {
+  url: 'https://global.transak.com/?apiKey=test',
+  browser: 'in-app',
+  orderId: 'order-123',
+};
+
+const createMockStore = (widgetUrlState = {}) =>
+  configureStore({
+    reducer: {
+      engine: () => ({
+        backgroundState: {
+          RampsController: {
+            widgetUrl: {
+              data: null,
+              selected: null,
+              isLoading: false,
+              error: null,
+              ...widgetUrlState,
+            },
+          },
+        },
+      }),
+    },
+  });
+
+const wrapper = (store: ReturnType<typeof createMockStore>) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(Provider, { store } as never, children);
+  };
+
+describe('useRampsWidgetUrl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('return value structure', () => {
+    it('returns widgetUrl, isLoading, and error', () => {
+      const store = createMockStore();
+      const { result } = renderHook(() => useRampsWidgetUrl(), {
+        wrapper: wrapper(store),
+      });
+
+      expect(result.current).toMatchObject({
+        widgetUrl: null,
+        isLoading: false,
+        error: null,
+      });
+    });
+  });
+
+  describe('widgetUrl state', () => {
+    it('returns widgetUrl from state', () => {
+      const store = createMockStore({ data: mockBuyWidget });
+      const { result } = renderHook(() => useRampsWidgetUrl(), {
+        wrapper: wrapper(store),
+      });
+
+      expect(result.current.widgetUrl).toEqual(mockBuyWidget);
+    });
+
+    it('returns null when widgetUrl is not available', () => {
+      const store = createMockStore();
+      const { result } = renderHook(() => useRampsWidgetUrl(), {
+        wrapper: wrapper(store),
+      });
+
+      expect(result.current.widgetUrl).toBeNull();
+    });
+  });
+
+  describe('loading state', () => {
+    it('returns isLoading true when widget URL is being fetched', () => {
+      const store = createMockStore({ isLoading: true });
+      const { result } = renderHook(() => useRampsWidgetUrl(), {
+        wrapper: wrapper(store),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('returns isLoading false when widget URL is not being fetched', () => {
+      const store = createMockStore();
+      const { result } = renderHook(() => useRampsWidgetUrl(), {
+        wrapper: wrapper(store),
+      });
+
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('error state', () => {
+    it('returns error when widget URL fetch fails', () => {
+      const store = createMockStore({ error: 'Failed to fetch widget URL' });
+      const { result } = renderHook(() => useRampsWidgetUrl(), {
+        wrapper: wrapper(store),
+      });
+
+      expect(result.current.error).toBe('Failed to fetch widget URL');
+    });
+
+    it('returns null when there is no error', () => {
+      const store = createMockStore();
+      const { result } = renderHook(() => useRampsWidgetUrl(), {
+        wrapper: wrapper(store),
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+  });
+});

--- a/app/components/UI/Ramp/hooks/useRampsWidgetUrl.ts
+++ b/app/components/UI/Ramp/hooks/useRampsWidgetUrl.ts
@@ -1,0 +1,40 @@
+import { useSelector } from 'react-redux';
+import { selectWidgetUrl } from '../../../../selectors/rampsController';
+import { type BuyWidget } from '@metamask/ramps-controller';
+
+/**
+ * Result returned by the useRampsWidgetUrl hook.
+ */
+export interface UseRampsWidgetUrlResult {
+  /**
+   * The widget URL data (URL, browser type, order ID), or null if not available.
+   */
+  widgetUrl: BuyWidget | null;
+  /**
+   * Whether the widget URL request is currently loading.
+   */
+  isLoading: boolean;
+  /**
+   * The error message if the request failed, or null.
+   */
+  error: string | null;
+}
+
+/**
+ * Hook to get widget URL state from RampsController.
+ * The widget URL is automatically fetched and stored in state
+ * whenever the selected quote changes.
+ *
+ * @returns Widget URL state.
+ */
+export function useRampsWidgetUrl(): UseRampsWidgetUrlResult {
+  const { data: widgetUrl, isLoading, error } = useSelector(selectWidgetUrl);
+
+  return {
+    widgetUrl,
+    isLoading,
+    error,
+  };
+}
+
+export default useRampsWidgetUrl;

--- a/app/selectors/rampsController/index.test.ts
+++ b/app/selectors/rampsController/index.test.ts
@@ -14,6 +14,7 @@ import {
   selectPaymentMethods,
   selectRampsControllerState,
   selectQuotes,
+  selectWidgetUrl,
 } from './index';
 
 const createDefaultResourceState = <TData, TSelected = null>(
@@ -47,6 +48,7 @@ const createMockState = (
             PaymentMethod | null
           >([], null),
           quotes: createDefaultResourceState(null),
+          widgetUrl: createDefaultResourceState(null),
           requests: {},
           ...rampsController,
         },
@@ -324,6 +326,78 @@ describe('RampsController Selectors', () => {
       const result = selectQuotes(state);
 
       expect(result.error).toBe('Failed to fetch quotes');
+    });
+  });
+
+  describe('selectWidgetUrl', () => {
+    it('returns widget URL resource state when data exists', () => {
+      const mockBuyWidget = {
+        url: 'https://global.transak.com/?apiKey=test',
+        browser: 'in-app',
+        orderId: 'order-123',
+      };
+      const state = createMockState({
+        widgetUrl: {
+          data: mockBuyWidget,
+          selected: null,
+          isLoading: false,
+          error: null,
+        },
+      });
+
+      const result = selectWidgetUrl(state);
+
+      expect(result).toEqual({
+        data: mockBuyWidget,
+        selected: null,
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('returns default resource state when widgetUrl is undefined', () => {
+      const state = createMockState({
+        widgetUrl: undefined,
+      });
+
+      const result = selectWidgetUrl(state);
+
+      expect(result).toEqual({
+        data: null,
+        selected: null,
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('returns isLoading true when widget URL is being fetched', () => {
+      const state = createMockState({
+        widgetUrl: {
+          data: null,
+          selected: null,
+          isLoading: true,
+          error: null,
+        },
+      });
+
+      const result = selectWidgetUrl(state);
+
+      expect(result.isLoading).toBe(true);
+    });
+
+    it('returns error when widget URL request failed', () => {
+      const state = createMockState({
+        widgetUrl: {
+          data: null,
+          selected: null,
+          isLoading: false,
+          error: 'Failed to fetch widget URL',
+        },
+      });
+
+      const result = selectWidgetUrl(state);
+
+      expect(result.error).toBe('Failed to fetch widget URL');
     });
   });
 

--- a/app/selectors/rampsController/index.ts
+++ b/app/selectors/rampsController/index.ts
@@ -9,6 +9,7 @@ import {
   type ResourceState,
   type Quote,
   type QuotesResponse,
+  type BuyWidget,
 } from '@metamask/ramps-controller';
 import { RootState } from '../../reducers';
 
@@ -97,4 +98,14 @@ export const selectQuotes = createSelector(
   (rampsControllerState): ResourceState<QuotesResponse | null, Quote | null> =>
     rampsControllerState?.quotes ??
     createDefaultResourceState<QuotesResponse | null, Quote | null>(null, null),
+);
+
+/**
+ * Selects the widget URL resource state (data, isLoading, error).
+ */
+export const selectWidgetUrl = createSelector(
+  selectRampsControllerState,
+  (rampsControllerState): ResourceState<BuyWidget | null> =>
+    rampsControllerState?.widgetUrl ??
+    createDefaultResourceState<BuyWidget | null>(null),
 );

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     ]
   },
   "resolutions": {
+    "@metamask/ramps-controller": "npm:@metamask-previews/ramps-controller@8.0.0-preview-38a9cf6c3",
     "@appium/schema/json-schema": "^0.4.0",
     "@metamask/react-native-payments/validator": "^13.7.0",
     "d3-color": "3.1.0",
@@ -182,6 +183,7 @@
     "@keystonehq/ur-decoder": "^0.12.2",
     "@lavamoat/react-native-lockdown": "^0.0.2",
     "@ledgerhq/react-native-hw-transport-ble": "^6.37.0",
+    "@metamask-previews/ramps-controller": "8.0.0-preview-38a9cf6c3",
     "@metamask/abi-utils": "^3.0.0",
     "@metamask/account-api": "^0.12.0",
     "@metamask/account-tree-controller": "^3.0.0",
@@ -253,7 +255,6 @@
     "@metamask/preinstalled-example-snap": "^0.7.2",
     "@metamask/profile-metrics-controller": "^2.0.0",
     "@metamask/profile-sync-controller": "^27.1.0",
-    "@metamask/ramps-controller": "^8.0.0",
     "@metamask/react-native-acm": "^1.0.1",
     "@metamask/react-native-actionsheet": "2.4.2",
     "@metamask/react-native-button": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7509,6 +7509,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask-previews/ramps-controller@npm:8.0.0-preview-38a9cf6c3":
+  version: 8.0.0-preview-38a9cf6c3
+  resolution: "@metamask-previews/ramps-controller@npm:8.0.0-preview-38a9cf6c3"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/messenger": "npm:^0.3.0"
+  checksum: 10/bcbc5d15287c00bdec1b1dde8a98a5eea28d3e65bc6ceb127a52e31e5c84df73d1d2bd560915a4adbb028cd0d447cb0ff35ee385e7510601bdcb32a35cda129e
+  languageName: node
+  linkType: hard
+
 "@metamask/7715-permission-types@npm:^0.3.0":
   version: 0.3.0
   resolution: "@metamask/7715-permission-types@npm:0.3.0"
@@ -9593,17 +9604,6 @@ __metadata:
   peerDependencies:
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   checksum: 10/50194c608fb308cee268c6eefb8c8d439a9d07aa41d07cb5ddcd7e706819aea7e746150f32688fe06d20309b49346440855b5d56aacf286b343da6fcb217cc12
-  languageName: node
-  linkType: hard
-
-"@metamask/ramps-controller@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@metamask/ramps-controller@npm:8.0.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/messenger": "npm:^0.3.0"
-  checksum: 10/fd016f8d51c835a120da2bd62816dc11f0ab670f1559b17d7bf280842b66c4d6b238a1efa16ce786eedf5876bb275d512a3cba7cdb740ac1ea8620139070ba6b
   languageName: node
   linkType: hard
 
@@ -35507,6 +35507,7 @@ __metadata:
     "@lavamoat/git-safe-dependencies": "npm:^0.2.1"
     "@lavamoat/react-native-lockdown": "npm:^0.0.2"
     "@ledgerhq/react-native-hw-transport-ble": "npm:^6.37.0"
+    "@metamask-previews/ramps-controller": "npm:8.0.0-preview-38a9cf6c3"
     "@metamask/abi-utils": "npm:^3.0.0"
     "@metamask/account-api": "npm:^0.12.0"
     "@metamask/account-tree-controller": "npm:^3.0.0"
@@ -35588,7 +35589,6 @@ __metadata:
     "@metamask/profile-metrics-controller": "npm:^2.0.0"
     "@metamask/profile-sync-controller": "npm:^27.1.0"
     "@metamask/providers": "npm:^18.3.1"
-    "@metamask/ramps-controller": "npm:^8.0.0"
     "@metamask/react-native-acm": "npm:^1.0.1"
     "@metamask/react-native-actionsheet": "npm:2.4.2"
     "@metamask/react-native-button": "npm:^3.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Refactors ramps to use the widget URL in controller state instead of fetching one when the user clicks continue.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Ramp checkout navigation path and readiness/disabled logic around quote selection, which could block purchases if the new widget URL state isn’t populated correctly. Changes are localized and covered by updated unit tests.
> 
> **Overview**
> **Refactors the Ramp buy flow to consume a pre-fetched `widgetUrl` from `RampsController` state** rather than calling `getWidgetUrl` on continue.
> 
> `BuildQuote` now gates the Continue button on `widgetUrl` readiness for aggregator providers (and shows loading while `widgetUrlLoading`), while native providers continue to route directly to the deposit flow. The PR introduces `useRampsWidgetUrl` + `selectWidgetUrl`, removes `getWidgetUrl` from `useRampsQuotes`/`useRampsController`, updates tests accordingly, and pins `@metamask/ramps-controller` to a preview build that includes the new `widgetUrl` state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71f7f0d377e0b41467ec68227ca4a78c2aa87bb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->