### PR TITLE
fix: migrate hype slip44 correct value NE ctrl

### DIFF
--- a/app/store/migrations/121.test.ts
+++ b/app/store/migrations/121.test.ts
@@ -1,0 +1,209 @@
+import migrate, { migrationVersion } from './121';
+import { captureException } from '@sentry/react-native';
+import { StateNECWithNativeAssetIdentifiers } from './121_utils';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+const mockedCaptureException = jest.mocked(captureException);
+describe(`migration #${migrationVersion}`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('DOES NOT modify the controller + exception if NetworkEnablementController is missing', () => {
+    const oldStorage = {
+      engine: {
+        backgroundState: {
+          OtherRandomController: {},
+        },
+      },
+    };
+
+    const newStorage = migrate(
+      oldStorage,
+    ) as StateNECWithNativeAssetIdentifiers;
+
+    expect(newStorage.engine.backgroundState).toStrictEqual({
+      OtherRandomController: {},
+    });
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${migrationVersion}: NetworkEnablementController not found.`,
+      ),
+    );
+  });
+
+  it('DOES NOT modify the controller + exception if NetworkEnablementController has changed type', () => {
+    const oldStorage = {
+      engine: {
+        backgroundState: {
+          NetworkEnablementController: [
+            {
+              foo: 'bar',
+            },
+          ],
+        },
+      },
+    };
+
+    const newStorage = migrate(
+      oldStorage,
+    ) as StateNECWithNativeAssetIdentifiers;
+
+    expect(newStorage.engine.backgroundState).toStrictEqual({
+      NetworkEnablementController: [
+        {
+          foo: 'bar',
+        },
+      ],
+    });
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${migrationVersion}: NetworkEnablementController is not an object: object`,
+      ),
+    );
+  });
+
+  it('DOES NOT modify the controller + exception if NetworkEnablementController.nativeAssetIdentifiers is missing', () => {
+    const oldStorage = {
+      engine: {
+        backgroundState: {
+          NetworkEnablementController: {
+            anotherFieldThatIsNotNativeAssetIdentifiers: {},
+          },
+        },
+      },
+    };
+
+    const newStorage = migrate(
+      oldStorage,
+    ) as StateNECWithNativeAssetIdentifiers;
+
+    expect(newStorage.engine.backgroundState).toStrictEqual({
+      NetworkEnablementController: {
+        anotherFieldThatIsNotNativeAssetIdentifiers: {},
+      },
+    });
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${migrationVersion}: NetworkEnablementController missing property nativeAssetIdentifiers.`,
+      ),
+    );
+  });
+
+  it('DOES NOT modify the controller + exception if NetworkEnablementController.nativeAssetIdentifiers has changed type', () => {
+    const oldStorage = {
+      engine: {
+        backgroundState: {
+          NetworkEnablementController: {
+            // Not the correct type, should be an object.
+            nativeAssetIdentifiers: [
+              'eip155:1/slip44:60',
+              'eip155:999/slip44:2457',
+            ],
+          },
+        },
+      },
+    };
+
+    const newStorage = migrate(
+      oldStorage,
+    ) as StateNECWithNativeAssetIdentifiers;
+
+    expect(newStorage.engine.backgroundState).toStrictEqual({
+      NetworkEnablementController: {
+        nativeAssetIdentifiers: [
+          'eip155:1/slip44:60',
+          'eip155:999/slip44:2457',
+        ],
+      },
+    });
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${migrationVersion}: NetworkEnablementController.nativeAssetIdentifiers is not an object: object.`,
+      ),
+    );
+  });
+
+  it('DOES NOT modify the controller if a HYPE entry with correct value already exists', () => {
+    const oldStorage = {
+      engine: {
+        backgroundState: {
+          NetworkEnablementController: {
+            nativeAssetIdentifiers: {
+              'eip155:1': 'eip155:1/slip44:60',
+              'eip155:999': 'eip155:999/slip44:2457',
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = migrate(
+      oldStorage,
+    ) as StateNECWithNativeAssetIdentifiers;
+
+    expect(newStorage.engine.backgroundState).toStrictEqual({
+      NetworkEnablementController: {
+        nativeAssetIdentifiers: {
+          'eip155:1': 'eip155:1/slip44:60',
+          'eip155:999': 'eip155:999/slip44:2457',
+        },
+      },
+    });
+  });
+
+  it('DOES NOT modify the controller if no HYPE entry already exist', () => {
+    const oldStorage = {
+      engine: {
+        backgroundState: {
+          NetworkEnablementController: {
+            nativeAssetIdentifiers: {
+              'eip155:1': 'eip155:1/slip44:60',
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = migrate(
+      oldStorage,
+    ) as StateNECWithNativeAssetIdentifiers;
+
+    expect(newStorage.engine.backgroundState).toStrictEqual({
+      NetworkEnablementController: {
+        nativeAssetIdentifiers: {
+          'eip155:1': 'eip155:1/slip44:60',
+        },
+      },
+    });
+  });
+
+  it('SUCCESSFULY transforms incorrect HYPE slip44 value to correct value', () => {
+    const oldStorage = {
+      engine: {
+        backgroundState: {
+          NetworkEnablementController: {
+            nativeAssetIdentifiers: {
+              'eip155:1': 'eip155:1/slip44:60',
+              'eip155:999': 'eip155:999/slip44:1',
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = migrate(
+      oldStorage,
+    ) as StateNECWithNativeAssetIdentifiers;
+
+    expect(newStorage.engine.backgroundState).toStrictEqual({
+      NetworkEnablementController: {
+        nativeAssetIdentifiers: {
+          'eip155:1': 'eip155:1/slip44:60',
+          'eip155:999': 'eip155:999/slip44:2457',
+        },
+      },
+    });
+  });
+});

--- a/app/store/migrations/121.ts
+++ b/app/store/migrations/121.ts
@@ -1,0 +1,51 @@
+import { hasProperty } from '@metamask/utils';
+import { ensureValidState } from './util';
+import { checkNetworkEnablementState } from './121_utils';
+import { captureException } from '@sentry/react-native';
+
+export const migrationVersion = 121;
+
+export const TARGET_KEY = 'eip155:999';
+export const VALUE_TO_SET = 'eip155:999/slip44:2457';
+
+// Context: HYPE token (eip155:999/slip44:2457) was incorrectly set to eip155:999/slip44:1 (1 instead of 2457)
+// for some users in NetworkEnablementController.nativeAssetIdentifiers state.
+// This is because https://chainid.network/chains.json is fetched to populate this state,
+// and that chainId "999" references a "WanChain testnet" instead of HyperEVM.
+// PR https://github.com/MetaMask/core/pull/7975 addresses future population by forcing an
+// override at fetch-time.
+// However such fetching is not always triggered if an user had already added the network,
+// hence the need for this migration that - ontop of the PR above - will migrate the incorrect
+// entry ('eip155:999/slip44:1') to the correct one ('eip155:999/slip44:2457').
+//
+// This migration will operate only if an entry already exists AND is not 'eip155:999/slip44:2457'.
+export default function migrate(state: unknown): unknown {
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  if (!checkNetworkEnablementState(state, migrationVersion)) {
+    return state;
+  }
+
+  try {
+    const { nativeAssetIdentifiers } =
+      state.engine.backgroundState.NetworkEnablementController;
+    // Only setting the value if the key already exists
+    if (!hasProperty(nativeAssetIdentifiers, TARGET_KEY)) {
+      return state;
+    }
+    // Only setting the value if the key isn't already correctly set
+    if (nativeAssetIdentifiers[TARGET_KEY] === VALUE_TO_SET) {
+      return state;
+    }
+    // Setting the correct value, overridding the wrong one
+    nativeAssetIdentifiers[TARGET_KEY] = VALUE_TO_SET;
+    return state;
+  } catch (error) {
+    captureException(
+      new Error(`Migration ${migrationVersion} failed: ${error}`),
+    );
+    return state;
+  }
+}

--- a/app/store/migrations/121_utils.ts
+++ b/app/store/migrations/121_utils.ts
@@ -1,0 +1,70 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { ValidState } from './util';
+import { captureException } from '@sentry/react-native';
+
+export interface StateNECWithNativeAssetIdentifiers {
+  engine: {
+    backgroundState: {
+      NetworkEnablementController: {
+        nativeAssetIdentifiers: { [key: string]: string };
+      };
+    };
+  };
+}
+
+// DO NOT MODIFY (copy for your own migration if needed).
+// The goal of this file is to centralize some logic that may already exist
+// in some other migration but for which we accept the fact that they are
+// repeated instead of being refactored.
+// Introducing "common functions" in migration may be a bad practice
+// because changes in them would affect multiple migrations.
+// Also, some migrations are only interested in some specific checks.
+// The idea is to have such logic in a separate <migrationNumber>_utils file
+// to make reviewing PRs less intimidating.
+// Functions of this file are tested as part of <migrationNumber>.test.ts
+// and for that reason they don't have their own tests.
+export const checkNetworkEnablementState = (
+  state: ValidState,
+  version: number,
+): state is ValidState & StateNECWithNativeAssetIdentifiers => {
+  if (
+    !hasProperty(state.engine.backgroundState, 'NetworkEnablementController')
+  ) {
+    captureException(
+      new Error(`Migration ${version}: NetworkEnablementController not found.`),
+    );
+    return false;
+  }
+
+  const networkEnablementState =
+    state.engine.backgroundState.NetworkEnablementController;
+
+  if (!isObject(networkEnablementState)) {
+    captureException(
+      new Error(
+        `Migration ${version}: NetworkEnablementController is not an object: ${typeof networkEnablementState}`,
+      ),
+    );
+    return false;
+  }
+
+  if (!hasProperty(networkEnablementState, 'nativeAssetIdentifiers')) {
+    captureException(
+      new Error(
+        `Migration ${version}: NetworkEnablementController missing property nativeAssetIdentifiers.`,
+      ),
+    );
+    return false;
+  }
+
+  if (!isObject(networkEnablementState.nativeAssetIdentifiers)) {
+    captureException(
+      new Error(
+        `Migration ${version}: NetworkEnablementController.nativeAssetIdentifiers is not an object: ${typeof networkEnablementState.nativeAssetIdentifiers}.`,
+      ),
+    );
+    return false;
+  }
+
+  return true;
+};

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -121,6 +121,7 @@ import migration117 from './117';
 import migration118 from './118';
 import migration119 from './119';
 import migration120 from './120';
+import migration121 from './121';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -261,6 +262,7 @@ export const migrationList: MigrationsList = {
   118: migration118,
   119: migration119,
   120: migration120,
+  121: migration121,
 };
 
 // Enable both synchronous and asynchronous migrations

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "@metamask/multichain-transactions-controller": "^6.0.0",
     "@metamask/native-utils": "^0.8.0",
     "@metamask/network-controller": "^30.0.0",
-    "@metamask/network-enablement-controller": "^4.1.0",
+    "@metamask/network-enablement-controller": "^4.1.1",
     "@metamask/notification-services-controller": "^22.0.0",
     "@metamask/permission-controller": "^12.1.0",
     "@metamask/phishing-controller": "^16.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9235,7 +9235,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-enablement-controller@npm:^4.1.0, @metamask/network-enablement-controller@npm:^4.1.2":
+"@metamask/network-enablement-controller@npm:^4.1.0, @metamask/network-enablement-controller@npm:^4.1.1, @metamask/network-enablement-controller@npm:^4.1.2":
   version: 4.1.2
   resolution: "@metamask/network-enablement-controller@npm:4.1.2"
   dependencies:
@@ -35526,7 +35526,7 @@ __metadata:
     "@metamask/multichain-transactions-controller": "npm:^6.0.0"
     "@metamask/native-utils": "npm:^0.8.0"
     "@metamask/network-controller": "npm:^30.0.0"
-    "@metamask/network-enablement-controller": "npm:^4.1.0"
+    "@metamask/network-enablement-controller": "npm:^4.1.1"
     "@metamask/notification-services-controller": "npm:^22.0.0"
     "@metamask/object-multiplex": "npm:^1.1.0"
     "@metamask/permission-controller": "npm:^12.1.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Context: HYPE token (`eip155:999/slip44:2457`) was incorrectly set to `eip155:999/slip44:1` (`1` instead of `2457`)
for some users in NetworkEnablementController.nativeAssetIdentifiers state.
This is because https://chainid.network/chains.json is fetched to populate this state,
and that chainId "999" references a "WanChain testnet" instead of HyperEVM.
PR https://github.com/MetaMask/core/pull/7975 addresses future population by forcing an
override at fetch-time.
However such fetching is not always triggered if an user had already added the network,
hence the need for this migration that - ontop of the PR above - will migrate the incorrect
entry ('eip155:999/slip44:1') to the correct one ('eip155:999/slip44:2457').

This migration will operate only if an entry already exists AND is not 'eip155:999/slip44:2457'.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: migrates `NetworkEnablementController.nativeAssetIdentifiers['eip155:999']` to value `eip155:999/slip44:2457` if applicable.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-574

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted migration logic and mutates controller state in-place for affected users, so a bug could impact stored network asset identifiers. Scope is narrowly targeted to one key/value and is covered by focused unit tests and defensive guards.
> 
> **Overview**
> Adds **migration `121`** to correct the persisted `NetworkEnablementController.nativeAssetIdentifiers['eip155:999']` value to `eip155:999/slip44:2457` *only when the key exists and is set incorrectly*; invalid/missing controller shapes are detected and reported via `captureException` without mutating state.
> 
> Introduces `121_utils.ts` for type-guard/validation logic (with Sentry reporting) and adds Jest coverage for the main success path and all early-return/error conditions. Registers the new migration in `migrations/index.ts` and bumps `@metamask/network-enablement-controller` from `^4.1.0` to `^4.1.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5969ed6948b5f76f184c8e958eb65b9fbe5129c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->