### PR TITLE
chore: modify sync script to use yarn instead of npx

### DIFF
--- a/scripts/perps/validate-core-sync.sh
+++ b/scripts/perps/validate-core-sync.sh
@@ -30,7 +30,7 @@ PERPS_SRC="app/controllers/perps"
 PERPS_DEST="packages/perps-controller/src"
 WORKSPACE="@metamask/perps-controller"
 
-STEP_COUNT=6
+STEP_COUNT=7
 STEP_RESULTS=()
 STEP_TIMES=()
 STEP_LABELS=()
@@ -166,7 +166,7 @@ if [[ -z "$CORE_PATH" ]]; then
 fi
 
 if $SKIP_BUILD; then
-  STEP_COUNT=5
+  STEP_COUNT=6
 fi
 
 # ─── Step functions ─────────────────────────────────────────────────────────────
@@ -230,6 +230,12 @@ step_copy() {
   echo "Copied $FILE_COUNT .ts files"
 }
 
+step_install() {
+  cd "$CORE_PATH"
+  yarn install
+  cd "$MOBILE_ROOT"
+}
+
 step_verify_fixes() {
   local errors=0
 
@@ -284,13 +290,13 @@ step_eslint_fix() {
   fi
 
   progress "  ├─ Running --fix"
-  npx eslint packages/perps-controller/src/ --ext .ts --fix || true
+  yarn eslint packages/perps-controller/src/ --ext .ts --fix || true
 
   progress "  ├─ Running --suppress-all"
-  npx eslint packages/perps-controller/src/ --ext .ts --suppress-all || true
+  yarn eslint packages/perps-controller/src/ --ext .ts --suppress-all || true
 
   progress "  └─ Running --prune-suppressions"
-  npx eslint packages/perps-controller/src/ --ext .ts --prune-suppressions || true
+  yarn eslint packages/perps-controller/src/ --ext .ts --prune-suppressions || true
 
   # Count suppressions
   if [[ -f "$supp_file" ]]; then
@@ -326,7 +332,7 @@ step_lint() {
   cd "$CORE_PATH"
   # No workspace-level lint script exists; run eslint directly to verify
   # all violations are either fixed or suppressed (exit 0 = clean).
-  npx eslint packages/perps-controller/src/ --ext .ts
+  yarn eslint packages/perps-controller/src/ --ext .ts
   cd "$MOBILE_ROOT"
 }
 
@@ -348,6 +354,9 @@ main() {
 
   step=$((step + 1))
   run_step $step "Copy source files" step_copy
+
+  step=$((step + 1))
+  run_step $step "Install dependencies" step_install
 
   step=$((step + 1))
   run_step $step "Verify build fixes" step_verify_fixes


### PR DESCRIPTION
## **Description**

npx is forbidden per repository guidelines as it is non-deterministic and leaves us open to supply chain attacks. This refactors the sync script to install yarn, and leverage it as the executable so that it is deterministic instead.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove npx in favor of yarn in sync script

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only changes that adjust how dependencies and linting are executed; low risk aside from potential differences in locally resolved eslint versions or longer runtime due to installs.
> 
> **Overview**
> The `validate-core-sync.sh` perps sync validation now runs a new **"Install dependencies"** step (`yarn install` in the Core checkout) between copying files and verification, and updates step counts accordingly (including `--skip-build`).
> 
> All eslint invocations in the script switch from `npx eslint` to `yarn eslint` for fix/suppress/prune and final lint verification, aligning the workflow with Core’s Yarn toolchain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4aa38f1b32b7afb5534c8395d83103fa7dfd8479. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->