### PR TITLE
fix: ButtonIconSize for mUSD conversion navbar icons cp-7.66.0

### DIFF
--- a/app/components/UI/Earn/hooks/useMusdConversionNavbar.tsx
+++ b/app/components/UI/Earn/hooks/useMusdConversionNavbar.tsx
@@ -57,7 +57,7 @@ export function useMusdConversionNavbar() {
       <View style={styles.headerLeft}>
         <ButtonIcon
           iconName={IconName.ArrowLeft}
-          size={ButtonIconSize.Lg}
+          size={ButtonIconSize.Md}
           iconProps={{ color: IconColor.IconDefault }}
           onPress={onBackPress}
         />
@@ -95,7 +95,7 @@ export function useMusdConversionNavbar() {
       <View style={styles.headerRight}>
         <ButtonIcon
           iconName={IconName.Info}
-          size={ButtonIconSize.Lg}
+          size={ButtonIconSize.Md}
           iconProps={{ color: IconColor.IconDefault }}
           onPress={onInfoPress}
         />


### PR DESCRIPTION
## **Description**

Update earn flow header icons from `ButtonIconSize.Lg` to `ButtonIconSize.Md` for the mUSD conversion navbar (`ArrowLeft` back button and `Info` button). The icons were rendering too large due to using the wrong size enum value.

**Reason for change:** The mUSD conversion navbar icons were visually oversized, using `ButtonIconSize.Lg` instead of the correct `ButtonIconSize.Md`.

**Cherry-pick target:** This fix needs to be cherry-picked into the latest release branch.

```bash
git cherry-pick f9cea7caa2663589890d16683ba7eae2e4221c16
```

Target branch: `release/7.66.0`

---
[Slack Thread](https://consensys.slack.com/archives/C0354T27M5M/p1770909295687339?thread_ts=1770909295.687339&cid=C0354T27M5M)

## **Changelog**

CHANGELOG entry: Fixed mUSD conversion navbar icons to use the correct button icon size

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Earn mUSD conversion navbar icons

  Scenario: user views the mUSD conversion navbar
    Given the user has navigated to the Earn mUSD conversion screen

    When user views the navbar header
    Then the back (ArrowLeft) and info (Info) icons should display at medium size (Md)
    And the icons should not appear oversized
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.