### PR TITLE
fix: adding security alert response details to transaction metrics

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.ts
+++ b/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.ts
@@ -20,6 +20,7 @@ import { getStxMetricsProperties } from '../metrics_properties/stx';
 import { getHashMetricsProperties } from '../metrics_properties/hash';
 import { getBatchMetricsProperties } from '../metrics_properties/batch';
 import { getGasMetricsProperties } from '../metrics_properties/gas';
+import { getSecurityAlertResponseProperties } from '../metrics_properties/security-alert-response';
 
 const log = createProjectLogger('transaction-metrics');
 
@@ -28,6 +29,7 @@ const METRICS_BUILDERS: TransactionMetricsBuilder[] = [
   getBatchMetricsProperties,
   getGasMetricsProperties,
   getMetaMaskPayProperties,
+  getSecurityAlertResponseProperties,
   getSimulationValuesProperties,
   getRPCMetricsProperties,
   getStxMetricsProperties,

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/security-alert-response.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/security-alert-response.test.ts
@@ -1,0 +1,153 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
+
+import { ResultType } from '../../../../../components/Views/confirmations/constants/signatures';
+import { TRANSACTION_EVENTS } from '../../../../Analytics/events/confirmations';
+import { TransactionMetricsBuilderRequest } from '../types';
+import { EMPTY_METRICS } from '../constants';
+import { getSecurityAlertResponseProperties } from './security-alert-response';
+
+const createMockRequest = (
+  securityAlertResponse?: Record<string, unknown>,
+  overrides: Partial<TransactionMetricsBuilderRequest> = {},
+): TransactionMetricsBuilderRequest => ({
+  eventType: TRANSACTION_EVENTS.TRANSACTION_ADDED,
+  transactionMeta: { securityAlertResponse } as unknown as TransactionMeta,
+  allTransactions: [],
+  getUIMetrics: () => EMPTY_METRICS,
+  getState: jest.fn() as TransactionMetricsBuilderRequest['getState'],
+  initMessenger: {} as never,
+  smartTransactionsController: {} as never,
+  ...overrides,
+});
+
+describe('getSecurityAlertResponseProperties', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns empty properties when securityAlertResponse is undefined', () => {
+    const request = createMockRequest(undefined);
+
+    const result = getSecurityAlertResponseProperties(request);
+
+    expect(result).toEqual({
+      properties: {},
+      sensitiveProperties: {},
+    });
+  });
+
+  it('returns security_alert_reason and security_alert_response', () => {
+    const request = createMockRequest({
+      result_type: ResultType.Benign,
+      reason: 'raw_native_token_transfer',
+    });
+
+    const result = getSecurityAlertResponseProperties(request);
+
+    expect(result).toEqual({
+      properties: {
+        security_alert_response: ResultType.Benign,
+        security_alert_reason: 'raw_native_token_transfer',
+      },
+      sensitiveProperties: {},
+    });
+  });
+
+  it('sets ui_customizations to flagged_as_malicious when result_type is Malicious', () => {
+    const request = createMockRequest({
+      result_type: ResultType.Malicious,
+      reason: 'malicious_domain',
+    });
+
+    const result = getSecurityAlertResponseProperties(request);
+
+    expect(result).toEqual({
+      properties: {
+        security_alert_response: ResultType.Malicious,
+        security_alert_reason: 'malicious_domain',
+        ui_customizations: ['flagged_as_malicious'],
+      },
+      sensitiveProperties: {},
+    });
+  });
+
+  it('sets ui_customizations to security_alert_loading and overrides security_alert_response when result_type is RequestInProgress', () => {
+    const request = createMockRequest({
+      result_type: ResultType.RequestInProgress,
+      reason: 'other',
+    });
+
+    const result = getSecurityAlertResponseProperties(request);
+
+    expect(result).toEqual({
+      properties: {
+        security_alert_response: 'loading',
+        security_alert_reason: 'other',
+        ui_customizations: ['security_alert_loading'],
+      },
+      sensitiveProperties: {},
+    });
+  });
+
+  it('includes ppom provider request counts', () => {
+    const request = createMockRequest({
+      result_type: ResultType.Benign,
+      reason: 'other',
+      providerRequestsCount: {
+        eth_call: 5,
+        eth_getCode: 3,
+      },
+    });
+
+    const result = getSecurityAlertResponseProperties(request);
+
+    expect(result).toEqual({
+      properties: {
+        security_alert_response: ResultType.Benign,
+        security_alert_reason: 'other',
+        ppom_eth_call_count: 5,
+        ppom_eth_getCode_count: 3,
+      },
+      sensitiveProperties: {},
+    });
+  });
+
+  it('handles securityAlertResponse with no providerRequestsCount', () => {
+    const request = createMockRequest({
+      result_type: ResultType.Warning,
+      reason: 'approval_farming',
+    });
+
+    const result = getSecurityAlertResponseProperties(request);
+
+    expect(result).toEqual({
+      properties: {
+        security_alert_response: ResultType.Warning,
+        security_alert_reason: 'approval_farming',
+      },
+      sensitiveProperties: {},
+    });
+  });
+
+  it('handles Malicious result_type with provider request counts', () => {
+    const request = createMockRequest({
+      result_type: ResultType.Malicious,
+      reason: 'permit_farming',
+      providerRequestsCount: {
+        eth_call: 2,
+      },
+    });
+
+    const result = getSecurityAlertResponseProperties(request);
+
+    expect(result).toEqual({
+      properties: {
+        security_alert_response: ResultType.Malicious,
+        security_alert_reason: 'permit_farming',
+        ui_customizations: ['flagged_as_malicious'],
+        ppom_eth_call_count: 2,
+      },
+      sensitiveProperties: {},
+    });
+  });
+});

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/security-alert-response.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/security-alert-response.ts
@@ -1,0 +1,47 @@
+import type { SecurityAlertResponse } from '@metamask/transaction-controller';
+
+import { ResultType } from '../../../../../components/Views/confirmations/constants/signatures';
+import type { JsonMap } from '../../../../Analytics/MetaMetrics.types';
+import type {
+  TransactionMetrics,
+  TransactionMetricsBuilderRequest,
+} from '../types';
+
+export function getSecurityAlertResponseProperties({
+  transactionMeta,
+}: TransactionMetricsBuilderRequest): TransactionMetrics {
+  const { securityAlertResponse } = transactionMeta;
+
+  if (!securityAlertResponse) {
+    return {
+      properties: {},
+      sensitiveProperties: {},
+    };
+  }
+
+  const { result_type, reason, providerRequestsCount } =
+    securityAlertResponse as SecurityAlertResponse & { source: string };
+
+  const properties: JsonMap = {
+    security_alert_response: result_type,
+    security_alert_reason: reason,
+  };
+
+  if (result_type === ResultType.Malicious) {
+    properties.ui_customizations = ['flagged_as_malicious'];
+  } else if (result_type === ResultType.RequestInProgress) {
+    properties.ui_customizations = ['security_alert_loading'];
+    properties.security_alert_response = 'loading';
+  }
+
+  if (providerRequestsCount) {
+    Object.keys(providerRequestsCount).forEach((key: string) => {
+      properties[`ppom_${key}_count`] = providerRequestsCount[key];
+    });
+  }
+
+  return {
+    properties,
+    sensitiveProperties: {},
+  };
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Security alert related properties were missing in transaction metrics events, this PR adds those.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7012

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes that add optional properties derived from existing `securityAlertResponse` data; minimal behavioral impact outside metrics payload shape.
> 
> **Overview**
> Transaction confirmation metrics now include *security alert* context when `transactionMeta.securityAlertResponse` is present.
> 
> A new metrics builder (`getSecurityAlertResponseProperties`) is added to all transaction metric events to emit `security_alert_response`/`security_alert_reason`, add `ui_customizations` for *malicious* and *loading* states, and append PPOM provider RPC request counters (e.g., `ppom_eth_call_count`). Tests are expanded/added to cover these new properties and the no-alert case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bca5ffdce157152bb60ac6758a816f9b84edf45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->