### PR TITLE
test: waits for token to be ready before tapping

### DIFF
--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -13,6 +13,7 @@ import Gestures from '../../framework/Gestures';
 import Matchers from '../../framework/Matchers';
 import TestHelpers from '../../helpers.js';
 import Assertions from '../../framework/Assertions';
+import Utilities from '../../framework/Utilities.js';
 
 class WalletView {
   static readonly MAX_SCROLL_ITERATIONS = 8;
@@ -198,6 +199,16 @@ class WalletView {
   async tapCurrentMainWalletAccountActions(): Promise<void> {
     await Gestures.waitAndTap(this.currentMainWalletAccountActions, {
       elemDescription: 'Current Main Wallet Account Actions',
+    });
+  }
+
+  async waitForTokenToBeReady(text: string, index = 0): Promise<DetoxElement> {
+    const elem = Matchers.getElementByText(text, index);
+    await Assertions.expectElementToBeVisible(elem, {
+      description: `${text} token in wallet list`,
+    });
+    return await Utilities.waitForReadyState(elem, {
+      elemDescription: `Token with text ${text} at index ${index}`,
     });
   }
 

--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -13,7 +13,7 @@ import Gestures from '../../framework/Gestures';
 import Matchers from '../../framework/Matchers';
 import TestHelpers from '../../helpers.js';
 import Assertions from '../../framework/Assertions';
-import Utilities from '../../framework/Utilities.js';
+import Utilities from '../../framework/Utilities';
 
 class WalletView {
   static readonly MAX_SCROLL_ITERATIONS = 8;

--- a/tests/smoke/confirmations/send/send-btc-token.spec.ts
+++ b/tests/smoke/confirmations/send/send-btc-token.spec.ts
@@ -6,6 +6,8 @@ import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
 import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
 import { loginToApp } from '../../../flows/wallet.flow';
 
+const TOKEN = 'Bitcoin';
+
 describe(SmokeConfirmations('Send Bitcoin'), () => {
   it('shows insufficient funds', async () => {
     await withFixtures(
@@ -16,7 +18,8 @@ describe(SmokeConfirmations('Send Bitcoin'), () => {
       async () => {
         await loginToApp();
         await device.disableSynchronization();
-        await WalletView.tapOnToken('Bitcoin');
+        await WalletView.waitForTokenToBeReady(TOKEN, 0);
+        await WalletView.tapOnToken(TOKEN);
         await TokenOverview.tapSendButton();
         await SendView.enterZeroAmount();
         await SendView.checkInsufficientFundsError();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR aims to stabilize the BTC no funds test as there is a race condition between the load of the BTC snap and the token Tap.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds an explicit UI ready-state wait to reduce flakiness; low impact outside the affected Detox smoke test flow.
> 
> **Overview**
> Stabilizes the BTC “insufficient funds” smoke test by waiting for the `Bitcoin` token row to reach a ready (visible/settled) state before tapping.
> 
> Adds `WalletView.waitForTokenToBeReady()` (wrapping `Utilities.waitForReadyState`) and updates `send-btc-token.spec.ts` to use it, reducing race conditions while the token/snap UI finishes loading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac1764ca14e3f5176b6ded6462d6fc05ca4b157d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->