### PR TITLE
refactor: use notifications network config from notification payload

### DIFF
--- a/app/components/UI/Notification/List/index.test.tsx
+++ b/app/components/UI/Notification/List/index.test.tsx
@@ -129,7 +129,7 @@ describe('NotificationsListItem', () => {
         n.type === TRIGGER_TYPES.ETH_SENT ||
         n.type === TRIGGER_TYPES.ETH_RECEIVED
       ) {
-        n.payload.chain_id = 123; // unsupported chainId
+        n.payload = undefined as never; // no valid network metadata
       }
 
       return n;
@@ -152,7 +152,7 @@ describe('NotificationsListItem', () => {
         n.type === TRIGGER_TYPES.ERC20_SENT ||
         n.type === TRIGGER_TYPES.ERC20_RECEIVED
       ) {
-        n.payload.chain_id = 123; // unsupported chainId
+        n.payload = undefined as never; // no valid network metadata
       }
 
       return n;

--- a/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.test.tsx
+++ b/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.test.tsx
@@ -1,18 +1,22 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { Linking } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { fireEvent, render } from '@testing-library/react-native';
+import type { OnChainRawNotification } from '@metamask/notification-services-controller/notification-services';
 import { strings } from '../../../../../../locales/i18n';
 import BlockExplorerFooter from './BlockExplorerFooter';
 import {
   MetaMetricsEvents,
   useMetrics,
 } from '../../../../../components/hooks/useMetrics';
-import { getBlockExplorerByChainId } from '../../../../../util/notifications';
 import { ModalFooterType } from '../../../../../util/notifications/constants/config';
-import MOCK_NOTIFICATIONS from '../../../../UI/Notification/__mocks__/mock_notifications';
+import {
+  MOCK_ON_CHAIN_NOTIFICATIONS,
+  MOCK_FEATURE_ANNOUNCEMENT_NOTIFICATIONS,
+} from '../../../../UI/Notification/__mocks__/mock_notifications';
 import { MetricsEventBuilder } from '../../../../../core/Analytics/MetricsEventBuilder';
+import { getNetworkDetailsFromNotifPayload } from '../../../../../util/notifications';
 
 jest.mock('react-native/Libraries/Linking/Linking', () => ({
   openURL: jest.fn(),
@@ -22,7 +26,7 @@ jest.mock('react-redux', () => ({
 }));
 
 jest.mock('../../../../../util/notifications', () => ({
-  getBlockExplorerByChainId: jest.fn(),
+  getNetworkDetailsFromNotifPayload: jest.fn(),
 }));
 
 jest.mock('../../../../../components/hooks/useMetrics');
@@ -54,32 +58,45 @@ describe('BlockExplorerFooter', () => {
 
   it('returns null when no URL is available', () => {
     (useSelector as jest.Mock).mockReturnValue({});
-    (getBlockExplorerByChainId as jest.Mock).mockReturnValue(undefined);
+    (getNetworkDetailsFromNotifPayload as jest.Mock).mockReturnValue({
+      blockExplorerUrl: undefined,
+    });
 
-    const props = {
+    const props: ComponentProps<typeof BlockExplorerFooter> = {
       chainId: 1,
       txHash: '0x123',
-      notification: MOCK_NOTIFICATIONS[0],
+      notification: MOCK_ON_CHAIN_NOTIFICATIONS[0],
       type: ModalFooterType.BLOCK_EXPLORER,
-    } as const;
+    };
 
     const { toJSON } = render(<BlockExplorerFooter {...props} />);
 
     expect(toJSON()).toBeNull();
   });
 
-  it('tracks event with chain_id when present in notification', () => {
-    (useSelector as jest.Mock).mockReturnValue({});
-    (getBlockExplorerByChainId as jest.Mock).mockReturnValue(
-      'https://blockexplorer.com',
-    );
-
-    const props = {
+  it('returns null when notification is not on-chain', () => {
+    const props: ComponentProps<typeof BlockExplorerFooter> = {
       chainId: 1,
       txHash: '0x123',
-      notification: { ...MOCK_NOTIFICATIONS[0], chain_id: 1 },
+      notification: MOCK_FEATURE_ANNOUNCEMENT_NOTIFICATIONS[0],
       type: ModalFooterType.BLOCK_EXPLORER,
-    } as const;
+    };
+    const { toJSON } = render(<BlockExplorerFooter {...props} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('tracks event with chain_id when present in notification', () => {
+    (useSelector as jest.Mock).mockReturnValue({});
+    (getNetworkDetailsFromNotifPayload as jest.Mock).mockReturnValue({
+      blockExplorerUrl: 'https://blockexplorer.com',
+    });
+
+    const props: ComponentProps<typeof BlockExplorerFooter> = {
+      chainId: 1,
+      txHash: '0x123',
+      notification: MOCK_ON_CHAIN_NOTIFICATIONS[0],
+      type: ModalFooterType.BLOCK_EXPLORER,
+    };
 
     const { getByText } = render(<BlockExplorerFooter {...props} />);
 
@@ -95,7 +112,8 @@ describe('BlockExplorerFooter', () => {
         .addProperties({
           notification_id: props.notification.id,
           notification_type: props.notification.type,
-          chain_id: props.notification.chain_id,
+          chain_id: (props.notification as OnChainRawNotification).payload
+            .chain_id,
           clicked_item: 'block_explorer',
         })
         .build(),

--- a/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.tsx
+++ b/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.tsx
@@ -7,14 +7,17 @@ import Button, {
   ButtonVariants,
 } from '../../../../../component-library/components/Buttons/Button';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
-import { getBlockExplorerByChainId } from '../../../../../util/notifications';
+import { getNetworkDetailsFromNotifPayload } from '../../../../../util/notifications';
 import { ModalFooterBlockExplorer } from '../../../../../util/notifications/notification-states/types/NotificationModalDetails';
 import useStyles from '../useStyles';
 import { IconName } from '../../../../../component-library/components/Icons/Icon';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
-import { type INotification } from '../../../../../util/notifications/types';
 import { useMetrics } from '../../../../../components/hooks/useMetrics';
 import onChainAnalyticProperties from '../../../../../util/notifications/methods/notification-analytics';
+import {
+  INotification,
+  isOnChainRawNotification,
+} from '@metamask/notification-services-controller/notification-services';
 
 type BlockExplorerFooterProps = ModalFooterBlockExplorer & {
   notification: INotification;
@@ -25,7 +28,6 @@ export default function BlockExplorerFooter(props: BlockExplorerFooterProps) {
   const { notification } = props;
   const { trackEvent, createEventBuilder } = useMetrics();
 
-  const defaultBlockExplorer = getBlockExplorerByChainId(props.chainId);
   const networkConfigurations = useSelector(
     selectEvmNetworkConfigurationsByChainId,
   );
@@ -36,7 +38,15 @@ export default function BlockExplorerFooter(props: BlockExplorerFooterProps) {
     )?.blockExplorerUrls?.[0];
   }, [networkConfigurations, props.chainId]);
 
-  const url = networkBlockExplorer ?? defaultBlockExplorer;
+  const isOnChainNotification = isOnChainRawNotification(notification);
+  if (!isOnChainNotification) {
+    return null;
+  }
+
+  const { blockExplorerUrl } = getNetworkDetailsFromNotifPayload(
+    notification.payload.network,
+  );
+  const url = networkBlockExplorer ?? blockExplorerUrl;
 
   if (!url) {
     return null;

--- a/app/components/Views/Notifications/Details/index.test.tsx
+++ b/app/components/Views/Notifications/Details/index.test.tsx
@@ -4,20 +4,18 @@ import { render } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import {
-  INotification,
-  TRIGGER_TYPES,
+  type INotification,
   processNotification,
+  TRIGGER_TYPES,
 } from '@metamask/notification-services-controller/notification-services';
-import {
+import NotificationsDetails from './index';
+import { backgroundState } from '../../../../util/test/initial-root-state';
+import MOCK_NOTIFICATIONS, {
   createMockNotificationERC20Received,
   createMockNotificationERC20Sent,
   createMockNotificationEthReceived,
   createMockNotificationEthSent,
-} from '@metamask/notification-services-controller/notification-services/mocks';
-
-import NotificationsDetails from './index';
-import { backgroundState } from '../../../../util/test/initial-root-state';
-import MOCK_NOTIFICATIONS from '../../../../components/UI/Notification/__mocks__/mock_notifications';
+} from '../../../../components/UI/Notification/__mocks__/mock_notifications';
 // eslint-disable-next-line import/no-namespace
 import * as UseNotificationsModule from '../../../../util/notifications/hooks/useNotifications';
 import { AvatarAccountType } from '../../../../component-library/components/Avatars/Avatar';
@@ -101,7 +99,7 @@ describe('NotificationsDetails', () => {
         n.type === TRIGGER_TYPES.ERC20_SENT ||
         n.type === TRIGGER_TYPES.ERC20_RECEIVED
       ) {
-        n.payload.chain_id = 123; // unsupported chainId
+        return { ...n, payload: undefined } as unknown as INotification; // delete payload
       }
       return n;
     }),

--- a/app/util/notifications/methods/notification-analytics.ts
+++ b/app/util/notifications/methods/notification-analytics.ts
@@ -1,4 +1,4 @@
-import { INotification } from '../types';
+import { INotification } from '@metamask/notification-services-controller/notification-services';
 
 const onChainAnalyticProperties = (item: INotification) => {
   if (

--- a/app/util/notifications/notification-states/erc1155-sent-received/erc1155-sent-received.tsx
+++ b/app/util/notifications/notification-states/erc1155-sent-received/erc1155-sent-received.tsx
@@ -48,7 +48,11 @@ const modalTitle = (n: ERC1155Notification) =>
       });
 
 const state: NotificationState<ERC1155Notification> = {
-  guardFn: isERC1155Notification,
+  guardFn: [
+    isERC1155Notification,
+    (notification) =>
+      !!getNetworkDetailsFromNotifPayload(notification.payload.network),
+  ],
   createMenuItem: (notification) => ({
     title: title(notification),
 

--- a/app/util/notifications/notification-states/erc1155-sent-received/erc1155-sent-received.tsx
+++ b/app/util/notifications/notification-states/erc1155-sent-received/erc1155-sent-received.tsx
@@ -12,7 +12,8 @@ import {
   NotificationState,
 } from '../types/NotificationState';
 import {
-  getNativeTokenDetailsByChainId,
+  getNetworkDetailsFromNotifPayload,
+  getNetworkImageByChainId,
   getNotificationBadge,
 } from '../../methods/common';
 import { ModalField } from '../types/NotificationModalDetails';
@@ -68,8 +69,9 @@ const state: NotificationState<ERC1155Notification> = {
     createdAt: notification.createdAt.toString(),
   }),
   createModalDetails: (notification) => {
-    const nativeTokenDetails = getNativeTokenDetailsByChainId(
-      notification.payload.chain_id,
+    const networkLogo = getNetworkImageByChainId(notification.payload.chain_id);
+    const { networkName } = getNetworkDetailsFromNotifPayload(
+      notification.payload.network,
     );
 
     const collectionField: ModalField[] = notification.payload.data.nft
@@ -79,7 +81,7 @@ const state: NotificationState<ERC1155Notification> = {
             type: ModalFieldType.NFT_COLLECTION_IMAGE,
             collectionName: notification.payload.data.nft.collection.name,
             collectionImageUrl: notification.payload.data.nft.collection.image,
-            networkBadgeUrl: nativeTokenDetails?.image,
+            networkBadgeUrl: networkLogo,
           },
         ]
       : [];
@@ -89,7 +91,7 @@ const state: NotificationState<ERC1155Notification> = {
       header: {
         type: ModalHeaderType.NFT_IMAGE,
         nftImageUrl: notification.payload.data.nft?.image ?? '',
-        networkBadgeUrl: nativeTokenDetails?.image,
+        networkBadgeUrl: networkLogo,
       },
       fields: [
         {
@@ -109,8 +111,8 @@ const state: NotificationState<ERC1155Notification> = {
         ...collectionField,
         {
           type: ModalFieldType.NETWORK,
-          iconUrl: nativeTokenDetails?.image,
-          name: nativeTokenDetails?.name,
+          iconUrl: networkLogo,
+          name: networkName,
         },
       ],
       footer: {

--- a/app/util/notifications/notification-states/erc20-sent-received/erc20-sent-received.ts
+++ b/app/util/notifications/notification-states/erc20-sent-received/erc20-sent-received.ts
@@ -47,7 +47,11 @@ const modalTitle = (n: ERC20Notification) =>
       });
 
 const state: NotificationState<ERC20Notification> = {
-  guardFn: [isERC20Notification],
+  guardFn: [
+    isERC20Notification,
+    (notification) =>
+      !!getNetworkDetailsFromNotifPayload(notification.payload.network),
+  ],
   createMenuItem: (notification) => ({
     title: menuTitle(notification),
 
@@ -72,9 +76,11 @@ const state: NotificationState<ERC20Notification> = {
   }),
   createModalDetails: (notification) => {
     const { networkName } = getNetworkDetailsFromNotifPayload(
-      notification.payload.network,
+      notification?.payload?.network,
     );
-    const networkLogo = getNetworkImageByChainId(notification.payload.chain_id);
+    const networkLogo = getNetworkImageByChainId(
+      notification?.payload?.chain_id,
+    );
 
     return {
       title: modalTitle(notification),

--- a/app/util/notifications/notification-states/erc20-sent-received/erc20-sent-received.ts
+++ b/app/util/notifications/notification-states/erc20-sent-received/erc20-sent-received.ts
@@ -9,8 +9,9 @@ import {
 } from '../types/NotificationState';
 import {
   getAmount,
-  getNativeTokenDetailsByChainId,
   getNotificationBadge,
+  getNetworkDetailsFromNotifPayload,
+  getNetworkImageByChainId,
 } from '../../methods/common';
 import { getTokenAmount, getTokenUSDAmount } from '../token-amounts';
 import { formatAddress } from '../../../address';
@@ -46,11 +47,7 @@ const modalTitle = (n: ERC20Notification) =>
       });
 
 const state: NotificationState<ERC20Notification> = {
-  guardFn: [
-    isERC20Notification,
-    (notification) =>
-      !!getNativeTokenDetailsByChainId(notification.payload.chain_id),
-  ],
+  guardFn: [isERC20Notification],
   createMenuItem: (notification) => ({
     title: menuTitle(notification),
 
@@ -74,9 +71,11 @@ const state: NotificationState<ERC20Notification> = {
     createdAt: notification.createdAt.toString(),
   }),
   createModalDetails: (notification) => {
-    const nativeTokenDetails = getNativeTokenDetailsByChainId(
-      notification.payload.chain_id,
+    const { networkName } = getNetworkDetailsFromNotifPayload(
+      notification.payload.network,
     );
+    const networkLogo = getNetworkImageByChainId(notification.payload.chain_id);
+
     return {
       title: modalTitle(notification),
       createdAt: notification.createdAt.toString(),
@@ -102,12 +101,12 @@ const state: NotificationState<ERC20Notification> = {
           amount: getTokenAmount(notification.payload.data.token),
           usdAmount: getTokenUSDAmount(notification.payload.data.token),
           tokenIconUrl: notification.payload.data.token.image,
-          tokenNetworkUrl: nativeTokenDetails?.image,
+          tokenNetworkUrl: networkLogo,
         },
         {
           type: ModalFieldType.NETWORK,
-          iconUrl: nativeTokenDetails?.image,
-          name: nativeTokenDetails?.name,
+          iconUrl: networkLogo,
+          name: `${networkName}`,
         },
       ],
       footer: {

--- a/app/util/notifications/notification-states/erc721-sent-received/erc721-sent-received.tsx
+++ b/app/util/notifications/notification-states/erc721-sent-received/erc721-sent-received.tsx
@@ -12,7 +12,8 @@ import {
   NotificationState,
 } from '../types/NotificationState';
 import {
-  getNativeTokenDetailsByChainId,
+  getNetworkDetailsFromNotifPayload,
+  getNetworkImageByChainId,
   getNotificationBadge,
 } from '../../methods/common';
 import { formatAddress } from '../../../address';
@@ -64,8 +65,9 @@ const state: NotificationState<ERC721Notification> = {
     createdAt: notification.createdAt.toString(),
   }),
   createModalDetails: (notification) => {
-    const nativeTokenDetails = getNativeTokenDetailsByChainId(
-      notification.payload.chain_id,
+    const networkLogo = getNetworkImageByChainId(notification.payload.chain_id);
+    const { networkName } = getNetworkDetailsFromNotifPayload(
+      notification.payload.network,
     );
     return {
       title: modalTitle(notification),
@@ -73,7 +75,7 @@ const state: NotificationState<ERC721Notification> = {
       header: {
         type: ModalHeaderType.NFT_IMAGE,
         nftImageUrl: notification.payload.data.nft.image,
-        networkBadgeUrl: nativeTokenDetails?.image,
+        networkBadgeUrl: networkLogo,
       },
       fields: [
         {
@@ -94,12 +96,12 @@ const state: NotificationState<ERC721Notification> = {
           type: ModalFieldType.NFT_COLLECTION_IMAGE,
           collectionName: notification.payload.data.nft.collection.name,
           collectionImageUrl: notification.payload.data.nft.collection.image,
-          networkBadgeUrl: nativeTokenDetails?.image,
+          networkBadgeUrl: networkLogo,
         },
         {
           type: ModalFieldType.NETWORK,
-          iconUrl: nativeTokenDetails?.image,
-          name: nativeTokenDetails?.name,
+          iconUrl: networkLogo,
+          name: networkName,
         },
       ],
       footer: {

--- a/app/util/notifications/notification-states/erc721-sent-received/erc721-sent-received.tsx
+++ b/app/util/notifications/notification-states/erc721-sent-received/erc721-sent-received.tsx
@@ -46,7 +46,11 @@ const modalTitle = (n: ERC721Notification) =>
       });
 
 const state: NotificationState<ERC721Notification> = {
-  guardFn: isERC721Notification,
+  guardFn: [
+    isERC721Notification,
+    (notification) =>
+      !!getNetworkDetailsFromNotifPayload(notification.payload.network),
+  ],
   createMenuItem: (notification) => ({
     title: title(notification),
 

--- a/app/util/notifications/notification-states/eth-sent-received/eth-sent-received.tsx
+++ b/app/util/notifications/notification-states/eth-sent-received/eth-sent-received.tsx
@@ -37,7 +37,11 @@ const title = (n: NativeSentReceiveNotification) => {
 };
 
 const state: NotificationState<NativeSentReceiveNotification> = {
-  guardFn: [isNativeTokenNotification],
+  guardFn: [
+    isNativeTokenNotification,
+    (notification) =>
+      !!getNetworkDetailsFromNotifPayload(notification.payload.network),
+  ],
   createMenuItem: (notification) => {
     const networkLogo = getNetworkImageByChainId(notification.payload.chain_id);
     const { networkName, nativeCurrencySymbol } =

--- a/app/util/notifications/notification-states/index.test.tsx
+++ b/app/util/notifications/notification-states/index.test.tsx
@@ -24,7 +24,7 @@ describe('isValidNotificationComponent()', () => {
     },
   );
 
-  it('filters out unsupported eth_sent and eth_received notifications', () => {
+  it('filters out eth_sent and eth_received notifications with missing payload', () => {
     const invalidNotifications = [
       processNotification(createMockNotificationEthSent()),
       processNotification(createMockNotificationEthReceived()),
@@ -33,9 +33,8 @@ describe('isValidNotificationComponent()', () => {
         n.type === TRIGGER_TYPES.ETH_SENT ||
         n.type === TRIGGER_TYPES.ETH_RECEIVED
       ) {
-        n.payload.chain_id = 123; // unsupported chainId
+        delete (n as Partial<typeof n>).payload;
       }
-
       return n;
     });
 
@@ -44,7 +43,7 @@ describe('isValidNotificationComponent()', () => {
     });
   });
 
-  it('filters out unsupported erc20_sent and erc20_received notifications', () => {
+  it('filters out erc20_sent and erc20_received notifications with missing payload', () => {
     const invalidNotifications = [
       processNotification(createMockNotificationERC20Sent()),
       processNotification(createMockNotificationERC20Received()),
@@ -53,9 +52,8 @@ describe('isValidNotificationComponent()', () => {
         n.type === TRIGGER_TYPES.ERC20_SENT ||
         n.type === TRIGGER_TYPES.ERC20_RECEIVED
       ) {
-        n.payload.chain_id = 123; // unsupported chainId
+        delete (n as Partial<typeof n>).payload;
       }
-
       return n;
     });
 

--- a/app/util/notifications/notification-states/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.tsx
+++ b/app/util/notifications/notification-states/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.tsx
@@ -17,7 +17,10 @@ const isLidoReadyWithDrawnNotification = isOfTypeNodeGuard([
 ]);
 
 const state: NotificationState<LidoReadyWithDrawnNotification> = {
-  guardFn: isLidoReadyWithDrawnNotification,
+  guardFn: [
+    isLidoReadyWithDrawnNotification,
+    (notification) => !!notification.payload.chain_id,
+  ],
   createMenuItem: (notification) => ({
     title: strings(`notifications.menu_item_title.${notification.type}`),
 

--- a/app/util/notifications/notification-states/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.tsx
+++ b/app/util/notifications/notification-states/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.tsx
@@ -5,7 +5,7 @@ import { ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';
 import { NotificationState } from '../types/NotificationState';
 import {
   formatAmount,
-  getNativeTokenDetailsByChainId,
+  getNetworkImageByChainId,
   getNotificationBadge,
 } from '../../methods/common';
 
@@ -37,9 +37,7 @@ const state: NotificationState<LidoReadyWithDrawnNotification> = {
     createdAt: notification.createdAt.toString(),
   }),
   createModalDetails: (notification) => {
-    const nativeTokenDetails = getNativeTokenDetailsByChainId(
-      notification.payload.chain_id,
-    );
+    const networkLogo = getNetworkImageByChainId(notification.payload.chain_id);
 
     return {
       title: strings('notifications.modal.title_untake_ready'),
@@ -63,7 +61,7 @@ const state: NotificationState<LidoReadyWithDrawnNotification> = {
             { shouldEllipse: true },
           )}`,
           tokenIconUrl: notification.payload.data.staked_eth.image,
-          tokenNetworkUrl: nativeTokenDetails?.image,
+          tokenNetworkUrl: networkLogo,
         },
         {
           type: ModalFieldType.TRANSACTION,

--- a/app/util/notifications/notification-states/lido-withdrawal-requested/lido-withdrawal-requested.tsx
+++ b/app/util/notifications/notification-states/lido-withdrawal-requested/lido-withdrawal-requested.tsx
@@ -18,7 +18,10 @@ const isLidoWithdrawalRequestedNotification = isOfTypeNodeGuard([
 ]);
 
 const state: NotificationState<LidoWithdrawalRequestedNotification> = {
-  guardFn: isLidoWithdrawalRequestedNotification,
+  guardFn: [
+    isLidoWithdrawalRequestedNotification,
+    (notification) => !!notification.payload.chain_id,
+  ],
   createMenuItem: (notification) => {
     const amount = getAmount(
       notification.payload.data.stake_in.amount,

--- a/app/util/notifications/notification-states/lido-withdrawal-requested/lido-withdrawal-requested.tsx
+++ b/app/util/notifications/notification-states/lido-withdrawal-requested/lido-withdrawal-requested.tsx
@@ -5,7 +5,7 @@ import { ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';
 import { NotificationState } from '../types/NotificationState';
 import {
   getAmount,
-  getNativeTokenDetailsByChainId,
+  getNetworkImageByChainId,
   getNotificationBadge,
 } from '../../methods/common';
 import { getTokenAmount } from '../token-amounts';
@@ -46,9 +46,8 @@ const state: NotificationState<LidoWithdrawalRequestedNotification> = {
     };
   },
   createModalDetails: (notification) => {
-    const nativeTokenDetails = getNativeTokenDetailsByChainId(
-      notification.payload.chain_id,
-    );
+    const networkLogo = getNetworkImageByChainId(notification.payload.chain_id);
+
     return {
       title: strings('notifications.modal.title_unstake_requested'),
       createdAt: notification.createdAt.toString(),
@@ -65,7 +64,7 @@ const state: NotificationState<LidoWithdrawalRequestedNotification> = {
           amount: getTokenAmount(notification.payload.data.stake_in),
           usdAmount: getTokenAmount(notification.payload.data.stake_in),
           tokenIconUrl: notification.payload.data.stake_in.image,
-          tokenNetworkUrl: nativeTokenDetails?.image,
+          tokenNetworkUrl: networkLogo,
         },
         {
           type: ModalFieldType.TRANSACTION,

--- a/app/util/notifications/notification-states/stake/stake.tsx
+++ b/app/util/notifications/notification-states/stake/stake.tsx
@@ -75,7 +75,10 @@ const modalTitle = (n: StakeNotification) => {
 };
 
 const state: NotificationState<StakeNotification> = {
-  guardFn: isStakeNotification,
+  guardFn: [
+    isStakeNotification,
+    (notification) => !!notification.payload.chain_id,
+  ],
   createMenuItem: (notification) => ({
     title: strings(`notifications.menu_item_title.${notification.type}`),
 

--- a/app/util/notifications/notification-states/stake/stake.tsx
+++ b/app/util/notifications/notification-states/stake/stake.tsx
@@ -5,8 +5,8 @@ import { ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';
 import { NotificationState } from '../types/NotificationState';
 import {
   getAmount,
-  getNativeTokenDetailsByChainId,
   getNotificationBadge,
+  getNetworkImageByChainId,
 } from '../../methods/common';
 import { ModalField } from '../types/NotificationModalDetails';
 import { getTokenAmount, getTokenUSDAmount } from '../token-amounts';
@@ -93,9 +93,7 @@ const state: NotificationState<StakeNotification> = {
     createdAt: notification.createdAt.toString(),
   }),
   createModalDetails: (notification) => {
-    const nativeTokenDetails = getNativeTokenDetailsByChainId(
-      notification.payload.chain_id,
-    );
+    const networkLogo = getNetworkImageByChainId(notification.payload.chain_id);
 
     const stakedAssetFields: ModalField[] = [
       {
@@ -105,7 +103,7 @@ const state: NotificationState<StakeNotification> = {
         amount: getTokenAmount(notification.payload.data.stake_in),
         usdAmount: getTokenUSDAmount(notification.payload.data.stake_in),
         tokenIconUrl: notification.payload.data.stake_in.image,
-        tokenNetworkUrl: nativeTokenDetails?.image,
+        tokenNetworkUrl: networkLogo,
       },
       {
         type: ModalFieldType.ASSET,
@@ -114,7 +112,7 @@ const state: NotificationState<StakeNotification> = {
         amount: getTokenAmount(notification.payload.data.stake_out),
         usdAmount: getTokenUSDAmount(notification.payload.data.stake_out),
         tokenIconUrl: notification.payload.data.stake_out.image,
-        tokenNetworkUrl: nativeTokenDetails?.image,
+        tokenNetworkUrl: networkLogo,
       },
     ];
 
@@ -126,7 +124,7 @@ const state: NotificationState<StakeNotification> = {
         amount: getTokenAmount(notification.payload.data.stake_in),
         usdAmount: getTokenUSDAmount(notification.payload.data.stake_in),
         tokenIconUrl: notification.payload.data.stake_in.image,
-        tokenNetworkUrl: nativeTokenDetails?.image,
+        tokenNetworkUrl: networkLogo,
       },
       {
         type: ModalFieldType.ASSET,
@@ -135,7 +133,7 @@ const state: NotificationState<StakeNotification> = {
         amount: getTokenAmount(notification.payload.data.stake_out),
         usdAmount: getTokenUSDAmount(notification.payload.data.stake_out),
         tokenIconUrl: notification.payload.data.stake_out.image,
-        tokenNetworkUrl: nativeTokenDetails?.image,
+        tokenNetworkUrl: networkLogo,
       },
     ];
 

--- a/app/util/notifications/notification-states/swap-completed/swap-completed.tsx
+++ b/app/util/notifications/notification-states/swap-completed/swap-completed.tsx
@@ -19,7 +19,11 @@ const isSwapCompletedNotification = isOfTypeNodeGuard([
 ]);
 
 const state: NotificationState<SwapCompletedNotification> = {
-  guardFn: isSwapCompletedNotification,
+  guardFn: [
+    isSwapCompletedNotification,
+    (notification) =>
+      !!getNetworkDetailsFromNotifPayload(notification.payload.network),
+  ],
   createMenuItem: (notification) => ({
     title: strings(`notifications.menu_item_title.${notification.type}`, {
       symbolIn: notification.payload.data.token_in.symbol,

--- a/app/util/notifications/notification-states/swap-completed/swap-completed.tsx
+++ b/app/util/notifications/notification-states/swap-completed/swap-completed.tsx
@@ -5,7 +5,8 @@ import { ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';
 import { NotificationState } from '../types/NotificationState';
 import {
   getAmount,
-  getNativeTokenDetailsByChainId,
+  getNetworkDetailsFromNotifPayload,
+  getNetworkImageByChainId,
   getNotificationBadge,
 } from '../../methods/common';
 import { getTokenAmount, getTokenUSDAmount } from '../token-amounts';
@@ -45,9 +46,11 @@ const state: NotificationState<SwapCompletedNotification> = {
     createdAt: notification.createdAt.toString(),
   }),
   createModalDetails: (notification) => {
-    const nativeTokenDetails = getNativeTokenDetailsByChainId(
-      notification.payload.chain_id,
+    const networkLogo = getNetworkImageByChainId(notification.payload.chain_id);
+    const { networkName } = getNetworkDetailsFromNotifPayload(
+      notification.payload.network,
     );
+
     return {
       title: strings('notifications.modal.title_swapped', {
         symbolIn: notification.payload.data.token_in.symbol,
@@ -67,7 +70,7 @@ const state: NotificationState<SwapCompletedNotification> = {
           amount: getTokenAmount(notification.payload.data.token_in),
           usdAmount: getTokenUSDAmount(notification.payload.data.token_in),
           tokenIconUrl: notification.payload.data.token_in.image,
-          tokenNetworkUrl: nativeTokenDetails?.image,
+          tokenNetworkUrl: networkLogo,
         },
         {
           type: ModalFieldType.ASSET,
@@ -76,7 +79,7 @@ const state: NotificationState<SwapCompletedNotification> = {
           amount: getTokenAmount(notification.payload.data.token_out),
           usdAmount: getTokenUSDAmount(notification.payload.data.token_out),
           tokenIconUrl: notification.payload.data.token_out.image,
-          tokenNetworkUrl: nativeTokenDetails?.image,
+          tokenNetworkUrl: networkLogo,
         },
         {
           type: ModalFieldType.TRANSACTION,
@@ -84,8 +87,8 @@ const state: NotificationState<SwapCompletedNotification> = {
         },
         {
           type: ModalFieldType.NETWORK,
-          iconUrl: nativeTokenDetails?.image,
-          name: nativeTokenDetails?.name,
+          iconUrl: networkLogo,
+          name: networkName,
         },
         {
           type: ModalFieldType.SWAP_RATE,

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
     "@metamask/native-utils": "^0.8.0",
     "@metamask/network-controller": "^29.0.0",
     "@metamask/network-enablement-controller": "^4.1.0",
-    "@metamask/notification-services-controller": "^21.0.0",
+    "@metamask/notification-services-controller": "^22.0.0",
     "@metamask/permission-controller": "^12.1.0",
     "@metamask/phishing-controller": "^16.1.0",
     "@metamask/post-message-stream": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9176,24 +9176,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/notification-services-controller@npm:^21.0.0":
-  version: 21.0.0
-  resolution: "@metamask/notification-services-controller@npm:21.0.0"
+"@metamask/notification-services-controller@npm:^22.0.0":
+  version: 22.0.0
+  resolution: "@metamask/notification-services-controller@npm:22.0.0"
   dependencies:
     "@contentful/rich-text-html-renderer": "npm:^16.5.2"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/keyring-controller": "npm:^25.1.0"
     "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/utils": "npm:^11.8.1"
+    "@metamask/profile-sync-controller": "npm:^27.1.0"
+    "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     firebase: "npm:^11.2.0"
     loglevel: "npm:^1.8.1"
     semver: "npm:^7.6.3"
     uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/keyring-controller": ^25.0.0
-    "@metamask/profile-sync-controller": ^27.0.0
-  checksum: 10/a36c10cb29bd6a9948f0cc0b8698ff9906aebb4ffc40a6ce1eca8bd9c17b4e181831a18996c0944b505eed1f0abadd58b5af73132dbc36ddb1efcf6cf3d2ab05
+  checksum: 10/edeaae4a61ce1ecce5ee5a2bbe30649f70ec0b7a68071e05d1cbc0ab99d62bd094640ca9f40b294052c5175084b7e1fd44c30ff43a20eb57a6ef7562134311ad
   languageName: node
   linkType: hard
 
@@ -35428,7 +35427,7 @@ __metadata:
     "@metamask/native-utils": "npm:^0.8.0"
     "@metamask/network-controller": "npm:^29.0.0"
     "@metamask/network-enablement-controller": "npm:^4.1.0"
-    "@metamask/notification-services-controller": "npm:^21.0.0"
+    "@metamask/notification-services-controller": "npm:^22.0.0"
     "@metamask/object-multiplex": "npm:^1.1.0"
     "@metamask/permission-controller": "npm:^12.1.0"
     "@metamask/phishing-controller": "npm:^16.1.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR refactors multiple notification components to now use the network details received by the backend in the notification payloads, instead of hardcoded values in the client

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-23
Related Extension PR: https://github.com/MetaMask/metamask-extension/pull/39821

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many notification state builders and guards, so missing/changed payload `network` fields could hide notifications or change displayed explorer links. Changes are localized to notification UI and tests, with minimal broader app impact.
> 
> **Overview**
> Refactors on-chain notification rendering to derive **network name, native symbol, logos, and block explorer URLs** from the notification payload (and user network configs when available), removing client hardcoded chain/block-explorer mappings.
> 
> `BlockExplorerFooter` now renders only for on-chain notifications and builds explorer links from `payload.network` metadata; multiple notification state definitions (ETH/ERC20/ERC721/ERC1155, swaps, staking/Lido flows) update guards and UI fields to depend on payload network data and shared `getNetworkImageByChainId`/`getNetworkDetailsFromNotifPayload` helpers. Tests are updated accordingly, and `@metamask/notification-services-controller` is bumped to `^22.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe6578db46c319de555bab12514edc31e58ba7c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->