### PR TITLE
fix(perps): update no-funds error copy to suggest deposit or different payment method cp-7.66.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -3229,7 +3229,9 @@ describe('PerpsOrderView', () => {
 
       // Assert - Should NOT show "No funds available" warning while loading
       expect(
-        queryByText('No funds available. Please deposit first.'),
+        queryByText(
+          'Not enough funds available. Deposit funds or select a different payment method',
+        ),
       ).toBeNull();
     });
 

--- a/app/components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.test.tsx
+++ b/app/components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.test.tsx
@@ -110,7 +110,9 @@ describe('PerpsAmountDisplay', () => {
 
       // Assert
       expect(
-        getByText('No funds available. Please deposit first.'),
+        getByText(
+          'Not enough funds available. Deposit funds or select a different payment method',
+        ),
       ).toBeTruthy();
     });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1040,7 +1040,7 @@
       "title": "Amount to deposit",
       "get_usdc_hyperliquid": "Get USDC • Hyperliquid",
       "insufficient_funds": "Insufficient funds",
-      "no_funds_available": "No funds available. Please deposit first.",
+      "no_funds_available": "Not enough funds available. Deposit funds or select a different payment method",
       "enter_amount": "Enter amount",
       "fetching_quote": "Fetching quote",
       "submitting": "Submitting transaction",


### PR DESCRIPTION
1. **What is the reason for the change?**  
   The previous error "No funds available. Please deposit first" was unclear when the user had some funds but not enough, and did not mention the option to choose another payment method.

2. **What is the improvement/solution?**  
   Copy is updated to: "Not enough funds available. Deposit funds or select a different payment method". This clarifies insufficient (not zero) funds and explicitly suggests depositing or changing payment method. Only the English locale and the tests that assert on this string were updated.

## **Changelog**

CHANGELOG entry: Fixed the Perps error message when funds are insufficient to show clearer guidance (deposit or select a different payment method).

## **Related issues**

Fixes:
Jira issue https://consensyssoftware.atlassian.net/browse/TAT-2569

## **Manual testing steps**

```gherkin
Feature: Perps order – insufficient funds messaging

  Scenario: user sees updated error when they have no/insufficient funds for selected payment method
    Given the user is on the Perps order flow with a payment method that has no or insufficient funds

    When the amount/payment state would show the "no funds" warning
    Then the message shown is "Not enough funds available. Deposit funds or select a different payment method"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="1206" height="2622" alt="simulator_screenshot_397C9500-3F3C-4165-A136-686935C8A0F1" src="https://github.com/user-attachments/assets/6f280947-fd5d-4316-a90b-3b7728bce2ec" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only i18n copy change with corresponding test updates; no business logic or data flow changes.
> 
> **Overview**
> Updates the English i18n string for `perps.deposit.no_funds_available` to a clearer insufficient-funds message that also suggests selecting a different payment method.
> 
> Adjusts Perps UI tests (`PerpsOrderView` and `PerpsAmountDisplay`) to assert against the new copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15f97080a831c76f773f19b52ff7893af156e1f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->