### PR TITLE
fix: swaps vertical networks fixes

### DIFF
--- a/app/components/UI/Bridge/_mocks_/bridgeReducerState.ts
+++ b/app/components/UI/Bridge/_mocks_/bridgeReducerState.ts
@@ -36,4 +36,5 @@ export const mockBridgeReducerState: BridgeState = {
   isSelectingToken: false,
   isDestTokenManuallySet: false,
   tokenSelectorNetworkFilter: undefined,
+  visiblePillChainIds: undefined,
 };

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -95,10 +95,7 @@ jest.mock('../../../../../core/redux/slices/bridge', () => {
     });
   return {
     selectBridgeFeatureFlags: jest.fn(() => getMockBridgeFeatureFlags()),
-    selectSourceChainRanking: jest.fn(
-      () => getMockBridgeFeatureFlags().chainRanking,
-    ),
-    selectDestChainRanking: jest.fn(
+    selectAllowedChainRanking: jest.fn(
       () => getMockBridgeFeatureFlags().chainRanking,
     ),
     setIsSelectingToken: jest.fn(() => ({

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -27,8 +27,7 @@ import { CaipChainId } from '@metamask/utils';
 import { useStyles } from '../../../../../component-library/hooks';
 import TextFieldSearch from '../../../../../component-library/components/Form/TextFieldSearch';
 import {
-  selectSourceChainRanking,
-  selectDestChainRanking,
+  selectAllowedChainRanking,
   selectTokenSelectorNetworkFilter,
   setIsSelectingToken,
   setTokenSelectorNetworkFilter,
@@ -104,13 +103,7 @@ export const BridgeTokenSelector: React.FC = () => {
     [searchString],
   );
 
-  // Use appropriate chain ranking based on selector type
-  const sourceChainRanking = useSelector(selectSourceChainRanking);
-  const destChainRanking = useSelector(selectDestChainRanking);
-  const enabledChainRanking =
-    route.params?.type === TokenSelectorType.Source
-      ? sourceChainRanking
-      : destChainRanking;
+  const enabledChainRanking = useSelector(selectAllowedChainRanking);
 
   // Set navigation options for header
   useEffect(() => {
@@ -539,10 +532,8 @@ export const BridgeTokenSelector: React.FC = () => {
           onMorePress={() =>
             navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
               screen: Routes.BRIDGE.MODALS.NETWORK_LIST_MODAL,
-              params: { type: route.params?.type },
             })
           }
-          type={route.params?.type}
         />
 
         <TextFieldSearch

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.test.tsx
@@ -4,8 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { CaipChainId } from '@metamask/utils';
 import NetworkListModal from './NetworkListModal';
 import {
-  selectSourceChainRanking,
-  selectDestChainRanking,
+  selectAllowedChainRanking,
   selectTokenSelectorNetworkFilter,
 } from '../../../../../core/redux/slices/bridge';
 
@@ -14,12 +13,6 @@ const mockOnCloseBottomSheet = jest.fn();
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
   useDispatch: jest.fn(),
-}));
-
-jest.mock('@react-navigation/native', () => ({
-  useRoute: () => ({
-    params: { type: 'source' },
-  }),
 }));
 
 jest.mock('../../../../../util/networks', () => ({
@@ -68,8 +61,7 @@ jest.mock(
 );
 
 jest.mock('../../../../../core/redux/slices/bridge', () => ({
-  selectSourceChainRanking: jest.fn(),
-  selectDestChainRanking: jest.fn(),
+  selectAllowedChainRanking: jest.fn(),
   selectTokenSelectorNetworkFilter: jest.fn(),
   setTokenSelectorNetworkFilter: jest.fn((chainId) => ({
     type: 'bridge/setTokenSelectorNetworkFilter',
@@ -119,10 +111,7 @@ describe('NetworkListModal', () => {
     (useDispatch as jest.Mock).mockReturnValue(mockDispatch);
 
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (
-        selector === selectSourceChainRanking ||
-        selector === selectDestChainRanking
-      ) {
+      if (selector === selectAllowedChainRanking) {
         return mockChainRanking;
       }
       if (selector === selectTokenSelectorNetworkFilter) {

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.tsx
@@ -16,29 +16,16 @@ import { AvatarSize } from '../../../../../component-library/components/Avatars/
 import { CaipChainId } from '@metamask/utils';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import {
-  selectSourceChainRanking,
-  selectDestChainRanking,
+  selectAllowedChainRanking,
   selectTokenSelectorNetworkFilter,
   setTokenSelectorNetworkFilter,
 } from '../../../../../core/redux/slices/bridge';
-import { useRoute, RouteProp } from '@react-navigation/native';
-import { TokenSelectorType } from '../../types';
-
-interface NetworkListModalParams {
-  type: TokenSelectorType;
-}
 
 const NetworkListModal: React.FC = () => {
   const dispatch = useDispatch();
-  const route =
-    useRoute<RouteProp<{ params: NetworkListModalParams }, 'params'>>();
   const sheetRef = useRef<BottomSheetRef>(null);
 
-  const type = route.params?.type;
-  const sourceChainRanking = useSelector(selectSourceChainRanking);
-  const destChainRanking = useSelector(selectDestChainRanking);
-  const chainRanking =
-    type === TokenSelectorType.Source ? sourceChainRanking : destChainRanking;
+  const chainRanking = useSelector(selectAllowedChainRanking);
   const selectedChainId = useSelector(selectTokenSelectorNetworkFilter);
 
   const handleClose = useCallback(() => {

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
@@ -3,10 +3,8 @@ import { render, fireEvent } from '@testing-library/react-native';
 import { NetworkPills } from './NetworkPills';
 import { CaipChainId } from '@metamask/utils';
 import { useSelector, useDispatch } from 'react-redux';
-import { TokenSelectorType } from '../../types';
 import {
-  selectSourceChainRanking,
-  selectDestChainRanking,
+  selectAllowedChainRanking,
   selectVisiblePillChainIds,
 } from '../../../../../core/redux/slices/bridge';
 
@@ -43,8 +41,7 @@ const mockSmallChainRanking = [
 ];
 
 jest.mock('../../../../../core/redux/slices/bridge', () => ({
-  selectSourceChainRanking: jest.fn(),
-  selectDestChainRanking: jest.fn(),
+  selectAllowedChainRanking: jest.fn(),
   selectVisiblePillChainIds: jest.fn(),
   setVisiblePillChainIds: jest.fn((ids) => ({
     type: 'bridge/setVisiblePillChainIds',
@@ -109,10 +106,7 @@ describe('NetworkPills', () => {
     jest.clearAllMocks();
     (useDispatch as jest.Mock).mockReturnValue(mockDispatch);
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (
-        selector === selectSourceChainRanking ||
-        selector === selectDestChainRanking
-      ) {
+      if (selector === selectAllowedChainRanking) {
         return mockChainRanking;
       }
       if (selector === selectVisiblePillChainIds) {
@@ -129,7 +123,6 @@ describe('NetworkPills', () => {
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -151,7 +144,6 @@ describe('NetworkPills', () => {
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -168,7 +160,6 @@ describe('NetworkPills', () => {
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -187,7 +178,6 @@ describe('NetworkPills', () => {
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -212,7 +202,6 @@ describe('NetworkPills', () => {
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -233,7 +222,6 @@ describe('NetworkPills', () => {
           selectedChainId={'eip155:1' as CaipChainId}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -248,7 +236,6 @@ describe('NetworkPills', () => {
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -263,7 +250,6 @@ describe('NetworkPills', () => {
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -280,7 +266,6 @@ describe('NetworkPills', () => {
           selectedChainId={'eip155:56' as CaipChainId}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -293,7 +278,6 @@ describe('NetworkPills', () => {
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -308,7 +292,6 @@ describe('NetworkPills', () => {
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -318,7 +301,6 @@ describe('NetworkPills', () => {
           selectedChainId={'eip155:137' as CaipChainId}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -340,7 +322,6 @@ describe('NetworkPills', () => {
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 
@@ -352,7 +333,6 @@ describe('NetworkPills', () => {
           selectedChainId={'eip155:1' as CaipChainId}
           onChainSelect={mockOnChainSelect}
           onMorePress={mockOnMorePress}
-          type={TokenSelectorType.Source}
         />,
       );
 

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
@@ -2,11 +2,19 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { NetworkPills } from './NetworkPills';
 import { CaipChainId } from '@metamask/utils';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { TokenSelectorType } from '../../types';
+import {
+  selectSourceChainRanking,
+  selectDestChainRanking,
+  selectVisiblePillChainIds,
+} from '../../../../../core/redux/slices/bridge';
+
+const mockDispatch = jest.fn();
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
+  useDispatch: jest.fn(),
 }));
 
 const mockUseSelector = useSelector as jest.Mock;
@@ -33,6 +41,16 @@ const mockSmallChainRanking = [
   { chainId: 'eip155:1' as CaipChainId, name: 'Ethereum' },
   { chainId: 'eip155:137' as CaipChainId, name: 'Polygon' },
 ];
+
+jest.mock('../../../../../core/redux/slices/bridge', () => ({
+  selectSourceChainRanking: jest.fn(),
+  selectDestChainRanking: jest.fn(),
+  selectVisiblePillChainIds: jest.fn(),
+  setVisiblePillChainIds: jest.fn((ids) => ({
+    type: 'bridge/setVisiblePillChainIds',
+    payload: ids,
+  })),
+}));
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({ style: (...args: unknown[]) => args }),
@@ -89,7 +107,19 @@ describe('NetworkPills', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseSelector.mockReturnValue(mockChainRanking);
+    (useDispatch as jest.Mock).mockReturnValue(mockDispatch);
+    mockUseSelector.mockImplementation((selector: unknown) => {
+      if (
+        selector === selectSourceChainRanking ||
+        selector === selectDestChainRanking
+      ) {
+        return mockChainRanking;
+      }
+      if (selector === selectVisiblePillChainIds) {
+        return undefined; // default: use first N from chainRanking
+      }
+      return undefined;
+    });
   });
 
   describe('rendering', () => {
@@ -147,7 +177,10 @@ describe('NetworkPills', () => {
     });
 
     it('does not render "+X more" when all networks are visible', () => {
-      mockUseSelector.mockReturnValue(mockSmallChainRanking);
+      mockUseSelector.mockImplementation((selector: unknown) => {
+        if (selector === selectVisiblePillChainIds) return undefined;
+        return mockSmallChainRanking;
+      });
 
       const { queryByTestId } = render(
         <NetworkPills
@@ -169,7 +202,10 @@ describe('NetworkPills', () => {
         { chainId: 'eip155:1' as CaipChainId, name: 'Ethereum' },
         { chainId: 'eip155:56' as CaipChainId, name: 'BNB Chain' },
       ];
-      mockUseSelector.mockReturnValue(customRanking);
+      mockUseSelector.mockImplementation((selector: unknown) => {
+        if (selector === selectVisiblePillChainIds) return undefined;
+        return customRanking;
+      });
 
       const { getByText, queryByText } = render(
         <NetworkPills
@@ -266,8 +302,8 @@ describe('NetworkPills', () => {
   });
 
   describe('visible pills update on selection', () => {
-    it('adds non-visible chain to front of visible list when selected', () => {
-      const { rerender, getByText, queryByText } = render(
+    it('dispatches new visible list when non-visible chain is selected', () => {
+      const { rerender } = render(
         <NetworkPills
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
@@ -276,10 +312,7 @@ describe('NetworkPills', () => {
         />,
       );
 
-      // Initially Polygon is not visible
-      expect(queryByText('Polygon')).toBeNull();
-
-      // Select Polygon (non-visible chain) by passing it as selectedChainId
+      // Select Polygon (non-visible chain)
       rerender(
         <NetworkPills
           selectedChainId={'eip155:137' as CaipChainId}
@@ -289,13 +322,20 @@ describe('NetworkPills', () => {
         />,
       );
 
-      // Now Polygon should be visible (pushed to front, Solana popped)
-      expect(getByText('Polygon')).toBeTruthy();
-      expect(queryByText('Solana')).toBeNull();
+      // Should dispatch with Polygon at front, Solana popped
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'bridge/setVisiblePillChainIds',
+        payload: [
+          'eip155:137', // Polygon pushed to front
+          'eip155:1', // Ethereum
+          'eip155:56', // BNB Chain
+          'bip122:000000000019d6689c085ae165831e93', // Bitcoin
+        ],
+      });
     });
 
-    it('does not change visible list when selecting an already visible chain', () => {
-      const { rerender, getByText } = render(
+    it('does not dispatch when selecting an already visible chain', () => {
+      const { rerender } = render(
         <NetworkPills
           selectedChainId={undefined}
           onChainSelect={mockOnChainSelect}
@@ -303,6 +343,8 @@ describe('NetworkPills', () => {
           type={TokenSelectorType.Source}
         />,
       );
+
+      mockDispatch.mockClear();
 
       // Select Ethereum (already visible)
       rerender(
@@ -314,11 +356,12 @@ describe('NetworkPills', () => {
         />,
       );
 
-      // All original 4 should still be visible
-      expect(getByText('Ethereum')).toBeTruthy();
-      expect(getByText('BNB Chain')).toBeTruthy();
-      expect(getByText('Bitcoin')).toBeTruthy();
-      expect(getByText('Solana')).toBeTruthy();
+      // Should not dispatch setVisiblePillChainIds
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'bridge/setVisiblePillChainIds',
+        }),
+      );
     });
   });
 });

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
@@ -15,8 +15,7 @@ import {
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import {
-  selectSourceChainRanking,
-  selectDestChainRanking,
+  selectAllowedChainRanking,
   selectVisiblePillChainIds,
   setVisiblePillChainIds,
 } from '../../../../../core/redux/slices/bridge';
@@ -24,7 +23,6 @@ import { CaipChainId } from '@metamask/utils';
 import { ScrollView } from 'react-native-gesture-handler';
 import ButtonToggle from '../../../../../component-library/components-temp/Buttons/ButtonToggle';
 import { ButtonSize } from '../../../../../component-library/components/Buttons/Button';
-import { TokenSelectorType } from '../../types';
 import { getNetworkImageSource } from '../../../../../util/networks';
 
 /** Maximum number of network pills visible in the horizontal list */
@@ -37,7 +35,6 @@ interface NetworkPillsProps {
   selectedChainId?: CaipChainId;
   onChainSelect: (chainId?: CaipChainId) => void;
   onMorePress: () => void;
-  type: TokenSelectorType;
 }
 
 interface ChainRankingEntry {
@@ -57,15 +54,13 @@ export const NetworkPills: React.FC<NetworkPillsProps> = ({
   selectedChainId,
   onChainSelect,
   onMorePress,
-  type,
 }) => {
   const tw = useTailwind();
   const dispatch = useDispatch();
   const scrollViewRef = useRef<ScrollView>(null);
-  const sourceChainRanking = useSelector(selectSourceChainRanking);
-  const destChainRanking = useSelector(selectDestChainRanking);
-  const chainRanking: ChainRankingEntry[] =
-    type === TokenSelectorType.Source ? sourceChainRanking : destChainRanking;
+  const chainRanking: ChainRankingEntry[] = useSelector(
+    selectAllowedChainRanking,
+  );
 
   // Visible pill chain IDs from Redux (shared across source/dest pickers).
   // Falls back to first N from chainRanking on initial mount.

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect, useMemo, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   AvatarBaseShape,
@@ -17,6 +17,8 @@ import { strings } from '../../../../../../locales/i18n';
 import {
   selectSourceChainRanking,
   selectDestChainRanking,
+  selectVisiblePillChainIds,
+  setVisiblePillChainIds,
 } from '../../../../../core/redux/slices/bridge';
 import { CaipChainId } from '@metamask/utils';
 import { ScrollView } from 'react-native-gesture-handler';
@@ -58,16 +60,18 @@ export const NetworkPills: React.FC<NetworkPillsProps> = ({
   type,
 }) => {
   const tw = useTailwind();
+  const dispatch = useDispatch();
   const scrollViewRef = useRef<ScrollView>(null);
   const sourceChainRanking = useSelector(selectSourceChainRanking);
   const destChainRanking = useSelector(selectDestChainRanking);
   const chainRanking: ChainRankingEntry[] =
     type === TokenSelectorType.Source ? sourceChainRanking : destChainRanking;
 
-  // Track which chain IDs are visible as pills
-  const [visibleChainIds, setVisibleChainIds] = useState<CaipChainId[]>(() =>
-    getVisibleChainIds(chainRanking),
-  );
+  // Visible pill chain IDs from Redux (shared across source/dest pickers).
+  // Falls back to first N from chainRanking on initial mount.
+  const reduxVisibleChainIds = useSelector(selectVisiblePillChainIds);
+  const visibleChainIds =
+    reduxVisibleChainIds ?? getVisibleChainIds(chainRanking);
 
   // Resolve visible chains to full entries from chainRanking
   const visibleChains = useMemo(
@@ -85,11 +89,10 @@ export const NetworkPills: React.FC<NetworkPillsProps> = ({
   // Also scroll the pills to bring the selected network into view.
   //
   // Only `selectedChainId` is listed as a dependency because
-  // `visibleChainIds` is a state variable that this effect mutates;
+  // `visibleChainIds` is derived from Redux state that this effect updates;
   // including it would cause an infinite update loop.
   useEffect(() => {
     if (!selectedChainId) {
-      // "All" selected — scroll to start
       scrollViewRef.current?.scrollTo({ x: 0, animated: true });
       return;
     }
@@ -98,10 +101,12 @@ export const NetworkPills: React.FC<NetworkPillsProps> = ({
 
     if (existingIndex === -1) {
       // Non-visible network: push to front and scroll to start
-      setVisibleChainIds((prev) => [
-        selectedChainId,
-        ...prev.slice(0, MAX_VISIBLE_PILLS - 1),
-      ]);
+      dispatch(
+        setVisiblePillChainIds([
+          selectedChainId,
+          ...visibleChainIds.slice(0, MAX_VISIBLE_PILLS - 1),
+        ]),
+      );
       scrollViewRef.current?.scrollTo({ x: 0, animated: true });
     } else {
       // Already visible: scroll to bring it into view

--- a/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
@@ -6,7 +6,7 @@ import {
   setIsDestTokenManuallySet,
 } from '../../../../core/redux/slices/bridge';
 import { createMockToken } from '../testUtils/fixtures';
-import { TokenSelectorType } from '../types';
+import { BridgeToken, TokenSelectorType } from '../types';
 
 const mockDispatch = jest.fn();
 const mockHandleSwitchTokensInner = jest.fn().mockResolvedValue(undefined);
@@ -85,7 +85,14 @@ const mockDestToken = createMockToken({
 });
 const mockDestAmount = '100';
 
-const defaultSelectorState = {
+interface SelectorState {
+  sourceToken: BridgeToken | null;
+  destToken: BridgeToken | null;
+  destAmount: string;
+  networkConfigurations: Record<string, unknown> | undefined;
+}
+
+const defaultSelectorState: SelectorState = {
   sourceToken: mockSourceToken,
   destToken: mockDestToken,
   destAmount: mockDestAmount,
@@ -97,7 +104,7 @@ const defaultSelectorState = {
 
 const renderTokenSelectionHook = (
   type: TokenSelectorType,
-  selectorOverrides: Partial<typeof defaultSelectorState> = {},
+  selectorOverrides: Partial<SelectorState> = {},
 ) => {
   const selectorState = {
     ...defaultSelectorState,

--- a/app/components/UI/Bridge/hooks/useTokenSelection.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.ts
@@ -48,7 +48,7 @@ export const useTokenSelection = (type: TokenSelectorType) => {
         token.chainId === otherToken.chainId;
 
       // Add the network if the user hasn't configured it yet
-      const isNetworkAdded = Boolean(networkConfigurations[token.chainId]);
+      const isNetworkAdded = Boolean(networkConfigurations?.[token.chainId]);
       if (!isNetworkAdded) {
         const popularNetwork = PopularList.find(
           (network) => network.chainId === token.chainId,

--- a/app/components/UI/Bridge/hooks/useTokenSelection.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.ts
@@ -13,6 +13,12 @@ import { BridgeToken, TokenSelectorType } from '../types';
 import { useSwitchTokens } from './useSwitchTokens';
 import { useIsNetworkEnabled } from './useIsNetworkEnabled';
 import { useAutoUpdateDestToken } from './useAutoUpdateDestToken';
+import { RpcEndpointType } from '@metamask/network-controller';
+import { toHex } from '@metamask/controller-utils';
+import { Hex } from '@metamask/utils';
+import Engine from '../../../../core/Engine';
+import { selectNetworkConfigurations } from '../../../../selectors/networkController';
+import { PopularList } from '../../../../util/networks/customNetworks';
 
 /**
  * Hook to manage token selection logic for Bridge token selector
@@ -28,6 +34,7 @@ export const useTokenSelection = (type: TokenSelectorType) => {
   const { handleSwitchTokens } = useSwitchTokens();
   const isDestNetworkEnabled = useIsNetworkEnabled(destToken?.chainId);
   const { autoUpdateDestToken } = useAutoUpdateDestToken();
+  const networkConfigurations = useSelector(selectNetworkConfigurations);
 
   const handleTokenPress = useCallback(
     async (token: BridgeToken) => {
@@ -39,6 +46,44 @@ export const useTokenSelection = (type: TokenSelectorType) => {
         otherToken &&
         token.address === otherToken.address &&
         token.chainId === otherToken.chainId;
+
+      // Add the network if the user hasn't configured it yet
+      const isNetworkAdded = Boolean(networkConfigurations[token.chainId]);
+      if (!isNetworkAdded) {
+        const popularNetwork = PopularList.find(
+          (network) => network.chainId === token.chainId,
+        );
+        if (popularNetwork) {
+          try {
+            const hexChainId = toHex(popularNetwork.chainId) as Hex;
+            const { blockExplorerUrl } = popularNetwork.rpcPrefs;
+            await Engine.context.NetworkController.addNetwork({
+              chainId: hexChainId,
+              blockExplorerUrls: blockExplorerUrl ? [blockExplorerUrl] : [],
+              defaultRpcEndpointIndex: 0,
+              defaultBlockExplorerUrlIndex: blockExplorerUrl ? 0 : undefined,
+              name: popularNetwork.nickname,
+              nativeCurrency: popularNetwork.ticker,
+              rpcEndpoints: [
+                {
+                  url: popularNetwork.rpcUrl,
+                  failoverUrls: popularNetwork.failoverRpcUrls,
+                  name: popularNetwork.nickname,
+                  type: RpcEndpointType.Custom,
+                },
+              ],
+            });
+          } catch {
+            if (isSourcePicker) {
+              // Source requires a configured network to sign transactions.
+              // Abort selection if the network couldn't be added.
+              navigation.goBack();
+              return;
+            }
+            // Dest can fail silently
+          }
+        }
+      }
 
       if (isSelectingOtherToken && sourceToken && destToken) {
         // Only allow swap if the destination network (which would become source) is enabled
@@ -79,6 +124,7 @@ export const useTokenSelection = (type: TokenSelectorType) => {
       handleSwitchTokens,
       isDestNetworkEnabled,
       autoUpdateDestToken,
+      networkConfigurations,
     ],
   );
 

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -14,8 +14,7 @@ import reducer, {
   selectBip44DefaultPair,
   selectGasIncludedQuoteParams,
   selectIsBridgeEnabledSource,
-  selectDestChainRanking,
-  selectSourceChainRanking,
+  selectAllowedChainRanking,
   setTokenSelectorNetworkFilter,
   selectTokenSelectorNetworkFilter,
   setVisiblePillChainIds,
@@ -561,88 +560,15 @@ describe('bridge slice', () => {
     });
   });
 
-  describe('selectSourceChainRanking', () => {
-    it('returns only supported and user-configured chains', () => {
-      const result = selectSourceChainRanking(
+  describe('selectAllowedChainRanking', () => {
+    it('returns all supported chains from feature flags', () => {
+      const result = selectAllowedChainRanking(
         mockRootState as unknown as RootState,
       );
 
-      // Should return chains that are both in ALLOWED_BRIDGE_CHAIN_IDS
-      // and in the user's configured networks
       expect(Array.isArray(result)).toBe(true);
       expect(result.length).toBeGreaterThan(0);
 
-      // Ethereum (0x1) is allowed and configured in the mock state
-      expect(result.some((chain) => chain.chainId === 'eip155:1')).toBe(true);
-    });
-
-    it('filters out unsupported EVM chains from chainRanking', () => {
-      const mockState = cloneDeep(mockRootState);
-      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2.chainRanking =
-        [
-          ...mockState.engine.backgroundState.RemoteFeatureFlagController
-            .remoteFeatureFlags.bridgeConfigV2.chainRanking,
-          { chainId: 'eip155:99999', name: 'Unsupported EVM Chain' },
-        ];
-
-      const result = selectSourceChainRanking(
-        mockState as unknown as RootState,
-      );
-
-      expect(result.some((chain) => chain.chainId === 'eip155:99999')).toBe(
-        false,
-      );
-    });
-
-    it('filters out unsupported non-EVM chains from chainRanking', () => {
-      const mockState = cloneDeep(mockRootState);
-      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2.chainRanking =
-        [
-          ...mockState.engine.backgroundState.RemoteFeatureFlagController
-            .remoteFeatureFlags.bridgeConfigV2.chainRanking,
-          { chainId: 'cosmos:cosmoshub-4', name: 'Unsupported Cosmos Chain' },
-        ];
-
-      const result = selectSourceChainRanking(
-        mockState as unknown as RootState,
-      );
-
-      expect(
-        result.some((chain) => chain.chainId === 'cosmos:cosmoshub-4'),
-      ).toBe(false);
-    });
-
-    it('filters out chains not in user-configured networks', () => {
-      const result = selectSourceChainRanking(
-        mockRootState as unknown as RootState,
-      );
-
-      // Optimism (0xa) is in chainRanking and ALLOWED_BRIDGE_CHAIN_IDS
-      // AND in the mock user's configured networks
-      const hasOptimism = result.some((chain) => chain.chainId === 'eip155:10');
-      expect(hasOptimism).toBe(true);
-
-      // Verify no chains appear that aren't in the user's configured networks
-      // The user only has Ethereum (0x1) and Optimism (0xa) configured as EVM networks
-      result.forEach((chain) => {
-        if (chain.chainId.startsWith('eip155:')) {
-          expect(['eip155:1', 'eip155:10']).toContain(chain.chainId);
-        }
-      });
-    });
-  });
-
-  describe('selectDestChainRanking', () => {
-    it('returns chainRanking from feature flags', () => {
-      const result = selectDestChainRanking(
-        mockRootState as unknown as RootState,
-      );
-
-      // Verify it returns an array with chain ranking data
-      expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBeGreaterThan(0);
-
-      // Verify the structure of each item
       result.forEach((chain) => {
         expect(chain).toHaveProperty('chainId');
         expect(chain).toHaveProperty('name');
@@ -650,22 +576,11 @@ describe('bridge slice', () => {
         expect(typeof chain.name).toBe('string');
       });
 
-      // Verify Ethereum is included (commonly in chainRanking)
-      const hasEthereum = result.some(
-        (chain) => chain.chainId === 'eip155:1' && chain.name === 'Ethereum',
-      );
-      expect(hasEthereum).toBe(true);
-    });
-
-    it('returns all supported chains without filtering by user-configured networks', () => {
-      const result = selectDestChainRanking(
-        mockRootState as unknown as RootState,
-      );
-
-      // selectDestChainRanking should return all supported chains from feature flags
-      // This is the key difference from selectSourceChainRanking which filters
-      // by user-configured networks
-      expect(result.length).toBeGreaterThan(0);
+      expect(
+        result.some(
+          (chain) => chain.chainId === 'eip155:1' && chain.name === 'Ethereum',
+        ),
+      ).toBe(true);
     });
 
     it('filters out unsupported EVM chains not in ALLOWED_BRIDGE_CHAIN_IDS', () => {
@@ -674,10 +589,12 @@ describe('bridge slice', () => {
         [
           ...mockState.engine.backgroundState.RemoteFeatureFlagController
             .remoteFeatureFlags.bridgeConfigV2.chainRanking,
-          { chainId: 'eip155:99999', name: 'Unsupported Future Chain' },
+          { chainId: 'eip155:99999', name: 'Unsupported EVM Chain' },
         ];
 
-      const result = selectDestChainRanking(mockState as unknown as RootState);
+      const result = selectAllowedChainRanking(
+        mockState as unknown as RootState,
+      );
 
       expect(result.some((chain) => chain.chainId === 'eip155:99999')).toBe(
         false,
@@ -694,7 +611,9 @@ describe('bridge slice', () => {
           { chainId: 'cosmos:cosmoshub-4', name: 'Unsupported Cosmos Chain' },
         ];
 
-      const result = selectDestChainRanking(mockState as unknown as RootState);
+      const result = selectAllowedChainRanking(
+        mockState as unknown as RootState,
+      );
 
       expect(
         result.some((chain) => chain.chainId === 'cosmos:cosmoshub-4'),

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -18,6 +18,8 @@ import reducer, {
   selectSourceChainRanking,
   setTokenSelectorNetworkFilter,
   selectTokenSelectorNetworkFilter,
+  setVisiblePillChainIds,
+  selectVisiblePillChainIds,
 } from '.';
 import {
   BridgeToken,
@@ -70,6 +72,7 @@ describe('bridge slice', () => {
         isMaxSourceAmount: false,
         isDestTokenManuallySet: false,
         tokenSelectorNetworkFilter: undefined,
+        visiblePillChainIds: undefined,
       });
     });
   });
@@ -761,6 +764,54 @@ describe('bridge slice', () => {
       );
 
       expect(result).toBe('eip155:10');
+    });
+  });
+
+  describe('setVisiblePillChainIds', () => {
+    it('should set the visible pill chain IDs', () => {
+      const chainIds = ['eip155:1', 'eip155:137'] as CaipChainId[];
+      const action = setVisiblePillChainIds(chainIds);
+      const state = reducer(initialState, action);
+
+      expect(state.visiblePillChainIds).toEqual(chainIds);
+    });
+
+    it('should clear visible pill chain IDs when set to undefined', () => {
+      const stateWithPills = {
+        ...initialState,
+        visiblePillChainIds: ['eip155:1'] as CaipChainId[],
+      };
+      const action = setVisiblePillChainIds(undefined);
+      const state = reducer(stateWithPills, action);
+
+      expect(state.visiblePillChainIds).toBeUndefined();
+    });
+  });
+
+  describe('selectVisiblePillChainIds', () => {
+    it('should return undefined when no pills are set', () => {
+      const mockState = cloneDeep(mockRootState);
+      (mockState as any).bridge = { ...initialState };
+
+      const result = selectVisiblePillChainIds(
+        mockState as unknown as RootState,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return the set chain IDs', () => {
+      const mockState = cloneDeep(mockRootState);
+      (mockState as any).bridge = {
+        ...initialState,
+        visiblePillChainIds: ['eip155:1', 'eip155:10'],
+      };
+
+      const result = selectVisiblePillChainIds(
+        mockState as unknown as RootState,
+      );
+
+      expect(result).toEqual(['eip155:1', 'eip155:10']);
     });
   });
 

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -687,7 +687,7 @@ describe('bridge slice', () => {
   });
 
   describe('setVisiblePillChainIds', () => {
-    it('should set the visible pill chain IDs', () => {
+    it('sets the visible pill chain IDs', () => {
       const chainIds = ['eip155:1', 'eip155:137'] as CaipChainId[];
       const action = setVisiblePillChainIds(chainIds);
       const state = reducer(initialState, action);
@@ -695,7 +695,7 @@ describe('bridge slice', () => {
       expect(state.visiblePillChainIds).toEqual(chainIds);
     });
 
-    it('should clear visible pill chain IDs when set to undefined', () => {
+    it('clears visible pill chain IDs when set to undefined', () => {
       const stateWithPills = {
         ...initialState,
         visiblePillChainIds: ['eip155:1'] as CaipChainId[],
@@ -708,7 +708,7 @@ describe('bridge slice', () => {
   });
 
   describe('selectVisiblePillChainIds', () => {
-    it('should return undefined when no pills are set', () => {
+    it('returns undefined when no pills are set', () => {
       const mockState = cloneDeep(mockRootState);
       (mockState as any).bridge = { ...initialState };
 
@@ -719,7 +719,7 @@ describe('bridge slice', () => {
       expect(result).toBeUndefined();
     });
 
-    it('should return the set chain IDs', () => {
+    it('returns the set chain IDs', () => {
       const mockState = cloneDeep(mockRootState);
       (mockState as any).bridge = {
         ...initialState,

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -69,6 +69,12 @@ export interface BridgeState {
    * When undefined, tokens from all chains are shown ("All" filter).
    */
   tokenSelectorNetworkFilter: CaipChainId | undefined;
+  /**
+   * Ordered list of chain IDs shown as pills in the token selector.
+   * Shared across source and dest pickers so pill order persists within a session.
+   * When undefined, defaults to the first N entries from chainRanking.
+   */
+  visiblePillChainIds: CaipChainId[] | undefined;
 }
 
 export const initialState: BridgeState = {
@@ -89,6 +95,7 @@ export const initialState: BridgeState = {
   isGasIncluded7702Supported: false,
   isDestTokenManuallySet: false,
   tokenSelectorNetworkFilter: undefined,
+  visiblePillChainIds: undefined,
 };
 
 const name = 'bridge';
@@ -182,6 +189,12 @@ const slice = createSlice({
       action: PayloadAction<CaipChainId | undefined>,
     ) => {
       state.tokenSelectorNetworkFilter = action.payload;
+    },
+    setVisiblePillChainIds: (
+      state,
+      action: PayloadAction<CaipChainId[] | undefined>,
+    ) => {
+      state.visiblePillChainIds = action.payload;
     },
   },
   extraReducers: (builder) => {
@@ -592,6 +605,11 @@ export const selectTokenSelectorNetworkFilter = createSelector(
   (bridgeState) => bridgeState.tokenSelectorNetworkFilter,
 );
 
+export const selectVisiblePillChainIds = createSelector(
+  selectBridgeState,
+  (bridgeState) => bridgeState.visiblePillChainIds,
+);
+
 export const selectIsDestTokenManuallySet = createSelector(
   selectBridgeState,
   (bridgeState) => bridgeState.isDestTokenManuallySet,
@@ -675,4 +693,5 @@ export const {
   setIsGasIncludedSTXSendBundleSupported,
   setIsGasIncluded7702Supported,
   setTokenSelectorNetworkFilter,
+  setVisiblePillChainIds,
 } = actions;


### PR DESCRIPTION
## **Description**

This PR fixes Bridge token selector network behavior across source and destination flows.

Reason for change:
- Source and destination selectors used different chain-ranking logic, causing inconsistent network visibility.
- Visible network pills were component-local state, so selection context did not persist cleanly across picker flows.
- Selecting tokens on unconfigured networks could block expected source selection behavior.

Improvement/solution:
- Unified source/destination network ranking to `selectAllowedChainRanking` (feature-flag ranking filtered by `ALLOWED_BRIDGE_CHAIN_IDS`).
- Removed source-only filtering by user-configured networks in network pills and network list modal so all supported bridge networks are visible.
- Lifted visible network-pill state into Redux (`visiblePillChainIds`) so ordering persists across picker flows.
- Updated pills behavior so selecting a non-visible network promotes it to the front.
- Added network auto-add during token selection via `PopularList` + `NetworkController.addNetwork`:
  - Source selection aborts if add-network fails.
  - Destination selection continues if add-network fails.

## **Changelog**

CHANGELOG entry: Fixed Bridge token selectors to show all supported networks, persist selected network pills, and auto-add missing networks on token selection.

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: Bridge token selector network visibility and selection behavior

  Scenario: source and destination selectors show the same supported network set
    Given a wallet with only a subset of networks configured
    And Bridge is enabled
    When the user opens the source token selector network controls
    And the user opens the destination token selector network controls
    Then both selectors show networks from the same allowed bridge chain ranking

  Scenario: selecting a non-visible network promotes it into pills
    Given the token selector shows limited visible network pills and a "+X more" control
    When the user opens the network list modal and selects a network not currently visible as a pill
    Then the selected network appears as the first visible pill
    And the remaining pills shift accordingly

  Scenario: selecting a token on an unconfigured source network adds the network
    Given a token exists on a supported network that is not currently configured in wallet settings
    When the user selects that token as source
    Then the app attempts to add the network configuration
    And source token selection completes if network add succeeds

  Scenario: source vs destination behavior when auto-add fails
    Given network add fails for a token on an unconfigured network
    When the user selects that token as source
    Then source selection is aborted and the selector closes
    When the user selects that token as destination
    Then the flow continues without blocking
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Bridge token selection flow and introduces automatic network addition via `NetworkController.addNetwork`, which could affect navigation and state if misconfigured or if the add-network call fails unexpectedly.
> 
> **Overview**
> Bridge token selection and network filtering are unified so source/dest pickers now use the same `selectAllowedChainRanking` list (feature-flag ranking filtered by `ALLOWED_BRIDGE_CHAIN_IDS`), and the network list modal no longer depends on route `type`.
> 
> Network pill ordering is lifted into Redux via new `visiblePillChainIds`, so selecting a network from the modal can promote it into the visible pill set and the order persists across picker flows.
> 
> Token selection now attempts to auto-add missing networks from `PopularList` via `NetworkController.addNetwork`, aborting *source* selection on failure but allowing *dest* selection to proceed; tests and bridge mocks are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b37e664f380efd83a047358467e09f81a8c9cb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->