### PR TITLE
test: add component view test coverage for network related bugs

### DIFF
--- a/app/components/Views/AssetDetails/AssetDetails.view.test.tsx
+++ b/app/components/Views/AssetDetails/AssetDetails.view.test.tsx
@@ -1,0 +1,36 @@
+import '../../../util/test/component-view/mocks';
+import { renderAssetDetailsView } from '../../../util/test/component-view/renderers/assetDetails';
+import { describeForPlatforms } from '../../../util/test/platform';
+
+// addresses Regression: #25100 – Token Details page shows wrong network
+
+describeForPlatforms('AssetDetails', () => {
+  it('displays network name from token chainId, not from selected network', () => {
+    const polygonTokenAddress = '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619';
+
+    const { getAllByText, queryByText } = renderAssetDetailsView({
+      deterministicFiat: true,
+      routeParams: {
+        address: polygonTokenAddress,
+        chainId: '0x89',
+        asset: {
+          address: polygonTokenAddress,
+          symbol: 'WETH',
+          decimals: 18,
+          name: 'Wrapped Ether',
+          image: '',
+          isNative: false,
+          isETH: false,
+          aggregators: [],
+        },
+      },
+    });
+
+    // Network name should appear twice: header subtitle + "Network" section body
+    const polygonTexts = getAllByText('Polygon');
+    expect(polygonTexts.length).toBeGreaterThanOrEqual(2);
+
+    // The globally selected network (Ethereum Main Network) should NOT appear
+    expect(queryByText('Ethereum Main Network')).toBeNull();
+  });
+});

--- a/app/components/Views/WalletActions/WalletActions.view.test.tsx
+++ b/app/components/Views/WalletActions/WalletActions.view.test.tsx
@@ -1,0 +1,17 @@
+import '../../../util/test/component-view/mocks';
+import { renderWalletActionsView } from '../../../util/test/component-view/renderers/walletActions';
+import { WalletActionsBottomSheetSelectorsIDs } from './WalletActionsBottomSheet.testIds';
+import { describeForPlatforms } from '../../../util/test/platform';
+
+// Regression: #24972 – Perps missing from Trade menu when non-EVM network selected
+describeForPlatforms('WalletActions', () => {
+  it('shows Perps button when non-EVM network is selected', () => {
+    const { getByTestId } = renderWalletActionsView({
+      isEvmSelected: false,
+    });
+
+    expect(
+      getByTestId(WalletActionsBottomSheetSelectorsIDs.PERPS_BUTTON),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/util/test/component-view/presets/assetDetails.ts
+++ b/app/util/test/component-view/presets/assetDetails.ts
@@ -1,0 +1,91 @@
+import { createStateFixture } from '../stateFixture';
+import type { DeepPartial } from '../../renderWithProvider';
+import type { RootState } from '../../../../reducers';
+
+interface InitialStateAssetDetailsOptions {
+  deterministicFiat?: boolean;
+}
+
+export const initialStateAssetDetails = (
+  options?: InitialStateAssetDetailsOptions,
+) => {
+  const builder = createStateFixture()
+    .withMinimalAccounts()
+    .withMinimalMainnetNetwork()
+    .withMinimalMultichainNetwork(true)
+    .withMinimalKeyringController()
+    .withMinimalTokenRates()
+    .withMinimalMultichainAssetsRates()
+    .withMinimalAnalyticsController()
+    .withAccountTreeForSelectedAccount()
+    .withRemoteFeatureFlags({})
+    .withOverrides({
+      engine: {
+        backgroundState: {
+          // Add Polygon alongside Mainnet (deepMerge preserves 0x1)
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              '0x89': {
+                chainId: '0x89',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'polygon-mainnet',
+                    url: 'https://polygon-rpc.com',
+                    type: 'custom',
+                  },
+                ],
+                defaultRpcEndpointIndex: 0,
+                blockExplorerUrls: ['https://polygonscan.com'],
+                defaultBlockExplorerUrlIndex: 0,
+                name: 'Polygon',
+                nativeCurrency: 'POL',
+              },
+            },
+            networksMetadata: {
+              'polygon-mainnet': {
+                status: 'available',
+                EIPS: { 1559: true },
+              },
+            },
+          },
+          CurrencyRateController: {
+            currentCurrency: 'USD',
+            currencyRates: {
+              ETH: { conversionRate: 2000 },
+              POL: { conversionRate: 0.5 },
+            },
+          },
+          PreferencesController: {
+            isIpfsGatewayEnabled: false,
+          },
+          TokenBalancesController: { tokenBalances: {} },
+          TokensController: {
+            allTokens: {},
+            allDetectedTokens: {},
+            allIgnoredTokens: {},
+          },
+        },
+      },
+      settings: { primaryCurrency: 'ETH' },
+    } as unknown as DeepPartial<RootState>);
+
+  if (options?.deterministicFiat) {
+    builder.withOverrides({
+      engine: {
+        backgroundState: {
+          CurrencyRateController: {
+            currentCurrency: 'USD',
+            currencyRates: {
+              ETH: { conversionRate: 2000 },
+              POL: { conversionRate: 0.5 },
+            },
+          },
+          TokenRatesController: { marketData: {} },
+          MultichainAssetsRatesController: { conversionRates: {} },
+        },
+      },
+    } as unknown as DeepPartial<RootState>);
+  }
+
+  return builder;
+};

--- a/app/util/test/component-view/presets/assetDetails.ts
+++ b/app/util/test/component-view/presets/assetDetails.ts
@@ -73,13 +73,6 @@ export const initialStateAssetDetails = (
     builder.withOverrides({
       engine: {
         backgroundState: {
-          CurrencyRateController: {
-            currentCurrency: 'USD',
-            currencyRates: {
-              ETH: { conversionRate: 2000 },
-              POL: { conversionRate: 0.5 },
-            },
-          },
           TokenRatesController: { marketData: {} },
           MultichainAssetsRatesController: { conversionRates: {} },
         },

--- a/app/util/test/component-view/presets/walletActions.ts
+++ b/app/util/test/component-view/presets/walletActions.ts
@@ -1,0 +1,92 @@
+import { createStateFixture } from '../stateFixture';
+import type { DeepPartial } from '../../renderWithProvider';
+import type { RootState } from '../../../../reducers';
+
+interface InitialStateWalletActionsOptions {
+  isEvmSelected?: boolean;
+}
+
+export const initialStateWalletActions = (
+  options?: InitialStateWalletActionsOptions,
+) => {
+  const isEvmSelected = options?.isEvmSelected ?? false;
+
+  const builder = createStateFixture()
+    .withMinimalAccounts()
+    .withMinimalMainnetNetwork()
+    .withMinimalMultichainNetwork(isEvmSelected)
+    .withOverrides({
+      engine: {
+        backgroundState: {
+          MultichainNetworkController: {
+            selectedMultichainNetworkChainId:
+              'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          },
+        },
+      },
+    } as unknown as DeepPartial<RootState>)
+    .withMinimalKeyringController()
+    .withMinimalTokenRates()
+    .withMinimalMultichainAssetsRates()
+    .withMinimalMultichainBalances()
+    .withMinimalMultichainAssets()
+    .withMinimalAnalyticsController()
+    .withAccountTreeForSelectedAccount()
+    .withRemoteFeatureFlags({
+      perpsPerpTradingEnabled: {
+        enabled: true,
+        minimumVersion: '1.0.0',
+      },
+    })
+    .withOverrides({
+      engine: {
+        backgroundState: {
+          PreferencesController: {
+            isIpfsGatewayEnabled: false,
+          },
+          TokenBalancesController: { tokenBalances: {} },
+          TokensController: {
+            allTokens: {},
+            allDetectedTokens: {},
+            allIgnoredTokens: {},
+          },
+          CurrencyRateController: {
+            currentCurrency: 'USD',
+            currencyRates: {
+              ETH: { conversionRate: 2000 },
+            },
+          },
+          EarnController: {
+            pooled_staking: {
+              isEligible: true,
+            },
+            lending: {
+              positions: [],
+              markets: [],
+            },
+          },
+        },
+      },
+      settings: {
+        basicFunctionalityEnabled: true,
+        primaryCurrency: 'ETH',
+      },
+      swaps: {
+        '0x1': { isLive: true },
+        hasOnboarded: false,
+        isLive: true,
+      },
+      fiatOrders: {
+        networks: [
+          {
+            active: true,
+            chainId: '1',
+            chainName: 'Ethereum Mainnet',
+            nativeTokenSupported: true,
+          },
+        ],
+      },
+    } as unknown as DeepPartial<RootState>);
+
+  return builder;
+};

--- a/app/util/test/component-view/presets/walletActions.ts
+++ b/app/util/test/component-view/presets/walletActions.ts
@@ -19,8 +19,9 @@ export const initialStateWalletActions = (
       engine: {
         backgroundState: {
           MultichainNetworkController: {
-            selectedMultichainNetworkChainId:
-              'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            selectedMultichainNetworkChainId: isEvmSelected
+              ? 'eip155:1'
+              : 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
           },
         },
       },

--- a/app/util/test/component-view/renderers/assetDetails.ts
+++ b/app/util/test/component-view/renderers/assetDetails.ts
@@ -1,0 +1,40 @@
+import '../mocks';
+import React from 'react';
+import type { DeepPartial } from '../../renderWithProvider';
+import type { RootState } from '../../../../reducers';
+import { renderComponentViewScreen } from '../render';
+import AssetDetailsContainer from '../../../../components/Views/AssetDetails';
+import { initialStateAssetDetails } from '../presets/assetDetails';
+
+interface RenderAssetDetailsViewOptions {
+  overrides?: DeepPartial<RootState>;
+  deterministicFiat?: boolean;
+  routeParams: {
+    address: string;
+    chainId: string;
+    asset: Record<string, unknown>;
+  };
+}
+
+/**
+ * Renders AssetDetails view with a sensible default AssetDetails preset.
+ * Pass overrides to tweak the state for each specific test.
+ */
+export function renderAssetDetailsView(
+  options: RenderAssetDetailsViewOptions,
+): ReturnType<typeof renderComponentViewScreen> {
+  const { overrides, deterministicFiat, routeParams } = options;
+
+  const builder = initialStateAssetDetails({ deterministicFiat });
+  if (overrides) {
+    builder.withOverrides(overrides);
+  }
+  const state = builder.build();
+
+  return renderComponentViewScreen(
+    AssetDetailsContainer as unknown as React.ComponentType,
+    { name: 'AssetDetails' },
+    { state },
+    routeParams,
+  );
+}

--- a/app/util/test/component-view/renderers/walletActions.ts
+++ b/app/util/test/component-view/renderers/walletActions.ts
@@ -1,0 +1,31 @@
+import '../mocks';
+import React from 'react';
+import type { DeepPartial } from '../../renderWithProvider';
+import type { RootState } from '../../../../reducers';
+import { renderComponentViewScreen } from '../render';
+import Routes from '../../../../constants/navigation/Routes';
+import WalletActions from '../../../../components/Views/WalletActions';
+import { initialStateWalletActions } from '../presets/walletActions';
+
+interface RenderWalletActionsViewOptions {
+  overrides?: DeepPartial<RootState>;
+  isEvmSelected?: boolean;
+}
+
+export function renderWalletActionsView(
+  options: RenderWalletActionsViewOptions = {},
+): ReturnType<typeof renderComponentViewScreen> {
+  const { overrides, isEvmSelected } = options;
+
+  const builder = initialStateWalletActions({ isEvmSelected });
+  if (overrides) {
+    builder.withOverrides(overrides);
+  }
+  const state = builder.build();
+
+  return renderComponentViewScreen(
+    WalletActions as unknown as React.ComponentType,
+    { name: Routes.MODAL.WALLET_ACTIONS },
+    { state },
+  );
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

  This PR adds component view tests covering two previously untested network-related regressions (#25100, #24972)                       

  ### What changed

  AssetDetails CVT (#25100) — A production regression was found in 7.61.6, where the token details page was pulling the network name from the globally selected network instead of the token's own chainId from route params. The existing unit tests never set up a cross-chain mismatch (e.g., viewing a Polygon token while Mainnet is selected), so this was not tested. The new CVT renders a Polygon WETH token against a Mainnet-selected state and asserts that "Polygon" appears in both the header and body, while "Ethereum Main Network" doesn't appear at all.

  WalletActions CVT (#24972) — Was a regression caught during RC testing for 7.62.0, where the Perps button was gated behind isEvmSelected, so it disappeared when the user had a non-EVM network (Solana, Bitcoin, etc.) selected. The existing unit tests mock selectIsEvmNetworkSelected directly and never exercise the false case for Perps. The new CVT sets up real state with isEvmSelected: false and a Solana chain ID, then asserts the Perps button is still in the tree. 


  Both tests were red-green validated: they pass on the current codebase and fail when the respective fixes are reverted.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions plus new test fixtures/render helpers; no production logic changes, with minimal risk beyond potential test flakiness from fixture assumptions.
> 
> **Overview**
> Adds component-view regression tests for two network-selection issues: `AssetDetails` now has coverage ensuring the displayed network name is derived from the token `chainId` in route params (e.g., Polygon token while Mainnet is selected), and `WalletActions` has coverage ensuring the Perps button remains visible when a non-EVM network is selected.
> 
> Introduces reusable component-view test helpers: new state presets (`initialStateAssetDetails`, `initialStateWalletActions`) and renderers (`renderAssetDetailsView`, `renderWalletActionsView`) that build minimal fixtures (including Polygon network config, deterministic fiat rate overrides, and feature-flag enablement for Perps) to make these scenarios easy to reproduce in tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30d9e1e25631cf48e86a37a72c6049e6b08839cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->