### PR TITLE
feat: add `rpc_method_name`, `type` and `retry_reason` to `degraded` RPC endpoint Segment events

### DIFF
--- a/app/core/Engine/controllers/network-controller-init.ts
+++ b/app/core/Engine/controllers/network-controller-init.ts
@@ -222,22 +222,21 @@ export const networkControllerInit: ControllerInitFunction<
       endpointUrl,
       error,
       rpcMethodName,
-    }: {
-      chainId: Hex;
-      endpointUrl: string;
-      error: unknown;
-      rpcMethodName: string;
+      type,
+      retryReason,
     }) => {
       onRpcEndpointDegraded({
         chainId,
         endpointUrl,
         error,
         infuraProjectId,
+        retryReason,
         rpcMethodName,
         trackEvent: ({ event, properties }) => {
           buildAndTrackEvent(initMessenger, event, properties);
         },
         metaMetricsId: analyticsId ?? '',
+        type,
       });
     },
   );

--- a/app/core/Engine/controllers/network-controller-init.ts
+++ b/app/core/Engine/controllers/network-controller-init.ts
@@ -197,16 +197,19 @@ export const networkControllerInit: ControllerInitFunction<
       chainId,
       endpointUrl,
       error,
+      rpcMethodName,
     }: {
       chainId: Hex;
       endpointUrl: string;
       error: unknown;
+      rpcMethodName: string;
     }) => {
       onRpcEndpointUnavailable({
         chainId,
         endpointUrl,
         infuraProjectId,
         error,
+        rpcMethodName,
         trackEvent: ({ event, properties }) => {
           buildAndTrackEvent(initMessenger, event, properties);
         },
@@ -221,16 +224,19 @@ export const networkControllerInit: ControllerInitFunction<
       chainId,
       endpointUrl,
       error,
+      rpcMethodName,
     }: {
       chainId: Hex;
       endpointUrl: string;
       error: unknown;
+      rpcMethodName: string;
     }) => {
       onRpcEndpointDegraded({
         chainId,
         endpointUrl,
         error,
         infuraProjectId,
+        rpcMethodName,
         trackEvent: ({ event, properties }) => {
           buildAndTrackEvent(initMessenger, event, properties);
         },

--- a/app/core/Engine/controllers/network-controller-init.ts
+++ b/app/core/Engine/controllers/network-controller-init.ts
@@ -197,19 +197,16 @@ export const networkControllerInit: ControllerInitFunction<
       chainId,
       endpointUrl,
       error,
-      rpcMethodName,
     }: {
       chainId: Hex;
       endpointUrl: string;
       error: unknown;
-      rpcMethodName: string;
     }) => {
       onRpcEndpointUnavailable({
         chainId,
         endpointUrl,
         infuraProjectId,
         error,
-        rpcMethodName,
         trackEvent: ({ event, properties }) => {
           buildAndTrackEvent(initMessenger, event, properties);
         },

--- a/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
+++ b/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
@@ -205,7 +205,7 @@ describe('onRpcEndpointDegraded', () => {
       rpcMethodName: 'eth_blockNumber',
       trackEvent,
       type: 'retries_exhausted',
-      retryReason: 'non_successful_response',
+      retryReason: 'non_successful_http_status',
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
     });
@@ -265,7 +265,7 @@ describe('onRpcEndpointDegraded', () => {
         rpcMethodName: 'eth_blockNumber',
         trackEvent,
         type: 'retries_exhausted',
-        retryReason: 'non_successful_response',
+        retryReason: 'non_successful_http_status',
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
       });
@@ -280,7 +280,7 @@ describe('onRpcEndpointDegraded', () => {
           chain_id_caip: 'eip155:11155111',
           degraded_event_type: 'retries_exhausted',
           http_status: 420,
-          retry_reason: 'non_successful_response',
+          retry_reason: 'non_successful_http_status',
           rpc_endpoint_url: 'example.com',
           rpc_domain: 'example.com',
           rpc_method_name: 'eth_blockNumber',

--- a/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
+++ b/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
@@ -42,6 +42,7 @@ describe('onRpcEndpointUnavailable', () => {
       endpointUrl: 'https://example.com',
       error: new HttpError(420),
       infuraProjectId: 'the-infura-project-id',
+      rpcMethodName: 'eth_blockNumber',
       trackEvent,
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -65,6 +66,7 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://example.com',
         error: undefined,
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -80,6 +82,7 @@ describe('onRpcEndpointUnavailable', () => {
           chain_id_caip: 'eip155:11155111',
           rpc_endpoint_url: 'example.com',
           rpc_domain: 'example.com',
+          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -95,6 +98,7 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://example.com',
         error: new HttpError(420),
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -111,6 +115,7 @@ describe('onRpcEndpointUnavailable', () => {
           http_status: 420,
           rpc_endpoint_url: 'example.com',
           rpc_domain: 'example.com',
+          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -126,6 +131,7 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://custom.com',
         error: undefined,
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -141,6 +147,7 @@ describe('onRpcEndpointUnavailable', () => {
           chain_id_caip: 'eip155:11155111',
           rpc_endpoint_url: 'custom',
           rpc_domain: 'custom',
+          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -157,6 +164,7 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://example.com',
         error: new Error('some error'),
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -202,6 +210,7 @@ describe('onRpcEndpointDegraded', () => {
       endpointUrl: 'https://example.com',
       error: new HttpError(420),
       infuraProjectId: 'the-infura-project-id',
+      rpcMethodName: 'eth_blockNumber',
       trackEvent,
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -225,6 +234,7 @@ describe('onRpcEndpointDegraded', () => {
         endpointUrl: 'https://example.com',
         error: undefined,
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -240,6 +250,7 @@ describe('onRpcEndpointDegraded', () => {
           chain_id_caip: 'eip155:11155111',
           rpc_endpoint_url: 'example.com',
           rpc_domain: 'example.com',
+          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -255,6 +266,7 @@ describe('onRpcEndpointDegraded', () => {
         endpointUrl: 'https://example.com',
         error: new HttpError(420),
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -271,6 +283,7 @@ describe('onRpcEndpointDegraded', () => {
           http_status: 420,
           rpc_endpoint_url: 'example.com',
           rpc_domain: 'example.com',
+          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -286,6 +299,7 @@ describe('onRpcEndpointDegraded', () => {
         endpointUrl: 'https://custom.com',
         error: undefined,
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -301,6 +315,7 @@ describe('onRpcEndpointDegraded', () => {
           chain_id_caip: 'eip155:11155111',
           rpc_endpoint_url: 'custom',
           rpc_domain: 'custom',
+          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -317,6 +332,7 @@ describe('onRpcEndpointDegraded', () => {
         endpointUrl: 'https://example.com',
         error: new Error('some error'),
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',

--- a/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
+++ b/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
@@ -42,7 +42,6 @@ describe('onRpcEndpointUnavailable', () => {
       endpointUrl: 'https://example.com',
       error: new HttpError(420),
       infuraProjectId: 'the-infura-project-id',
-      rpcMethodName: 'eth_blockNumber',
       trackEvent,
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -66,7 +65,6 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://example.com',
         error: undefined,
         infuraProjectId: 'the-infura-project-id',
-        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -82,7 +80,6 @@ describe('onRpcEndpointUnavailable', () => {
           chain_id_caip: 'eip155:11155111',
           rpc_endpoint_url: 'example.com',
           rpc_domain: 'example.com',
-          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -98,7 +95,6 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://example.com',
         error: new HttpError(420),
         infuraProjectId: 'the-infura-project-id',
-        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -115,7 +111,6 @@ describe('onRpcEndpointUnavailable', () => {
           http_status: 420,
           rpc_endpoint_url: 'example.com',
           rpc_domain: 'example.com',
-          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -131,7 +126,6 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://custom.com',
         error: undefined,
         infuraProjectId: 'the-infura-project-id',
-        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -147,7 +141,6 @@ describe('onRpcEndpointUnavailable', () => {
           chain_id_caip: 'eip155:11155111',
           rpc_endpoint_url: 'custom',
           rpc_domain: 'custom',
-          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -164,7 +157,6 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://example.com',
         error: new Error('some error'),
         infuraProjectId: 'the-infura-project-id',
-        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',

--- a/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
+++ b/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
@@ -243,7 +243,7 @@ describe('onRpcEndpointDegraded', () => {
         }),
         properties: {
           chain_id_caip: 'eip155:11155111',
-          degraded_event_type: 'slow_success',
+          type: 'slow_success',
           rpc_endpoint_url: 'example.com',
           rpc_domain: 'example.com',
           rpc_method_name: 'eth_blockNumber',
@@ -278,7 +278,7 @@ describe('onRpcEndpointDegraded', () => {
         }),
         properties: {
           chain_id_caip: 'eip155:11155111',
-          degraded_event_type: 'retries_exhausted',
+          type: 'retries_exhausted',
           http_status: 420,
           retry_reason: 'non_successful_http_status',
           rpc_endpoint_url: 'example.com',
@@ -314,7 +314,7 @@ describe('onRpcEndpointDegraded', () => {
         }),
         properties: {
           chain_id_caip: 'eip155:11155111',
-          degraded_event_type: 'slow_success',
+          type: 'slow_success',
           rpc_endpoint_url: 'custom',
           rpc_domain: 'custom',
           rpc_method_name: 'eth_blockNumber',

--- a/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
+++ b/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
@@ -204,6 +204,8 @@ describe('onRpcEndpointDegraded', () => {
       infuraProjectId: 'the-infura-project-id',
       rpcMethodName: 'eth_blockNumber',
       trackEvent,
+      type: 'retries_exhausted',
+      retryReason: 'non_successful_response',
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
     });
@@ -228,6 +230,7 @@ describe('onRpcEndpointDegraded', () => {
         infuraProjectId: 'the-infura-project-id',
         rpcMethodName: 'eth_blockNumber',
         trackEvent,
+        type: 'slow_success',
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
       });
@@ -240,6 +243,7 @@ describe('onRpcEndpointDegraded', () => {
         }),
         properties: {
           chain_id_caip: 'eip155:11155111',
+          degraded_event_type: 'slow_success',
           rpc_endpoint_url: 'example.com',
           rpc_domain: 'example.com',
           rpc_method_name: 'eth_blockNumber',
@@ -260,6 +264,8 @@ describe('onRpcEndpointDegraded', () => {
         infuraProjectId: 'the-infura-project-id',
         rpcMethodName: 'eth_blockNumber',
         trackEvent,
+        type: 'retries_exhausted',
+        retryReason: 'non_successful_response',
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
       });
@@ -272,7 +278,9 @@ describe('onRpcEndpointDegraded', () => {
         }),
         properties: {
           chain_id_caip: 'eip155:11155111',
+          degraded_event_type: 'retries_exhausted',
           http_status: 420,
+          retry_reason: 'non_successful_response',
           rpc_endpoint_url: 'example.com',
           rpc_domain: 'example.com',
           rpc_method_name: 'eth_blockNumber',
@@ -293,6 +301,7 @@ describe('onRpcEndpointDegraded', () => {
         infuraProjectId: 'the-infura-project-id',
         rpcMethodName: 'eth_blockNumber',
         trackEvent,
+        type: 'slow_success',
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
       });
@@ -305,6 +314,7 @@ describe('onRpcEndpointDegraded', () => {
         }),
         properties: {
           chain_id_caip: 'eip155:11155111',
+          degraded_event_type: 'slow_success',
           rpc_endpoint_url: 'custom',
           rpc_domain: 'custom',
           rpc_method_name: 'eth_blockNumber',
@@ -326,6 +336,7 @@ describe('onRpcEndpointDegraded', () => {
         infuraProjectId: 'the-infura-project-id',
         rpcMethodName: 'eth_blockNumber',
         trackEvent,
+        type: 'retries_exhausted',
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
       });

--- a/app/core/Engine/controllers/network-controller/messenger-action-handlers.ts
+++ b/app/core/Engine/controllers/network-controller/messenger-action-handlers.ts
@@ -186,7 +186,7 @@ export function trackRpcEndpointEvent(
     rpc_endpoint_url: rpcDomain,
     rpc_domain: rpcDomain,
     ...(rpcMethodName ? { rpc_method_name: rpcMethodName } : {}),
-    ...(type ? { degraded_event_type: type } : {}),
+    ...(type ? { type } : {}),
     ...(retryReason ? { retry_reason: retryReason } : {}),
     ...(isObject(error) &&
     'httpStatus' in error &&

--- a/app/core/Engine/controllers/network-controller/messenger-action-handlers.ts
+++ b/app/core/Engine/controllers/network-controller/messenger-action-handlers.ts
@@ -26,7 +26,6 @@ import { MetaMetricsEvents } from '../../../Analytics/MetaMetrics.events';
  * a request to the RPC endpoint.
  * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
- * @param args.rpcMethodName - The JSON-RPC method that was being executed.
  * @param args.trackEvent - The function that will create the Segment event.
  */
 export function onRpcEndpointUnavailable({
@@ -35,7 +34,6 @@ export function onRpcEndpointUnavailable({
   error,
   infuraProjectId,
   metaMetricsId,
-  rpcMethodName,
   trackEvent,
 }: {
   chainId: Hex;
@@ -43,7 +41,6 @@ export function onRpcEndpointUnavailable({
   error: unknown;
   infuraProjectId: string;
   metaMetricsId: string | null | undefined;
-  rpcMethodName: string;
   trackEvent: (options: {
     event: IMetaMetricsEvent | ITrackingEvent;
     properties: JsonMap;
@@ -55,7 +52,6 @@ export function onRpcEndpointUnavailable({
     error,
     infuraProjectId,
     metaMetricsId,
-    rpcMethodName,
     trackEvent,
   });
 }
@@ -122,7 +118,8 @@ export function onRpcEndpointDegraded({
  * a request to the RPC endpoint.
  * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
- * @param args.rpcMethodName - The JSON-RPC method that was being executed.
+ * @param args.rpcMethodName - The JSON-RPC method that was being executed
+ * (only present for degraded events).
  * @param args.trackEvent - The function that will create the Segment event.
  */
 export function trackRpcEndpointEvent(
@@ -140,7 +137,7 @@ export function trackRpcEndpointEvent(
     endpointUrl: string;
     error: unknown;
     infuraProjectId: string;
-    rpcMethodName: string;
+    rpcMethodName?: string;
     trackEvent: (options: {
       event: IMetaMetricsEvent | ITrackingEvent;
       properties: JsonMap;
@@ -166,7 +163,7 @@ export function trackRpcEndpointEvent(
     // @deprecated: will be removed in a future release
     rpc_endpoint_url: rpcDomain,
     rpc_domain: rpcDomain,
-    rpc_method_name: rpcMethodName,
+    ...(rpcMethodName ? { rpc_method_name: rpcMethodName } : {}),
     ...(isObject(error) &&
     'httpStatus' in error &&
     isValidJson(error.httpStatus)

--- a/app/core/Engine/controllers/network-controller/messenger-action-handlers.ts
+++ b/app/core/Engine/controllers/network-controller/messenger-action-handlers.ts
@@ -26,6 +26,7 @@ import { MetaMetricsEvents } from '../../../Analytics/MetaMetrics.events';
  * a request to the RPC endpoint.
  * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
+ * @param args.rpcMethodName - The JSON-RPC method that was being executed.
  * @param args.trackEvent - The function that will create the Segment event.
  */
 export function onRpcEndpointUnavailable({
@@ -34,6 +35,7 @@ export function onRpcEndpointUnavailable({
   error,
   infuraProjectId,
   metaMetricsId,
+  rpcMethodName,
   trackEvent,
 }: {
   chainId: Hex;
@@ -41,6 +43,7 @@ export function onRpcEndpointUnavailable({
   error: unknown;
   infuraProjectId: string;
   metaMetricsId: string | null | undefined;
+  rpcMethodName: string;
   trackEvent: (options: {
     event: IMetaMetricsEvent | ITrackingEvent;
     properties: JsonMap;
@@ -52,6 +55,7 @@ export function onRpcEndpointUnavailable({
     error,
     infuraProjectId,
     metaMetricsId,
+    rpcMethodName,
     trackEvent,
   });
 }
@@ -72,6 +76,7 @@ export function onRpcEndpointUnavailable({
  * a request to the RPC endpoint.
  * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
+ * @param args.rpcMethodName - The JSON-RPC method that was being executed.
  * @param args.trackEvent - The function that will create the Segment event.
  */
 export function onRpcEndpointDegraded({
@@ -80,6 +85,7 @@ export function onRpcEndpointDegraded({
   error,
   infuraProjectId,
   metaMetricsId,
+  rpcMethodName,
   trackEvent,
 }: {
   chainId: Hex;
@@ -87,6 +93,7 @@ export function onRpcEndpointDegraded({
   error: unknown;
   infuraProjectId: string;
   metaMetricsId: string | null | undefined;
+  rpcMethodName: string;
   trackEvent: (options: {
     event: IMetaMetricsEvent | ITrackingEvent;
     properties: JsonMap;
@@ -98,6 +105,7 @@ export function onRpcEndpointDegraded({
     error,
     infuraProjectId,
     metaMetricsId,
+    rpcMethodName,
     trackEvent,
   });
 }
@@ -114,6 +122,7 @@ export function onRpcEndpointDegraded({
  * a request to the RPC endpoint.
  * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
+ * @param args.rpcMethodName - The JSON-RPC method that was being executed.
  * @param args.trackEvent - The function that will create the Segment event.
  */
 export function trackRpcEndpointEvent(
@@ -123,6 +132,7 @@ export function trackRpcEndpointEvent(
     endpointUrl,
     error,
     infuraProjectId,
+    rpcMethodName,
     trackEvent,
     metaMetricsId,
   }: {
@@ -130,6 +140,7 @@ export function trackRpcEndpointEvent(
     endpointUrl: string;
     error: unknown;
     infuraProjectId: string;
+    rpcMethodName: string;
     trackEvent: (options: {
       event: IMetaMetricsEvent | ITrackingEvent;
       properties: JsonMap;
@@ -155,6 +166,7 @@ export function trackRpcEndpointEvent(
     // @deprecated: will be removed in a future release
     rpc_endpoint_url: rpcDomain,
     rpc_domain: rpcDomain,
+    rpc_method_name: rpcMethodName,
     ...(isObject(error) &&
     'httpStatus' in error &&
     isValidJson(error.httpStatus)

--- a/package.json
+++ b/package.json
@@ -758,7 +758,7 @@
   "previewBuilds": {
     "@metamask/network-controller": {
       "type": "breaking",
-      "previewVersion": "29.0.0-preview-d9075b666"
+      "previewVersion": "29.0.0-preview-1821148"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -754,5 +754,11 @@
       }
     },
     "version": "v0.3.0"
+  },
+  "previewBuilds": {
+    "@metamask/network-controller": {
+      "type": "non-breaking",
+      "previewVersion": "29.0.0-preview-33dbba4f3"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "@metamask/multichain-network-controller": "^2.0.0",
     "@metamask/multichain-transactions-controller": "^6.0.0",
     "@metamask/native-utils": "^0.8.0",
-    "@metamask/network-controller": "^29.0.0",
+    "@metamask/network-controller": "^30.0.0",
     "@metamask/network-enablement-controller": "^4.1.0",
     "@metamask/notification-services-controller": "^22.0.0",
     "@metamask/permission-controller": "^12.1.0",
@@ -754,11 +754,5 @@
       }
     },
     "version": "v0.3.0"
-  },
-  "previewBuilds": {
-    "@metamask/network-controller": {
-      "type": "breaking",
-      "previewVersion": "29.0.0-preview-1821148"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -757,8 +757,8 @@
   },
   "previewBuilds": {
     "@metamask/network-controller": {
-      "type": "non-breaking",
-      "previewVersion": "29.0.0-preview-33dbba4f3"
+      "type": "breaking",
+      "previewVersion": "29.0.0-preview-d9075b666"
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8027,9 +8027,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.14.1, @metamask/controller-utils@npm:^11.15.0, @metamask/controller-utils@npm:^11.16.0, @metamask/controller-utils@npm:^11.17.0, @metamask/controller-utils@npm:^11.18.0, @metamask/controller-utils@npm:^11.3.0":
-  version: 11.18.0
-  resolution: "@metamask/controller-utils@npm:11.18.0"
+"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.14.1, @metamask/controller-utils@npm:^11.15.0, @metamask/controller-utils@npm:^11.16.0, @metamask/controller-utils@npm:^11.17.0, @metamask/controller-utils@npm:^11.18.0, @metamask/controller-utils@npm:^11.19.0, @metamask/controller-utils@npm:^11.3.0":
+  version: 11.19.0
+  resolution: "@metamask/controller-utils@npm:11.19.0"
   dependencies:
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-unit": "npm:^0.3.0"
@@ -8044,7 +8044,7 @@ __metadata:
     lodash: "npm:^4.17.21"
   peerDependencies:
     "@babel/runtime": ^7.0.0
-  checksum: 10/0c96701e3639b887c51c02416158bfeef42bf80701a4ca0d1ad2c888a370ccd9a6f2cb4677ef075a17a341c0dc9135e91c4f3079a7d498d9368d2f5e6fdf5d1b
+  checksum: 10/d66ff170a6c2fb5726aa34c94e4870d79e96737043d3450f87d34eec8b24209b27a09df9935aad9e3e5bb685ebb3ee2c918e6d4cfbeec497c2fa823a177fc227
   languageName: node
   linkType: hard
 
@@ -9105,34 +9105,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:@metamask-previews/network-controller@29.0.0-preview-1821148":
-  version: 29.0.0-preview-1821148
-  resolution: "@metamask-previews/network-controller@npm:29.0.0-preview-1821148"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/connectivity-controller": "npm:^0.1.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/eth-block-tracker": "npm:^15.0.1"
-    "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
-    "@metamask/eth-json-rpc-middleware": "npm:^23.1.0"
-    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/json-rpc-engine": "npm:^10.2.2"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/swappable-obj-proxy": "npm:^2.3.0"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    fast-deep-equal: "npm:^3.1.3"
-    immer: "npm:^9.0.6"
-    loglevel: "npm:^1.8.1"
-    reselect: "npm:^5.1.1"
-    uri-js: "npm:^4.4.1"
-    uuid: "npm:^8.3.2"
-  checksum: 10/17137c892c948750f21d94e98a33518e089fdc63f9a431e577cef0d8d50687595ca223070d72bec75029a7103283ccc5151a25b3c02757cd960b68b5d1a93901
-  languageName: node
-  linkType: hard
-
 "@metamask/network-controller@npm:^27.0.0":
   version: 27.2.0
   resolution: "@metamask/network-controller@npm:27.2.0"
@@ -9185,6 +9157,34 @@ __metadata:
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
   checksum: 10/873a68a3c5012f84c925a868aac2741bd1de7c047f3696874cabd911f5632acb162e07210c345447ed9765f94a2c33e034e589ff1f59ce92b09b6e29d68c5940
+  languageName: node
+  linkType: hard
+
+"@metamask/network-controller@npm:^30.0.0":
+  version: 30.0.0
+  resolution: "@metamask/network-controller@npm:30.0.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/connectivity-controller": "npm:^0.1.0"
+    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/eth-block-tracker": "npm:^15.0.1"
+    "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
+    "@metamask/eth-json-rpc-middleware": "npm:^23.1.0"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/json-rpc-engine": "npm:^10.2.2"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/swappable-obj-proxy": "npm:^2.3.0"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    fast-deep-equal: "npm:^3.1.3"
+    immer: "npm:^9.0.6"
+    loglevel: "npm:^1.8.1"
+    reselect: "npm:^5.1.1"
+    uri-js: "npm:^4.4.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/3f16a1be8f35995147580c23d5fa977c7ac5e231662ac43a75ea8bedea6b2039261bcfaac399a1a9f3dc310eed1f1f4896dcb0ff634add2597da519432789710
   languageName: node
   linkType: hard
 
@@ -35478,7 +35478,7 @@ __metadata:
     "@metamask/multichain-network-controller": "npm:^2.0.0"
     "@metamask/multichain-transactions-controller": "npm:^6.0.0"
     "@metamask/native-utils": "npm:^0.8.0"
-    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/network-controller": "npm:^30.0.0"
     "@metamask/network-enablement-controller": "npm:^4.1.0"
     "@metamask/notification-services-controller": "npm:^22.0.0"
     "@metamask/object-multiplex": "npm:^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9105,9 +9105,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:@metamask-previews/network-controller@29.0.0-preview-d9075b666":
-  version: 29.0.0-preview-d9075b666
-  resolution: "@metamask-previews/network-controller@npm:29.0.0-preview-d9075b666"
+"@metamask/network-controller@npm:@metamask-previews/network-controller@29.0.0-preview-1821148":
+  version: 29.0.0-preview-1821148
+  resolution: "@metamask-previews/network-controller@npm:29.0.0-preview-1821148"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/connectivity-controller": "npm:^0.1.0"
@@ -9129,7 +9129,7 @@ __metadata:
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/71719a65a64f390dae1eeb62587cddbefb108c5ed1fe108fbc97fc40f7d0f949efd8c427271faa5ce28eac3b19415011a77a47a281abb8c3c6fad2a297f8cadf
+  checksum: 10/17137c892c948750f21d94e98a33518e089fdc63f9a431e577cef0d8d50687595ca223070d72bec75029a7103283ccc5151a25b3c02757cd960b68b5d1a93901
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8321,7 +8321,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:^23.1.0":
+"@metamask/eth-json-rpc-middleware@npm:^23.0.0, @metamask/eth-json-rpc-middleware@npm:^23.1.0":
   version: 23.1.0
   resolution: "@metamask/eth-json-rpc-middleware@npm:23.1.0"
   dependencies:
@@ -9105,9 +9105,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:@metamask-previews/network-controller@29.0.0-preview-33dbba4f3":
-  version: 29.0.0-preview-33dbba4f3
-  resolution: "@metamask-previews/network-controller@npm:29.0.0-preview-33dbba4f3"
+"@metamask/network-controller@npm:@metamask-previews/network-controller@29.0.0-preview-d9075b666":
+  version: 29.0.0-preview-d9075b666
+  resolution: "@metamask-previews/network-controller@npm:29.0.0-preview-d9075b666"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/connectivity-controller": "npm:^0.1.0"
@@ -9129,7 +9129,7 @@ __metadata:
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/bdacf157bb1c4fd6391cd0f98ccd58a881bbaf2192d3ef33a6c9b7a806ae1fcb6a5f590e1392846313cee737dfdfd7e5b7a9ee2d1af795ca904e43dc32535581
+  checksum: 10/71719a65a64f390dae1eeb62587cddbefb108c5ed1fe108fbc97fc40f7d0f949efd8c427271faa5ce28eac3b19415011a77a47a281abb8c3c6fad2a297f8cadf
   languageName: node
   linkType: hard
 
@@ -9157,6 +9157,34 @@ __metadata:
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
   checksum: 10/52f9523b30d1136c3a8cd466bf81bbf0ca5e9399ecc8b256054a09597940b1bddecb2bc117ba8f1872ba0b0dc55537521d2cbf2fb1b4c1aa741322879b2f7ba8
+  languageName: node
+  linkType: hard
+
+"@metamask/network-controller@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "@metamask/network-controller@npm:29.0.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/connectivity-controller": "npm:^0.1.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/eth-block-tracker": "npm:^15.0.1"
+    "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
+    "@metamask/eth-json-rpc-middleware": "npm:^23.0.0"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/json-rpc-engine": "npm:^10.2.1"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/swappable-obj-proxy": "npm:^2.3.0"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    fast-deep-equal: "npm:^3.1.3"
+    immer: "npm:^9.0.6"
+    loglevel: "npm:^1.8.1"
+    reselect: "npm:^5.1.1"
+    uri-js: "npm:^4.4.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/873a68a3c5012f84c925a868aac2741bd1de7c047f3696874cabd911f5632acb162e07210c345447ed9765f94a2c33e034e589ff1f59ce92b09b6e29d68c5940
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8321,7 +8321,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:^23.0.0, @metamask/eth-json-rpc-middleware@npm:^23.1.0":
+"@metamask/eth-json-rpc-middleware@npm:^23.1.0":
   version: 23.1.0
   resolution: "@metamask/eth-json-rpc-middleware@npm:23.1.0"
   dependencies:
@@ -8673,9 +8673,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/json-rpc-engine@npm:^10.0.0, @metamask/json-rpc-engine@npm:^10.0.2, @metamask/json-rpc-engine@npm:^10.0.3, @metamask/json-rpc-engine@npm:^10.1.0, @metamask/json-rpc-engine@npm:^10.1.1, @metamask/json-rpc-engine@npm:^10.2.0, @metamask/json-rpc-engine@npm:^10.2.1":
-  version: 10.2.1
-  resolution: "@metamask/json-rpc-engine@npm:10.2.1"
+"@metamask/json-rpc-engine@npm:^10.0.0, @metamask/json-rpc-engine@npm:^10.0.2, @metamask/json-rpc-engine@npm:^10.0.3, @metamask/json-rpc-engine@npm:^10.1.0, @metamask/json-rpc-engine@npm:^10.1.1, @metamask/json-rpc-engine@npm:^10.2.0, @metamask/json-rpc-engine@npm:^10.2.1, @metamask/json-rpc-engine@npm:^10.2.2":
+  version: 10.2.2
+  resolution: "@metamask/json-rpc-engine@npm:10.2.2"
   dependencies:
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/safe-event-emitter": "npm:^3.0.0"
@@ -8683,7 +8683,7 @@ __metadata:
     "@types/deep-freeze-strict": "npm:^1.1.0"
     deep-freeze-strict: "npm:^1.1.1"
     klona: "npm:^2.0.6"
-  checksum: 10/f218065b6fe2354c79f9ffc8780fd86a781f75b9a5f1a2fceb277d44d13e48a216bdcdca14e8a5be76dffa2b63cb321631bc49dc259d54bd71fe3ffeb4a593af
+  checksum: 10/e2449e80f8ca3aed58d0778c220eba6c98e0848359da2703bcb68879c1b315774a1a8a90b2a7cd8d3eb3e0f022f9d0e30503e75a2645ec32cbfc5ba2e537f807
   languageName: node
   linkType: hard
 
@@ -9105,6 +9105,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/network-controller@npm:@metamask-previews/network-controller@29.0.0-preview-33dbba4f3":
+  version: 29.0.0-preview-33dbba4f3
+  resolution: "@metamask-previews/network-controller@npm:29.0.0-preview-33dbba4f3"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/connectivity-controller": "npm:^0.1.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/eth-block-tracker": "npm:^15.0.1"
+    "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
+    "@metamask/eth-json-rpc-middleware": "npm:^23.1.0"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/json-rpc-engine": "npm:^10.2.2"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/swappable-obj-proxy": "npm:^2.3.0"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    fast-deep-equal: "npm:^3.1.3"
+    immer: "npm:^9.0.6"
+    loglevel: "npm:^1.8.1"
+    reselect: "npm:^5.1.1"
+    uri-js: "npm:^4.4.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/bdacf157bb1c4fd6391cd0f98ccd58a881bbaf2192d3ef33a6c9b7a806ae1fcb6a5f590e1392846313cee737dfdfd7e5b7a9ee2d1af795ca904e43dc32535581
+  languageName: node
+  linkType: hard
+
 "@metamask/network-controller@npm:^27.0.0":
   version: 27.2.0
   resolution: "@metamask/network-controller@npm:27.2.0"
@@ -9129,34 +9157,6 @@ __metadata:
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
   checksum: 10/52f9523b30d1136c3a8cd466bf81bbf0ca5e9399ecc8b256054a09597940b1bddecb2bc117ba8f1872ba0b0dc55537521d2cbf2fb1b4c1aa741322879b2f7ba8
-  languageName: node
-  linkType: hard
-
-"@metamask/network-controller@npm:^29.0.0":
-  version: 29.0.0
-  resolution: "@metamask/network-controller@npm:29.0.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/connectivity-controller": "npm:^0.1.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/eth-block-tracker": "npm:^15.0.1"
-    "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
-    "@metamask/eth-json-rpc-middleware": "npm:^23.0.0"
-    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/json-rpc-engine": "npm:^10.2.1"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/swappable-obj-proxy": "npm:^2.3.0"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    fast-deep-equal: "npm:^3.1.3"
-    immer: "npm:^9.0.6"
-    loglevel: "npm:^1.8.1"
-    reselect: "npm:^5.1.1"
-    uri-js: "npm:^4.4.1"
-    uuid: "npm:^8.3.2"
-  checksum: 10/873a68a3c5012f84c925a868aac2741bd1de7c047f3696874cabd911f5632acb162e07210c345447ed9765f94a2c33e034e589ff1f59ce92b09b6e29d68c5940
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add `rpc_method_name`, `type` and `retry_reason` to the `RPC Service Degraded` Segment events. This lets us identify which JSON-RPC methods produce the most slow requests or retry exhaustions, enabling better debugging of RPC endpoint health issues.

Consumes the new `rpcMethodName`, `type` and `retryReason` field added to `NetworkController:rpcEndpointDegraded` events in `@metamask/network-controller` (core PR [#7954](https://github.com/MetaMask/core/pull/7954), [#7988](https://github.com/MetaMask/core/pull/7988)).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPC-441

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to analytics payload enrichment and dependency upgrades, with updated unit tests to validate new properties.
> 
> **Overview**
> **Enhances `RPC Service Degraded` Segment telemetry** by propagating new fields from `NetworkController:rpcEndpointDegraded` into analytics events: `rpc_method_name`, degraded `type`, and (when applicable) `retry_reason`.
> 
> Updates `onRpcEndpointDegraded`/`trackRpcEndpointEvent` to accept these typed inputs (from `@metamask/network-controller`) and conditionally include them in tracked properties, with corresponding unit test updates. Also bumps `@metamask/network-controller` to `^30.0.0` (and lockfile deps) to consume the new event payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7aacf1748e51003b4186bfbd2b3b4d458cd1995. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->