### PR TITLE
fix(ramps): prevents blank "DepositRoot" screen on Android cp-7.66.0

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/Root/Root.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Root/Root.test.tsx
@@ -123,7 +123,7 @@ describe('Root Component', () => {
     (
       getAllDepositOrders as jest.MockedFunction<typeof getAllDepositOrders>
     ).mockReturnValue(mockOrders);
-    mockCheckExistingToken.mockResolvedValue(true); // User is authenticated
+    mockCheckExistingToken.mockResolvedValue(true);
     render(Root);
 
     await waitFor(() => {
@@ -154,7 +154,7 @@ describe('Root Component', () => {
     (
       getAllDepositOrders as jest.MockedFunction<typeof getAllDepositOrders>
     ).mockReturnValue(mockOrders);
-    mockCheckExistingToken.mockResolvedValue(false); // User is not authenticated
+    mockCheckExistingToken.mockResolvedValue(false);
     render(Root);
 
     await waitFor(() => {
@@ -167,6 +167,25 @@ describe('Root Component', () => {
               redirectToRootAfterAuth: true,
               animationEnabled: false,
             },
+          },
+        ],
+      });
+    });
+  });
+
+  it('falls back to BUILD_QUOTE when checkExistingToken rejects', async () => {
+    mockCheckExistingToken.mockRejectedValue(
+      new Error('SecureKeychain unavailable'),
+    );
+    render(Root);
+
+    await waitFor(() => {
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [
+          {
+            name: Routes.DEPOSIT.BUILD_QUOTE,
+            params: { animationEnabled: false },
           },
         ],
       });

--- a/app/components/UI/Ramp/Deposit/Views/Root/Root.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Root/Root.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { ActivityIndicator } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import { Box } from '@metamask/design-system-react-native';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { useDepositSDK } from '../../sdk';
 import { useSelector } from 'react-redux';
@@ -9,6 +11,23 @@ import { createBankDetailsNavDetails } from '../BankDetails/BankDetails';
 import { createEnterEmailNavDetails } from '../EnterEmail/EnterEmail';
 import { DepositNavigationParams } from '../../types';
 import { useParams } from '../../../../../../util/navigation/navUtils';
+import { useTheme } from '../../../../../../util/theme';
+import Logger from '../../../../../../util/Logger';
+
+export const TOKEN_CHECK_TIMEOUT_MS = 5000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error(`Operation timed out after ${ms}ms`)),
+      ms,
+    );
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() =>
+    clearTimeout(timeoutId),
+  );
+}
 
 const Root = () => {
   const navigation = useNavigation();
@@ -17,6 +36,7 @@ const Root = () => {
   const { checkExistingToken, setIntent } = useDepositSDK();
   const hasCheckedToken = useRef(false);
   const orders = useSelector(getAllDepositOrders);
+  const theme = useTheme();
 
   useEffect(() => {
     if (params) {
@@ -25,10 +45,40 @@ const Root = () => {
   }, [params, setIntent]);
 
   useEffect(() => {
+    const navigateToDefaultRoute = () => {
+      navigation.reset({
+        index: 0,
+        routes: [
+          {
+            name: initialRoute,
+            params: {
+              animationEnabled: false,
+              ...(params?.shouldRouteImmediately && {
+                shouldRouteImmediately: true,
+              }),
+              ...(params?.amount !== undefined && { amount: params.amount }),
+            },
+          },
+        ],
+      });
+    };
+
     const initializeFlow = async () => {
       if (hasCheckedToken.current) return;
 
-      const isAuthenticatedFromToken = await checkExistingToken();
+      let isAuthenticatedFromToken = false;
+      try {
+        isAuthenticatedFromToken = await withTimeout(
+          checkExistingToken(),
+          TOKEN_CHECK_TIMEOUT_MS,
+        );
+      } catch (error) {
+        Logger.error(
+          error as Error,
+          'Deposit Root: checkExistingToken failed or timed out',
+        );
+      }
+
       hasCheckedToken.current = true;
 
       const createdOrder = orders.find(
@@ -37,7 +87,7 @@ const Root = () => {
 
       if (createdOrder) {
         if (!isAuthenticatedFromToken) {
-          const [routeName, params] = createEnterEmailNavDetails({
+          const [routeName, navParams] = createEnterEmailNavDetails({
             redirectToRootAfterAuth: true,
           });
           navigation.reset({
@@ -45,42 +95,37 @@ const Root = () => {
             routes: [
               {
                 name: routeName,
-                params: { ...params, animationEnabled: false },
+                params: { ...navParams, animationEnabled: false },
               },
             ],
           });
           return;
         }
 
-        const [routeName, params] = createBankDetailsNavDetails({
+        const [routeName, navParams] = createBankDetailsNavDetails({
           orderId: createdOrder.id,
         });
         navigation.reset({
           index: 0,
           routes: [
-            { name: routeName, params: { ...params, animationEnabled: false } },
-          ],
-        });
-      } else {
-        navigation.reset({
-          index: 0,
-          routes: [
             {
-              name: initialRoute,
-              params: {
-                animationEnabled: false,
-                ...(params?.shouldRouteImmediately && {
-                  shouldRouteImmediately: true,
-                }),
-                ...(params?.amount !== undefined && { amount: params.amount }),
-              },
+              name: routeName,
+              params: { ...navParams, animationEnabled: false },
             },
           ],
         });
+      } else {
+        navigateToDefaultRoute();
       }
     };
 
-    initializeFlow();
+    initializeFlow().catch((error) => {
+      Logger.error(
+        error as Error,
+        'Deposit Root: initializeFlow failed unexpectedly',
+      );
+      navigateToDefaultRoute();
+    });
   }, [
     checkExistingToken,
     orders,
@@ -90,7 +135,11 @@ const Root = () => {
     params?.amount,
   ]);
 
-  return null;
+  return (
+    <Box twClassName="flex-1 items-center justify-center">
+      <ActivityIndicator size="large" color={theme.colors.primary.default} />
+    </Box>
+  );
 };
 
 export default Root;

--- a/app/components/UI/Ramp/Deposit/Views/Root/__snapshots__/Root.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Root/__snapshots__/Root.test.tsx.snap
@@ -311,7 +311,28 @@ exports[`Root Component render matches snapshot 1`] = `
                         "flex": 1,
                       }
                     }
-                  />
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "alignItems": "center",
+                            "display": "flex",
+                            "flexBasis": "0%",
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                            "justifyContent": "center",
+                          },
+                          undefined,
+                        ]
+                      }
+                    >
+                      <ActivityIndicator
+                        color="#4459ff"
+                        size="large"
+                      />
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a bug where clicking "Buy" / "Add Funds" on Android lands on a blank screen showing only "DepositRoot" in the header, instead of proceeding to the Buy flow.

### Root Cause

When the V1 unified buy flag is enabled, selecting a token routes to the Deposit flow's `Root` component. This component renders nothing (`return null`) and relies on an async `useEffect` to check for an existing auth token via `SecureKeychain.getSecureItem()` before navigating to `BuildQuote`. On Android, the Keystore operation can hang indefinitely in certain device states, causing `initializeFlow` to never complete — leaving the user stuck on a blank screen.

### Changes

- **Added a 5-second timeout** around `checkExistingToken()` so the flow continues even if the Android Keystore hangs
- **Added `.catch()` error handling** on `initializeFlow()` so any unexpected failure falls back to navigating to `BuildQuote` instead of leaving the user stranded
- **Replaced `return null` with a loading spinner** so users see visual feedback during initialization instead of a blank page
- **Fixed variable shadowing** of `params` inside the effect (renamed to `navParams`)
- **Added test coverage** for the error fallback path


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes a buy navigation bug on Android and adds a loading spinner

## **Related issues**

Fixes:

https://github.com/MetaMask/metamask-mobile/issues/26079

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Deposit navigation initialization and introduces timeout/error fallback behavior; risk is moderate due to potential routing changes, but scope is contained and covered by tests.
> 
> **Overview**
> Prevents the Deposit `Root` flow from getting stuck by wrapping `checkExistingToken()` in a **5s timeout** and logging/falling back to `Routes.DEPOSIT.BUILD_QUOTE` when token lookup fails or `initializeFlow` throws.
> 
> Replaces the previous blank render (`return null`) with a centered loading spinner, and cleans up navigation param handling (avoids `params` shadowing). Adds a new unit test + snapshot update to cover the rejection fallback path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd626fb97b9b7eb202118b65ec2f26aa34e57b2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->