### PR TITLE
fix: Prevent insufficient alert while loading quotes

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -17,6 +17,7 @@ import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
 import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
 import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
+import { useIsTransactionPayLoading } from '../pay/useTransactionPayData';
 import { Hex } from '@metamask/utils';
 
 jest.mock('../../../../../util/navigation/navUtils', () => ({
@@ -56,6 +57,7 @@ jest.mock('../../../../UI/Ramp/hooks/useRampNavigation', () => ({
 }));
 jest.mock('../gas/useIsGaslessSupported');
 jest.mock('../pay/useTransactionPayHasSourceAmount');
+jest.mock('../pay/useTransactionPayData');
 
 describe('useInsufficientBalanceAlert', () => {
   const mockUseTransactionMetadataRequest = jest.mocked(
@@ -74,6 +76,9 @@ describe('useInsufficientBalanceAlert', () => {
     useTransactionPayHasSourceAmount,
   );
   const useHasInsufficientBalanceMock = jest.mocked(useHasInsufficientBalance);
+  const useIsTransactionPayLoadingMock = jest.mocked(
+    useIsTransactionPayLoading,
+  );
 
   const mockChainId = '0x1' as Hex;
   const mockFromAddress = '0x123';
@@ -134,6 +139,8 @@ describe('useInsufficientBalanceAlert', () => {
       hasInsufficientBalance: true,
       nativeCurrency: mockNativeCurrency,
     });
+
+    useIsTransactionPayLoadingMock.mockReturnValue(false);
   });
 
   it('return empty array when no transaction metadata is available', () => {
@@ -334,6 +341,119 @@ describe('useInsufficientBalanceAlert', () => {
 
       const { result } = renderHook(() => useInsufficientBalanceAlert());
       expect(result.current).toEqual([]);
+    });
+  });
+
+  describe('isQuotesLoading', () => {
+    it('returns empty array when quotes are loading and gas fee tokens exist but none selected', () => {
+      useIsGaslessSupportedMock.mockReturnValueOnce({
+        isSmartTransaction: true,
+        isSupported: true,
+        pending: false,
+      });
+      mockSelectUseTransactionSimulations.mockReturnValueOnce(true);
+      useIsTransactionPayLoadingMock.mockReturnValue(true);
+
+      const txWithGasFeeTokens = {
+        ...mockTransaction,
+        gasFeeTokens: [
+          {
+            tokenAddress: '0xabc' as Hex,
+            symbol: 'GFT',
+            decimals: 18,
+          },
+        ],
+        selectedGasFeeToken: undefined,
+      } as unknown as TransactionMeta;
+      mockUseTransactionMetadataRequest.mockReturnValue(txWithGasFeeTokens);
+
+      const { result } = renderHook(() => useInsufficientBalanceAlert());
+
+      expect(result.current).toEqual([]);
+    });
+
+    it('returns alert when quotes are not loading and gas fee tokens exist but none selected', () => {
+      useIsGaslessSupportedMock.mockReturnValueOnce({
+        isSmartTransaction: true,
+        isSupported: true,
+        pending: false,
+      });
+      mockSelectUseTransactionSimulations.mockReturnValueOnce(true);
+      useIsTransactionPayLoadingMock.mockReturnValue(false);
+
+      const txWithGasFeeTokens = {
+        ...mockTransaction,
+        gasFeeTokens: [
+          {
+            tokenAddress: '0xabc' as Hex,
+            symbol: 'GFT',
+            decimals: 18,
+          },
+        ],
+        selectedGasFeeToken: undefined,
+      } as unknown as TransactionMeta;
+      mockUseTransactionMetadataRequest.mockReturnValue(txWithGasFeeTokens);
+
+      const { result } = renderHook(() => useInsufficientBalanceAlert());
+
+      expect(result.current).toEqual([
+        {
+          action: {
+            label: `Buy ${mockNativeCurrency}`,
+            callback: expect.any(Function),
+          },
+          isBlocking: true,
+          field: RowAlertKey.EstimatedFee,
+          key: AlertKeys.InsufficientBalance,
+          message: `Insufficient ${mockNativeCurrency} balance`,
+          title: 'Insufficient Balance',
+          severity: Severity.Danger,
+          skipConfirmation: true,
+        },
+      ]);
+    });
+
+    it('returns alert when quotes loading is undefined (default case)', () => {
+      useIsGaslessSupportedMock.mockReturnValueOnce({
+        isSmartTransaction: true,
+        isSupported: true,
+        pending: false,
+      });
+      mockSelectUseTransactionSimulations.mockReturnValueOnce(true);
+      useIsTransactionPayLoadingMock.mockReturnValue(
+        undefined as unknown as ReturnType<typeof useIsTransactionPayLoading>,
+      );
+
+      const txWithGasFeeTokens = {
+        ...mockTransaction,
+        gasFeeTokens: [
+          {
+            tokenAddress: '0xabc' as Hex,
+            symbol: 'GFT',
+            decimals: 18,
+          },
+        ],
+        selectedGasFeeToken: undefined,
+      } as unknown as TransactionMeta;
+      mockUseTransactionMetadataRequest.mockReturnValue(txWithGasFeeTokens);
+
+      const { result } = renderHook(() => useInsufficientBalanceAlert());
+
+      expect(result.current).toEqual([
+        {
+          action: {
+            label: `Buy ${mockNativeCurrency}`,
+            callback: expect.any(Function),
+          },
+          isBlocking: true,
+          field: RowAlertKey.EstimatedFee,
+          key: AlertKeys.InsufficientBalance,
+          message: `Insufficient ${mockNativeCurrency} balance`,
+          title: 'Insufficient Balance',
+          severity: Severity.Danger,
+          skipConfirmation: true,
+        },
+      ]);
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -14,6 +14,7 @@ import { hasTransactionType } from '../../utils/transaction';
 import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
 import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
 import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
+import { useIsTransactionPayLoading } from '../pay/useTransactionPayData';
 
 const IGNORE_TYPES = [TransactionType.predictWithdraw];
 
@@ -32,6 +33,7 @@ export const useInsufficientBalanceAlert = ({
   const isSimulationEnabled = useSelector(selectUseTransactionSimulations);
   const { hasInsufficientBalance, nativeCurrency } =
     useHasInsufficientBalance();
+  const isQuotesLoading = useIsTransactionPayLoading();
 
   return useMemo(() => {
     if (!transactionMetadata || isTransactionValueUpdating || isUsingPay) {
@@ -63,7 +65,7 @@ export const useInsufficientBalanceAlert = ({
       isGaslessCheckComplete &&
       (!isGaslessSupported ||
         isGasFeeTokensEmpty ||
-        (!isGasFeeTokensEmpty && !selectedGasFeeToken));
+        (!isGasFeeTokensEmpty && !selectedGasFeeToken && !isQuotesLoading));
 
     const showAlert =
       hasInsufficientBalance &&
@@ -109,6 +111,7 @@ export const useInsufficientBalanceAlert = ({
     isUsingPay,
     hasInsufficientBalance,
     nativeCurrency,
+    isQuotesLoading,
     goToBuy,
     onReject,
   ]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to prevent rendering insufficient native balance when MMPay tries to go gasless route but still shows an alert on loading state.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/26024

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/b2f22a09-fe1f-4e18-8006-dde487ec7000



### **After**


https://github.com/user-attachments/assets/f2bfd38b-a19a-4b6c-8126-63077518bdab



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes alert gating in the confirmation flow, which could unintentionally hide or show a blocking insufficient-balance alert depending on quote-loading state. Covered by new unit tests, but still impacts a critical transaction UX path.
> 
> **Overview**
> Prevents the *Insufficient Balance* confirmation alert from showing while Transaction Pay (gasless) quotes are still loading, specifically when `gasFeeTokens` exist but no `selectedGasFeeToken` has been chosen yet.
> 
> `useInsufficientBalanceAlert` now gates the gasless-condition check on `useIsTransactionPayLoading()`, and the test suite adds coverage for the loading, non-loading, and `undefined` loading-state cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3ed70c0828ba120da5a6b93b8434b1de89e73f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->