### PR TITLE
refactor(analytics): migrate Batch 2-4: confirmations

### DIFF
--- a/app/components/Views/confirmations/hooks/signatures/useSignatureMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/signatures/useSignatureMetrics.test.ts
@@ -21,25 +21,18 @@ jest.mock('../../../../../util/address', () => ({
   getAddressAccountType: (str: string) => str,
 }));
 
-const mockTrackEvent = jest.fn().mockImplementation();
-jest.mock('../../../../../core/Analytics', () => ({
-  ...jest.requireActual('../../../../../core/Analytics'),
-  MetaMetrics: {
-    getInstance: () => ({
-      trackEvent: mockTrackEvent,
-      updateDataRecordingFlag: jest.fn(),
-    }),
-  },
-}));
-
+const mockTrackEvent = jest.fn();
 const mockAddProperties = jest
   .fn()
   .mockImplementation(() => ({ build: () => ({}) }));
-jest.mock('../../../../../core/Analytics/MetricsEventBuilder', () => ({
-  ...jest.requireActual('../../../../../core/Analytics/MetricsEventBuilder'),
-  MetricsEventBuilder: {
-    createEventBuilder: () => ({ addProperties: mockAddProperties }),
-  },
+jest.mock('../../../../../components/hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: () => ({
+      addProperties: mockAddProperties,
+      build: () => ({}),
+    }),
+  }),
 }));
 
 const SignatureMetrics = {

--- a/app/components/Views/confirmations/hooks/signatures/useSignatureMetrics.ts
+++ b/app/components/Views/confirmations/hooks/signatures/useSignatureMetrics.ts
@@ -4,8 +4,8 @@ import { SecurityAlertResponse } from '@metamask/transaction-controller';
 import { useCallback, useEffect, useMemo } from 'react';
 
 import getDecimalChainId from '../../../../../util/networks/getDecimalChainId';
-import { MetricsEventBuilder } from '../../../../../core/Analytics/MetricsEventBuilder';
-import { MetaMetrics, MetaMetricsEvents } from '../../../../../core/Analytics';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { useAnalytics } from '../../../../../components/hooks/useAnalytics/useAnalytics';
 import { getAddressAccountType } from '../../../../../util/address';
 import { getBlockaidMetricsParams } from '../../../../../util/blockaid';
 import { getHostFromUrl } from '../../utils/generic';
@@ -67,6 +67,7 @@ const getAnalyticsParams = (
 };
 
 export const useSignatureMetrics = () => {
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const signatureRequest = useSignatureRequest();
   const isSimulationEnabled = useTypedSignSimulationEnabled();
   const { securityAlertResponse } = useSecurityAlertResponse();
@@ -115,13 +116,11 @@ export const useSignatureMetrics = () => {
         return;
       }
 
-      MetaMetrics.getInstance().trackEvent(
-        MetricsEventBuilder.createEventBuilder(event)
-          .addProperties(analyticsParams)
-          .build(),
+      trackEvent(
+        createEventBuilder(event).addProperties(analyticsParams).build(),
       );
     },
-    [analyticsParams],
+    [analyticsParams, trackEvent, createEventBuilder],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## **Description**

Phase 2 analytics migration (Batch 2-4): migrate Confirmations' signature metrics hook from MetaMetrics.getInstance() to the new analytics system (useAnalytics + AnalyticsEventBuilder).

**Reason**: Deprecate MetaMetrics in favour of the shared analytics utility and AnalyticsController.

**Changes**: `useSignatureMetrics.ts` now uses `useAnalytics()` and `createEventBuilder` from the analytics hook instead of `MetaMetrics.getInstance().trackEvent()` and `MetricsEventBuilder`; test mocks updated to mock `useAnalytics` at `app/components/hooks/useAnalytics/useAnalytics` with a chainable createEventBuilder.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-297 (Batch 2-4)

## **Manual testing steps**

```gherkin
Feature: Confirmations analytics

  Scenario: user triggers a confirmations flow event
    Given app is open and user is in a confirmations flow

    When user performs an action that triggers analytics (e.g. signature requested, signature approved, signature rejected)
    Then the event is tracked on Mixpanel
```

## **Screenshots/Recordings**

N/A – analytics migration, no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change to how analytics events are dispatched; behavior should be equivalent aside from potential wiring/mocking mismatches.
> 
> **Overview**
> Migrates the confirmations `useSignatureMetrics` hook off `MetaMetrics.getInstance()`/`MetricsEventBuilder` to the new analytics API via `useAnalytics()` with `trackEvent` + `createEventBuilder`.
> 
> Updates `useSignatureMetrics.test.ts` to mock `useAnalytics` (including a chainable event builder) instead of mocking `MetaMetrics`, while keeping existing signature event coverage (requested/approved/rejected) and property expectations intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a27ea8f206eb6e838f2962fe4704a442f50cd8fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->