### PR TITLE
chore: change ota version display

### DIFF
--- a/app/components/Views/Settings/AppInformation/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/AppInformation/__snapshots__/index.test.tsx.snap
@@ -480,7 +480,9 @@ exports[`AppInformation renders correctly with snapshot 1`] = `
                                   "textAlign": "left",
                                 }
                               }
-                            />
+                            >
+                              MetaMask v7.0.0 (1000)
+                            </Text>
                             <Text
                               style={
                                 {

--- a/app/components/Views/Settings/AppInformation/index.js
+++ b/app/components/Views/Settings/AppInformation/index.js
@@ -24,7 +24,7 @@ import {
   checkAutomatically,
 } from 'expo-updates';
 import { connect } from 'react-redux';
-import { getFullVersion } from '../../../../constants/ota';
+import { OTA_VERSION } from '../../../../constants/ota';
 import { fontStyles } from '../../../../styles/common';
 import PropTypes from 'prop-types';
 import { strings } from '../../../../../locales/i18n';
@@ -136,8 +136,11 @@ class AppInformation extends PureComponent {
     const appName = await getApplicationName();
     const appVersion = await getVersion();
     const buildNumber = await getBuildNumber();
+    const appInfo = `${appName} v${appVersion} (${buildNumber})`;
+    const appInfoOta = `${appName} ota ${OTA_VERSION} (${buildNumber})`;
+    const versionDisplay = isEmbeddedLaunch || __DEV__ ? appInfo : appInfoOta;
     this.setState({
-      appInfo: `${appName} v${appVersion} (${buildNumber})`,
+      appInfo: versionDisplay,
       appVersion,
     });
   };
@@ -219,9 +222,7 @@ class AppInformation extends PureComponent {
                 resizeMethod={'auto'}
               />
             </TouchableOpacity>
-            <Text style={styles.versionInfo}>
-              {getFullVersion(this.state.appInfo)}
-            </Text>
+            <Text style={styles.versionInfo}>{this.state.appInfo}</Text>
             {isQa ? (
               <Text style={styles.branchInfo}>
                 {`Branch: ${process.env['GIT_BRANCH']}`}

--- a/app/components/Views/Settings/AppInformation/index.test.tsx
+++ b/app/components/Views/Settings/AppInformation/index.test.tsx
@@ -36,15 +36,9 @@ jest.mock(
   }),
 );
 
-jest.mock('../../../../constants/ota', () => {
-  const actual = jest.requireActual('../../../../constants/ota');
-
-  return {
-    ...actual,
-    // Make getFullVersion a pass-through so tests don't depend on OTA_VERSION
-    getFullVersion: (appVersion: string) => appVersion,
-  };
-});
+jest.mock('../../../../constants/ota', () => ({
+  OTA_VERSION: 'v0',
+}));
 
 const MOCK_STATE = {
   engine: {
@@ -79,12 +73,15 @@ describe('AppInformation', () => {
     mockGetFeatureFlagAppDistribution.mockReturnValue('main');
   });
 
-  it('renders correctly with snapshot', () => {
-    const { toJSON } = renderScreen(
+  it('renders correctly with snapshot', async () => {
+    const { toJSON, getByText } = renderScreen(
       AppInformation,
       { name: 'AppInformation' },
       { state: MOCK_STATE },
     );
+    await waitFor(() => {
+      expect(getByText('MetaMask v7.0.0 (1000)')).toBeTruthy();
+    });
     expect(toJSON()).toMatchSnapshot();
   });
 

--- a/app/constants/ota.ts
+++ b/app/constants/ota.ts
@@ -6,15 +6,7 @@ import otaConfig from '../../ota.config.js';
  * Reset to v0 when releasing a new native build
  * We keep this OTA_VERSION here to because changes in ota.config.js will affect the fingerprint and break the workflow in Github Actions
  */
-export const OTA_VERSION: string = 'v0';
+export const OTA_VERSION: string = 'vX.XX.X';
 export const RUNTIME_VERSION = otaConfig.RUNTIME_VERSION;
 export const PROJECT_ID = otaConfig.PROJECT_ID;
 export const UPDATE_URL = otaConfig.UPDATE_URL;
-
-/**
- * Gets the full version string including OTA version
- * @param appVersion - The app version from package.json/device info
- * @returns Full version string (e.g., "7.58.0 OTA Version: v3")
- */
-export const getFullVersion = (appVersion: string): string =>
-  OTA_VERSION !== 'v0' ? `${appVersion} OTA: ${OTA_VERSION}` : `${appVersion}`;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
We are changing the way we version OTA update. We are using the patch digit for OTA update. Therefore instead of 7.64.0 ota v1 we would just version it as ota 7.64.1 where we get the ota version from ota.ts which is set to vX.XX.X until we have the first OTA update.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed OTA version display

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-02-17 at 19 14 58" src="https://github.com/user-attachments/assets/511772f6-4feb-4b87-89d0-d74dea3da773" />


### **After**
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-02-17 at 19 11 31" src="https://github.com/user-attachments/assets/593da96d-9e7f-407c-8fe5-e5e482327a9b" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit ca9a5d3732f3aa543eceeba734c8394f9cf21c88. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->