### PR TITLE
fix: use push navigation for Bridge asset details

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -62,12 +62,14 @@ const renderWithReduxProvider = (component: React.ReactElement) =>
 
 const mockSetOptions = jest.fn();
 const mockNavigate = jest.fn();
+const mockNavigationDispatch = jest.fn();
 let mockRouteParams: { type: 'source' | 'dest' } = { type: 'source' };
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
+    dispatch: mockNavigationDispatch,
     goBack: jest.fn(),
     setOptions: mockSetOptions,
   }),
@@ -399,6 +401,7 @@ const resetMocks = () => {
   mockSelectedToken = null;
   mockFormatAddressToAssetId.mockReturnValue('eip155:1/erc20:0x1234');
   mockIsNonEvmChainId.mockReturnValue(false);
+  mockNavigationDispatch.mockReset();
 };
 
 describe('tokenToIncludeAsset', () => {
@@ -690,15 +693,21 @@ describe('BridgeTokenSelector', () => {
       await act(async () => {
         fireEvent.press(getByTestId('button-icon-info'));
       });
-      expect(mockNavigate).toHaveBeenCalledWith(
-        'Asset',
+      expect(mockNavigationDispatch).toHaveBeenCalledWith(
         expect.objectContaining({
-          symbol: 'USDC',
-          name: 'USD Coin',
-          assetId: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
-          chainId: '0x1',
-          decimals: 18,
-          image: 'https://example.com/token.png',
+          type: 'PUSH',
+          payload: expect.objectContaining({
+            name: 'Asset',
+            params: expect.objectContaining({
+              symbol: 'USDC',
+              name: 'USD Coin',
+              assetId:
+                'eip155:1/erc20:0x1234567890123456789012345678901234567890',
+              chainId: '0x1',
+              decimals: 18,
+              image: 'https://example.com/token.png',
+            }),
+          }),
         }),
       );
       expect(mockTrackEvent).toHaveBeenCalled();

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -11,7 +11,12 @@ import {
   ListRenderItemInfo,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import {
+  useNavigation,
+  useRoute,
+  RouteProp,
+  StackActions,
+} from '@react-navigation/native';
 import { useSelector, useDispatch } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
 import { getHeaderCompactStandardNavbarOptions } from '../../../../../component-library/components-temp/HeaderCompactStandard';
@@ -371,10 +376,14 @@ export const BridgeTokenSelector: React.FC = () => {
       );
       const networkName = chainData?.name ?? '';
 
-      navigation.navigate('Asset', {
-        ...item,
-        source: TokenDetailsSource.Swap,
-      });
+      // Use push so we always open details for the tapped token.
+      // navigate('Asset') can reuse an existing Asset route with stale params.
+      navigation.dispatch(
+        StackActions.push('Asset', {
+          ...item,
+          source: TokenDetailsSource.Swap,
+        }),
+      );
 
       Engine.context.BridgeController.trackUnifiedSwapBridgeEvent(
         UnifiedSwapBridgeEventName.AssetDetailTooltipClicked,


### PR DESCRIPTION
## **Description**

This PR fixes a swaps token-info navigation bug where tapping the info icon in the token selector could open the wrong asset details screen.

Root cause:
- In `BridgeTokenSelector`, info-icon navigation used `navigate('Asset', params)`.
- When swaps was entered from an existing asset details route, React Navigation could reuse that existing `Asset` route instance, resulting in stale params (the entry token) instead of the tapped token.

Fix:
- Switched info-icon navigation to `navigation.dispatch(StackActions.push('Asset', params))` so a fresh `Asset` route is always created with the tapped token params.
- Kept analytics tracking behavior unchanged.
- Updated unit test assertions to validate a `PUSH` action with correct token params.

## **Changelog**

CHANGELOG entry: Fixed a bug where tapping a token’s info icon in Swaps could open the wrong asset details page.

## **Related issues**

Fixes: SWAPS-4107

## **Manual testing steps**

```gherkin
Feature: Swaps token info navigation opens correct asset details

  Scenario: Open swaps from asset details and inspect another token
    Given I am on any token asset details page
    When I tap "Swap"
    And I open the token selector
    And I tap the info icon for a different token
    Then the asset details page opens for the tapped token
    And not for the original token I started from

  Scenario: Open swaps from a non-asset-details entrypoint
    Given I open swaps from home/wallet actions
    When I open the token selector
    And I tap the info icon for a token
    Then the asset details page opens for that tapped token
```

## **Screenshots/Recordings**

### **Before**

Behavior reproduced in Jira recording attached to `SWAPS-4107` (wrong token details opened).

### **After**

Pending fresh verification recording showing tapped token details open correctly on iOS and Android.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.