### PR TITLE
refactor(analytics): migrate Batch 2-6: mobile-core-ux

### DIFF
--- a/app/components/Views/NetworkSelector/NetworkSelector.test.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.test.tsx
@@ -21,23 +21,25 @@ jest.mock('../../../util/metrics/MultichainAPI/networkMetricUtils', () => ({
   }),
 }));
 
-jest.mock('../../../components/hooks/useMetrics', () => ({
-  useMetrics: () => ({
+jest.mock('../../../components/hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
     trackEvent: jest.fn(),
     createEventBuilder: jest.fn(() => ({
       addProperties: jest.fn(() => ({
         build: jest.fn(),
       })),
+      build: jest.fn(),
     })),
   }),
 }));
 
-jest.mock('../../../core/Analytics', () => ({
-  MetaMetrics: {
-    getInstance: jest.fn().mockReturnValue({
-      addTraitsToUser: jest.fn(),
-    }),
+jest.mock('../../../util/analytics/analytics', () => ({
+  analytics: {
+    identify: jest.fn(),
   },
+}));
+
+jest.mock('../../../core/Analytics', () => ({
   MetaMetricsEvents: {
     NETWORK_SWITCHED: 'Network Switched',
   },

--- a/app/components/Views/NetworkSelector/NetworkSelector.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.tsx
@@ -102,7 +102,7 @@ import { isNonEvmChainId } from '../../../core/Multichain/utils';
 import { MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
 import { useSwitchNetworks } from './useSwitchNetworks';
 import { removeItemFromChainIdList } from '../../../util/metrics/MultichainAPI/networkMetricUtils';
-import { MetaMetrics } from '../../../core/Analytics';
+import { analytics } from '../../../util/analytics/analytics';
 import {
   NETWORK_SELECTOR_SOURCES,
   NetworkSelectorSource,
@@ -884,9 +884,7 @@ const NetworkSelector = () => {
       const { NetworkController } = Engine.context;
       NetworkController.removeNetwork(chainId);
 
-      MetaMetrics.getInstance().addTraitsToUser(
-        removeItemFromChainIdList(chainId),
-      );
+      analytics.identify(removeItemFromChainIdList(chainId));
 
       // set tokenNetworkFilter
       const { PreferencesController } = Engine.context;

--- a/app/components/Views/NetworkSelector/useNetworkSwitch.test.ts
+++ b/app/components/Views/NetworkSelector/useNetworkSwitch.test.ts
@@ -3,7 +3,7 @@ import {
   NetworkType,
 } from '../../hooks/useNetworksByNamespace/useNetworksByNamespace';
 import { useNetworkSelection } from '../../hooks/useNetworkSelection/useNetworkSelection';
-import { useMetrics } from '../../hooks/useMetrics';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import Engine from '../../../core/Engine';
 
 // Mock the feature flags
@@ -23,8 +23,8 @@ jest.mock('../../hooks/useNetworkSelection/useNetworkSelection', () => ({
   useNetworkSelection: jest.fn(),
 }));
 
-jest.mock('../../hooks/useMetrics', () => ({
-  useMetrics: jest.fn(),
+jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(),
 }));
 
 // Mock Engine
@@ -80,7 +80,9 @@ const mockUseNetworksByNamespace =
 const mockUseNetworkSelection = useNetworkSelection as jest.MockedFunction<
   typeof useNetworkSelection
 >;
-const mockUseMetrics = useMetrics as jest.MockedFunction<typeof useMetrics>;
+const mockUseAnalytics = useAnalytics as jest.MockedFunction<
+  typeof useAnalytics
+>;
 
 const mockSelectNetwork = jest.fn();
 const mockTrackEvent = jest.fn();
@@ -108,7 +110,7 @@ describe('useSwitchNetworks Feature Flag Tests', () => {
       customNetworksToReset: [],
     });
 
-    mockUseMetrics.mockReturnValue({
+    mockUseAnalytics.mockReturnValue({
       trackEvent: mockTrackEvent,
       createEventBuilder: mockCreateEventBuilder,
       isEnabled: () => true,
@@ -119,7 +121,7 @@ describe('useSwitchNetworks Feature Flag Tests', () => {
       getDeleteRegulationCreationDate: jest.fn(),
       getDeleteRegulationId: jest.fn(),
       isDataRecorded: jest.fn(),
-      getMetaMetricsId: jest.fn(),
+      getAnalyticsId: jest.fn(),
     });
 
     // Mock the event builder
@@ -164,7 +166,7 @@ describe('useSwitchNetworks Feature Flag Tests', () => {
       // Verify that the hooks are properly initialized
       expect(mockUseNetworksByNamespace).toBeDefined();
       expect(mockUseNetworkSelection).toBeDefined();
-      expect(mockUseMetrics).toBeDefined();
+      expect(mockUseAnalytics).toBeDefined();
     });
 
     it('should have all necessary Engine controllers available', () => {
@@ -183,7 +185,7 @@ describe('useSwitchNetworks Feature Flag Tests', () => {
 
     it('should have proper metrics setup', () => {
       // Verify that metrics are properly set up
-      expect(mockUseMetrics).toBeDefined();
+      expect(mockUseAnalytics).toBeDefined();
       expect(mockTrackEvent).toBeDefined();
       expect(mockCreateEventBuilder).toBeDefined();
     });

--- a/app/components/Views/NetworkSelector/useSwitchNetworks.ts
+++ b/app/components/Views/NetworkSelector/useSwitchNetworks.ts
@@ -19,7 +19,7 @@ import {
   selectEvmNetworkConfigurationsByChainId,
   selectIsAllNetworks,
 } from '../../../selectors/networkController';
-import { useMetrics } from '../../hooks/useMetrics';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import {
   TraceContext,
@@ -67,7 +67,7 @@ export function useSwitchNetworks({
   const networkConfigurations = useSelector(
     selectEvmNetworkConfigurationsByChainId,
   );
-  const { trackEvent, createEventBuilder } = useMetrics();
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   /**
    * Sets the token network filter based on the chain ID

--- a/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.test.ts
+++ b/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.test.ts
@@ -2,7 +2,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { useAddPopularNetwork } from './useAddPopularNetwork';
 import Engine from '../../../core/Engine';
 import { useDispatch, useSelector } from 'react-redux';
-import { useMetrics } from '../useMetrics';
+import { useAnalytics } from '../useAnalytics/useAnalytics';
 import { useNetworkEnablement } from '../useNetworkEnablement/useNetworkEnablement';
 import { networkSwitched } from '../../../actions/onboardNetwork';
 import { MetaMetricsEvents } from '../../../core/Analytics';
@@ -14,8 +14,8 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
-jest.mock('../useMetrics', () => ({
-  useMetrics: jest.fn(),
+jest.mock('../useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(),
 }));
 
 jest.mock('../useNetworkEnablement/useNetworkEnablement', () => ({
@@ -65,7 +65,7 @@ describe('useAddPopularNetwork', () => {
 
     (useDispatch as jest.Mock).mockReturnValue(mockDispatch);
     (useSelector as jest.Mock).mockReturnValue({});
-    (useMetrics as jest.Mock).mockReturnValue({
+    (useAnalytics as jest.Mock).mockReturnValue({
       trackEvent: mockTrackEvent,
       createEventBuilder: mockCreateEventBuilder.mockReturnValue({
         addProperties: jest.fn().mockReturnValue({

--- a/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.ts
+++ b/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.ts
@@ -7,7 +7,7 @@ import { toHex } from '@metamask/controller-utils';
 import Engine from '../../../core/Engine';
 import { networkSwitched } from '../../../actions/onboardNetwork';
 import { MetaMetricsEvents } from '../../../core/Analytics';
-import { useMetrics } from '../useMetrics';
+import { useAnalytics } from '../useAnalytics/useAnalytics';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../selectors/networkController';
 import { addItemToChainIdList } from '../../../util/metrics/MultichainAPI/networkMetricUtils';
 import { Network } from '../../Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
@@ -36,7 +36,7 @@ interface UseAddPopularNetworkResult {
  */
 export const useAddPopularNetwork = (): UseAddPopularNetworkResult => {
   const dispatch = useDispatch();
-  const { trackEvent, createEventBuilder, addTraitsToUser } = useMetrics();
+  const { trackEvent, createEventBuilder, addTraitsToUser } = useAnalytics();
   const networkConfigurationByChainId = useSelector(
     selectEvmNetworkConfigurationsByChainId,
   );

--- a/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.test.tsx
+++ b/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.test.tsx
@@ -12,7 +12,8 @@ import {
 
 import useNetworkConnectionBanner from './useNetworkConnectionBanner';
 import Engine from '../../../core/Engine';
-import { MetaMetricsEvents, useMetrics } from '../useMetrics';
+import { useAnalytics } from '../useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../core/Analytics';
 import { selectNetworkConnectionBannerState } from '../../../selectors/networkConnectionBanner';
 import { selectIsDeviceOffline } from '../../../selectors/connectivityController';
 import { selectEVMEnabledNetworks } from '../../../selectors/networkEnablementController';
@@ -28,7 +29,7 @@ import { IconName } from '../../../component-library/components/Icons/Icon';
 jest.mock('@react-navigation/native');
 jest.mock('../../../core/Engine');
 jest.mock('../../../selectors/networkEnablementController');
-jest.mock('../useMetrics');
+jest.mock('../useAnalytics/useAnalytics');
 jest.mock('../../../selectors/networkConnectionBanner');
 jest.mock('../../../selectors/connectivityController');
 jest.mock('react-redux', () => {
@@ -207,7 +208,7 @@ describe('useNetworkConnectionBanner', () => {
       build: mockBuild,
     }));
 
-    (useMetrics as jest.Mock).mockReturnValue({
+    (useAnalytics as jest.Mock).mockReturnValue({
       trackEvent: stableTrackEvent,
       createEventBuilder: stableCreateEventBuilder,
     });

--- a/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.ts
+++ b/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.ts
@@ -7,7 +7,8 @@ import { selectNetworkConnectionBannerState } from '../../../selectors/networkCo
 import { selectIsDeviceOffline } from '../../../selectors/connectivityController';
 import Engine from '../../../core/Engine';
 import Routes from '../../../constants/navigation/Routes';
-import { MetaMetricsEvents, useMetrics } from '../useMetrics';
+import { useAnalytics } from '../useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../core/Analytics';
 import {
   hideNetworkConnectionBanner,
   showNetworkConnectionBanner,
@@ -55,7 +56,7 @@ const useNetworkConnectionBanner = (): {
 } => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
-  const { trackEvent, createEventBuilder } = useMetrics();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const { toastRef } = useContext(ToastContext);
   const networkConnectionBannerState = useSelector(
     selectNetworkConnectionBannerState,


### PR DESCRIPTION
## **Description**

Phase 2 analytics migration (Batch 2-6): migrate mobile-core-ux's Network Management components and hooks from the legacy MetaMetrics system to the new analytics system.

**Reason**: Deprecate MetaMetrics in favour of the shared analytics utility and AnalyticsController.

**Changes**:
- `NetworkSelector.tsx` now uses `analytics.identify()` from `app/util/analytics/analytics` instead of `MetaMetrics.getInstance().addTraitsToUser()`.
- `useSwitchNetworks.ts`, `useNetworkConnectionBanner.ts`, and `useAddPopularNetwork.ts` now use `useAnalytics` from `app/components/hooks/useAnalytics/useAnalytics` instead of `useMetrics`; `MetaMetricsEvents` is imported from `app/core/Analytics`.
- Test mocks updated to mock `useAnalytics` and `analytics` instead of `useMetrics` and `MetaMetrics`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-298 (Batch 2-6)

## **Manual testing steps**

```gherkin
Feature: Network Management analytics

  Scenario: user triggers a network management flow event
    Given app is open and user is in a network management flow

    When user performs an action that triggers analytics (e.g. network switch, add popular network, network connection banner interaction)
    Then the event is tracked on Mixpanel
```

## **Screenshots/Recordings**

N/A – analytics migration, no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a refactor of analytics wiring and test mocks with minimal impact to user-facing behavior; main risk is altered analytics/identify calls or event payloads.
> 
> **Overview**
> Migrates Network Management analytics instrumentation off legacy MetaMetrics APIs.
> 
> `NetworkSelector` now records network-removal traits via `analytics.identify(removeItemFromChainIdList(...))` instead of `MetaMetrics.getInstance().addTraitsToUser(...)`, and `useSwitchNetworks`, `useAddPopularNetwork`, and `useNetworkConnectionBanner` now use `useAnalytics` (with `MetaMetricsEvents` imported from `core/Analytics`) in place of `useMetrics`. Associated unit tests were updated to mock `useAnalytics`/`analytics` and to align with renamed IDs (`getAnalyticsId` vs `getMetaMetricsId`) and event builder shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 593461a8386164f8ea8df395d5e942f97fdc8cc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->