### PR TITLE
fix(perps): address bugbot findings on Core PR #7941

### DIFF
--- a/app/components/UI/Perps/__mocks__/serviceMocks.ts
+++ b/app/components/UI/Perps/__mocks__/serviceMocks.ts
@@ -224,6 +224,7 @@ export const createMockMessenger = (
     subscribe: jest.fn(),
     unsubscribe: jest.fn(),
     registerActionHandler: jest.fn(),
+    registerMethodActionHandlers: jest.fn(),
     unregisterActionHandler: jest.fn(),
     // Additional methods used by PerpsController
     registerEventHandler: jest.fn(),

--- a/app/controllers/perps/PerpsController.ts
+++ b/app/controllers/perps/PerpsController.ts
@@ -1912,7 +1912,7 @@ export class PerpsController extends BaseController<
 
         // Add deposit request to tracking
         const depositRequest = {
-          id: currentDepositId,
+          id: currentDepositId ?? uuidv4(),
           timestamp: Date.now(),
           amount: amount ?? '0', // Use provided amount or default to '0'
           asset: USDC_SYMBOL,


### PR DESCRIPTION
## **Description**

Defensive hardening for edge cases in `PerpsController` surfaced by static analysis on Core PR [#7941](https://github.com/MetaMask/core/pull/7941). None of these bugs are currently triggerable in production — the app works correctly today — but all represent latent issues that could bite under future changes or unusual network conditions.

### What changed

**1. `toggleTestnet()` — false success on silent init failure**

`performInitialization()` catches errors internally and sets `InitializationState.Failed` instead of throwing. `toggleTestnet()` was not checking for this, so it could return `{ success: true }` even when the network switch failed. This patch:
- Adds the same `InitializationState.Failed` check after `await this.init()`
- Rolls back `isTestnet` to its previous value on failure

**2. `depositWithConfirmation()` — never-resolving promise when `placeOrder=true`**

The `placeOrder` path created `new Promise(() => {})` — a promise that can never be GC'd and would hang any consumer who awaits it. Replaced with `Promise.resolve(transactionMeta.id)` for proper fire-and-forget semantics.

**3. `depositWithConfirmation()` — failed deposits remain permanently pending**

`depositWithConfirmation` adds a pending entry to `state.depositRequests` before validating `networkClientId`. If the validation throws, the deposit request stays `status: 'pending'` forever. This patch marks the deposit request as `failed` in the outer catch when a pre-submission error occurs.

**4. Feature flag listener lost after disconnect**

`disconnect()` unsubscribed `RemoteFeatureFlagController:stateChange` but no reconnect path re-subscribed. After disconnect → reconnect, geo-blocking and HIP-3 flag changes stopped propagating. The feature-flag subscription is a controller-lifetime concern (not session-lifetime), so we removed the unsubscribe from `disconnect()` entirely — the subscription now lives for the full controller lifecycle.

**5. `depositWithConfirmation()` — deposit+order request stays pending forever**

When `placeOrder=true`, the `if (!placeOrder)` guard skips the `.then()/.catch()` lifecycle block that transitions the deposit request to `completed`/`failed`. No other handler exists for this path. Added an `else if` branch that attaches lifecycle tracking to `addResult.result` (the real transaction promise) for the deposit+order flow.

**6. Non-EVM account switch leaves stale cache**

The account-change handler only cleared cached user data when `currentAddress` is truthy. Switching to an account group with no EVM account (e.g., Bitcoin-only) skipped cache clearing, leaving stale positions/orders visible. Restructured the condition so cache is always cleared when the account group changes, with preload guarded separately behind `if (currentAddress)`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: bugbot findings from Core PR [#7941](https://github.com/MetaMask/core/pull/7941)

## **Manual testing steps**

These are defensive fixes for edge cases not reachable through normal UI flows. Verification is via unit tests.

```gherkin
Feature: Perps network toggle resilience

  Scenario: toggleTestnet reports accurate status when init fails silently
    Given user is on mainnet with perps initialized
    When user toggles to testnet and initialization fails internally
    Then toggleTestnet returns { success: false }
    And isTestnet is rolled back to its previous value

Feature: Perps deposit promise contract

  Scenario: depositWithConfirmation result promise resolves when placeOrder is true
    Given user initiates a deposit with placeOrder=true
    When the transaction is submitted
    Then the result promise resolves with the transaction ID

Feature: Perps deposit request lifecycle

  Scenario: deposit request is marked failed on pre-submission error
    Given user initiates a deposit and the deposit request is added as pending
    When the networkClientId lookup fails
    Then the deposit request status is updated to 'failed'

  Scenario: deposit+order request transitions from pending
    Given user initiates a deposit with placeOrder=true
    When the transaction completes or fails
    Then the deposit request status is updated to 'completed' or 'failed'

Feature: Feature flag subscription resilience

  Scenario: geo-blocking flags propagate after disconnect/reconnect
    Given perps controller is initialized with feature flag subscription
    When disconnect() is called and controller reconnects
    Then feature flag changes still propagate correctly

Feature: Account switch cache clearing

  Scenario: switching to non-EVM account clears stale perps cache
    Given user has cached perps data from an EVM account
    When user switches to a Bitcoin-only account group
    Then cached positions, orders, and account state are cleared
```

## **Screenshots/Recordings**

N/A — no UI changes, logic-only hardening.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.