### PR TITLE
revert: remove Input lineHeight and textAlignVertical overrides to fix Android and iOS regressions

### DIFF
--- a/app/component-library/components/Form/TextField/foundation/Input/Input.styles.ts
+++ b/app/component-library/components/Form/TextField/foundation/Input/Input.styles.ts
@@ -1,5 +1,5 @@
 // Third party dependencies.
-import { StyleSheet, TextStyle, Platform } from 'react-native';
+import { StyleSheet, TextStyle } from 'react-native';
 
 // External dependencies.
 import { Theme } from '../../../../../../util/theme/models';
@@ -45,11 +45,6 @@ const styleSheet = (params: { theme: Theme; vars: InputStyleSheetVars }) => {
         fontWeight: theme.typography[textVariant].fontWeight,
         fontSize: theme.typography[textVariant].fontSize,
         letterSpacing: theme.typography[textVariant].letterSpacing,
-        lineHeight: 0,
-        // iOS-specific fix for custom font baseline alignment
-        ...(Platform.OS === 'ios' && {
-          textAlignVertical: 'center',
-        }),
       },
       style,
     ) as TextStyle,

--- a/app/component-library/components/Form/TextField/foundation/Input/__snapshots__/Input.test.tsx.snap
+++ b/app/component-library/components/Form/TextField/foundation/Input/__snapshots__/Input.test.tsx.snap
@@ -17,9 +17,7 @@ exports[`Input should render correctly 1`] = `
       "fontSize": 16,
       "fontWeight": "400",
       "letterSpacing": 0,
-      "lineHeight": 0,
       "opacity": 1,
-      "textAlignVertical": "center",
     }
   }
   testID="input"

--- a/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
+++ b/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
@@ -223,7 +223,6 @@ exports[`SnapUIAddressInput renders with an invalid CAIP Account ID 1`] = `
             "letterSpacing": 0,
             "lineHeight": 0,
             "opacity": 1,
-            "textAlignVertical": "center",
           }
         }
         testID="input-snap-address-input"

--- a/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
+++ b/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
@@ -221,7 +221,6 @@ exports[`SnapUIAddressInput renders with an invalid CAIP Account ID 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
-            "lineHeight": 0,
             "opacity": 1,
           }
         }

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
@@ -298,9 +298,7 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="input-snap-ui-input"
@@ -460,9 +458,7 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="input-snap-ui-input"
@@ -557,9 +553,7 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="input2-snap-ui-input"
@@ -718,9 +712,7 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="input-snap-ui-input"
@@ -814,9 +806,7 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="input2-snap-ui-input"
@@ -1970,9 +1960,7 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="input-snap-ui-input"
@@ -2169,9 +2157,7 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="input-snap-ui-input"

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
@@ -158,7 +158,6 @@ exports[`SnapUIDateTimePicker can show an error 1`] = `
                           "letterSpacing": 0,
                           "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="snap-ui-renderer__date-time-picker--datetime-input"
@@ -338,7 +337,6 @@ exports[`SnapUIDateTimePicker renders a date picker 1`] = `
                           "letterSpacing": 0,
                           "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="snap-ui-renderer__date-time-picker--date-input"
@@ -503,7 +501,6 @@ exports[`SnapUIDateTimePicker renders a date time picker 1`] = `
                           "letterSpacing": 0,
                           "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="snap-ui-renderer__date-time-picker--datetime-input"
@@ -668,7 +665,6 @@ exports[`SnapUIDateTimePicker renders a time picker 1`] = `
                           "letterSpacing": 0,
                           "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="snap-ui-renderer__date-time-picker--time-input"
@@ -848,7 +844,6 @@ exports[`SnapUIDateTimePicker renders inside a field 1`] = `
                           "letterSpacing": 0,
                           "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="snap-ui-renderer__date-time-picker--datetime-input"

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
@@ -156,7 +156,6 @@ exports[`SnapUIDateTimePicker can show an error 1`] = `
                           "fontSize": 16,
                           "fontWeight": "400",
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
                         }
                       }
@@ -335,7 +334,6 @@ exports[`SnapUIDateTimePicker renders a date picker 1`] = `
                           "fontSize": 16,
                           "fontWeight": "400",
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
                         }
                       }
@@ -499,7 +497,6 @@ exports[`SnapUIDateTimePicker renders a date time picker 1`] = `
                           "fontSize": 16,
                           "fontWeight": "400",
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
                         }
                       }
@@ -663,7 +660,6 @@ exports[`SnapUIDateTimePicker renders a time picker 1`] = `
                           "fontSize": 16,
                           "fontWeight": "400",
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
                         }
                       }
@@ -842,7 +838,6 @@ exports[`SnapUIDateTimePicker renders inside a field 1`] = `
                           "fontSize": 16,
                           "fontWeight": "400",
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
                         }
                       }

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -151,9 +151,7 @@ exports[`SnapUIForm will render 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="input-snap-ui-input"
@@ -373,9 +371,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="input-snap-ui-input"

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/input.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/input.test.ts.snap
@@ -138,9 +138,7 @@ exports[`SnapUIInput handles disabled input 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="testInput-snap-ui-input"
@@ -299,9 +297,7 @@ exports[`SnapUIInput renders with initial value 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="testInput-snap-ui-input"

--- a/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
+++ b/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
@@ -426,7 +426,6 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                             "lineHeight": 50,
                                             "opacity": 1,
                                             "paddingVertical": 2,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="source-token-area-input"
@@ -798,7 +797,6 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                             "lineHeight": 50,
                                             "opacity": 1,
                                             "paddingVertical": 2,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="dest-token-area-input"
@@ -2239,7 +2237,6 @@ exports[`BridgeView renders 1`] = `
                                             "lineHeight": 50,
                                             "opacity": 1,
                                             "paddingVertical": 2,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="source-token-area-input"
@@ -2611,7 +2608,6 @@ exports[`BridgeView renders 1`] = `
                                             "lineHeight": 50,
                                             "opacity": 1,
                                             "paddingVertical": 2,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="dest-token-area-input"

--- a/app/components/UI/Bridge/components/InputStepper/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/Bridge/components/InputStepper/__snapshots__/index.test.tsx.snap
@@ -130,7 +130,6 @@ exports[`InputStepper complete component snapshot renders complete component cor
               "letterSpacing": 0,
               "lineHeight": 50,
               "opacity": 1,
-              "textAlignVertical": "center",
             }
           }
           testID="input-stepper-input"
@@ -380,7 +379,6 @@ exports[`InputStepper complete component snapshot renders with description 1`] =
               "letterSpacing": 0,
               "lineHeight": 50,
               "opacity": 1,
-              "textAlignVertical": "center",
             }
           }
           testID="input-stepper-input"
@@ -603,7 +601,6 @@ exports[`InputStepper description row should render InputStepperDescriptionRow 1
               "letterSpacing": 0,
               "lineHeight": 50,
               "opacity": 1,
-              "textAlignVertical": "center",
             }
           }
           testID="input-stepper-input"
@@ -826,7 +823,6 @@ exports[`InputStepper input renders correct style when value character length is
               "letterSpacing": 0,
               "lineHeight": 50,
               "opacity": 1,
-              "textAlignVertical": "center",
             }
           }
           testID="input-stepper-input"
@@ -1049,7 +1045,6 @@ exports[`InputStepper input renders correct style when value character length is
               "letterSpacing": 0,
               "lineHeight": 43.75,
               "opacity": 1,
-              "textAlignVertical": "center",
             }
           }
           testID="input-stepper-input"
@@ -1272,7 +1267,6 @@ exports[`InputStepper input renders correct style when value character length is
               "letterSpacing": 0,
               "lineHeight": 37.5,
               "opacity": 1,
-              "textAlignVertical": "center",
             }
           }
           testID="input-stepper-input"
@@ -1495,7 +1489,6 @@ exports[`InputStepper input renders correct style when value character length is
               "letterSpacing": 0,
               "lineHeight": 31.25,
               "opacity": 1,
-              "textAlignVertical": "center",
             }
           }
           testID="input-stepper-input"
@@ -1718,7 +1711,6 @@ exports[`InputStepper input renders correct style when value character length is
               "letterSpacing": 0,
               "lineHeight": 25,
               "opacity": 1,
-              "textAlignVertical": "center",
             }
           }
           testID="input-stepper-input"
@@ -1941,7 +1933,6 @@ exports[`InputStepper minus button renders correct style of minus button when di
               "letterSpacing": 0,
               "lineHeight": 50,
               "opacity": 1,
-              "textAlignVertical": "center",
             }
           }
           testID="input-stepper-input"
@@ -2164,7 +2155,6 @@ exports[`InputStepper minus button renders correct style of minus button when en
               "letterSpacing": 0,
               "lineHeight": 50,
               "opacity": 1,
-              "textAlignVertical": "center",
             }
           }
           testID="input-stepper-input"
@@ -2387,7 +2377,6 @@ exports[`InputStepper plus button renders correct style of plus button when disa
               "letterSpacing": 0,
               "lineHeight": 50,
               "opacity": 1,
-              "textAlignVertical": "center",
             }
           }
           testID="input-stepper-input"
@@ -2610,7 +2599,6 @@ exports[`InputStepper plus button renders correct style of plus button when enab
               "letterSpacing": 0,
               "lineHeight": 50,
               "opacity": 1,
-              "textAlignVertical": "center",
             }
           }
           testID="input-stepper-input"

--- a/app/components/UI/Card/Views/CardAuthentication/__snapshots__/CardAuthentication.test.tsx.snap
+++ b/app/components/UI/Card/Views/CardAuthentication/__snapshots__/CardAuthentication.test.tsx.snap
@@ -718,9 +718,7 @@ exports[`CardAuthentication Component Login Step - Component Rendering matches l
                                           "fontWeight": "400",
                                           "height": 46,
                                           "letterSpacing": 0,
-                                          "lineHeight": 0,
                                           "opacity": 1,
-                                          "textAlignVertical": "center",
                                         }
                                       }
                                       testID="email-field"
@@ -833,9 +831,7 @@ exports[`CardAuthentication Component Login Step - Component Rendering matches l
                                           "fontWeight": "400",
                                           "height": 46,
                                           "letterSpacing": 0,
-                                          "lineHeight": 0,
                                           "opacity": 1,
-                                          "textAlignVertical": "center",
                                         }
                                       }
                                       testID="password-field"

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/ActivationKeyForm.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/ActivationKeyForm.test.tsx.snap
@@ -588,7 +588,6 @@ exports[`AddActivationKey renders correctly 1`] = `
                                         "fontWeight": "400",
                                         "height": 46,
                                         "letterSpacing": 0,
-                                        "lineHeight": 0,
                                         "opacity": 1,
                                       }
                                     }
@@ -702,7 +701,6 @@ exports[`AddActivationKey renders correctly 1`] = `
                                         "fontWeight": "400",
                                         "height": 46,
                                         "letterSpacing": 0,
-                                        "lineHeight": 0,
                                         "opacity": 1,
                                       }
                                     }

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/ActivationKeyForm.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/ActivationKeyForm.test.tsx.snap
@@ -590,7 +590,6 @@ exports[`AddActivationKey renders correctly 1`] = `
                                         "letterSpacing": 0,
                                         "lineHeight": 0,
                                         "opacity": 1,
-                                        "textAlignVertical": "center",
                                       }
                                     }
                                     value=""
@@ -705,7 +704,6 @@ exports[`AddActivationKey renders correctly 1`] = `
                                         "letterSpacing": 0,
                                         "lineHeight": 0,
                                         "opacity": 1,
-                                        "textAlignVertical": "center",
                                       }
                                     }
                                     value=""

--- a/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
@@ -687,7 +687,6 @@ exports[`FiatSelectorModal renders the modal with currency list 1`] = `
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -1688,7 +1687,6 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -2689,7 +2687,6 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -3690,7 +3687,6 @@ exports[`FiatSelectorModal search displays max 20 results 1`] = `
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"

--- a/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
@@ -685,7 +685,6 @@ exports[`FiatSelectorModal renders the modal with currency list 1`] = `
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -1685,7 +1684,6 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -2685,7 +2683,6 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -3685,7 +3682,6 @@ exports[`FiatSelectorModal search displays max 20 results 1`] = `
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }

--- a/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
@@ -873,7 +873,6 @@ exports[`TokenSelectModal renders the modal with token list 1`] = `
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="token-select-modal-search-input"

--- a/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
@@ -871,7 +871,6 @@ exports[`TokenSelectModal renders the modal with token list 1`] = `
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }

--- a/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
@@ -690,9 +690,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="first-name-input"
@@ -809,9 +807,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="last-name-input"
@@ -976,9 +972,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="deposit-phone-field-test-id"
@@ -1261,9 +1255,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="ssn-input"
@@ -2138,9 +2130,7 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="first-name-input"
@@ -2257,9 +2247,7 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="last-name-input"
@@ -2424,9 +2412,7 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="deposit-phone-field-test-id"
@@ -2709,9 +2695,7 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="ssn-input"
@@ -3586,9 +3570,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="first-name-input"
@@ -3705,9 +3687,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="last-name-input"
@@ -3872,9 +3852,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="deposit-phone-field-test-id"
@@ -4157,9 +4135,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="ssn-input"
@@ -5034,9 +5010,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="first-name-input"
@@ -5153,9 +5127,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="last-name-input"
@@ -5320,9 +5292,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="deposit-phone-field-test-id"
@@ -5605,9 +5575,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="ssn-input"
@@ -6482,9 +6450,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="first-name-input"
@@ -6616,9 +6582,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="last-name-input"
@@ -6798,9 +6762,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="deposit-phone-field-test-id"
@@ -7098,9 +7060,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="ssn-input"
@@ -7990,9 +7950,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="first-name-input"
@@ -8124,9 +8082,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="last-name-input"
@@ -8306,9 +8262,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="deposit-phone-field-test-id"
@@ -8591,9 +8545,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="ssn-input"
@@ -9483,9 +9435,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="first-name-input"
@@ -9617,9 +9567,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="last-name-input"
@@ -9799,9 +9747,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="deposit-phone-field-test-id"

--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
@@ -690,7 +690,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                             "letterSpacing": 0,
                                             "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="address-line-1-input"
@@ -822,7 +821,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                             "letterSpacing": 0,
                                             "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="address-line-2-input"
@@ -949,7 +947,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="city-input"
@@ -1204,7 +1201,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="postal-code-input"
@@ -1357,7 +1353,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="country-input"
@@ -2232,7 +2227,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                             "letterSpacing": 0,
                                             "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="address-line-1-input"
@@ -2349,7 +2343,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                             "letterSpacing": 0,
                                             "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="address-line-2-input"
@@ -2476,7 +2469,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="city-input"
@@ -2693,7 +2685,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="postal-code-input"
@@ -2831,7 +2822,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="country-input"
@@ -3706,7 +3696,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                             "letterSpacing": 0,
                                             "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="address-line-1-input"
@@ -3823,7 +3812,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                             "letterSpacing": 0,
                                             "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="address-line-2-input"
@@ -3950,7 +3938,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="city-input"
@@ -4175,7 +4162,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="postal-code-input"
@@ -4313,7 +4299,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="country-input"
@@ -5188,7 +5173,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                             "letterSpacing": 0,
                                             "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="address-line-1-input"
@@ -5305,7 +5289,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                             "letterSpacing": 0,
                                             "lineHeight": 0,
                                             "opacity": 1,
-                                            "textAlignVertical": "center",
                                           }
                                         }
                                         testID="address-line-2-input"
@@ -5432,7 +5415,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="city-input"
@@ -5550,7 +5532,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="state-input"
@@ -5679,7 +5660,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="postal-code-input"
@@ -5817,7 +5797,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "letterSpacing": 0,
                                               "lineHeight": 0,
                                               "opacity": 1,
-                                              "textAlignVertical": "center",
                                             }
                                           }
                                           testID="country-input"

--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
@@ -688,7 +688,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
                                           }
                                         }
@@ -819,7 +818,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
                                           }
                                         }
@@ -945,7 +943,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }
@@ -1199,7 +1196,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }
@@ -1351,7 +1347,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }
@@ -2225,7 +2220,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
                                           }
                                         }
@@ -2341,7 +2335,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
                                           }
                                         }
@@ -2467,7 +2460,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }
@@ -2683,7 +2675,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }
@@ -2820,7 +2811,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }
@@ -3694,7 +3684,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
                                           }
                                         }
@@ -3810,7 +3799,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
                                           }
                                         }
@@ -3936,7 +3924,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }
@@ -4160,7 +4147,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }
@@ -4297,7 +4283,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }
@@ -5171,7 +5156,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
                                           }
                                         }
@@ -5287,7 +5271,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                             "fontWeight": "400",
                                             "height": 46,
                                             "letterSpacing": 0,
-                                            "lineHeight": 0,
                                             "opacity": 1,
                                           }
                                         }
@@ -5413,7 +5396,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }
@@ -5530,7 +5512,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }
@@ -5658,7 +5639,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }
@@ -5795,7 +5775,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "fontWeight": "400",
                                               "height": 46,
                                               "letterSpacing": 0,
-                                              "lineHeight": 0,
                                               "opacity": 1,
                                             }
                                           }

--- a/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
@@ -630,7 +630,6 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                                         "fontWeight": "400",
                                         "height": 46,
                                         "letterSpacing": 0,
-                                        "lineHeight": 0,
                                         "opacity": 1,
                                       }
                                     }
@@ -1350,7 +1349,6 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                                         "fontWeight": "400",
                                         "height": 46,
                                         "letterSpacing": 0,
-                                        "lineHeight": 0,
                                         "opacity": 1,
                                       }
                                     }
@@ -2084,7 +2082,6 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                                         "fontWeight": "400",
                                         "height": 46,
                                         "letterSpacing": 0,
-                                        "lineHeight": 0,
                                         "opacity": 1,
                                       }
                                     }
@@ -2804,7 +2801,6 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                                         "fontWeight": "400",
                                         "height": 46,
                                         "letterSpacing": 0,
-                                        "lineHeight": 0,
                                         "opacity": 1,
                                       }
                                     }

--- a/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
@@ -632,7 +632,6 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                                         "letterSpacing": 0,
                                         "lineHeight": 0,
                                         "opacity": 1,
-                                        "textAlignVertical": "center",
                                       }
                                     }
                                     value=""
@@ -1353,7 +1352,6 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                                         "letterSpacing": 0,
                                         "lineHeight": 0,
                                         "opacity": 1,
-                                        "textAlignVertical": "center",
                                       }
                                     }
                                     value="test@example.com"
@@ -2088,7 +2086,6 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                                         "letterSpacing": 0,
                                         "lineHeight": 0,
                                         "opacity": 1,
-                                        "textAlignVertical": "center",
                                       }
                                     }
                                     value=""
@@ -2809,7 +2806,6 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                                         "letterSpacing": 0,
                                         "lineHeight": 0,
                                         "opacity": 1,
-                                        "textAlignVertical": "center",
                                       }
                                     }
                                     value="invalid-email"

--- a/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -685,7 +685,6 @@ exports[`RegionSelectorModal Component handles empty regions array from navigati
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -1454,7 +1453,6 @@ exports[`RegionSelectorModal Component receives and uses regions from navigation
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -2419,7 +2417,6 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -3616,7 +3613,6 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -4426,7 +4422,6 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -5324,7 +5319,6 @@ exports[`RegionSelectorModal Component render matches snapshot with allRegionsSe
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -6521,7 +6515,6 @@ exports[`RegionSelectorModal Component render matches snapshot with custom selec
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -7718,7 +7711,6 @@ exports[`RegionSelectorModal Component sorts recommended regions to the top when
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -687,7 +687,6 @@ exports[`RegionSelectorModal Component handles empty regions array from navigati
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -1457,7 +1456,6 @@ exports[`RegionSelectorModal Component receives and uses regions from navigation
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -2423,7 +2421,6 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -3621,7 +3618,6 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -4432,7 +4428,6 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -5331,7 +5326,6 @@ exports[`RegionSelectorModal Component render matches snapshot with allRegionsSe
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -6529,7 +6523,6 @@ exports[`RegionSelectorModal Component render matches snapshot with custom selec
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -7727,7 +7720,6 @@ exports[`RegionSelectorModal Component sorts recommended regions to the top when
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"

--- a/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
@@ -685,7 +685,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -1550,7 +1549,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -2359,7 +2357,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -3224,7 +3221,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -4089,7 +4085,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -5217,7 +5212,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
@@ -687,7 +687,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -1553,7 +1552,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -2363,7 +2361,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -3229,7 +3226,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -4095,7 +4091,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -5224,7 +5219,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -871,7 +871,6 @@ exports[`TokenSelectorModal Component displays empty state when no tokens match 
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }
@@ -3106,7 +3105,6 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
                                     }
                                   }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -873,7 +873,6 @@ exports[`TokenSelectorModal Component displays empty state when no tokens match 
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"
@@ -3109,7 +3108,6 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                       "letterSpacing": 0,
                                       "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="textfieldsearch"

--- a/app/components/UI/Ramp/Deposit/components/DepositPhoneField/__snapshots__/DepositPhoneField.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/DepositPhoneField/__snapshots__/DepositPhoneField.test.tsx.snap
@@ -154,9 +154,7 @@ exports[`DepositPhoneField renders correctly after flag button press 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
-            "lineHeight": 0,
             "opacity": 1,
-            "textAlignVertical": "center",
           }
         }
         testID="deposit-phone-field-test-id"
@@ -322,9 +320,7 @@ exports[`DepositPhoneField renders correctly after input change 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
-            "lineHeight": 0,
             "opacity": 1,
-            "textAlignVertical": "center",
           }
         }
         testID="deposit-phone-field-test-id"
@@ -490,9 +486,7 @@ exports[`DepositPhoneField renders correctly with default props 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
-            "lineHeight": 0,
             "opacity": 1,
-            "textAlignVertical": "center",
           }
         }
         testID="deposit-phone-field-test-id"
@@ -658,9 +652,7 @@ exports[`DepositPhoneField renders correctly with different region 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
-            "lineHeight": 0,
             "opacity": 1,
-            "textAlignVertical": "center",
           }
         }
         testID="deposit-phone-field-test-id"
@@ -826,9 +818,7 @@ exports[`DepositPhoneField renders correctly with error message 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
-            "lineHeight": 0,
             "opacity": 1,
-            "textAlignVertical": "center",
           }
         }
         testID="deposit-phone-field-test-id"
@@ -1009,9 +999,7 @@ exports[`DepositPhoneField renders correctly with long phone number 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
-            "lineHeight": 0,
             "opacity": 1,
-            "textAlignVertical": "center",
           }
         }
         testID="deposit-phone-field-test-id"
@@ -1178,9 +1166,7 @@ exports[`DepositPhoneField renders correctly with onSubmitEditing callback 1`] =
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
-            "lineHeight": 0,
             "opacity": 1,
-            "textAlignVertical": "center",
           }
         }
         testID="deposit-phone-field-test-id"
@@ -1346,9 +1332,7 @@ exports[`DepositPhoneField renders correctly with special characters in phone nu
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
-            "lineHeight": 0,
             "opacity": 1,
-            "textAlignVertical": "center",
           }
         }
         testID="deposit-phone-field-test-id"
@@ -1514,9 +1498,7 @@ exports[`DepositPhoneField renders correctly with unsupported region 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
-            "lineHeight": 0,
             "opacity": 1,
-            "textAlignVertical": "center",
           }
         }
         testID="deposit-phone-field-test-id"
@@ -1682,9 +1664,7 @@ exports[`DepositPhoneField renders correctly with value 1`] = `
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
-            "lineHeight": 0,
             "opacity": 1,
-            "textAlignVertical": "center",
           }
         }
         testID="deposit-phone-field-test-id"
@@ -1850,9 +1830,7 @@ exports[`DepositPhoneField updates phone region when region is selected from mod
             "fontWeight": "400",
             "height": 46,
             "letterSpacing": 0,
-            "lineHeight": 0,
             "opacity": 1,
-            "textAlignVertical": "center",
           }
         }
         testID="deposit-phone-field-test-id"

--- a/app/components/UI/Ramp/Views/NativeFlow/__snapshots__/BasicInfo.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/NativeFlow/__snapshots__/BasicInfo.test.tsx.snap
@@ -318,9 +318,7 @@ exports[`V2BasicInfo handles region with no phone prefix 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="first-name-input"
@@ -437,9 +435,7 @@ exports[`V2BasicInfo handles region with no phone prefix 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="last-name-input"
@@ -587,9 +583,7 @@ exports[`V2BasicInfo handles region with no phone prefix 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     textContentType="telephoneNumber"
@@ -1213,9 +1207,7 @@ exports[`V2BasicInfo matches snapshot 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="first-name-input"
@@ -1332,9 +1324,7 @@ exports[`V2BasicInfo matches snapshot 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="last-name-input"
@@ -1496,9 +1486,7 @@ exports[`V2BasicInfo matches snapshot 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     textContentType="telephoneNumber"
@@ -1779,9 +1767,7 @@ exports[`V2BasicInfo matches snapshot 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="ssn-input"
@@ -2274,9 +2260,7 @@ exports[`V2BasicInfo matches snapshot for non-US region 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="first-name-input"
@@ -2393,9 +2377,7 @@ exports[`V2BasicInfo matches snapshot for non-US region 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="last-name-input"
@@ -2557,9 +2539,7 @@ exports[`V2BasicInfo matches snapshot for non-US region 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     textContentType="telephoneNumber"

--- a/app/components/UI/Ramp/Views/NativeFlow/__snapshots__/EnterAddress.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/NativeFlow/__snapshots__/EnterAddress.test.tsx.snap
@@ -316,9 +316,7 @@ exports[`V2EnterAddress matches snapshot 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="address-line-1-input"
@@ -433,9 +431,7 @@ exports[`V2EnterAddress matches snapshot 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="address-line-2-input"
@@ -560,9 +556,7 @@ exports[`V2EnterAddress matches snapshot 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="city-input"
@@ -674,9 +668,7 @@ exports[`V2EnterAddress matches snapshot 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="state-input"
@@ -802,9 +794,7 @@ exports[`V2EnterAddress matches snapshot 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="postal-code-input"
@@ -940,9 +930,7 @@ exports[`V2EnterAddress matches snapshot 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="country-input"
@@ -1433,9 +1421,7 @@ exports[`V2EnterAddress matches snapshot for non-US region 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="address-line-1-input"
@@ -1550,9 +1536,7 @@ exports[`V2EnterAddress matches snapshot for non-US region 1`] = `
                         "fontWeight": "400",
                         "height": 46,
                         "letterSpacing": 0,
-                        "lineHeight": 0,
                         "opacity": 1,
-                        "textAlignVertical": "center",
                       }
                     }
                     testID="address-line-2-input"
@@ -1677,9 +1661,7 @@ exports[`V2EnterAddress matches snapshot for non-US region 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="city-input"
@@ -1791,9 +1773,7 @@ exports[`V2EnterAddress matches snapshot for non-US region 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="state-input"
@@ -1919,9 +1899,7 @@ exports[`V2EnterAddress matches snapshot for non-US region 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="postal-code-input"
@@ -2057,9 +2035,7 @@ exports[`V2EnterAddress matches snapshot for non-US region 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="country-input"

--- a/app/components/UI/Ramp/Views/NativeFlow/__snapshots__/EnterEmail.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/NativeFlow/__snapshots__/EnterEmail.test.tsx.snap
@@ -170,9 +170,7 @@ exports[`V2EnterEmail matches snapshot 1`] = `
                     "fontWeight": "400",
                     "height": 46,
                     "letterSpacing": 0,
-                    "lineHeight": 0,
                     "opacity": 1,
-                    "textAlignVertical": "center",
                   }
                 }
                 value=""

--- a/app/components/UI/Ramp/Views/Settings/RegionSelector/__snapshots__/RegionSelector.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Settings/RegionSelector/__snapshots__/RegionSelector.test.tsx.snap
@@ -445,9 +445,7 @@ exports[`RegionSelector clears search and scrolls to top when clear button is pr
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -1521,9 +1519,7 @@ exports[`RegionSelector clears search text when clear button is pressed 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -2597,9 +2593,7 @@ exports[`RegionSelector displays empty state when search has no results 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -3169,9 +3163,7 @@ exports[`RegionSelector displays grouped search results showing country and matc
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -3982,9 +3974,7 @@ exports[`RegionSelector displays standalone countries in search results 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -4652,9 +4642,7 @@ exports[`RegionSelector displays standalone states in search results 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -5465,9 +5453,7 @@ exports[`RegionSelector does not highlight country when regionCode does not matc
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -6545,9 +6531,7 @@ exports[`RegionSelector does not highlight state when country does not match 1`]
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -7240,9 +7224,7 @@ exports[`RegionSelector does not highlight state when state ID does not match 1`
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -7950,9 +7932,7 @@ exports[`RegionSelector does not highlight state when userRegion has no state 1`
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -8654,9 +8634,7 @@ exports[`RegionSelector falls back to userCountryCode when regionInTransit is nu
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -9530,9 +9508,7 @@ exports[`RegionSelector filters regions when search text is entered 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -10254,9 +10230,7 @@ exports[`RegionSelector highlights country when regionCode exactly matches count
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -11365,9 +11339,7 @@ exports[`RegionSelector highlights country when regionCode starts with country c
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -12497,9 +12469,7 @@ exports[`RegionSelector highlights state in grouped search results when parent c
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -13365,9 +13335,7 @@ exports[`RegionSelector highlights state when selected in state view 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -14091,9 +14059,7 @@ exports[`RegionSelector limits search results 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -16002,9 +15968,7 @@ exports[`RegionSelector navigates back to countries view when back button is pre
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -16670,9 +16634,7 @@ exports[`RegionSelector navigates to states view when country with states is sel
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -17354,9 +17316,7 @@ exports[`RegionSelector renders countries list 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -18430,9 +18390,7 @@ exports[`RegionSelector renders country with supported set to false 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -19058,9 +19016,7 @@ exports[`RegionSelector renders country without flag 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -19703,9 +19659,7 @@ exports[`RegionSelector renders description text only in country view 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -20763,9 +20717,7 @@ exports[`RegionSelector renders description text only in country view 2`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -21447,9 +21399,7 @@ exports[`RegionSelector renders disabled country 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -22507,9 +22457,7 @@ exports[`RegionSelector renders disabled state 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -23191,9 +23139,7 @@ exports[`RegionSelector renders error state when countries error occurs 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -23737,9 +23683,7 @@ exports[`RegionSelector renders loading state when regions are loading 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -24257,9 +24201,7 @@ exports[`RegionSelector renders recommended countries 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -24989,9 +24931,7 @@ exports[`RegionSelector renders state with supported set to false 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -25585,9 +25525,7 @@ exports[`RegionSelector renders state without stateId 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -26236,9 +26174,7 @@ exports[`RegionSelector renders states view 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -26920,9 +26856,7 @@ exports[`RegionSelector renders unsupported country 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -27980,9 +27914,7 @@ exports[`RegionSelector renders unsupported state 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -28664,9 +28596,7 @@ exports[`RegionSelector renders when country has states and user region state is
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -29796,9 +29726,7 @@ exports[`RegionSelector renders with empty regions array 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -30300,9 +30228,7 @@ exports[`RegionSelector renders with selected user region 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -31416,9 +31342,7 @@ exports[`RegionSelector resets search when navigating to state view 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -32100,9 +32024,7 @@ exports[`RegionSelector scrolls to top when search text changes 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -32656,9 +32578,7 @@ exports[`RegionSelector sets up back button in state view 1`] = `
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -33340,9 +33260,7 @@ exports[`RegionSelector shows state name in country view when user has selected 
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"
@@ -34482,9 +34400,7 @@ exports[`RegionSelector sorts regions with recommended first when no search 1`] 
                                   "fontWeight": "400",
                                   "height": 46,
                                   "letterSpacing": 0,
-                                  "lineHeight": 0,
                                   "opacity": 1,
-                                  "textAlignVertical": "center",
                                 }
                               }
                               testID="textfieldsearch"

--- a/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
@@ -720,9 +720,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="token-select-modal-search-input"
@@ -1582,9 +1580,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="token-select-modal-search-input"
@@ -3958,9 +3954,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                       "fontWeight": "400",
                                       "height": 46,
                                       "letterSpacing": 0,
-                                      "lineHeight": 0,
                                       "opacity": 1,
-                                      "textAlignVertical": "center",
                                     }
                                   }
                                   testID="token-select-modal-search-input"

--- a/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
@@ -217,9 +217,7 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                       "fontWeight": "400",
                       "height": 46,
                       "letterSpacing": 0,
-                      "lineHeight": 0,
                       "opacity": 1,
-                      "textAlignVertical": "center",
                     }
                   }
                   submitBehavior="submit"
@@ -373,9 +371,7 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                       "fontWeight": "400",
                       "height": 46,
                       "letterSpacing": 0,
-                      "lineHeight": 0,
                       "opacity": 1,
-                      "textAlignVertical": "center",
                     }
                   }
                   testID="create-password-second-input-field"

--- a/app/components/Views/EditAccountName/__snapshots__/EditAccountName.test.tsx.snap
+++ b/app/components/Views/EditAccountName/__snapshots__/EditAccountName.test.tsx.snap
@@ -115,7 +115,6 @@ exports[`EditAccountName should render correctly 1`] = `
                 "letterSpacing": 0,
                 "lineHeight": 0,
                 "opacity": 1,
-                "textAlignVertical": "center",
               }
             }
             testID="account-name-input"
@@ -220,7 +219,6 @@ exports[`EditAccountName should render correctly 1`] = `
                 "letterSpacing": 0,
                 "lineHeight": 0,
                 "opacity": 1,
-                "textAlignVertical": "center",
               }
             }
             testID="input"

--- a/app/components/Views/EditAccountName/__snapshots__/EditAccountName.test.tsx.snap
+++ b/app/components/Views/EditAccountName/__snapshots__/EditAccountName.test.tsx.snap
@@ -113,7 +113,6 @@ exports[`EditAccountName should render correctly 1`] = `
                 "fontWeight": "400",
                 "height": 46,
                 "letterSpacing": 0,
-                "lineHeight": 0,
                 "opacity": 1,
               }
             }
@@ -217,7 +216,6 @@ exports[`EditAccountName should render correctly 1`] = `
                 "fontWeight": "400",
                 "height": 46,
                 "letterSpacing": 0,
-                "lineHeight": 0,
                 "opacity": 1,
               }
             }

--- a/app/components/Views/Login/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Login/__snapshots__/index.test.tsx.snap
@@ -128,9 +128,7 @@ exports[`Login renders matching snapshot 1`] = `
                 "fontWeight": "400",
                 "height": 46,
                 "letterSpacing": 0,
-                "lineHeight": 0,
                 "opacity": 1,
-                "textAlignVertical": "center",
               }
             }
             testID="login-password-input"
@@ -431,9 +429,7 @@ exports[`Login renders matching snapshot when password input is focused 1`] = `
                 "fontWeight": "400",
                 "height": 46,
                 "letterSpacing": 0,
-                "lineHeight": 0,
                 "opacity": 1,
-                "textAlignVertical": "center",
               }
             }
             testID="login-password-input"

--- a/app/components/Views/ResetPassword/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ResetPassword/__snapshots__/index.test.tsx.snap
@@ -199,9 +199,7 @@ exports[`ResetPassword render matches snapshot 1`] = `
                           "fontWeight": "400",
                           "height": 46,
                           "letterSpacing": 0,
-                          "lineHeight": 0,
                           "opacity": 1,
-                          "textAlignVertical": "center",
                         }
                       }
                       testID="create-password-first-input-field"


### PR DESCRIPTION
## **Description**

Reverts `lineHeight: 0` and removes `textAlignVertical: 'center'` from `Input.styles.ts` to fix two regressions introduced by #26049:

- **Android**: typed text disappearing in non-`secureTextEntry` inputs while typing
- **iOS**: unfocused input text wrapping to multiple lines

This reintroduces the intermittent iOS placeholder text misalignment that #26049 was attempting to fix. That issue is lower severity than the regressions above — it is intermittent and cosmetic — so we are accepting it while a proper native patch is worked on.

### History

`textAlignVertical: 'center'` was first introduced in #20331 (Oct 2025) inside an iOS-only `Platform.OS === 'ios'` guard as part of a custom font baseline alignment fix. It was never effective on any platform:

- On iOS it is silently ignored — `textAlignVertical` is an Android-only prop.
- On Android `TextInput` it is a no-op — the underlying `EditText` manages vertical alignment internally. The React Native Fabric source stores it as `std::optional<TextAlignmentVertical>{}` with no default, meaning the native view falls back to its own alignment logic when absent.

`lineHeight: 0` was added in #26049 (Feb 2026) to work around an unfixed React Native bug where `TextInput` on iOS does not apply `usesFontLeading = NO`, unlike `Text` which was patched in [2020](https://github.com/facebook/react-native/commit/5d08aab526b2702b46ff75ea7e943a33aa6df288). Without an explicit `lineHeight`, the Geist font's extreme metrics (ascender taller than the font size at 16px, 3.4:1 ascender-to-descender ratio) cause Fabric's async text measurement to produce inconsistent results, making placeholder text intermittently shift or clip on iOS. The workaround caused the regressions above.

The root cause fix — patching `RCTBaseTextInputShadowView.mm` via `.yarn/patches` — requires a native rebuild and is tracked separately ([RN issue](https://github.com/facebook/react-native/issues/39145)).

[Slack thread](https://consensys.slack.com/archives/C02U025CVU4/p1771364576236249?thread_ts=1771364576.236249&cid=C02U025CVU4)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Text input rendering

  Scenario: user types in a text input on Android
    Given the app is open on an Android device
    When user taps a text input and types characters
    Then the typed text remains visible while typing

  Scenario: user unfocuses a text input on iOS
    Given the app is open on an iOS device
    When user taps a text input, types text, then taps away
    Then the input text does not wrap to multiple lines
```

## **Screenshots/Recordings**

### **Before**

Android text disappearing and iOS multi-line wrap reproduced from #26049

Android

https://github.com/user-attachments/assets/49a7fb14-4d2e-4aa9-aa27-8bbf09c47229

iOS

https://github.com/user-attachments/assets/e596ce88-e1ac-418c-bf2e-dd054c78aa85

### **After**

Android text no longer disappears and no multi-line wrap on iOS BUT misalignment for placeholder is back 

Android

https://github.com/user-attachments/assets/1aaa2c89-dc20-4ae9-8519-f179256ea31e

iOS

https://github.com/user-attachments/assets/16ddafcf-0850-48c8-835a-d77727eebcbf

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small styling change scoped to text inputs; main risk is minor visual alignment differences across platforms, but no business logic or data handling is touched.
> 
> **Overview**
> Reverts the recent TextField `Input` styling workaround by removing `lineHeight: 0` and the iOS-guarded `textAlignVertical: 'center'` override from `Input.styles.ts`.
> 
> Updates a large set of Jest snapshots across Snap UI, Ramp, Bridge, and account flows to reflect the new `TextInput` style output (no longer asserting those two properties).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b723b5fd5eb2c31a0c323162e975142d9ba71b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->