### PR TITLE
feat:  input a limited use promo code to claim bonus points

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -124,6 +124,7 @@ import CardRoutes from '../../UI/Card/routes';
 import { Send } from '../../Views/confirmations/components/send';
 import { TransactionDetails } from '../../Views/confirmations/components/activity/transaction-details/transaction-details';
 import RewardsBottomSheetModal from '../../UI/Rewards/components/RewardsBottomSheetModal';
+import BonusCodeBottomSheet from '../../UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/BonusCodeBottomSheet';
 import RewardsClaimBottomSheetModal from '../../UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal';
 import RewardOptInAccountGroupModal from '../../UI/Rewards/components/Settings/RewardOptInAccountGroupModal';
 import EndOfSeasonClaimBottomSheet from '../../UI/Rewards/components/EndOfSeasonClaimBottomSheet/EndOfSeasonClaimBottomSheet';
@@ -259,6 +260,10 @@ const RewardsHome = () => (
     <Stack.Screen
       name={Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL}
       component={RewardsBottomSheetModal}
+    />
+    <Stack.Screen
+      name={Routes.MODAL.REWARDS_BONUS_CODE_BOTTOM_SHEET}
+      component={BonusCodeBottomSheet}
     />
     <Stack.Screen
       name={Routes.MODAL.REWARDS_CLAIM_BOTTOM_SHEET_MODAL}

--- a/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.tsx
+++ b/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.tsx
@@ -18,7 +18,10 @@ import {
 } from '../../../../../reducers/rewards/selectors';
 import TextField from '../../../../../component-library/components/Form/TextField';
 import { useReferralDetails } from '../../hooks/useReferralDetails';
-import { useValidateReferralCode } from '../../hooks/useValidateReferralCode';
+import {
+  useValidateReferralCode,
+  REFERRAL_CODE_LENGTH,
+} from '../../hooks/useValidateReferralCode';
 import { useApplyReferralCode } from '../../hooks/useApplyReferralCode';
 import { Skeleton } from '../../../../../component-library/components/Skeleton';
 import { useTheme } from '../../../../../util/theme';
@@ -188,6 +191,7 @@ const ReferredByCodeSection: React.FC = () => {
           placeholder={strings('rewards.referred_by_code.input_placeholder')}
           value={hasReferredByCode ? (referredByCode ?? '') : inputCode}
           onChangeText={hasReferredByCode ? undefined : handleInputChange}
+          maxLength={REFERRAL_CODE_LENGTH}
           isDisabled={hasReferredByCode}
           autoCapitalize="characters"
           endAccessory={renderIcon()}

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/ActivityDetailsSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/ActivityDetailsSheet.test.tsx
@@ -41,6 +41,7 @@ jest.mock('../../../../../../../../locales/i18n', () => ({
       'rewards.events.points_boost': 'Boost',
       'rewards.events.points_total': 'Total',
       'rewards.events.description': 'Description',
+      'rewards.events.code': 'Code',
       'rewards.events.for_deposit_period': 'For deposit period',
     };
     return t[key] || key;
@@ -157,10 +158,10 @@ describe('ActivityDetailsSheet', () => {
       );
 
       // Verify GenericEventDetails content is rendered (base component)
-      expect(screen.getByText('Details')).toBeTruthy();
+      expect(screen.getByText('Details')).toBeOnTheScreen();
       // Verify SwapEventDetails specific content
-      expect(screen.getByText('Asset')).toBeTruthy();
-      expect(screen.getByText('1 ETH to 1 USDC')).toBeTruthy();
+      expect(screen.getByText('Asset')).toBeOnTheScreen();
+      expect(screen.getByText('1 ETH to 1 USDC')).toBeOnTheScreen();
     });
 
     it('renders CardEventDetails for CARD event type', () => {
@@ -188,10 +189,10 @@ describe('ActivityDetailsSheet', () => {
       );
 
       // Verify GenericEventDetails content is rendered (base component)
-      expect(screen.getByText('Details')).toBeTruthy();
+      expect(screen.getByText('Details')).toBeOnTheScreen();
       // Verify CardEventDetails specific content
-      expect(screen.getByText('Amount')).toBeTruthy();
-      expect(screen.getByText('43.25 USDC')).toBeTruthy();
+      expect(screen.getByText('Amount')).toBeOnTheScreen();
+      expect(screen.getByText('43.25 USDC')).toBeOnTheScreen();
     });
 
     it('renders MusdDepositEventDetails for MUSD_DEPOSIT event type', () => {
@@ -215,10 +216,55 @@ describe('ActivityDetailsSheet', () => {
       );
 
       // Verify GenericEventDetails content is rendered (base component)
-      expect(screen.getByText('Details')).toBeTruthy();
+      expect(screen.getByText('Details')).toBeOnTheScreen();
       // Verify MusdDepositEventDetails specific content
-      expect(screen.getByText('For deposit period')).toBeTruthy();
-      expect(screen.getByText('Nov 11, 2025')).toBeTruthy();
+      expect(screen.getByText('For deposit period')).toBeOnTheScreen();
+      expect(screen.getByText('Nov 11, 2025')).toBeOnTheScreen();
+    });
+
+    it('renders BonusCodeEventDetails for BONUS_CODE event type', () => {
+      const bonusCodeEvent: Extract<PointsEventDto, { type: 'BONUS_CODE' }> = {
+        ...baseEvent,
+        type: 'BONUS_CODE',
+        payload: {
+          code: 'BNS123',
+        },
+      };
+
+      render(
+        <ActivityDetailsSheet
+          event={bonusCodeEvent}
+          accountName="Primary"
+          activityTypes={mockActivityTypes}
+        />,
+      );
+
+      // Verify GenericEventDetails content is rendered (base component)
+      expect(screen.getByText('Details')).toBeOnTheScreen();
+      // Verify BonusCodeEventDetails specific content
+      expect(screen.getByText('Code')).toBeOnTheScreen();
+      expect(screen.getByText('BNS123')).toBeOnTheScreen();
+    });
+
+    it('renders BonusCodeEventDetails without code row when payload is null', () => {
+      const bonusCodeEventNoPayload = {
+        ...baseEvent,
+        type: 'BONUS_CODE' as const,
+        payload: null,
+      };
+
+      render(
+        <ActivityDetailsSheet
+          event={bonusCodeEventNoPayload}
+          accountName="Primary"
+          activityTypes={mockActivityTypes}
+        />,
+      );
+
+      // Verify GenericEventDetails content is rendered
+      expect(screen.getByText('Details')).toBeOnTheScreen();
+      // Code row should not be present
+      expect(screen.queryByText('Code')).toBeNull();
     });
 
     it('renders GenericEventDetails for unspecified type when payload exists', () => {
@@ -237,9 +283,9 @@ describe('ActivityDetailsSheet', () => {
       );
 
       // Verify GenericEventDetails content is rendered
-      expect(screen.getByText('Details')).toBeTruthy();
-      expect(screen.getByText('Points')).toBeTruthy();
-      expect(screen.getByText('Date')).toBeTruthy();
+      expect(screen.getByText('Details')).toBeOnTheScreen();
+      expect(screen.getByText('Points')).toBeOnTheScreen();
+      expect(screen.getByText('Date')).toBeOnTheScreen();
     });
 
     it('renders GenericEventDetails for unspecified type when payload is null', () => {
@@ -258,9 +304,9 @@ describe('ActivityDetailsSheet', () => {
       );
 
       // Verify GenericEventDetails content is rendered
-      expect(screen.getByText('Details')).toBeTruthy();
-      expect(screen.getByText('Points')).toBeTruthy();
-      expect(screen.getByText('Date')).toBeTruthy();
+      expect(screen.getByText('Details')).toBeOnTheScreen();
+      expect(screen.getByText('Points')).toBeOnTheScreen();
+      expect(screen.getByText('Date')).toBeOnTheScreen();
     });
   });
 
@@ -380,7 +426,7 @@ describe('ActivityDetailsSheet', () => {
       // Verify the component can be rendered (checks it's a valid React element)
       const { description } = callArgs;
       render(description);
-      expect(screen.getByText('Details')).toBeTruthy();
+      expect(screen.getByText('Details')).toBeOnTheScreen();
     });
 
     it('handles undefined accountName', () => {

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/ActivityDetailsSheet.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/ActivityDetailsSheet.tsx
@@ -13,6 +13,7 @@ import {
   PointsEventDto,
   SeasonActivityTypeDto,
 } from '../../../../../../../core/Engine/controllers/rewards-controller/types';
+import { BonusCodeEventDetails } from './BonusCodeEventDetails';
 
 interface ActivityDetailsSheetProps {
   event: PointsEventDto;
@@ -45,6 +46,13 @@ export const ActivityDetailsSheet: React.FC<ActivityDetailsSheetProps> = ({
       return (
         <MusdDepositEventDetails
           event={event as Extract<PointsEventDto, { type: 'MUSD_DEPOSIT' }>}
+          accountName={accountName}
+        />
+      );
+    case 'BONUS_CODE':
+      return (
+        <BonusCodeEventDetails
+          event={event as Extract<PointsEventDto, { type: 'BONUS_CODE' }>}
           accountName={accountName}
         />
       );

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/BonusCodeEventDetails.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/BonusCodeEventDetails.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import { BonusCodeEventDetails } from './BonusCodeEventDetails';
+import { AvatarAccountType } from '../../../../../../../component-library/components/Avatars/Avatar';
+import TEST_ADDRESS from '../../../../../../../constants/address';
+import { PointsEventDto } from '../../../../../../../core/Engine/controllers/rewards-controller/types';
+
+// Mock react-redux
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+// Mock i18n strings used by GenericEventDetails
+jest.mock('../../../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => {
+    const t: Record<string, string> = {
+      'rewards.events.details': 'Details',
+      'rewards.events.date': 'Date',
+      'rewards.events.account': 'Account',
+      'rewards.events.code': 'Code',
+      'rewards.events.points': 'Points',
+      'rewards.events.points_base': 'Base',
+      'rewards.events.points_boost': 'Boost',
+      'rewards.events.points_total': 'Total',
+    };
+    return t[key] || key;
+  }),
+}));
+
+// Mock format utils used by GenericEventDetails
+jest.mock('../../../../utils/formatUtils', () => ({
+  formatRewardsDate: jest.fn(() => 'Sep 9, 2025'),
+  formatNumber: jest.fn((n: number) => n.toString()),
+}));
+
+// Mock SVG used in the component to avoid native rendering issues
+jest.mock(
+  '../../../../../../../images/rewards/metamask-rewards-points.svg',
+  () => 'SvgMock',
+);
+
+describe('BonusCodeEventDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockReturnValue(AvatarAccountType.JazzIcon);
+  });
+
+  const bonusCodeEvent: Extract<PointsEventDto, { type: 'BONUS_CODE' }> = {
+    id: 'bonus-1',
+    timestamp: new Date('2025-09-09T09:09:33.000Z'),
+    type: 'BONUS_CODE',
+    value: 500,
+    bonus: null,
+    accountAddress: TEST_ADDRESS,
+    updatedAt: new Date('2025-09-09T09:09:33.000Z'),
+    payload: {
+      code: 'BNS123',
+    },
+  };
+
+  it('renders code row with bonus code from payload', () => {
+    render(
+      <BonusCodeEventDetails event={bonusCodeEvent} accountName="Primary" />,
+    );
+
+    expect(screen.getByText('Details')).toBeOnTheScreen();
+    expect(screen.getByText('Code')).toBeOnTheScreen();
+    expect(screen.getByText('BNS123')).toBeOnTheScreen();
+  });
+
+  it('renders generic details without code row when payload is null', () => {
+    const eventWithNullPayload = {
+      ...bonusCodeEvent,
+      payload: null,
+    };
+
+    render(
+      <BonusCodeEventDetails
+        event={eventWithNullPayload}
+        accountName="Primary"
+      />,
+    );
+
+    expect(screen.getByText('Details')).toBeOnTheScreen();
+    expect(screen.queryByText('Code')).toBeNull();
+  });
+
+  it('renders points section', () => {
+    render(
+      <BonusCodeEventDetails event={bonusCodeEvent} accountName="Primary" />,
+    );
+
+    expect(screen.getByText('Points')).toBeOnTheScreen();
+    expect(screen.getByText('Total')).toBeOnTheScreen();
+    expect(screen.getAllByText('500').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/BonusCodeEventDetails.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/BonusCodeEventDetails.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Text, TextVariant } from '@metamask/design-system-react-native';
+import { GenericEventDetails, DetailsRow } from './GenericEventDetails';
+import { PointsEventDto } from '../../../../../../../core/Engine/controllers/rewards-controller/types';
+import { strings } from '../../../../../../../../locales/i18n';
+
+export const BonusCodeEventDetails: React.FC<{
+  event: Extract<PointsEventDto, { type: 'BONUS_CODE' }>;
+  accountName?: string;
+}> = ({ event, accountName }) => {
+  const bonusCodePayload = event.payload;
+
+  return (
+    <GenericEventDetails
+      event={event}
+      accountName={accountName}
+      extraDetails={
+        bonusCodePayload?.code ? (
+          <DetailsRow label={strings('rewards.events.code')}>
+            <Text variant={TextVariant.BodySm}>{bonusCodePayload.code}</Text>
+          </DetailsRow>
+        ) : undefined
+      }
+    />
+  );
+};

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/BonusCodeBottomSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/BonusCodeBottomSheet.test.tsx
@@ -1,0 +1,444 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import BonusCodeBottomSheet from './BonusCodeBottomSheet';
+import { useValidateBonusCode } from '../../../../hooks/useValidateBonusCode';
+import { useApplyBonusCode } from '../../../../hooks/useApplyBonusCode';
+
+const mockGoBack = jest.fn();
+const mockShowToast = jest.fn();
+const mockRewardsToastOptions = {
+  success: (title: string) => ({ type: 'success', title }),
+  error: (title: string) => ({ type: 'error', title }),
+};
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: mockGoBack }),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const {
+    View,
+    Text: RNText,
+    TouchableOpacity,
+  } = jest.requireActual('react-native');
+  const R = jest.requireActual('react');
+
+  return {
+    Box: (p: Record<string, unknown>) =>
+      R.createElement(View, { testID: p.testID }, p.children),
+    Text: (p: Record<string, unknown>) =>
+      R.createElement(RNText, { testID: p.testID }, p.children),
+    Icon: (p: Record<string, unknown>) =>
+      R.createElement(View, { testID: p.testID || `icon-${p.name}` }),
+    Button: (p: Record<string, unknown>) =>
+      R.createElement(
+        TouchableOpacity,
+        {
+          testID: p.testID,
+          onPress: p.onPress,
+          disabled: p.isDisabled,
+          accessibilityState: { disabled: p.isDisabled },
+        },
+        p.isLoading
+          ? R.createElement(View, { testID: `${p.testID}-loading` })
+          : R.createElement(RNText, null, p.children),
+      ),
+    TextVariant: { HeadingMd: 'HeadingMd', BodyMd: 'BodyMd', BodySm: 'BodySm' },
+    BoxAlignItems: { Center: 'Center', Start: 'Start' },
+    BoxFlexDirection: { Column: 'Column' },
+    ButtonSize: { Lg: 'Lg' },
+    ButtonVariant: { Primary: 'Primary' },
+    IconName: { Confirmation: 'Confirmation', Error: 'Error' },
+    IconSize: { Lg: 'Lg' },
+    IconColor: {
+      SuccessDefault: 'SuccessDefault',
+      ErrorDefault: 'ErrorDefault',
+    },
+  };
+});
+
+jest.mock(
+  '../../../../../../../component-library/components/BottomSheets/BottomSheet',
+  () => {
+    const { View } = jest.requireActual('react-native');
+    const R = jest.requireActual('react');
+    const Sheet = R.forwardRef((p: Record<string, unknown>, _ref: unknown) =>
+      R.createElement(View, { testID: p.testID }, p.children),
+    );
+    Sheet.displayName = 'BottomSheet';
+    return { __esModule: true, default: Sheet };
+  },
+);
+
+jest.mock(
+  '../../../../../../../component-library/components/Form/TextField',
+  () => {
+    const { View, TextInput } = jest.requireActual('react-native');
+    const R = jest.requireActual('react');
+    return {
+      __esModule: true,
+      default: (p: Record<string, unknown>) =>
+        R.createElement(
+          View,
+          { testID: p.testID },
+          R.createElement(TextInput, {
+            testID: `${p.testID}-input`,
+            value: p.value,
+            onChangeText: p.onChangeText,
+            editable: !p.isDisabled,
+            placeholder: p.placeholder,
+          }),
+          p.endAccessory &&
+            R.createElement(
+              View,
+              { testID: `${p.testID}-end-accessory` },
+              p.endAccessory,
+            ),
+        ),
+    };
+  },
+);
+
+jest.mock('../../../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => key),
+}));
+
+jest.mock('../../../../hooks/useValidateBonusCode', () => ({
+  ...jest.requireActual('../../../../hooks/useValidateBonusCode'),
+  useValidateBonusCode: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useApplyBonusCode', () => ({
+  useApplyBonusCode: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useRewardsToast', () => ({
+  __esModule: true,
+  default: () => ({
+    showToast: mockShowToast,
+    RewardsToastOptions: mockRewardsToastOptions,
+  }),
+}));
+
+jest.mock('../../../../../../../util/theme', () => ({
+  useTheme: () => ({ colors: { icon: { default: '#000000' } } }),
+}));
+
+const mockUseValidateBonusCode = useValidateBonusCode as jest.MockedFunction<
+  typeof useValidateBonusCode
+>;
+const mockUseApplyBonusCode = useApplyBonusCode as jest.MockedFunction<
+  typeof useApplyBonusCode
+>;
+
+describe('BonusCodeBottomSheet', () => {
+  const mockApplyBonusCode = jest.fn();
+  const mockClearApplyBonusCodeError = jest.fn();
+  const mockSetBonusCode = jest.fn();
+
+  const defaultRoute = {
+    params: {
+      title: 'Bonus Code',
+      description: 'Enter your bonus code to claim points.',
+      ctaLabel: 'Submit',
+    },
+  };
+
+  const defaultValidateReturn = {
+    bonusCode: '',
+    setBonusCode: mockSetBonusCode,
+    isValidating: false,
+    isValid: false,
+    isUnknownError: false,
+    error: '',
+  };
+
+  const defaultApplyReturn = {
+    applyBonusCode: mockApplyBonusCode,
+    isApplyingBonusCode: false,
+    applyBonusCodeError: undefined,
+    clearApplyBonusCodeError: mockClearApplyBonusCodeError,
+    applyBonusCodeSuccess: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseValidateBonusCode.mockReturnValue(defaultValidateReturn);
+    mockUseApplyBonusCode.mockReturnValue(defaultApplyReturn);
+  });
+
+  describe('Default State', () => {
+    it('renders the bottom sheet with title and description from params', () => {
+      const { getByTestId, getByText } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('bonus-code-bottom-sheet')).toBeOnTheScreen();
+      expect(getByText('Bonus Code')).toBeOnTheScreen();
+      expect(
+        getByText('Enter your bonus code to claim points.'),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders ReactNode title and description', () => {
+      const customRoute = {
+        params: {
+          title: <></>,
+          description: <></>,
+          ctaLabel: 'Go',
+        },
+      };
+
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={customRoute} />,
+      );
+
+      expect(getByTestId('bonus-code-bottom-sheet')).toBeOnTheScreen();
+    });
+
+    it('renders the text input', () => {
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('bonus-code-input')).toBeOnTheScreen();
+    });
+
+    it('renders submit button with ctaLabel', () => {
+      const { getByTestId, getByText } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('bonus-code-submit-button')).toBeOnTheScreen();
+      expect(getByText('Submit')).toBeOnTheScreen();
+    });
+
+    it('disables submit button when code is not valid', () => {
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      const button = getByTestId('bonus-code-submit-button');
+      expect(button.props.accessibilityState.disabled).toBe(true);
+    });
+  });
+
+  describe('Input Handling', () => {
+    it('calls setBonusCode when input text changes', () => {
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      fireEvent.changeText(getByTestId('bonus-code-input-input'), 'ABC123');
+
+      expect(mockSetBonusCode).toHaveBeenCalledWith('ABC123');
+    });
+
+    it('shows validation error when code is invalid and 4+ chars', () => {
+      mockUseValidateBonusCode.mockReturnValue({
+        ...defaultValidateReturn,
+        bonusCode: 'ABCD',
+        error: 'Invalid bonus code',
+      });
+
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('bonus-code-invalid-code')).toBeOnTheScreen();
+    });
+
+    it('does not show validation error when code is less than 4 chars', () => {
+      mockUseValidateBonusCode.mockReturnValue({
+        ...defaultValidateReturn,
+        bonusCode: 'ABC',
+        error: 'some error',
+      });
+
+      const { queryByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      expect(queryByTestId('bonus-code-invalid-code')).toBeNull();
+    });
+
+    it('shows loading indicator in input when validating', () => {
+      mockUseValidateBonusCode.mockReturnValue({
+        ...defaultValidateReturn,
+        bonusCode: 'BNS123',
+        isValidating: true,
+      });
+
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('bonus-code-input-end-accessory')).toBeOnTheScreen();
+    });
+
+    it('shows success icon in input when code is valid', () => {
+      mockUseValidateBonusCode.mockReturnValue({
+        ...defaultValidateReturn,
+        bonusCode: 'BNS123',
+        isValid: true,
+      });
+
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('bonus-code-input-end-accessory')).toBeOnTheScreen();
+    });
+
+    it('does not show error icon when isUnknownError is true', () => {
+      mockUseValidateBonusCode.mockReturnValue({
+        ...defaultValidateReturn,
+        bonusCode: 'BNS123',
+        isUnknownError: true,
+      });
+
+      const { queryByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      expect(queryByTestId('bonus-code-input-end-accessory')).toBeNull();
+    });
+  });
+
+  describe('Valid Code State', () => {
+    it('enables submit button when code is valid', () => {
+      mockUseValidateBonusCode.mockReturnValue({
+        ...defaultValidateReturn,
+        bonusCode: 'BNS123',
+        isValid: true,
+      });
+
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      const button = getByTestId('bonus-code-submit-button');
+      expect(button.props.accessibilityState.disabled).toBe(false);
+    });
+
+    it('calls applyBonusCode when submit is pressed', () => {
+      mockApplyBonusCode.mockResolvedValue(undefined);
+      mockUseValidateBonusCode.mockReturnValue({
+        ...defaultValidateReturn,
+        bonusCode: 'BNS123',
+        isValid: true,
+      });
+
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      fireEvent.press(getByTestId('bonus-code-submit-button'));
+
+      expect(mockClearApplyBonusCodeError).toHaveBeenCalled();
+      expect(mockApplyBonusCode).toHaveBeenCalledWith('BNS123');
+    });
+
+    it('shows success toast and navigates back after successful submit', async () => {
+      mockApplyBonusCode.mockResolvedValue(undefined);
+      mockUseValidateBonusCode.mockReturnValue({
+        ...defaultValidateReturn,
+        bonusCode: 'BNS123',
+        isValid: true,
+      });
+
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      await fireEvent.press(getByTestId('bonus-code-submit-button'));
+      await new Promise(process.nextTick);
+
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success' }),
+      );
+      expect(mockGoBack).toHaveBeenCalled();
+    });
+  });
+
+  describe('Applying State', () => {
+    it('disables submit button while applying', () => {
+      mockUseValidateBonusCode.mockReturnValue({
+        ...defaultValidateReturn,
+        bonusCode: 'BNS123',
+        isValid: true,
+      });
+      mockUseApplyBonusCode.mockReturnValue({
+        ...defaultApplyReturn,
+        isApplyingBonusCode: true,
+      });
+
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      const button = getByTestId('bonus-code-submit-button');
+      expect(button.props.accessibilityState.disabled).toBe(true);
+    });
+
+    it('shows loading state on submit button while applying', () => {
+      mockUseValidateBonusCode.mockReturnValue({
+        ...defaultValidateReturn,
+        bonusCode: 'BNS123',
+        isValid: true,
+      });
+      mockUseApplyBonusCode.mockReturnValue({
+        ...defaultApplyReturn,
+        isApplyingBonusCode: true,
+      });
+
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('bonus-code-submit-button-loading')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Apply Error State', () => {
+    it('renders apply error message', () => {
+      mockUseApplyBonusCode.mockReturnValue({
+        ...defaultApplyReturn,
+        applyBonusCodeError: 'Failed to apply',
+      });
+
+      const { getByTestId, getByText } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      expect(getByTestId('bonus-code-apply-error')).toBeOnTheScreen();
+      expect(getByText('Failed to apply')).toBeOnTheScreen();
+    });
+
+    it('does not render apply error when none exists', () => {
+      const { queryByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      expect(queryByTestId('bonus-code-apply-error')).toBeNull();
+    });
+
+    it('does not navigate back when submit fails', async () => {
+      mockApplyBonusCode.mockRejectedValue(new Error('Apply failed'));
+      mockUseValidateBonusCode.mockReturnValue({
+        ...defaultValidateReturn,
+        bonusCode: 'BNS123',
+        isValid: true,
+      });
+
+      const { getByTestId } = render(
+        <BonusCodeBottomSheet route={defaultRoute} />,
+      );
+
+      await fireEvent.press(getByTestId('bonus-code-submit-button'));
+      await new Promise(process.nextTick);
+
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/BonusCodeBottomSheet.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/BonusCodeBottomSheet.tsx
@@ -1,0 +1,228 @@
+import React, { useCallback, useRef } from 'react';
+import { ActivityIndicator } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import {
+  Text,
+  TextVariant,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
+} from '@metamask/design-system-react-native';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../../../component-library/components/BottomSheets/BottomSheet';
+import TextField from '../../../../../../../component-library/components/Form/TextField';
+import { strings } from '../../../../../../../../locales/i18n';
+import {
+  useValidateBonusCode,
+  BONUS_CODE_MIN_LENGTH,
+  BONUS_CODE_MAX_LENGTH,
+} from '../../../../hooks/useValidateBonusCode';
+import { useApplyBonusCode } from '../../../../hooks/useApplyBonusCode';
+import useRewardsToast from '../../../../hooks/useRewardsToast';
+import { useTheme } from '../../../../../../../util/theme';
+
+interface BonusCodeBottomSheetProps {
+  route: {
+    params: {
+      title: string | React.ReactNode;
+      description: string | React.ReactNode;
+      ctaLabel: string;
+    };
+  };
+}
+
+const BonusCodeBottomSheet: React.FC<BonusCodeBottomSheetProps> = ({
+  route,
+}) => {
+  const { title, description, ctaLabel } = route.params;
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const navigation = useNavigation();
+  const { colors } = useTheme();
+  const { showToast, RewardsToastOptions } = useRewardsToast();
+
+  const {
+    bonusCode,
+    setBonusCode,
+    isValidating,
+    isValid,
+    isUnknownError,
+    error,
+  } = useValidateBonusCode();
+
+  const {
+    applyBonusCode,
+    isApplyingBonusCode,
+    applyBonusCodeError,
+    clearApplyBonusCodeError,
+    applyBonusCodeSuccess,
+  } = useApplyBonusCode();
+
+  const handleSubmit = useCallback(async () => {
+    clearApplyBonusCodeError();
+    try {
+      await applyBonusCode(bonusCode);
+      showToast(
+        RewardsToastOptions.success(
+          strings('rewards.bonus_code.apply_success'),
+        ),
+      );
+      navigation.goBack();
+    } catch {
+      // Error is handled by the hook
+    }
+  }, [
+    applyBonusCode,
+    bonusCode,
+    clearApplyBonusCodeError,
+    navigation,
+    showToast,
+    RewardsToastOptions,
+  ]);
+
+  const isSubmitDisabled =
+    !isValid || isApplyingBonusCode || isValidating || applyBonusCodeSuccess;
+
+  const showValidationError =
+    bonusCode.length >= BONUS_CODE_MIN_LENGTH &&
+    !isValid &&
+    !isValidating &&
+    !isUnknownError;
+
+  const renderInputIcon = () => {
+    if (isValidating) {
+      return <ActivityIndicator color={colors.icon.default} />;
+    }
+
+    if (isValid) {
+      return (
+        <Icon
+          name={IconName.Confirmation}
+          size={IconSize.Lg}
+          color={IconColor.SuccessDefault}
+        />
+      );
+    }
+
+    if (
+      bonusCode.length >= BONUS_CODE_MIN_LENGTH &&
+      !isValid &&
+      !isUnknownError
+    ) {
+      return (
+        <Icon
+          name={IconName.Error}
+          size={IconSize.Lg}
+          color={IconColor.ErrorDefault}
+        />
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <BottomSheet ref={sheetRef}>
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        twClassName="p-4"
+        testID="bonus-code-bottom-sheet"
+      >
+        <Box
+          alignItems={
+            typeof title === 'string'
+              ? BoxAlignItems.Center
+              : BoxAlignItems.Start
+          }
+          twClassName="mb-3 w-full"
+        >
+          {typeof title === 'string' ? (
+            <Text variant={TextVariant.HeadingMd}>{title}</Text>
+          ) : (
+            title
+          )}
+        </Box>
+        <Box
+          alignItems={
+            typeof description === 'string'
+              ? BoxAlignItems.Center
+              : BoxAlignItems.Start
+          }
+          twClassName="mb-3 w-full"
+        >
+          {typeof description === 'string' ? (
+            <Text
+              variant={TextVariant.BodyMd}
+              twClassName="text-alternative text-center"
+            >
+              {description}
+            </Text>
+          ) : (
+            description
+          )}
+        </Box>
+
+        <Box twClassName="w-full mb-6">
+          <TextField
+            testID="bonus-code-input"
+            placeholder={strings('rewards.bonus_code.input_placeholder')}
+            value={bonusCode}
+            onChangeText={(text: string) => {
+              clearApplyBonusCodeError();
+              setBonusCode(text);
+            }}
+            maxLength={BONUS_CODE_MAX_LENGTH}
+            autoCapitalize="characters"
+            endAccessory={renderInputIcon()}
+            isError={showValidationError || Boolean(applyBonusCodeError)}
+          />
+          {showValidationError && (
+            <Text
+              variant={TextVariant.BodySm}
+              twClassName="text-error-default mt-1"
+              testID="bonus-code-invalid-code"
+            >
+              {error}
+            </Text>
+          )}
+        </Box>
+
+        {applyBonusCodeError && (
+          <Box twClassName="w-full mb-4">
+            <Text
+              variant={TextVariant.BodySm}
+              twClassName="text-error-default"
+              testID="bonus-code-apply-error"
+            >
+              {applyBonusCodeError}
+            </Text>
+          </Box>
+        )}
+
+        <Box twClassName="w-full">
+          <Button
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            onPress={handleSubmit}
+            isDisabled={isSubmitDisabled}
+            isLoading={isApplyingBonusCode}
+            twClassName="w-full"
+            testID="bonus-code-submit-button"
+          >
+            {ctaLabel}
+          </Button>
+        </Box>
+      </Box>
+    </BottomSheet>
+  );
+};
+
+export default BonusCodeBottomSheet;

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/BonusCodeBottomSheet.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/BonusCodeBottomSheet.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useRef } from 'react';
 import { ActivityIndicator } from 'react-native';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { useNavigation } from '@react-navigation/native';
 import {
   Text,
@@ -129,98 +130,104 @@ const BonusCodeBottomSheet: React.FC<BonusCodeBottomSheetProps> = ({
   };
 
   return (
-    <BottomSheet ref={sheetRef}>
-      <Box
-        flexDirection={BoxFlexDirection.Column}
-        alignItems={BoxAlignItems.Center}
-        twClassName="p-4"
-        testID="bonus-code-bottom-sheet"
+    <BottomSheet ref={sheetRef} keyboardAvoidingViewEnabled={false}>
+      <KeyboardAwareScrollView
+        keyboardShouldPersistTaps="handled"
+        enableOnAndroid
+        extraScrollHeight={20}
       >
         <Box
-          alignItems={
-            typeof title === 'string'
-              ? BoxAlignItems.Center
-              : BoxAlignItems.Start
-          }
-          twClassName="mb-3 w-full"
+          flexDirection={BoxFlexDirection.Column}
+          alignItems={BoxAlignItems.Center}
+          twClassName="p-4"
+          testID="bonus-code-bottom-sheet"
         >
-          {typeof title === 'string' ? (
-            <Text variant={TextVariant.HeadingMd}>{title}</Text>
-          ) : (
-            title
-          )}
-        </Box>
-        <Box
-          alignItems={
-            typeof description === 'string'
-              ? BoxAlignItems.Center
-              : BoxAlignItems.Start
-          }
-          twClassName="mb-3 w-full"
-        >
-          {typeof description === 'string' ? (
-            <Text
-              variant={TextVariant.BodyMd}
-              twClassName="text-alternative text-center"
-            >
-              {description}
-            </Text>
-          ) : (
-            description
-          )}
-        </Box>
-
-        <Box twClassName="w-full mb-6">
-          <TextField
-            testID="bonus-code-input"
-            placeholder={strings('rewards.bonus_code.input_placeholder')}
-            value={bonusCode}
-            onChangeText={(text: string) => {
-              clearApplyBonusCodeError();
-              setBonusCode(text);
-            }}
-            maxLength={BONUS_CODE_MAX_LENGTH}
-            autoCapitalize="characters"
-            endAccessory={renderInputIcon()}
-            isError={showValidationError || Boolean(applyBonusCodeError)}
-          />
-          {showValidationError && (
-            <Text
-              variant={TextVariant.BodySm}
-              twClassName="text-error-default mt-1"
-              testID="bonus-code-invalid-code"
-            >
-              {error}
-            </Text>
-          )}
-        </Box>
-
-        {applyBonusCodeError && (
-          <Box twClassName="w-full mb-4">
-            <Text
-              variant={TextVariant.BodySm}
-              twClassName="text-error-default"
-              testID="bonus-code-apply-error"
-            >
-              {applyBonusCodeError}
-            </Text>
-          </Box>
-        )}
-
-        <Box twClassName="w-full">
-          <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Lg}
-            onPress={handleSubmit}
-            isDisabled={isSubmitDisabled}
-            isLoading={isApplyingBonusCode}
-            twClassName="w-full"
-            testID="bonus-code-submit-button"
+          <Box
+            alignItems={
+              typeof title === 'string'
+                ? BoxAlignItems.Center
+                : BoxAlignItems.Start
+            }
+            twClassName="mb-3 w-full"
           >
-            {ctaLabel}
-          </Button>
+            {typeof title === 'string' ? (
+              <Text variant={TextVariant.HeadingMd}>{title}</Text>
+            ) : (
+              title
+            )}
+          </Box>
+          <Box
+            alignItems={
+              typeof description === 'string'
+                ? BoxAlignItems.Center
+                : BoxAlignItems.Start
+            }
+            twClassName="mb-3 w-full"
+          >
+            {typeof description === 'string' ? (
+              <Text
+                variant={TextVariant.BodyMd}
+                twClassName="text-alternative text-center"
+              >
+                {description}
+              </Text>
+            ) : (
+              description
+            )}
+          </Box>
+
+          <Box twClassName="w-full mb-6">
+            <TextField
+              testID="bonus-code-input"
+              placeholder={strings('rewards.bonus_code.input_placeholder')}
+              value={bonusCode}
+              onChangeText={(text: string) => {
+                clearApplyBonusCodeError();
+                setBonusCode(text);
+              }}
+              maxLength={BONUS_CODE_MAX_LENGTH}
+              autoCapitalize="characters"
+              endAccessory={renderInputIcon()}
+              isError={showValidationError || Boolean(applyBonusCodeError)}
+            />
+            {showValidationError && (
+              <Text
+                variant={TextVariant.BodySm}
+                twClassName="text-error-default mt-1"
+                testID="bonus-code-invalid-code"
+              >
+                {error}
+              </Text>
+            )}
+          </Box>
+
+          {applyBonusCodeError && (
+            <Box twClassName="w-full mb-4">
+              <Text
+                variant={TextVariant.BodySm}
+                twClassName="text-error-default"
+                testID="bonus-code-apply-error"
+              >
+                {applyBonusCodeError}
+              </Text>
+            </Box>
+          )}
+
+          <Box twClassName="w-full">
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Lg}
+              onPress={handleSubmit}
+              isDisabled={isSubmitDisabled}
+              isLoading={isApplyingBonusCode}
+              twClassName="w-full"
+              testID="bonus-code-submit-button"
+            >
+              {ctaLabel}
+            </Button>
+          </Box>
         </Box>
-      </Box>
+      </KeyboardAwareScrollView>
     </BottomSheet>
   );
 };

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.test.tsx
@@ -206,6 +206,19 @@ const urlWayToEarn = createWayToEarn({
   buttonAction: { url: 'https://example.com/earn' },
 });
 
+const bonusCodeWayToEarn = createWayToEarn({
+  id: 'bonus-code-id',
+  type: 'BONUS_CODE',
+  title: 'Bonus code',
+  icon: 'Gift',
+  shortDescription: 'Redeem a code',
+  bottomSheetTitle: 'Enter bonus code',
+  pointsEarningRule: 'Varies',
+  description: 'Enter a bonus code to earn points.',
+  buttonLabel: 'Submit',
+  buttonAction: undefined,
+});
+
 const noActionWayToEarn = createWayToEarn({
   id: 'no-action-id',
   type: 'INFO_ONLY',
@@ -359,6 +372,74 @@ describe('WaysToEarn', () => {
       );
       expect(modalCall?.[1]?.description).toBeTruthy();
       expect(modalCall?.[1]?.description.type).toBeDefined();
+    });
+  });
+
+  describe('BONUS_CODE earning way press', () => {
+    it('navigates to BonusCodeBottomSheet instead of generic modal', () => {
+      // Arrange
+      const mockUseSelector = jest.requireMock('react-redux')
+        .useSelector as jest.Mock;
+      mockUseSelector.mockReturnValue([bonusCodeWayToEarn]);
+
+      const { getByText } = render(<WaysToEarn />);
+
+      // Act
+      fireEvent.press(getByText('Bonus code'));
+
+      // Assert
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.MODAL.REWARDS_BONUS_CODE_BOTTOM_SHEET,
+        expect.objectContaining({
+          ctaLabel: 'Submit',
+        }),
+      );
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL,
+        expect.anything(),
+      );
+    });
+
+    it('passes title and description to BonusCodeBottomSheet', () => {
+      // Arrange
+      const mockUseSelector = jest.requireMock('react-redux')
+        .useSelector as jest.Mock;
+      mockUseSelector.mockReturnValue([bonusCodeWayToEarn]);
+
+      const { getByText } = render(<WaysToEarn />);
+
+      // Act
+      fireEvent.press(getByText('Bonus code'));
+
+      // Assert
+      const navCall = mockNavigate.mock.calls.find(
+        (call) => call[0] === Routes.MODAL.REWARDS_BONUS_CODE_BOTTOM_SHEET,
+      );
+      expect(navCall?.[1]?.title).toBeTruthy();
+      expect(navCall?.[1]?.description).toBeTruthy();
+      expect(navCall?.[1]?.ctaLabel).toBe('Submit');
+    });
+
+    it('tracks button click event for BONUS_CODE type', () => {
+      // Arrange
+      const mockUseSelector = jest.requireMock('react-redux')
+        .useSelector as jest.Mock;
+      mockUseSelector.mockReturnValue([bonusCodeWayToEarn]);
+
+      const { getByText } = render(<WaysToEarn />);
+
+      // Act
+      fireEvent.press(getByText('Bonus code'));
+
+      // Assert
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED,
+      );
+      const builder = mockCreateEventBuilder.mock.results[0].value;
+      expect(builder.addProperties).toHaveBeenCalledWith({
+        button_type: RewardsMetricsButtons.WAYS_TO_EARN,
+        ways_to_earn_type: 'BONUS_CODE',
+      });
     });
   });
 

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
@@ -128,6 +128,16 @@ export const WaysToEarn = () => {
     );
 
     const { title, description, ctaLabel } = getBottomSheetData(wayToEarn);
+
+    if (wayToEarn.type === 'BONUS_CODE') {
+      navigation.navigate(Routes.MODAL.REWARDS_BONUS_CODE_BOTTOM_SHEET, {
+        title,
+        description,
+        ctaLabel,
+      });
+      return;
+    }
+
     navigation.navigate(Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL, {
       title,
       description,

--- a/app/components/UI/Rewards/hooks/useApplyBonusCode.test.ts
+++ b/app/components/UI/Rewards/hooks/useApplyBonusCode.test.ts
@@ -1,0 +1,269 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useSelector } from 'react-redux';
+import { useApplyBonusCode } from './useApplyBonusCode';
+import Engine from '../../../../core/Engine';
+import { handleRewardsErrorMessage } from '../utils';
+
+// Mock dependencies
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/rewards', () => ({
+  selectRewardsSubscriptionId: jest.fn(),
+}));
+
+jest.mock('../../../../core/Engine', () => ({
+  controllerMessenger: {
+    call: jest.fn(),
+  },
+}));
+
+jest.mock('../utils', () => ({
+  handleRewardsErrorMessage: jest.fn(),
+}));
+
+describe('useApplyBonusCode', () => {
+  const mockUseSelector = useSelector as jest.MockedFunction<
+    typeof useSelector
+  >;
+  const mockEngineCall = Engine.controllerMessenger.call as jest.MockedFunction<
+    typeof Engine.controllerMessenger.call
+  >;
+  const mockHandleRewardsErrorMessage =
+    handleRewardsErrorMessage as jest.MockedFunction<
+      typeof handleRewardsErrorMessage
+    >;
+
+  const mockSubscriptionId = 'test-subscription-id';
+  const mockBonusCode = 'BNS123';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockReturnValue(mockSubscriptionId);
+    mockHandleRewardsErrorMessage.mockReturnValue('Mocked error message');
+  });
+
+  describe('initial state', () => {
+    it('returns correct initial values', () => {
+      const { result } = renderHook(() => useApplyBonusCode());
+
+      expect(result.current.isApplyingBonusCode).toBe(false);
+      expect(result.current.applyBonusCodeError).toBeUndefined();
+      expect(result.current.applyBonusCodeSuccess).toBe(false);
+      expect(typeof result.current.applyBonusCode).toBe('function');
+      expect(typeof result.current.clearApplyBonusCodeError).toBe('function');
+    });
+  });
+
+  describe('applyBonusCode function', () => {
+    it('successfully applies bonus code', async () => {
+      mockEngineCall.mockResolvedValueOnce(undefined);
+      const { result } = renderHook(() => useApplyBonusCode());
+
+      await act(async () => {
+        await result.current.applyBonusCode(mockBonusCode);
+      });
+
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:applyBonusCode',
+        mockBonusCode,
+        mockSubscriptionId,
+      );
+      expect(result.current.isApplyingBonusCode).toBe(false);
+      expect(result.current.applyBonusCodeError).toBeUndefined();
+      expect(result.current.applyBonusCodeSuccess).toBe(true);
+    });
+
+    it('converts bonus code to uppercase', async () => {
+      mockEngineCall.mockResolvedValueOnce(undefined);
+      const { result } = renderHook(() => useApplyBonusCode());
+
+      await act(async () => {
+        await result.current.applyBonusCode('bns123');
+      });
+
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:applyBonusCode',
+        'BNS123',
+        mockSubscriptionId,
+      );
+    });
+
+    it('trims bonus code', async () => {
+      mockEngineCall.mockResolvedValueOnce(undefined);
+      const { result } = renderHook(() => useApplyBonusCode());
+
+      await act(async () => {
+        await result.current.applyBonusCode('  BNS123  ');
+      });
+
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:applyBonusCode',
+        'BNS123',
+        mockSubscriptionId,
+      );
+    });
+
+    it('sets loading state during apply process', async () => {
+      let resolvePromise: () => void;
+      const promise = new Promise<void>((resolve) => {
+        resolvePromise = resolve;
+      });
+      mockEngineCall.mockReturnValueOnce(promise);
+
+      const { result } = renderHook(() => useApplyBonusCode());
+
+      act(() => {
+        result.current.applyBonusCode(mockBonusCode);
+      });
+
+      expect(result.current.isApplyingBonusCode).toBe(true);
+      expect(result.current.applyBonusCodeError).toBeUndefined();
+      expect(result.current.applyBonusCodeSuccess).toBe(false);
+
+      await act(async () => {
+        resolvePromise();
+        await promise;
+      });
+
+      expect(result.current.isApplyingBonusCode).toBe(false);
+      expect(result.current.applyBonusCodeSuccess).toBe(true);
+    });
+
+    it('handles missing subscription ID', async () => {
+      mockUseSelector.mockReturnValue(null);
+      const { result } = renderHook(() => useApplyBonusCode());
+
+      await act(async () => {
+        await result.current.applyBonusCode(mockBonusCode);
+      });
+
+      expect(mockEngineCall).not.toHaveBeenCalled();
+      expect(result.current.applyBonusCodeError).toBe(
+        'No subscription found. Please try again.',
+      );
+      expect(result.current.isApplyingBonusCode).toBe(false);
+      expect(result.current.applyBonusCodeSuccess).toBe(false);
+    });
+
+    it('handles empty bonus code', async () => {
+      const { result } = renderHook(() => useApplyBonusCode());
+
+      await act(async () => {
+        await result.current.applyBonusCode('');
+      });
+
+      expect(mockEngineCall).not.toHaveBeenCalled();
+      expect(result.current.applyBonusCodeError).toBe(
+        'Please enter a bonus code.',
+      );
+      expect(result.current.isApplyingBonusCode).toBe(false);
+      expect(result.current.applyBonusCodeSuccess).toBe(false);
+    });
+
+    it('handles whitespace-only bonus code', async () => {
+      const { result } = renderHook(() => useApplyBonusCode());
+
+      await act(async () => {
+        await result.current.applyBonusCode('   ');
+      });
+
+      expect(mockEngineCall).not.toHaveBeenCalled();
+      expect(result.current.applyBonusCodeError).toBe(
+        'Please enter a bonus code.',
+      );
+    });
+
+    it('handles apply error', async () => {
+      const mockError = new Error('Invalid bonus code');
+      mockEngineCall.mockRejectedValueOnce(mockError);
+      mockHandleRewardsErrorMessage.mockReturnValue(
+        'Invalid bonus code. Please check and try again.',
+      );
+
+      const { result } = renderHook(() => useApplyBonusCode());
+
+      await act(async () => {
+        try {
+          await result.current.applyBonusCode(mockBonusCode);
+        } catch {
+          // Expected to throw
+        }
+      });
+
+      expect(mockHandleRewardsErrorMessage).toHaveBeenCalledWith(mockError);
+      expect(result.current.applyBonusCodeError).toBe(
+        'Invalid bonus code. Please check and try again.',
+      );
+      expect(result.current.isApplyingBonusCode).toBe(false);
+      expect(result.current.applyBonusCodeSuccess).toBe(false);
+    });
+
+    it('re-throws error after handling', async () => {
+      const mockError = new Error('Apply failed');
+      mockEngineCall.mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => useApplyBonusCode());
+
+      await act(async () => {
+        await expect(
+          result.current.applyBonusCode(mockBonusCode),
+        ).rejects.toThrow('Apply failed');
+      });
+    });
+
+    it('clears error before new apply attempt', async () => {
+      const mockError = new Error('First error');
+      mockEngineCall.mockRejectedValueOnce(mockError);
+      mockHandleRewardsErrorMessage.mockReturnValue('First error message');
+
+      const { result } = renderHook(() => useApplyBonusCode());
+
+      await act(async () => {
+        try {
+          await result.current.applyBonusCode(mockBonusCode);
+        } catch {
+          // Expected to throw
+        }
+      });
+
+      expect(result.current.applyBonusCodeError).toBe('First error message');
+
+      mockEngineCall.mockResolvedValueOnce(undefined);
+
+      await act(async () => {
+        await result.current.applyBonusCode(mockBonusCode);
+      });
+
+      expect(result.current.applyBonusCodeError).toBeUndefined();
+      expect(result.current.applyBonusCodeSuccess).toBe(true);
+    });
+  });
+
+  describe('clearApplyBonusCodeError function', () => {
+    it('clears error state', async () => {
+      const mockError = new Error('Test error');
+      mockEngineCall.mockRejectedValueOnce(mockError);
+      mockHandleRewardsErrorMessage.mockReturnValue('Test error message');
+
+      const { result } = renderHook(() => useApplyBonusCode());
+
+      await act(async () => {
+        try {
+          await result.current.applyBonusCode(mockBonusCode);
+        } catch {
+          // Expected to throw
+        }
+      });
+
+      expect(result.current.applyBonusCodeError).toBe('Test error message');
+
+      act(() => {
+        result.current.clearApplyBonusCodeError();
+      });
+
+      expect(result.current.applyBonusCodeError).toBeUndefined();
+    });
+  });
+});

--- a/app/components/UI/Rewards/hooks/useApplyBonusCode.ts
+++ b/app/components/UI/Rewards/hooks/useApplyBonusCode.ts
@@ -1,0 +1,92 @@
+import { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
+import { handleRewardsErrorMessage } from '../utils';
+import Engine from '../../../../core/Engine';
+
+export interface UseApplyBonusCodeResult {
+  /**
+   * Function to apply a bonus code to the current subscription
+   */
+  applyBonusCode: (bonusCode: string) => Promise<void>;
+
+  /**
+   * Loading state for apply bonus code operation
+   */
+  isApplyingBonusCode: boolean;
+
+  /**
+   * Error message from apply bonus code process
+   */
+  applyBonusCodeError?: string;
+
+  /**
+   * Function to clear the apply bonus code error
+   */
+  clearApplyBonusCodeError: () => void;
+
+  /**
+   * Success state for apply bonus code process
+   */
+  applyBonusCodeSuccess: boolean;
+}
+
+export const useApplyBonusCode = (): UseApplyBonusCodeResult => {
+  const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const [applyBonusCodeError, setApplyBonusCodeError] = useState<
+    string | undefined
+  >(undefined);
+  const [isApplyingBonusCode, setIsApplyingBonusCode] =
+    useState<boolean>(false);
+  const [applyBonusCodeSuccess, setApplyBonusCodeSuccess] =
+    useState<boolean>(false);
+
+  const handleApplyBonusCode = useCallback(
+    async (bonusCode: string) => {
+      if (!subscriptionId) {
+        setApplyBonusCodeError('No subscription found. Please try again.');
+        return;
+      }
+
+      if (!bonusCode.trim()) {
+        setApplyBonusCodeError('Please enter a bonus code.');
+        return;
+      }
+
+      try {
+        setIsApplyingBonusCode(true);
+        setApplyBonusCodeError(undefined);
+        setApplyBonusCodeSuccess(false);
+        await Engine.controllerMessenger.call(
+          'RewardsController:applyBonusCode',
+          bonusCode.trim().toUpperCase(),
+          subscriptionId,
+        );
+        setApplyBonusCodeSuccess(true);
+      } catch (error) {
+        const errorMessage = handleRewardsErrorMessage(error);
+
+        setApplyBonusCodeError(errorMessage);
+        throw error;
+      } finally {
+        setIsApplyingBonusCode(false);
+      }
+    },
+    [subscriptionId],
+  );
+
+  const clearApplyBonusCodeError = useCallback(
+    () => setApplyBonusCodeError(undefined),
+    [],
+  );
+
+  return {
+    applyBonusCode: handleApplyBonusCode,
+    isApplyingBonusCode,
+    applyBonusCodeError,
+    clearApplyBonusCodeError,
+    applyBonusCodeSuccess,
+  };
+};
+
+export default useApplyBonusCode;

--- a/app/components/UI/Rewards/hooks/useValidateBonusCode.test.ts
+++ b/app/components/UI/Rewards/hooks/useValidateBonusCode.test.ts
@@ -1,0 +1,327 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useSelector } from 'react-redux';
+import {
+  useValidateBonusCode,
+  BONUS_CODE_MIN_LENGTH,
+  BONUS_CODE_MAX_LENGTH,
+  BONUS_CODE_DEBOUNCE_MS,
+} from './useValidateBonusCode';
+import Engine from '../../../../core/Engine';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/rewards', () => ({
+  selectRewardsSubscriptionId: jest.fn(),
+}));
+
+jest.mock('../../../../core/Engine', () => ({
+  controllerMessenger: {
+    call: jest.fn(),
+  },
+}));
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => key),
+}));
+
+describe('useValidateBonusCode', () => {
+  const mockUseSelector = useSelector as jest.MockedFunction<
+    typeof useSelector
+  >;
+  const mockEngineCall = Engine.controllerMessenger.call as jest.MockedFunction<
+    typeof Engine.controllerMessenger.call
+  >;
+
+  const mockSubscriptionId = 'test-subscription-id';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockUseSelector.mockReturnValue(mockSubscriptionId);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('initializes with correct default values', () => {
+    const { result } = renderHook(() => useValidateBonusCode());
+
+    expect(result.current.bonusCode).toBe('');
+    expect(result.current.isValidating).toBe(false);
+    expect(result.current.isValid).toBe(false);
+    expect(result.current.isUnknownError).toBe(false);
+    expect(result.current.error).toBe('');
+    expect(typeof result.current.setBonusCode).toBe('function');
+  });
+
+  it('does not trigger validation for codes shorter than minimum length', () => {
+    const { result } = renderHook(() => useValidateBonusCode());
+
+    act(() => {
+      result.current.setBonusCode('AB');
+    });
+    jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+
+    expect(result.current.bonusCode).toBe('AB');
+    expect(result.current.isValid).toBe(false);
+    expect(result.current.isValidating).toBe(false);
+    expect(mockEngineCall).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger validation for codes longer than maximum length', () => {
+    const { result } = renderHook(() => useValidateBonusCode());
+    const longCode = 'A'.repeat(BONUS_CODE_MAX_LENGTH + 1);
+
+    act(() => {
+      result.current.setBonusCode(longCode);
+    });
+    jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+
+    expect(result.current.isValidating).toBe(false);
+    expect(mockEngineCall).not.toHaveBeenCalled();
+  });
+
+  it('converts code to uppercase and trims whitespace', async () => {
+    mockEngineCall.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useValidateBonusCode());
+
+    act(() => {
+      result.current.setBonusCode('  abcd  ');
+    });
+
+    expect(result.current.bonusCode).toBe('ABCD');
+
+    await act(async () => {
+      jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+    });
+
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:validateBonusCode',
+      'ABCD',
+      mockSubscriptionId,
+    );
+  });
+
+  it('triggers debounced validation at minimum length', async () => {
+    mockEngineCall.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useValidateBonusCode());
+    const code = 'A'.repeat(BONUS_CODE_MIN_LENGTH);
+
+    act(() => {
+      result.current.setBonusCode(code);
+    });
+
+    expect(result.current.isValidating).toBe(true);
+    expect(mockEngineCall).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+    });
+
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:validateBonusCode',
+      code,
+      mockSubscriptionId,
+    );
+  });
+
+  it('triggers debounced validation at maximum length', async () => {
+    mockEngineCall.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useValidateBonusCode());
+    const code = 'B'.repeat(BONUS_CODE_MAX_LENGTH);
+
+    act(() => {
+      result.current.setBonusCode(code);
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+    });
+
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:validateBonusCode',
+      code,
+      mockSubscriptionId,
+    );
+  });
+
+  it('validates successfully for a valid bonus code', async () => {
+    mockEngineCall.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useValidateBonusCode());
+
+    act(() => {
+      result.current.setBonusCode('BNS123');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+    });
+
+    expect(result.current.isValid).toBe(true);
+    expect(result.current.isValidating).toBe(false);
+    expect(result.current.error).toBe('');
+    expect(result.current.isUnknownError).toBe(false);
+  });
+
+  it('sets error when validation returns false', async () => {
+    mockEngineCall.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => useValidateBonusCode());
+
+    act(() => {
+      result.current.setBonusCode('BNS123');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+    });
+
+    expect(result.current.isValid).toBe(false);
+    expect(result.current.isValidating).toBe(false);
+    expect(result.current.error).toBe(
+      'rewards.error_messages.invalid_bonus_code',
+    );
+  });
+
+  it('sets error when no subscription ID is available', async () => {
+    mockUseSelector.mockReturnValue(null);
+    const { result } = renderHook(() => useValidateBonusCode());
+
+    act(() => {
+      result.current.setBonusCode('BNS123');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+    });
+
+    expect(result.current.isValid).toBe(false);
+    expect(result.current.error).toBe(
+      'No subscription found. Please try again.',
+    );
+    expect(mockEngineCall).not.toHaveBeenCalled();
+  });
+
+  it('sets isUnknownError when validation throws', async () => {
+    mockEngineCall.mockRejectedValueOnce(new Error('Network error'));
+    const { result } = renderHook(() => useValidateBonusCode());
+
+    act(() => {
+      result.current.setBonusCode('BNS123');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+    });
+
+    expect(result.current.isUnknownError).toBe(true);
+    expect(result.current.isValid).toBe(false);
+    expect(result.current.isValidating).toBe(false);
+  });
+
+  it('clears error and unknownError when code changes', async () => {
+    mockEngineCall.mockRejectedValueOnce(new Error('Network error'));
+    const { result } = renderHook(() => useValidateBonusCode());
+
+    act(() => {
+      result.current.setBonusCode('BNS123');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+    });
+
+    expect(result.current.isUnknownError).toBe(true);
+
+    act(() => {
+      result.current.setBonusCode('XYZ');
+    });
+
+    expect(result.current.isUnknownError).toBe(false);
+    expect(result.current.error).toBe('');
+  });
+
+  it('debounces rapid input changes and only validates the last value', async () => {
+    mockEngineCall.mockResolvedValue(true);
+    const { result } = renderHook(() => useValidateBonusCode());
+
+    act(() => {
+      result.current.setBonusCode('ABCD');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS / 2);
+    });
+
+    act(() => {
+      result.current.setBonusCode('EFGH');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+    });
+
+    expect(mockEngineCall).toHaveBeenCalledTimes(1);
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:validateBonusCode',
+      'EFGH',
+      mockSubscriptionId,
+    );
+  });
+
+  it('discards stale responses when a newer validation is in flight', async () => {
+    let resolveFirst: (value: boolean) => void;
+    const firstPromise = new Promise<boolean>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockEngineCall
+      .mockReturnValueOnce(firstPromise)
+      .mockResolvedValueOnce(true);
+
+    const { result } = renderHook(() => useValidateBonusCode());
+
+    act(() => {
+      result.current.setBonusCode('CODE1');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+    });
+
+    act(() => {
+      result.current.setBonusCode('CODE2');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+    });
+
+    await act(async () => {
+      resolveFirst?.(false);
+    });
+
+    expect(result.current.isValid).toBe(true);
+    expect(result.current.error).toBe('');
+  });
+
+  it('resets isValidating when code drops below minimum length', async () => {
+    mockEngineCall.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useValidateBonusCode());
+
+    act(() => {
+      result.current.setBonusCode('ABCD');
+    });
+
+    expect(result.current.isValidating).toBe(true);
+
+    act(() => {
+      result.current.setBonusCode('AB');
+    });
+
+    expect(result.current.isValidating).toBe(false);
+    jest.advanceTimersByTime(BONUS_CODE_DEBOUNCE_MS);
+    expect(mockEngineCall).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Rewards/hooks/useValidateBonusCode.ts
+++ b/app/components/UI/Rewards/hooks/useValidateBonusCode.ts
@@ -1,0 +1,144 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import Engine from '../../../../core/Engine';
+import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
+import { strings } from '../../../../../locales/i18n';
+
+export const BONUS_CODE_MIN_LENGTH = 4;
+export const BONUS_CODE_MAX_LENGTH = 16;
+export const BONUS_CODE_DEBOUNCE_MS = 500;
+
+export interface UseValidateBonusCodeResult {
+  /**
+   * Current bonus code value
+   */
+  bonusCode: string;
+  /**
+   * Function to update the bonus code and trigger debounced validation
+   * when 4-16 Base32 characters are entered.
+   */
+  setBonusCode: (code: string) => void;
+  /**
+   * Whether validation is currently in progress
+   */
+  isValidating: boolean;
+  /**
+   * Whether the current bonus code is valid
+   */
+  isValid: boolean;
+  /**
+   * Whether an unknown error occurred while validating the bonus code
+   */
+  isUnknownError: boolean;
+  /**
+   * Error message from validation
+   */
+  error: string;
+}
+
+/**
+ * Custom hook for validating bonus codes.
+ * Validates with debounce when the code is 4-16 Base32 characters.
+ * Stale responses from older requests are automatically discarded.
+ *
+ * @returns UseValidateBonusCodeResult object with validation state and methods
+ */
+export const useValidateBonusCode = (): UseValidateBonusCodeResult => {
+  const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const [bonusCode, setBonusCodeState] = useState('');
+  const [error, setError] = useState('');
+  const [isValidating, setIsValidating] = useState(false);
+  const [unknownError, setUnknownError] = useState(false);
+
+  const requestIdRef = useRef(0);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  const validateCode = useCallback(
+    async (code: string) => {
+      if (!subscriptionId) {
+        setIsValidating(false);
+        setError('No subscription found. Please try again.');
+        return;
+      }
+
+      const currentRequestId = ++requestIdRef.current;
+
+      setError('');
+      setUnknownError(false);
+      setIsValidating(true);
+
+      try {
+        const valid = await Engine.controllerMessenger.call(
+          'RewardsController:validateBonusCode',
+          code,
+          subscriptionId,
+        );
+
+        if (currentRequestId !== requestIdRef.current) return;
+
+        if (!valid) {
+          setError(strings('rewards.error_messages.invalid_bonus_code'));
+        }
+      } catch {
+        if (currentRequestId !== requestIdRef.current) return;
+        setUnknownError(true);
+        setError('Unknown error');
+      } finally {
+        if (currentRequestId === requestIdRef.current) {
+          setIsValidating(false);
+        }
+      }
+    },
+    [subscriptionId],
+  );
+
+  const isValidLength = (len: number) =>
+    len >= BONUS_CODE_MIN_LENGTH && len <= BONUS_CODE_MAX_LENGTH;
+
+  const setBonusCode = useCallback(
+    (code: string) => {
+      const refinedCode = code.trim().toUpperCase();
+      setBonusCodeState(refinedCode);
+      setError('');
+      setUnknownError(false);
+
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+
+      if (isValidLength(refinedCode.length)) {
+        setIsValidating(true);
+        debounceTimerRef.current = setTimeout(() => {
+          validateCode(refinedCode);
+        }, BONUS_CODE_DEBOUNCE_MS);
+      } else {
+        ++requestIdRef.current;
+        setIsValidating(false);
+      }
+    },
+    [validateCode],
+  );
+
+  const isValid = isValidLength(bonusCode.length) && !error && !isValidating;
+
+  return {
+    bonusCode,
+    setBonusCode,
+    isValidating,
+    isValid,
+    isUnknownError: unknownError,
+    error,
+  };
+};
+
+export default useValidateBonusCode;

--- a/app/components/UI/Rewards/hooks/useValidateReferralCode.test.ts
+++ b/app/components/UI/Rewards/hooks/useValidateReferralCode.test.ts
@@ -2,20 +2,10 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { useValidateReferralCode } from './useValidateReferralCode';
 import Engine from '../../../../core/Engine';
 
-// Mock dependencies
 jest.mock('../../../../core/Engine', () => ({
   controllerMessenger: {
     call: jest.fn(),
   },
-}));
-
-jest.mock('lodash', () => ({
-  debounce: jest.fn((fn) => {
-    // Return a simple mock that calls the function immediately for testing
-    const mockFn = (...args: unknown[]) => fn(...args);
-    mockFn.cancel = jest.fn();
-    return mockFn;
-  }),
 }));
 
 describe('useValidateReferralCode', () => {
@@ -27,7 +17,7 @@ describe('useValidateReferralCode', () => {
     jest.clearAllMocks();
   });
 
-  it('should initialize with correct default values', () => {
+  it('initializes with correct default values', () => {
     const { result } = renderHook(() => useValidateReferralCode());
 
     expect(result.current.referralCode).toBe('');
@@ -38,120 +28,187 @@ describe('useValidateReferralCode', () => {
     expect(typeof result.current.validateCode).toBe('function');
   });
 
-  it('should initialize with custom initial value', () => {
-    const { result } = renderHook(() => useValidateReferralCode('INITIAL'));
-
-    expect(result.current.referralCode).toBe('INITIAL');
-  });
-
-  it('should validate code successfully', async () => {
+  it('initializes with custom initial value and validates immediately', async () => {
     mockEngineCall.mockResolvedValueOnce(true);
 
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useValidateReferralCode('ABCDEF'),
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.referralCode).toBe('ABCDEF');
+    expect(result.current.isValid).toBe(true);
+  });
+
+  it('validates code directly via validateCode', async () => {
+    mockEngineCall.mockResolvedValueOnce(true);
     const { result } = renderHook(() => useValidateReferralCode());
 
     await act(async () => {
-      const error = await result.current.validateCode('VALID123');
+      const error = await result.current.validateCode('VALID1');
       expect(error).toBe('');
     });
 
     expect(mockEngineCall).toHaveBeenCalledWith(
       'RewardsController:validateReferralCode',
-      'VALID123',
+      'VALID1',
     );
   });
 
-  it('should return error for invalid code', async () => {
+  it('returns error from validateCode for invalid code', async () => {
     mockEngineCall.mockResolvedValueOnce(false);
-
     const { result } = renderHook(() => useValidateReferralCode());
 
     await act(async () => {
-      const error = await result.current.validateCode('INVALID');
-      expect(error).toBe('Invalid code');
+      const error = await result.current.validateCode('BADONE');
+      expect(error).toBe('Invalid referral code. Please check and try again.');
     });
   });
 
-  it('should update referral code', () => {
+  it('converts code to uppercase and trims whitespace', async () => {
+    mockEngineCall.mockResolvedValueOnce(true);
     const { result } = renderHook(() => useValidateReferralCode());
 
-    act(() => {
-      result.current.setReferralCode('NEW123');
+    await act(async () => {
+      result.current.setReferralCode('  abcdef  ');
     });
 
-    expect(result.current.referralCode).toBe('NEW123');
+    expect(result.current.referralCode).toBe('ABCDEF');
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:validateReferralCode',
+      'ABCDEF',
+    );
   });
 
-  it('should set validating state when code is provided', () => {
+  it('does not validate when code is shorter than 6 characters', () => {
     const { result } = renderHook(() => useValidateReferralCode());
 
     act(() => {
-      result.current.setReferralCode('TEST123');
+      result.current.setReferralCode('ABC');
     });
 
-    expect(result.current.referralCode).toBe('TEST123');
+    expect(result.current.referralCode).toBe('ABC');
+    expect(result.current.isValid).toBe(false);
+    expect(result.current.isValidating).toBe(false);
+    expect(mockEngineCall).not.toHaveBeenCalled();
   });
 
-  it('should not validate when code length is less than 6 but set relevant error', () => {
+  it('does not validate when code is longer than 6 characters', () => {
     const { result } = renderHook(() => useValidateReferralCode());
 
     act(() => {
-      result.current.setReferralCode('12345');
+      result.current.setReferralCode('ABCDEFG');
     });
 
-    expect(result.current.referralCode).toBe('12345');
+    expect(result.current.isValid).toBe(false);
+    expect(result.current.isValidating).toBe(false);
+    expect(mockEngineCall).not.toHaveBeenCalled();
+  });
+
+  it('validates immediately for valid 6-char code', async () => {
+    mockEngineCall.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useValidateReferralCode());
+
+    await act(async () => {
+      result.current.setReferralCode('ABCDEF');
+    });
+
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:validateReferralCode',
+      'ABCDEF',
+    );
+    expect(result.current.isValid).toBe(true);
+    expect(result.current.isValidating).toBe(false);
+  });
+
+  it('sets isUnknownError when validation throws', async () => {
+    mockEngineCall.mockRejectedValueOnce(new Error('Network error'));
+    const { result } = renderHook(() => useValidateReferralCode());
+
+    await act(async () => {
+      result.current.setReferralCode('ABCDEF');
+    });
+
+    expect(result.current.isUnknownError).toBe(true);
     expect(result.current.isValid).toBe(false);
   });
 
-  it('should set isUnknownError when validation fails with network error', async () => {
-    // Arrange
-    const mockError = new Error('Network error');
-    mockEngineCall.mockRejectedValueOnce(mockError);
+  it('clears isUnknownError on subsequent successful validation', async () => {
+    mockEngineCall
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce(true);
 
     const { result } = renderHook(() => useValidateReferralCode());
 
-    // Act
     await act(async () => {
-      try {
-        await result.current.validateCode('TEST123');
-      } catch {
-        // Expected to throw
-      }
+      result.current.setReferralCode('ABCDEF');
     });
 
-    // Assert
     expect(result.current.isUnknownError).toBe(true);
+
+    await act(async () => {
+      result.current.setReferralCode('GHJKMN');
+    });
+
+    expect(result.current.isUnknownError).toBe(false);
+    expect(result.current.isValid).toBe(true);
   });
 
-  it('should clear isUnknownError on successful validation', async () => {
-    // Arrange - First fail, then succeed
-    const mockError = new Error('Network error');
-    mockEngineCall.mockRejectedValueOnce(mockError).mockResolvedValueOnce(true);
+  it('discards stale responses when a newer validation is in flight', async () => {
+    let resolveFirst: (value: boolean) => void;
+    const firstPromise = new Promise<boolean>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockEngineCall
+      .mockReturnValueOnce(firstPromise)
+      .mockResolvedValueOnce(true);
 
     const { result } = renderHook(() => useValidateReferralCode());
 
-    // Act - First validation fails
-    await act(async () => {
-      try {
-        await result.current.validateCode('TEST123');
-      } catch {
-        // Expected to throw
-      }
+    act(() => {
+      result.current.setReferralCode('ABCDEF');
     });
 
-    // Verify unknown error is set
-    expect(result.current.isUnknownError).toBe(true);
-
-    // Act - Set referral code to trigger validation which should succeed
     await act(async () => {
-      result.current.setReferralCode('VALID1');
+      result.current.setReferralCode('GHJKMN');
     });
 
-    // Wait for debounced validation to complete
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 1100)); // Wait longer than debounce
+      resolveFirst?.(false);
     });
 
-    // Assert - Unknown error should be cleared
-    expect(result.current.isUnknownError).toBe(false);
+    expect(result.current.isValid).toBe(true);
+    expect(result.current.referralCode).toBe('GHJKMN');
+  });
+
+  it('invalidates in-flight request when code length changes away from 6', async () => {
+    let resolveValidation: (value: boolean) => void;
+    const validationPromise = new Promise<boolean>((resolve) => {
+      resolveValidation = resolve;
+    });
+    mockEngineCall.mockReturnValueOnce(validationPromise);
+
+    const { result } = renderHook(() => useValidateReferralCode());
+
+    act(() => {
+      result.current.setReferralCode('ABCDEF');
+    });
+
+    expect(result.current.isValidating).toBe(true);
+
+    act(() => {
+      result.current.setReferralCode('ABCDE');
+    });
+
+    expect(result.current.isValidating).toBe(false);
+    expect(result.current.isValid).toBe(false);
+
+    await act(async () => {
+      resolveValidation?.(true);
+    });
+
+    expect(result.current.isValid).toBe(false);
+    expect(result.current.referralCode).toBe('ABCDE');
   });
 });

--- a/app/components/UI/Rewards/utils.ts
+++ b/app/components/UI/Rewards/utils.ts
@@ -65,6 +65,17 @@ export const handleRewardsErrorMessage = (error: unknown) => {
     return strings('rewards.error_messages.cannot_use_own_referral_code');
   }
 
+  // Bonus code errors
+  if (message.toLowerCase().includes('invalid bonus code')) {
+    return strings('rewards.error_messages.invalid_bonus_code');
+  }
+  if (message.toLowerCase().includes('already redeemed')) {
+    return strings('rewards.error_messages.already_redeemed');
+  }
+  if (message.toLowerCase().includes('reached its maximum')) {
+    return strings('rewards.error_messages.reached_maximum');
+  }
+
   return message;
 };
 

--- a/app/components/UI/Rewards/utils/eventDetailsUtils.ts
+++ b/app/components/UI/Rewards/utils/eventDetailsUtils.ts
@@ -8,6 +8,7 @@ import {
   MusdDepositEventPayload,
   EventAssetDto,
   SeasonActivityTypeDto,
+  BonusCodeEventPayload,
 } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { isNullOrUndefined } from '@metamask/utils';
 import { formatUnits } from 'viem';
@@ -16,7 +17,6 @@ import { PerpsEventType } from './eventConstants';
 import {
   formatRewardsMusdDepositPayloadDate,
   getIconName,
-  resolveTemplate,
 } from './formatUtils';
 
 /**
@@ -240,6 +240,8 @@ export const resolveEventDetails = (
           : undefined,
       };
     }
+    case 'BONUS_CODE':
+      return { details: (payload as BonusCodeEventPayload)?.code };
     case 'REFERRAL':
     case 'APPLY_REFERRAL_BONUS':
     case 'ONE_TIME_BONUS':
@@ -284,20 +286,6 @@ export const getEventDetails = (
         icon: getIconName(matchingActivityType.icon),
       };
     }
-
-    // For unknown types, fall back to description template resolution
-    return {
-      title: matchingActivityType.title,
-      details: resolveTemplate(
-        (
-          matchingActivityType as SeasonActivityTypeDto & {
-            description: string;
-          }
-        ).description ?? '',
-        (event.payload ?? {}) as Record<string, string>,
-      ),
-      icon: getIconName(matchingActivityType.icon),
-    };
   }
 
   return {

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -127,6 +127,7 @@ const Routes = {
     MULTICHAIN_ACCOUNTS_LEARN_MORE: 'MultichainAccountsLearnMoreBottomSheet',
     PNA25_NOTICE_BOTTOM_SHEET: 'Pna25BottomSheet',
     REWARDS_BOTTOM_SHEET_MODAL: 'RewardsBottomSheetModal',
+    REWARDS_BONUS_CODE_BOTTOM_SHEET: 'BonusCodeBottomSheet',
     REWARDS_CLAIM_BOTTOM_SHEET_MODAL: 'RewardsClaimBottomSheetModal',
     REWARDS_OPTIN_ACCOUNT_GROUP_MODAL: 'RewardOptInAccountGroupModal',
     OTA_UPDATES_MODAL: 'OTAUpdatesModal',

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -342,6 +342,7 @@ describe('RewardsController', () => {
       getReferralDetails: jest.fn(),
       optIn: jest.fn(),
       validateReferralCode: jest.fn(),
+      validateBonusCode: jest.fn(),
       claimReward: jest.fn(),
       login: jest.fn(),
     }));
@@ -372,11 +373,11 @@ describe('RewardsController', () => {
   });
 
   describe('initialization', () => {
-    it('should initialize with default state', () => {
+    it('initializes with default state', () => {
       expect(controller.state).toEqual(getRewardsControllerDefaultState());
     });
 
-    it('should register action handlers', () => {
+    it('registers action handlers', () => {
       expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
         'RewardsController:getHasAccountOptedIn',
         expect.any(Function),
@@ -411,14 +412,14 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should subscribe to account group change events', () => {
+    it('subscribes to account group change events', () => {
       expect(mockMessenger.subscribe).toHaveBeenCalledWith(
         'AccountTreeController:selectedAccountGroupChange',
         expect.any(Function),
       );
     });
 
-    it('should subscribe to keyring unlock events', () => {
+    it('subscribes to keyring unlock events', () => {
       expect(mockMessenger.subscribe).toHaveBeenCalledWith(
         'KeyringController:unlock',
         expect.any(Function),
@@ -427,7 +428,7 @@ describe('RewardsController', () => {
   });
 
   describe('state management', () => {
-    it('should reset state to default', () => {
+    it('resets state to default', () => {
       // Set some initial state
       const initialState: Partial<RewardsControllerState> = {
         activeAccount: {
@@ -469,7 +470,7 @@ describe('RewardsController', () => {
       expect(controller.state.activeAccount).toBeNull();
     });
 
-    it('should manage account state correctly', () => {
+    it('manages account state correctly', () => {
       const accountState = {
         account: CAIP_ACCOUNT_1,
         hasOptedIn: false,
@@ -612,7 +613,7 @@ describe('RewardsController', () => {
   });
 
   describe('getHasAccountOptedIn', () => {
-    it('should return false when disabled via isDisabled callback', async () => {
+    it('returns false when disabled via isDisabled callback', async () => {
       const isDisabled = () => true;
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -630,7 +631,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return cached hasOptedIn value when cache is fresh', async () => {
+    it('returns cached hasOptedIn value when cache is fresh', async () => {
       const recentTime = Date.now() - 60000; // 1 minute ago
       const accountState = {
         account: CAIP_ACCOUNT_1,
@@ -660,7 +661,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return false from cached data when account has not opted in', async () => {
+    it('returns false from cached data when account has not opted in', async () => {
       const recentTime = Date.now() - 60000; // 1 minute ago
       const accountState = {
         account: CAIP_ACCOUNT_1,
@@ -690,7 +691,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should fetch fresh data when cache is stale', async () => {
+    it('fetches fresh data when cache is stale', async () => {
       const staleTime = Date.now() - 600000; // 10 minutes ago (stale)
       const accountState = {
         account: CAIP_ACCOUNT_1,
@@ -724,7 +725,7 @@ describe('RewardsController', () => {
       expect(result).toBe(true);
     });
 
-    it('should update store state with new hasOptedIn value when fetching fresh data', async () => {
+    it('updates store state with new hasOptedIn value when fetching fresh data', async () => {
       const staleTime = Date.now() - 600000; // 10 minutes ago (stale)
       const accountState = {
         account: CAIP_ACCOUNT_1,
@@ -764,7 +765,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should update store state when creating new account on first opt-in check', async () => {
+    it('updates store state when creating new account on first opt-in check', async () => {
       mockMessenger.call.mockResolvedValue({
         hasOptedIn: true,
         discountBips: 1200,
@@ -788,7 +789,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should call data service for unknown accounts', async () => {
+    it('calls data service for unknown accounts', async () => {
       mockMessenger.call.mockResolvedValue({
         hasOptedIn: false,
         discountBips: 500,
@@ -803,7 +804,7 @@ describe('RewardsController', () => {
       expect(result).toBe(false);
     });
 
-    it('should return true when data service indicates opted in', async () => {
+    it('returns true when data service indicates opted in', async () => {
       mockMessenger.call.mockResolvedValue({
         hasOptedIn: true,
         discountBips: 1000,
@@ -818,7 +819,7 @@ describe('RewardsController', () => {
       expect(result).toBe(true);
     });
 
-    it('should handle data service errors and return false', async () => {
+    it('handles data service errors and return false', async () => {
       mockMessenger.call.mockRejectedValue(new Error('Network error'));
 
       const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_2);
@@ -826,7 +827,7 @@ describe('RewardsController', () => {
       expect(result).toBe(false);
     });
 
-    it('should fetch fresh data when no cache timestamp exists', async () => {
+    it('fetches fresh data when no cache timestamp exists', async () => {
       const accountState = {
         account: CAIP_ACCOUNT_1,
         hasOptedIn: false,
@@ -861,7 +862,7 @@ describe('RewardsController', () => {
   });
 
   describe('estimatePoints', () => {
-    it('should return default response when disabled via isDisabled callback', async () => {
+    it('returns default response when disabled via isDisabled callback', async () => {
       const isDisabled = () => true;
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -884,7 +885,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should successfully estimate points', async () => {
+    it('successfully estimate points', async () => {
       const mockRequest = {
         activityType: 'SWAP' as const,
         account: CAIP_ACCOUNT_1,
@@ -945,7 +946,7 @@ describe('RewardsController', () => {
       jest.useRealTimers();
     });
 
-    it('should handle estimate points errors', async () => {
+    it('handles estimate points errors', async () => {
       const mockRequest = {
         activityType: 'SWAP' as const,
         account: CAIP_ACCOUNT_1,
@@ -1069,7 +1070,7 @@ describe('RewardsController', () => {
       jest.useRealTimers();
     });
 
-    it('should return default response when there is no active season', async () => {
+    it('returns default response when there is no active season', async () => {
       const mockRequest = {
         activityType: 'SWAP' as const,
         account: CAIP_ACCOUNT_1,
@@ -1098,7 +1099,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should proceed with API call when rewards are enabled and there is an active season', async () => {
+    it('proceeds with API call when rewards are enabled and there is an active season', async () => {
       const mockRequest = {
         activityType: 'SWAP' as const,
         account: CAIP_ACCOUNT_1,
@@ -1161,7 +1162,7 @@ describe('RewardsController', () => {
       jest.useRealTimers();
     });
 
-    it('should add successful estimate to history with flattened swap context', async () => {
+    it('adds successful estimate to history with flattened swap context', async () => {
       const mockSwapContext = {
         srcAsset: {
           id: 'eip155:1/slip44:60' as const,
@@ -1283,7 +1284,7 @@ describe('RewardsController', () => {
       jest.useRealTimers();
     });
 
-    it('should add successful estimate to history with flattened perps context', async () => {
+    it('adds successful estimate to history with flattened perps context', async () => {
       const mockPerpsContext = {
         type: 'OPEN_POSITION' as const,
         usdFeeValue: '12.34',
@@ -1353,7 +1354,7 @@ describe('RewardsController', () => {
       jest.useRealTimers();
     });
 
-    it('should add successful estimate to history with flattened predict context', async () => {
+    it('adds successful estimate to history with flattened predict context', async () => {
       const mockPredictFeeAsset = {
         id: 'eip155:1/slip44:60' as const,
         amount: '1000000000000000',
@@ -1429,7 +1430,7 @@ describe('RewardsController', () => {
       jest.useRealTimers();
     });
 
-    it('should add successful estimate to history with flattened shield context', async () => {
+    it('adds successful estimate to history with flattened shield context', async () => {
       const mockShieldFeeAsset = {
         id: 'eip155:1/slip44:60' as const,
         amount: '2000000000000000',
@@ -1503,7 +1504,7 @@ describe('RewardsController', () => {
       jest.useRealTimers();
     });
 
-    it('should not add to history when rewards are disabled', async () => {
+    it('does not add to history when rewards are disabled', async () => {
       const isDisabled = () => true;
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -1522,7 +1523,7 @@ describe('RewardsController', () => {
       expect(disabledController.state.pointsEstimateHistory).toHaveLength(0);
     });
 
-    it('should limit history to 50 entries', async () => {
+    it('limits history to 50 entries', async () => {
       const mockRequest = {
         activityType: 'SWAP' as const,
         account: CAIP_ACCOUNT_1,
@@ -1581,7 +1582,7 @@ describe('RewardsController', () => {
       jest.useRealTimers();
     });
 
-    it('should store estimates in history keyed by timestamp', async () => {
+    it('stores estimates in history keyed by timestamp', async () => {
       const mockRequest = {
         activityType: 'SWAP' as const,
         account: CAIP_ACCOUNT_1,
@@ -1653,7 +1654,7 @@ describe('RewardsController', () => {
       jest.useRealTimers();
     });
 
-    it('should return successful estimate even when history tracking fails', async () => {
+    it('returns successful estimate even when history tracking fails', async () => {
       const mockRequest = {
         activityType: 'SWAP' as const,
         account: CAIP_ACCOUNT_1,
@@ -2086,7 +2087,7 @@ describe('RewardsController', () => {
   });
 
   describe('hasActiveSeason', () => {
-    it('should return false when rewards feature is disabled', async () => {
+    it('returns false when rewards feature is disabled', async () => {
       const isDisabled = () => true;
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -2100,7 +2101,7 @@ describe('RewardsController', () => {
       expect(mockMessenger.call).not.toHaveBeenCalled();
     });
 
-    it('should return false when getSeasonMetadata returns null', async () => {
+    it('returns false when getSeasonMetadata returns null', async () => {
       // Mock getSeasonMetadata to return null by having getDiscoverSeasons return null for current
       mockMessenger.call.mockImplementation((method, ..._args): any => {
         if (method === 'RewardsDataService:getDiscoverSeasons') {
@@ -2118,7 +2119,7 @@ describe('RewardsController', () => {
       expect(result).toBe(false);
     });
 
-    it('should return false when getSeasonMetadata throws an error', async () => {
+    it('returns false when getSeasonMetadata throws an error', async () => {
       mockMessenger.call.mockImplementation((method, ..._args): any => {
         if (method === 'RewardsDataService:getDiscoverSeasons') {
           return Promise.reject(new Error('API error'));
@@ -2135,7 +2136,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return true when getSeasonMetadata returns an active season (current date between start and end)', async () => {
+    it('returns true when getSeasonMetadata returns an active season (current date between start and end)', async () => {
       // Use a realistic timestamp (2023-11-15)
       const now = 1700000000000;
       const mockSeasonId = 'season123';
@@ -2178,7 +2179,7 @@ describe('RewardsController', () => {
       jest.useRealTimers();
     });
 
-    it('should return false when season has not started yet (startDate in future)', async () => {
+    it('returns false when season has not started yet (startDate in future)', async () => {
       const now = Date.now();
       const mockSeasonId = 'season123';
       const mockSeasonMetadata = {
@@ -2212,7 +2213,7 @@ describe('RewardsController', () => {
       expect(result).toBe(false);
     });
 
-    it('should return false when season has ended (endDate in past)', async () => {
+    it('returns false when season has ended (endDate in past)', async () => {
       const now = Date.now();
       const mockSeasonId = 'season123';
       const mockSeasonMetadata = {
@@ -2246,7 +2247,7 @@ describe('RewardsController', () => {
       expect(result).toBe(false);
     });
 
-    it('should return true when season starts exactly today (startDate equals current date)', async () => {
+    it('returns true when season starts exactly today (startDate equals current date)', async () => {
       // Use a realistic timestamp (2023-11-15)
       const now = 1700000000000;
       const mockSeasonId = 'season123';
@@ -2289,7 +2290,7 @@ describe('RewardsController', () => {
       jest.useRealTimers();
     });
 
-    it('should return true when season ends exactly today (endDate equals current date)', async () => {
+    it('returns true when season ends exactly today (endDate equals current date)', async () => {
       // Use a realistic timestamp (2023-11-15)
       const now = 1700000000000;
       const mockSeasonId = 'season123';
@@ -2334,7 +2335,7 @@ describe('RewardsController', () => {
   });
 
   describe('getPointsEvents', () => {
-    it('should return empty response when disabled via isDisabled callback', async () => {
+    it('returns empty response when disabled via isDisabled callback', async () => {
       const isDisabled = () => true;
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -2361,7 +2362,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should successfully get points events', async () => {
+    it('successfully get points events', async () => {
       const mockRequest = {
         seasonId: 'current',
         subscriptionId: 'sub-123',
@@ -2411,7 +2412,7 @@ describe('RewardsController', () => {
       expect(result).toEqual(mockResponse);
     });
 
-    it('should successfully get points events with cursor', async () => {
+    it('successfully get points events with cursor', async () => {
       const mockRequest = {
         seasonId: 'current',
         subscriptionId: 'sub-123',
@@ -2445,7 +2446,7 @@ describe('RewardsController', () => {
       expect(result).toEqual(mockResponse);
     });
 
-    it('should handle getPointsEvents errors and rethrow them', async () => {
+    it('handles getPointsEvents errors and rethrow them', async () => {
       const mockRequest = {
         seasonId: 'current',
         subscriptionId: 'sub-123',
@@ -2477,7 +2478,7 @@ describe('RewardsController', () => {
         mockMessenger.publish.mockClear();
       });
 
-      it('should emit balance updated event when earliest event is newer than cached balance timestamp', async () => {
+      it('emits balance updated event when earliest event is newer than cached balance timestamp', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -2545,7 +2546,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should not emit balance updated event when cached balance and season status are newer than earliest event', async () => {
+      it('does not emit balance updated event when cached balance and season status are newer than earliest event', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -2604,7 +2605,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should not emit balance updated event when no cached season status exists', async () => {
+      it('does not emit balance updated event when no cached season status exists', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -2642,7 +2643,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should not emit balance updated event when points events result is empty', async () => {
+      it('does not emit balance updated event when points events result is empty', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -2669,7 +2670,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should find the latest event from multiple points events with different timestamps', async () => {
+      it('finds the latest event from multiple points events with different timestamps', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -2752,7 +2753,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should handle Date vs string updatedAt timestamps in points events', async () => {
+      it('handles Date vs string updatedAt timestamps in points events', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -2813,7 +2814,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should add 500ms buffer to cached balance timestamp and include season status timestamp in comparison', async () => {
+      it('adds 500ms buffer to cached balance timestamp and include season status timestamp in comparison', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -2874,7 +2875,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should not emit balance updated event when both cache timestamps are newer than latest event', async () => {
+      it('does not emit balance updated event when both cache timestamps are newer than latest event', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -2934,7 +2935,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should invalidate subscription cache when balance updated event is emitted', async () => {
+      it('invalidates subscription cache when balance updated event is emitted', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -3014,7 +3015,7 @@ describe('RewardsController', () => {
         mockMessenger.publish.mockClear();
       });
 
-      it('should emit pointsEventsUpdated event when oldMostRecentId differs from freshMostRecentId', async () => {
+      it('emits pointsEventsUpdated event when oldMostRecentId differs from freshMostRecentId', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -3081,7 +3082,7 @@ describe('RewardsController', () => {
         expect(result).toEqual(oldPointsEvents); // Should return stale data immediately
       });
 
-      it('should not emit pointsEventsUpdated event when oldMostRecentId equals freshMostRecentId', async () => {
+      it('does not emit pointsEventsUpdated event when oldMostRecentId equals freshMostRecentId', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -3158,7 +3159,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should not emit pointsEventsUpdated event when both old and fresh results are empty', async () => {
+      it('does not emit pointsEventsUpdated event when both old and fresh results are empty', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -3202,7 +3203,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should emit pointsEventsUpdated event', async () => {
+      it('emits pointsEventsUpdated event', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -3652,7 +3653,7 @@ describe('RewardsController', () => {
   });
 
   describe('getPointsEventsLastUpdated', () => {
-    it('should successfully get points events last updated timestamp', async () => {
+    it('successfully get points events last updated timestamp', async () => {
       // Arrange
       const mockRequest = {
         seasonId: 'current',
@@ -3676,7 +3677,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle getPointsEventsLastUpdated errors and rethrow them', async () => {
+    it('handles getPointsEventsLastUpdated errors and rethrow them', async () => {
       // Arrange
       const mockRequest = {
         seasonId: 'current',
@@ -3696,7 +3697,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return null when data service returns null', async () => {
+    it('returns null when data service returns null', async () => {
       // Arrange
       const mockRequest = {
         seasonId: 'current',
@@ -3717,7 +3718,7 @@ describe('RewardsController', () => {
   });
 
   describe('getPerpsDiscountForAccount', () => {
-    it('should return 0 when disabled via isDisabled callback', async () => {
+    it('returns 0 when disabled via isDisabled callback', async () => {
       const isDisabled = () => true;
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -3731,7 +3732,7 @@ describe('RewardsController', () => {
       expect(result).toBe(0);
     });
 
-    it('should return cached discount when available and fresh', async () => {
+    it('returns cached discount when available and fresh', async () => {
       const recentTime = Date.now() - 60000; // 1 minute ago
       const accountState = {
         account: CAIP_ACCOUNT_1,
@@ -3761,7 +3762,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should fetch fresh discount when cache is stale', async () => {
+    it('fetches fresh discount when cache is stale', async () => {
       const staleTime = Date.now() - 600000; // 10 minutes ago
       const accountState = {
         account: CAIP_ACCOUNT_1,
@@ -3796,7 +3797,7 @@ describe('RewardsController', () => {
       expect(result).toBe(1000);
     });
 
-    it('should update store state with new discount value when fetching fresh data', async () => {
+    it('updates store state with new discount value when fetching fresh data', async () => {
       const staleTime = Date.now() - 600000; // 10 minutes ago
       const accountState = {
         account: CAIP_ACCOUNT_1,
@@ -3839,7 +3840,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should fetch discount for new accounts', async () => {
+    it('fetches discount for new accounts', async () => {
       mockMessenger.call.mockResolvedValue({
         hasOptedIn: false,
         discountBips: 1500,
@@ -3855,7 +3856,7 @@ describe('RewardsController', () => {
       expect(result).toBe(1500);
     });
 
-    it('should update store state when creating new account on first discount check', async () => {
+    it('updates store state when creating new account on first discount check', async () => {
       mockMessenger.call.mockResolvedValue({
         hasOptedIn: false,
         discountBips: 2000,
@@ -3880,7 +3881,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return 0 on data service error', async () => {
+    it('returns 0 on data service error', async () => {
       mockMessenger.call.mockRejectedValue(new Error('Network error'));
 
       const result =
@@ -3890,7 +3891,7 @@ describe('RewardsController', () => {
     });
 
     describe('CAIP account ID coercion', () => {
-      it('should coerce eip155:1:0xABC to eip155:0:0xabc format when storing state', async () => {
+      it('coerces eip155:1:0xABC to eip155:0:0xabc format when storing state', async () => {
         // Arrange - account with chain ID 1 (needs coercion to chain ID 0)
         const nonCoercedAccount = 'eip155:1:0xABCDEF' as CaipAccountId;
         const expectedCoercedAccount = 'eip155:0:0xabcdef' as CaipAccountId;
@@ -3920,7 +3921,7 @@ describe('RewardsController', () => {
         expect(nonCoercedAccountState).toBeUndefined();
       });
 
-      it('should update existing account with coerced key when hasOptedIn changes to false', async () => {
+      it('updates existing account with coerced key when hasOptedIn changes to false', async () => {
         // Arrange - existing account with coerced format, currently opted in with subscription
         const coercedAccount = 'eip155:0:0xabcdef' as CaipAccountId;
         const accountState = {
@@ -3963,7 +3964,7 @@ describe('RewardsController', () => {
         expect(updatedAccountState.perpsFeeDiscount).toBe(1000);
       });
 
-      it('should handle eip155:0:0xABC format without coercion (already correct format)', async () => {
+      it('handles eip155:0:0xABC format without coercion (already correct format)', async () => {
         // Arrange - account already in correct format (eip155:0:...)
         const correctAccount = 'eip155:0:0xDEF123' as CaipAccountId;
 
@@ -3985,7 +3986,7 @@ describe('RewardsController', () => {
         expect(accountState.perpsFeeDiscount).toBe(2000);
       });
 
-      it('should consistently use coerced account when updating existing account that opted out', async () => {
+      it('consistently use coerced account when updating existing account that opted out', async () => {
         // Arrange - existing account stored with different chain ID format
         const existingAccount = 'eip155:0:0xabc123' as CaipAccountId;
         const accountState = {
@@ -4030,7 +4031,7 @@ describe('RewardsController', () => {
         expect(wrongKeyEntry).toBeUndefined();
       });
 
-      it('should set subscriptionId to null using coerced account when hasOptedIn becomes false', async () => {
+      it('sets subscriptionId to null using coerced account when hasOptedIn becomes false', async () => {
         // This test specifically verifies the bug fix on line 988
         // where state.accounts[account] should be state.accounts[coercedAccount]
 
@@ -4078,7 +4079,7 @@ describe('RewardsController', () => {
         expect(controller.state.accounts[queryFormat]).toBeUndefined();
       });
 
-      it('should preserve subscriptionId when hasOptedIn remains true', async () => {
+      it('preserves subscriptionId when hasOptedIn remains true', async () => {
         // Arrange - account with subscription that stays opted in
         const coercedFormat = 'eip155:0:0xffffff' as CaipAccountId;
         const existingState = {
@@ -4122,13 +4123,13 @@ describe('RewardsController', () => {
   });
 
   describe('isRewardsFeatureEnabled', () => {
-    it('should return true when not disabled', () => {
+    it('returns true when not disabled', () => {
       const result = controller.isRewardsFeatureEnabled();
 
       expect(result).toBe(true);
     });
 
-    it('should return false when disabled via isDisabled callback', () => {
+    it('returns false when disabled via isDisabled callback', () => {
       const isDisabled = () => true;
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -4223,7 +4224,7 @@ describe('RewardsController', () => {
       )?.[1] as (_current?: any, _previous?: any) => void;
     });
 
-    it('should format and convert authentication message to hex correctly', async () => {
+    it('formats and convert authentication message to hex correctly', async () => {
       const mockInternalAccount = {
         address: '0x1234567890abcdef',
         type: 'eip155:eoa' as const,
@@ -4275,7 +4276,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should skip silent auth for hardware accounts', async () => {
+    it('skips silent auth for hardware accounts', async () => {
       // Arrange
       mockIsHardwareAccount.mockReturnValue(true);
       const mockAccount = {
@@ -4318,7 +4319,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should NOT skip silent auth for Solana addresses', async () => {
+    it('does NOT skip silent auth for Solana addresses', async () => {
       // Arrange
       mockIsSolanaAddress.mockReturnValue(true);
       mockIsHardwareAccount.mockReturnValue(false);
@@ -4351,7 +4352,7 @@ describe('RewardsController', () => {
       expect(mockIsSolanaAddress).toHaveBeenCalledWith('solana-address');
     });
 
-    it('should handle Solana message signing', async () => {
+    it('handles Solana message signing', async () => {
       // Arrange
       const mockTimestamp = 1234567890;
       jest.spyOn(Date, 'now').mockReturnValue(mockTimestamp);
@@ -4402,7 +4403,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should log errors that do not include "Engine does not exist"', async () => {
+    it('logs errors that do not include "Engine does not exist"', async () => {
       // Directly test the error filtering logic
       const regularError = new Error('Regular error message');
       const errorMessage = regularError.message;
@@ -4424,7 +4425,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should not log errors that include "Engine does not exist"', async () => {
+    it('does not log errors that include "Engine does not exist"', async () => {
       // Directly test the error filtering logic
       const engineError = new Error(
         'Error signing Solana rewards message: [Error: Engine does not exist]',
@@ -4448,7 +4449,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle non-Error objects in catch block', async () => {
+    it('handles non-Error objects in catch block', async () => {
       // Directly test the error filtering logic with a string error
       const stringError = 'String error message';
       const errorMessage = stringError;
@@ -4468,7 +4469,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle non-string errors.in catch block', async () => {
+    it('handles non-string errors.in catch block', async () => {
       // Directly test the error filtering logic with a non-string, non-Error object
       const numberError = 404;
       const errorMessage = String(numberError);
@@ -4573,7 +4574,7 @@ describe('RewardsController', () => {
     const mockSeasonId = 'season123';
     const mockSubscriptionId = 'sub123';
 
-    it('should return null when feature flag is disabled', async () => {
+    it('returns null when feature flag is disabled', async () => {
       const disabledController = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
@@ -4587,7 +4588,7 @@ describe('RewardsController', () => {
       expect(result).toBeNull();
     });
 
-    it('should return cached season status when cache is fresh', async () => {
+    it('returns cached season status when cache is fresh', async () => {
       const recentTime = Date.now() - 30000; // 30 seconds ago (within 1 minute threshold)
       const compositeKey = `${mockSeasonId}:${mockSubscriptionId}`;
 
@@ -4711,7 +4712,7 @@ describe('RewardsController', () => {
       getSeasonStatusSpy.mockRestore();
     });
 
-    it('should fetch fresh season status when cache is stale', async () => {
+    it('fetches fresh season status when cache is stale', async () => {
       const mockSeasonMetadata = {
         id: mockSeasonId,
         name: 'Mock Season',
@@ -4788,7 +4789,7 @@ describe('RewardsController', () => {
       expect(result?.lastFetched).toBeGreaterThan(Date.now() - 1000);
     });
 
-    it('should update state when fetching fresh season status', async () => {
+    it('updates state when fetching fresh season status', async () => {
       const mockSeasonMetadata = {
         id: mockSeasonId,
         name: 'Mock Season',
@@ -4869,7 +4870,7 @@ describe('RewardsController', () => {
       expect(storedSeason.tiers).toHaveLength(4);
     });
 
-    it('should throw error when season is not found in state', async () => {
+    it('throws error when season is not found in state', async () => {
       controller = new RewardsController({
         messenger: mockMessenger,
         state: {
@@ -4896,7 +4897,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle errors from data service', async () => {
+    it('handles errors from data service', async () => {
       controller = new RewardsController({
         messenger: mockMessenger,
         state: {
@@ -4935,7 +4936,7 @@ describe('RewardsController', () => {
       ).rejects.toThrow('API error');
     });
 
-    it('should handle network timeout error and log it', async () => {
+    it('handles network timeout error and log it', async () => {
       // Arrange
       const mockTimeoutError = new Error('Request timed out');
       const localMockMessenger = {
@@ -5133,7 +5134,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle 403 error, reauth, and re-throw error if reauth failed', async () => {
+    it('handles 403 error, reauth, and re-throw error if reauth failed', async () => {
       // Arrange
       const mock403Error = new AuthorizationFailedError(
         'Rewards authorization failed. Please login and try again.',
@@ -5928,7 +5929,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle API server error (500)', async () => {
+    it('handles API server error (500)', async () => {
       // Arrange
       const serverError = new Error('Internal Server Error: 500');
       const localMockMessenger = {
@@ -5987,7 +5988,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle API rate limit error (429)', async () => {
+    it('handles API rate limit error (429)', async () => {
       // Arrange
       const rateLimitError = new Error('Too Many Requests: 429');
       const localMockMessenger = {
@@ -6047,7 +6048,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle SeasonNotFoundError by clearing seasons and rethrowing error', async () => {
+    it('handles SeasonNotFoundError by clearing seasons and rethrowing error', async () => {
       // Arrange
       const seasonNotFoundError = new SeasonNotFoundError('Season not found');
       const localMockMessenger = {
@@ -6925,7 +6926,7 @@ describe('RewardsController', () => {
       mockIsSolanaAddress.mockReturnValue(false);
     });
 
-    it('should call performSilentAuth with null when no accounts are available', async () => {
+    it('calls performSilentAuth with null when no accounts are available', async () => {
       // Arrange
       mockMessenger.call.mockReturnValueOnce([]); // Empty accounts array
 
@@ -6940,7 +6941,7 @@ describe('RewardsController', () => {
       expect(controller.state.activeAccount).toBeNull();
     });
 
-    it('should call performSilentAuth with null when accounts is null', async () => {
+    it('calls performSilentAuth with null when accounts is null', async () => {
       // Arrange
       mockMessenger.call.mockReturnValueOnce(null); // Null accounts
 
@@ -6955,7 +6956,7 @@ describe('RewardsController', () => {
       expect(controller.state.activeAccount).toBeNull();
     });
 
-    it('should successfully authenticate with single account', async () => {
+    it('successfully authenticate with single account', async () => {
       // Arrange
       const mockAccount = {
         address: '0x1234567890abcdef',
@@ -6991,7 +6992,7 @@ describe('RewardsController', () => {
       ).toBeDefined();
     });
 
-    it('should try multiple accounts', async () => {
+    it('tries multiple accounts', async () => {
       // Arrange
       const mockAccount1 = {
         address: '0x1111111111111111',
@@ -7055,7 +7056,7 @@ describe('RewardsController', () => {
       performSilentAuthSpy.mockRestore();
     });
 
-    it('should stop after first successful account and track first successful account', async () => {
+    it('stops after first successful account and track first successful account', async () => {
       // Arrange
       const mockAccount1 = {
         address: '0x1111111111111111',
@@ -7118,7 +7119,7 @@ describe('RewardsController', () => {
       performSilentAuthSpy.mockRestore();
     });
 
-    it('should try multiple accounts and succeed on second account after first fails', async () => {
+    it('tries multiple accounts and succeed on second account after first fails', async () => {
       // Arrange
       const mockAccount1 = {
         address: '0x1111111111111111',
@@ -7177,7 +7178,7 @@ describe('RewardsController', () => {
       ).toBeDefined();
     });
 
-    it('should set activeAccount to first account when all accounts fail authentication', async () => {
+    it('sets activeAccount to first account when all accounts fail authentication', async () => {
       // Arrange
       const mockAccount1 = {
         address: '0x1111111111111111',
@@ -7281,7 +7282,7 @@ describe('RewardsController', () => {
       convertSpy.mockRestore();
     });
 
-    it('should not throw error when single account fails authentication', async () => {
+    it('does not throw error when single account fails authentication', async () => {
       // Arrange
       const mockAccount = {
         address: '0x1234567890abcdef',
@@ -7317,7 +7318,7 @@ describe('RewardsController', () => {
       expect(controller.state.activeAccount?.account).toBeDefined();
     });
 
-    it('should handle "Engine does not exist" errors silently', async () => {
+    it('handles "Engine does not exist" errors silently', async () => {
       // Arrange
       const mockAccount = {
         address: '0x1234567890abcdef',
@@ -7353,7 +7354,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle messenger.call throwing an error', async () => {
+    it('handles messenger.call throwing an error', async () => {
       // Arrange
       mockMessenger.call.mockImplementation(() => {
         throw new Error('Messaging system error');
@@ -7372,7 +7373,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle non-Error objects thrown', async () => {
+    it('handles non-Error objects thrown', async () => {
       // Arrange
       mockMessenger.call.mockImplementation(() => {
         throw 'String error'; // Non-Error object
@@ -7391,7 +7392,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should sort accounts correctly using sortAccounts utility', async () => {
+    it('sorts accounts correctly using sortAccounts utility', async () => {
       // Arrange - Create accounts with different types to test sorting
       const mockEvmAccount = {
         address: '0x1111111111111111',
@@ -7447,7 +7448,7 @@ describe('RewardsController', () => {
       mockIsSolanaAddress.mockReturnValue(false);
     });
 
-    it('should return false when account has no state (never checked before)', async () => {
+    it('returns false when account has no state (never checked before)', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0x123',
@@ -7490,7 +7491,7 @@ describe('RewardsController', () => {
       expect(result).toBe(false);
     });
 
-    it('should return true when account has opted in', async () => {
+    it('returns true when account has opted in', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0x123',
@@ -7549,7 +7550,7 @@ describe('RewardsController', () => {
       expect(mockGetSubscriptionToken).toHaveBeenCalledWith(subscriptionId);
     });
 
-    it('should return false when account has not opted in and lastFreshOptInStatusCheck is missing', async () => {
+    it('returns false when account has not opted in and lastFreshOptInStatusCheck is missing', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0x123',
@@ -7600,7 +7601,7 @@ describe('RewardsController', () => {
       expect(result).toBe(false);
     });
 
-    it('should return true when account has not opted in but cache is fresh (within 1 hour)', async () => {
+    it('returns true when account has not opted in but cache is fresh (within 1 hour)', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0x123',
@@ -7653,7 +7654,7 @@ describe('RewardsController', () => {
       expect(result).toBe(true);
     });
 
-    it('should return false when account has not opted in and cache is stale (beyond 1 hour)', async () => {
+    it('returns false when account has not opted in and cache is stale (beyond 1 hour)', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0x123',
@@ -7706,7 +7707,7 @@ describe('RewardsController', () => {
       expect(result).toBe(false);
     });
 
-    it('should handle CAIP ID normalization correctly (eip155:0 format)', async () => {
+    it('handles CAIP ID normalization correctly (eip155:0 format)', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0xABC',
@@ -7772,7 +7773,7 @@ describe('RewardsController', () => {
   // Removed outdated 'reset' tests; behavior covered by 'resetAll' and 'logout' tests
 
   describe('logout', () => {
-    it('should skip logout when disabled via isDisabled callback', async () => {
+    it('skips logout when disabled via isDisabled callback', async () => {
       // Arrange
       const isDisabled = () => true;
       const disabledController = new RewardsController({
@@ -7791,7 +7792,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should skip logout when no authenticated account exists', async () => {
+    it('skips logout when no authenticated account exists', async () => {
       // Arrange
       controller = new RewardsController({
         messenger: mockMessenger,
@@ -7817,7 +7818,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should clear last authenticated account only if subscription matches', async () => {
+    it('clears last authenticated account only if subscription matches', async () => {
       // Arrange
       const mockSubscriptionId = 'sub-123';
 
@@ -7852,7 +7853,7 @@ describe('RewardsController', () => {
       expect(controller.state.activeAccount).toBeNull();
     });
 
-    it('should successfully complete full logout flow - happy path', async () => {
+    it('successfully complete full logout flow - happy path', async () => {
       // Arrange
       const mockSubscriptionId = 'sub-456';
       const mockActiveAccount = {
@@ -7948,7 +7949,7 @@ describe('RewardsController', () => {
       expect(controller.state.subscriptions[mockSubscriptionId]).toBeDefined();
     });
 
-    it('should log error and re-throw when logout fails', async () => {
+    it('logs error and re-throw when logout fails', async () => {
       // Arrange
       const mockSubscriptionId = 'sub-123';
       const mockError = new Error('Logout service failed');
@@ -7996,7 +7997,7 @@ describe('RewardsController', () => {
   });
 
   describe('resetAll', () => {
-    it('should skip reset when feature flag is disabled', async () => {
+    it('skips reset when feature flag is disabled', async () => {
       // Arrange
       const mockSubscriptionId = 'sub-abc';
       const activeAccountState = {
@@ -8037,7 +8038,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should clear tokens and reset state, preserving active account opted-out', async () => {
+    it('clears tokens and reset state, preserving active account opted-out', async () => {
       // Arrange
       const mockSubscriptionId = 'sub-123';
       const activeAccountState = {
@@ -8094,7 +8095,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should log error and re-throw when token reset fails', async () => {
+    it('logs error and re-throw when token reset fails', async () => {
       // Arrange
       const mockSubscriptionId = 'sub-err';
       const activeAccountState = {
@@ -8142,7 +8143,7 @@ describe('RewardsController', () => {
   });
 
   describe('validateReferralCode', () => {
-    it('should return false when feature flag is disabled', async () => {
+    it('returns false when feature flag is disabled', async () => {
       // Arrange
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -8161,20 +8162,32 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return false for empty or whitespace-only codes', async () => {
+    it('returns false for empty or whitespace-only codes', async () => {
       // Act & Assert
       expect(await controller.validateReferralCode('')).toBe(false);
       expect(await controller.validateReferralCode('   ')).toBe(false);
       expect(await controller.validateReferralCode('\t\n')).toBe(false);
     });
 
-    it('should return false for codes with incorrect length', async () => {
+    it('returns false for codes with incorrect length', async () => {
       // Act & Assert
       expect(await controller.validateReferralCode('ABC12')).toBe(false); // Too short
       expect(await controller.validateReferralCode('ABC1234')).toBe(false); // Too long
     });
 
-    it('should return true for valid referral codes from service', async () => {
+    it('returns false for codes with characters outside Base32 alphabet', async () => {
+      // I, L, O, U are excluded from the Base32 alphabet
+      expect(await controller.validateReferralCode('ABCIOU')).toBe(false);
+      expect(await controller.validateReferralCode('LIONER')).toBe(false);
+    });
+
+    it('returns false for codes with special characters', async () => {
+      // Act & Assert
+      expect(await controller.validateReferralCode('AB-C!D')).toBe(false);
+      expect(await controller.validateReferralCode('CO@E12')).toBe(false);
+    });
+
+    it('returns true for valid referral codes from service', async () => {
       // Arrange
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mockMessenger.call.mockImplementation((action, ..._args): any => {
@@ -8195,7 +8208,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return false for invalid referral codes from service', async () => {
+    it('returns false for invalid referral codes from service', async () => {
       // Arrange
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mockMessenger.call.mockImplementation((action, ..._args): any => {
@@ -8216,7 +8229,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should accept valid base32 characters', async () => {
+    it('accepts valid base32 characters', async () => {
       // Act & Assert
       const validCodes = ['ABCDEF', 'ABC234', 'XYZ567', 'DEF237'];
 
@@ -8238,7 +8251,7 @@ describe('RewardsController', () => {
       }
     });
 
-    it('should handle service errors and throw error', async () => {
+    it('handles service errors and throw error', async () => {
       // Arrange
       mockMessenger.call.mockRejectedValue(new Error('Service error'));
 
@@ -8249,8 +8262,231 @@ describe('RewardsController', () => {
     });
   });
 
+  describe('validateBonusCode', () => {
+    const mockSubscriptionId = 'test-subscription-123';
+
+    it('returns false when feature flag is disabled', async () => {
+      // Arrange
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
+      });
+
+      // Act
+      const result = await disabledController.validateBonusCode(
+        'BNS123',
+        mockSubscriptionId,
+      );
+
+      // Assert
+      expect(result).toBe(false);
+      expect(mockMessenger.call).not.toHaveBeenCalledWith(
+        'RewardsDataService:validateBonusCode',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('returns false for empty or whitespace-only codes', async () => {
+      // Act & Assert
+      expect(await controller.validateBonusCode('', mockSubscriptionId)).toBe(
+        false,
+      );
+      expect(
+        await controller.validateBonusCode('   ', mockSubscriptionId),
+      ).toBe(false);
+      expect(
+        await controller.validateBonusCode('\t\n', mockSubscriptionId),
+      ).toBe(false);
+    });
+
+    it('returns false for codes shorter than 4 characters', async () => {
+      // Act & Assert
+      expect(await controller.validateBonusCode('AB', mockSubscriptionId)).toBe(
+        false,
+      );
+      expect(
+        await controller.validateBonusCode('ABC', mockSubscriptionId),
+      ).toBe(false);
+    });
+
+    it('returns false for codes longer than 16 characters', async () => {
+      // Act & Assert
+      expect(
+        await controller.validateBonusCode(
+          'ABCDEFGHIJKLMNOPQ',
+          mockSubscriptionId,
+        ),
+      ).toBe(false);
+    });
+
+    it('accepts codes with any alphanumeric characters', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockMessenger.call.mockImplementation((action, ..._args): any => {
+        if (action === 'RewardsDataService:validateBonusCode') {
+          return Promise.resolve({ valid: true });
+        }
+        return Promise.resolve();
+      });
+
+      expect(
+        await controller.validateBonusCode('AIOU', mockSubscriptionId),
+      ).toBe(true);
+      expect(
+        await controller.validateBonusCode('LION', mockSubscriptionId),
+      ).toBe(true);
+    });
+
+    it('returns false for codes with non-alphanumeric characters', async () => {
+      // Act & Assert
+      expect(
+        await controller.validateBonusCode('AB-C!', mockSubscriptionId),
+      ).toBe(false);
+      expect(
+        await controller.validateBonusCode('CODE@123', mockSubscriptionId),
+      ).toBe(false);
+      expect(
+        await controller.validateBonusCode('A B C D', mockSubscriptionId),
+      ).toBe(false);
+    });
+
+    it('returns true for valid bonus codes from service', async () => {
+      // Arrange
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockMessenger.call.mockImplementation((action, ..._args): any => {
+        if (action === 'RewardsDataService:validateBonusCode') {
+          return Promise.resolve({ valid: true });
+        }
+        return Promise.resolve();
+      });
+
+      // Act
+      const result = await controller.validateBonusCode(
+        'BNS234',
+        mockSubscriptionId,
+      );
+
+      // Assert
+      expect(result).toBe(true);
+      expect(mockMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:validateBonusCode',
+        'BNS234',
+        mockSubscriptionId,
+      );
+    });
+
+    it('returns false for invalid bonus codes from service', async () => {
+      // Arrange
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockMessenger.call.mockImplementation((action, ..._args): any => {
+        if (action === 'RewardsDataService:validateBonusCode') {
+          return Promise.resolve({ valid: false });
+        }
+        return Promise.resolve();
+      });
+
+      // Act
+      const result = await controller.validateBonusCode(
+        'XYZ567',
+        mockSubscriptionId,
+      );
+
+      // Assert
+      expect(result).toBe(false);
+      expect(mockMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:validateBonusCode',
+        'XYZ567',
+        mockSubscriptionId,
+      );
+    });
+
+    it('handles service errors and throw error', async () => {
+      // Arrange
+      mockMessenger.call.mockRejectedValue(new Error('Service error'));
+
+      // Act & Assert
+      await expect(
+        controller.validateBonusCode('BNS123', mockSubscriptionId),
+      ).rejects.toThrow('Service error');
+    });
+  });
+
+  describe('applyBonusCode', () => {
+    const mockSubscriptionId = 'test-subscription-123';
+    const mockBonusCode = 'BNS123';
+
+    it('throws error when feature flag is disabled', async () => {
+      // Arrange
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
+      });
+
+      // Act & Assert
+      await expect(
+        disabledController.applyBonusCode(mockBonusCode, mockSubscriptionId),
+      ).rejects.toThrow('Rewards are not enabled');
+      expect(mockMessenger.call).not.toHaveBeenCalledWith(
+        'RewardsDataService:applyBonusCode',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('successfully apply bonus code and invalidate cache', async () => {
+      // Arrange
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockMessenger.call.mockImplementation((action, ..._args): any => {
+        if (action === 'RewardsDataService:applyBonusCode') {
+          return Promise.resolve();
+        }
+        return Promise.resolve();
+      });
+
+      const invalidateSpy = jest.spyOn(
+        controller,
+        'invalidateSubscriptionCache',
+      );
+
+      // Act
+      await controller.applyBonusCode(mockBonusCode, mockSubscriptionId);
+
+      // Assert
+      expect(mockMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:applyBonusCode',
+        { bonusCode: mockBonusCode },
+        mockSubscriptionId,
+      );
+      expect(invalidateSpy).toHaveBeenCalledWith(mockSubscriptionId);
+
+      invalidateSpy.mockRestore();
+    });
+
+    it('throws error when service fails', async () => {
+      // Arrange
+      mockMessenger.call.mockRejectedValue(new Error('Invalid bonus code'));
+
+      // Act & Assert
+      await expect(
+        controller.applyBonusCode(mockBonusCode, mockSubscriptionId),
+      ).rejects.toThrow('Invalid bonus code');
+    });
+
+    it('throws error on network failure', async () => {
+      // Arrange
+      mockMessenger.call.mockRejectedValue(new Error('Network error'));
+
+      // Act & Assert
+      await expect(
+        controller.applyBonusCode(mockBonusCode, mockSubscriptionId),
+      ).rejects.toThrow('Network error');
+    });
+  });
+
   describe('calculateTierStatus', () => {
-    it('should return null immediately when current tier ID is not found in season tiers', () => {
+    it('returns null immediately when current tier ID is not found in season tiers', () => {
       // Arrange
       const tiers = createTestTiers();
       const invalidCurrentTierId = 'invalid-tier';
@@ -8271,7 +8507,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should return null for next tier when current tier is the last tier', () => {
+    it('returns null for next tier when current tier is the last tier', () => {
       // Arrange
       const tiers = createTestTiers();
       const lastTierCurrentTierId = 'platinum'; // Last tier in createTestTiers
@@ -8290,7 +8526,7 @@ describe('RewardsController', () => {
       expect(result.nextTierPointsNeeded).toBeNull();
     });
 
-    it('should calculate nextTierPointsNeeded correctly with Math.max', () => {
+    it('calculates nextTierPointsNeeded correctly with Math.max', () => {
       // Arrange
       const tiers = createTestTiers();
       const currentTierId = 'silver'; // Silver requires 1000 points, Gold requires 5000
@@ -8311,7 +8547,7 @@ describe('RewardsController', () => {
       expect(result.nextTierPointsNeeded).toBe(0); // Math.max(0, 5000 - 6000) = 0
     });
 
-    it('should calculate nextTierPointsNeeded correctly when points needed is positive', () => {
+    it('calculates nextTierPointsNeeded correctly when points needed is positive', () => {
       // Arrange
       const tiers = createTestTiers();
       const currentTierId = 'bronze'; // Bronze requires 0 points, Silver requires 1000
@@ -8330,7 +8566,7 @@ describe('RewardsController', () => {
       expect(result.nextTierPointsNeeded).toBe(750); // Math.max(0, 1000 - 250) = 750
     });
 
-    it('should sort tiers by points needed before processing', () => {
+    it('sorts tiers by points needed before processing', () => {
       // Arrange - Create tiers in random order
       const unsortedTiers: SeasonTierDto[] = [
         {
@@ -8396,7 +8632,7 @@ describe('RewardsController', () => {
   });
 
   describe('convertToSeasonStatusDto', () => {
-    it('should convert SeasonDtoState and SeasonStateDto to SeasonStatusDto with all required fields', () => {
+    it('converts SeasonDtoState and SeasonStateDto to SeasonStatusDto with all required fields', () => {
       // Arrange
       const tiers = createTestTiers();
       const seasonMetadata: SeasonDtoState = {
@@ -8434,7 +8670,7 @@ describe('RewardsController', () => {
       expect(result.currentTierId).toBe('gold');
     });
 
-    it('should correctly convert timestamp numbers to Date objects', () => {
+    it('correctly convert timestamp numbers to Date objects', () => {
       // Arrange
       const startTimestamp = 1672531200000; // 2023-01-01
       const endTimestamp = 1704067200000; // 2024-01-01
@@ -8467,7 +8703,7 @@ describe('RewardsController', () => {
       expect(result.season.endDate.getTime()).toBe(endTimestamp);
     });
 
-    it('should handle balance with updatedAt present', () => {
+    it('handles balance with updatedAt present', () => {
       // Arrange
       const seasonMetadata: SeasonDtoState = {
         id: 'season-789',
@@ -8497,7 +8733,7 @@ describe('RewardsController', () => {
       expect(result.balance.updatedAt).toEqual(updatedAtDate);
     });
 
-    it('should preserve tier data structure from SeasonDtoState', () => {
+    it('preserves tier data structure from SeasonDtoState', () => {
       // Arrange
       const customTiers: SeasonTierDto[] = [
         {
@@ -8555,7 +8791,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle balance with zero points', () => {
+    it('handles balance with zero points', () => {
       // Arrange
       const seasonMetadata: SeasonDtoState = {
         id: 'new-season',
@@ -8584,7 +8820,7 @@ describe('RewardsController', () => {
       expect(result.currentTierId).toBe('bronze');
     });
 
-    it('should handle large balance values', () => {
+    it('handles large balance values', () => {
       // Arrange
       const seasonMetadata: SeasonDtoState = {
         id: 'season-large',
@@ -8613,7 +8849,7 @@ describe('RewardsController', () => {
       expect(result.balance.total).toBe(largeBalance);
     });
 
-    it('should preserve shouldInstallNewVersion when present', () => {
+    it('preserves shouldInstallNewVersion when present', () => {
       // Arrange
       const seasonMetadata: SeasonDtoState = {
         id: 'season-update',
@@ -8642,7 +8878,7 @@ describe('RewardsController', () => {
       expect(result.season.shouldInstallNewVersion).toBe('1.2.3');
     });
 
-    it('should handle shouldInstallNewVersion when undefined', () => {
+    it('handles shouldInstallNewVersion when undefined', () => {
       // Arrange
       const seasonMetadata: SeasonDtoState = {
         id: 'season-no-update',
@@ -8673,7 +8909,7 @@ describe('RewardsController', () => {
   });
 
   describe('convertInternalAccountToCaipAccountId', () => {
-    it('should log error when conversion fails due to invalid internal account', () => {
+    it('logs error when conversion fails due to invalid internal account', () => {
       // Arrange
       const invalidInternalAccount = {
         address: '0x123',
@@ -8702,7 +8938,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return null and log error when account scopes is empty', () => {
+    it('returns null and log error when account scopes is empty', () => {
       // Arrange
       const accountWithNoScopes = {
         address: '0x123',
@@ -8730,7 +8966,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should successfully convert valid internal account to CAIP account ID', () => {
+    it('successfully convert valid internal account to CAIP account ID', () => {
       // Arrange
       const validInternalAccount = {
         address: '0x123456789',
@@ -8957,7 +9193,7 @@ describe('RewardsController', () => {
   });
 
   describe('invalidateSubscriptionAndAccounts', () => {
-    it('should correctly invalidate a specific subscription and its linked accounts', async () => {
+    it('correctly invalidate a specific subscription and its linked accounts', async () => {
       // Arrange
       const subscriptionId = 'sub123';
       const testController = new RewardsController({
@@ -9031,7 +9267,7 @@ describe('RewardsController', () => {
       expect(mockRemoveSubscriptionToken).toHaveBeenCalledWith(subscriptionId);
     });
 
-    it('should handle case with no active account', async () => {
+    it('handles case with no active account', async () => {
       // Arrange
       const subscriptionId = 'sub123';
       const testController = new RewardsController({
@@ -9092,7 +9328,7 @@ describe('RewardsController', () => {
       expect(mockRemoveSubscriptionToken).toHaveBeenCalledWith(subscriptionId);
     });
 
-    it('should preserve activeAccount account field while resetting other properties', async () => {
+    it('preserves activeAccount account field while resetting other properties', async () => {
       // Arrange
       const subscriptionId = 'sub456';
       const testController = new RewardsController({
@@ -9152,7 +9388,7 @@ describe('RewardsController', () => {
       expect(mockRemoveSubscriptionToken).toHaveBeenCalledWith(subscriptionId);
     });
 
-    it('should only invalidate accounts linked to the specified subscription', async () => {
+    it('only invalidate accounts linked to the specified subscription', async () => {
       // Arrange
       const subscriptionId1 = 'sub1';
       const subscriptionId2 = 'sub2';
@@ -9240,7 +9476,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should invalidate multiple accounts linked to the same subscription', async () => {
+    it('invalidates multiple accounts linked to the same subscription', async () => {
       // Arrange
       const subscriptionId = 'sub1';
       const testController = new RewardsController({
@@ -9336,7 +9572,7 @@ describe('RewardsController', () => {
       expect(mockRemoveSubscriptionToken).toHaveBeenCalledWith(subscriptionId);
     });
 
-    it('should not affect other state properties', async () => {
+    it('does not affect other state properties', async () => {
       // Arrange
       const subscriptionId = 'sub123';
       const testController = new RewardsController({
@@ -9444,7 +9680,7 @@ describe('RewardsController', () => {
       expect(mockRemoveSubscriptionToken).toHaveBeenCalledWith(subscriptionId);
     });
 
-    it('should not affect activeAccount when it is not linked to the subscription', async () => {
+    it('does not affect activeAccount when it is not linked to the subscription', async () => {
       // Arrange
       const subscriptionId = 'sub123';
       const testController = new RewardsController({
@@ -9519,7 +9755,7 @@ describe('RewardsController', () => {
   });
 
   describe('getGeoRewardsMetadata', () => {
-    it('should return default metadata when rewards feature is disabled', async () => {
+    it('returns default metadata when rewards feature is disabled', async () => {
       // Arrange
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -9543,7 +9779,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return cached geo location when available', async () => {
+    it('returns cached geo location when available', async () => {
       // Arrange
       const mockCachedGeoData = {
         geoLocation: 'US-NY',
@@ -9575,7 +9811,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should successfully fetch geo location for allowed region', async () => {
+    it('successfully fetch geo location for allowed region', async () => {
       // Arrange
       const mockGeoLocation = 'US-CA';
       mockMessenger.call.mockResolvedValueOnce(mockGeoLocation);
@@ -9603,7 +9839,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should handle blocked regions correctly', async () => {
+    it('handles blocked regions correctly', async () => {
       // Arrange
       const mockGeoLocation = 'UK-ENG'; // UK is in DEFAULT_BLOCKED_REGIONS
       mockMessenger.call.mockResolvedValueOnce(mockGeoLocation);
@@ -9621,7 +9857,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should handle geo location service errors with fallback', async () => {
+    it('handles geo location service errors with fallback', async () => {
       // Arrange
       const geoServiceError = new Error('Geo service unavailable');
       mockMessenger.call.mockRejectedValueOnce(geoServiceError);
@@ -9646,7 +9882,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should handle non-Error objects in catch block', async () => {
+    it('handles non-Error objects in catch block', async () => {
       // Arrange
       const nonErrorObject = 'String error';
       mockMessenger.call.mockRejectedValueOnce(nonErrorObject);
@@ -9709,7 +9945,7 @@ describe('RewardsController', () => {
       jest.clearAllMocks();
     });
 
-    it('should successfully opt in with account group and link remaining accounts', async () => {
+    it('successfully opt in with account group and link remaining accounts', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
@@ -9750,7 +9986,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should successfully opt in with referral code', async () => {
+    it('successfully opt in with referral code', async () => {
       // Arrange
       const referralCode = 'REF123';
       const mockAccounts = [mockEvmInternalAccount];
@@ -9784,7 +10020,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return null when rewards feature is disabled', async () => {
+    it('returns null when rewards feature is disabled', async () => {
       // Arrange
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -9800,7 +10036,7 @@ describe('RewardsController', () => {
       expect(mockMessenger.call).not.toHaveBeenCalled();
     });
 
-    it('should return null when no accounts found in selected account group', async () => {
+    it('returns null when no accounts found in selected account group', async () => {
       // Arrange
       const mockAccounts: InternalAccount[] = [];
 
@@ -9814,7 +10050,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should throw error when all accounts fail to opt in', async () => {
+    it('throws error when all accounts fail to opt in', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
@@ -9835,7 +10071,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle InvalidTimestampError and retry with server timestamp', async () => {
+    it('handles InvalidTimestampError and retry with server timestamp', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       const mockError = new InvalidTimestampError('Invalid timestamp', 12345);
@@ -9867,7 +10103,7 @@ describe('RewardsController', () => {
       expect(callCount).toBe(2); // Should retry once
     });
 
-    it('should handle optin service errors gracefully', async () => {
+    it('handles optin service errors gracefully', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
@@ -9890,7 +10126,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle signature generation errors', async () => {
+    it('handles signature generation errors', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
@@ -9911,7 +10147,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should update controller state after successful opt-in', async () => {
+    it('updates controller state after successful opt-in', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
@@ -9942,7 +10178,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should link remaining accounts after successful opt-in', async () => {
+    it('links remaining accounts after successful opt-in', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
@@ -9981,7 +10217,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle linkAccountsToSubscriptionCandidate failure gracefully', async () => {
+    it('handles linkAccountsToSubscriptionCandidate failure gracefully', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
@@ -10012,7 +10248,7 @@ describe('RewardsController', () => {
       expect(result).toBe(mockSubscriptionId); // Should still return the subscription ID even if linking fails
     });
 
-    it('should handle subscription token storage failure gracefully', async () => {
+    it('handles subscription token storage failure gracefully', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       jest.doMock('./utils/multi-subscription-token-vault', () => ({
@@ -10042,7 +10278,7 @@ describe('RewardsController', () => {
       expect(result).toBe(mockSubscriptionId); // Should still succeed even if token storage fails
     });
 
-    it('should handle mixed account types with proper sorting', async () => {
+    it('handles mixed account types with proper sorting', async () => {
       // Arrange
       const mockSolanaAccount = {
         address: 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH',
@@ -10087,7 +10323,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle empty remaining accounts array', async () => {
+    it('handles empty remaining accounts array', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
@@ -10116,7 +10352,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle InvalidTimestampError retry with server timestamp in #optIn', async () => {
+    it('handles InvalidTimestampError retry with server timestamp in #optIn', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       const mockError = new InvalidTimestampError('Invalid timestamp', 12345);
@@ -10148,7 +10384,7 @@ describe('RewardsController', () => {
       expect(callCount).toBe(2); // Should retry once with server timestamp
     });
 
-    it('should handle InvalidTimestampError exceeding max retry attempts', async () => {
+    it('handles InvalidTimestampError exceeding max retry attempts', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       const mockError = new InvalidTimestampError('Invalid timestamp', 12345);
@@ -10173,7 +10409,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle non-InvalidTimestampError without retry', async () => {
+    it('handles non-InvalidTimestampError without retry', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       const mockError = new Error('Network error');
@@ -10198,7 +10434,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle #optIn returning null when rewards disabled', async () => {
+    it('handles #optIn returning null when rewards disabled', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
 
@@ -10230,7 +10466,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle convertInternalAccountToCaipAccountId returning null in #optIn', async () => {
+    it('handles convertInternalAccountToCaipAccountId returning null in #optIn', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
 
@@ -10260,7 +10496,7 @@ describe('RewardsController', () => {
       expect(result).toBe(mockSubscriptionId); // Should still succeed even if convertInternalAccountToCaipAccountId returns null
     });
 
-    it('should handle #optIn with missing subscription or sessionId in response', async () => {
+    it('handles #optIn with missing subscription or sessionId in response', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       const incompleteResponse = {
@@ -10289,7 +10525,7 @@ describe('RewardsController', () => {
       expect(result).toBe(mockSubscriptionId); // Should still succeed even if sessionId is missing
     });
 
-    it('should handle #optIn with missing subscription id in response', async () => {
+    it('handles #optIn with missing subscription id in response', async () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       const incompleteResponse = {
@@ -10432,7 +10668,7 @@ describe('RewardsController', () => {
       },
     } as unknown as InternalAccount;
 
-    it('should return empty array when accounts array is empty', async () => {
+    it('returns empty array when accounts array is empty', async () => {
       // Act
       const result = await controller.linkAccountsToSubscriptionCandidate([]);
 
@@ -10440,7 +10676,7 @@ describe('RewardsController', () => {
       expect(result).toEqual([]);
     });
 
-    it('should return all accounts as failed when rewards feature is disabled', async () => {
+    it('returns all accounts as failed when rewards feature is disabled', async () => {
       // Arrange
       const accounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
 
@@ -10455,7 +10691,7 @@ describe('RewardsController', () => {
       ]);
     });
 
-    it('should successfully link multiple accounts', async () => {
+    it('successfully link multiple accounts', async () => {
       // Arrange
       const accounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
       const testSubscriptionId = 'test-subscription-id';
@@ -10508,7 +10744,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should skip accounts that already have a subscription', async () => {
+    it('skips accounts that already have a subscription', async () => {
       // Arrange
       const accounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
       // Set up controller state with one account already having a subscription
@@ -10562,7 +10798,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle mixed account types correctly', async () => {
+    it('handles mixed account types correctly', async () => {
       // Arrange
       const accounts = [mockEvmInternalAccount, mockSolanaAccount];
       const testSubscriptionId = 'test-subscription-id';
@@ -10601,7 +10837,7 @@ describe('RewardsController', () => {
       ]);
     });
 
-    it('should handle convertInternalAccountToCaipAccountId returning null', async () => {
+    it('handles convertInternalAccountToCaipAccountId returning null', async () => {
       // Arrange
       const accounts = [mockEvmInternalAccount];
       const testSubscriptionId = 'test-subscription-id';
@@ -10635,7 +10871,7 @@ describe('RewardsController', () => {
       ]);
     });
 
-    it('should handle linkAccountToSubscriptionCandidate returning false', async () => {
+    it('handles linkAccountToSubscriptionCandidate returning false', async () => {
       // Arrange
       const accounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
       const testSubscriptionId = 'test-subscription-id';
@@ -10677,7 +10913,7 @@ describe('RewardsController', () => {
   });
 
   describe('optOut', () => {
-    it('should return false when subscription ID is not found', async () => {
+    it('returns false when subscription ID is not found', async () => {
       // Arrange
       const testController = new TestableRewardsController({
         messenger: mockMessenger,
@@ -10696,7 +10932,7 @@ describe('RewardsController', () => {
       // Skip the log assertion since it's not critical to the test
     });
 
-    it('should handle service errors during opt-out', async () => {
+    it('handles service errors during opt-out', async () => {
       // Arrange
       const mockOptOutResponse = { success: false, error: 'Service error' };
       mockMessenger.call.mockResolvedValue(mockOptOutResponse);
@@ -10730,7 +10966,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should successfully opt out and reset state', async () => {
+    it('successfully opt out and reset state', async () => {
       // Arrange
       const mockOptOutResponse = { success: true };
       mockMessenger.call.mockResolvedValue(mockOptOutResponse);
@@ -10780,7 +11016,7 @@ describe('RewardsController', () => {
       expect(newState.accounts).toEqual({});
     });
 
-    it('should return false when opt-out service returns false', async () => {
+    it('returns false when opt-out service returns false', async () => {
       // Arrange
       const mockOptOutResponse = { success: false };
       mockMessenger.call.mockResolvedValue(mockOptOutResponse);
@@ -10818,7 +11054,7 @@ describe('RewardsController', () => {
       expect(mockRemoveSubscriptionToken).not.toHaveBeenCalled();
     });
 
-    it('should return false when subscription not found in map', async () => {
+    it('returns false when subscription not found in map', async () => {
       // Arrange
       const testController = new RewardsController({
         messenger: mockMessenger,
@@ -10878,7 +11114,7 @@ describe('RewardsController', () => {
       expect(result).toBe(true);
     });
 
-    it('should handle multiple subscriptions correctly', async () => {
+    it('handles multiple subscriptions correctly', async () => {
       // Arrange
       const subscriptionId1 = 'test-subscription-id';
       const subscriptionId2 = 'test-subscription-id-2';
@@ -10921,7 +11157,7 @@ describe('RewardsController', () => {
 
   describe('optIn and optOut edge cases', () => {
     describe('optIn edge cases', () => {
-      it('should handle empty account group gracefully', async () => {
+      it('handles empty account group gracefully', async () => {
         // Arrange
         const mockAccounts: InternalAccount[] = [];
 
@@ -10935,7 +11171,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should handle null account group gracefully', async () => {
+      it('handles null account group gracefully', async () => {
         // Arrange
         const mockAccounts = null as unknown as InternalAccount[];
 
@@ -10949,7 +11185,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should handle undefined account group gracefully', async () => {
+      it('handles undefined account group gracefully', async () => {
         // Arrange
         const mockAccounts = undefined as unknown as InternalAccount[];
 
@@ -10963,7 +11199,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should handle account group with unsupported accounts', async () => {
+      it('handles account group with unsupported accounts', async () => {
         // Arrange
         const unsupportedAccount = {
           address: 'unsupported-address',
@@ -10995,7 +11231,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should handle very long referral codes', async () => {
+      it('handles very long referral codes', async () => {
         // Arrange
         const longReferralCode = 'A'.repeat(1000); // Very long referral code
         const mockEvmInternalAccount = {
@@ -11038,7 +11274,7 @@ describe('RewardsController', () => {
         expect(result).toBe('test-subscription-id');
       });
 
-      it('should handle special characters in referral codes', async () => {
+      it('handles special characters in referral codes', async () => {
         // Arrange
         const specialReferralCode = 'REF@#$%^&*()_+-=[]{}|;:,.<>?';
         const mockEvmInternalAccount = {
@@ -11086,7 +11322,7 @@ describe('RewardsController', () => {
     });
 
     describe('optOut edge cases', () => {
-      it('should handle empty subscription ID', async () => {
+      it('handles empty subscription ID', async () => {
         // Arrange
         const testController = new TestableRewardsController({
           messenger: mockMessenger,
@@ -11107,7 +11343,7 @@ describe('RewardsController', () => {
         expect(mockMessenger.call).not.toHaveBeenCalled();
       });
 
-      it('should handle null subscription ID', async () => {
+      it('handles null subscription ID', async () => {
         // Arrange
         const testController = new TestableRewardsController({
           messenger: mockMessenger,
@@ -11128,7 +11364,7 @@ describe('RewardsController', () => {
         expect(mockMessenger.call).not.toHaveBeenCalled();
       });
 
-      it('should handle undefined subscription ID', async () => {
+      it('handles undefined subscription ID', async () => {
         // Arrange
         const testController = new TestableRewardsController({
           messenger: mockMessenger,
@@ -11149,7 +11385,7 @@ describe('RewardsController', () => {
         expect(mockMessenger.call).not.toHaveBeenCalled();
       });
 
-      it('should handle very long subscription ID', async () => {
+      it('handles very long subscription ID', async () => {
         // Arrange
         const longSubscriptionId = 'A'.repeat(1000);
         mockMessenger.call.mockResolvedValue({ success: true });
@@ -11180,7 +11416,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should handle special characters in subscription ID', async () => {
+      it('handles special characters in subscription ID', async () => {
         // Arrange
         const specialSubscriptionId = 'sub@#$%^&*()_+-=[]{}|;:,.<>?';
         mockMessenger.call.mockResolvedValue({ success: true });
@@ -11211,7 +11447,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should handle subscription ID with whitespace', async () => {
+      it('handles subscription ID with whitespace', async () => {
         // Arrange
         const subscriptionIdWithWhitespace = '  sub123  ';
         mockMessenger.call.mockResolvedValue({ success: true });
@@ -11247,7 +11483,7 @@ describe('RewardsController', () => {
   });
 
   describe('getCandidateSubscriptionId', () => {
-    it('should return null when feature flag is disabled', async () => {
+    it('returns null when feature flag is disabled', async () => {
       // Arrange
 
       // Act
@@ -11257,7 +11493,7 @@ describe('RewardsController', () => {
       expect(result).toBeNull();
     });
 
-    it('should fallback to first subscription ID from subscriptions map', async () => {
+    it('falls back to first subscription ID from subscriptions map', async () => {
       // Arrange
       const testController = new RewardsController({
         messenger: mockMessenger,
@@ -11292,7 +11528,7 @@ describe('RewardsController', () => {
       expect(result).toBe('fallback-sub-123');
     });
 
-    it('should return null when no subscriptions found and no accounts opted in', async () => {
+    it('returns null when no subscriptions found and no accounts opted in', async () => {
       // Arrange
       const mockInternalAccounts = [
         {
@@ -11410,7 +11646,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return active account subscription ID when available', async () => {
+    it('returns active account subscription ID when available', async () => {
       // Arrange
       const activeSubscriptionId = 'active-sub-123';
       const testController = new RewardsController({
@@ -11447,7 +11683,7 @@ describe('RewardsController', () => {
       expect(result).toBe(activeSubscriptionId);
     });
 
-    it('should return first opted-in account when no subscriptions found', async () => {
+    it('returns first opted-in account when no subscriptions found', async () => {
       // Arrange
       const mockSubscriptionId = 'new-sub-123';
 
@@ -11481,7 +11717,7 @@ describe('RewardsController', () => {
       expect(result).toBe(mockSubscriptionId);
     });
 
-    it('should return null when no accounts are available', async () => {
+    it('returns null when no accounts are available', async () => {
       // Arrange
       mockMessenger.call.mockReturnValueOnce([]); // Empty accounts array
 
@@ -11502,7 +11738,7 @@ describe('RewardsController', () => {
       expect(result).toBeNull();
     });
 
-    it('should handle error when getting opt-in status fails', async () => {
+    it('handles error when getting opt-in status fails', async () => {
       // Arrange
       // Create a test controller with a custom implementation
       class TestRewardsController extends RewardsController {
@@ -11543,7 +11779,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should skip accounts that fail silent auth and continue to next account', async () => {
+    it('skips accounts that fail silent auth and continue to next account', async () => {
       // Arrange
       const mockSubscriptionId = 'success-sub-123';
 
@@ -11585,7 +11821,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle case when account is undefined during iteration', async () => {
+    it('handles case when account is undefined during iteration', async () => {
       // Arrange
       const mockSubscriptionId = 'success-sub-123';
 
@@ -11621,7 +11857,7 @@ describe('RewardsController', () => {
       expect(result).toBe(mockSubscriptionId);
     });
 
-    it('should process only the first 10 opted-in accounts', async () => {
+    it('processes only the first 10 opted-in accounts', async () => {
       // Arrange
       const mockSubscriptionId = 'success-sub-123';
       let processedAccounts = 0;
@@ -11668,7 +11904,7 @@ describe('RewardsController', () => {
       expect(processedAccounts).toBe(5); // Should stop after finding subscription
     });
 
-    it('should return first successful subscription ID and stop processing', async () => {
+    it('returns first successful subscription ID and stop processing', async () => {
       // Arrange
       const mockSubscriptionId = 'success-sub-123';
       const processedAccounts: string[] = [];
@@ -11769,7 +12005,7 @@ describe('RewardsController', () => {
       expect(processedAccounts).toEqual(['0x123', '0x456']); // Should process first two accounts only
     });
 
-    it('should handle timeout errors during candidate subscription search', async () => {
+    it('handles timeout errors during candidate subscription search', async () => {
       // Arrange
       const timeoutError = new Error(
         'Request timeout during subscription search',
@@ -11816,7 +12052,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle API errors during candidate subscription search', async () => {
+    it('handles API errors during candidate subscription search', async () => {
       // Arrange
       const apiError = new Error('API returned 500: Internal server error');
       // Create a test controller with a custom implementation
@@ -11861,7 +12097,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle network errors during candidate subscription search', async () => {
+    it('handles network errors during candidate subscription search', async () => {
       // Arrange
       const networkError = new Error('Network connection failed');
       // Create a test controller with a custom implementation
@@ -11906,7 +12142,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should add delay between processing accounts except for the last one', async () => {
+    it('adds delay between processing accounts except for the last one', async () => {
       // Arrange
       const mockSubscriptionId = 'success-sub-123';
       const delaysCalled: boolean[] = [];
@@ -12001,7 +12237,7 @@ describe('RewardsController', () => {
     });
 
     describe('candidate subscription ID coverage', () => {
-      it('should return null when no accounts are available', async () => {
+      it('returns null when no accounts are available', async () => {
         // Arrange - Test empty accounts array
         const mockInternalAccounts: never[] = [];
 
@@ -12033,7 +12269,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should handle undefined or null allAccounts response', async () => {
+      it('handles undefined or null allAccounts response', async () => {
         // Arrange - Test undefined response from listMultichainAccounts
         mockMessenger.call.mockReturnValueOnce(undefined); // listMultichainAccounts returns undefined
 
@@ -12063,7 +12299,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should log and return null when no opted-in accounts are found via getOptInStatus', async () => {
+    it('logs and return null when no opted-in accounts are found via getOptInStatus', async () => {
       // Arrange
       const mockAccounts = [
         { address: '0x123', type: 'eip155:eoa' as const },
@@ -12107,7 +12343,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should log when attempting silent auth and throw error when all silent auth attempts fail', async () => {
+    it('logs when attempting silent auth and throw error when all silent auth attempts fail', async () => {
       // Arrange
       const mockAccounts = [
         { address: '0x123', type: 'eip155:eoa' as const },
@@ -12149,7 +12385,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle getOptInStatus throwing an error and log failure', async () => {
+    it('handles getOptInStatus throwing an error and log failure', async () => {
       // Arrange
       const mockAccounts = [
         { address: '0x123', type: 'eip155:eoa' as const },
@@ -12191,7 +12427,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should exclude hardware accounts from getOptInStatus call', async () => {
+    it('excludes hardware accounts from getOptInStatus call', async () => {
       // Arrange
       const mockInternalAccounts = [
         {
@@ -12310,7 +12546,7 @@ describe('RewardsController', () => {
       mockIsSolanaAddress.mockReturnValue(false); // Default to non-Solana
     });
 
-    it('should return false when feature flag is disabled', async () => {
+    it('returns false when feature flag is disabled', async () => {
       // Arrange
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -12331,7 +12567,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should no longer block Solana accounts', async () => {
+    it('no longer block Solana accounts', async () => {
       // Arrange
       const solanaAccount = {
         ...mockInternalAccount,
@@ -12353,7 +12589,7 @@ describe('RewardsController', () => {
       }
     });
 
-    it('should return false when account is not supported for opt-in', async () => {
+    it('returns false when account is not supported for opt-in', async () => {
       // Arrange
       const testController = new RewardsController({
         messenger: mockMessenger,
@@ -12387,7 +12623,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle InvalidTimestampError and retry with server timestamp', async () => {
+    it('handles InvalidTimestampError and retry with server timestamp', async () => {
       // Arrange
       const mockError = new InvalidTimestampError(
         'Invalid timestamp',
@@ -12440,7 +12676,7 @@ describe('RewardsController', () => {
       }
     });
 
-    it('should return true if account already has subscription', async () => {
+    it('returns true if account already has subscription', async () => {
       // Arrange
       const testController = new RewardsController({
         messenger: mockMessenger,
@@ -12483,7 +12719,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should throw error when no candidate subscription found', async () => {
+    it('throws error when no candidate subscription found', async () => {
       // Arrange
       const testController = new RewardsController({
         messenger: mockMessenger,
@@ -12504,7 +12740,7 @@ describe('RewardsController', () => {
       ).rejects.toThrow('No valid subscription found to link account to');
     });
 
-    it('should successfully link account to subscription', async () => {
+    it('successfully link account to subscription', async () => {
       // Arrange
       const mockUpdatedSubscription = {
         id: 'candidate-sub-123',
@@ -12569,7 +12805,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should not invalidate cache or publish event when invalidateRelatedData is false', async () => {
+    it('does not invalidate cache or publish event when invalidateRelatedData is false', async () => {
       // Arrange
       const mockUpdatedSubscription = {
         id: 'candidate-sub-123',
@@ -12636,7 +12872,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should invalidate cache and publish event when invalidateRelatedData is true', async () => {
+    it('invalidates cache and publish event when invalidateRelatedData is true', async () => {
       // Arrange
       const subscriptionId = 'candidate-sub-123';
       const currentSeasonCompositeKey = `current:${subscriptionId}`;
@@ -12749,7 +12985,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle mobile join errors gracefully', async () => {
+    it('handles mobile join errors gracefully', async () => {
       // Arrange
       const mockError = new Error('Mobile join failed');
 
@@ -12791,7 +13027,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should invalidate subscription cache after successful account linking', async () => {
+    it('invalidates subscription cache after successful account linking', async () => {
       // Arrange
       const subscriptionId = 'candidate-sub-123';
       const currentSeasonCompositeKey = `current:${subscriptionId}`;
@@ -12905,7 +13141,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should invalidate cache for all seasons when no seasonId is provided', async () => {
+    it('invalidates cache for all seasons when no seasonId is provided', async () => {
       // Arrange
       const subscriptionId = 'test-sub-456';
       const season1Key = `season-1:${subscriptionId}`;
@@ -13287,7 +13523,7 @@ describe('RewardsController', () => {
       mockIsSolanaAddress.mockReturnValue(false);
     });
 
-    it('should return all accounts as failed when feature flag is disabled', async () => {
+    it('returns all accounts as failed when feature flag is disabled', async () => {
       // Arrange
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -13310,7 +13546,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return empty array when accounts array is empty', async () => {
+    it('returns empty array when accounts array is empty', async () => {
       // Arrange
       const accounts: InternalAccount[] = [];
 
@@ -13322,7 +13558,7 @@ describe('RewardsController', () => {
       expect(result).toEqual([]);
     });
 
-    it('should not invalidate cache or emit event when no accounts are successfully linked', async () => {
+    it('does not invalidate cache or emit event when no accounts are successfully linked', async () => {
       // Arrange
       const accounts = [mockInternalAccount1, mockInternalAccount2];
 
@@ -13371,7 +13607,7 @@ describe('RewardsController', () => {
     const mockParams = { addresses: ['0x123', '0x456'] };
     const mockResponse = { ois: [true, false], sids: ['sub_123', null] };
 
-    it('should return false array when feature flag is disabled', async () => {
+    it('returns false array when feature flag is disabled', async () => {
       // Arrange
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -13386,7 +13622,7 @@ describe('RewardsController', () => {
       expect(result).toEqual({ ois: [false, false], sids: [null, null] });
     });
 
-    it('should successfully get opt-in status from service', async () => {
+    it('successfully get opt-in status from service', async () => {
       // Arrange
       const mockAccounts = [
         {
@@ -13433,7 +13669,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should cache subscription IDs from sids array in account state', async () => {
+    it('caches subscription IDs from sids array in account state', async () => {
       // Arrange
       const mockAccounts = [
         {
@@ -13490,7 +13726,7 @@ describe('RewardsController', () => {
       expect(account2State.subscriptionId).toBe(null);
     });
 
-    it('should handle service errors and rethrow them', async () => {
+    it('handles service errors and rethrow them', async () => {
       // Arrange
       const mockError = new Error('Service error');
       const mockAccounts = [
@@ -13538,7 +13774,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle non-Error objects in catch block', async () => {
+    it('handles non-Error objects in catch block', async () => {
       // Arrange
       const mockError = 'String error';
       const mockAccounts = [
@@ -13562,7 +13798,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should use cached data when account state has hasOptedIn defined', async () => {
+    it('uses cached data when account state has hasOptedIn defined', async () => {
       // Arrange
       const mockParams = { addresses: ['0x123', '0x456'] };
       const mockAccounts = [
@@ -13643,7 +13879,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should update existing account state when fresh data is fetched', async () => {
+    it('updates existing account state when fresh data is fetched', async () => {
       // Arrange
       const mockParams = { addresses: ['0x123'] };
       const mockAccounts = [
@@ -13704,7 +13940,7 @@ describe('RewardsController', () => {
       expect(updatedAccountState.lastFreshOptInStatusCheck).toBeDefined();
     });
 
-    it('should use cached results in final combination loop', async () => {
+    it('uses cached results in final combination loop', async () => {
       // Arrange
       const mockParams = { addresses: ['0x123', '0x456', '0x789'] };
       const mockAccounts = [
@@ -13803,7 +14039,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should update activeAccount when it matches an account being checked', async () => {
+    it('updates activeAccount when it matches an account being checked', async () => {
       // Arrange
       const mockParams = { addresses: ['0x123', '0x456'] };
       const mockAccounts = [
@@ -13877,7 +14113,7 @@ describe('RewardsController', () => {
       expect(account456State.subscriptionId).toBe(null);
     });
 
-    it('should not update activeAccount when it does not match any account being checked', async () => {
+    it('does not update activeAccount when it does not match any account being checked', async () => {
       // Arrange
       const mockParams = { addresses: ['0x123', '0x999'] };
       const mockAccounts = [
@@ -13970,7 +14206,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should fetch active points boosts successfully', async () => {
+    it('fetches active points boosts successfully', async () => {
       // Arrange
       const seasonId = 'season-123';
       const subscriptionId = 'sub-456';
@@ -14022,7 +14258,7 @@ describe('RewardsController', () => {
       expect(result[1].seasonLong).toBe(false);
     });
 
-    it('should return empty array when no boosts available', async () => {
+    it('returns empty array when no boosts available', async () => {
       // Arrange
       const seasonId = 'season-123';
       const subscriptionId = 'sub-456';
@@ -14042,7 +14278,7 @@ describe('RewardsController', () => {
       expect(result).toHaveLength(0);
     });
 
-    it('should handle data service errors', async () => {
+    it('handles data service errors', async () => {
       // Arrange
       const seasonId = 'season-123';
       const subscriptionId = 'sub-456';
@@ -14062,7 +14298,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle network timeout errors', async () => {
+    it('handles network timeout errors', async () => {
       // Arrange
       const seasonId = 'season-123';
       const subscriptionId = 'sub-456';
@@ -14076,7 +14312,7 @@ describe('RewardsController', () => {
       ).rejects.toThrow('Request timeout after 10000ms');
     });
 
-    it('should handle authentication errors', async () => {
+    it('handles authentication errors', async () => {
       // Arrange
       const seasonId = 'season-123';
       const subscriptionId = 'sub-456';
@@ -14090,7 +14326,7 @@ describe('RewardsController', () => {
       ).rejects.toThrow('Authentication failed');
     });
 
-    it('should pass through different season and subscription IDs correctly', async () => {
+    it('passes through different season and subscription IDs correctly', async () => {
       // Arrange
       const seasonId = 'winter-2024';
       const subscriptionId = 'premium-sub-789';
@@ -14127,7 +14363,7 @@ describe('RewardsController', () => {
       expect(result[0].name).toBe('Winter Special');
     });
 
-    it('should return empty array when rewards feature is disabled', async () => {
+    it('returns empty array when rewards feature is disabled', async () => {
       // Arrange
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -14152,7 +14388,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return cached active boosts when cache is fresh', async () => {
+    it('returns cached active boosts when cache is fresh', async () => {
       // Arrange
       const seasonId = 'season-123';
       const subscriptionId = 'sub-456';
@@ -14225,7 +14461,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should fetch fresh active boosts when cache is stale', async () => {
+    it('fetches fresh active boosts when cache is stale', async () => {
       // Arrange
       mockMessenger.call.mockClear();
       const seasonId = 'season-123';
@@ -14317,7 +14553,7 @@ describe('RewardsController', () => {
       expect(result[1].name).toBe('Fresh Boost 2');
     });
 
-    it('should update state when fetching fresh active boosts', async () => {
+    it('updates state when fetching fresh active boosts', async () => {
       // Arrange
       const seasonId = 'season-456';
       const subscriptionId = 'sub-789';
@@ -14394,7 +14630,7 @@ describe('RewardsController', () => {
       expect(cachedBoosts.boosts[1].endDate).toBe('2024-03-31');
     });
 
-    it('should handle cache miss and fetch fresh data', async () => {
+    it('handles cache miss and fetch fresh data', async () => {
       // Arrange
       const seasonId = 'new-season';
       const subscriptionId = 'new-sub';
@@ -14452,7 +14688,7 @@ describe('RewardsController', () => {
       expect(cachedBoosts.lastFetched).toBeGreaterThan(Date.now() - 1000);
     });
 
-    it('should handle different composite keys for different season/subscription combinations', async () => {
+    it('handles different composite keys for different season/subscription combinations', async () => {
       // Arrange
       mockMessenger.call.mockClear();
       const seasonId1 = 'season-A';
@@ -14584,7 +14820,7 @@ describe('RewardsController', () => {
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
     });
 
-    it('should return empty array when feature flag is disabled', async () => {
+    it('returns empty array when feature flag is disabled', async () => {
       const disabledController = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
@@ -14604,7 +14840,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return cached unlocked rewards when cache is fresh', async () => {
+    it('returns cached unlocked rewards when cache is fresh', async () => {
       const recentTime = Date.now() - 5000; // 5 seconds ago (within 1 minute threshold)
       const compositeKey = `${mockSeasonId}:${mockSubscriptionId}`;
 
@@ -14659,7 +14895,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should fetch fresh unlocked rewards when cache is stale', async () => {
+    it('fetches fresh unlocked rewards when cache is stale', async () => {
       const staleTime = Date.now() - 120000; // 2 minutes ago (beyond 1 minute threshold)
       const compositeKey = `${mockSeasonId}:${mockSubscriptionId}`;
 
@@ -14734,7 +14970,7 @@ describe('RewardsController', () => {
       expect(updatedCache.lastFetched).toBeGreaterThan(Date.now() - 1000);
     });
 
-    it('should handle cache miss and fetch fresh data', async () => {
+    it('handles cache miss and fetch fresh data', async () => {
       const mockApiRewards = [
         {
           id: 'api-reward-1',
@@ -14778,7 +15014,7 @@ describe('RewardsController', () => {
       expect(cachedData.lastFetched).toBeGreaterThan(Date.now() - 1000);
     });
 
-    it('should throw error when API fails', async () => {
+    it('throws error when API fails', async () => {
       controller = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
@@ -14797,7 +15033,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle null API response', async () => {
+    it('handles null API response', async () => {
       controller = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
@@ -14819,7 +15055,7 @@ describe('RewardsController', () => {
       expect(cachedData.rewards).toEqual([]);
     });
 
-    it('should handle empty rewards array from API', async () => {
+    it('handles empty rewards array from API', async () => {
       controller = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
@@ -14843,7 +15079,7 @@ describe('RewardsController', () => {
       expect(cachedData.lastFetched).toBeGreaterThan(Date.now() - 1000);
     });
 
-    it('should handle multiple concurrent calls with different parameters', async () => {
+    it('handles multiple concurrent calls with different parameters', async () => {
       const seasonId1 = 'season-A';
       const subscriptionId1 = 'sub-X';
       const seasonId2 = 'season-B';
@@ -14932,7 +15168,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should use current season ID as default', async () => {
+    it('uses current season ID as default', async () => {
       const currentSeasonId = 'current';
       const mockRewards = [
         {
@@ -14974,7 +15210,7 @@ describe('RewardsController', () => {
       mockLogger.log.mockClear();
     });
 
-    it('should successfully claim reward without DTO', async () => {
+    it('successfully claim reward without DTO', async () => {
       // Arrange
       controller = new RewardsController({
         messenger: mockMessenger,
@@ -15009,7 +15245,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should successfully claim reward with DTO', async () => {
+    it('successfully claim reward with DTO', async () => {
       // Arrange
       const mockDto = {
         data: {
@@ -15051,7 +15287,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should invalidate subscription cache after successful claim', async () => {
+    it('invalidates subscription cache after successful claim', async () => {
       const currentSeasonCompositeKey = `current:${mockSubscriptionId}`;
       const initialState = {
         activeAccount: null,
@@ -15129,7 +15365,7 @@ describe('RewardsController', () => {
       ).toBeUndefined();
     });
 
-    it('should throw error when rewards are not enabled', async () => {
+    it('throws error when rewards are not enabled', async () => {
       // Arrange
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -15146,7 +15382,7 @@ describe('RewardsController', () => {
       expect(mockMessenger.publish).not.toHaveBeenCalled();
     });
 
-    it('should handle and re-throw API errors', async () => {
+    it('handles and re-throw API errors', async () => {
       // Arrange
       const mockError = new Error('API Error: Reward already claimed');
       controller = new RewardsController({
@@ -15174,7 +15410,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle non-Error objects in catch block', async () => {
+    it('handles non-Error objects in catch block', async () => {
       // Arrange
       const mockError = 'String error';
       controller = new RewardsController({
@@ -15192,7 +15428,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle empty DTO object', async () => {
+    it('handles empty DTO object', async () => {
       // Arrange
       const emptyDto = {};
       controller = new RewardsController({
@@ -15215,7 +15451,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle DTO with nested data structure', async () => {
+    it('handles DTO with nested data structure', async () => {
       // Arrange
       const complexDto = {
         data: {
@@ -15254,7 +15490,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should invalidate cache for current season by default', async () => {
+    it('invalidates cache for current season by default', async () => {
       // Arrange
       const currentSeasonCompositeKey = `current:${mockSubscriptionId}`;
       const initialState = {
@@ -15311,7 +15547,7 @@ describe('RewardsController', () => {
       ).toBeUndefined();
     });
 
-    it('should log cache invalidation', async () => {
+    it('logs cache invalidation', async () => {
       // Arrange
       controller = new RewardsController({
         messenger: mockMessenger,
@@ -15340,7 +15576,7 @@ describe('RewardsController', () => {
       mockLogger.log.mockClear();
     });
 
-    it('should successfully get Season 1 Linea reward tokens', async () => {
+    it('successfully get Season 1 Linea reward tokens', async () => {
       // Arrange
       const mockLineaTokenReward: LineaTokenRewardDto = {
         subscriptionId: mockSubscriptionId,
@@ -15366,7 +15602,7 @@ describe('RewardsController', () => {
       expect(result).toEqual(mockLineaTokenReward);
     });
 
-    it('should throw error when rewards are not enabled', async () => {
+    it('throws error when rewards are not enabled', async () => {
       // Arrange
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -15382,7 +15618,7 @@ describe('RewardsController', () => {
       expect(mockMessenger.call).not.toHaveBeenCalled();
     });
 
-    it('should handle and re-throw API errors', async () => {
+    it('handles and re-throw API errors', async () => {
       // Arrange
       const mockError = new Error('API Error: Failed to get tokens');
       controller = new RewardsController({
@@ -15407,7 +15643,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle non-Error objects in catch block', async () => {
+    it('handles non-Error objects in catch block', async () => {
       // Arrange
       const mockError = 'String error';
       controller = new RewardsController({
@@ -15428,7 +15664,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return null when data service returns null', async () => {
+    it('returns null when data service returns null', async () => {
       // Arrange
       controller = new RewardsController({
         messenger: mockMessenger,
@@ -15449,7 +15685,7 @@ describe('RewardsController', () => {
       expect(result).toBeNull();
     });
 
-    it('should handle different subscription IDs correctly', async () => {
+    it('handles different subscription IDs correctly', async () => {
       // Arrange
       const differentSubscriptionId = 'different-subscription-456';
       const mockLineaTokenReward: LineaTokenRewardDto = {
@@ -15567,7 +15803,7 @@ describe('RewardsController', () => {
       jest.resetAllMocks();
     });
 
-    it('should sign EVM message correctly', async () => {
+    it('signs EVM message correctly', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0x123',
@@ -15619,7 +15855,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should sign Solana message correctly', async () => {
+    it('signs Solana message correctly', async () => {
       // Arrange
       const mockInternalAccount = {
         address: 'solana-address',
@@ -15988,7 +16224,7 @@ describe('RewardsController', () => {
       expect(mockSignTronRewardsMessage).not.toHaveBeenCalled();
     });
 
-    it('should throw error for unsupported account type', async () => {
+    it('throws error for unsupported account type', async () => {
       // Arrange
       const mockInternalAccount = {
         address: 'unsupported-address',
@@ -16021,7 +16257,7 @@ describe('RewardsController', () => {
       ).rejects.toThrow('Unsupported account type for signing rewards message');
     });
 
-    it('should handle errors from KeyringController when signing EVM message', async () => {
+    it('handles errors from KeyringController when signing EVM message', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0x123',
@@ -16059,7 +16295,7 @@ describe('RewardsController', () => {
   });
 
   describe('#invalidateSubscriptionCache', () => {
-    it('should invalidate specific season data when seasonId is provided', async () => {
+    it('invalidates specific season data when seasonId is provided', async () => {
       // Arrange
       const subscriptionId = 'test-subscription-id';
       const seasonId = 'test-season-id';
@@ -16113,7 +16349,7 @@ describe('RewardsController', () => {
       expect(testController.state.pointsEvents[compositeKey]).toBeUndefined();
     });
 
-    it('should invalidate all seasons when seasonId is not provided', async () => {
+    it('invalidates all seasons when seasonId is not provided', async () => {
       // Arrange
       const subscriptionId = 'test-subscription-id';
       const seasonId1 = 'season-1';
@@ -16204,7 +16440,7 @@ describe('RewardsController', () => {
       expect(testController.state.pointsEvents[compositeKey2]).toBeUndefined();
     });
 
-    it('should handle empty state gracefully when invalidating specific season', async () => {
+    it('handles empty state gracefully when invalidating specific season', async () => {
       // Arrange
       const subscriptionId = 'test-subscription-id';
       const seasonId = 'test-season-id';
@@ -16233,7 +16469,7 @@ describe('RewardsController', () => {
       expect(Object.keys(controller.state.pointsEvents)).toHaveLength(0);
     });
 
-    it('should handle empty state gracefully when invalidating all seasons', async () => {
+    it('handles empty state gracefully when invalidating all seasons', async () => {
       // Arrange
       const subscriptionId = 'test-subscription-id';
 
@@ -16261,7 +16497,7 @@ describe('RewardsController', () => {
       expect(Object.keys(controller.state.pointsEvents)).toHaveLength(0);
     });
 
-    it('should only invalidate data for the specified subscription when invalidating all seasons', async () => {
+    it('only invalidate data for the specified subscription when invalidating all seasons', async () => {
       // Arrange
       const subscriptionId1 = 'test-subscription-1';
       const subscriptionId2 = 'test-subscription-2';
@@ -16349,7 +16585,7 @@ describe('RewardsController', () => {
       expect(testController.state.pointsEvents[compositeKey2]).toBeDefined();
     });
 
-    it('should invalidate multiple cache entries when subscription appears in multiple seasons', async () => {
+    it('invalidates multiple cache entries when subscription appears in multiple seasons', async () => {
       // Arrange
       const subscriptionId = 'test-subscription-id';
       const seasonId1 = 'season-1';
@@ -16424,7 +16660,7 @@ describe('RewardsController', () => {
       expect(testController.state.pointsEvents[compositeKey2]).toBeUndefined();
     });
 
-    it('should handle partial cache invalidation when only some cache types exist', async () => {
+    it('handles partial cache invalidation when only some cache types exist', async () => {
       // Arrange
       const subscriptionId = 'test-subscription-id';
       const seasonId = 'test-season-id';
@@ -16465,7 +16701,7 @@ describe('RewardsController', () => {
       expect(testController.state.pointsEvents[compositeKey]).toBeUndefined();
     });
 
-    it('should handle special characters in subscription and season IDs', async () => {
+    it('handles special characters in subscription and season IDs', async () => {
       // Arrange
       const subscriptionId = 'test-subscription-id-with-special-chars_123';
       const seasonId = 'test-season-id-with-hyphens_and_underscores';
@@ -16533,7 +16769,7 @@ describe('RewardsController', () => {
       mockLogger.log.mockClear();
     });
 
-    it('should return false for hardware accounts', () => {
+    it('returns false for hardware accounts', () => {
       // Arrange
       const hardwareAccount = {
         address: '0x123',
@@ -16559,7 +16795,7 @@ describe('RewardsController', () => {
       expect(mockIsHardwareAccount).toHaveBeenCalledWith('0x123');
     });
 
-    it('should return true for EVM accounts that are not hardware', () => {
+    it('returns true for EVM accounts that are not hardware', () => {
       // Arrange
       const evmAccount = {
         address: '0x123',
@@ -16588,7 +16824,7 @@ describe('RewardsController', () => {
       expect(mockIsNonEvmAddress).toHaveBeenCalledWith('0x123');
     });
 
-    it('should return true for Solana accounts that are not hardware', () => {
+    it('returns true for Solana accounts that are not hardware', () => {
       // Arrange
       // Note: Hardware wallets are not supported for Solana (or any non-EVM chains).
       // Only non-hardware Solana accounts can opt-in to rewards.
@@ -16873,7 +17109,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return false and log error when hardware account check throws an exception', () => {
+    it('returns false and log error when hardware account check throws an exception', () => {
       // Arrange
       const account = {
         address: '0x123',
@@ -16906,7 +17142,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should return false and log error when address validation throws an exception', () => {
+    it('returns false and log error when address validation throws an exception', () => {
       // Arrange
       const account = {
         address: '0x123',
@@ -16941,7 +17177,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should prioritize hardware check over other checks', () => {
+    it('prioritizes hardware check over other checks', () => {
       // Arrange - Hardware account that would otherwise be supported
       // Note: Hardware wallets only support EVM chains. Non-EVM chains (Bitcoin, Solana, Tron)
       // are not supported by hardware wallets and use Snap-based implementations instead.
@@ -16976,7 +17212,7 @@ describe('RewardsController', () => {
       expect(mockIsBtcAccount).not.toHaveBeenCalled();
     });
 
-    it('should return false for hardware accounts regardless of chain type', () => {
+    it('returns false for hardware accounts regardless of chain type', () => {
       // Arrange
       // Note: Hardware wallets (Ledger, QR-based) only support EVM chains.
       // Non-EVM chains (Bitcoin, Solana, Tron) are not supported by hardware wallets.
@@ -17012,7 +17248,7 @@ describe('RewardsController', () => {
   });
 
   describe('getActualSubscriptionId', () => {
-    it('should return subscription ID for existing account', () => {
+    it('returns subscription ID for existing account', () => {
       // Arrange
       const accountState = {
         account: CAIP_ACCOUNT_1,
@@ -17037,7 +17273,7 @@ describe('RewardsController', () => {
       expect(result).toBe('test-sub-123');
     });
 
-    it('should return null for non-existent account', () => {
+    it('returns null for non-existent account', () => {
       // Arrange
       controller = new RewardsController({
         messenger: mockMessenger,
@@ -17051,7 +17287,7 @@ describe('RewardsController', () => {
       expect(result).toBeNull();
     });
 
-    it('should return null when account has no subscription ID', () => {
+    it('returns null when account has no subscription ID', () => {
       // Arrange
       const accountState = {
         account: CAIP_ACCOUNT_1,
@@ -17078,7 +17314,7 @@ describe('RewardsController', () => {
   });
 
   describe('getFirstSubscriptionId', () => {
-    it('should return first subscription ID when subscriptions exist', () => {
+    it('returns first subscription ID when subscriptions exist', () => {
       // Arrange
       const subscriptions = {
         'sub-123': {
@@ -17108,7 +17344,7 @@ describe('RewardsController', () => {
       expect(result).toBe('sub-123'); // First key in the object
     });
 
-    it('should return null when no subscriptions exist', () => {
+    it('returns null when no subscriptions exist', () => {
       // Arrange
       controller = new RewardsController({
         messenger: mockMessenger,
@@ -17515,7 +17751,7 @@ describe('RewardsController', () => {
         });
     });
 
-    it('should return all cached results when all addresses have cached opt-in status', () => {
+    it('returns all cached results when all addresses have cached opt-in status', () => {
       // Arrange
       const addresses = [ADDRESS_1, ADDRESS_2, ADDRESS_3];
       const addressToAccountMap = new Map([
@@ -17577,7 +17813,7 @@ describe('RewardsController', () => {
       expect(result.addressesNeedingFresh).toEqual([]);
     });
 
-    it('should return no cached results when no addresses have cached opt-in status', () => {
+    it('returns no cached results when no addresses have cached opt-in status', () => {
       // Arrange
       const addresses = [ADDRESS_1, ADDRESS_2, ADDRESS_3];
       const addressToAccountMap = new Map([
@@ -17612,7 +17848,7 @@ describe('RewardsController', () => {
       ]);
     });
 
-    it('should return mixed results when some addresses have cached opt-in status', () => {
+    it('returns mixed results when some addresses have cached opt-in status', () => {
       // Arrange
       const addresses = [ADDRESS_1, ADDRESS_2, ADDRESS_3];
       const addressToAccountMap = new Map([
@@ -17654,7 +17890,7 @@ describe('RewardsController', () => {
       expect(result.addressesNeedingFresh).toEqual([ADDRESS_2, ADDRESS_3]);
     });
 
-    it('should handle addresses with undefined hasOptedIn status', () => {
+    it('handles addresses with undefined hasOptedIn status', () => {
       // Arrange
       const addresses = [ADDRESS_1, ADDRESS_2];
       const addressToAccountMap = new Map([
@@ -17703,7 +17939,7 @@ describe('RewardsController', () => {
       expect(result.addressesNeedingFresh).toEqual([ADDRESS_1]);
     });
 
-    it('should handle addresses not found in addressToAccountMap', () => {
+    it('handles addresses not found in addressToAccountMap', () => {
       // Arrange
       const addresses = [ADDRESS_1, ADDRESS_2, ADDRESS_3];
       const addressToAccountMap = new Map([
@@ -17742,7 +17978,7 @@ describe('RewardsController', () => {
       expect(result.addressesNeedingFresh).toEqual([ADDRESS_2, ADDRESS_3]);
     });
 
-    it('should handle empty addresses array', () => {
+    it('handles empty addresses array', () => {
       // Arrange
       const addresses: string[] = [];
       const addressToAccountMap = new Map();
@@ -17759,7 +17995,7 @@ describe('RewardsController', () => {
       expect(result.addressesNeedingFresh).toEqual([]);
     });
 
-    it('should handle convertInternalAccountToCaipAccountId returning null', () => {
+    it('handles convertInternalAccountToCaipAccountId returning null', () => {
       // Arrange
       const addresses = [ADDRESS_1, ADDRESS_2];
       const addressToAccountMap = new Map([
@@ -17807,7 +18043,7 @@ describe('RewardsController', () => {
       expect(result.addressesNeedingFresh).toEqual([ADDRESS_1]);
     });
 
-    it('should preserve order of results matching input addresses order', () => {
+    it('preserves order of results matching input addresses order', () => {
       // Arrange
       const addresses = [ADDRESS_3, ADDRESS_1, ADDRESS_2]; // Different order
       const addressToAccountMap = new Map([

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -31,6 +31,7 @@ import {
   type SeasonMetadataDto,
   type SeasonStateDto,
   type LineaTokenRewardDto,
+  BASE32_REGEX,
 } from './types';
 import type { RewardsControllerMessenger } from '../../messengers/rewards-controller-messenger';
 import {
@@ -527,6 +528,10 @@ export class RewardsController extends BaseController<
       this.validateReferralCode.bind(this),
     );
     this.messenger.registerActionHandler(
+      'RewardsController:validateBonusCode',
+      this.validateBonusCode.bind(this),
+    );
+    this.messenger.registerActionHandler(
       'RewardsController:linkAccountToSubscriptionCandidate',
       this.linkAccountToSubscriptionCandidate.bind(this),
     );
@@ -601,6 +606,10 @@ export class RewardsController extends BaseController<
     this.messenger.registerActionHandler(
       'RewardsController:getDefaultRewardsEnvUrl',
       this.getDefaultRewardsEnvUrl.bind(this),
+    );
+    this.messenger.registerActionHandler(
+      'RewardsController:applyBonusCode',
+      this.applyBonusCode.bind(this),
     );
   }
 
@@ -2645,6 +2654,10 @@ export class RewardsController extends BaseController<
       return false;
     }
 
+    if (!BASE32_REGEX.test(code)) {
+      return false;
+    }
+
     try {
       const response = await this.messenger.call(
         'RewardsDataService:validateReferralCode',
@@ -2654,6 +2667,49 @@ export class RewardsController extends BaseController<
     } catch (error) {
       Logger.log(
         'RewardsController: Failed to validate referral code:',
+        error instanceof Error ? error.message : String(error),
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Validate a bonus code
+   * @param code - The bonus code to validate
+   * @param subscriptionId - The subscription ID for authentication
+   * @returns Promise<boolean> - True if the code is valid, false otherwise
+   */
+  async validateBonusCode(
+    code: string,
+    subscriptionId: string,
+  ): Promise<boolean> {
+    const rewardsEnabled = this.isRewardsFeatureEnabled();
+    if (!rewardsEnabled) {
+      return false;
+    }
+
+    if (!code.trim()) {
+      return false;
+    }
+
+    if (code.length < 4 || code.length > 16) {
+      return false;
+    }
+
+    if (!/^[A-Za-z0-9]+$/.test(code)) {
+      return false;
+    }
+
+    try {
+      const response = await this.messenger.call(
+        'RewardsDataService:validateBonusCode',
+        code,
+        subscriptionId,
+      );
+      return response.valid;
+    } catch (error) {
+      Logger.log(
+        'RewardsController: Failed to validate bonus code:',
         error instanceof Error ? error.message : String(error),
       );
       throw error;
@@ -3340,6 +3396,45 @@ export class RewardsController extends BaseController<
     } catch (error) {
       Logger.log(
         'RewardsController: Failed to apply referral code:',
+        error instanceof Error ? error.message : String(error),
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Apply a bonus code to a subscription.
+   * @param bonusCode - The bonus code to apply.
+   * @param subscriptionId - The subscription ID to apply the bonus code to.
+   * @returns Promise that resolves when the bonus code is applied successfully.
+   * @throws Error with the error message from the API response.
+   */
+  async applyBonusCode(
+    bonusCode: string,
+    subscriptionId: string,
+  ): Promise<void> {
+    const rewardsEnabled = this.isRewardsFeatureEnabled();
+    if (!rewardsEnabled) {
+      throw new Error('Rewards are not enabled');
+    }
+
+    try {
+      await this.messenger.call(
+        'RewardsDataService:applyBonusCode',
+        { bonusCode },
+        subscriptionId,
+      );
+
+      // Invalidate caches so hooks refetch fresh data on next render
+      this.invalidateSubscriptionCache(subscriptionId);
+
+      Logger.log(
+        'RewardsController: Successfully applied bonus code',
+        subscriptionId,
+      );
+    } catch (error) {
+      Logger.log(
+        'RewardsController: Failed to apply bonus code:',
         error instanceof Error ? error.message : String(error),
       );
       throw error;

--- a/app/core/Engine/controllers/rewards-controller/services/index.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/index.ts
@@ -12,6 +12,8 @@ export type {
   RewardsDataServiceLogoutAction,
   RewardsDataServiceFetchGeoLocationAction,
   RewardsDataServiceValidateReferralCodeAction,
+  RewardsDataServiceValidateBonusCodeAction,
+  RewardsDataServiceApplyBonusCodeAction,
   RewardsDataServiceMobileJoinAction,
   RewardsDataServiceGetOptInStatusAction,
   RewardsDataServiceOptOutAction,

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -202,6 +202,18 @@ describe('RewardsDataService', () => {
         'RewardsDataService:setRewardsEnvUrl',
         expect.any(Function),
       );
+      expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
+        'RewardsDataService:getDefaultRewardsEnvUrl',
+        expect.any(Function),
+      );
+      expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
+        'RewardsDataService:validateBonusCode',
+        expect.any(Function),
+      );
+      expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
+        'RewardsDataService:applyBonusCode',
+        expect.any(Function),
+      );
     });
   });
 
@@ -2583,6 +2595,140 @@ describe('RewardsDataService', () => {
     });
   });
 
+  describe('validateBonusCode', () => {
+    const mockSubscriptionId = 'test-subscription-123';
+    const mockToken = 'test-access-token';
+
+    beforeEach(() => {
+      mockGetSubscriptionToken.mockResolvedValue({
+        success: true,
+        token: mockToken,
+      });
+    });
+
+    it('should successfully validate a bonus code', async () => {
+      // Arrange
+      const bonusCode = 'BONUS123';
+      const mockValidationResponse = { valid: true };
+
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockValidationResponse),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await service.validateBonusCode(
+        bonusCode,
+        mockSubscriptionId,
+      );
+
+      // Assert
+      expect(result).toEqual(mockValidationResponse);
+      expect(mockGetSubscriptionToken).toHaveBeenCalledWith(mockSubscriptionId);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.rewards.test/subscriptions/bonus-code?code=BONUS123',
+        expect.objectContaining({
+          method: 'GET',
+          credentials: 'omit',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            'rewards-client-id': 'mobile-7.50.1',
+            'rewards-access-token': mockToken,
+          }),
+        }),
+      );
+    });
+
+    it('should return invalid response for invalid codes', async () => {
+      // Arrange
+      const bonusCode = 'INVALID';
+      const mockValidationResponse = { valid: false };
+
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockValidationResponse),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await service.validateBonusCode(
+        bonusCode,
+        mockSubscriptionId,
+      );
+
+      // Assert
+      expect(result).toEqual(mockValidationResponse);
+      expect(result.valid).toBe(false);
+    });
+
+    it('should properly encode special characters in bonus code', async () => {
+      // Arrange
+      const bonusCode = 'A+B/C=';
+      const mockValidationResponse = { valid: true };
+
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockValidationResponse),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await service.validateBonusCode(
+        bonusCode,
+        mockSubscriptionId,
+      );
+
+      // Assert
+      expect(result).toEqual(mockValidationResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.rewards.test/subscriptions/bonus-code?code=A%2BB%2FC%3D',
+        expect.any(Object),
+      );
+    });
+
+    it('should handle validation errors', async () => {
+      // Arrange
+      const bonusCode = 'BONUS123';
+      const mockResponse = {
+        ok: false,
+        status: 400,
+      } as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act & Assert
+      await expect(
+        service.validateBonusCode(bonusCode, mockSubscriptionId),
+      ).rejects.toThrow(
+        'Failed to validate bonus code. Please try again shortly.',
+      );
+    });
+
+    it('should handle network errors during validation', async () => {
+      // Arrange
+      const bonusCode = 'BONUS123';
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      // Act & Assert
+      await expect(
+        service.validateBonusCode(bonusCode, mockSubscriptionId),
+      ).rejects.toThrow('Network error');
+    });
+
+    it('should handle timeout errors during validation', async () => {
+      // Arrange
+      const bonusCode = 'BONUS123';
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      mockFetch.mockRejectedValue(abortError);
+
+      // Act & Assert
+      await expect(
+        service.validateBonusCode(bonusCode, mockSubscriptionId),
+      ).rejects.toThrow('Request timeout after 10000ms');
+    });
+  });
+
   describe('getOptInStatus', () => {
     const mockOptInStatusRequest = {
       addresses: ['0x123456789', '0x987654321', '0xabcdefabc'],
@@ -3938,6 +4084,149 @@ describe('RewardsDataService', () => {
       // Act
       await service.applyReferralCode(
         { referralCode: mockReferralCode },
+        mockSubscriptionId,
+      );
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            'rewards-access-token': expect.any(String),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('applyBonusCode', () => {
+    const mockSubscriptionId = 'test-subscription-123';
+    const mockToken = 'test-access-token';
+    const mockBonusCode = 'BNS123';
+
+    beforeEach(() => {
+      mockGetSubscriptionToken.mockResolvedValue({
+        success: true,
+        token: mockToken,
+      });
+    });
+
+    it('should successfully apply bonus code', async () => {
+      // Arrange
+      const mockResponse = {
+        ok: true,
+        status: 204,
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act
+      await service.applyBonusCode(
+        { bonusCode: mockBonusCode },
+        mockSubscriptionId,
+      );
+
+      // Assert
+      expect(mockGetSubscriptionToken).toHaveBeenCalledWith(mockSubscriptionId);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.rewards.test/wr/subscriptions/apply-bonus-code',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ bonusCode: mockBonusCode }),
+          headers: expect.objectContaining({
+            'Accept-Language': 'en-US',
+            'Content-Type': 'application/json',
+            'rewards-client-id': 'mobile-7.50.1',
+            'rewards-access-token': mockToken,
+          }),
+          credentials: 'omit',
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
+
+    it('should throw error for invalid bonus code', async () => {
+      // Arrange
+      const mockResponse = {
+        ok: false,
+        status: 400,
+        json: jest.fn().mockResolvedValue({ message: 'Invalid bonus code' }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act & Assert
+      await expect(
+        service.applyBonusCode(
+          { bonusCode: mockBonusCode },
+          mockSubscriptionId,
+        ),
+      ).rejects.toThrow('Invalid bonus code');
+    });
+
+    it('should throw error with server message for other errors', async () => {
+      // Arrange
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        json: jest.fn().mockResolvedValue({ message: 'Internal server error' }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act & Assert
+      await expect(
+        service.applyBonusCode(
+          { bonusCode: mockBonusCode },
+          mockSubscriptionId,
+        ),
+      ).rejects.toThrow('Internal server error');
+    });
+
+    it('should throw error with status code when no error message', async () => {
+      // Arrange
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        json: jest.fn().mockResolvedValue({}),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act & Assert
+      await expect(
+        service.applyBonusCode(
+          { bonusCode: mockBonusCode },
+          mockSubscriptionId,
+        ),
+      ).rejects.toThrow('Apply bonus code failed: 500');
+    });
+
+    it('should throw error when fetch fails', async () => {
+      // Arrange
+      const fetchError = new Error('Network error');
+      mockFetch.mockRejectedValue(fetchError);
+
+      // Act & Assert
+      await expect(
+        service.applyBonusCode(
+          { bonusCode: mockBonusCode },
+          mockSubscriptionId,
+        ),
+      ).rejects.toThrow('Network error');
+    });
+
+    it('should handle missing subscription token gracefully', async () => {
+      // Arrange
+      mockGetSubscriptionToken.mockResolvedValue({
+        success: false,
+        token: undefined,
+      });
+      const mockResponse = {
+        ok: true,
+        status: 204,
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act
+      await service.applyBonusCode(
+        { bonusCode: mockBonusCode },
         mockSubscriptionId,
       );
 

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -2627,7 +2627,7 @@ describe('RewardsDataService', () => {
       expect(result).toEqual(mockValidationResponse);
       expect(mockGetSubscriptionToken).toHaveBeenCalledWith(mockSubscriptionId);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.rewards.test/subscriptions/bonus-code?code=BONUS123',
+        'https://uat.rewards.test/subscriptions/bonus-code?code=BONUS123',
         expect.objectContaining({
           method: 'GET',
           credentials: 'omit',
@@ -2682,7 +2682,7 @@ describe('RewardsDataService', () => {
       // Assert
       expect(result).toEqual(mockValidationResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.rewards.test/subscriptions/bonus-code?code=A%2BB%2FC%3D',
+        'https://uat.rewards.test/subscriptions/bonus-code?code=A%2BB%2FC%3D',
         expect.any(Object),
       );
     });
@@ -4128,7 +4128,7 @@ describe('RewardsDataService', () => {
       // Assert
       expect(mockGetSubscriptionToken).toHaveBeenCalledWith(mockSubscriptionId);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.rewards.test/wr/subscriptions/apply-bonus-code',
+        'https://uat.rewards.test/wr/subscriptions/apply-bonus-code',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ bonusCode: mockBonusCode }),

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
@@ -24,6 +24,7 @@ import type {
   SeasonStateDto,
   LineaTokenRewardDto,
   ApplyReferralDto,
+  ApplyBonusCodeDto,
   SnapshotDto,
 } from '../types';
 import { getSubscriptionToken } from '../utils/multi-subscription-token-vault';
@@ -194,6 +195,16 @@ export interface RewardsDataServiceApplyReferralCodeAction {
   handler: RewardsDataService['applyReferralCode'];
 }
 
+export interface RewardsDataServiceValidateBonusCodeAction {
+  type: `${typeof SERVICE_NAME}:validateBonusCode`;
+  handler: RewardsDataService['validateBonusCode'];
+}
+
+export interface RewardsDataServiceApplyBonusCodeAction {
+  type: `${typeof SERVICE_NAME}:applyBonusCode`;
+  handler: RewardsDataService['applyBonusCode'];
+}
+
 export interface RewardsDataServiceGetSnapshotsAction {
   type: `${typeof SERVICE_NAME}:getSnapshots`;
   handler: RewardsDataService['getSnapshots'];
@@ -245,7 +256,10 @@ export type RewardsDataServiceActions =
   | RewardsDataServiceGetRewardsEnvUrlAction
   | RewardsDataServiceCanChangeRewardsEnvUrlAction
   | RewardsDataServiceSetRewardsEnvUrlAction
-  | RewardsDataServiceGetDefaultRewardsEnvUrlAction;
+  | RewardsDataServiceGetDefaultRewardsEnvUrlAction
+  | RewardsDataServiceValidateBonusCodeAction
+  | RewardsDataServiceApplyBonusCodeAction
+  | RewardsDataServiceGetSnapshotsAction;
 
 export type RewardsDataServiceMessenger = Messenger<
   typeof SERVICE_NAME,
@@ -371,6 +385,14 @@ export class RewardsDataService {
     this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:applyReferralCode`,
       this.applyReferralCode.bind(this),
+    );
+    this.#messenger.registerActionHandler(
+      `${SERVICE_NAME}:validateBonusCode`,
+      this.validateBonusCode.bind(this),
+    );
+    this.#messenger.registerActionHandler(
+      `${SERVICE_NAME}:applyBonusCode`,
+      this.applyBonusCode.bind(this),
     );
     this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:getSnapshots`,
@@ -860,6 +882,33 @@ export class RewardsDataService {
   }
 
   /**
+   * Validate a bonus code.
+   * @param code - The bonus code to validate.
+   * @param subscriptionId - The subscription ID for authentication.
+   * @returns Promise<{valid: boolean}> - Object indicating if the code is valid.
+   */
+  async validateBonusCode(
+    code: string,
+    subscriptionId: string,
+  ): Promise<{ valid: boolean }> {
+    const response = await this.makeRequest(
+      `/subscriptions/bonus-code?code=${encodeURIComponent(code)}`,
+      {
+        method: 'GET',
+      },
+      subscriptionId,
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to validate bonus code. Please try again shortly.`,
+      );
+    }
+
+    return (await response.json()) as { valid: boolean };
+  }
+
+  /**
    * Join an account to a subscription via mobile login.
    * @param body - The mobile login request body containing account, timestamp, and signature.
    * @param subscriptionId - The subscription ID to join the account to.
@@ -1180,6 +1229,39 @@ export class RewardsDataService {
       const errorData = await response.json();
       const errorMessage =
         errorData?.message || `Apply referral code failed: ${response.status}`;
+
+      throw new Error(errorMessage);
+    }
+  }
+
+  /**
+   * Apply a bonus code to a subscription.
+   * @param dto - The DTO containing the bonus code to apply.
+   * @param subscriptionId - The subscription ID to apply the bonus code to.
+   * @returns Promise that resolves when the bonus code is applied successfully.
+   * @throws Error with the error message from the API response.
+   */
+  async applyBonusCode(
+    dto: ApplyBonusCodeDto,
+    subscriptionId: string,
+  ): Promise<void> {
+    const response = await this.makeRequest(
+      '/wr/subscriptions/apply-bonus-code',
+      {
+        method: 'POST',
+        body: JSON.stringify(dto),
+      },
+      subscriptionId,
+    );
+
+    if (!response.ok) {
+      if (response.status === 204) {
+        return;
+      }
+
+      const errorData = await response.json();
+      const errorMessage =
+        errorData?.message || `Apply bonus code failed: ${response.status}`;
 
       throw new Error(errorMessage);
     }

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -5,6 +5,11 @@ import {
 import { CaipAccountId, CaipAssetType } from '@metamask/utils';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 
+/**
+ * Crockford's Base32 alphabet — excludes I, L, O, U to avoid ambiguity.
+ */
+export const BASE32_REGEX = /^[0-9A-HJKMNP-TV-Z]+$/i;
+
 export interface LoginResponseDto {
   sessionId: string;
   subscription: SubscriptionDto;
@@ -72,6 +77,14 @@ export interface ApplyReferralDto {
    * @example 'ABC123'
    */
   referralCode: string;
+}
+
+export interface ApplyBonusCodeDto {
+  /**
+   * The bonus code to apply
+   * @example 'BNS123'
+   */
+  bonusCode: string;
 }
 
 /**
@@ -443,6 +456,17 @@ export interface MusdDepositEventPayload {
 }
 
 /**
+ * Bonus code event payload
+ */
+export interface BonusCodeEventPayload {
+  /**
+   * Bonus code
+   * @example 'BNS123'
+   */
+  code: string;
+}
+
+/**
  * Base points event interface
  */
 interface BasePointsEventDto {
@@ -516,6 +540,7 @@ export type PointsEventDto = BasePointsEventDto &
         type: 'REFERRAL' | 'SIGN_UP_BONUS' | 'LOYALTY_BONUS' | 'ONE_TIME_BONUS';
         payload: null;
       }
+    | { type: 'BONUS_CODE'; payload: BonusCodeEventPayload | null }
     | { type: string; payload: Record<string, string> | null }
   );
 
@@ -1412,6 +1437,14 @@ export interface RewardsControllerValidateReferralCodeAction {
 }
 
 /**
+ * Action for validating bonus codes
+ */
+export interface RewardsControllerValidateBonusCodeAction {
+  type: 'RewardsController:validateBonusCode';
+  handler: (code: string, subscriptionId: string) => Promise<boolean>;
+}
+
+/**
  * Action for checking if an account supports opt-in
  */
 export interface RewardsControllerIsOptInSupportedAction {
@@ -1556,6 +1589,14 @@ export interface RewardsControllerApplyReferralCodeAction {
 }
 
 /**
+ * Action for applying a bonus code to an existing subscription
+ */
+export interface RewardsControllerApplyBonusCodeAction {
+  type: 'RewardsController:applyBonusCode';
+  handler: (bonusCode: string, subscriptionId: string) => Promise<void>;
+}
+
+/**
  * Actions that can be performed by the RewardsController
  */
 export type RewardsControllerActions =
@@ -1574,6 +1615,7 @@ export type RewardsControllerActions =
   | RewardsControllerLogoutAction
   | RewardsControllerGetGeoRewardsMetadataAction
   | RewardsControllerValidateReferralCodeAction
+  | RewardsControllerValidateBonusCodeAction
   | RewardsControllerIsOptInSupportedAction
   | RewardsControllerGetActualSubscriptionIdAction
   | RewardsControllerGetFirstSubscriptionIdAction
@@ -1591,7 +1633,8 @@ export type RewardsControllerActions =
   | RewardsControllerGetRewardsEnvUrlAction
   | RewardsControllerCanChangeRewardsEnvUrlAction
   | RewardsControllerSetRewardsEnvUrlAction
-  | RewardsControllerGetDefaultRewardsEnvUrlAction;
+  | RewardsControllerGetDefaultRewardsEnvUrlAction
+  | RewardsControllerApplyBonusCodeAction;
 
 /**
  * Input DTO for getting opt-in status of multiple addresses

--- a/app/core/Engine/messengers/rewards-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/rewards-controller-messenger/index.ts
@@ -18,6 +18,7 @@ import {
   RewardsDataServiceLogoutAction,
   RewardsDataServiceFetchGeoLocationAction,
   RewardsDataServiceValidateReferralCodeAction,
+  RewardsDataServiceValidateBonusCodeAction,
   RewardsDataServiceMobileJoinAction,
   RewardsDataServiceOptOutAction,
 } from '../../controllers/rewards-controller/services';
@@ -46,6 +47,7 @@ import {
   RewardsDataServiceGetSeasonMetadataAction,
   RewardsDataServiceGetSeasonOneLineaRewardTokensAction,
   RewardsDataServiceApplyReferralCodeAction,
+  RewardsDataServiceApplyBonusCodeAction,
   RewardsDataServiceGetSnapshotsAction,
   RewardsDataServiceGetRewardsEnvUrlAction,
   RewardsDataServiceCanChangeRewardsEnvUrlAction,
@@ -74,6 +76,7 @@ type AllowedActions =
   | RewardsDataServiceLogoutAction
   | RewardsDataServiceFetchGeoLocationAction
   | RewardsDataServiceValidateReferralCodeAction
+  | RewardsDataServiceValidateBonusCodeAction
   | RewardsDataServiceMobileJoinAction
   | RewardsDataServiceGetOptInStatusAction
   | RewardsDataServiceOptOutAction
@@ -88,7 +91,9 @@ type AllowedActions =
   | RewardsDataServiceGetRewardsEnvUrlAction
   | RewardsDataServiceCanChangeRewardsEnvUrlAction
   | RewardsDataServiceSetRewardsEnvUrlAction
-  | RewardsDataServiceGetDefaultRewardsEnvUrlAction;
+  | RewardsDataServiceGetDefaultRewardsEnvUrlAction
+  | RewardsDataServiceApplyBonusCodeAction
+  | RewardsDataServiceGetSnapshotsAction;
 
 // Don't reexport as per guidelines
 type AllowedEvents =
@@ -133,6 +138,7 @@ export function getRewardsControllerMessenger(
       'RewardsDataService:logout',
       'RewardsDataService:fetchGeoLocation',
       'RewardsDataService:validateReferralCode',
+      'RewardsDataService:validateBonusCode',
       'RewardsDataService:mobileJoin',
       'RewardsDataService:getOptInStatus',
       'RewardsDataService:optOut',
@@ -143,6 +149,7 @@ export function getRewardsControllerMessenger(
       'RewardsDataService:getSeasonMetadata',
       'RewardsDataService:getSeasonOneLineaRewardTokens',
       'RewardsDataService:applyReferralCode',
+      'RewardsDataService:applyBonusCode',
       'RewardsDataService:getSnapshots',
       'RewardsDataService:getRewardsEnvUrl',
       'RewardsDataService:canChangeRewardsEnvUrl',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7322,7 +7322,10 @@
       "service_not_available": "Service is not available at the moment. Please try again shortly.",
       "invalid_referral_code": "Invalid referral code. Please check and try again.",
       "already_referred": "You have already been referred by another user.",
-      "cannot_use_own_referral_code": "You cannot use your own referral code."
+      "cannot_use_own_referral_code": "You cannot use your own referral code.",
+      "invalid_bonus_code": "Invalid bonus code",
+      "already_redeemed": "You have already redeemed this bonus code",
+      "reached_maximum": "This bonus code has reached its maximum number of uses"
     },
     "claim_reward_error": {
       "title": "Failed to claim reward"
@@ -7379,8 +7382,10 @@
         "predict": "Prediction",
         "musd_deposit": "mUSD deposit",
         "apply_referral_bonus": "Referral code bonus",
+        "bonus_code": "Bonus code",
         "uncategorized_event": "Uncategorized event"
       },
+      "code": "Code",
       "date": "Date",
       "account": "Account",
       "bonus": "Bonus",
@@ -7492,6 +7497,10 @@
       "input_placeholder": "Enter referral code",
       "invalid_code": "Invalid referral code",
       "apply_button": "Apply referral code"
+    },
+    "bonus_code": {
+      "input_placeholder": "Enter bonus code",
+      "apply_success": "Bonus code applied!"
     },
     "optout": {
       "title": "Opt out of Rewards",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

https://consensyssoftware.atlassian.net/browse/RWDS-1027
Allow user to redeem a bonus code in WaysToEarn 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Allow user to redeem a bonus code in WaysToEarn 


## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-02-13 at 15 09 15" src="https://github.com/user-attachments/assets/ae439ae7-13dd-4b74-9b4e-541a9b21ae2e" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-02-13 at 15 09 05" src="https://github.com/user-attachments/assets/a2a5de6c-41c2-48fb-8001-04786ad42ed7" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-02-13 at 17 08 22" src="https://github.com/user-attachments/assets/7b3f311b-3633-4257-8354-d1b9a7d889cf" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-02-13 at 17 16 26" src="https://github.com/user-attachments/assets/5e85eede-47c9-4ca0-99dd-43a524924187" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new navigation/modal flow and new Engine controller calls for bonus code validate/apply; behavior changes to referral validation could affect existing referral-code entry and needs regression testing around edge cases and localization.
> 
> **Overview**
> Adds a dedicated **Bonus Code** redemption flow in Rewards: selecting a `BONUS_CODE` item in *Ways to Earn* now opens a new `BonusCodeBottomSheet` modal (wired via new `Routes.MODAL.REWARDS_BONUS_CODE_BOTTOM_SHEET` and registered in `MainNavigator`) that validates the code and submits it to `RewardsController:applyBonusCode`, showing success/error UI and a toast.
> 
> Extends Rewards activity/event rendering to recognize `BONUS_CODE` events (new `BonusCodeEventDetails`, updated `ActivityDetailsSheet` dispatch, and `eventDetailsUtils` details extraction) and expands error mapping in `handleRewardsErrorMessage` for bonus-code-specific server messages.
> 
> Tightens referral code UX by enforcing `REFERRAL_CODE_LENGTH` via `maxLength` and refactors `useValidateReferralCode` to validate immediately with stale-response protection (removing lodash debounce), with test updates across the new/changed behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a950834a14b8c365893f6df3f9c9bb01c103b5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->