### PR TITLE
fix: prevent WalletConnect session proposal race conditions (WAPI-1070)

### DIFF
--- a/app/components/Approvals/PermissionApproval/PermissionApproval.test.tsx
+++ b/app/components/Approvals/PermissionApproval/PermissionApproval.test.tsx
@@ -289,7 +289,7 @@ describe('PermissionApproval', () => {
     expect(navigationMock.navigate).toHaveBeenCalledTimes(0);
   });
 
-  it('re-runs effect when pendingApprovals changes', async () => {
+  it('does not re-navigate for the same approval when pendingApprovals changes', async () => {
     const navigationMock = {
       navigate: jest.fn(),
     };
@@ -329,12 +329,13 @@ describe('PermissionApproval', () => {
       anotherRequestId: anotherApprovalRequest,
     };
 
+    // The current approvalRequest is still the same (same metadata.id),
+    // so navigation should not fire again even though the queue changed.
     mockApprovalRequest(approvalRequest, pendingApprovals2);
 
     rerender(<PermissionApproval navigation={navigationMock} />);
 
-    // Effect should re-run when pendingApprovals content changes, causing navigation again
-    expect(navigationMock.navigate).toHaveBeenCalledTimes(2);
+    expect(navigationMock.navigate).toHaveBeenCalledTimes(1);
   });
 
   it('navigates when new approval added after queue cleared', async () => {
@@ -369,7 +370,10 @@ describe('PermissionApproval', () => {
 
     const approvalRequest2 = {
       type: ApprovalTypes.REQUEST_PERMISSIONS,
-      requestData: HOST_INFO_MOCK,
+      requestData: {
+        ...HOST_INFO_MOCK,
+        metadata: { id: 'newRequestId' },
+      },
       id: 'newRequestId',
       // TODO: Replace "any" with type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/components/UI/SDKLoading/index.tsx
+++ b/app/components/UI/SDKLoading/index.tsx
@@ -7,6 +7,10 @@ import { EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
 import Device from '../../../../app/util/device';
 import { useTheme, useAssetFromTheme } from '../../../util/theme';
 
+// Intrinsic dimensions of the Lottie assets (logo-light.json / logo-dark.json).
+const LOTTIE_INTRINSIC_WIDTH = 1000;
+const LOTTIE_INTRINSIC_HEIGHT = 1624;
+
 const animationSize = Device.getDeviceWidth() / 2;
 
 const loadingLight = require('./logo-light.json');
@@ -36,6 +40,7 @@ const createStyles = (colors: ThemeColors, _safeAreaInsets: EdgeInsets) =>
     },
     animation: {
       width: animationSize,
+      aspectRatio: LOTTIE_INTRINSIC_WIDTH / LOTTIE_INTRINSIC_HEIGHT,
       alignSelf: 'center',
       alignItems: 'center',
       justifyContent: 'center',

--- a/app/core/DeeplinkManager/handlers/legacy/connectWithWC.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/connectWithWC.ts
@@ -27,7 +27,7 @@ export function connectWithWC({
       }),
     )
     .catch((err) => {
-      console.warn(`DeepLinkManager failed to connect`, err);
+      console.warn(`connectWithWC failed`, err);
     });
 }
 

--- a/app/core/DeeplinkManager/handlers/legacy/handleMetaMaskDeeplink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleMetaMaskDeeplink.ts
@@ -115,7 +115,6 @@ export function handleMetaMaskDeeplink({
     url.startsWith(`${PREFIXES.METAMASK}${ACTIONS.WC}`) ||
     url.startsWith(`${PREFIXES.METAMASK}/${ACTIONS.WC}`)
   ) {
-    // console.debug(`test now deeplink hack ${url}`);
     let fixedUrl = wcURL;
     if (url.startsWith(`${PREFIXES.METAMASK}/${ACTIONS.WC}`)) {
       fixedUrl = url.replace(


### PR DESCRIPTION
## **Description**

Fixes a set of race conditions in the WalletConnect v2 connection flow that caused a "stuck" or looping connection tray when scanning QR codes. The root cause was multiple layers of concurrent/duplicate processing:

1. **Duplicate OS deeplink delivery**:
The OS can deliver the same deeplink 3-5 times via Linking + Branch. Each delivery called `pair()` and pushed a loading modal, stacking duplicate modals on screen.
2. **Duplicate relay events**: 
The WalletConnect relay can fire the same `session_proposal` event multiple times when duplicate `pair()` calls were made, causing duplicate AccountConnect screens.
3. **Concurrent proposal handling**: 
Rapid QR scans caused overlapping proposals to fight over shared state (`wc2Metadata`, navigation, approval queue).
4. **Navigation re-trigger loop**: 
Changes to the `pendingApprovals` Redux state re-triggered `PermissionApproval`'s `useEffect`, causing repeated navigation to AccountConnect for the same approval.

Each issue is fixed at the layer where it occurs:

| Layer | Guard | Purpose |
|-------|-------|---------|
| `connect()` | `seenTopics` + 5 s TTL | Blocks duplicate OS deeplink deliveries; TTL allows manual retries |
| `onSessionProposal()` | `proposalLock` | Serializes concurrent proposals |
| `_handleSessionProposal()` | `handledProposalIds` | Blocks duplicate relay events |
| `PermissionApproval` | `lastNavigatedApprovalIdRef` | Prevents re-navigation for the same approval ID |

Additionally fixes the `SDKLoading` Lottie animation not being visible.

**Compatibility with #24040:** The `PermissionApproval` change keeps `pendingApprovals` in the `useEffect` deps (so the effect still re-runs when the queue changes, preventing stuck approvals). The added ref guard only skips navigation for the *same* approval ID; new approvals with a different ID navigate normally.

## **Changelog**

CHANGELOG entry: Fixed WalletConnect connection tray getting stuck or looping when scanning QR codes, and fixed the loading animation not displaying during connection.

## **Related issues**

Fixes: [WAPI-1070](https://consensyssoftware.atlassian.net/browse/WAPI-1070)

## **Manual testing steps**

```gherkin
Feature: WalletConnect QR code connection

  Scenario: In-app QR scanner connection
    Given the user opens a dApp that supports WalletConnect (e.g. Coinbase Commerce)
    When the user scans the WC QR code using the in-app scanner
    Then a loading animation should briefly appear
    And the AccountConnect approval screen should appear once
    And tapping Connect should complete the connection

  Scenario: Camera app deeplink connection
    Given the user opens a dApp that supports WalletConnect
    When the user scans the WC QR code using the device camera app
    Then the loading modal should appear only once (not duplicated)
    And the AccountConnect screen should appear once
    And tapping Connect should complete the connection

  Scenario: Rapid repeated scans
    Given the user has completed one connection via QR scan
    When the user immediately scans another WC QR code
    Then each scan should produce exactly one connection flow
    And no flows should get stuck or loop

  Scenario: Retry after failed relay delivery
    Given the user scans a QR code but the WC relay fails to send a session_proposal
    When the user waits ~5 seconds and scans the same QR code again
    Then a new connection attempt should proceed normally
```

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/843c71da-25ac-4b85-b26f-85cbc02961ae



## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR


[WAPI-1070]: https://consensyssoftware.atlassian.net/browse/WAPI-1070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WalletConnect v2 connection/proposal control flow and approval navigation, so regressions could block or duplicate connection attempts. Changes are localized and include added guards and updated tests, reducing but not eliminating behavioral risk.
> 
> **Overview**
> Prevents WalletConnect v2 connection flows from looping/stacking by **deduplicating `connect()` calls per pairing topic (5s TTL)** and **serializing `session_proposal` handling** with a lock plus proposal-id dedupe.
> 
> Fixes repeated AccountConnect navigation by guarding `PermissionApproval` against re-navigating for the same approval `metadata.id` even when `pendingApprovals` changes, and updates tests accordingly. Also fixes the SDK loading tray animation sizing by adding an explicit Lottie `aspectRatio`, and tightens logging/metadata cleanup on proposal rejection to avoid stale UI state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 183bbe0da8685b8d209d504cf8f8c74525bc0014. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->