### PR TITLE
feat: add Homepage component with feature flag integration

### DIFF
--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -1,0 +1,43 @@
+import React, { createRef } from 'react';
+import { screen } from '@testing-library/react-native';
+import renderWithProvider from '../../../util/test/renderWithProvider';
+import Homepage from './Homepage';
+import { SectionRefreshHandle } from './types';
+
+describe('Homepage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders placeholder content', () => {
+    renderWithProvider(<Homepage />);
+
+    expect(
+      screen.getByText('Homepage sections coming soon...'),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders container element', () => {
+    renderWithProvider(<Homepage />);
+
+    expect(screen.getByTestId('homepage-container')).toBeOnTheScreen();
+  });
+
+  it('exposes refresh function via ref', () => {
+    const ref = createRef<SectionRefreshHandle>();
+
+    renderWithProvider(<Homepage ref={ref} />);
+
+    expect(ref.current).not.toBeNull();
+    expect(typeof ref.current?.refresh).toBe('function');
+  });
+
+  it('refresh function returns a resolved promise', async () => {
+    const ref = createRef<SectionRefreshHandle>();
+    renderWithProvider(<Homepage ref={ref} />);
+
+    const result = ref.current?.refresh();
+
+    await expect(result).resolves.toBeUndefined();
+  });
+});

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -1,0 +1,25 @@
+import React, { forwardRef, useCallback, useImperativeHandle } from 'react';
+import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import { SectionRefreshHandle } from './types';
+
+/**
+ * Homepage component - Main view for the redesigned wallet homepage.
+ *
+ * This component will contain various sections like Tokens, NFTs, DeFi, etc.
+ * Currently a placeholder while sections are being incrementally adopted.
+ */
+const Homepage = forwardRef<SectionRefreshHandle>((_, ref) => {
+  const refresh = useCallback(async () => {
+    // TODO: Implement refresh logic as sections are added
+  }, []);
+
+  useImperativeHandle(ref, () => ({ refresh }), [refresh]);
+
+  return (
+    <Box gap={6} marginBottom={8} testID="homepage-container">
+      <Text variant={TextVariant.BodyMd}>Homepage sections coming soon...</Text>
+    </Box>
+  );
+});
+
+export default Homepage;

--- a/app/components/Views/Homepage/index.ts
+++ b/app/components/Views/Homepage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Homepage';

--- a/app/components/Views/Homepage/types.ts
+++ b/app/components/Views/Homepage/types.ts
@@ -1,0 +1,6 @@
+/**
+ * Handle for section components that support refresh functionality
+ */
+export interface SectionRefreshHandle {
+  refresh: () => Promise<void>;
+}

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -122,6 +122,7 @@ import {
   selectHomepageSectionsV1Enabled,
 } from '../../../selectors/featureFlagController/homepage';
 import Homepage from '../Homepage';
+import { SectionRefreshHandle } from '../Homepage/types';
 import AccountGroupBalance from '../../UI/Assets/components/Balance/AccountGroupBalance';
 import useCheckNftAutoDetectionModal from '../../hooks/useCheckNftAutoDetectionModal';
 import useCheckMultiRpcModal from '../../hooks/useCheckMultiRpcModal';
@@ -1070,7 +1071,7 @@ const Wallet = ({
     selectHomepageSectionsV1Enabled,
   );
 
-  const homepageRef = useRef<{ refresh: () => Promise<void> }>(null);
+  const homepageRef = useRef<SectionRefreshHandle>(null);
 
   // Enable parent scroll when homepage redesign or sections feature flags are enabled
   const shouldEnableParentScroll =

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -117,7 +117,11 @@ import ErrorBoundary from '../ErrorBoundary';
 import { Token } from '@metamask/assets-controllers';
 import { Hex } from '@metamask/utils';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
-import { selectHomepageRedesignV1Enabled } from '../../../selectors/featureFlagController/homepage';
+import {
+  selectHomepageRedesignV1Enabled,
+  selectHomepageSectionsV1Enabled,
+} from '../../../selectors/featureFlagController/homepage';
+import Homepage from '../Homepage';
 import AccountGroupBalance from '../../UI/Assets/components/Balance/AccountGroupBalance';
 import useCheckNftAutoDetectionModal from '../../hooks/useCheckNftAutoDetectionModal';
 import useCheckMultiRpcModal from '../../hooks/useCheckMultiRpcModal';
@@ -1062,6 +1066,15 @@ const Wallet = ({
   const isHomepageRedesignV1Enabled = useSelector(
     selectHomepageRedesignV1Enabled,
   );
+  const isHomepageSectionsV1Enabled = useSelector(
+    selectHomepageSectionsV1Enabled,
+  );
+
+  const homepageRef = useRef<{ refresh: () => Promise<void> }>(null);
+
+  // Enable parent scroll when homepage redesign or sections feature flags are enabled
+  const shouldEnableParentScroll =
+    isHomepageRedesignV1Enabled || isHomepageSectionsV1Enabled;
 
   useEffect(() => {
     if (!selectedInternalAccount) return;
@@ -1232,9 +1245,9 @@ const Wallet = ({
   const scrollViewContentStyle = useMemo(
     () => [
       styles.wrapper,
-      isHomepageRedesignV1Enabled && { flex: undefined, flexGrow: 0 },
+      shouldEnableParentScroll && { flex: undefined, flexGrow: 0 },
     ],
-    [styles.wrapper, isHomepageRedesignV1Enabled],
+    [styles.wrapper, shouldEnableParentScroll],
   );
 
   const handleRefresh = useCallback(async () => {
@@ -1247,7 +1260,16 @@ const Wallet = ({
     setRefreshing(true);
 
     try {
-      await walletTokensTabViewRef.current?.refresh(refreshBalance);
+      if (isHomepageSectionsV1Enabled) {
+        // Homepage sections mode - refresh homepage and balance
+        await Promise.allSettled([
+          refreshBalance(),
+          homepageRef.current?.refresh(),
+        ]);
+      } else {
+        // Legacy tab mode
+        await walletTokensTabViewRef.current?.refresh(refreshBalance);
+      }
     } catch (error) {
       Logger.error(error as Error, 'Error refreshing wallet');
     } finally {
@@ -1258,7 +1280,7 @@ const Wallet = ({
         setRefreshing(false);
       }
     }
-  }, [refreshBalance]);
+  }, [refreshBalance, isHomepageSectionsV1Enabled]);
 
   const content = (
     <>
@@ -1297,13 +1319,17 @@ const Wallet = ({
 
         {isCarouselBannersEnabled && <Carousel style={styles.carousel} />}
 
-        <WalletTokensTabView
-          ref={walletTokensTabViewRef}
-          navigation={navigation}
-          onChangeTab={onChangeTab}
-          defiEnabled={defiEnabled}
-          collectiblesEnabled={collectiblesEnabled}
-        />
+        {isHomepageSectionsV1Enabled ? (
+          <Homepage ref={homepageRef} />
+        ) : (
+          <WalletTokensTabView
+            ref={walletTokensTabViewRef}
+            navigation={navigation}
+            onChangeTab={onChangeTab}
+            defiEnabled={defiEnabled}
+            collectiblesEnabled={collectiblesEnabled}
+          />
+        )}
       </>
     </>
   );
@@ -1326,11 +1352,11 @@ const Wallet = ({
           >
             <ConditionalScrollView
               ref={scrollViewRef}
-              isScrollEnabled={isHomepageRedesignV1Enabled}
+              isScrollEnabled={shouldEnableParentScroll}
               scrollViewProps={{
                 contentContainerStyle: scrollViewContentStyle,
                 showsVerticalScrollIndicator: false,
-                refreshControl: isHomepageRedesignV1Enabled ? (
+                refreshControl: shouldEnableParentScroll ? (
                   <RefreshControl
                     colors={[colors.primary.default]}
                     tintColor={colors.icon.default}

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -1262,10 +1262,7 @@ const Wallet = ({
     try {
       if (isHomepageSectionsV1Enabled) {
         // Homepage sections mode - refresh homepage and balance
-        await Promise.allSettled([
-          refreshBalance(),
-          homepageRef.current?.refresh(),
-        ]);
+        await Promise.all([refreshBalance(), homepageRef.current?.refresh()]);
       } else {
         // Legacy tab mode
         await walletTokensTabViewRef.current?.refresh(refreshBalance);


### PR DESCRIPTION
## **Description**

This PR introduces the initial Homepage component infrastructure with feature flag integration for the new wallet homepage redesign.

**Why:**
The wallet homepage is being redesigned to provide a more streamlined and organized view of user assets and activities. This PR sets up the foundational component structure that will be incrementally expanded with additional sections (Tokens, NFTs, DeFi, Perps, Predictions, etc.).

**What's included:**
- New `Homepage` component with placeholder content
- `SectionRefreshHandle` type for coordinating refresh across future sections
- Feature flag integration via `selectHomepageSectionsV1Enabled` selector
- Conditional rendering in Wallet view to toggle between old tab-based UI and new Homepage
- Unit tests for the Homepage component

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs:[ TMCU-407](https://consensyssoftware.atlassian.net/browse/TMCU-407)

## **Manual testing steps**

```gherkin
Feature: Homepage feature flag integration

  Scenario: user sees placeholder homepage when feature flag is enabled
    Given the homepageSectionsV1 feature flag is enabled

    When user opens the Wallet view
    Then user sees "Homepage sections coming soon..." placeholder text

  Scenario: user sees existing wallet view when feature flag is disabled
    Given the homepageSectionsV1 feature flag is disabled

    When user opens the Wallet view
    Then user sees the existing tab-based wallet interface
```

## **Screenshots/Recordings**

### **Before**

<img width="300" alt="before" src="https://github.com/user-attachments/assets/25a2d5ec-8b18-4a72-bbeb-6f5932fb97a7" />


### **After**

#### FLAG OFF no changes
<img width="300" alt="after" src="https://github.com/user-attachments/assets/25a2d5ec-8b18-4a72-bbeb-6f5932fb97a7" />

#### FLAG ON
<img width="300" alt="after_flag_on" src="https://github.com/user-attachments/assets/64889e83-f68a-4982-b736-8cc3b238fd98" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Wallet’s main rendering and refresh/scroll behavior behind a feature flag; risk is primarily UI/UX regressions or refresh issues when the flag is enabled.
> 
> **Overview**
> Introduces a new `Homepage` view (currently placeholder UI) that exposes a `refresh()` method via `forwardRef`/`useImperativeHandle`, plus a `SectionRefreshHandle` type and basic unit tests.
> 
> Updates the Wallet screen to gate rendering between the legacy `WalletTokensTabView` and the new `Homepage` using the `selectHomepageSectionsV1Enabled` flag, and adjusts pull-to-refresh/scroll behavior so refresh triggers both balance and homepage refresh (and enables parent scrolling/refresh control when either redesign flag is on).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaf18dcd8014602b554a869fa14610c0985f4f68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->