### PR TITLE
refactor: Use remote feature flag for withdraw-to-any-token, fix feature flag name

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
@@ -15,7 +15,7 @@ const log = createProjectLogger('transaction-pay-post-quote');
  * quote retrieval. The UI renders the default token when no payment
  * token is selected.
  *
- * When the withdrawal token picker feature flag (MM_PREDICT_WITHDRAW_ANY_TOKEN)
+ * When the withdrawal token picker feature flag (predictWithdrawAnyToken)
  * is disabled via canSelectWithdrawToken, this hook does nothing -
  * withdrawals will use same-token-same-chain flow without bridging.
  */

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.test.ts
@@ -31,7 +31,7 @@ function runHook({
   mockState.engine.backgroundState.RemoteFeatureFlagController = {
     ...mockState.engine.backgroundState.RemoteFeatureFlagController,
     remoteFeatureFlags: {
-      confirmation_pay: {
+      confirmations_pay: {
         predictWithdrawAnyToken,
       },
     },

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.ts
@@ -1,12 +1,7 @@
+import { useSelector } from 'react-redux';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { isTransactionPayWithdraw } from '../../utils/transaction';
-
-/**
- * Whether the withdraw token picker feature is enabled.
- * When false, withdrawals always use the default Polygon USDC.E.
- */
-const isWithdrawTokenPickerEnabled =
-  process.env.MM_PREDICT_WITHDRAW_ANY_TOKEN === 'true';
+import { selectMetaMaskPayFlags } from '../../../../../selectors/featureFlagController/confirmations';
 
 export interface UseTransactionPayWithdrawResult {
   /** Whether this transaction is a withdraw type */
@@ -24,10 +19,9 @@ export interface UseTransactionPayWithdrawResult {
 export function useTransactionPayWithdraw(): UseTransactionPayWithdrawResult {
   const transactionMeta = useTransactionMetadataRequest();
   const isWithdraw = isTransactionPayWithdraw(transactionMeta);
+  const { predictWithdrawAnyToken } = useSelector(selectMetaMaskPayFlags);
 
-  // Feature flag check is tied to withdraw transaction type.
-  // Future transaction types (e.g., Perps) may have their own feature flags.
-  const canSelectWithdrawToken = isWithdraw && isWithdrawTokenPickerEnabled;
+  const canSelectWithdrawToken = isWithdraw && predictWithdrawAnyToken;
 
   return {
     isWithdraw,

--- a/app/selectors/featureFlagController/confirmations/index.test.ts
+++ b/app/selectors/featureFlagController/confirmations/index.test.ts
@@ -54,7 +54,7 @@ describe('MetaMask Pay Feature Flags', () => {
 
     state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
       {
-        confirmation_pay: {
+        confirmations_pay: {
           bufferStep: 1.234,
         },
       };
@@ -67,7 +67,7 @@ describe('MetaMask Pay Feature Flags', () => {
 
     state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
       {
-        confirmation_pay: {
+        confirmations_pay: {
           bufferInitial: 2.345,
         },
       };
@@ -80,7 +80,7 @@ describe('MetaMask Pay Feature Flags', () => {
 
     state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
       {
-        confirmation_pay: {
+        confirmations_pay: {
           bufferSubsequent: 5.678,
         },
       };
@@ -93,7 +93,7 @@ describe('MetaMask Pay Feature Flags', () => {
 
     state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
       {
-        confirmation_pay: {
+        confirmations_pay: {
           attemptsMax: 3,
         },
       };
@@ -106,7 +106,7 @@ describe('MetaMask Pay Feature Flags', () => {
 
     state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
       {
-        confirmation_pay: {
+        confirmations_pay: {
           slippage: 0.123,
         },
       };
@@ -257,7 +257,7 @@ describe('Gas Fee Token Flags', () => {
 });
 
 describe('Withdraw Any Token Flags (in selectMetaMaskPayFlags)', () => {
-  it('returns withdraw defaults when confirmation_pay is missing', () => {
+  it('returns withdraw defaults when confirmations_pay is missing', () => {
     const result = selectMetaMaskPayFlags(mockedEmptyFlagsState);
 
     expect(result.predictWithdrawAnyToken).toBe(false);
@@ -268,7 +268,7 @@ describe('Withdraw Any Token Flags (in selectMetaMaskPayFlags)', () => {
     const state = cloneDeep(mockedEmptyFlagsState);
     state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
       {
-        confirmation_pay: {
+        confirmations_pay: {
           predictWithdrawAnyToken: true,
         },
       };
@@ -282,7 +282,7 @@ describe('Withdraw Any Token Flags (in selectMetaMaskPayFlags)', () => {
     const state = cloneDeep(mockedEmptyFlagsState);
     state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
       {
-        confirmation_pay: {
+        confirmations_pay: {
           perpsWithdrawAnyToken: true,
         },
       };

--- a/app/selectors/featureFlagController/confirmations/index.test.ts
+++ b/app/selectors/featureFlagController/confirmations/index.test.ts
@@ -255,3 +255,40 @@ describe('Gas Fee Token Flags', () => {
     expect(result).toEqual({ gasFeeTokens: {} });
   });
 });
+
+describe('Withdraw Any Token Flags (in selectMetaMaskPayFlags)', () => {
+  it('returns withdraw defaults when confirmation_pay is missing', () => {
+    const result = selectMetaMaskPayFlags(mockedEmptyFlagsState);
+
+    expect(result.predictWithdrawAnyToken).toBe(false);
+    expect(result.perpsWithdrawAnyToken).toBe(false);
+  });
+
+  it('returns predictWithdrawAnyToken from feature flag', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmation_pay: {
+          predictWithdrawAnyToken: true,
+        },
+      };
+
+    const result = selectMetaMaskPayFlags(state);
+    expect(result.predictWithdrawAnyToken).toBe(true);
+    expect(result.perpsWithdrawAnyToken).toBe(false);
+  });
+
+  it('returns perpsWithdrawAnyToken from feature flag', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmation_pay: {
+          perpsWithdrawAnyToken: true,
+        },
+      };
+
+    const result = selectMetaMaskPayFlags(state);
+    expect(result.perpsWithdrawAnyToken).toBe(true);
+    expect(result.predictWithdrawAnyToken).toBe(false);
+  });
+});

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -14,6 +14,8 @@ export interface MetaMaskPayFlags {
   bufferStep: number;
   bufferSubsequent: number;
   slippage: number;
+  predictWithdrawAnyToken: boolean;
+  perpsWithdrawAnyToken: boolean;
 }
 
 export interface GasFeeTokenFlags {
@@ -56,6 +58,10 @@ export const selectMetaMaskPayFlags = createSelector(
       bufferStep,
       bufferSubsequent,
       slippage,
+      predictWithdrawAnyToken:
+        (metaMaskPayFlags?.predictWithdrawAnyToken as boolean) ?? false,
+      perpsWithdrawAnyToken:
+        (metaMaskPayFlags?.perpsWithdrawAnyToken as boolean) ?? false,
     };
   },
 );

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -33,7 +33,7 @@ export interface GasFeeTokenFlags {
 export const selectMetaMaskPayFlags = createSelector(
   selectRemoteFeatureFlags,
   (featureFlags): MetaMaskPayFlags => {
-    const metaMaskPayFlags = featureFlags?.confirmation_pay as
+    const metaMaskPayFlags = featureFlags?.confirmations_pay as
       | Record<string, Json>
       | undefined;
 


### PR DESCRIPTION
## **Description**

The withdraw-to-any-token capability (`canSelectWithdrawToken`) was gated by the `MM_PREDICT_WITHDRAW_ANY_TOKEN` environment variable, which required a rebuild to toggle. This PR replaces it with the `predictWithdrawAnyToken` remote feature flag from the `confirmation_pay` flag group, allowing it to be toggled server-side without app rebuilds.

It fixes naming from `confirmation_pay` to `confirmations_pay`.

Also adds `perpsWithdrawAnyToken` to the same selector in preparation for Perps withdraw support.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6987

## **Manual testing steps**
1. predictWithdrawAnyToken on, you can see a select box for tokens on the Predict Withdraw page
2. predictWithdrawAnyToken off, you cannot see a select box for tokens on the Predict Withdraw page

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to feature-flag plumbing and tests; main risk is misnaming/misconfiguring the remote flag key causing the token picker to be incorrectly enabled/disabled.
> 
> **Overview**
> Switches the withdraw token picker gate (`canSelectWithdrawToken`) from the build-time env var `MM_PREDICT_WITHDRAW_ANY_TOKEN` to the remote feature flag `confirmations_pay.predictWithdrawAnyToken`, so it can be toggled without rebuilding.
> 
> Fixes the remote flag group key from `confirmation_pay` to `confirmations_pay`, extends `selectMetaMaskPayFlags` to expose `predictWithdrawAnyToken` and a new `perpsWithdrawAnyToken` (defaulting to `false`), and updates/expands unit tests accordingly; `useTransactionPayPostQuote` docs are updated to match the new flag name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14c52df73e7b858b4d1e9c36d22b3f87325e34a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->