### PR TITLE
fix: prevent full app reload when editing Trending files

### DIFF
--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -35,7 +35,7 @@ import {
   getNonEvmNetworkImageSourceByChainId,
 } from '../../../../../util/networks/customNetworks';
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
-import { formatMarketStats } from './utils';
+import { formatMarketStats, getPriceChangeFieldKey } from './utils';
 import { formatPriceWithSubscriptNotation } from '../../../Predict/utils/format';
 import { TimeOption, PriceChangeOption } from '../TrendingTokensBottomSheet';
 import { selectNetworkConfigurationsByCaipChainId } from '../../../../../selectors/networkController';
@@ -124,26 +124,6 @@ const getPriceChangePrefix = (
 ): string => {
   if (priceChange === 0) return '';
   return isPositive ? '+' : '-';
-};
-
-/**
- * Maps TimeOption to the corresponding priceChangePct field key
- */
-export const getPriceChangeFieldKey = (
-  timeOption: TimeOption,
-): 'h24' | 'h6' | 'h1' | 'm5' => {
-  switch (timeOption) {
-    case TimeOption.TwentyFourHours:
-      return 'h24';
-    case TimeOption.SixHours:
-      return 'h6';
-    case TimeOption.OneHour:
-      return 'h1';
-    case TimeOption.FiveMinutes:
-      return 'm5';
-    default:
-      return 'h24';
-  }
 };
 
 interface TrendingTokenRowItemProps {

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/utils.ts
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/utils.ts
@@ -1,3 +1,5 @@
+import { TimeOption } from '../TrendingTokensBottomSheet/TrendingTokenTimeBottomSheet';
+
 /**
  * Formats a number as compact USD currency string
  * @param value - The number to format
@@ -35,3 +37,23 @@ export function formatMarketStats(marketCap: number, volume: number): string {
   const volStr = volume === 0 ? '-' : formatCompactUSD(volume);
   return `${capStr} cap • ${volStr} vol`;
 }
+
+/**
+ * Maps TimeOption to the corresponding priceChangePct field key
+ */
+export const getPriceChangeFieldKey = (
+  timeOption: TimeOption,
+): 'h24' | 'h6' | 'h1' | 'm5' => {
+  switch (timeOption) {
+    case TimeOption.TwentyFourHours:
+      return 'h24';
+    case TimeOption.SixHours:
+      return 'h6';
+    case TimeOption.OneHour:
+      return 'h1';
+    case TimeOption.FiveMinutes:
+      return 'm5';
+    default:
+      return 'h24';
+  }
+};

--- a/app/components/UI/Trending/utils/sortTrendingTokens.ts
+++ b/app/components/UI/Trending/utils/sortTrendingTokens.ts
@@ -4,7 +4,7 @@ import {
   SortDirection,
   TimeOption,
 } from '../components/TrendingTokensBottomSheet';
-import { getPriceChangeFieldKey } from '../components/TrendingTokenRowItem/TrendingTokenRowItem';
+import { getPriceChangeFieldKey } from '../components/TrendingTokenRowItem/utils';
 
 /**
  * Sorts trending tokens based on the selected option and direction


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Moved getPriceChangeFieldKey from TrendingTokenRowItem.tsx to utils.ts to fix React Fast Refresh triggering a full app restart instead of a hot reload.
Fast Refresh requires modules to exclusively export React components. TrendingTokenRowItem.tsx was exporting both the component and a utility function, which caused Metro to fall back to a full restart on every save.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: prevent full app reload when editing Trending files

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2684

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of a small helper function and import paths; no changes to business logic or data handling beyond module boundaries.
> 
> **Overview**
> Prevents Metro/React Fast Refresh from doing full app restarts by removing the non-component export (`getPriceChangeFieldKey`) from `TrendingTokenRowItem.tsx` and relocating it to `TrendingTokenRowItem/utils.ts`.
> 
> Updates all call sites (including `sortTrendingTokens`) to import `getPriceChangeFieldKey` from the new utils module; runtime behavior should be unchanged aside from improved hot reload behavior during development.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaa2c9ba965a3db051d0a426ac874dafcfe62bf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->