### PR TITLE
chore: standardize back ButtonIcon sizes to md

### DIFF
--- a/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.tsx
@@ -35,7 +35,7 @@ const BottomSheetHeader: React.FC<BottomSheetHeaderProps> = ({
       iconName={IconName.ArrowLeft}
       iconColor={IconColor.Default}
       onPress={onBack}
-      size={ButtonIconSizes.Lg}
+      size={ButtonIconSizes.Md}
       {...backButtonProps}
     />
   );

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -968,25 +968,25 @@ exports[`SnapUIForm will render with fields 1`] = `
                                   {
                                     "alignItems": "center",
                                     "borderRadius": 8,
-                                    "height": 32,
+                                    "height": 28,
                                     "justifyContent": "center",
                                     "opacity": 1,
-                                    "width": 32,
+                                    "width": 28,
                                   }
                                 }
                               >
                                 <SvgMock
                                   color="#131416"
                                   fill="currentColor"
-                                  height={24}
+                                  height={20}
                                   name="ArrowLeft"
                                   style={
                                     {
-                                      "height": 24,
-                                      "width": 24,
+                                      "height": 20,
+                                      "width": 20,
                                     }
                                   }
-                                  width={24}
+                                  width={20}
                                 />
                               </TouchableOpacity>
                             </View>
@@ -1701,25 +1701,25 @@ exports[`SnapUIForm will render with fields 1`] = `
                                   {
                                     "alignItems": "center",
                                     "borderRadius": 8,
-                                    "height": 32,
+                                    "height": 28,
                                     "justifyContent": "center",
                                     "opacity": 1,
-                                    "width": 32,
+                                    "width": 28,
                                   }
                                 }
                               >
                                 <SvgMock
                                   color="#131416"
                                   fill="currentColor"
-                                  height={24}
+                                  height={20}
                                   name="ArrowLeft"
                                   style={
                                     {
-                                      "height": 24,
-                                      "width": 24,
+                                      "height": 20,
+                                      "width": 20,
                                     }
                                   }
-                                  width={24}
+                                  width={20}
                                 />
                               </TouchableOpacity>
                             </View>

--- a/app/components/UI/Card/components/Onboarding/KYCFailed.tsx
+++ b/app/components/UI/Card/components/Onboarding/KYCFailed.tsx
@@ -108,7 +108,7 @@ const KYCFailed = () => {
         <Box twClassName="px-4 py-2 items-start">
           <ButtonIcon
             iconName={IconName.ArrowLeft}
-            size={ButtonIconSizes.Lg}
+            size={ButtonIconSizes.Md}
             iconColor={importedColors.white}
             onPress={navigateToHome}
             testID="kyc-failed-back-button"

--- a/app/components/UI/Card/components/Onboarding/KYCPending.tsx
+++ b/app/components/UI/Card/components/Onboarding/KYCPending.tsx
@@ -64,7 +64,7 @@ const KYCPending = () => {
         <Box twClassName="px-4 py-2 items-start">
           <ButtonIcon
             iconName={IconName.ArrowLeft}
-            size={ButtonIconSizes.Lg}
+            size={ButtonIconSizes.Md}
             iconColor={importedColors.white}
             onPress={navigateToHome}
             testID="kyc-pending-back-button"

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -256,7 +256,7 @@ export function getNavigationOptionsTitle(
     headerLeft: () =>
       isFullScreenModal ? null : (
         <ButtonIcon
-          size={ButtonIconSize.Lg}
+          size={ButtonIconSize.Md}
           iconName={IconName.ArrowLeft}
           onPress={navigationPop}
           style={innerStyles.accessories}
@@ -1249,7 +1249,7 @@ export function getNetworkNavbarOptions(
             style={styles.headerLeftButton}
             onPress={() => navigation.pop()}
             testID={CommonSelectorsIDs.BACK_ARROW_BUTTON}
-            size={ButtonIconSize.Lg}
+            size={ButtonIconSize.Md}
             iconName={IconName.ArrowLeft}
             iconColor={IconColor.Default}
           />
@@ -1651,7 +1651,7 @@ export function getPerpsTransactionsDetailsNavbar(navigation, title) {
       <ButtonIcon
         iconName={IconName.Arrow2Left}
         onPress={leftAction}
-        size={ButtonIconSize.Lg}
+        size={ButtonIconSize.Md}
       />
     ),
     headerRight: () => <View style={innerStyles.rightSpacer} />,
@@ -1684,7 +1684,7 @@ export function getPerpsMarketDetailsNavbar(navigation, title) {
       <ButtonIcon
         iconName={IconName.Arrow2Left}
         onPress={leftAction}
-        size={ButtonIconSize.Lg}
+        size={ButtonIconSize.Md}
       />
     ),
   };
@@ -1901,7 +1901,7 @@ export function getStakingNavbar(
     headerLeft: () =>
       hasBackButton ? (
         <ButtonIcon
-          size={ButtonIconSize.Lg}
+          size={ButtonIconSize.Md}
           iconName={IconName.ArrowLeft}
           onPress={handleBackPress}
           style={innerStyles.headerLeft}
@@ -1947,7 +1947,7 @@ export function getDeFiProtocolPositionDetailsNavbarOptions(navigation) {
         style={styles.headerLeftButton}
         onPress={() => navigation.pop()}
         testID={CommonSelectorsIDs.BACK_ARROW_BUTTON}
-        size={ButtonIconSize.Lg}
+        size={ButtonIconSize.Md}
         iconName={IconName.ArrowLeft}
         iconColor={IconColor.Default}
       />

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
@@ -499,7 +499,7 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
             <ButtonIcon
               iconName={IconName.ArrowLeft}
               iconColor={IconColor.Default}
-              size={ButtonIconSizes.Lg}
+              size={ButtonIconSizes.Md}
               onPress={handleBack}
               testID={PerpsOrderBookViewSelectorsIDs.BACK_BUTTON}
             />

--- a/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.tsx
+++ b/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.tsx
@@ -93,7 +93,7 @@ interface HeaderBackButtonProps {
 function HeaderBackButton({ onPress, testID }: HeaderBackButtonProps) {
   return (
     <ButtonIcon
-      size={ButtonIconSizes.Lg}
+      size={ButtonIconSizes.Md}
       iconName={IconName.ArrowLeft}
       onPress={onPress}
       style={navigationOptionsStyles.headerLeft}
@@ -706,7 +706,7 @@ RegionSelector.navigationOptions = ({
 }) => ({
   headerLeft: () => (
     <ButtonIcon
-      size={ButtonIconSizes.Lg}
+      size={ButtonIconSizes.Md}
       iconName={IconName.ArrowLeft}
       onPress={() => navigation.goBack()}
       style={navigationOptionsStyles.headerLeft}

--- a/app/components/UI/Tabs/index.js
+++ b/app/components/UI/Tabs/index.js
@@ -258,7 +258,7 @@ class Tabs extends PureComponent {
       <View style={styles.topBar}>
         <ButtonIcon
           iconName={IconName.ArrowLeft}
-          size={ButtonIconSizes.Lg}
+          size={ButtonIconSizes.Md}
           onPress={closeTabsView}
           testID={BrowserViewSelectorsIDs.TABS_BACK_BUTTON}
           accessibilityLabel={strings('browser.go_back')}

--- a/app/components/UI/TokenDetails/components/TokenDetailsInlineHeader.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsInlineHeader.tsx
@@ -66,7 +66,7 @@ export const TokenDetailsInlineHeader = ({
       <ButtonIcon
         style={styles.leftButton}
         onPress={onBackPress}
-        size={ButtonIconSize.Lg}
+        size={ButtonIconSize.Md}
         iconName={IconName.ArrowLeft}
         testID="back-arrow-button"
       />

--- a/app/components/Views/AssetDetails/index.tsx
+++ b/app/components/Views/AssetDetails/index.tsx
@@ -414,7 +414,7 @@ const AssetDetails = (props: InnerProps) => {
         <ButtonIcon
           style={inlineHeaderStyles.leftButton}
           onPress={() => navigation.goBack()}
-          size={ButtonIconSize.Lg}
+          size={ButtonIconSize.Md}
           iconName={IconName.ArrowLeft}
         />
         <View style={inlineHeaderStyles.titleWrapper}>

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -1441,7 +1441,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
               {!isUrlBarFocused && (
                 <ButtonIcon
                   iconName={IconName.ArrowLeft}
-                  size={ButtonIconSize.Lg}
+                  size={ButtonIconSize.Md}
                   onPress={handleClosePress}
                   testID="browser-tab-close-button"
                 />

--- a/app/components/Views/BrowserTab/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/BrowserTab/__snapshots__/index.test.tsx.snap
@@ -69,10 +69,10 @@ exports[`BrowserTab render Browser 1`] = `
               "alignItems": "center",
               "backgroundColor": "transparent",
               "borderRadius": 8,
-              "height": 40,
+              "height": 32,
               "justifyContent": "center",
               "opacity": 1,
-              "width": 40,
+              "width": 32,
             },
             undefined,
             {
@@ -93,8 +93,8 @@ exports[`BrowserTab render Browser 1`] = `
             [
               {
                 "color": "#131416",
-                "height": 32,
-                "width": 32,
+                "height": 24,
+                "width": 24,
               },
               undefined,
             ]

--- a/app/components/Views/Settings/DeveloperOptions/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/DeveloperOptions/__snapshots__/index.test.tsx.snap
@@ -152,10 +152,10 @@ exports[`DeveloperOptions renders correctly 1`] = `
                       "alignItems": "center",
                       "backgroundColor": "transparent",
                       "borderRadius": 8,
-                      "height": 40,
+                      "height": 32,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 40,
+                      "width": 32,
                     },
                     {
                       "marginHorizontal": 16,
@@ -178,8 +178,8 @@ exports[`DeveloperOptions renders correctly 1`] = `
                     [
                       {
                         "color": "#131416",
-                        "height": 32,
-                        "width": 32,
+                        "height": 24,
+                        "width": 24,
                       },
                       undefined,
                     ]

--- a/app/components/Views/Settings/NotificationsSettings/index.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/index.tsx
@@ -134,7 +134,7 @@ NotificationsSettings.navigationOptions = ({
 }) => ({
   headerLeft: () => (
     <ButtonIcon
-      size={ButtonIconSizes.Lg}
+      size={ButtonIconSizes.Md}
       iconName={IconName.ArrowLeft}
       onPress={() =>
         !isNotificationEnabled

--- a/app/components/Views/TokensFullView/TokensFullView.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.tsx
@@ -23,7 +23,7 @@ const TokensFullView = () => {
       <HeaderBase
         startAccessory={
           <ButtonIcon
-            size={ButtonIconSizes.Lg}
+            size={ButtonIconSizes.Md}
             onPress={handleBackPress}
             iconName={IconName.ArrowLeft}
             testID="back-button"

--- a/app/components/Views/confirmations/components/UI/navbar/navbar.tsx
+++ b/app/components/Views/confirmations/components/UI/navbar/navbar.tsx
@@ -72,7 +72,7 @@ export function getNavbar({
 
   const defaultHeaderLeft = () => (
     <ButtonIcon
-      size={ButtonIconSizes.Lg}
+      size={ButtonIconSizes.Md}
       iconName={IconName.ArrowLeft}
       onPress={handleBackPress}
       style={innerStyles.headerLeft}

--- a/app/components/Views/confirmations/components/flat-nav-header/flat-nav-header.tsx
+++ b/app/components/Views/confirmations/components/flat-nav-header/flat-nav-header.tsx
@@ -36,7 +36,7 @@ const FlatNavHeader = ({ title, onLeftPress }: FlatNavHeaderProps) => {
       <ButtonIcon
         iconName={IconName.ArrowLeft}
         onPress={handleLeftPress}
-        size={ButtonIconSizes.Lg}
+        size={ButtonIconSizes.Md}
         style={styles.left}
         testID="flat-nav-header-back-button"
       />

--- a/app/components/hooks/useOnboardingHeader.tsx
+++ b/app/components/hooks/useOnboardingHeader.tsx
@@ -19,7 +19,7 @@ export const useOnboardingHeader = (title: string) => {
   const renderBackButton = useCallback(
     () => (
       <ButtonIcon
-        size={ButtonIconSizes.Lg}
+        size={ButtonIconSizes.Md}
         iconName={IconName.ArrowLeft}
         accessibilityRole="button"
         accessibilityLabel="back"


### PR DESCRIPTION
## **Description**

Any `ButtonIcon` inside of a header should be size `md`.

This PR standardizes header back button icon sizing from large to medium across navigation surfaces that use `ButtonIcon` (both design-system-react-native and component-library variants), with a targeted Security & Privacy override to keep behavior consistent.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Header back button icon sizing consistency

  Scenario: user opens screens with header back buttons
    Given the app is launched and user can navigate to Settings, Assets, Browser, Perps, Ramp, and Card flows

    When user opens screens that render back-arrow ButtonIcon controls in the header
    Then back-arrow ButtonIcon controls render at medium size consistently
```

## **Screenshots/Recordings**

### **Before**

Not collected for every header.

### **After**

Not collected for every header.

Given the low-risk nature of this change and confidence from direct code-level verification, I am forgoing exhaustive visual regression screenshots for every navbar.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change that adjusts back button sizing and snapshot expectations without altering navigation behavior or business logic.
> 
> **Overview**
> Standardizes header back-arrow `ButtonIcon` size from `Lg` to `Md` across common navigation surfaces (navbar headers, onboarding/card KYC screens, perps order book, ramp region selector, browser tabs, token/asset inline headers, confirmations, and bottom sheet headers).
> 
> Updates affected Jest snapshots to match the new rendered touch target/icon dimensions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff40b4d873c7ec1218db499fcae1f9d5cdd453bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->