### PR TITLE
test: fixed perps/predictions tests and added a patch for device loca…

### DIFF
--- a/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch
+++ b/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch
@@ -148,7 +148,7 @@ index 638c5df686413ffe050ef7e7329b9e9446e98002..6599e6dd453de2cc38a4c299d3509e85
          const sessionData = await getSessionDetails(sessionId);
          const sessionDetails = sessionData?.automation_session;
          const videoURL = sessionDetails?.video_url;
-@@ -241,8 +248,15 @@ class BrowserStackDeviceProvider {
+@@ -241,8 +248,16 @@ class BrowserStackDeviceProvider {
              capabilities: {
                  "bstack:options": {
                      debug: true,
@@ -157,6 +157,7 @@ index 638c5df686413ffe050ef7e7329b9e9446e98002..6599e6dd453de2cc38a4c299d3509e85
                      interactiveDebugging: true,
 +                    selfHeal: true,
 +                    appProfiling: true,
++                    geoLocation: 'ES',
                      networkLogs: true,
 +                    networkLogsOptions:{
 +                        captureContent: true,
@@ -164,7 +165,7 @@ index 638c5df686413ffe050ef7e7329b9e9446e98002..6599e6dd453de2cc38a4c299d3509e85
                      appiumVersion: "2.6.0",
                      enableCameraImageInjection: this.project.use.device?.enableCameraImageInjection,
                      idleTimeout: 180,
-@@ -250,10 +264,10 @@ class BrowserStackDeviceProvider {
+@@ -250,10 +265,10 @@ class BrowserStackDeviceProvider {
                      osVersion: this.project.use.device.osVersion,
                      platformName: platformName,
                      deviceOrientation: this.project.use.device?.orientation,
@@ -176,7 +177,7 @@ index 638c5df686413ffe050ef7e7329b9e9446e98002..6599e6dd453de2cc38a4c299d3509e85
                          : process.env.USER,
                  },
                  "appium:autoGrantPermissions": true,
-@@ -261,6 +275,25 @@ class BrowserStackDeviceProvider {
+@@ -261,6 +276,25 @@ class BrowserStackDeviceProvider {
                  "appium:autoAcceptAlerts": true,
                  "appium:fullReset": true,
                  "appium:settings[snapshotMaxDepth]": 62,

--- a/tests/performance/login/perps-add-funds.spec.js
+++ b/tests/performance/login/perps-add-funds.spec.js
@@ -70,7 +70,7 @@ test.describe(PerformancePreps, () => {
         await PerpsDepositScreen.isAmountInputVisible();
       });
 
-      await PerpsDepositScreen.fillUsdAmount(5);
+      await PerpsDepositScreen.fillUsdAmount(2);
       // Get quote
       await getQuoteTimer.measure(async () => {
         await PerpsDepositScreen.isAddFundsVisible();

--- a/wdio/screen-objects/AmountScreen.js
+++ b/wdio/screen-objects/AmountScreen.js
@@ -9,7 +9,7 @@ import {
   NEXT_BUTTON,
   TRANSACTION_AMOUNT_INPUT,
 } from './testIDs/Screens/AmountScreen.testIds';
-import { splitAmountIntoDigits } from '../../tests/framework/utils/Utils';
+import { splitAmountIntoDigits } from '../utils/splitAmountIntoDigits';
 
 class AmountScreen {
 

--- a/wdio/screen-objects/PerpsOrderView.js
+++ b/wdio/screen-objects/PerpsOrderView.js
@@ -2,7 +2,7 @@ import AppwrightSelectors from '../../tests/framework/AppwrightSelectors';
 import AppwrightGestures from '../../tests/framework/AppwrightGestures';
 import AmountScreen from './AmountScreen';
 import { expect as appwrightExpect } from 'appwright';
-import { splitAmountIntoDigits } from '../../tests/framework/utils/Utils';
+import { splitAmountIntoDigits } from '../utils/splitAmountIntoDigits';
 import PerpsPositionDetailsView from './PerpsPositionDetailsView';
 
 class PerpsOrderView {

--- a/wdio/screen-objects/SwapScreen.js
+++ b/wdio/screen-objects/SwapScreen.js
@@ -5,7 +5,7 @@ import { expect as appwrightExpect } from 'appwright';
 import { PerpsWithdrawViewSelectorsIDs } from '../../app/components/UI/Perps/Perps.testIds';
 import { QuoteViewSelectorIDs,QuoteViewSelectorText } from '../../app/components/UI/Swaps/QuoteView.testIds';
 import { SwapsViewSelectorsIDs } from '../../app/components/UI/Swaps/SwapsView.testIds';
-import { splitAmountIntoDigits } from '../../tests/framework/utils/Utils';
+import { splitAmountIntoDigits } from '../utils/splitAmountIntoDigits';
 
 class SwapScreen {
 

--- a/wdio/utils/splitAmountIntoDigits.ts
+++ b/wdio/utils/splitAmountIntoDigits.ts
@@ -1,0 +1,7 @@
+export const splitAmountIntoDigits = (amount: number | string): (number | string)[] =>
+  amount
+    .toString()
+    .split('')
+    .map((char: string): number | string =>
+      /\d/.test(char) ? parseInt(char, 10) : char,
+    );

--- a/yarn.lock
+++ b/yarn.lock
@@ -21840,7 +21840,7 @@ __metadata:
 
 "appwright@patch:appwright@npm%3A0.1.45#~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch":
   version: 0.1.45
-  resolution: "appwright@patch:appwright@npm%3A0.1.45#~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch::version=0.1.45&hash=1a5b9e"
+  resolution: "appwright@patch:appwright@npm%3A0.1.45#~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch::version=0.1.45&hash=81bb53"
   dependencies:
     "@empiricalrun/llm": "npm:^0.9.25"
     "@ffmpeg-installer/ffmpeg": "npm:^1.1.0"
@@ -21856,7 +21856,7 @@ __metadata:
     webdriver: "npm:^8.36.1"
   bin:
     appwright: dist/bin/index.js
-  checksum: 10/98ecffbac7f46eae0f0c854246ccb924ae6c6b53e54f0a7cb81c93503590f4e204faefad19d5d0133644257f6d36f6d2c534227b5380c6677aff5cb47c94876f
+  checksum: 10/1f001f633ca7598b230b8d09bafc4538ed084ced6fe3321a55defc2c46116e1638e43bd71afbc7b8ab279400eda072a4049f3fc029ab81f3b014fac2f8048c79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
## Summary

- **Appwright patch: Add `geoLocation: 'ES'` to BrowserStack sessions** — Forces all performance test sessions to run with Spain geolocation, ensuring Polymarket geo-eligibility checks pass without needing API mocks.

- **Move `splitAmountIntoDigits` to proper TypeScript** — Converted the utility to typed TS (`wdio/utils/splitAmountIntoDigits.ts`) and updated all imports in `AmountScreen.js`, `SwapScreen.js`, and `PerpsOrderView.js` to use the new path.
- **Perps and Prediction fixes**

## Test plan

- [ ] Verify BrowserStack sessions report `geoLocation: ES` in capabilities
- [ ] Verify Predict deposit performance test passes geo-eligibility check
- [ ] Verify `splitAmountIntoDigits` works correctly in swap, perps, and amount flows
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
