### PR TITLE
feat(card): prefill country from geolocation and extract reusable SelectField component

### DIFF
--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
@@ -1,13 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import {
-  Box,
-  Icon,
-  IconName,
-  IconSize,
-  Text,
-  TextVariant,
-} from '@metamask/design-system-react-native';
+import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
 import Button, {
   ButtonSize,
   ButtonVariants,
@@ -18,6 +11,7 @@ import Label from '../../../../../component-library/components/Form/Label';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import OnboardingStep from './OnboardingStep';
+import SelectField from './SelectField';
 import DepositDateField from '../../../Ramp/Deposit/components/DepositDateField';
 import {
   resetOnboardingState,
@@ -43,7 +37,6 @@ import {
   Region,
   setOnValueChange,
 } from './RegionSelectorModal';
-import { TouchableOpacity } from 'react-native';
 
 const PersonalDetails = () => {
   const navigation = useNavigation();
@@ -360,19 +353,11 @@ const PersonalDetails = () => {
         <Label>
           {strings('card.card_onboarding.personal_details.nationality_label')}
         </Label>
-        <Box twClassName="w-full border border-solid border-border-default rounded-lg py-1">
-          <TouchableOpacity
-            onPress={handleNationalitySelect}
-            testID="personal-details-nationality-select"
-          >
-            <Box twClassName="flex flex-row items-center justify-between px-4 py-2">
-              <Text variant={TextVariant.BodyMd}>
-                {nationalityName || nationalityKey}
-              </Text>
-              <Icon name={IconName.ArrowDown} size={IconSize.Sm} />
-            </Box>
-          </TouchableOpacity>
-        </Box>
+        <SelectField
+          value={nationalityName || nationalityKey}
+          onPress={handleNationalitySelect}
+          testID="personal-details-nationality-select"
+        />
       </Box>
 
       {/* SSN */}

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
@@ -6,14 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import {
-  Box,
-  Icon,
-  IconName,
-  IconSize,
-  Text,
-  TextVariant,
-} from '@metamask/design-system-react-native';
+import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
 import Button, {
   ButtonSize,
   ButtonVariants,
@@ -24,6 +17,7 @@ import Label from '../../../../../component-library/components/Form/Label';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import OnboardingStep from './OnboardingStep';
+import SelectField from './SelectField';
 import type { ShippingAddress } from '../../Views/ReviewOrder';
 import useRegisterPhysicalAddress from '../../hooks/useRegisterPhysicalAddress';
 import { useDispatch, useSelector } from 'react-redux';
@@ -48,7 +42,7 @@ import { useCardSDK } from '../../sdk';
 import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
 import { CardActions, CardScreens } from '../../util/metrics';
 import Logger from '../../../../../util/Logger';
-import { Linking, TouchableOpacity } from 'react-native';
+import { Linking } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import Checkbox from '../../../../../component-library/components/Checkbox';
 import {
@@ -183,14 +177,11 @@ export const AddressFields = ({
           <Label>
             {strings('card.card_onboarding.physical_address.state_label')}
           </Label>
-          <Box twClassName="w-full border border-solid border-border-default rounded-lg py-1">
-            <TouchableOpacity onPress={handleStateSelect} testID="state-select">
-              <Box twClassName="flex flex-row items-center justify-between px-4 py-2">
-                <Text variant={TextVariant.BodyMd}>{state}</Text>
-                <Icon name={IconName.ArrowDown} size={IconSize.Sm} />
-              </Box>
-            </TouchableOpacity>
-          </Box>
+          <SelectField
+            value={state}
+            onPress={handleStateSelect}
+            testID="state-select"
+          />
         </Box>
       )}
       {/* ZIP Code */}
@@ -217,16 +208,7 @@ export const AddressFields = ({
         <Label>
           {strings('card.card_onboarding.physical_address.country_label')}
         </Label>
-        <Box twClassName="w-full border border-solid border-border-default rounded-lg py-1">
-          <Box twClassName="flex flex-row items-center justify-between px-4 py-2">
-            <Text
-              variant={TextVariant.BodyMd}
-              twClassName="text-text-alternative"
-            >
-              {selectedCountry?.name}
-            </Text>
-          </Box>
-        </Box>
+        <SelectField value={selectedCountry?.name} />
       </Box>
     </>
   );

--- a/app/components/UI/Card/components/Onboarding/SelectField.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/SelectField.test.tsx
@@ -66,7 +66,7 @@ describe('SelectField', () => {
 
   it('renders the value text', () => {
     const { getByText } = render(<SelectField value="United States" />);
-    expect(getByText('United States')).toBeTruthy();
+    expect(getByText('United States')).toBeOnTheScreen();
   });
 
   it('renders as read-only when onPress is not provided', () => {
@@ -74,7 +74,7 @@ describe('SelectField', () => {
       <SelectField value="Canada" />,
     );
 
-    expect(queryByText('Canada')).toBeTruthy();
+    expect(queryByText('Canada')).toBeOnTheScreen();
     expect(queryByTestId('icon-arrow-down')).toBeNull();
   });
 
@@ -96,7 +96,7 @@ describe('SelectField', () => {
     const { getByTestId } = render(
       <SelectField value="United States" onPress={mockOnPress} />,
     );
-    expect(getByTestId('icon-arrow-down')).toBeTruthy();
+    expect(getByTestId('icon-arrow-down')).toBeOnTheScreen();
   });
 
   it('hides the arrow-down icon when hideIcon is true', () => {
@@ -170,7 +170,7 @@ describe('SelectField', () => {
     const { getByTestId } = render(
       <SelectField onPress={mockOnPress} testID="select-field" />,
     );
-    expect(getByTestId('select-field')).toBeTruthy();
+    expect(getByTestId('select-field')).toBeOnTheScreen();
   });
 
   it('wraps content in TouchableOpacity when interactive', () => {
@@ -178,7 +178,7 @@ describe('SelectField', () => {
       <SelectField value="Test" onPress={mockOnPress} testID="select-field" />,
     );
     const touchable = getByTestId('select-field');
-    expect(touchable).toBeTruthy();
+    expect(touchable).toBeOnTheScreen();
   });
 
   it('does not wrap content in TouchableOpacity when read-only', () => {

--- a/app/components/UI/Card/components/Onboarding/SelectField.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/SelectField.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import SelectField from './SelectField';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+
+  const TextVariant = {
+    BodyMd: 'BodyMd',
+  };
+
+  const IconName = {
+    ArrowDown: 'arrow-down',
+  };
+
+  const IconSize = {
+    Sm: 'sm',
+  };
+
+  return {
+    Box: ({
+      children,
+      testID,
+      twClassName,
+      ...props
+    }: {
+      children: React.ReactNode;
+      testID?: string;
+      twClassName?: string;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID, accessibilityHint: twClassName, ...props },
+        children,
+      ),
+    Text: ({
+      children,
+      testID,
+      twClassName,
+      ...props
+    }: {
+      children: React.ReactNode;
+      testID?: string;
+      twClassName?: string;
+    }) =>
+      ReactActual.createElement(
+        Text,
+        { testID, accessibilityHint: twClassName, ...props },
+        children,
+      ),
+    Icon: ({ name }: { name: string }) =>
+      ReactActual.createElement(View, { testID: `icon-${name}` }),
+    TextVariant,
+    IconName,
+    IconSize,
+  };
+});
+
+describe('SelectField', () => {
+  const mockOnPress = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the value text', () => {
+    const { getByText } = render(<SelectField value="United States" />);
+    expect(getByText('United States')).toBeTruthy();
+  });
+
+  it('renders as read-only when onPress is not provided', () => {
+    const { queryByTestId, queryByText } = render(
+      <SelectField value="Canada" />,
+    );
+
+    expect(queryByText('Canada')).toBeTruthy();
+    expect(queryByTestId('icon-arrow-down')).toBeNull();
+  });
+
+  it('applies text-text-alternative style in read-only mode', () => {
+    const { getByText } = render(<SelectField value="Canada" />);
+    const textElement = getByText('Canada');
+    expect(textElement.props.accessibilityHint).toBe('text-text-alternative');
+  });
+
+  it('does not apply alternative text style in interactive mode', () => {
+    const { getByText } = render(
+      <SelectField value="Canada" onPress={mockOnPress} />,
+    );
+    const textElement = getByText('Canada');
+    expect(textElement.props.accessibilityHint).toBeUndefined();
+  });
+
+  it('renders the arrow-down icon when interactive', () => {
+    const { getByTestId } = render(
+      <SelectField value="United States" onPress={mockOnPress} />,
+    );
+    expect(getByTestId('icon-arrow-down')).toBeTruthy();
+  });
+
+  it('hides the arrow-down icon when hideIcon is true', () => {
+    const { queryByTestId } = render(
+      <SelectField value="United States" onPress={mockOnPress} hideIcon />,
+    );
+    expect(queryByTestId('icon-arrow-down')).toBeNull();
+  });
+
+  it('calls onPress when tapped', () => {
+    const { getByTestId } = render(
+      <SelectField
+        value="United States"
+        onPress={mockOnPress}
+        testID="select-field"
+      />,
+    );
+    fireEvent.press(getByTestId('select-field'));
+    expect(mockOnPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets disabled prop on TouchableOpacity when isDisabled is true', () => {
+    const { getByTestId } = render(
+      <SelectField
+        value="United States"
+        onPress={mockOnPress}
+        isDisabled
+        testID="select-field"
+      />,
+    );
+    const touchable = getByTestId('select-field');
+    expect(touchable.props.disabled).toBe(true);
+  });
+
+  it('applies opacity-50 class when disabled', () => {
+    const { UNSAFE_root } = render(
+      <SelectField
+        value="United States"
+        onPress={mockOnPress}
+        isDisabled
+        testID="select-field"
+      />,
+    );
+
+    const boxElements = UNSAFE_root.findAll(
+      (node) =>
+        typeof node.props.accessibilityHint === 'string' &&
+        node.props.accessibilityHint.includes('opacity-50'),
+    );
+    expect(boxElements.length).toBeGreaterThan(0);
+  });
+
+  it('does not apply opacity-50 class when not disabled', () => {
+    const { UNSAFE_root } = render(
+      <SelectField
+        value="United States"
+        onPress={mockOnPress}
+        testID="select-field"
+      />,
+    );
+
+    const boxElements = UNSAFE_root.findAll(
+      (node) =>
+        typeof node.props.accessibilityHint === 'string' &&
+        node.props.accessibilityHint.includes('opacity-50'),
+    );
+    expect(boxElements).toHaveLength(0);
+  });
+
+  it('renders without a value', () => {
+    const { getByTestId } = render(
+      <SelectField onPress={mockOnPress} testID="select-field" />,
+    );
+    expect(getByTestId('select-field')).toBeTruthy();
+  });
+
+  it('wraps content in TouchableOpacity when interactive', () => {
+    const { getByTestId } = render(
+      <SelectField value="Test" onPress={mockOnPress} testID="select-field" />,
+    );
+    const touchable = getByTestId('select-field');
+    expect(touchable).toBeTruthy();
+  });
+
+  it('does not wrap content in TouchableOpacity when read-only', () => {
+    const { queryByTestId } = render(
+      <SelectField value="Test" testID="select-field" />,
+    );
+    expect(queryByTestId('select-field')).toBeNull();
+  });
+});

--- a/app/components/UI/Card/components/Onboarding/SelectField.tsx
+++ b/app/components/UI/Card/components/Onboarding/SelectField.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import {
+  Box,
+  Text,
+  TextVariant,
+  Icon,
+  IconSize,
+  IconName,
+} from '@metamask/design-system-react-native';
+
+interface SelectFieldProps {
+  /** The display value shown in the field */
+  value?: string;
+  /** Called when the field is pressed. Omit for read-only display. */
+  onPress?: () => void;
+  /** Whether the field is disabled */
+  isDisabled?: boolean;
+  /** Whether to hide the arrow-down icon. Defaults to false. */
+  hideIcon?: boolean;
+  /** Test ID for the touchable element */
+  testID?: string;
+}
+
+/**
+ * A select-style field that matches the TextField visual style.
+ * Used for dropdown/picker triggers across onboarding screens.
+ * Supports both interactive (with arrow icon) and read-only modes.
+ */
+const SelectField: React.FC<SelectFieldProps> = ({
+  value,
+  onPress,
+  isDisabled = false,
+  hideIcon = false,
+  testID,
+}) => {
+  const isReadOnly = !onPress;
+  const showIcon = !isReadOnly && !hideIcon;
+
+  const content = (
+    <Box
+      twClassName={`flex-row items-center justify-between h-12 rounded-xl border border-solid border-border-muted bg-background-muted px-4 ${isDisabled ? 'opacity-50' : ''}`}
+    >
+      <Text
+        variant={TextVariant.BodyMd}
+        twClassName={isReadOnly ? 'text-text-alternative' : undefined}
+      >
+        {value}
+      </Text>
+      {showIcon && <Icon name={IconName.ArrowDown} size={IconSize.Sm} />}
+    </Box>
+  );
+
+  if (isReadOnly) {
+    return content;
+  }
+
+  return (
+    <TouchableOpacity onPress={onPress} disabled={isDisabled} testID={testID}>
+      {content}
+    </TouchableOpacity>
+  );
+};
+
+export default SelectField;

--- a/app/components/UI/Card/components/Onboarding/SetPhoneNumber.tsx
+++ b/app/components/UI/Card/components/Onboarding/SetPhoneNumber.tsx
@@ -32,8 +32,8 @@ import {
   Region,
   setOnValueChange,
 } from './RegionSelectorModal';
-import { TouchableOpacity } from 'react-native';
 import { useCardSDK } from '../../sdk';
+import SelectField from './SelectField';
 
 const US_PHONE_REGEX = /^[2-9]\d{2}[2-9]\d{6}$/;
 
@@ -248,19 +248,13 @@ const SetPhoneNumber = () => {
       </Label>
       {/* Area code selector */}
       <Box twClassName="flex flex-row items-center justify-center gap-2">
-        <Box twClassName="flex flex-row items-center border border-solid border-border-default rounded-lg h-full">
-          <Box twClassName="w-26 justify-center items-center flex">
-            <TouchableOpacity
-              onPress={handleCountrySelect}
-              testID="set-phone-number-country-area-code-select"
-            >
-              <Box twClassName="flex flex-row items-center justify-between px-4 py-2">
-                <Text variant={TextVariant.BodyMd}>
-                  {`${selectedCountryEmoji} +${selectedCountryAreaCode}`}
-                </Text>
-              </Box>
-            </TouchableOpacity>
-          </Box>
+        <Box twClassName="w-26">
+          <SelectField
+            value={`${selectedCountryEmoji} +${selectedCountryAreaCode}`}
+            onPress={handleCountrySelect}
+            hideIcon
+            testID="set-phone-number-country-area-code-select"
+          />
         </Box>
 
         {/* Phone number input */}

--- a/app/components/UI/Card/components/Onboarding/SignUp.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/SignUp.test.tsx
@@ -391,7 +391,7 @@ describe('SignUp Component', () => {
         </Provider>,
       );
 
-      expect(getByText('Canada')).toBeTruthy();
+      expect(getByText('Canada')).toBeOnTheScreen();
       expect(storeWithGeo.getState().card.userCardLocation).toBe(
         'international',
       );

--- a/app/components/UI/Card/components/Onboarding/SignUp.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/SignUp.test.tsx
@@ -94,6 +94,7 @@ const createTestStore = (initialState = {}) =>
             user: null,
           },
           userCardLocation: 'international',
+          geoLocation: 'UNKNOWN',
           ...initialState,
         },
         action = { type: '', payload: null },
@@ -379,6 +380,86 @@ describe('SignUp Component', () => {
       fireEvent.press(countrySelect);
 
       expect(mockNavigate).toHaveBeenCalled();
+    });
+
+    it('prefills country when geoLocation matches a supported country', () => {
+      const storeWithGeo = createTestStore({ geoLocation: 'CA' });
+
+      const { getByText } = render(
+        <Provider store={storeWithGeo}>
+          <SignUp />
+        </Provider>,
+      );
+
+      expect(getByText('Canada')).toBeTruthy();
+      expect(storeWithGeo.getState().card.userCardLocation).toBe(
+        'international',
+      );
+    });
+
+    it('prefills country and sets US location when geoLocation is US', () => {
+      const storeWithGeo = createTestStore({ geoLocation: 'US' });
+
+      render(
+        <Provider store={storeWithGeo}>
+          <SignUp />
+        </Provider>,
+      );
+
+      expect(storeWithGeo.getState().card.onboarding.selectedCountry).toEqual(
+        expect.objectContaining({ key: 'US', name: 'United States' }),
+      );
+      expect(storeWithGeo.getState().card.userCardLocation).toBe('us');
+    });
+
+    it('does not prefill country when geoLocation is UNKNOWN', () => {
+      const storeWithUnknown = createTestStore({ geoLocation: 'UNKNOWN' });
+
+      render(
+        <Provider store={storeWithUnknown}>
+          <SignUp />
+        </Provider>,
+      );
+
+      expect(
+        storeWithUnknown.getState().card.onboarding.selectedCountry,
+      ).toBeNull();
+    });
+
+    it('does not prefill country when geoLocation does not match any available region', () => {
+      const storeWithUnsupported = createTestStore({ geoLocation: 'JP' });
+
+      render(
+        <Provider store={storeWithUnsupported}>
+          <SignUp />
+        </Provider>,
+      );
+
+      expect(
+        storeWithUnsupported.getState().card.onboarding.selectedCountry,
+      ).toBeNull();
+    });
+
+    it('does not override an already selected country with geoLocation', () => {
+      const storeWithExisting = createTestStore({
+        geoLocation: 'US',
+        onboarding: {
+          selectedCountry: { key: 'DE', name: 'Germany' },
+          onboardingId: null,
+          contactVerificationId: null,
+          user: null,
+        },
+      });
+
+      render(
+        <Provider store={storeWithExisting}>
+          <SignUp />
+        </Provider>,
+      );
+
+      expect(
+        storeWithExisting.getState().card.onboarding.selectedCountry,
+      ).toEqual(expect.objectContaining({ key: 'DE', name: 'Germany' }));
     });
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR introduces two improvements to the Card onboarding flow:

1. **Country prefill based on geolocation**: The `SignUp` screen now reads the `geoLocation` property from the Redux card slice and automatically selects the matching country of residence. If `geoLocation` is `'UNKNOWN'` or doesn't match any available region, the field remains empty. An existing manually-selected country is never overridden.

2. **Reusable `SelectField` component**: A recurring "select/dropdown trigger" UI pattern was duplicated across four onboarding screens (`SignUp`, `PersonalDetails`, `PhysicalAddress`, `SetPhoneNumber`) with slightly inconsistent markup. This PR extracts it into a shared `SelectField` component that matches the `TextField` visual style (rounded-xl border, muted background, consistent height). It supports three modes:
   - **Interactive** (with `onPress`): renders a `TouchableOpacity` with an arrow-down icon.
   - **Interactive without icon** (`hideIcon`): same touchable behavior but no arrow (used by the area code selector).
   - **Read-only** (no `onPress`): renders as a non-interactive display with alternative text color.

All four screens have been refactored to use `SelectField`, removing duplicated inline `TouchableOpacity` + `Box` + `Icon` patterns and cleaning up unused imports.

## **Changelog**

CHANGELOG entry: Prefill country of residence from geolocation on Card onboarding SignUp and extract reusable SelectField component across onboarding screens

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Country of residence prefill on SignUp

  Scenario: user's geolocation matches a supported country
    Given the user's detected geolocation is a supported country (e.g. "CA")
    And no country has been previously selected

    When the SignUp screen loads
    Then the country of residence field is automatically set to "Canada"

  Scenario: user's geolocation is US
    Given the user's detected geolocation is "US"
    And no country has been previously selected

    When the SignUp screen loads
    Then the country of residence field is set to "United States"
    And the user card location is set to "us"

  Scenario: user's geolocation is unknown
    Given the user's detected geolocation is "UNKNOWN"

    When the SignUp screen loads
    Then the country of residence field remains empty

  Scenario: user already selected a country
    Given the user previously selected "Germany" as their country
    And their detected geolocation is "US"

    When the SignUp screen loads
    Then the country remains "Germany" (not overridden)

Feature: SelectField component consistency

  Scenario: country, state, nationality, and area code selectors match TextField style
    Given the user navigates through SignUp, PersonalDetails, PhysicalAddress, or SetPhoneNumber

    When the user views any dropdown/select trigger field
    Then it visually matches the TextField style (rounded-xl, muted background, consistent height)
    And interactive fields show an arrow-down icon (except area code which uses hideIcon)
    And read-only fields display text in alternative color without an icon
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots or recordings to help explain the visual changes -->

### **Before**

<!-- Add before screenshots -->

### **After**

<!-- Add after screenshots -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding UX and defaults by changing how `selectedCountry`/`userCardLocation` are initialized based on geolocation, which could impact eligibility and downstream flow for some users. UI refactor is otherwise low risk and is covered by new/updated tests.
> 
> **Overview**
> The Card onboarding `SignUp` screen now *auto-selects the country of residence* from `card.geoLocation` when it matches an available signup region, and sets `userCardLocation` to `us` vs `international` accordingly (without overriding an existing selection).
> 
> A new reusable `SelectField` component replaces duplicated select/dropdown trigger markup across onboarding screens (`SignUp`, `PersonalDetails`, `PhysicalAddress`, `SetPhoneNumber`), supporting interactive, disabled, icon-hidden, and read-only variants with consistent styling; unit tests were added for `SelectField` and `SignUp` coverage was extended for geolocation-prefill scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2034729c670ddc66bb1f68c4ec1e2b84720ba3c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->