### PR TITLE
fix: remove O(n) API calls to ENS on the swaps flow

### DIFF
--- a/app/components/UI/Bridge/hooks/useDestinationAccounts.ts
+++ b/app/components/UI/Bridge/hooks/useDestinationAccounts.ts
@@ -9,7 +9,7 @@ import { selectMultichainAccountsState2Enabled } from '../../../../selectors/fea
  * Custom hook that provides filtered destination accounts for bridge operations
  */
 export const useDestinationAccounts = () => {
-  const { accounts, ensByAccountAddress } = useAccounts();
+  const { accounts, ensByAccountAddress } = useAccounts({ fetchENS: false });
 
   // Filter accounts using BIP-44 aware multichain selectors via account IDs
   const validDestIds = useSelector(selectValidDestInternalAccountIds);

--- a/app/components/UI/Bridge/hooks/useDestinationAccounts.ts
+++ b/app/components/UI/Bridge/hooks/useDestinationAccounts.ts
@@ -9,7 +9,7 @@ import { selectMultichainAccountsState2Enabled } from '../../../../selectors/fea
  * Custom hook that provides filtered destination accounts for bridge operations
  */
 export const useDestinationAccounts = () => {
-  const { accounts, ensByAccountAddress } = useAccounts({ fetchENS: false });
+  const { accounts } = useAccounts({ fetchENS: false });
 
   // Filter accounts using BIP-44 aware multichain selectors via account IDs
   const validDestIds = useSelector(selectValidDestInternalAccountIds);
@@ -43,5 +43,5 @@ export const useDestinationAccounts = () => {
     isMultichainAccountsState2Enabled,
   ]);
 
-  return { destinationAccounts, ensByAccountAddress };
+  return { destinationAccounts };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
When the bridge/swaps flow opens, useRecipientInitialization calls useDestinationAccounts, which calls useAccounts() with the default fetchENS: true. This triggers doENSReverseLookup() for every account in the wallet, each making an eth_call to the ENS Registry contract. The number of RPC calls scales linearly with the number of accounts, causing unnecessary network traffic and latency.

None of the ENS data is consumed anywhere in the bridge flow:
- useRecipientInitialization only reads destinationAccounts, never ensByAccountAddress
- RecipientSelectorModal builds its own account list from Redux selectors with no ENS involvement
- useRecipientDisplayData uses internalAccount.metadata.name and account group metadata, not ENS
The fix passes { fetchENS: false } to useAccounts() in useDestinationAccounts, eliminating the wasted ENS lookups with zero impact on functionality. The unused ensByAccountAddress return value is also removed from the hook.

[Slack thread
](https://consensys.slack.com/archives/C08ANMLF2UW/p1770799431765079)
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed excessive ENS API calls when opening the bridge/swaps flow that scaled with the number of accounts

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/25967

https://consensyssoftware.atlassian.net/browse/ASSETS-2682

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/d988f7ab-e0ee-42d9-956c-1efdaafab45f

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only affects account display data fetching and a hook return shape; low chance of impacting bridge logic beyond any remaining callers expecting ENS data.
> 
> **Overview**
> Prevents per-account ENS network calls in Bridge destination account selection by calling `useAccounts({ fetchENS: false })`.
> 
> Simplifies `useDestinationAccounts` to only return `destinationAccounts` (drops `ensByAccountAddress` from the hook API).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55a204e80c716d7f2212e55c9cc6baaa10c07b2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->