### PR TITLE
fix: fallbackToPassword for rehydrate and sync password TO-523 cp-7.66.0

### DIFF
--- a/app/components/Views/Login/index.test.tsx
+++ b/app/components/Views/Login/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Login from './';
 import renderWithProvider from '../../../util/test/renderWithProvider';
-import { fireEvent, act } from '@testing-library/react-native';
+import { fireEvent, act, waitFor } from '@testing-library/react-native';
 import { LoginViewSelectors } from './LoginView.testIds';
 import { InteractionManager, BackHandler, Image, Platform } from 'react-native';
 import METAMASK_NAME from '../../../images/branding/metamask-name.png';
@@ -861,6 +861,133 @@ describe('Login', () => {
         expect(getByTestId(LoginViewSelectors.CONTAINER)).toBeDefined();
         expect(getByTestId(LoginViewSelectors.PASSWORD_INPUT)).toBeDefined();
         expect(getByTestId(LoginViewSelectors.LOGIN_BUTTON_ID)).toBeDefined();
+      });
+    });
+  });
+
+  describe('Biometric fallback alert after seedless password sync', () => {
+    beforeEach(() => {
+      mockRoute.mockReturnValue({
+        params: {
+          locked: false,
+          oauthLoginSuccess: false,
+        },
+      });
+      mockUnlockWallet.mockResolvedValue(true);
+    });
+
+    it('checks seedless password status and calls getAuthType when outdated', async () => {
+      // Arrange - device supports biometrics but auth fell back to PASSWORD
+      mockCheckIsSeedlessPasswordOutdated.mockResolvedValue(true);
+      mockGetAuthType.mockResolvedValue({
+        currentAuthType: 'password',
+        availableBiometryType: 'FaceID',
+      });
+      const getAuthTypeCallCountBefore = mockGetAuthType.mock.calls.length;
+
+      const { getByTestId } = renderWithProvider(<Login />);
+      const passwordInput = getByTestId(LoginViewSelectors.PASSWORD_INPUT);
+
+      // Act
+      fireEvent.changeText(passwordInput, 'valid-password123');
+      await act(async () => {
+        fireEvent(passwordInput, 'submitEditing');
+      });
+
+      // Assert - verify the full code path executed
+      await waitFor(() => {
+        expect(mockCheckIsSeedlessPasswordOutdated).toHaveBeenCalledWith(false);
+      });
+      await waitFor(() => {
+        expect(mockUnlockWallet).toHaveBeenCalled();
+      });
+      // getAuthType called extra time inside the if(isSeedlessPasswordOutdated) block
+      await waitFor(() => {
+        expect(mockGetAuthType.mock.calls.length).toBeGreaterThan(
+          getAuthTypeCallCountBefore,
+        );
+      });
+    });
+
+    it('does not call getAuthType after unlock when seedless password is not outdated', async () => {
+      // Arrange
+      mockCheckIsSeedlessPasswordOutdated.mockResolvedValue(false);
+
+      const { getByTestId } = renderWithProvider(<Login />);
+
+      // Wait for mount effects that call getAuthType
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      const getAuthTypeCallCountAfterMount = mockGetAuthType.mock.calls.length;
+
+      const passwordInput = getByTestId(LoginViewSelectors.PASSWORD_INPUT);
+
+      // Act
+      fireEvent.changeText(passwordInput, 'valid-password123');
+      await act(async () => {
+        fireEvent(passwordInput, 'submitEditing');
+      });
+
+      // Assert
+      await waitFor(() => {
+        expect(mockUnlockWallet).toHaveBeenCalled();
+      });
+      // getAuthType should NOT be called extra times after unlock
+      expect(mockGetAuthType.mock.calls.length).toBe(
+        getAuthTypeCallCountAfterMount,
+      );
+    });
+
+    it('does not enter alert branch when auth type is BIOMETRIC even if seedless password is outdated', async () => {
+      // Arrange
+      mockCheckIsSeedlessPasswordOutdated.mockResolvedValue(true);
+      mockGetAuthType.mockResolvedValue({
+        currentAuthType: 'biometrics',
+        availableBiometryType: 'FaceID',
+      });
+
+      const { getByTestId } = renderWithProvider(<Login />);
+      const passwordInput = getByTestId(LoginViewSelectors.PASSWORD_INPUT);
+
+      // Act
+      fireEvent.changeText(passwordInput, 'valid-password123');
+      await act(async () => {
+        fireEvent(passwordInput, 'submitEditing');
+      });
+
+      // Assert - flow reaches getAuthType but BIOMETRIC type skips the alert branch
+      await waitFor(() => {
+        expect(mockUnlockWallet).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(mockCheckIsSeedlessPasswordOutdated).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it('does not enter alert branch when device has no biometry support', async () => {
+      // Arrange - auth type is PASSWORD but device doesn't support biometrics
+      mockCheckIsSeedlessPasswordOutdated.mockResolvedValue(true);
+      mockGetAuthType.mockResolvedValue({
+        currentAuthType: 'password',
+        availableBiometryType: null,
+      });
+
+      const { getByTestId } = renderWithProvider(<Login />);
+      const passwordInput = getByTestId(LoginViewSelectors.PASSWORD_INPUT);
+
+      // Act
+      fireEvent.changeText(passwordInput, 'valid-password123');
+      await act(async () => {
+        fireEvent(passwordInput, 'submitEditing');
+      });
+
+      // Assert - flow completes normally (no alert needed since no biometry)
+      await waitFor(() => {
+        expect(mockUnlockWallet).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(mockCheckIsSeedlessPasswordOutdated).toHaveBeenCalledWith(false);
       });
     });
   });

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -340,7 +340,10 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
           await unlockWallet({ password });
           if (isSeedlessPasswordOutdated) {
             const authData = await getAuthType();
-            if (authData.currentAuthType === AUTHENTICATION_TYPE.PASSWORD) {
+            if (
+              authData.currentAuthType === AUTHENTICATION_TYPE.PASSWORD &&
+              authData.availableBiometryType
+            ) {
               Alert.alert(
                 strings('login.biometric_authentication_cancelled_title'),
                 strings('login.biometric_authentication_cancelled_description'),

--- a/app/components/Views/OAuthRehydration/index.test.tsx
+++ b/app/components/Views/OAuthRehydration/index.test.tsx
@@ -152,6 +152,10 @@ describe('OAuthRehydration', () => {
       undefined,
     );
     mockUnlockWallet.mockResolvedValue(undefined);
+    mockGetAuthType.mockResolvedValue({
+      currentAuthType: 'password',
+      availableBiometryType: null,
+    });
     mockComponentAuthenticationType.mockResolvedValue({
       currentAuthType: 'password',
     });

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -172,7 +172,10 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
 
   const promptBiometricFailedAlert = useCallback(async () => {
     const authData = await getAuthType();
-    if (authData.currentAuthType === AUTHENTICATION_TYPE.PASSWORD) {
+    if (
+      authData.currentAuthType === AUTHENTICATION_TYPE.PASSWORD &&
+      authData.availableBiometryType
+    ) {
       Alert.alert(
         strings('login.biometric_authentication_cancelled_title'),
         strings('login.biometric_authentication_cancelled_description'),

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -94,6 +94,7 @@ import HelpText, {
 } from '../../../component-library/components/Form/HelpText';
 import { useAuthentication } from '../../../core/Authentication';
 import { containsErrorMessage } from '../../../util/errorHandling';
+import AUTHENTICATION_TYPE from '../../../constants/userProperties';
 
 const EmptyRecordConstant = {};
 
@@ -149,7 +150,8 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
 
   const passwordLoginAttemptTraceCtxRef = useRef<TraceContext | null>(null);
 
-  const { componentAuthenticationType, unlockWallet } = useAuthentication();
+  const { componentAuthenticationType, unlockWallet, getAuthType } =
+    useAuthentication();
 
   const track = useCallback(
     (
@@ -167,6 +169,21 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
   );
 
   const [biometryChoice, setBiometryChoice] = useState(true);
+
+  const prommptBiometricFailedAlert = useCallback(async () => {
+    const authData = await getAuthType();
+    if (authData.currentAuthType === AUTHENTICATION_TYPE.PASSWORD) {
+      Alert.alert(
+        strings('login.biometric_authentication_cancelled_title'),
+        strings('login.biometric_authentication_cancelled_description'),
+        [
+          {
+            text: strings('login.biometric_authentication_cancelled_button'),
+          },
+        ],
+      );
+    }
+  }, [getAuthType]);
 
   // default biometric choice to true
   useEffect(() => {
@@ -467,6 +484,8 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
         },
         async () => {
           await unlockWallet({ password, authPreference: authType });
+          // prompt biometric failed alert if biometric failed
+          await prommptBiometricFailedAlert();
         },
       );
 
@@ -496,6 +515,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
     handleLoginError,
     passwordLoginAttemptTraceCtxRef,
     track,
+    prommptBiometricFailedAlert,
     componentAuthenticationType,
     unlockWallet,
   ]);
@@ -519,6 +539,8 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
         },
         async () => {
           await unlockWallet({ password, authPreference: authType });
+          // prompt biometric failed alert if biometric failed
+          await prommptBiometricFailedAlert();
         },
       );
 
@@ -532,6 +554,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
     biometryChoice,
     finalLoading,
     handleLoginError,
+    prommptBiometricFailedAlert,
     componentAuthenticationType,
     unlockWallet,
   ]);

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -170,7 +170,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
 
   const [biometryChoice, setBiometryChoice] = useState(true);
 
-  const prommptBiometricFailedAlert = useCallback(async () => {
+  const promptBiometricFailedAlert = useCallback(async () => {
     const authData = await getAuthType();
     if (authData.currentAuthType === AUTHENTICATION_TYPE.PASSWORD) {
       Alert.alert(
@@ -485,7 +485,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
         async () => {
           await unlockWallet({ password, authPreference: authType });
           // prompt biometric failed alert if biometric failed
-          await prommptBiometricFailedAlert();
+          await promptBiometricFailedAlert();
         },
       );
 
@@ -515,7 +515,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
     handleLoginError,
     passwordLoginAttemptTraceCtxRef,
     track,
-    prommptBiometricFailedAlert,
+    promptBiometricFailedAlert,
     componentAuthenticationType,
     unlockWallet,
   ]);
@@ -540,7 +540,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
         async () => {
           await unlockWallet({ password, authPreference: authType });
           // prompt biometric failed alert if biometric failed
-          await prommptBiometricFailedAlert();
+          await promptBiometricFailedAlert();
         },
       );
 
@@ -554,7 +554,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
     biometryChoice,
     finalLoading,
     handleLoginError,
-    prommptBiometricFailedAlert,
+    promptBiometricFailedAlert,
     componentAuthenticationType,
     unlockWallet,
   ]);

--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -4166,6 +4166,67 @@ describe('Authentication', () => {
       expect(setItemSpy).toHaveBeenCalledWith(PASSCODE_DISABLED, TRUE);
       expect(updateAuthMockDispatch).toHaveBeenCalledWith(passwordSet());
     });
+
+    it('passes fallbackToPassword through to storePassword', async () => {
+      const storePasswordSpy = jest.spyOn(Authentication, 'storePassword');
+
+      await Authentication.updateAuthPreference({
+        authType: AUTHENTICATION_TYPE.BIOMETRIC,
+        password: mockPassword,
+        fallbackToPassword: true,
+      });
+
+      // Verify storePassword receives the fallbackToPassword flag.
+      expect(storePasswordSpy).toHaveBeenCalledWith(
+        mockPassword,
+        AUTHENTICATION_TYPE.BIOMETRIC,
+        true,
+      );
+    });
+
+    it('passes fallbackToPassword as undefined to storePassword when not provided', async () => {
+      const storePasswordSpy = jest.spyOn(Authentication, 'storePassword');
+
+      await Authentication.updateAuthPreference({
+        authType: AUTHENTICATION_TYPE.BIOMETRIC,
+        password: mockPassword,
+      });
+
+      // Verify storePassword receives undefined fallbackToPassword when not provided.
+      expect(storePasswordSpy).toHaveBeenCalledWith(
+        mockPassword,
+        AUTHENTICATION_TYPE.BIOMETRIC,
+        undefined,
+      );
+    });
+
+    it('falls back to PASSWORD storage when fallbackToPassword is true and biometric storage fails', async () => {
+      // Make biometric storage fail, then password storage succeed.
+      jest
+        .spyOn(SecureKeychain, 'setGenericPassword')
+        .mockRejectedValueOnce(new Error('Biometric keychain failed'))
+        .mockResolvedValueOnce(undefined);
+
+      await Authentication.updateAuthPreference({
+        authType: AUTHENTICATION_TYPE.BIOMETRIC,
+        password: mockPassword,
+        fallbackToPassword: true,
+      });
+
+      // Verify it retried with PASSWORD type.
+      expect(SecureKeychain.setGenericPassword).toHaveBeenCalledTimes(2);
+      expect(SecureKeychain.setGenericPassword).toHaveBeenNthCalledWith(
+        1,
+        mockPassword,
+        SecureKeychain.TYPES.BIOMETRICS,
+      );
+      expect(SecureKeychain.setGenericPassword).toHaveBeenNthCalledWith(
+        2,
+        mockPassword,
+        undefined,
+      );
+      expect(updateAuthMockDispatch).toHaveBeenCalledWith(passwordSet());
+    });
   });
   describe('checkAndShowSeedlessPasswordOutdatedModal', () => {
     let Engine: typeof import('../Engine').default;
@@ -4588,10 +4649,11 @@ describe('Authentication', () => {
         authPreference: { currentAuthType: AUTHENTICATION_TYPE.BIOMETRIC },
       });
 
-      // Verify that the authentication preference is updated.
+      // Verify that the authentication preference is updated with fallbackToPassword: false (default).
       expect(updateAuthPreferenceSpy).toHaveBeenCalledWith({
         authType: AUTHENTICATION_TYPE.BIOMETRIC,
         password: passwordToUse,
+        fallbackToPassword: false,
       });
     });
 
@@ -4739,6 +4801,90 @@ describe('Authentication', () => {
             password: passwordToUse,
           }),
         ).rejects.toThrow('Failed to sync password and unlock wallet');
+      });
+
+      it('passes fallbackToPassword: true to updateAuthPreference when oauth2Login is true', async () => {
+        // Spy on rehydrateSeedPhrase and updateAuthPreference.
+        jest
+          .spyOn(Authentication, 'rehydrateSeedPhrase')
+          .mockResolvedValueOnce();
+        const updateAuthPreferenceSpy = jest.spyOn(
+          Authentication,
+          'updateAuthPreference',
+        );
+
+        // Call unlockWallet with oauth2Login set to true.
+        await Authentication.unlockWallet({
+          password: passwordToUse,
+          authPreference: {
+            currentAuthType: AUTHENTICATION_TYPE.BIOMETRIC,
+            oauth2Login: true,
+          },
+        });
+
+        // Verify fallbackToPassword is true after rehydration.
+        expect(updateAuthPreferenceSpy).toHaveBeenCalledWith({
+          authType: AUTHENTICATION_TYPE.BIOMETRIC,
+          password: passwordToUse,
+          fallbackToPassword: true,
+        });
+      });
+
+      it('passes fallbackToPassword: true to updateAuthPreference when seedless password is outdated', async () => {
+        // Mock seedless password as outdated.
+        jest
+          .spyOn(Authentication, 'checkIsSeedlessPasswordOutdated')
+          .mockResolvedValueOnce(true);
+        jest
+          .spyOn(Authentication, 'syncPasswordAndUnlockWallet')
+          .mockResolvedValueOnce();
+
+        const updateAuthPreferenceSpy = jest.spyOn(
+          Authentication,
+          'updateAuthPreference',
+        );
+
+        // Call unlockWallet with an authPreference (non-oauth) to trigger the outdated path.
+        await Authentication.unlockWallet({
+          password: passwordToUse,
+          authPreference: {
+            currentAuthType: AUTHENTICATION_TYPE.BIOMETRIC,
+          },
+        });
+
+        // Verify fallbackToPassword is true after password sync.
+        expect(updateAuthPreferenceSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fallbackToPassword: true,
+          }),
+        );
+      });
+
+      it('passes fallbackToPassword: false to updateAuthPreference in normal non-seedless flow', async () => {
+        // Mock checkIsSeedlessPasswordOutdated to return false (normal flow).
+        jest
+          .spyOn(Authentication, 'checkIsSeedlessPasswordOutdated')
+          .mockResolvedValueOnce(false);
+
+        const updateAuthPreferenceSpy = jest.spyOn(
+          Authentication,
+          'updateAuthPreference',
+        );
+
+        // Call unlockWallet with a non-oauth authPreference.
+        await Authentication.unlockWallet({
+          password: passwordToUse,
+          authPreference: {
+            currentAuthType: AUTHENTICATION_TYPE.BIOMETRIC,
+          },
+        });
+
+        // Verify fallbackToPassword is false in normal flow.
+        expect(updateAuthPreferenceSpy).toHaveBeenCalledWith({
+          authType: AUTHENTICATION_TYPE.BIOMETRIC,
+          password: passwordToUse,
+          fallbackToPassword: false,
+        });
       });
     });
   });

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -717,15 +717,12 @@ class AuthenticationService {
     {
       password,
       authPreference,
-      fallbackToPassword,
     }: {
       password?: string;
       authPreference?: AuthData;
-      fallbackToPassword?: boolean;
     } = {
       password: undefined,
       authPreference: undefined,
-      fallbackToPassword: false,
     },
   ) => {
     let passwordToUse: string | undefined;
@@ -736,6 +733,7 @@ class AuthenticationService {
         // User exists. Attempt to unlock wallet.
         // existing user is always false when user try to rehydrate
 
+        let fallbackToPassword = false;
         if (password !== undefined) {
           // Explicitly provided password.
           passwordToUse = password;

--- a/app/core/Authentication/hooks/useAuthentication.ts
+++ b/app/core/Authentication/hooks/useAuthentication.ts
@@ -11,4 +11,6 @@ export default () => ({
   revealPrivateKey: Authentication.revealPrivateKey,
   getAuthType: Authentication.getType,
   componentAuthenticationType: Authentication.componentAuthenticationType,
+  checkIsSeedlessPasswordOutdated:
+    Authentication.checkIsSeedlessPasswordOutdated,
 });

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -458,7 +458,11 @@
     "reset_wallet_desc_bold": "permanently erased",
     "reset_wallet_desc_2": "from MetaMask on this device. This can’t be undone.",
     "reset_wallet_desc_login": "To restore your wallet, you can use your Secret Recovery Phrase, or your Google or Apple account password. MetaMask doesn’t have this information.",
-    "reset_wallet_desc_srp": "To restore your wallet, make sure you have your Secret Recovery Phrase. MetaMask doesn’t have this information."
+    "reset_wallet_desc_srp": "To restore your wallet, make sure you have your Secret Recovery Phrase. MetaMask doesn’t have this information.",
+    "biometric_authentication_cancelled": "Biometric authentication cancelled",
+    "biometric_authentication_cancelled_title": "Biometric Setup Failed",
+    "biometric_authentication_cancelled_description": "Please re-setup biometric authentication from the settings.",
+    "biometric_authentication_cancelled_button": "Confirm"
   },
   "connect_hardware": {
     "title_select_hardware": "Connect a hardware wallet",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fallback to password on biometric failure for rehydrate and sync password flow.

Due to removal of biometric switch on Login Screen and OAuthRehydrate screen, user is required to enable biometric to navigate to Home wallet screen after rehydrate or password changed

Biometric failure would causing user to fallback or OAuthRehydrate Screen.

Similar behaviour for sync password flow that cause fallback to OAuthRehydrate or Login Screen.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/26208

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user login with social rehydrate and cancel biometric
    Given user login with social rehydrate

    When user cancel biometric
    Then should login with password only
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/e6f4ad88-b27c-498f-9baa-223041cdc090


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/75759451-fb44-4f26-af5a-2e66f347d3a3


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core login/auth preference persistence and keychain write behavior for seedless flows; mistakes could cause incorrect auth type storage or unexpected login prompts, but changes are scoped and covered by new tests.
> 
> **Overview**
> Improves seedless rehydration and password-sync login flows by propagating a new `fallbackToPassword` flag through `Authentication.unlockWallet`/`updateAuthPreference`, allowing biometric preference updates to *fallback to plain password storage* when biometric keychain writes fail.
> 
> Adds post-unlock checks in `Login` and `OAuthRehydration` to detect when a device supports biometrics but the stored auth type fell back to `PASSWORD`, then shows a new localized alert prompting the user to re-enable biometrics in settings. Updates/expands unit tests to cover the new fallback flag propagation and the new alert-triggering conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5caba18e0fcbe3fea99e148151488463fab47f88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->