### PR TITLE
test: Add bridge network picker regression tests

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -171,7 +171,7 @@ let mockPopularTokensState = {
   popularTokens: [createMockPopularToken({ symbol: 'USDC', name: 'USD Coin' })],
   isLoading: false,
 };
-const mockUsePopularTokens = jest.fn(() => mockPopularTokensState);
+const mockUsePopularTokens = jest.fn((_: unknown) => mockPopularTokensState);
 jest.mock('../../hooks/usePopularTokens', () => ({
   usePopularTokens: (params: unknown) => mockUsePopularTokens(params),
 }));
@@ -189,7 +189,7 @@ let mockSearchTokensState = {
   debouncedSearch: mockDebouncedSearch,
   resetSearch: mockResetSearch,
 };
-const mockUseSearchTokens = jest.fn(() => mockSearchTokensState);
+const mockUseSearchTokens = jest.fn((_: unknown) => mockSearchTokensState);
 jest.mock('../../hooks/useSearchTokens', () => ({
   useSearchTokens: (params: unknown) => mockUseSearchTokens(params),
 }));
@@ -198,7 +198,9 @@ let mockBalancesByAssetIdState = {
   tokensWithBalance: [] as ReturnType<typeof createMockToken>[],
   balancesByAssetId: {},
 };
-const mockUseBalancesByAssetId = jest.fn(() => mockBalancesByAssetIdState);
+const mockUseBalancesByAssetId = jest.fn(
+  (_: unknown) => mockBalancesByAssetIdState,
+);
 jest.mock('../../hooks/useBalancesByAssetId', () => ({
   useBalancesByAssetId: (params: unknown) => mockUseBalancesByAssetId(params),
 }));

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -18,8 +18,22 @@ let mockBridgeFeatureFlags = {
   ],
 };
 
+interface MockBridgeState {
+  sourceToken: ReturnType<typeof createMockToken> | null;
+  destToken: ReturnType<typeof createMockToken> | null;
+  tokenSelectorNetworkFilter: CaipChainId | undefined;
+  visiblePillChainIds: CaipChainId[] | undefined;
+}
+
+const defaultMockBridgeState: MockBridgeState = {
+  sourceToken: null,
+  destToken: null,
+  tokenSelectorNetworkFilter: undefined,
+  visiblePillChainIds: undefined,
+};
+
 // Create a Redux store with all the state needed by the component
-const createMockStore = () =>
+const createMockStore = (bridgeStateOverrides: Partial<MockBridgeState> = {}) =>
   configureStore({
     reducer: {
       user: () => ({ appTheme: 'light' }),
@@ -46,19 +60,39 @@ const createMockStore = () =>
           },
         },
       }),
-      bridge: () => ({
-        sourceToken: null,
-        destToken: null,
-        tokenSelectorNetworkFilter: undefined,
-      }),
+      bridge: (
+        state: MockBridgeState | undefined,
+        action: { type: string; payload?: CaipChainId | CaipChainId[] },
+      ) => {
+        const resolvedState = state ?? {
+          ...defaultMockBridgeState,
+          ...bridgeStateOverrides,
+        };
+
+        if (action.type === 'bridge/setTokenSelectorNetworkFilter') {
+          return {
+            ...resolvedState,
+            tokenSelectorNetworkFilter: action.payload as
+              | CaipChainId
+              | undefined,
+          };
+        }
+        if (action.type === 'bridge/setVisiblePillChainIds') {
+          return {
+            ...resolvedState,
+            visiblePillChainIds: action.payload as CaipChainId[] | undefined,
+          };
+        }
+        return resolvedState;
+      },
     },
   });
 
-const mockStore = createMockStore();
-
 // Helper function to render with Redux Provider
-const renderWithReduxProvider = (component: React.ReactElement) =>
-  render(<Provider store={mockStore}>{component}</Provider>);
+const renderWithReduxProvider = (
+  component: React.ReactElement,
+  store = createMockStore(),
+) => render(<Provider store={store}>{component}</Provider>);
 
 const mockSetOptions = jest.fn();
 const mockNavigate = jest.fn();
@@ -87,24 +121,48 @@ jest.mock('../../../../../selectors/networkController', () => ({
 // Use a getter to access mockBridgeFeatureFlags at runtime (after variable is defined)
 // This is needed because jest.mock is hoisted before variable declarations
 jest.mock('../../../../../core/redux/slices/bridge', () => {
-  // Access the variable from the outer scope via module exports hack
-  const getMockBridgeFeatureFlags = () =>
-    // This is evaluated when the selector is called, not when the mock is defined
-    ({
-      chainRanking: [{ chainId: 'eip155:1' }, { chainId: 'eip155:137' }],
-    });
+  const emptyChainRanking: CaipChainId[] = [];
   return {
-    selectBridgeFeatureFlags: jest.fn(() => getMockBridgeFeatureFlags()),
+    selectBridgeFeatureFlags: jest.fn(
+      (state: {
+        engine: {
+          backgroundState: {
+            BridgeController: { bridgeState: { bridgeFeatureFlags: unknown } };
+          };
+        };
+      }) =>
+        state.engine.backgroundState.BridgeController.bridgeState
+          .bridgeFeatureFlags,
+    ),
     selectAllowedChainRanking: jest.fn(
-      () => getMockBridgeFeatureFlags().chainRanking,
+      (state: {
+        engine: {
+          backgroundState: {
+            BridgeController: {
+              bridgeState: {
+                bridgeFeatureFlags?: { chainRanking?: CaipChainId[] };
+              };
+            };
+          };
+        };
+      }) =>
+        state.engine.backgroundState.BridgeController.bridgeState
+          .bridgeFeatureFlags?.chainRanking ?? emptyChainRanking,
     ),
     setIsSelectingToken: jest.fn(() => ({
       type: 'bridge/setIsSelectingToken',
     })),
-    selectTokenSelectorNetworkFilter: jest.fn(() => undefined),
+    selectTokenSelectorNetworkFilter: jest.fn(
+      (state: { bridge: { tokenSelectorNetworkFilter?: CaipChainId } }) =>
+        state.bridge.tokenSelectorNetworkFilter,
+    ),
     setTokenSelectorNetworkFilter: jest.fn((chainId) => ({
       type: 'bridge/setTokenSelectorNetworkFilter',
       payload: chainId,
+    })),
+    setVisiblePillChainIds: jest.fn((chainIds) => ({
+      type: 'bridge/setVisiblePillChainIds',
+      payload: chainIds,
     })),
   };
 });
@@ -113,8 +171,9 @@ let mockPopularTokensState = {
   popularTokens: [createMockPopularToken({ symbol: 'USDC', name: 'USD Coin' })],
   isLoading: false,
 };
+const mockUsePopularTokens = jest.fn(() => mockPopularTokensState);
 jest.mock('../../hooks/usePopularTokens', () => ({
-  usePopularTokens: () => mockPopularTokensState,
+  usePopularTokens: (params: unknown) => mockUsePopularTokens(params),
 }));
 
 const mockSearchTokens = jest.fn();
@@ -130,16 +189,18 @@ let mockSearchTokensState = {
   debouncedSearch: mockDebouncedSearch,
   resetSearch: mockResetSearch,
 };
+const mockUseSearchTokens = jest.fn(() => mockSearchTokensState);
 jest.mock('../../hooks/useSearchTokens', () => ({
-  useSearchTokens: () => mockSearchTokensState,
+  useSearchTokens: (params: unknown) => mockUseSearchTokens(params),
 }));
 
 let mockBalancesByAssetIdState = {
   tokensWithBalance: [] as ReturnType<typeof createMockToken>[],
   balancesByAssetId: {},
 };
+const mockUseBalancesByAssetId = jest.fn(() => mockBalancesByAssetIdState);
 jest.mock('../../hooks/useBalancesByAssetId', () => ({
-  useBalancesByAssetId: () => mockBalancesByAssetIdState,
+  useBalancesByAssetId: (params: unknown) => mockUseBalancesByAssetId(params),
 }));
 
 jest.mock('../../hooks/useTokensWithBalances', () => ({
@@ -281,11 +342,20 @@ jest.mock('../../../../../util/networks', () => ({
 jest.mock('./NetworkPills', () => ({
   NetworkPills: ({
     onChainSelect,
+    onMorePress,
   }: {
     onChainSelect: (chainId?: CaipChainId) => void;
+    onMorePress: () => void;
   }) => {
     const { createElement } = jest.requireActual('react');
-    const { View, TouchableOpacity } = jest.requireActual('react-native');
+    const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
+    const reactRedux =
+      jest.requireActual<typeof import('react-redux')>('react-redux');
+    const visiblePillChainIds = reactRedux.useSelector(
+      (state: { bridge: { visiblePillChainIds?: CaipChainId[] } }) =>
+        state.bridge.visiblePillChainIds,
+    );
+
     return createElement(
       View,
       { testID: 'network-pills' },
@@ -293,6 +363,19 @@ jest.mock('./NetworkPills', () => ({
         testID: 'select-eth-network',
         onPress: () => onChainSelect(MOCK_CHAIN_IDS.ethereum),
       }),
+      createElement(TouchableOpacity, {
+        testID: 'select-polygon-network',
+        onPress: () => onChainSelect(MOCK_CHAIN_IDS.polygon),
+      }),
+      createElement(TouchableOpacity, {
+        testID: 'open-network-modal',
+        onPress: onMorePress,
+      }),
+      createElement(
+        Text,
+        { testID: 'visible-pill-chain-ids' },
+        JSON.stringify(visiblePillChainIds ?? []),
+      ),
     );
   },
 }));
@@ -399,6 +482,9 @@ const resetMocks = () => {
   mockFormatAddressToAssetId.mockReturnValue('eip155:1/erc20:0x1234');
   mockIsNonEvmChainId.mockReturnValue(false);
   mockNavigationDispatch.mockReset();
+  mockUsePopularTokens.mockClear();
+  mockUseSearchTokens.mockClear();
+  mockUseBalancesByAssetId.mockClear();
 };
 
 describe('tokenToIncludeAsset', () => {
@@ -517,6 +603,7 @@ describe('BridgeTokenSelector', () => {
     });
 
     it('renders noFee tokens for source and dest types', async () => {
+      const store = createMockStore();
       mockPopularTokensState = {
         popularTokens: [
           {
@@ -528,11 +615,12 @@ describe('BridgeTokenSelector', () => {
       };
       const { getByTestId, rerender } = renderWithReduxProvider(
         <BridgeTokenSelector />,
+        store,
       );
       await waitFor(() => expect(getByTestId('token-USDC')).toBeTruthy());
       mockRouteParams = { type: 'dest' };
       rerender(
-        <Provider store={mockStore}>
+        <Provider store={store}>
           <BridgeTokenSelector />
         </Provider>,
       );
@@ -580,6 +668,59 @@ describe('BridgeTokenSelector', () => {
     });
   });
 
+  describe('picker defaults', () => {
+    it.each([
+      { pickerType: 'source' as const, selectedToken: null },
+      { pickerType: 'dest' as const, selectedToken: null },
+    ])(
+      'uses all allowed chains by default for $pickerType picker',
+      async ({ pickerType, selectedToken }) => {
+        mockRouteParams = { type: pickerType };
+        mockSelectedToken = selectedToken;
+
+        renderWithReduxProvider(<BridgeTokenSelector />);
+
+        await waitFor(() => {
+          expect(mockUseBalancesByAssetId).toHaveBeenCalledWith(
+            expect.objectContaining({
+              chainIds: [MOCK_CHAIN_IDS.ethereum, MOCK_CHAIN_IDS.polygon],
+            }),
+          );
+          expect(mockUsePopularTokens).toHaveBeenCalledWith(
+            expect.objectContaining({
+              chainIds: [MOCK_CHAIN_IDS.ethereum, MOCK_CHAIN_IDS.polygon],
+            }),
+          );
+          expect(mockUseSearchTokens).toHaveBeenCalledWith(
+            expect.objectContaining({
+              chainIds: [MOCK_CHAIN_IDS.ethereum, MOCK_CHAIN_IDS.polygon],
+            }),
+          );
+        });
+      },
+    );
+
+    it('uses selected destination token chain when destination picker opens', async () => {
+      mockRouteParams = { type: 'dest' };
+      mockSelectedToken = createMockToken({ chainId: '0x89' });
+
+      renderWithReduxProvider(<BridgeTokenSelector />);
+
+      await waitFor(() => {
+        expect(mockUseBalancesByAssetId).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chainIds: [MOCK_CHAIN_IDS.polygon],
+          }),
+        );
+        expect(mockUsePopularTokens).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chainIds: [MOCK_CHAIN_IDS.polygon],
+          }),
+        );
+      });
+    });
+  });
+
   describe('token selection', () => {
     it('calls handleTokenPress when token pressed', async () => {
       const { getByTestId } = renderWithReduxProvider(<BridgeTokenSelector />);
@@ -611,6 +752,78 @@ describe('BridgeTokenSelector', () => {
       mockBridgeFeatureFlags = { chainRanking: undefined as never };
       const { getByTestId } = renderWithReduxProvider(<BridgeTokenSelector />);
       expect(getByTestId('bridge-token-search-input')).toBeTruthy();
+    });
+
+    it('scopes token fetch and search to selected chain after network selection', async () => {
+      const { getByTestId } = renderWithReduxProvider(<BridgeTokenSelector />);
+
+      fireEvent.changeText(getByTestId('bridge-token-search-input'), 'ETH');
+      mockSearchTokens.mockClear();
+
+      await act(async () => {
+        fireEvent.press(getByTestId('select-polygon-network'));
+      });
+
+      expect(mockDebouncedSearch.cancel).toHaveBeenCalled();
+      expect(mockResetSearch).toHaveBeenCalled();
+
+      await waitFor(() => {
+        expect(mockUsePopularTokens).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chainIds: [MOCK_CHAIN_IDS.polygon],
+          }),
+        );
+        expect(mockUseSearchTokens).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chainIds: [MOCK_CHAIN_IDS.polygon],
+          }),
+        );
+      });
+      await waitFor(() => {
+        expect(mockSearchTokens).toHaveBeenCalledWith('ETH');
+      });
+    });
+  });
+
+  describe('pill order persistence', () => {
+    it('keeps visible pill order while moving between source and destination pickers', async () => {
+      const store = createMockStore();
+      const persistentOrder = [MOCK_CHAIN_IDS.polygon, MOCK_CHAIN_IDS.ethereum];
+      const { getByTestId, rerender } = renderWithReduxProvider(
+        <BridgeTokenSelector />,
+        store,
+      );
+
+      await act(async () => {
+        store.dispatch({
+          type: 'bridge/setVisiblePillChainIds',
+          payload: persistentOrder,
+        });
+      });
+
+      expect(getByTestId('visible-pill-chain-ids').props.children).toBe(
+        JSON.stringify(persistentOrder),
+      );
+
+      mockRouteParams = { type: 'dest' };
+      rerender(
+        <Provider store={store}>
+          <BridgeTokenSelector />
+        </Provider>,
+      );
+      expect(getByTestId('visible-pill-chain-ids').props.children).toBe(
+        JSON.stringify(persistentOrder),
+      );
+
+      mockRouteParams = { type: 'source' };
+      rerender(
+        <Provider store={store}>
+          <BridgeTokenSelector />
+        </Provider>,
+      );
+      expect(getByTestId('visible-pill-chain-ids').props.children).toBe(
+        JSON.stringify(persistentOrder),
+      );
     });
   });
 

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
@@ -201,7 +201,7 @@ describe('NetworkPills', () => {
         />,
       );
 
-      expect(getByText('Ethereum')).toBeTruthy();
+      expect(getByText('Ethereum')).toBeOnTheScreen();
       expect(queryByTestId('network-pills-more-button')).toBeNull();
     });
 

--- a/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
@@ -4,14 +4,29 @@ import {
   setSourceToken,
   setDestToken,
   setIsDestTokenManuallySet,
+  selectSourceToken,
+  selectDestToken,
+  selectDestAmount,
 } from '../../../../core/redux/slices/bridge';
 import { createMockToken } from '../testUtils/fixtures';
 import { BridgeToken, TokenSelectorType } from '../types';
+import { selectNetworkConfigurations } from '../../../../selectors/networkController';
+import { PopularList } from '../../../../util/networks/customNetworks';
 
 const mockDispatch = jest.fn();
 const mockHandleSwitchTokensInner = jest.fn().mockResolvedValue(undefined);
 const mockHandleSwitchTokens = jest.fn(() => mockHandleSwitchTokensInner);
 const mockAddNetwork = jest.fn();
+const mockEngineModule = {
+  __esModule: true,
+  default: {
+    context: {
+      NetworkController: {
+        addNetwork: mockAddNetwork,
+      },
+    },
+  },
+};
 
 jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch,
@@ -38,16 +53,8 @@ jest.mock('./useAutoUpdateDestToken', () => ({
   }),
 }));
 
-jest.mock('../../../../core/Engine', () => ({
-  __esModule: true,
-  default: {
-    context: {
-      NetworkController: {
-        addNetwork: mockAddNetwork,
-      },
-    },
-  },
-}));
+jest.mock('../../../../core/Engine', () => mockEngineModule);
+jest.mock('../../../../core/Engine/index', () => mockEngineModule);
 
 jest.mock('../../../../util/networks/customNetworks', () => {
   const actual = jest.requireActual('../../../../util/networks/customNetworks');
@@ -117,11 +124,20 @@ const renderTokenSelectionHook = (
     selectorState.destAmount,
     selectorState.networkConfigurations,
   ];
-  let selectorCallIndex = 0;
-  mockUseSelector.mockImplementation(() => {
-    const value = selectorValues[selectorCallIndex % selectorValues.length];
-    selectorCallIndex += 1;
-    return value;
+  mockUseSelector.mockImplementation((selector: unknown) => {
+    if (selector === selectSourceToken) {
+      return selectorValues[0];
+    }
+    if (selector === selectDestToken) {
+      return selectorValues[1];
+    }
+    if (selector === selectDestAmount) {
+      return selectorValues[2];
+    }
+    if (selector === selectNetworkConfigurations) {
+      return selectorValues[3];
+    }
+    return undefined;
   });
 
   return renderHook(() => useTokenSelection(type));
@@ -224,6 +240,45 @@ describe('useTokenSelection', () => {
   });
 
   describe('network auto-add', () => {
+    it('attempts network auto-add and continues destination selection', async () => {
+      const { result } = renderTokenSelectionHook(TokenSelectorType.Dest, {
+        networkConfigurations: {},
+      });
+      const popularListFindSpy = jest
+        .spyOn(PopularList, 'find')
+        .mockReturnValue({
+          chainId: '0xffff',
+          nickname: 'Mock Network',
+          rpcUrl: 'https://mock-network-rpc.example',
+          failoverRpcUrls: [],
+          ticker: 'ETH',
+          rpcPrefs: {
+            blockExplorerUrl: 'https://mock-network-explorer.example',
+          },
+        });
+      const tokenOnMissingNetwork = createMockToken({
+        address: '0xdest-new',
+        chainId: '0xffff',
+      });
+
+      try {
+        await act(async () => {
+          await result.current.handleTokenPress(tokenOnMissingNetwork);
+        });
+      } finally {
+        expect(popularListFindSpy).toHaveBeenCalled();
+        popularListFindSpy.mockRestore();
+      }
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setDestToken(tokenOnMissingNetwork),
+      );
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setIsDestTokenManuallySet(true),
+      );
+      expect(mockGoBack).toHaveBeenCalled();
+    });
+
     it('aborts source selection when addNetwork rejects', async () => {
       mockAddNetwork.mockRejectedValueOnce(new Error('addNetwork failed'));
       const { result } = renderTokenSelectionHook(TokenSelectorType.Source, {

--- a/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
@@ -254,6 +254,8 @@ describe('useTokenSelection', () => {
           ticker: 'ETH',
           rpcPrefs: {
             blockExplorerUrl: 'https://mock-network-explorer.example',
+            imageUrl: 'MOCK',
+            imageSource: 'mock-image',
           },
         });
       const tokenOnMissingNetwork = createMockToken({

--- a/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
@@ -11,7 +11,6 @@ import {
 import { createMockToken } from '../testUtils/fixtures';
 import { BridgeToken, TokenSelectorType } from '../types';
 import { selectNetworkConfigurations } from '../../../../selectors/networkController';
-import { PopularList } from '../../../../util/networks/customNetworks';
 
 const mockDispatch = jest.fn();
 const mockHandleSwitchTokensInner = jest.fn().mockResolvedValue(undefined);
@@ -244,33 +243,14 @@ describe('useTokenSelection', () => {
       const { result } = renderTokenSelectionHook(TokenSelectorType.Dest, {
         networkConfigurations: {},
       });
-      const popularListFindSpy = jest
-        .spyOn(PopularList, 'find')
-        .mockReturnValue({
-          chainId: '0xffff',
-          nickname: 'Mock Network',
-          rpcUrl: 'https://mock-network-rpc.example',
-          failoverRpcUrls: [],
-          ticker: 'ETH',
-          rpcPrefs: {
-            blockExplorerUrl: 'https://mock-network-explorer.example',
-            imageUrl: 'MOCK',
-            imageSource: 'mock-image',
-          },
-        });
       const tokenOnMissingNetwork = createMockToken({
         address: '0xdest-new',
-        chainId: '0xffff',
+        chainId: '0xa',
       });
 
-      try {
-        await act(async () => {
-          await result.current.handleTokenPress(tokenOnMissingNetwork);
-        });
-      } finally {
-        expect(popularListFindSpy).toHaveBeenCalled();
-        popularListFindSpy.mockRestore();
-      }
+      await act(async () => {
+        await result.current.handleTokenPress(tokenOnMissingNetwork);
+      });
 
       expect(mockDispatch).toHaveBeenCalledWith(
         setDestToken(tokenOnMissingNetwork),

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -265,6 +265,17 @@ describe('bridge slice', () => {
 
       expect(newState).toEqual(initialState);
     });
+
+    it('resets visible pill chain IDs when bridge state resets', () => {
+      const stateWithVisiblePills = {
+        ...initialState,
+        visiblePillChainIds: ['eip155:137', 'eip155:1'] as CaipChainId[],
+      };
+
+      const newState = reducer(stateWithVisiblePills, resetBridgeState());
+
+      expect(newState.visiblePillChainIds).toBeUndefined();
+    });
   });
 
   describe('selectBip44DefaultPair', () => {


### PR DESCRIPTION
## **Description**

This PR adds unit test coverage for the vertical network list acceptance criteria in Bridge token selection flows.

What changed:
- Added source/destination default network filter coverage in token selector tests.
- Added destination-with-selected-token default chain scoping coverage.
- Added selected-network filter + search scoping coverage.
- Added shared pill-order persistence coverage across source/destination picker navigation.
- Added sequential non-visible network selection reorder coverage in pills.
- Added single-supported-network no-`+N` coverage.
- Added explicit reducer reset proof for `visiblePillChainIds` on `resetBridgeState`.
- Added network auto-add continuation coverage in `useTokenSelection` for destination flow, while retaining existing reject-path coverage.

Scope notes:
- Test-only changes.
- No production runtime logic changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Bridge token selector network filtering and pill order behavior

  Scenario: default picker network behavior
    Given the Bridge token selector is opened for source and destination pickers
    When the selector loads with no destination token selected
    Then token fetch/search hooks are called with all allowed chains

  Scenario: destination selected-token default behavior
    Given the destination picker opens with a selected destination token
    When the selector initializes
    Then token fetch/search hooks are scoped to the selected token chain

  Scenario: network selection updates filter and search scope
    Given the user has entered a search query
    When the user selects a specific network pill
    Then search is reset and re-issued for only the selected chain

  Scenario: sequential non-visible network selections
    Given visible pills are initialized from the default ranking
    When two non-visible networks are selected sequentially
    Then the visible pill order rolls forward with each selection

  Scenario: shared pill order persistence across pickers
    Given visible pill order is modified in source picker
    When the user switches to destination picker and back
    Then the same visible pill order remains in both pickers during the session

  Scenario: reset on flow exit
    Given visible pill chain IDs are set in bridge state
    When resetBridgeState is dispatched
    Then visible pill chain IDs reset to undefined

  Scenario: network auto-add behavior
    Given destination token selection is on a missing network
    When a token is selected
    Then network auto-add is attempted and destination selection continues
```

## **Screenshots/Recordings**

### **Before**

N/A (test-only PR)

### **After**

N/A (test-only PR)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust mocks and add coverage; no production logic is modified, with minimal risk beyond potential test brittleness.
> 
> **Overview**
> Adds regression tests around Bridge token selection network filtering and pill ordering.
> 
> Updates `BridgeTokenSelector` tests to use a more realistic mock bridge reducer (supports `tokenSelectorNetworkFilter` and `visiblePillChainIds`) and asserts default chain scoping, chain-selection-driven search reset/re-issue, and persistence of visible pill order when navigating between source/dest pickers. Extends `NetworkPills` tests to cover single-network rendering (no "+N more") and rolling pill reordering across consecutive non-visible selections, plus adds `useTokenSelection` and bridge-slice tests for destination network auto-add continuation and `visiblePillChainIds` reset on `resetBridgeState`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be4c47b713c9048df1940dde0e1c24811d64bc21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->