### PR TITLE
feat(analytics): add transaction detail events and monetized primitives

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
@@ -20,6 +20,8 @@ import {
 import type { CaipAccountId } from '@metamask/utils';
 import { createMockAccountsControllerState } from '../../../../../util/test/accountsControllerTestUtils';
 import { mockNetworkState } from '../../../../../util/test/network';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { TRANSACTION_DETAIL_EVENTS } from '../../../../../core/Analytics/events/transactions';
 
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
@@ -835,6 +837,33 @@ describe('PerpsTransactionsView', () => {
         skipInitialFetch: false,
         accountId: secondAccountId,
       });
+    });
+  });
+
+  describe('Analytics Tracking', () => {
+    it('tracks Transaction Detail List Item Clicked when a transaction item is pressed', async () => {
+      const component = renderWithProvider(<PerpsTransactionsView />, {
+        state: mockInitialState,
+      });
+
+      await waitFor(() => {
+        expect(mockUsePerpsTransactionHistory).toHaveBeenCalled();
+      });
+
+      const transactionItems = component.queryAllByTestId(
+        PerpsTransactionSelectorsIDs.TRANSACTION_ITEM,
+      );
+
+      if (transactionItems.length > 0) {
+        await act(async () => {
+          fireEvent.press(transactionItems[0]);
+        });
+
+        const mockAnalytics = (useAnalytics as jest.Mock)();
+        expect(mockAnalytics.createEventBuilder).toHaveBeenCalledWith(
+          TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED,
+        );
+      }
     });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
@@ -20,8 +20,13 @@ import {
 import type { CaipAccountId } from '@metamask/utils';
 import { createMockAccountsControllerState } from '../../../../../util/test/accountsControllerTestUtils';
 import { mockNetworkState } from '../../../../../util/test/network';
-import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { TRANSACTION_DETAIL_EVENTS } from '../../../../../core/Analytics/events/transactions';
+import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
+
+const mockTrackEvent = jest.fn();
+const mockAddProperties = jest.fn();
+const mockBuild = jest.fn(() => ({ name: 'test-event' }));
+const mockCreateEventBuilder = jest.fn();
 
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
@@ -125,6 +130,20 @@ describe('PerpsTransactionsView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockNavigate.mockClear();
+
+    // Set up analytics mock
+    const { useAnalytics } = jest.requireMock(
+      '../../../../hooks/useAnalytics/useAnalytics',
+    );
+    mockAddProperties.mockReturnValue({ build: mockBuild });
+    mockCreateEventBuilder.mockReturnValue({
+      addProperties: mockAddProperties,
+      build: mockBuild,
+    });
+    useAnalytics.mockReturnValue({
+      trackEvent: mockTrackEvent,
+      createEventBuilder: mockCreateEventBuilder,
+    });
 
     mockUsePerpsConnection.mockReturnValue({
       isConnected: true,
@@ -859,10 +878,16 @@ describe('PerpsTransactionsView', () => {
           fireEvent.press(transactionItems[0]);
         });
 
-        const mockAnalytics = (useAnalytics as jest.Mock)();
-        expect(mockAnalytics.createEventBuilder).toHaveBeenCalledWith(
+        expect(mockCreateEventBuilder).toHaveBeenCalledWith(
           TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED,
         );
+        expect(mockAddProperties).toHaveBeenCalledWith(
+          expect.objectContaining({
+            transaction_type: 'perps_trade',
+            monetized_primitive: MonetizedPrimitive.Perps,
+          }),
+        );
+        expect(mockTrackEvent).toHaveBeenCalled();
       }
     });
   });

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
@@ -869,26 +869,28 @@ describe('PerpsTransactionsView', () => {
         expect(mockUsePerpsTransactionHistory).toHaveBeenCalled();
       });
 
-      const transactionItems = component.queryAllByTestId(
-        PerpsTransactionSelectorsIDs.TRANSACTION_ITEM,
+      let transactionItems: ReturnType<typeof component.queryAllByTestId> = [];
+      await waitFor(() => {
+        transactionItems = component.queryAllByTestId(
+          PerpsTransactionSelectorsIDs.TRANSACTION_ITEM,
+        );
+        expect(transactionItems.length).toBeGreaterThan(0);
+      });
+
+      await act(async () => {
+        fireEvent.press(transactionItems[0]);
+      });
+
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED,
       );
-
-      if (transactionItems.length > 0) {
-        await act(async () => {
-          fireEvent.press(transactionItems[0]);
-        });
-
-        expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-          TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED,
-        );
-        expect(mockAddProperties).toHaveBeenCalledWith(
-          expect.objectContaining({
-            transaction_type: 'perps_trade',
-            monetized_primitive: MonetizedPrimitive.Perps,
-          }),
-        );
-        expect(mockTrackEvent).toHaveBeenCalled();
-      }
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transaction_type: 'perps_trade',
+          monetized_primitive: MonetizedPrimitive.Perps,
+        }),
+      );
+      expect(mockTrackEvent).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -32,6 +32,13 @@ import {
 import PerpsTransactionItem from '../../components/PerpsTransactionItem';
 import PerpsTransactionsSkeleton from '../../components/PerpsTransactionsSkeleton';
 import { usePerpsConnection, usePerpsTransactionHistory } from '../../hooks';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
+import {
+  TRANSACTION_DETAIL_EVENTS,
+  TransactionDetailLocation,
+} from '../../../../../core/Analytics/events/transactions';
+import { PERPS_BALANCE_CHAIN_ID } from '../../constants/perpsConfig';
 import {
   FilterTab,
   ListItem,
@@ -244,7 +251,23 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
     [activeFilter],
   );
 
+  const { trackEvent, createEventBuilder } = useAnalytics();
+
   const handleTransactionPress = (transaction: PerpsTransaction) => {
+    trackEvent(
+      createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
+        .addProperties({
+          transaction_type: `perps_${transaction.type}`,
+          transaction_status:
+            transaction.depositWithdrawal?.status ?? 'confirmed',
+          location: TransactionDetailLocation.Home,
+          chain_id_source: PERPS_BALANCE_CHAIN_ID,
+          chain_id_destination: PERPS_BALANCE_CHAIN_ID,
+          monetized_primitive: MonetizedPrimitive.Perps,
+        })
+        .build(),
+    );
+
     switch (transaction.type) {
       case 'trade':
         navigation.navigate(Routes.PERPS.POSITION_TRANSACTION, {

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.test.tsx
@@ -4,6 +4,13 @@ import PerpsMarketTradesList from './PerpsMarketTradesList';
 import Routes from '../../../../../constants/navigation/Routes';
 import { usePerpsMarketFills } from '../../hooks/usePerpsMarketFills';
 import { type OrderFill } from '@metamask/perps-controller';
+import { TRANSACTION_DETAIL_EVENTS } from '../../../../../core/Analytics/events/transactions';
+import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
+
+const mockTrackEvent = jest.fn();
+const mockAddProperties = jest.fn();
+const mockBuild = jest.fn(() => ({ name: 'test-event' }));
+const mockCreateEventBuilder = jest.fn();
 
 // Mock dependencies
 jest.mock('@react-navigation/native', () => ({
@@ -207,6 +214,20 @@ describe('PerpsMarketTradesList', () => {
     });
     // Set default mock for usePerpsMarketFills
     mockUsePerpsMarketFills.mockReturnValue(createMockFillsReturn());
+
+    // Re-set up analytics mock (resetAllMocks in afterEach clears implementations)
+    const { useAnalytics } = jest.requireMock(
+      '../../../../hooks/useAnalytics/useAnalytics',
+    );
+    mockAddProperties.mockReturnValue({ build: mockBuild });
+    mockCreateEventBuilder.mockReturnValue({
+      addProperties: mockAddProperties,
+      build: mockBuild,
+    });
+    useAnalytics.mockReturnValue({
+      trackEvent: mockTrackEvent,
+      createEventBuilder: mockCreateEventBuilder,
+    });
   });
 
   afterEach(() => {
@@ -574,6 +595,30 @@ describe('PerpsMarketTradesList', () => {
       const { root } = render(<PerpsMarketTradesList symbol="ETH" />);
 
       expect(root).toBeTruthy();
+    });
+  });
+
+  describe('Analytics Tracking', () => {
+    it('tracks Transaction Detail List Item Clicked when a trade is pressed', () => {
+      mockUsePerpsMarketFills.mockReturnValue(
+        createMockFillsReturn(mockOrderFills),
+      );
+
+      render(<PerpsMarketTradesList symbol="ETH" />);
+
+      const tradeItem = screen.getByText('Opened long');
+      fireEvent.press(tradeItem.parent?.parent || tradeItem);
+
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED,
+      );
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transaction_type: 'perps_trade',
+          monetized_primitive: MonetizedPrimitive.Perps,
+        }),
+      );
+      expect(mockTrackEvent).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
@@ -22,8 +22,17 @@ import PerpsTokenLogo from '../PerpsTokenLogo';
 import PerpsFillTag from '../PerpsFillTag';
 import { useStyles } from '../../../../../component-library/hooks';
 import styleSheet from './PerpsRecentActivityList.styles';
-import { HOME_SCREEN_CONFIG } from '../../constants/perpsConfig';
+import {
+  HOME_SCREEN_CONFIG,
+  PERPS_BALANCE_CHAIN_ID,
+} from '../../constants/perpsConfig';
 import PerpsRowSkeleton from '../PerpsRowSkeleton';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
+import {
+  TRANSACTION_DETAIL_EVENTS,
+  TransactionDetailLocation,
+} from '../../../../../core/Analytics/events/transactions';
 
 interface PerpsRecentActivityListProps {
   transactions: PerpsTransaction[];
@@ -38,6 +47,7 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
 }) => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const handleSeeAll = useCallback(() => {
     navigation.navigate(Routes.PERPS.ACTIVITY, {
@@ -50,12 +60,25 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
     (transaction: PerpsTransaction) => {
       // Navigate to position transaction detail view for trades
       if (transaction.fill) {
+        trackEvent(
+          createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
+            .addProperties({
+              transaction_type: `perps_${transaction.type}`,
+              transaction_status: 'confirmed',
+              location: TransactionDetailLocation.Home,
+              chain_id_source: PERPS_BALANCE_CHAIN_ID,
+              chain_id_destination: PERPS_BALANCE_CHAIN_ID,
+              monetized_primitive: MonetizedPrimitive.Perps,
+            })
+            .build(),
+        );
+
         navigation.navigate(Routes.PERPS.POSITION_TRANSACTION, {
           transaction,
         });
       }
     },
-    [navigation],
+    [navigation, trackEvent, createEventBuilder],
   );
 
   // Render right content for trades (only type shown)

--- a/app/components/UI/TokenDetails/Views/TokenDetails.tsx
+++ b/app/components/UI/TokenDetails/Views/TokenDetails.tsx
@@ -42,6 +42,7 @@ import { getIsSwapsAssetAllowed } from '../../../Views/Asset/utils';
 import ActivityHeader from '../../../Views/Asset/ActivityHeader';
 import Transactions from '../../Transactions';
 import MultichainTransactionsView from '../../../Views/MultichainTransactionsView/MultichainTransactionsView';
+import { TransactionDetailLocation } from '../../../../core/Analytics/events/transactions';
 import BottomSheetFooter, {
   ButtonsAlignment,
 } from '../../../../component-library/components/BottomSheets/BottomSheetFooter';
@@ -264,6 +265,7 @@ const TokenDetails: React.FC<{ token: TokenDetailsRouteParams }> = ({
           chainId={token.chainId as SupportedCaipChainId}
           enableRefresh
           showDisclaimer
+          location={TransactionDetailLocation.AssetDetails}
         />
       ) : (
         <Transactions
@@ -281,6 +283,7 @@ const TokenDetails: React.FC<{ token: TokenDetailsRouteParams }> = ({
           headerHeight={280}
           tokenChainId={token.chainId}
           skipScrollOnClick
+          location={TransactionDetailLocation.AssetDetails}
         />
       )}
       {networkModal}

--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -19,7 +19,7 @@ import decodeTransaction from './utils';
 import { TRANSACTION_TYPES } from '../../../util/transactions';
 import ListItem from '../../Base/ListItem';
 import StatusText from '../../Base/StatusText';
-import { isTestNet } from '../../../util/networks';
+import { isTestNet, getDecimalChainId } from '../../../util/networks';
 import { weiHexToGweiDec } from '@metamask/controller-utils';
 import {
   TransactionType,
@@ -751,6 +751,7 @@ const TransactionElementWithBridge = (props) => {
   const trackTransactionDetailClicked = useCallback(() => {
     const tx = props.tx;
     const chainId = tx.chainId ?? '';
+    const decimalChainId = getDecimalChainId(chainId);
     const monetizedPrimitive = getMonetizedPrimitive(tx.type);
     const destChainId =
       bridgeTxHistoryData?.bridgeTxHistoryItem?.quote?.destChainId;
@@ -761,8 +762,8 @@ const TransactionElementWithBridge = (props) => {
           transaction_type: getTransactionTypeValue(tx.type, tx),
           transaction_status: tx.status,
           location: props.location ?? TransactionDetailLocation.Home,
-          chain_id_source: String(chainId),
-          chain_id_destination: String(destChainId ?? chainId),
+          chain_id_source: String(decimalChainId),
+          chain_id_destination: String(destChainId ?? decimalChainId),
           ...(monetizedPrimitive && {
             monetized_primitive: monetizedPrimitive,
           }),

--- a/app/components/UI/TransactionElement/index.test.tsx
+++ b/app/components/UI/TransactionElement/index.test.tsx
@@ -297,8 +297,8 @@ describe('TransactionElement', () => {
           transaction_type: expect.any(String),
           transaction_status: 'confirmed',
           location: TransactionDetailLocation.Home,
-          chain_id_source: '0x1',
-          chain_id_destination: '0x1',
+          chain_id_source: '1',
+          chain_id_destination: '1',
         }),
       );
       expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'test-event' });

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -197,6 +197,10 @@ class Transactions extends PureComponent {
      * Useful in views like Asset Details scrolling inside modals will cause issues (such as closing the stacked tx modal)
      */
     skipScrollOnClick: PropTypes.bool,
+    /**
+     * Location context for analytics tracking (home or asset_details)
+     */
+    location: PropTypes.string,
   };
 
   static defaultProps = {
@@ -660,6 +664,7 @@ class Transactions extends PureComponent {
       currentCurrency={this.props.currentCurrency}
       navigation={this.props.navigation}
       txChainId={item.chainId}
+      location={this.props.location}
     />
   );
 

--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -84,6 +84,7 @@ import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../select
 import { getIsSwapsAssetAllowed } from './utils';
 import MultichainTransactionsView from '../MultichainTransactionsView/MultichainTransactionsView';
 import { AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS } from '@metamask/multichain-network-controller';
+import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -702,6 +703,7 @@ class Asset extends PureComponent {
             enableRefresh
             showDisclaimer
             onScroll={this.onScrollThroughContent}
+            location={TransactionDetailLocation.AssetDetails}
           />
         ) : (
           // For EVM assets, use the existing Transactions component
@@ -733,6 +735,7 @@ class Asset extends PureComponent {
             onScrollThroughContent={this.onScrollThroughContent}
             tokenChainId={asset.chainId}
             skipScrollOnClick
+            location={TransactionDetailLocation.AssetDetails}
           />
         )}
       </View>

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -27,6 +27,8 @@ import MultichainBridgeTransactionListItem from '../../../components/UI/Multicha
 import { KnownCaipNamespace, parseCaipChainId } from '@metamask/utils';
 import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
 import { TabEmptyState } from '../../../component-library/components-temp/TabEmptyState';
+import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
+
 interface MultichainTransactionsViewProps {
   /**
    * Override transactions instead of using selector
@@ -64,6 +66,10 @@ interface MultichainTransactionsViewProps {
    * Scroll event handler
    */
   onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  /**
+   * Location context for analytics tracking (home or asset_details)
+   */
+  location?: TransactionDetailLocation;
 }
 
 const MultichainTransactionsView = ({
@@ -76,6 +82,7 @@ const MultichainTransactionsView = ({
   emptyMessage,
   showDisclaimer = false,
   onScroll,
+  location,
 }: MultichainTransactionsViewProps) => {
   const { colors } = useTheme();
   const style = styles();
@@ -154,6 +161,7 @@ const MultichainTransactionsView = ({
         bridgeHistoryItem={bridgeHistoryItem}
         navigation={nav}
         index={index}
+        location={location}
       />
     ) : (
       <MultichainTransactionListItem
@@ -161,6 +169,7 @@ const MultichainTransactionsView = ({
         navigation={nav}
         index={index}
         chainId={chainId}
+        location={location}
       />
     );
   };

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -53,6 +53,7 @@ import { getAddressUrl } from '../../../core/Multichain/utils';
 import UpdateEIP1559Tx from '../confirmations/legacy/components/UpdateEIP1559Tx';
 import styleSheet from './UnifiedTransactionsView.styles';
 import { useUnifiedTxActions } from './useUnifiedTxActions';
+import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
 import { useTransactionAutoScroll } from './useTransactionAutoScroll';
 import useBlockExplorer from '../../hooks/useBlockExplorer';
 import { selectBridgeHistoryForAccount } from '../../../selectors/bridgeStatusController';
@@ -86,11 +87,13 @@ interface UnifiedTransactionsViewProps {
   header?: React.ReactElement;
   tabLabel?: string;
   chainId?: string; // used by non-EVM list items for explorer links
+  location?: TransactionDetailLocation;
 }
 
 const UnifiedTransactionsView = ({
   header,
   chainId,
+  location,
 }: UnifiedTransactionsViewProps) => {
   const navigation =
     useNavigation<NavigationProp<Record<string, object | undefined>>>();
@@ -593,6 +596,7 @@ const UnifiedTransactionsView = ({
           signLedgerTransaction={signLedgerTransaction}
           currentCurrency={currentCurrency}
           showBottomBorder
+          location={location}
         />
       );
     }
@@ -606,6 +610,7 @@ const UnifiedTransactionsView = ({
         bridgeHistoryItem={bridgeHistoryItem}
         navigation={navigation}
         index={index}
+        location={location}
       />
     ) : (
       <MultichainTransactionListItem
@@ -614,6 +619,7 @@ const UnifiedTransactionsView = ({
         index={index}
         // Use the transaction's chain property for non-EVM transactions (contains CAIP chainId)
         chainId={item.tx.chain as unknown as SupportedCaipChainId}
+        location={location}
       />
     );
   };

--- a/app/core/Analytics/MetaMetrics.types.ts
+++ b/app/core/Analytics/MetaMetrics.types.ts
@@ -152,6 +152,18 @@ export interface IDeleteRegulationStatus {
 }
 
 /**
+ * Monetized primitives associated with a transaction.
+ * Only propagated when the transaction involves a monetized primitive.
+ */
+export enum MonetizedPrimitive {
+  Swaps = 'swaps',
+  Perps = 'perps',
+  Ramps = 'ramps',
+  Predict = 'predict',
+  MmPay = 'mm_pay',
+}
+
+/**
  * The API type used to perform a request to MetaMask Mobile
  * @description Indicates whether the request came through the Ethereum Provider API or the Multichain API
  * @see MetaMetricsRequestedThrough.EthereumProvider - Standard EIP-1193 provider API

--- a/app/core/Analytics/events/transactions/constants.ts
+++ b/app/core/Analytics/events/transactions/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Location from which a transaction detail list item was tapped.
+ */
+export enum TransactionDetailLocation {
+  Home = 'home',
+  AssetDetails = 'asset_details',
+}

--- a/app/core/Analytics/events/transactions/events.ts
+++ b/app/core/Analytics/events/transactions/events.ts
@@ -1,0 +1,18 @@
+import {
+  generateOpt,
+  EVENT_NAME as METRICS_EVENT_NAME,
+} from '../../MetaMetrics.events';
+
+enum EVENT_NAME {
+  TRANSACTION_DETAIL_LIST_ITEM_CLICKED = 'Transaction Detail List Item Clicked',
+}
+
+// This function helps prevent repeat of type conversions
+const createEvent = (name: EVENT_NAME) =>
+  generateOpt(name as unknown as METRICS_EVENT_NAME);
+
+export const TRANSACTION_DETAIL_EVENTS = {
+  LIST_ITEM_CLICKED: createEvent(
+    EVENT_NAME.TRANSACTION_DETAIL_LIST_ITEM_CLICKED,
+  ),
+};

--- a/app/core/Analytics/events/transactions/index.ts
+++ b/app/core/Analytics/events/transactions/index.ts
@@ -1,0 +1,3 @@
+export * from './constants';
+export * from './events';
+export * from './properties';

--- a/app/core/Analytics/events/transactions/index.ts
+++ b/app/core/Analytics/events/transactions/index.ts
@@ -1,3 +1,4 @@
 export * from './constants';
 export * from './events';
 export * from './properties';
+export * from './utils';

--- a/app/core/Analytics/events/transactions/properties.ts
+++ b/app/core/Analytics/events/transactions/properties.ts
@@ -1,0 +1,27 @@
+import { TransactionStatus } from '@metamask/transaction-controller';
+
+import type { JsonMap, MonetizedPrimitive } from '../../MetaMetrics.types';
+import { TransactionDetailLocation } from './constants';
+
+/**
+ * Properties for the "Transaction Detail List Item Clicked" event.
+ *
+ * @property transaction_type - TX type value from getTransactionTypeValue()
+ * (e.g. 'simple_send', 'swap', 'bridge', 'contract_interaction').
+ * @property transaction_status - Status from TransactionStatus enum
+ * (e.g. 'confirmed', 'submitted', 'failed').
+ * @property location - Where the user clicked (home or asset_details).
+ * @property chain_id_source - Source chain ID.
+ * @property chain_id_destination - Destination chain ID.
+ * Same as chain_id_source for single-chain transactions.
+ * @property monetized_primitive - Only propagated when the transaction
+ * involves a monetized primitive.
+ */
+export interface TransactionDetailListItemClickedProperties extends JsonMap {
+  transaction_type: string;
+  transaction_status: TransactionStatus;
+  location: TransactionDetailLocation;
+  chain_id_source: string;
+  chain_id_destination: string;
+  monetized_primitive?: MonetizedPrimitive;
+}

--- a/app/core/Analytics/events/transactions/utils.ts
+++ b/app/core/Analytics/events/transactions/utils.ts
@@ -1,0 +1,28 @@
+import { TransactionType } from '@metamask/transaction-controller';
+import { MonetizedPrimitive } from '../../MetaMetrics.types';
+
+/**
+ * Determines the monetized primitive for a given EVM transaction type.
+ * Returns undefined if the transaction doesn't involve a monetized primitive.
+ */
+export function getMonetizedPrimitive(
+  transactionType: TransactionType | string | undefined,
+): MonetizedPrimitive | undefined {
+  switch (transactionType) {
+    case TransactionType.swap:
+    case TransactionType.swapApproval:
+    case TransactionType.swapAndSend:
+    case TransactionType.bridge:
+    case TransactionType.bridgeApproval:
+      return MonetizedPrimitive.Swaps;
+    case TransactionType.perpsDeposit:
+    case TransactionType.perpsDepositAndOrder:
+      return MonetizedPrimitive.Perps;
+    case TransactionType.predictDeposit:
+    case TransactionType.predictWithdraw:
+    case TransactionType.predictClaim:
+      return MonetizedPrimitive.Predict;
+    default:
+      return undefined;
+  }
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a new analytics event **"Transaction Detail List Item Clicked"** that fires whenever a user taps on a transaction row to view its details. The event is tracked across all transaction list item types:

- **EVM transactions** (`TransactionElement`) — on Home and Asset Details screens
- **Multichain transactions** (`MultichainTransactionListItem`) — on Home and Asset Details screens
- **Multichain bridge/swap transactions** (`MultichainBridgeTransactionListItem`) — on Home and Asset Details screens
- **Perps transactions** (`PerpsTransactionsView`, `PerpsRecentActivityList`, `PerpsMarketTradesList`) — on Perps activity screens
- **Predict transactions** (`PredictActivity`) — on Predict activity screens

Event properties include `transaction_type`, `transaction_status`, `location` (home vs asset_details), `chain_id_source`, `chain_id_destination`, and an optional `monetized_primitive` (swaps, perps, predict) for revenue-relevant transactions.

### New analytics infrastructure:
- `MonetizedPrimitive` enum in `MetaMetrics.types.ts`
- `TRANSACTION_DETAIL_EVENTS` event definition
- `TransactionDetailLocation` enum (home / asset_details)
- `TransactionDetailListItemClickedProperties` interface
- `getMonetizedPrimitive()` utility to map EVM transaction types to monetized primitives

The `location` prop is threaded down from parent views (`Asset`, `TokenDetails`) to transaction list items, defaulting to `home` when not provided.

**Segment schema PR:** https://github.com/Consensys/segment-schema/pull/459

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-434

## **Manual testing steps**

```gherkin
Feature: Transaction Detail List Item Clicked analytics event

  Scenario: user taps an EVM transaction on the Home activity tab
    Given the user is on the Home screen with transaction history visible

    When user taps on a transaction row in the activity list
    Then a "Transaction Detail List Item Clicked" event is tracked
    And the event includes transaction_type, transaction_status, location="home", chain_id_source, chain_id_destination

  Scenario: user taps a transaction on the Asset Details screen
    Given the user is on an Asset Details screen with transaction history visible

    When user taps on a transaction row
    Then a "Transaction Detail List Item Clicked" event is tracked
    And the event includes location="asset_details"

  Scenario: user taps a bridge/swap transaction
    Given the user has a bridge or swap transaction in their activity

    When user taps on that transaction row
    Then a "Transaction Detail List Item Clicked" event is tracked
    And the event includes monetized_primitive="swaps" and distinct chain_id_source/chain_id_destination

  Scenario: user taps a Perps transaction
    Given the user is on the Perps activity screen with trades visible

    When user taps on a perps trade row
    Then a "Transaction Detail List Item Clicked" event is tracked
    And the event includes monetized_primitive="perps" and transaction_type="perps_trade"

  Scenario: user taps a Predict activity
    Given the user is on the Predict activity screen

    When user taps on a predict activity row
    Then a "Transaction Detail List Item Clicked" event is tracked
    And the event includes monetized_primitive="predict" and transaction_type="predict_buy" (or sell/claim)

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple high-traffic transaction list components and navigation press handlers; risk is primarily incorrect analytics payloads or missed events rather than functional transaction behavior.
> 
> **Overview**
> Adds a new analytics event, `TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED` ("Transaction Detail List Item Clicked"), plus shared typing/utilities (`TransactionDetailLocation`, `MonetizedPrimitive`, `TransactionDetailListItemClickedProperties`, `getMonetizedPrimitive`) to standardize payloads.
> 
> Wires this event into transaction-row taps across EVM (`TransactionElement`), multichain (`MultichainTransactionListItem` / `MultichainBridgeTransactionListItem`), Perps views, and Predict activity, including consistent properties (type/status, source/destination chain IDs, optional monetized primitive) and a new `location` prop threaded from Asset/TokenDetails/transaction views to distinguish *Home* vs *Asset Details*. Tests are updated/added to assert event tracking and swap/bridge/perps/predict-specific property behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2a6ad675ead4004b290679b73aa901a6314c2c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->