### PR TITLE
fix: Swap migrations 118 and 119 to match released version cp-7.66.0

### DIFF
--- a/app/store/migrations/118.test.ts
+++ b/app/store/migrations/118.test.ts
@@ -1,168 +1,215 @@
-import { captureException } from '@sentry/react-native';
 import migrate, { migrationVersion } from './118';
-import { ensureValidState } from './util';
-import FilesystemStorage from 'redux-persist-filesystem-storage';
-import { STORAGE_KEY_PREFIX } from '@metamask/storage-service';
+import { NETWORK_CHAIN_ID } from '../../util/networks/customNetworks';
+import {
+  NetworkConfiguration,
+  RpcEndpointType,
+} from '@metamask/network-controller';
 
 jest.mock('@sentry/react-native', () => ({
   captureException: jest.fn(),
 }));
 
 jest.mock('./util', () => ({
-  ensureValidState: jest.fn(),
+  ensureValidState: jest.fn((_state: unknown, _version: number) => true),
 }));
 
-const mockedEnsureValidState = jest.mocked(ensureValidState);
-const mockedCaptureException = jest.mocked(captureException);
+const mockedEnsureValidState = jest.mocked(
+  jest.requireMock<{ ensureValidState: (s: unknown, v: number) => boolean }>(
+    './util',
+  ).ensureValidState,
+);
 
-describe(`migration #${migrationVersion}`, () => {
+interface MigrationState {
+  engine: {
+    backgroundState: {
+      NetworkController: {
+        networkConfigurationsByChainId: Record<string, NetworkConfiguration>;
+      };
+    };
+  };
+}
+
+describe(`Migration ${migrationVersion}`, () => {
+  const megaEthChainId = NETWORK_CHAIN_ID.MEGAETH_MAINNET;
+
   beforeEach(() => {
-    jest.restoreAllMocks();
-    jest.resetAllMocks();
+    jest.clearAllMocks();
+    mockedEnsureValidState.mockReturnValue(true);
   });
 
-  it('returns state unchanged if SnapController is not found', async () => {
-    const oldState = {
-      engine: {
-        backgroundState: {
-          OtherController: { someData: true },
+  const createTestState = (networkConfig?: NetworkConfiguration): unknown => ({
+    meta: { version: migrationVersion - 1 },
+    engine: {
+      backgroundState: {
+        NetworkController: {
+          networkConfigurationsByChainId: networkConfig
+            ? { [megaEthChainId]: networkConfig }
+            : {},
         },
       },
-    };
-
-    mockedEnsureValidState.mockReturnValue(true);
-
-    const migratedState = await migrate(oldState);
-
-    expect(mockedCaptureException).toHaveBeenCalledWith(
-      new Error(`Migration ${migrationVersion}: SnapController not found.`),
-    );
-
-    expect(migratedState).toEqual(oldState);
+    },
   });
 
-  it('returns state unchanged if SnapController is not an object', async () => {
-    const oldState = {
-      engine: {
-        backgroundState: {
-          SnapController: 'not an object',
-        },
-      },
-    };
-
-    mockedEnsureValidState.mockReturnValue(true);
-
-    const migratedState = await migrate(oldState);
-
-    expect(mockedCaptureException).toHaveBeenCalledWith(
-      new Error(
-        `Migration ${migrationVersion}: SnapController is not an object: string`,
-      ),
-    );
-
-    expect(migratedState).toEqual(oldState);
-  });
-
-  it('returns state unchanged if SnapController.snaps is not found', async () => {
-    const oldState = {
-      engine: {
-        backgroundState: {
-          SnapController: {
-            foo: 'bar',
-          },
-        },
-      },
-    };
-
-    mockedEnsureValidState.mockReturnValue(true);
-
-    const migratedState = await migrate(oldState);
-
-    expect(mockedCaptureException).toHaveBeenCalledWith(
-      new Error(
-        `Migration ${migrationVersion}: SnapController missing property snaps.`,
-      ),
-    );
-
-    expect(migratedState).toEqual(oldState);
-  });
-
-  it('returns state unchanged if SnapController.snaps is not an object', async () => {
-    const oldState = {
-      engine: {
-        backgroundState: {
-          SnapController: { snaps: 'not an object' },
-        },
-      },
-    };
-
-    mockedEnsureValidState.mockReturnValue(true);
-
-    const migratedState = await migrate(oldState);
-
-    expect(mockedCaptureException).toHaveBeenCalledWith(
-      new Error(
-        `Migration ${migrationVersion}: SnapController.snaps is not an object: string`,
-      ),
-    );
-
-    expect(migratedState).toEqual(oldState);
-  });
-
-  it('stores the sourceCode in the browser storage and removes it from the SnapController state', async () => {
-    const oldState = {
-      engine: {
-        backgroundState: {
-          SnapController: {
-            snaps: {
-              'mock-snap-id': { sourceCode: 'sourceCode', id: 'mock-snap-id' },
-              'foo-snap-id': { id: 'foo-snap-id', sourceCode: 'sourceCode2' },
-              'bar-snap-id': { id: 'bar-snap-id', sourceCode: 'sourceCode3 ' },
+  describe('ensureValidState validation', () => {
+    it('returns original state if state version is >= migration version', () => {
+      mockedEnsureValidState.mockReturnValue(false);
+      const oldState = {
+        meta: { version: migrationVersion },
+        engine: {
+          backgroundState: {
+            NetworkController: {
+              networkConfigurationsByChainId: {},
             },
           },
         },
-      },
-    };
+      };
 
-    jest.spyOn(FilesystemStorage, 'setItem').mockResolvedValue(undefined);
+      const result = migrate(oldState);
+      expect(result).toBe(oldState);
+    });
 
-    mockedEnsureValidState.mockReturnValue(true);
+    it('returns original state if engine is missing', () => {
+      const oldState = { meta: { version: migrationVersion - 1 } };
+      const result = migrate(oldState);
+      expect(result).toBe(oldState);
+    });
 
-    const migratedState = await migrate(oldState);
-
-    expect(FilesystemStorage.setItem).toHaveBeenNthCalledWith(
-      1,
-      `${STORAGE_KEY_PREFIX}SnapController:mock-snap-id`,
-      '{"sourceCode":"sourceCode"}',
-      true,
-    );
-
-    expect(FilesystemStorage.setItem).toHaveBeenNthCalledWith(
-      2,
-      `${STORAGE_KEY_PREFIX}SnapController:foo-snap-id`,
-      '{"sourceCode":"sourceCode2"}',
-      true,
-    );
-
-    expect(FilesystemStorage.setItem).toHaveBeenNthCalledWith(
-      3,
-      `${STORAGE_KEY_PREFIX}SnapController:bar-snap-id`,
-      '{"sourceCode":"sourceCode3 "}',
-      true,
-    );
-
-    expect(migratedState).toStrictEqual({
-      engine: {
-        backgroundState: {
-          SnapController: {
-            snaps: {
-              'mock-snap-id': { id: 'mock-snap-id' },
-              'foo-snap-id': { id: 'foo-snap-id' },
-              'bar-snap-id': { id: 'bar-snap-id' },
-            },
-          },
+    it('returns original state if NetworkController is missing', () => {
+      const oldState = {
+        meta: { version: migrationVersion - 1 },
+        engine: {
+          backgroundState: {},
         },
-      },
+      };
+      const result = migrate(oldState);
+      expect(result).toBe(oldState);
+    });
+  });
+
+  describe('NetworkController state transformations', () => {
+    it('updates MegaETH Mainnet name from MegaEth to MegaETH', () => {
+      const oldState = createTestState({
+        chainId: megaEthChainId,
+        name: 'MegaEth',
+        rpcEndpoints: [
+          {
+            networkClientId: 'test-id',
+            url: 'https://mainnet.megaeth.com/rpc',
+            type: RpcEndpointType.Custom,
+            name: 'MegaEth',
+          },
+        ],
+        defaultRpcEndpointIndex: 0,
+        blockExplorerUrls: [],
+        nativeCurrency: 'ETH',
+      });
+
+      const result = migrate(oldState);
+
+      const resultState = result as MigrationState;
+      const migratedConfig =
+        resultState.engine.backgroundState.NetworkController
+          .networkConfigurationsByChainId[megaEthChainId];
+
+      expect(migratedConfig.name).toBe('MegaETH');
+      expect(migratedConfig.rpcEndpoints[0].name).toBe('MegaETH');
+    });
+
+    it('updates only RPC endpoint name if network name is already correct', () => {
+      const oldState = createTestState({
+        chainId: megaEthChainId,
+        name: 'MegaETH',
+        rpcEndpoints: [
+          {
+            networkClientId: 'test-id',
+            url: 'https://mainnet.megaeth.com/rpc',
+            type: RpcEndpointType.Custom,
+            name: 'MegaEth',
+          },
+        ],
+        defaultRpcEndpointIndex: 0,
+        blockExplorerUrls: [],
+        nativeCurrency: 'ETH',
+      });
+
+      const result = migrate(oldState);
+
+      const resultState = result as MigrationState;
+      const migratedConfig =
+        resultState.engine.backgroundState.NetworkController
+          .networkConfigurationsByChainId[megaEthChainId];
+
+      expect(migratedConfig.name).toBe('MegaETH');
+      expect(migratedConfig.rpcEndpoints[0].name).toBe('MegaETH');
+    });
+
+    it('leaves network unchanged if name is not MegaEth', () => {
+      const oldState = createTestState({
+        chainId: megaEthChainId,
+        name: 'MegaETH Mainnet',
+        rpcEndpoints: [
+          {
+            networkClientId: 'test-id',
+            url: 'https://mainnet.megaeth.com/rpc',
+            type: RpcEndpointType.Custom,
+            name: 'MegaETH Mainnet',
+          },
+        ],
+        defaultRpcEndpointIndex: 0,
+        blockExplorerUrls: [],
+        nativeCurrency: 'ETH',
+      });
+
+      const result = migrate(oldState);
+
+      const resultState = result as MigrationState;
+      const migratedConfig =
+        resultState.engine.backgroundState.NetworkController
+          .networkConfigurationsByChainId[megaEthChainId];
+
+      expect(migratedConfig.name).toBe('MegaETH Mainnet');
+      expect(migratedConfig.rpcEndpoints[0].name).toBe('MegaETH Mainnet');
+    });
+
+    it('returns original state if MegaETH Mainnet is not in state', () => {
+      const oldState = createTestState();
+      const result = migrate(oldState);
+      expect(result).toBe(oldState);
+    });
+
+    it('handles multiple RPC endpoints correctly', () => {
+      const oldState = createTestState({
+        chainId: megaEthChainId,
+        name: 'MegaEth',
+        rpcEndpoints: [
+          {
+            networkClientId: 'test-id-1',
+            url: 'https://mainnet.megaeth.com/rpc',
+            type: RpcEndpointType.Custom,
+            name: 'MegaEth',
+          },
+          {
+            networkClientId: 'test-id-2',
+            url: 'https://mainnet.megaeth.com/rpc2',
+            type: RpcEndpointType.Custom,
+            name: 'MegaEth',
+          },
+        ],
+        defaultRpcEndpointIndex: 0,
+        blockExplorerUrls: [],
+        nativeCurrency: 'ETH',
+      });
+
+      const result = migrate(oldState);
+
+      const resultState = result as MigrationState;
+      const migratedConfig =
+        resultState.engine.backgroundState.NetworkController
+          .networkConfigurationsByChainId[megaEthChainId];
+
+      expect(migratedConfig.name).toBe('MegaETH');
+      expect(migratedConfig.rpcEndpoints[0].name).toBe('MegaETH');
+      expect(migratedConfig.rpcEndpoints[1].name).toBe('MegaETH');
     });
   });
 });

--- a/app/store/migrations/118.ts
+++ b/app/store/migrations/118.ts
@@ -1,105 +1,90 @@
-import { cloneDeep } from 'lodash';
-import { ensureValidState, ValidState } from './util';
+import { hasProperty, isObject } from '@metamask/utils';
 import { captureException } from '@sentry/react-native';
-import { getErrorMessage, hasProperty, isObject } from '@metamask/utils';
-import FilesystemStorage from 'redux-persist-filesystem-storage';
-import { STORAGE_KEY_PREFIX } from '@metamask/storage-service';
-import Device from '../../util/device';
+import { ensureValidState } from './util';
+import { NETWORK_CHAIN_ID } from '../../util/networks/customNetworks';
 
 export const migrationVersion = 118;
 
 /**
- * This migration does:
- * - Remove the sourceCode property from each snap in the SnapController state.
- * - Store the sourceCode in the file system storage in order to allow the StorageService to fetch the snap source code.
+ * Migration 118: Update MegaETH Mainnet name from 'MegaEth' to 'MegaETH'
  *
- * @param versionedState - The versioned state to migrate.
- * @returns The migrated state.
+ * This migration updates:
+ * - the MegaETH Mainnet network name from `MegaEth` to `MegaETH`.
+ * - the MegaETH Mainnet RPC endpoint names from `MegaEth` to `MegaETH`.
  */
-export default async function migrate(versionedState: unknown) {
-  const state = cloneDeep(versionedState);
-
+export default function migrate(state: unknown): unknown {
   if (!ensureValidState(state, migrationVersion)) {
     return state;
   }
 
   try {
-    return await transformState(state);
+    // Validate if the NetworkController state exists and has the expected structure.
+    if (
+      !(
+        hasProperty(state, 'engine') &&
+        hasProperty(state.engine, 'backgroundState') &&
+        hasProperty(state.engine.backgroundState, 'NetworkController') &&
+        isObject(state.engine.backgroundState.NetworkController) &&
+        hasProperty(
+          state.engine.backgroundState.NetworkController,
+          'networkConfigurationsByChainId',
+        ) &&
+        isObject(
+          state.engine.backgroundState.NetworkController
+            .networkConfigurationsByChainId,
+        )
+      )
+    ) {
+      return state;
+    }
+
+    const megaEthChainId = NETWORK_CHAIN_ID.MEGAETH_MAINNET;
+    const networkConfigsByChainId =
+      state.engine.backgroundState.NetworkController
+        .networkConfigurationsByChainId;
+
+    // If the chain ID is not found, skip it.
+    if (!hasProperty(networkConfigsByChainId, megaEthChainId)) {
+      return state;
+    }
+
+    const networkConfig = networkConfigsByChainId[megaEthChainId];
+
+    if (!isObject(networkConfig)) {
+      return state;
+    }
+
+    // Update the network name if it matches the old name
+    if (
+      isObject(networkConfig) &&
+      hasProperty(networkConfig, 'name') &&
+      networkConfig.name === 'MegaEth'
+    ) {
+      networkConfig.name = 'MegaETH';
+    }
+
+    // Update RPC endpoint names if they match the old name
+    if (
+      hasProperty(networkConfig, 'rpcEndpoints') &&
+      Array.isArray(networkConfig.rpcEndpoints)
+    ) {
+      networkConfig.rpcEndpoints.forEach((endpoint) => {
+        if (isObject(endpoint) && endpoint.name === 'MegaEth') {
+          endpoint.name = 'MegaETH';
+        }
+      });
+    }
+
+    return state;
   } catch (error) {
-    console.error(error);
-    const newError = new Error(
-      `Migration #${migrationVersion}: ${getErrorMessage(error)}`,
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Failed to update MegaETH network name: ${String(
+          error,
+        )}`,
+      ),
     );
-    captureException(newError);
-
     // Return the original state if migration fails to avoid breaking the app
-    return versionedState;
-  }
-}
-
-/**
- * Transforms the state to remove the sourceCode property from each snap in the SnapController state and store the sourceCode in the file system storage.
- * @param state - The state to transform.
- * @returns The transformed state.
- */
-async function transformState(state: ValidState) {
-  if (!hasProperty(state.engine.backgroundState, 'SnapController')) {
-    captureException(
-      new Error(`Migration ${migrationVersion}: SnapController not found.`),
-    );
-
     return state;
   }
-
-  const snapControllerState = state.engine.backgroundState.SnapController;
-
-  if (!isObject(snapControllerState)) {
-    captureException(
-      new Error(
-        `Migration ${migrationVersion}: SnapController is not an object: ${typeof snapControllerState}`,
-      ),
-    );
-
-    return state;
-  }
-
-  if (!hasProperty(snapControllerState, 'snaps')) {
-    captureException(
-      new Error(
-        `Migration ${migrationVersion}: SnapController missing property snaps.`,
-      ),
-    );
-
-    return state;
-  }
-
-  if (!isObject(snapControllerState.snaps)) {
-    captureException(
-      new Error(
-        `Migration ${migrationVersion}: SnapController.snaps is not an object: ${typeof snapControllerState.snaps}`,
-      ),
-    );
-
-    return state;
-  }
-
-  await Promise.all(
-    Object.values(
-      snapControllerState.snaps as Record<string, Record<string, unknown>>,
-    ).map(async (snap) => {
-      const sourceCode = snap.sourceCode as string;
-
-      const fullKey = `${STORAGE_KEY_PREFIX}SnapController:${snap.id}`;
-
-      await FilesystemStorage.setItem(
-        fullKey,
-        JSON.stringify({ sourceCode }),
-        Device.isIos(),
-      );
-
-      delete snap.sourceCode;
-    }),
-  );
-
-  return state;
 }

--- a/app/store/migrations/119.test.ts
+++ b/app/store/migrations/119.test.ts
@@ -1,215 +1,168 @@
+import { captureException } from '@sentry/react-native';
 import migrate, { migrationVersion } from './119';
-import { NETWORK_CHAIN_ID } from '../../util/networks/customNetworks';
-import {
-  NetworkConfiguration,
-  RpcEndpointType,
-} from '@metamask/network-controller';
+import { ensureValidState } from './util';
+import FilesystemStorage from 'redux-persist-filesystem-storage';
+import { STORAGE_KEY_PREFIX } from '@metamask/storage-service';
 
 jest.mock('@sentry/react-native', () => ({
   captureException: jest.fn(),
 }));
 
 jest.mock('./util', () => ({
-  ensureValidState: jest.fn((_state: unknown, _version: number) => true),
+  ensureValidState: jest.fn(),
 }));
 
-const mockedEnsureValidState = jest.mocked(
-  jest.requireMock<{ ensureValidState: (s: unknown, v: number) => boolean }>(
-    './util',
-  ).ensureValidState,
-);
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+const mockedCaptureException = jest.mocked(captureException);
 
-interface MigrationState {
-  engine: {
-    backgroundState: {
-      NetworkController: {
-        networkConfigurationsByChainId: Record<string, NetworkConfiguration>;
-      };
-    };
-  };
-}
-
-describe(`Migration ${migrationVersion}`, () => {
-  const megaEthChainId = NETWORK_CHAIN_ID.MEGAETH_MAINNET;
-
+describe(`migration #${migrationVersion}`, () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-    mockedEnsureValidState.mockReturnValue(true);
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
   });
 
-  const createTestState = (networkConfig?: NetworkConfiguration): unknown => ({
-    meta: { version: migrationVersion - 1 },
-    engine: {
-      backgroundState: {
-        NetworkController: {
-          networkConfigurationsByChainId: networkConfig
-            ? { [megaEthChainId]: networkConfig }
-            : {},
+  it('returns state unchanged if SnapController is not found', async () => {
+    const oldState = {
+      engine: {
+        backgroundState: {
+          OtherController: { someData: true },
         },
       },
-    },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(oldState);
+
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(`Migration ${migrationVersion}: SnapController not found.`),
+    );
+
+    expect(migratedState).toEqual(oldState);
   });
 
-  describe('ensureValidState validation', () => {
-    it('returns original state if state version is >= migration version', () => {
-      mockedEnsureValidState.mockReturnValue(false);
-      const oldState = {
-        meta: { version: migrationVersion },
-        engine: {
-          backgroundState: {
-            NetworkController: {
-              networkConfigurationsByChainId: {},
+  it('returns state unchanged if SnapController is not an object', async () => {
+    const oldState = {
+      engine: {
+        backgroundState: {
+          SnapController: 'not an object',
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(oldState);
+
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${migrationVersion}: SnapController is not an object: string`,
+      ),
+    );
+
+    expect(migratedState).toEqual(oldState);
+  });
+
+  it('returns state unchanged if SnapController.snaps is not found', async () => {
+    const oldState = {
+      engine: {
+        backgroundState: {
+          SnapController: {
+            foo: 'bar',
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(oldState);
+
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${migrationVersion}: SnapController missing property snaps.`,
+      ),
+    );
+
+    expect(migratedState).toEqual(oldState);
+  });
+
+  it('returns state unchanged if SnapController.snaps is not an object', async () => {
+    const oldState = {
+      engine: {
+        backgroundState: {
+          SnapController: { snaps: 'not an object' },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = await migrate(oldState);
+
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${migrationVersion}: SnapController.snaps is not an object: string`,
+      ),
+    );
+
+    expect(migratedState).toEqual(oldState);
+  });
+
+  it('stores the sourceCode in the browser storage and removes it from the SnapController state', async () => {
+    const oldState = {
+      engine: {
+        backgroundState: {
+          SnapController: {
+            snaps: {
+              'mock-snap-id': { sourceCode: 'sourceCode', id: 'mock-snap-id' },
+              'foo-snap-id': { id: 'foo-snap-id', sourceCode: 'sourceCode2' },
+              'bar-snap-id': { id: 'bar-snap-id', sourceCode: 'sourceCode3 ' },
             },
           },
         },
-      };
+      },
+    };
 
-      const result = migrate(oldState);
-      expect(result).toBe(oldState);
-    });
+    jest.spyOn(FilesystemStorage, 'setItem').mockResolvedValue(undefined);
 
-    it('returns original state if engine is missing', () => {
-      const oldState = { meta: { version: migrationVersion - 1 } };
-      const result = migrate(oldState);
-      expect(result).toBe(oldState);
-    });
+    mockedEnsureValidState.mockReturnValue(true);
 
-    it('returns original state if NetworkController is missing', () => {
-      const oldState = {
-        meta: { version: migrationVersion - 1 },
-        engine: {
-          backgroundState: {},
+    const migratedState = await migrate(oldState);
+
+    expect(FilesystemStorage.setItem).toHaveBeenNthCalledWith(
+      1,
+      `${STORAGE_KEY_PREFIX}SnapController:mock-snap-id`,
+      '{"sourceCode":"sourceCode"}',
+      true,
+    );
+
+    expect(FilesystemStorage.setItem).toHaveBeenNthCalledWith(
+      2,
+      `${STORAGE_KEY_PREFIX}SnapController:foo-snap-id`,
+      '{"sourceCode":"sourceCode2"}',
+      true,
+    );
+
+    expect(FilesystemStorage.setItem).toHaveBeenNthCalledWith(
+      3,
+      `${STORAGE_KEY_PREFIX}SnapController:bar-snap-id`,
+      '{"sourceCode":"sourceCode3 "}',
+      true,
+    );
+
+    expect(migratedState).toStrictEqual({
+      engine: {
+        backgroundState: {
+          SnapController: {
+            snaps: {
+              'mock-snap-id': { id: 'mock-snap-id' },
+              'foo-snap-id': { id: 'foo-snap-id' },
+              'bar-snap-id': { id: 'bar-snap-id' },
+            },
+          },
         },
-      };
-      const result = migrate(oldState);
-      expect(result).toBe(oldState);
-    });
-  });
-
-  describe('NetworkController state transformations', () => {
-    it('updates MegaETH Mainnet name from MegaEth to MegaETH', () => {
-      const oldState = createTestState({
-        chainId: megaEthChainId,
-        name: 'MegaEth',
-        rpcEndpoints: [
-          {
-            networkClientId: 'test-id',
-            url: 'https://mainnet.megaeth.com/rpc',
-            type: RpcEndpointType.Custom,
-            name: 'MegaEth',
-          },
-        ],
-        defaultRpcEndpointIndex: 0,
-        blockExplorerUrls: [],
-        nativeCurrency: 'ETH',
-      });
-
-      const result = migrate(oldState);
-
-      const resultState = result as MigrationState;
-      const migratedConfig =
-        resultState.engine.backgroundState.NetworkController
-          .networkConfigurationsByChainId[megaEthChainId];
-
-      expect(migratedConfig.name).toBe('MegaETH');
-      expect(migratedConfig.rpcEndpoints[0].name).toBe('MegaETH');
-    });
-
-    it('updates only RPC endpoint name if network name is already correct', () => {
-      const oldState = createTestState({
-        chainId: megaEthChainId,
-        name: 'MegaETH',
-        rpcEndpoints: [
-          {
-            networkClientId: 'test-id',
-            url: 'https://mainnet.megaeth.com/rpc',
-            type: RpcEndpointType.Custom,
-            name: 'MegaEth',
-          },
-        ],
-        defaultRpcEndpointIndex: 0,
-        blockExplorerUrls: [],
-        nativeCurrency: 'ETH',
-      });
-
-      const result = migrate(oldState);
-
-      const resultState = result as MigrationState;
-      const migratedConfig =
-        resultState.engine.backgroundState.NetworkController
-          .networkConfigurationsByChainId[megaEthChainId];
-
-      expect(migratedConfig.name).toBe('MegaETH');
-      expect(migratedConfig.rpcEndpoints[0].name).toBe('MegaETH');
-    });
-
-    it('leaves network unchanged if name is not MegaEth', () => {
-      const oldState = createTestState({
-        chainId: megaEthChainId,
-        name: 'MegaETH Mainnet',
-        rpcEndpoints: [
-          {
-            networkClientId: 'test-id',
-            url: 'https://mainnet.megaeth.com/rpc',
-            type: RpcEndpointType.Custom,
-            name: 'MegaETH Mainnet',
-          },
-        ],
-        defaultRpcEndpointIndex: 0,
-        blockExplorerUrls: [],
-        nativeCurrency: 'ETH',
-      });
-
-      const result = migrate(oldState);
-
-      const resultState = result as MigrationState;
-      const migratedConfig =
-        resultState.engine.backgroundState.NetworkController
-          .networkConfigurationsByChainId[megaEthChainId];
-
-      expect(migratedConfig.name).toBe('MegaETH Mainnet');
-      expect(migratedConfig.rpcEndpoints[0].name).toBe('MegaETH Mainnet');
-    });
-
-    it('returns original state if MegaETH Mainnet is not in state', () => {
-      const oldState = createTestState();
-      const result = migrate(oldState);
-      expect(result).toBe(oldState);
-    });
-
-    it('handles multiple RPC endpoints correctly', () => {
-      const oldState = createTestState({
-        chainId: megaEthChainId,
-        name: 'MegaEth',
-        rpcEndpoints: [
-          {
-            networkClientId: 'test-id-1',
-            url: 'https://mainnet.megaeth.com/rpc',
-            type: RpcEndpointType.Custom,
-            name: 'MegaEth',
-          },
-          {
-            networkClientId: 'test-id-2',
-            url: 'https://mainnet.megaeth.com/rpc2',
-            type: RpcEndpointType.Custom,
-            name: 'MegaEth',
-          },
-        ],
-        defaultRpcEndpointIndex: 0,
-        blockExplorerUrls: [],
-        nativeCurrency: 'ETH',
-      });
-
-      const result = migrate(oldState);
-
-      const resultState = result as MigrationState;
-      const migratedConfig =
-        resultState.engine.backgroundState.NetworkController
-          .networkConfigurationsByChainId[megaEthChainId];
-
-      expect(migratedConfig.name).toBe('MegaETH');
-      expect(migratedConfig.rpcEndpoints[0].name).toBe('MegaETH');
-      expect(migratedConfig.rpcEndpoints[1].name).toBe('MegaETH');
+      },
     });
   });
 });

--- a/app/store/migrations/119.ts
+++ b/app/store/migrations/119.ts
@@ -1,90 +1,105 @@
-import { hasProperty, isObject } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+import { ensureValidState, ValidState } from './util';
 import { captureException } from '@sentry/react-native';
-import { ensureValidState } from './util';
-import { NETWORK_CHAIN_ID } from '../../util/networks/customNetworks';
+import { getErrorMessage, hasProperty, isObject } from '@metamask/utils';
+import FilesystemStorage from 'redux-persist-filesystem-storage';
+import { STORAGE_KEY_PREFIX } from '@metamask/storage-service';
+import Device from '../../util/device';
 
 export const migrationVersion = 119;
 
 /**
- * Migration 119: Update MegaETH Mainnet name from 'MegaEth' to 'MegaETH'
+ * This migration does:
+ * - Remove the sourceCode property from each snap in the SnapController state.
+ * - Store the sourceCode in the file system storage in order to allow the StorageService to fetch the snap source code.
  *
- * This migration updates:
- * - the MegaETH Mainnet network name from `MegaEth` to `MegaETH`.
- * - the MegaETH Mainnet RPC endpoint names from `MegaEth` to `MegaETH`.
+ * @param versionedState - The versioned state to migrate.
+ * @returns The migrated state.
  */
-export default function migrate(state: unknown): unknown {
+export default async function migrate(versionedState: unknown) {
+  const state = cloneDeep(versionedState);
+
   if (!ensureValidState(state, migrationVersion)) {
     return state;
   }
 
   try {
-    // Validate if the NetworkController state exists and has the expected structure.
-    if (
-      !(
-        hasProperty(state, 'engine') &&
-        hasProperty(state.engine, 'backgroundState') &&
-        hasProperty(state.engine.backgroundState, 'NetworkController') &&
-        isObject(state.engine.backgroundState.NetworkController) &&
-        hasProperty(
-          state.engine.backgroundState.NetworkController,
-          'networkConfigurationsByChainId',
-        ) &&
-        isObject(
-          state.engine.backgroundState.NetworkController
-            .networkConfigurationsByChainId,
-        )
-      )
-    ) {
-      return state;
-    }
-
-    const megaEthChainId = NETWORK_CHAIN_ID.MEGAETH_MAINNET;
-    const networkConfigsByChainId =
-      state.engine.backgroundState.NetworkController
-        .networkConfigurationsByChainId;
-
-    // If the chain ID is not found, skip it.
-    if (!hasProperty(networkConfigsByChainId, megaEthChainId)) {
-      return state;
-    }
-
-    const networkConfig = networkConfigsByChainId[megaEthChainId];
-
-    if (!isObject(networkConfig)) {
-      return state;
-    }
-
-    // Update the network name if it matches the old name
-    if (
-      isObject(networkConfig) &&
-      hasProperty(networkConfig, 'name') &&
-      networkConfig.name === 'MegaEth'
-    ) {
-      networkConfig.name = 'MegaETH';
-    }
-
-    // Update RPC endpoint names if they match the old name
-    if (
-      hasProperty(networkConfig, 'rpcEndpoints') &&
-      Array.isArray(networkConfig.rpcEndpoints)
-    ) {
-      networkConfig.rpcEndpoints.forEach((endpoint) => {
-        if (isObject(endpoint) && endpoint.name === 'MegaEth') {
-          endpoint.name = 'MegaETH';
-        }
-      });
-    }
-
-    return state;
+    return await transformState(state);
   } catch (error) {
-    captureException(
-      new Error(
-        `Migration ${migrationVersion}: Failed to update MegaETH network name: ${String(
-          error,
-        )}`,
-      ),
+    console.error(error);
+    const newError = new Error(
+      `Migration #${migrationVersion}: ${getErrorMessage(error)}`,
     );
+    captureException(newError);
+
     // Return the original state if migration fails to avoid breaking the app
+    return versionedState;
+  }
+}
+
+/**
+ * Transforms the state to remove the sourceCode property from each snap in the SnapController state and store the sourceCode in the file system storage.
+ * @param state - The state to transform.
+ * @returns The transformed state.
+ */
+async function transformState(state: ValidState) {
+  if (!hasProperty(state.engine.backgroundState, 'SnapController')) {
+    captureException(
+      new Error(`Migration ${migrationVersion}: SnapController not found.`),
+    );
+
     return state;
   }
+
+  const snapControllerState = state.engine.backgroundState.SnapController;
+
+  if (!isObject(snapControllerState)) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: SnapController is not an object: ${typeof snapControllerState}`,
+      ),
+    );
+
+    return state;
+  }
+
+  if (!hasProperty(snapControllerState, 'snaps')) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: SnapController missing property snaps.`,
+      ),
+    );
+
+    return state;
+  }
+
+  if (!isObject(snapControllerState.snaps)) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: SnapController.snaps is not an object: ${typeof snapControllerState.snaps}`,
+      ),
+    );
+
+    return state;
+  }
+
+  await Promise.all(
+    Object.values(
+      snapControllerState.snaps as Record<string, Record<string, unknown>>,
+    ).map(async (snap) => {
+      const sourceCode = snap.sourceCode as string;
+
+      const fullKey = `${STORAGE_KEY_PREFIX}SnapController:${snap.id}`;
+
+      await FilesystemStorage.setItem(
+        fullKey,
+        JSON.stringify({ sourceCode }),
+        Device.isIos(),
+      );
+
+      delete snap.sourceCode;
+    }),
+  );
+
+  return state;
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Context
A release shipped with migration 119 labeled as 118. To align the codebase with what users have, we need to swap these migrations.

Problem
- Migration 119 (MegaETH network name update) was released as migration 118
- Migration 118 (SnapController sourceCode migration) was released as migration 119

The codebase has them reversed, causing a mismatch with released state

Solution
- Swapped migrations 118 and 119:
- Migration 118 now contains the MegaETH network name update (previously 119)
- Migration 119 now contains the SnapController sourceCode migration (previously 118)
- Updated all version numbers, imports, and test references

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed migration numbering to match released version by swapping migrations 118 and 119

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted-state migration ordering and behavior; a numbering mismatch or subtle state-shape assumption could lead to users skipping or misapplying a migration during upgrades.
> 
> **Overview**
> Aligns migration numbering with the already-released state by **swapping the implementations of migrations `118` and `119`**.
> 
> `118` is now the MegaETH Mainnet rename migration (updates `NetworkController.networkConfigurationsByChainId[MEGAETH_MAINNET]` network and RPC endpoint names from `MegaEth` to `MegaETH`) and is made synchronous, while `119` now performs the async SnapController `sourceCode` extraction to filesystem storage (writing `${STORAGE_KEY_PREFIX}SnapController:<id>` and deleting `sourceCode`). Tests were rewritten accordingly to validate the new behaviors for each migration number.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13677760f2305ea1ad2fdbaf96340254afdab58c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->