### PR TITLE
refactor(predict): remove claim navigation stack workaround

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictClaim.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.test.ts
@@ -143,7 +143,6 @@ describe('usePredictClaim', () => {
       expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
         headerShown: false,
         loader: ConfirmationLoader.PredictClaim,
-        stack: 'Predict',
       });
       expect(mockClaimWinnings).toHaveBeenCalledWith({
         providerId: POLYMARKET_PROVIDER_ID,
@@ -274,7 +273,6 @@ describe('usePredictClaim', () => {
       expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
         headerShown: false,
         loader: ConfirmationLoader.PredictClaim,
-        stack: 'Predict',
       });
       expect(mockClaimWinnings).toHaveBeenCalledWith({
         providerId: POLYMARKET_PROVIDER_ID,

--- a/app/components/UI/Predict/hooks/usePredictClaim.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.ts
@@ -12,7 +12,6 @@ import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 import { ensureError } from '../utils/predictErrorHandler';
 import { usePredictTrading } from './usePredictTrading';
 import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
-import Routes from '../../../../constants/navigation/Routes';
 
 interface UsePredictClaimParams {
   providerId?: string;
@@ -32,8 +31,6 @@ export const usePredictClaim = ({
       navigateToConfirmation({
         headerShown: false,
         loader: ConfirmationLoader.PredictClaim,
-        // TODO: remove once navigation stack is fixed properly
-        stack: Routes.PREDICT.ROOT,
       });
       await claimWinnings({ providerId });
     } catch (err) {


### PR DESCRIPTION
## **Description**

This PR addresses Predict tech debt by removing a stale claim-flow navigation workaround in `usePredictClaim`.

`usePredictClaim` no longer passes `stack: Routes.PREDICT.ROOT` into `navigateToConfirmation`, and the corresponding unit tests were updated to reflect the current navigation contract.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict claim confirmation navigation

  Scenario: user initiates claim and retries on failure
    Given the user triggers claim in Predict
    When claim navigation is started
    Then claim navigates to the confirmation loader without a stack override

    When claim fails and user taps Try again
    Then claim retries and reuses the same confirmation navigation payload
```

## **Screenshots/Recordings**

### **Before**

N/A (non-visual hook/navigation payload refactor)

### **After**

N/A (non-visual hook/navigation payload refactor)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
