### PR TITLE
fix: fix marging value on OrderView from tokenDetails page cp-7.66.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -334,6 +334,18 @@ jest.mock('../../hooks', () => ({
 }));
 
 // Mock direct hook imports (when imported from specific file paths)
+jest.mock('../../hooks/usePerpsConnection', () => ({
+  usePerpsConnection: jest.fn(() => ({
+    isConnected: true,
+    isConnecting: false,
+    isInitialized: true,
+    error: null,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    resetError: jest.fn(),
+  })),
+}));
+
 jest.mock('../../hooks/usePerpsPaymentTokens', () => ({
   usePerpsPaymentTokens: jest.fn(() => [
     {
@@ -679,6 +691,7 @@ const defaultMockHooks = {
     placeOrder: jest.fn(),
     depositWithConfirmation: jest.fn().mockResolvedValue(undefined),
     withdrawWithConfirmation: jest.fn(),
+    subscribeToPrices: jest.fn(() => jest.fn()),
     getMarkets: jest.fn().mockResolvedValue([
       {
         name: 'ETH',


### PR DESCRIPTION
## **Description**

When navigating to the Perps order view from the **Token Details** page (Long/Short buttons), the margin value at the bottom of the order screen is permanently stuck at **$0**, regardless of the amount entered. This does not happen when entering from the Perps main flow (Market Details → Long/Short), because an earlier screen (`PerpsMarketStatisticsCard`) subscribes to price data with `includeMarketData: true`, which populates the `HyperLiquidSubscriptionService`'s `#marketDataCache` with oracle prices.

### Root cause

The `marginRequired` calculation in `PerpsOrderView` uses `assetData.markPrice` (oracle price). This value comes from `usePerpsLivePrices` → `PriceStreamChannel` → `PerpsController.subscribeToPrices()`. However, the `PriceStreamChannel` **never passes `includeMarketData: true`** in its subscription. Without this flag, the `activeAssetCtx` WebSocket subscription is not created, the `#marketDataCache` stays empty, and `markPrice` is always `undefined` — resulting in a `$0` margin.

When the user visits the Perps Market Details page first, `usePerpsMarketStats` subscribes with `includeMarketData: true`, which populates the shared singleton cache. Subsequent price updates from `allMids` then include `markPrice` from the cache. This is why the bug only manifests on a fresh app start when going directly from Token Details.

### Fix

Added a `useEffect` in `PerpsOrderViewContentBase` that subscribes to `PerpsController.subscribeToPrices` with `includeMarketData: true` for the traded asset. This creates an `activeAssetCtx` WebSocket subscription that populates the `#marketDataCache` with the oracle price. The existing `usePerpsLivePrices` subscription then picks up `markPrice` from the cache on the next `allMids` update. This mirrors what `usePerpsMarketStats` already does on the Market Details page.

## **Changelog**

CHANGELOG entry: Fixed perpetual trading margin display showing $0 when placing orders from the Token Details page

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/26106

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/30213d59-b131-4459-8b74-d37f7f0e152f


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/c0fb6543-1744-46cf-9f92-128f8118cb2b



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new live price subscription side-effect in `PerpsOrderView`, which can impact WebSocket usage and lifecycle/cleanup behavior, but is scoped to a single screen and gated on connection initialization.
> 
> **Overview**
> Fixes margin showing as `$0` when opening `PerpsOrderView` directly from Token Details by *forcing an `includeMarketData: true` price subscription* for the selected asset, ensuring `markPrice` (oracle price) is available for margin calculations.
> 
> Introduces a dependency on `usePerpsConnection().isInitialized` to defer the subscription until the perps controller is ready, and updates tests/mocks to cover the new direct hook import and the `usePerpsTrading().subscribeToPrices` unsubscribe behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0e4982ba1f10776ca0c4f3b829c3665c132a3ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->