### PR TITLE
refactor: clean up Migration 82 error reporting

### DIFF
--- a/app/store/migrations/082.test.ts
+++ b/app/store/migrations/082.test.ts
@@ -1,17 +1,11 @@
-import { captureException } from '@sentry/react-native';
 import migrate from './082';
 import { cloneDeep } from 'lodash';
 import { ensureValidState } from './util';
-
-jest.mock('@sentry/react-native', () => ({
-  captureException: jest.fn(),
-}));
 
 jest.mock('./util', () => ({
   ensureValidState: jest.fn(),
 }));
 
-const mockedCaptureException = jest.mocked(captureException);
 const mockedEnsureValidState = jest.mocked(ensureValidState);
 
 describe('Migration 82', () => {
@@ -30,8 +24,6 @@ describe('Migration 82', () => {
         },
       },
       test: 'invalid TokenBalancesController state',
-      expectedError:
-        "FATAL ERROR: Migration 82: Invalid TokenBalancesController state error: 'string'",
     },
     {
       state: {
@@ -42,8 +34,6 @@ describe('Migration 82', () => {
         },
       },
       test: 'empty TokenBalancesController state',
-      expectedError:
-        "FATAL ERROR: Migration 82: Invalid TokenBalancesController state error: 'object'",
     },
     {
       state: {
@@ -57,8 +47,6 @@ describe('Migration 82', () => {
         },
       },
       test: 'invalid TokensController state',
-      expectedError:
-        "FATAL ERROR: Migration 82: Invalid TokensController state error: 'string'",
     },
     {
       state: {
@@ -72,8 +60,6 @@ describe('Migration 82', () => {
         },
       },
       test: 'empty TokensController state',
-      expectedError:
-        "FATAL ERROR: Migration 82: Invalid TokensController state error: 'object'",
     },
     {
       state: {
@@ -89,8 +75,6 @@ describe('Migration 82', () => {
         },
       },
       test: 'TokensController state without allDetectedTokens and allIgnoredTokens',
-      expectedError:
-        "FATAL ERROR: Migration 82: Invalid TokensController state error: 'object'",
     },
     {
       state: {
@@ -109,8 +93,6 @@ describe('Migration 82', () => {
         },
       },
       test: 'invalid accountsController state',
-      expectedError:
-        "FATAL ERROR: Migration 82: Invalid AccountsController state error: 'string'",
     },
     {
       state: {
@@ -133,12 +115,10 @@ describe('Migration 82', () => {
         },
       },
       test: 'invalid accountsController accounts state',
-      expectedError:
-        "FATAL ERROR: Migration 82: Invalid AccountsController state error: 'object'",
     },
   ])(
-    'captures exception and returns state unchanged for invalid state - $test',
-    ({ state, expectedError }) => {
+    'returns state unchanged for invalid state - $test',
+    ({ state }) => {
       const orgState = cloneDeep(state);
       mockedEnsureValidState.mockReturnValue(true);
 
@@ -146,11 +126,6 @@ describe('Migration 82', () => {
 
       // State should be unchanged
       expect(migratedState).toStrictEqual(orgState);
-      expect(mockedCaptureException).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expectedError,
-        }),
-      );
     },
   );
 

--- a/app/store/migrations/082.test.ts
+++ b/app/store/migrations/082.test.ts
@@ -116,18 +116,15 @@ describe('Migration 82', () => {
       },
       test: 'invalid accountsController accounts state',
     },
-  ])(
-    'returns state unchanged for invalid state - $test',
-    ({ state }) => {
-      const orgState = cloneDeep(state);
-      mockedEnsureValidState.mockReturnValue(true);
+  ])('returns state unchanged for invalid state - $test', ({ state }) => {
+    const orgState = cloneDeep(state);
+    mockedEnsureValidState.mockReturnValue(true);
 
-      const migratedState = migrate(state);
+    const migratedState = migrate(state);
 
-      // State should be unchanged
-      expect(migratedState).toStrictEqual(orgState);
-    },
-  );
+    // State should be unchanged
+    expect(migratedState).toStrictEqual(orgState);
+  });
 
   it('does not remove any tokens from state if all accounts in TokensController state exist in AccountsController state', () => {
     mockedEnsureValidState.mockReturnValue(true);

--- a/app/store/migrations/082.ts
+++ b/app/store/migrations/082.ts
@@ -1,6 +1,5 @@
 import { hasProperty, Hex, isObject } from '@metamask/utils';
 import { ensureValidState } from './util';
-import { captureException } from '@sentry/react-native';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { Token } from '@metamask/assets-controllers';
@@ -38,11 +37,6 @@ const migration = (state: unknown): unknown => {
     !hasProperty(tokenBalancesControllerState, 'tokenBalances') ||
     !isObject(tokenBalancesControllerState.tokenBalances)
   ) {
-    captureException(
-      new Error(
-        `FATAL ERROR: Migration 82: Invalid TokenBalancesController state error: '${typeof tokenBalancesControllerState}'`,
-      ),
-    );
     return state;
   }
 
@@ -55,11 +49,6 @@ const migration = (state: unknown): unknown => {
     !hasProperty(tokensControllerState, 'allIgnoredTokens') ||
     !isObject(tokensControllerState.allIgnoredTokens)
   ) {
-    captureException(
-      new Error(
-        `FATAL ERROR: Migration 82: Invalid TokensController state error: '${typeof tokensControllerState}'`,
-      ),
-    );
     return state;
   }
 
@@ -70,11 +59,6 @@ const migration = (state: unknown): unknown => {
     !hasProperty(accountsControllerState.internalAccounts, 'accounts') ||
     !isObject(accountsControllerState.internalAccounts.accounts)
   ) {
-    captureException(
-      new Error(
-        `FATAL ERROR: Migration 82: Invalid AccountsController state error: '${typeof accountsControllerState}'`,
-      ),
-    );
     return state;
   }
 


### PR DESCRIPTION
## **Description**

Remove Sentry error reporting for state assertions in migration 082.

The migration already handles cases where controller state fields are not found or have unexpected shapes by returning the state unchanged, making Sentry error reporting redundant.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: silence unnecessary sentry errors

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/26127 https://consensyssoftware.atlassian.net/browse/ASSETS-2681

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<p><a href="https://cursor.com/background-agent?bcId=bc-483da7c1-13d6-4e6c-8b8b-de1aa4c219cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-483da7c1-13d6-4e6c-8b8b-de1aa4c219cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes redundant error reporting without changing migration behavior beyond logging/telemetry; functional state migration logic remains the same.
> 
> **Overview**
> Migration `082` no longer calls Sentry (`captureException`) when `TokenBalancesController`, `TokensController`, or `AccountsController` state shapes are missing/invalid; it now simply returns the original state in these guard paths.
> 
> Tests for migration `082` were updated to remove Sentry mocking/assertions and to only verify that invalid states are returned unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit deb2dd9e0a7d9dad4769033e74fead25c06da901. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->