### PR TITLE
fix: suppress network add/remove toast on bridge routes

### DIFF
--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -298,9 +298,15 @@ const Main = (props) => {
       previousNetworkConfigurations.current ?? {},
     );
 
+    /*
+     * Emit network addition/deletion toast if network list changes
+     *
+     * Bridge routes are skipped as they interfere with bridge UI
+     */
     if (
       previousNetworkValues.length &&
-      currentNetworkValues.length !== previousNetworkValues.length
+      currentNetworkValues.length !== previousNetworkValues.length &&
+      !isOnBridgeRoute
     ) {
       // Find the newly added network by comparing chainIds
       const newNetwork = currentNetworkValues.find(
@@ -336,7 +342,7 @@ const Main = (props) => {
       });
     }
     previousNetworkConfigurations.current = networkConfigurations;
-  }, [networkConfigurations, networkName, networkImage, toastRef]);
+  }, [isOnBridgeRoute, networkConfigurations, networkImage, toastRef]);
 
   useEffect(() => {
     if (locale.current !== I18n.locale) {

--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -298,11 +298,8 @@ const Main = (props) => {
       previousNetworkConfigurations.current ?? {},
     );
 
-    /*
-     * Emit network addition/deletion toast if network list changes
-     *
-     * Bridge routes are skipped as they interfere with bridge UI
-     */
+    // Emit network addition/deletion toast if network list changes
+    // Bridge routes are skipped as they interfere with bridge UI
     if (
       previousNetworkValues.length &&
       currentNetworkValues.length !== previousNetworkValues.length &&


### PR DESCRIPTION
## **Description**

This change adds route-based suppression for the network add/remove confirmation toast during Bridge flows.

Reason for the change:
- Selecting a Bridge token on a network the user has not configured can auto-add that network.
- The global add/remove network toast could appear during Bridge UI flows and create noise/interruption.

Improvement/solution:
- Kept the existing add/remove toast detection logic in `Main`.
- Added a Bridge route guard (`useIsOnBridgeRoute`) in that effect so the toast is skipped while on Bridge routes.
- Still updates `previousNetworkConfigurations.current` when suppressed, so future diffs remain accurate.

## **Changelog**

CHANGELOG entry: Fixed a bug where add/remove network confirmation toasts appeared during Bridge flows.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Bridge route network toast suppression

  Scenario: Selecting a token on an unconfigured network in Bridge
    Given the user is in the Bridge flow
    And the selected token network is not yet configured

    When the user selects that token
    Then the network is added in the background
    And the add/remove network confirmation toast is not shown

  Scenario: Network add/remove outside Bridge
    Given the user is not on any Bridge route

    When network configurations change by adding or removing a network
    Then the add/remove network confirmation toast is shown

  Scenario: Suppression keeps network snapshot in sync
    Given the user is on a Bridge route and a network configuration change occurs

    When the user leaves Bridge and another network configuration change occurs
    Then toast behavior reflects only the latest diff (no stale catch-up toast)
```

## **Screenshots/Recordings**

### **Before**

N/A (behavioral toast suppression change)

### **After**

N/A (behavioral toast suppression change)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-notification gating change scoped to Bridge routes; minimal behavioral impact outside Bridge.
> 
> **Overview**
> Suppresses the network add/remove confirmation toast emitted from `Main` when the current route is a Bridge route, avoiding UI interruptions during Bridge flows.
> 
> The toast detection logic still updates the `previousNetworkConfigurations` snapshot even when suppressed, and the effect dependencies are adjusted accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22cb3376d4c07b07ab4b13212695f4fc41e6a183. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->