### PR TITLE
fix: token list item V2 does not show price for non-evm tokens

### DIFF
--- a/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.test.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.test.tsx
@@ -16,6 +16,12 @@ import { act, fireEvent, waitFor } from '@testing-library/react-native';
 import Routes from '../../../../../constants/navigation/Routes';
 import { toHex } from '@metamask/controller-utils';
 import { strings } from '../../../../../../locales/i18n';
+import { selectTokenMarketData } from '../../../../../selectors/tokenRatesController';
+import { selectMultichainAssetsRates } from '../../../../../selectors/multichain/multichain';
+import {
+  selectCurrencyRates,
+  selectCurrentCurrency,
+} from '../../../../../selectors/currencyRateController';
 
 import { useMusdConversionTokens } from '../../../Earn/hooks/useMusdConversionTokens';
 import { useMusdConversionEligibility } from '../../../Earn/hooks/useMusdConversionEligibility';
@@ -347,6 +353,12 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
     isMerklClaimingEnabled?: boolean;
     claimableReward?: string | null;
     isMerklEligible?: boolean;
+    tokenMarketData?: Record<string, Record<string, { price: number }>>;
+    currencyRatesData?: Record<string, { conversionRate: number }>;
+    nativeCurrency?: string;
+    currentCurrency?: string;
+    multichainRates?: Record<string, { rate: number }>;
+    isTestNetwork?: boolean;
   }
 
   function prepareMocks({
@@ -361,6 +373,12 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
     isMerklClaimingEnabled = false,
     claimableReward = null,
     isMerklEligible = false,
+    tokenMarketData,
+    currencyRatesData,
+    nativeCurrency,
+    currentCurrency,
+    multichainRates,
+    isTestNetwork = false,
   }: PrepareMocksOptions = {}) {
     jest.clearAllMocks();
 
@@ -428,6 +446,22 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
           return isMerklClaimingEnabled;
         }
 
+        if (selector === selectTokenMarketData) {
+          return tokenMarketData ?? {};
+        }
+
+        if (selector === selectCurrencyRates) {
+          return currencyRatesData ?? {};
+        }
+
+        if (selector === selectCurrentCurrency) {
+          return currentCurrency ?? 'usd';
+        }
+
+        if (selector === selectMultichainAssetsRates) {
+          return multichainRates ?? {};
+        }
+
         const selectorString = selector.toString();
 
         // TokenListItemV2 selectors
@@ -462,12 +496,16 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
           return 'pooled-staking';
         }
 
+        if (selectorString.includes('selectNativeCurrencyByChainId')) {
+          return nativeCurrency ?? undefined;
+        }
+
         return {};
       },
     );
 
     mockUseTokenPricePercentageChange.mockReturnValue(pricePercentChange1d);
-    mockIsTestNet.mockReturnValue(false);
+    mockIsTestNet.mockReturnValue(isTestNetwork);
     mockFormatWithThreshold.mockImplementation((value) => `${value} FORMATTED`);
   }
 
@@ -500,7 +538,7 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
   });
 
   describe('Percentage Logic', () => {
-    it('covers Number.isFinite check for valid finite number', () => {
+    it('displays positive percentage change with success color', () => {
       prepareMocks({
         asset: defaultAsset,
       });
@@ -526,7 +564,7 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
       expect(percentageText.props.style.color).toBe('#457a39');
     });
 
-    it('covers Number.isFinite check preventing Infinity', () => {
+    it('displays dash when percentage change is not finite', () => {
       prepareMocks({
         asset: defaultAsset,
         pricePercentChange1d: Infinity,
@@ -552,10 +590,10 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
       expect(percentageText?.props.children).toBe('-');
     });
 
-    it('covers Number.isFinite check preventing NaN', () => {
+    it('displays negative percentage change with error color', () => {
       prepareMocks({
         asset: defaultAsset,
-        pricePercentChange1d: NaN,
+        pricePercentChange1d: -3.45,
       });
 
       const assetKey: FlashListAssetKey = {
@@ -564,7 +602,7 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
         isStaked: false,
       };
 
-      const { queryByTestId } = renderWithProvider(
+      const { getByTestId } = renderWithProvider(
         <TokenListItemV2
           assetKey={assetKey}
           showRemoveMenu={jest.fn()}
@@ -573,15 +611,17 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
         />,
       );
 
-      const percentageText = queryByTestId(SECONDARY_BALANCE_TEST_ID);
-      expect(percentageText).toBeOnTheScreen();
-      expect(percentageText?.props.children).toBe('-');
+      const percentageText = getByTestId(SECONDARY_BALANCE_TEST_ID);
+      expect(percentageText.props.children).toBe('-3.45%');
+      // Negative percentage should NOT have success color
+      expect(percentageText.props.style.color).not.toBe('#457a39');
     });
 
-    it('covers Number.isFinite check preventing negative Infinity', () => {
+    it('hides percentage change on testnet', () => {
       prepareMocks({
         asset: defaultAsset,
-        pricePercentChange1d: -Infinity,
+        pricePercentChange1d: 5.0,
+        isTestNetwork: true,
       });
 
       const assetKey: FlashListAssetKey = {
@@ -590,7 +630,7 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
         isStaked: false,
       };
 
-      const { queryByTestId } = renderWithProvider(
+      const { getByTestId } = renderWithProvider(
         <TokenListItemV2
           assetKey={assetKey}
           showRemoveMenu={jest.fn()}
@@ -599,9 +639,8 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
         />,
       );
 
-      const percentageText = queryByTestId(SECONDARY_BALANCE_TEST_ID);
-      expect(percentageText).toBeOnTheScreen();
-      expect(percentageText?.props.children).toBe('-');
+      const percentageText = getByTestId(SECONDARY_BALANCE_TEST_ID);
+      expect(percentageText.props.children).toBe('-');
     });
   });
 
@@ -948,111 +987,6 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
       expect(queryByTestId('stock-badge')).toBeNull();
       expect(mockIsStockToken).toHaveBeenCalled();
     });
-
-    it('passes the asset to isStockToken function', () => {
-      prepareMocks({
-        asset: stockAsset,
-        isStockToken: true,
-      });
-
-      renderWithProvider(
-        <TokenListItemV2
-          assetKey={assetKey}
-          showRemoveMenu={jest.fn()}
-          setShowScamWarningModal={jest.fn()}
-          privacyMode={false}
-        />,
-      );
-
-      expect(mockIsStockToken).toHaveBeenCalledWith(
-        expect.objectContaining({
-          symbol: 'AAPL',
-          name: 'Apple Inc.',
-        }),
-      );
-    });
-
-    it('renders StockBadge with correct token prop', () => {
-      prepareMocks({
-        asset: stockAsset,
-        isStockToken: true,
-      });
-
-      const { getByText } = renderWithProvider(
-        <TokenListItemV2
-          assetKey={assetKey}
-          showRemoveMenu={jest.fn()}
-          setShowScamWarningModal={jest.fn()}
-          privacyMode={false}
-        />,
-      );
-
-      expect(getByText('Stock Badge: AAPL')).toBeOnTheScreen();
-    });
-
-    it('renders StockBadge alongside other token information', () => {
-      prepareMocks({
-        asset: stockAsset,
-        isStockToken: true,
-      });
-
-      const { getByTestId, getByText } = renderWithProvider(
-        <TokenListItemV2
-          assetKey={assetKey}
-          showRemoveMenu={jest.fn()}
-          setShowScamWarningModal={jest.fn()}
-          privacyMode={false}
-        />,
-      );
-
-      expect(getByText('Apple Inc.')).toBeOnTheScreen();
-      expect(getByText('1.23 AAPL')).toBeOnTheScreen();
-      expect(getByTestId('stock-badge')).toBeOnTheScreen();
-    });
-
-    it('renders StockBadge with percentage change when both conditions are met', () => {
-      prepareMocks({
-        asset: stockAsset,
-        isStockToken: true,
-        pricePercentChange1d: 2.5,
-      });
-
-      const { getByTestId, getByText } = renderWithProvider(
-        <TokenListItemV2
-          assetKey={assetKey}
-          showRemoveMenu={jest.fn()}
-          setShowScamWarningModal={jest.fn()}
-          privacyMode={false}
-        />,
-      );
-
-      expect(getByTestId('stock-badge')).toBeOnTheScreen();
-      expect(getByText('+2.50%')).toBeOnTheScreen();
-    });
-
-    it('does NOT render StockBadge when RWA feature flag is disabled (isStockToken returns false)', () => {
-      prepareMocks({
-        asset: {
-          ...stockAsset,
-          rwaData: {
-            instrumentType: 'stock',
-            market: { nextOpen: '2024-01-01', nextClose: '2024-01-02' },
-          },
-        },
-        isStockToken: false, // RWA disabled, so isStockToken returns false
-      });
-
-      const { queryByTestId } = renderWithProvider(
-        <TokenListItemV2
-          assetKey={assetKey}
-          showRemoveMenu={jest.fn()}
-          setShowScamWarningModal={jest.fn()}
-          privacyMode={false}
-        />,
-      );
-
-      expect(queryByTestId('stock-badge')).toBeNull();
-    });
   });
 
   describe('Stablecoin lending Earn CTA threshold', () => {
@@ -1238,6 +1172,139 @@ describe('TokenListItemV2 - Component Rendering Tests for Coverage', () => {
 
       expect(queryByText(strings('earn.claim_bonus'))).toBeNull();
       expect(getByText('+1.50%')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Token Price in Fiat', () => {
+    it('displays token fiat price from multichain rates for non-EVM assets', () => {
+      const solAddress = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501';
+      const solAsset = {
+        ...defaultAsset,
+        address: solAddress,
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        symbol: 'SOL',
+        name: 'Solana',
+        balance: '10',
+        balanceFiat: '$255.00',
+      };
+
+      prepareMocks({
+        asset: solAsset,
+        currentCurrency: 'usd',
+        multichainRates: {
+          [solAddress]: { rate: 25.5 },
+        },
+      });
+
+      const assetKey: FlashListAssetKey = {
+        address: solAddress,
+        chainId: solAsset.chainId,
+        isStaked: false,
+      };
+
+      const { getByText } = renderWithProvider(
+        <TokenListItemV2
+          assetKey={assetKey}
+          showRemoveMenu={jest.fn()}
+          setShowScamWarningModal={jest.fn()}
+          privacyMode={false}
+        />,
+      );
+
+      expect(getByText(/\$25\.50/)).toBeOnTheScreen();
+    });
+
+    it('displays token fiat price calculated from EVM market data', () => {
+      const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+      const evmAsset = {
+        ...defaultAsset,
+        address: usdcAddress,
+        symbol: 'USDC',
+        name: 'USD Coin',
+      };
+
+      prepareMocks({
+        asset: evmAsset,
+        currentCurrency: 'usd',
+        nativeCurrency: 'ETH',
+        tokenMarketData: {
+          '0x1': {
+            [usdcAddress]: { price: 0.0005 },
+          },
+        },
+        currencyRatesData: {
+          ETH: { conversionRate: 2000 },
+        },
+      });
+
+      const assetKey: FlashListAssetKey = {
+        address: usdcAddress,
+        chainId: '0x1',
+        isStaked: false,
+      };
+
+      const { getByText } = renderWithProvider(
+        <TokenListItemV2
+          assetKey={assetKey}
+          showRemoveMenu={jest.fn()}
+          setShowScamWarningModal={jest.fn()}
+          privacyMode={false}
+        />,
+      );
+
+      // 0.0005 ETH/token * 2000 USD/ETH = $1.00
+      expect(getByText(/\$1\.00/)).toBeOnTheScreen();
+    });
+  });
+
+  describe('Component Edge Cases', () => {
+    it('returns null when asset is not found', () => {
+      prepareMocks({
+        asset: undefined,
+      });
+
+      const assetKey: FlashListAssetKey = {
+        address: '0x999',
+        chainId: '0x1',
+        isStaked: false,
+      };
+
+      const { toJSON } = renderWithProvider(
+        <TokenListItemV2
+          assetKey={assetKey}
+          showRemoveMenu={jest.fn()}
+          setShowScamWarningModal={jest.fn()}
+          privacyMode={false}
+        />,
+      );
+
+      expect(toJSON()).toBeNull();
+    });
+
+    it('falls back to symbol when name is not available', () => {
+      prepareMocks({
+        asset: {
+          ...defaultAsset,
+          name: '',
+        },
+      });
+
+      const assetKey: FlashListAssetKey = {
+        address: '0x456',
+        chainId: '0x1',
+        isStaked: false,
+      };
+
+      const { getByText } = renderWithProvider(
+        <TokenListItemV2
+          assetKey={assetKey}
+          showRemoveMenu={jest.fn()}
+          setShowScamWarningModal={jest.fn()}
+          privacyMode={false}
+        />,
+      );
+
+      expect(getByText('TEST')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.tsx
@@ -107,10 +107,15 @@ const createStyles = (colors: Colors) =>
     assetNameContainer: {
       flexDirection: 'row',
       alignItems: 'center',
+      flexShrink: 1,
     },
     assetName: {
       flexDirection: 'row',
       gap: 8,
+      flexShrink: 1,
+    },
+    assetNameText: {
+      flexShrink: 1,
     },
     percentageChange: {
       flexDirection: 'row',
@@ -518,7 +523,11 @@ export const TokenListItemV2 = React.memo(
                */}
               <View style={styles.assetNameContainer}>
                 <View style={styles.assetName}>
-                  <Text variant={TextVariant.BodyMDBold} numberOfLines={1}>
+                  <Text
+                    variant={TextVariant.BodyMDBold}
+                    numberOfLines={1}
+                    style={styles.assetNameText}
+                  >
                     {asset.name || asset.symbol}
                   </Text>
                   {label && (

--- a/app/selectors/featureFlagController/tokenListLayout/index.test.ts
+++ b/app/selectors/featureFlagController/tokenListLayout/index.test.ts
@@ -1,22 +1,91 @@
 import { selectTokenListLayoutV2Enabled } from '.';
+import { hasMinimumRequiredVersion } from '../../../util/remoteFeatureFlag';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('1.0.0'),
+}));
+
+jest.mock('../../../util/remoteFeatureFlag', () => ({
+  ...jest.requireActual('../../../util/remoteFeatureFlag'),
+  hasMinimumRequiredVersion: jest.fn(),
+}));
 
 describe('selectTokenListLayoutV2Enabled', () => {
-  it('returns true when tokenListItemV2Abtest is true', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(hasMinimumRequiredVersion).mockReturnValue(true);
+  });
+
+  it('returns true when flag is valid and enabled', () => {
     const result = selectTokenListLayoutV2Enabled.resultFunc({
-      tokenListItemV2Abtest: true,
+      tokenListItemV2Abtest: {
+        enabled: true,
+        minimumVersion: '1.0.0',
+      },
     });
     expect(result).toBe(true);
   });
 
-  it('returns false when tokenListItemV2Abtest is false', () => {
+  it('returns false when flag is valid but disabled', () => {
     const result = selectTokenListLayoutV2Enabled.resultFunc({
-      tokenListItemV2Abtest: false,
+      tokenListItemV2Abtest: {
+        enabled: false,
+        minimumVersion: '1.0.0',
+      },
     });
     expect(result).toBe(false);
   });
 
-  it('returns false when tokenListItemV2Abtest is undefined', () => {
+  it('returns false when version check fails', () => {
+    jest.mocked(hasMinimumRequiredVersion).mockReturnValue(false);
+    const result = selectTokenListLayoutV2Enabled.resultFunc({
+      tokenListItemV2Abtest: {
+        enabled: true,
+        minimumVersion: '99.0.0',
+      },
+    });
+    expect(result).toBe(false);
+  });
+
+  it('returns false when flag has invalid types', () => {
+    const result = selectTokenListLayoutV2Enabled.resultFunc({
+      tokenListItemV2Abtest: {
+        enabled: 'invalid',
+        minimumVersion: 123,
+      },
+    });
+    expect(result).toBe(false);
+  });
+
+  it('returns false when remote feature flags are empty', () => {
     const result = selectTokenListLayoutV2Enabled.resultFunc({});
     expect(result).toBe(false);
+  });
+
+  it('returns false when tokenListItemV2Abtest flag is missing', () => {
+    const result = selectTokenListLayoutV2Enabled.resultFunc({
+      someOtherFlag: true,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('returns false when flag is a plain boolean (legacy shape)', () => {
+    const result = selectTokenListLayoutV2Enabled.resultFunc({
+      tokenListItemV2Abtest: true,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('handles progressive rollout wrapper shape', () => {
+    const result = selectTokenListLayoutV2Enabled.resultFunc({
+      tokenListItemV2Abtest: {
+        name: 'token-list-item-v2-abtest',
+        value: {
+          enabled: true,
+          minimumVersion: '1.0.0',
+        },
+      },
+    });
+    expect(result).toBe(true);
   });
 });

--- a/app/selectors/featureFlagController/tokenListLayout/index.test.ts
+++ b/app/selectors/featureFlagController/tokenListLayout/index.test.ts
@@ -18,7 +18,7 @@ describe('selectTokenListLayoutV2Enabled', () => {
 
   it('returns true when flag is valid and enabled', () => {
     const result = selectTokenListLayoutV2Enabled.resultFunc({
-      tokenListItemV2Abtest: {
+      tokenListItemV2AbtestVersioned: {
         enabled: true,
         minimumVersion: '1.0.0',
       },
@@ -28,7 +28,7 @@ describe('selectTokenListLayoutV2Enabled', () => {
 
   it('returns false when flag is valid but disabled', () => {
     const result = selectTokenListLayoutV2Enabled.resultFunc({
-      tokenListItemV2Abtest: {
+      tokenListItemV2AbtestVersioned: {
         enabled: false,
         minimumVersion: '1.0.0',
       },
@@ -39,7 +39,7 @@ describe('selectTokenListLayoutV2Enabled', () => {
   it('returns false when version check fails', () => {
     jest.mocked(hasMinimumRequiredVersion).mockReturnValue(false);
     const result = selectTokenListLayoutV2Enabled.resultFunc({
-      tokenListItemV2Abtest: {
+      tokenListItemV2AbtestVersioned: {
         enabled: true,
         minimumVersion: '99.0.0',
       },
@@ -49,7 +49,7 @@ describe('selectTokenListLayoutV2Enabled', () => {
 
   it('returns false when flag has invalid types', () => {
     const result = selectTokenListLayoutV2Enabled.resultFunc({
-      tokenListItemV2Abtest: {
+      tokenListItemV2AbtestVersioned: {
         enabled: 'invalid',
         minimumVersion: 123,
       },
@@ -62,7 +62,7 @@ describe('selectTokenListLayoutV2Enabled', () => {
     expect(result).toBe(false);
   });
 
-  it('returns false when tokenListItemV2Abtest flag is missing', () => {
+  it('returns false when tokenListItemV2AbtestVersioned flag is missing', () => {
     const result = selectTokenListLayoutV2Enabled.resultFunc({
       someOtherFlag: true,
     });
@@ -71,14 +71,14 @@ describe('selectTokenListLayoutV2Enabled', () => {
 
   it('returns false when flag is a plain boolean (legacy shape)', () => {
     const result = selectTokenListLayoutV2Enabled.resultFunc({
-      tokenListItemV2Abtest: true,
+      tokenListItemV2AbtestVersioned: true,
     });
     expect(result).toBe(false);
   });
 
   it('handles progressive rollout wrapper shape', () => {
     const result = selectTokenListLayoutV2Enabled.resultFunc({
-      tokenListItemV2Abtest: {
+      tokenListItemV2AbtestVersioned: {
         name: 'token-list-item-v2-abtest',
         value: {
           enabled: true,

--- a/app/selectors/featureFlagController/tokenListLayout/index.ts
+++ b/app/selectors/featureFlagController/tokenListLayout/index.ts
@@ -7,7 +7,7 @@ import { validatedVersionGatedFeatureFlag } from '../../../util/remoteFeatureFla
  * Returns true if V2 layout is enabled AND the current app version meets
  * the minimum version requirement.
  *
- * LD flag name: token-list-item-v2-abtest -> camelCased to tokenListItemV2Abtest
+ * LD flag name: token-list-item-v2-abtest-versioned
  * Expected flag shape: { enabled: boolean, minimumVersion: string }
  *
  * @returns true if V2 layout is enabled, false otherwise

--- a/app/selectors/featureFlagController/tokenListLayout/index.ts
+++ b/app/selectors/featureFlagController/tokenListLayout/index.ts
@@ -1,11 +1,6 @@
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
-import {
-  validatedVersionGatedFeatureFlag,
-  VersionGatedFeatureFlag,
-} from '../../../util/remoteFeatureFlag';
-
-const TOKEN_LIST_LAYOUT_FLAG_KEY = 'tokenListItemV2AbtestVersioned';
+import { validatedVersionGatedFeatureFlag } from '../../../util/remoteFeatureFlag';
 
 /**
  * Selector for token list item V2 A/B test from LaunchDarkly.
@@ -20,9 +15,7 @@ const TOKEN_LIST_LAYOUT_FLAG_KEY = 'tokenListItemV2AbtestVersioned';
 export const selectTokenListLayoutV2Enabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean => {
-    const remoteFlag = remoteFeatureFlags[
-      TOKEN_LIST_LAYOUT_FLAG_KEY
-    ] as unknown as VersionGatedFeatureFlag;
+    const remoteFlag = remoteFeatureFlags?.tokenListItemV2AbtestVersioned;
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
   },
 );

--- a/app/selectors/featureFlagController/tokenListLayout/index.ts
+++ b/app/selectors/featureFlagController/tokenListLayout/index.ts
@@ -1,15 +1,28 @@
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
+import {
+  validatedVersionGatedFeatureFlag,
+  VersionGatedFeatureFlag,
+} from '../../../util/remoteFeatureFlag';
+
+const TOKEN_LIST_LAYOUT_FLAG_KEY = 'tokenListItemV2AbtestVersioned';
 
 /**
  * Selector for token list item V2 A/B test from LaunchDarkly.
- * Boolean flag: true = V2 layout, false/null = V1 layout (control).
+ * Returns true if V2 layout is enabled AND the current app version meets
+ * the minimum version requirement.
+ *
  * LD flag name: token-list-item-v2-abtest -> camelCased to tokenListItemV2Abtest
+ * Expected flag shape: { enabled: boolean, minimumVersion: string }
  *
  * @returns true if V2 layout is enabled, false otherwise
  */
 export const selectTokenListLayoutV2Enabled = createSelector(
   selectRemoteFeatureFlags,
-  (remoteFeatureFlags): boolean =>
-    remoteFeatureFlags?.tokenListItemV2Abtest === true,
+  (remoteFeatureFlags): boolean => {
+    const remoteFlag = remoteFeatureFlags[
+      TOKEN_LIST_LAYOUT_FLAG_KEY
+    ] as unknown as VersionGatedFeatureFlag;
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixed the Token List Item V2 component to display prices for non-EVM tokens (e.g. Solana, Bitcoin). The V2 layout was only computing fiat prices using EVM market data, causing non-EVM tokens to show no price. This PR adds a lookup to MultichainAssetsRatesController for non-EVM assets so their fiat rate is used when available.

Additionally, the [feature flag](https://app.launchdarkly.com/projects/metamask-client-config-api-mobile/flags/token-list-item-v2-abtest-versioned/targeting?env=production&env=flask-prod&env=qa-prod&env=test&selected-env=test) selector was updated to read from the new tokenListItemV2AbtestVersioned key (a version-gated flag shape), and the corresponding tests were updated to match.

Minor UI fix: long token names now properly shrink with flexShrink instead of overflowing the row.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed token prices not displaying for non-EVM tokens in the V2 token list layout.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2683

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="407" height="846" alt="image" src="https://github.com/user-attachments/assets/4fee4925-ad57-4d0d-bd3e-83b3f0c9025b" />

<!-- [screenshots/recordings] -->

### **After**
<img width="414" height="846" alt="image" src="https://github.com/user-attachments/assets/1b69b1e0-ccf2-407a-9169-d73e99606f59" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches token price computation/rendering and the feature-flag gate for the V2 layout; a mistake could hide prices or flip layout enablement for some app versions.
> 
> **Overview**
> Fixes `TokenListItemV2` fiat price display for non-EVM assets by first looking up rates from `selectMultichainAssetsRates` (CAIP asset IDs) and falling back to the existing EVM market-data + native-currency conversion path.
> 
> Updates the token list V2 layout feature flag selector to use the new version-gated LaunchDarkly flag (`tokenListItemV2AbtestVersioned`) via `validatedVersionGatedFeatureFlag`, adds comprehensive selector tests for invalid/missing shapes and version failures, and adjusts `TokenListItemV2` styles so long token names shrink instead of overflowing. Test coverage is expanded to validate multichain/EVM price paths, percentage-change edge cases, and null-asset rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81740a76c48c471893ee7c80971ee9d8f6f11728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->