### PR TITLE
ci: align build workflow with builds.yml, add iOS env setup and artifact renaming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,6 +174,17 @@ jobs:
           aws-secret-name: ${{ needs.prepare.outputs.signing_aws_secret }}
           android-keystore-path: ${{ needs.prepare.outputs.signing_android_keystore_path }}
 
+      # iOS: install Ruby, Bundler, and CocoaPods so setup:github-ci has a working Ruby (fixes self-hosted runners)
+      - name: Installing iOS Environment Setup
+        if: matrix.platform == 'ios'
+        timeout-minutes: 15
+        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1
+        with:
+          platform: ios
+          configure-keystores: false
+          setup-simulator: false
+          ruby-version: '3.1.6'
+
       - name: Setup project dependencies with retry
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,9 +80,6 @@ jobs:
     # Android: Cirrus lg (large) runner for 8GB Gradle heap; iOS: GitHub-hosted macOS
     runs-on: ${{ matrix.platform == 'ios' && 'ghcr.io/cirruslabs/macos-runner:sequoia-xl' || 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg' }}
     environment: ${{ needs.prepare.outputs.github_environment }}
-    env:
-      # So bundle exec (in yarn pod:install) finds ios/Gemfile when running from repo root
-      BUNDLE_GEMFILE: ios/Gemfile
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ permissions:
   id-token: write
 
 jobs:
-  # Load config 
+  # Load config
   prepare:
     runs-on: ubuntu-latest
     outputs:
@@ -188,11 +188,6 @@ jobs:
               yarn setup:github-ci --no-build-ios
             fi
 
-      # Android: use CI Gradle settings (8GB heap, OOM handling) to avoid daemon OOM
-      - name: Use CI Gradle properties (Android)
-        if: matrix.platform == 'android'
-        run: cp android/gradle.properties.github android/gradle.properties
-
       - name: Build ${{ matrix.platform }}
         timeout-minutes: 115
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
@@ -207,10 +202,26 @@ jobs:
             SCRIPT_NAME="build:${{ matrix.platform }}:${BUILD_NAME//-/:}"
             yarn "$SCRIPT_NAME"
 
-      # Expo development builds: upload iOS .app for simulator (Runway-style artifact)
-      - name: Upload iOS Expo development build
-        if: matrix.platform == 'ios' && (inputs.build_name == 'main-dev' || inputs.build_name == 'flask-dev' || inputs.build_name == 'qa-dev')
+      # Rename build artifacts
+      - name: Rename ${{ matrix.platform }} artifacts
+        run: node scripts/rename-artifacts.js ${{ matrix.platform }}
+
+      # Upload build artifacts (only if build succeeded)
+      - name: Upload iOS artifacts
+        if: matrix.platform == 'ios'
         uses: actions/upload-artifact@v4
         with:
-          name: expo-dev-ios-${{ inputs.build_name }}
-          path: ios/build/Build/Products/Debug-iphonesimulator/
+          name: ios-${{ inputs.build_name }}
+          path: |
+            ios/build/Build/Products/
+            ios/build/output/
+            ios/build/*.xcarchive
+          if-no-files-found: error
+
+      - name: Upload Android artifacts
+        if: matrix.platform == 'android' && success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-${{ inputs.build_name }}
+          path: android/app/build/outputs/
+          if-no-files-found: error

--- a/scripts/rename-artifacts.js
+++ b/scripts/rename-artifacts.js
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * Rename build artifacts with standardized naming convention.
+ * Called after Android/iOS builds complete to rename outputs.
+ *
+ * Usage:
+ *   node scripts/rename-artifacts.js android
+ *   node scripts/rename-artifacts.js ios
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const platform = process.argv[2];
+
+if (!platform || !['android', 'ios'].includes(platform)) {
+  console.error('Usage: node scripts/rename-artifacts.js <android|ios>');
+  process.exit(1);
+}
+
+// Get version from package.json
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'),
+);
+const appVersion = packageJson.version;
+
+// Get build number from environment (GitHub Actions run number or 1 for local)
+const buildNumber = process.env.GITHUB_RUN_NUMBER || '1';
+
+// Required env vars
+const buildType = process.env.METAMASK_BUILD_TYPE;
+const environment = process.env.METAMASK_ENVIRONMENT;
+const configuration = process.env.CONFIGURATION;
+
+if (!buildType || !environment) {
+  console.error(
+    '❌ Required env vars not set: METAMASK_BUILD_TYPE, METAMASK_ENVIRONMENT',
+  );
+  process.exit(1);
+}
+
+/**
+ * Find files matching a pattern
+ */
+function findFiles(dir, pattern) {
+  try {
+    const output = execSync(`find "${dir}" -name "${pattern}" -type f 2>/dev/null || true`, {
+      encoding: 'utf8',
+    }).trim();
+    return output ? output.split('\n') : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Find directories matching a pattern
+ */
+function findDirs(dir, pattern) {
+  try {
+    const output = execSync(`find "${dir}" -name "${pattern}" -type d 2>/dev/null || true`, {
+      encoding: 'utf8',
+    }).trim();
+    return output ? output.split('\n') : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Rename Android artifacts
+ */
+function renameAndroid() {
+  console.log('📦 Renaming Android artifacts...');
+
+  // Determine flavor based on build type
+  let appFlavor;
+  switch (buildType) {
+    case 'main':
+      appFlavor = 'prod';
+      break;
+    case 'flask':
+      appFlavor = 'flask';
+      break;
+    case 'qa':
+      appFlavor = 'qa';
+      break;
+    default:
+      console.error(`❌ Unknown build type: ${buildType}`);
+      process.exit(1);
+  }
+
+  // Determine if Debug or Release
+  const buildConfig = configuration === 'Debug' ? 'debug' : 'release';
+
+  // Set paths
+  const apkDir = path.join(
+    __dirname,
+    `../android/app/build/outputs/apk/${appFlavor}/${buildConfig}`,
+  );
+  const bundleDir = path.join(
+    __dirname,
+    `../android/app/build/outputs/bundle/${appFlavor}Release`,
+  );
+
+  // Create new base name: metamask-{environment}-{buildType}-{version}-{buildNumber}
+  const newBaseName = `metamask-${environment}-${buildType}-${appVersion}-${buildNumber}`;
+  console.log(`📝 Renaming artifacts to: ${newBaseName}`);
+
+  // Rename APK
+  const oldApk = path.join(apkDir, `app-${appFlavor}-${buildConfig}.apk`);
+  if (fs.existsSync(oldApk)) {
+    const newApk = path.join(apkDir, `${newBaseName}.apk`);
+    fs.copyFileSync(oldApk, newApk);
+    console.log(`✅ Renamed APK: ${newApk}`);
+  } else {
+    console.log(`⚠️  APK not found: ${oldApk}`);
+  }
+
+  // Rename AAB (only for Release builds)
+  if (buildConfig === 'release') {
+    const oldAab = path.join(bundleDir, `app-${appFlavor}-release.aab`);
+    if (fs.existsSync(oldAab)) {
+      const newAab = path.join(bundleDir, `${newBaseName}.aab`);
+      fs.copyFileSync(oldAab, newAab);
+      console.log(`✅ Renamed AAB: ${newAab}`);
+    } else {
+      console.log(`⚠️  AAB not found: ${oldAab}`);
+    }
+  }
+
+  // List final artifacts
+  console.log('📦 Final artifacts:');
+  const outputDir = path.join(__dirname, '../android/app/build/outputs');
+  const apks = findFiles(outputDir, '*.apk');
+  const aabs = findFiles(outputDir, '*.aab');
+  [...apks, ...aabs].forEach((file) => {
+    try {
+      const stats = fs.statSync(file);
+      const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
+      console.log(`  ${file} (${sizeMB} MB)`);
+    } catch {
+      console.log(`  ${file}`);
+    }
+  });
+}
+
+/**
+ * Rename iOS artifacts
+ */
+function renameIos() {
+  console.log('📦 Renaming iOS artifacts...');
+
+  const isSimBuild = process.env.IS_SIM_BUILD === 'true';
+
+  // Determine app name based on build type
+  let appName;
+  switch (buildType) {
+    case 'main':
+      appName = 'MetaMask';
+      break;
+    case 'flask':
+      appName = 'MetaMask-Flask';
+      break;
+    case 'qa':
+      appName = 'MetaMask-QA';
+      break;
+    default:
+      console.error(`❌ Unknown build type: ${buildType}`);
+      process.exit(1);
+  }
+
+  // Determine build paths based on simulator vs device
+  let buildDir, deviceType, binaryExtension;
+  if (isSimBuild) {
+    buildDir = path.join(
+      __dirname,
+      `../ios/build/Build/Products/${configuration || 'Release'}-iphonesimulator`,
+    );
+    deviceType = 'simulator';
+    binaryExtension = '.app';
+  } else {
+    buildDir = path.join(__dirname, '../ios/build/output');
+    deviceType = 'device';
+    binaryExtension = '.ipa';
+  }
+
+  // Create new base name: metamask-{deviceType}-{environment}-{buildType}-{version}-{buildNumber}
+  const newBaseName = `metamask-${deviceType}-${environment}-${buildType}-${appVersion}-${buildNumber}`;
+  console.log(`📝 Renaming artifacts to: ${newBaseName}`);
+
+  // Rename binary (.app or .ipa)
+  const oldBinary = path.join(buildDir, `${appName}${binaryExtension}`);
+  if (fs.existsSync(oldBinary)) {
+    const newBinary = path.join(buildDir, `${newBaseName}${binaryExtension}`);
+    // Use cp -r for directories (.app), regular copy for files (.ipa)
+    if (binaryExtension === '.app') {
+      execSync(`cp -r "${oldBinary}" "${newBinary}"`);
+    } else {
+      fs.copyFileSync(oldBinary, newBinary);
+    }
+    console.log(`✅ Renamed binary: ${newBinary}`);
+  } else {
+    console.log(`⚠️  Binary not found: ${oldBinary}`);
+  }
+
+  // Rename xcarchive (only for device builds)
+  if (!isSimBuild) {
+    const oldArchive = path.join(__dirname, `../ios/build/${appName}.xcarchive`);
+    if (fs.existsSync(oldArchive)) {
+      const newArchive = path.join(
+        __dirname,
+        `../ios/build/${newBaseName}.xcarchive`,
+      );
+      execSync(`cp -r "${oldArchive}" "${newArchive}"`);
+      console.log(`✅ Renamed archive: ${newArchive}`);
+    } else {
+      console.log(`⚠️  Archive not found: ${oldArchive}`);
+    }
+  }
+
+  // List final artifacts
+  console.log('📦 Final artifacts:');
+  if (isSimBuild) {
+    const apps = findDirs(
+      path.join(__dirname, '../ios/build/Build/Products'),
+      '*.app',
+    );
+    apps.forEach((app) => {
+      console.log(`  ${app}`);
+    });
+  } else {
+    const ipas = findFiles(path.join(__dirname, '../ios/build/output'), '*.ipa');
+    const archives = findDirs(path.join(__dirname, '../ios/build'), '*.xcarchive');
+    [...ipas, ...archives].forEach((file) => {
+      try {
+        const stats = fs.statSync(file);
+        const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
+        console.log(`  ${file} (${sizeMB} MB)`);
+      } catch {
+        console.log(`  ${file}`);
+      }
+    });
+  }
+}
+
+// Execute
+if (platform === 'android') {
+  renameAndroid();
+} else if (platform === 'ios') {
+  renameIos();
+}
+
+console.log('✅ Artifact renaming complete');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

1. **What is the reason for the change?**
   - The build workflow was failing on some runners (e.g. self-hosted) during iOS setup: missing Ruby 3.1.6 (rbenv) and/or wrong Gemfile path (`ios/ios/Gemfile`) when using job-level `BUNDLE_GEMFILE` with setup-e2e-env. The workflow also relied on remap env vars for secrets instead of `builds.yml`, and artifact upload/naming was inconsistent across build types.

2. **What is the improvement/solution?**
   - Use the **setup-e2e-env** action for iOS (same as build-ios-e2e): install Ruby 3.1.6, Bundler, and CocoaPods before `yarn setup:github-ci`, and remove job-level `BUNDLE_GEMFILE` so the action’s steps that run from `ios/` find the Gemfile correctly.
   - In `build.sh`, when `GITHUB_ACTIONS` is set, use `loadBuildConfig()` from `builds.yml` instead of remap*; keep remap* for Bitrise/local.
   - Add `scripts/rename-artifacts.js` and a single “Rename build artifacts” + upload flow for all build types (iOS and Android), with consistent naming (e.g. `metamask-{environment}-{buildType}-{version}-{buildNumber}`).
   
   
   To note, codefencing or built in feature flags values are not being applied properly, It's missing some changes that will be reflected on a new PR ([Bigger PR here for reference](https://github.com/MetaMask/metamask-mobile/pull/25177/))




Android and IOS is working
Android build: https://github.com/MetaMask/metamask-mobile/actions/runs/22079638138

IOS build: https://github.com/MetaMask/metamask-mobile/actions/runs/22080704672


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes modify CI build configuration and artifact handling for both iOS and Android; misconfiguration could break builds or produce incorrectly named/missing artifacts, but no production runtime code is affected.
> 
> **Overview**
> Build workflow now applies non-secret config from `builds.yml` into `GITHUB_ENV` and updates `scripts/build.sh` to load build config via `apply-build-config.js` when running in GitHub Actions (keeping legacy Bitrise env remapping for non-GHA runs).
> 
> CI setup is adjusted to improve iOS reliability on self-hosted runners by adding the `setup-e2e-env` action (Ruby/Bundler/CocoaPods) and removing job-level `BUNDLE_GEMFILE`/Android gradle-properties copying. The workflow also adds `scripts/rename-artifacts.js` to standardize Android/iOS artifact names and replaces the prior iOS-only dev-build upload with consistent artifact uploads for both platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f52c4d9a3948a6aba359bfd0c5dda62bdc1875f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->